### PR TITLE
OSDOCS-3087:Operators overview

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1244,6 +1244,8 @@ Name: Operators
 Dir: operators
 Distros: openshift-enterprise,openshift-origin
 Topics:
+- Name: Operators Overview
+  File: index
 - Name: Understanding Operators
   Dir: understanding
   Topics:

--- a/modules/operators-overview.adoc
+++ b/modules/operators-overview.adoc
@@ -1,19 +1,29 @@
 // Module included in the following assemblies:
 //
 // * architecture/control-plane.adoc
+:_content-type: CONCEPT
+
+ifeval::["{context}" == "operators-overview"]
+:index:
+endif::[]
 
 [id="operators-overview_{context}"]
-= Operators in {product-title}
 
 Operators are among the most important components of {product-title}. Operators are the preferred method of packaging, deploying, and managing services on the control plane. They can also provide advantages to applications that users run.
 
 Operators integrate with Kubernetes APIs and CLI tools such as `kubectl` and `oc` commands. They provide the means of monitoring applications, performing health checks, managing over-the-air (OTA) updates, and ensuring that applications remain in your specified state.
 
+ifndef::index[]
 Operators also offer a more granular configuration experience. You configure each component by modifying the API that the Operator exposes instead of modifying a global configuration file.
 
 Because CRI-O and the Kubelet run on every node, almost every other cluster function can be managed on the control plane by using Operators. Components that are added to the control plane by using Operators include critical networking and credential services.
+endif::[]
 
 While both follow similar Operator concepts and goals, Operators in {product-title} are managed by two different systems, depending on their purpose:
 
 * Platform Operators, which are managed by the Cluster Version Operator (CVO), are installed by default to perform cluster functions.
 * Optional add-on Operators, which are managed by Operator Lifecycle Manager (OLM), can be made accessible for users to run in their applications.
+
+ifeval::["{context}" == "operators-overview"]
+:!index:
+endif::[]

--- a/operators/index.adoc
+++ b/operators/index.adoc
@@ -1,0 +1,43 @@
+:_content-type: ASSEMBLY
+[id="operators-overview"]
+= Operators overview
+include::modules/common-attributes.adoc[]
+:context: operators-overview
+
+toc::[]
+
+[id="importance-of-operators"]
+== The importance of Operators
+include::modules/operators-overview.adoc[leveloffset=+1]
+
+With Operators, you an create applications to monitor the running services in the cluster.
+Operators are designed specifically for your applications. Operators implement and automate the common Day 1 operations such as installation and configuration as well as Day 2 operations such as auto-scaling up and down and backups. All these activities are in a piece of software running inside your cluster.
+To understand more about Operators, see xref:../operators/understanding/olm-what-operators-are.adoc#olm-what-operators-are[What are Operators?]
+
+[id="developer-tasks"]
+== For developers
+
+As a developer, you can perform the following Operator tasks:
+
+** xref:../operators/user/olm-creating-apps-from-installed-operators.adoc#olm-creating-apps-from-installed-operators[Create an application from an installed Operator through the web console].
+** xref:../operators/user/olm-installing-operators-in-namespace.adoc#olm-installing-operators-in-namespace[Install and subscribe an Operator to your namespace].
+** xref:../operators/operator_sdk/osdk-about.adoc#osdk-about[Use Operator SDK to build,test, and deploy an Operator].
+** xref:../operators/operator_sdk/osdk-installing-cli.adoc#osdk-installing-cli[Install Operator SDK CLI].
+** Create xref:../operators/operator_sdk/golang/osdk-golang-quickstart.adoc#osdk-golang-quickstart[Go-based Operators], xref:../operators/operator_sdk/ansible/osdk-ansible-quickstart.adoc#osdk-ansible-quickstart[Ansible-based Operators], and xref:../operators/operator_sdk/helm/osdk-helm-quickstart.adoc#osdk-helm-quickstart[Helm-based Operators].
+
+[id="administrator-tasks"]
+== For administrators
+
+As a cluster administrator, you can perform the following Operator tasks:
+
+** xref:../operators/user/olm-installing-operators-in-namespace.adoc#olm-installing-operators-in-namespace[Install an Operator from OperatorHub]
+** xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Upgrade installed Operators]
+** xref:../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Delete installed Operators]
+** xref:../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configure proxy support]
+** xref:../operators/admin/olm-status.adoc#olm-status[View Operator status].
+** xref:../operators/admin/olm-managing-operatorconditions.adoc#olm-managing-operatorconditions[Manage Operator conditions]
+** xref:../operators/admin/olm-creating-policy.adoc#olm-creating-policy[Allow non-cluster administrators to install Operators]
+** xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Manage custom catalogs]
+** xref:../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Use Operator Lifecycle Manager on restricted networks]
+
+To know all about the Platform Operators that Red Hat provides, see xref:../operators/operator-reference.adoc#platform-operators-ref[Red Hat Operators]


### PR DESCRIPTION
- Applies to 4.7+ versions
- [Jira](https://issues.redhat.com/browse/OSDOCS-3087)
- [Preview](https://deploy-preview-40820--osdocs.netlify.app/openshift-enterprise/latest/operators/index.html)

Note:
@adellape please share your thoughts/feedback.

1. In the Assembly **About the Operator SDK** we have the following:

What are Operators?
For an overview about basic Operator concepts and terminology, see Understanding Operators.
Should we not remove this since we now have an overview page for the whole Operators book?

2.  **For Developers** , I have not referenced all the assemblies as there are too many only highlighted a number , is that ok?
3.  4.6 The TOC strcuture is slightly different , I will raise a PR for that once this is reviewed and add the link here. 


@jianzhangbjz PTAL
