### PR TITLE
SRVCOM-1575: Add Serverless 1.20.0 release notes

### DIFF
--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -1,0 +1,61 @@
+[id="serverless-deprecated-removed-features_{context}"]
+= Deprecated and removed features
+
+Some features available in previous releases have been deprecated or removed.
+
+Deprecated functionality is still included in {ServerlessProductName} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. For the most recent list of major functionality deprecated and removed within {ServerlessProductName}, refer to the table below.
+
+In the table, features are marked with the following statuses:
+
+* *-*: _Not yet available_
+* *TP*: _Technology Preview_
+* *GA*: _General Availability_
+* *DEP*: _Deprecated_
+* *REM*: _Removed_
+
+.Deprecated and removed features tracker
+[cols="3,1,1,1",options="header"]
+|====
+|Feature |1.18|1.19|1.20
+
+|`kn func emit` (`kn func invoke` in 1.21+)
+|TP
+|TP
+|TP
+
+|mTLS
+|GA
+|GA
+|GA
+
+|`kn func` TypeScript templates
+|TP
+|TP
+|TP
+
+|`kn func` Rust templates
+|TP
+|TP
+|TP
+
+|`emptyDir` volumes
+|GA
+|GA
+|GA
+
+|`KafkaBinding` API
+|GA
+|DEP
+|DEP
+
+|HTTPS redirection
+|-
+|GA
+|GA
+
+|Kafka broker
+|-
+|-
+|TP
+
+|====

--- a/modules/serverless-rn-1-20-0.adoc
+++ b/modules/serverless-rn-1-20-0.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+[id="serverless-rn-1-20-0_{context}"]
+= Release Notes for Red Hat {ServerlessProductName} 1.20.0
+
+{ServerlessProductName} 1.20.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+[id="new-features-1-20-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 0.26.
+* {ServerlessProductName} now uses Knative Eventing 0.26.
+* {ServerlessProductName} now uses Kourier 0.26.
+* {ServerlessProductName} now uses Knative `kn` CLI 0.26.
+* {ServerlessProductName} now uses Knative Kafka 0.26.
+* The `kn func` CLI plug-in now uses `func` 0.20.
+
+* The Kafka broker is now available as a Technology Preview.
+* The `kn event` plug-in is now available as a Technology Preview.
+
+[id="known-issues-1-20-0_{context}"]
+== Known issues
+
+* {ServerlessProductName} deploys Knative services with a default address that uses HTTPS. When sending an event to a resource inside the cluster, the sender does not have the cluster certificate authority (CA) configured. This causes event delivery to fail, unless the cluster uses globally accepted certificates.
++
+For example, an event delivery to a publicly accessible address works:
++
+[source,terminal]
+----
+$ kn event send --to-url https://ce-api.foo.example.com/
+----
++
+On the other hand, this delivery fails if the service uses a public address with an HTTPS certificate issued by a custom CA:
++
+[source,terminal]
+----
+$ kn event send --to Service:serving.knative.dev/v1:event-display
+----
++
+Sending an event to other addressable objects, such as brokers or channels, is not affected by this issue and works as expected.
+
+* The Kafka broker currently does not work on a cluster with Federal Information Processing Standards (FIPS) mode enabled.
+
+* If you create a Springboot function project directory with the `kn func create` command, subsequent running of the `kn func build` command fails with this error message:
++
+[source,terminal]
+----
+[analyzer] no stack metadata found at path ''
+[analyzer] ERROR: failed to : set API for buildpack 'paketo-buildpacks/ca-certificates@3.0.2': buildpack API version '0.7' is incompatible with the lifecycle
+----
++
+As a workaround, you can change the `builder` property to `gcr.io/paketo-buildpacks/builder:base` in the function configuration file `func.yaml`.
+
+* Deploying a function using the `gcr.io` registry fails with this error message:
++
+[source,terminal]
+----
+Error: failed to get credentials: failed to verify credentials: status code: 404
+----
++
+As a workaround, use a different registry than `gcr.io`, such as `quay.io` or `docker.io`.
+
+* TypeScript functions created with the `http` template fail to deploy on the cluster.
++
+As a workaround, in the `func.yaml` file, replace the following section:
++
+[source,terminal]
+----
+buildEnvs: []
+----
++
+with this:
++
+[source,terminal]
+----
+buildEnvs:
+- name: BP_NODE_RUN_SCRIPTS
+  value: build
+----
+
+* In `func` version 0.20, some runtimes might be unable to build a function by using podman. You might see an error message similar to the following:
++
+[source,terminal]
+----
+ERROR: failed to image: error during connect: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.40/info": EOF
+----
++
+** The following workaround exists for this issue:
+
+.. Update the podman service by adding `--time=0` to the service `ExecStart` definition:
++
+.Example service configuration
+[source,terminal]
+----
+ExecStart=/usr/bin/podman $LOGGING system service --time=0
+----
+.. Restart the podman service by running the following commands:
++
+[source,terminal]
+----
+$ systemctl --user daemon-reload
+----
++
+[source,terminal]
+----
+$ systemctl restart --user podman.socket
+----
+
+** Alternatively, you can expose the podman API by using TCP:
++
+[source,terminal]
+----
+$ podman system service --time=0 tcp:127.0.0.1:5534 &
+export DOCKER_HOST=tcp://127.0.0.1:5534
+----

--- a/serverless/functions/serverless-functions-setup.adoc
+++ b/serverless/functions/serverless-functions-setup.adoc
@@ -19,7 +19,7 @@ To enable the use of {FunctionsProductName} on your cluster, you must complete t
 * {ServerlessProductName} is installed on your cluster.
 * The xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[`oc` CLI] is installed on your cluster.
 * The xref:../../serverless/cli_tools/installing-kn.adoc#installing-kn[Knative (`kn`) CLI] is installed on your cluster. Installing the `kn` CLI enables the use of `kn func` commands which you can use to create and manage functions.
-* You have installed Docker Container Engine or podman, and have access to an available image registry.
+* You have installed Docker Container Engine or podman version 3.3 or higher, and have access to an available image registry.
 * If you are using link:https://quay.io/[Quay.io] as the image registry, you must ensure that either the repository is not private, or that you have followed the {product-title} documentation on xref:../../openshift_images/managing_images/using-image-pull-secrets.adoc#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets[Allowing pods to reference images from other secured registries].
 * If you are using the OpenShift Container Registry, a cluster administrator must xref:../../registry/securing-exposing-registry.adoc#securing-exposing-registry[expose the registry].
 

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -16,8 +16,10 @@ For details about the latest Knative component releases, see the link:https://kn
 ====
 
 include::modules/serverless-api-versions.adoc[leveloffset=+1]
+include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/serverless-rn-1-20-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-19-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-18-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-17-0.adoc[leveloffset=+1]


### PR DESCRIPTION
For versions 4.6+

https://issues.redhat.com/browse/SRVCOM-1575

Preview: https://deploy-preview-40821--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes