### PR TITLE
BZ2036700: Updates supported ignition version

### DIFF
--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -37,7 +37,7 @@ Before you install a cluster that contains user-provisioned infrastructure on VM
       ]
     },
     "timeouts": {},
-    "version": "3.2.0"
+    "version": "3.1.0"
   },
   "networkd": {},
   "passwd": {},


### PR DESCRIPTION
The ignition version has been changed from 3.2.0 to 3.1.0.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2036700

OCP version: **Applicable only to 4.6**

Doc Preview Link: https://deploy-preview-40822--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-machines_installing-vsphere