### PR TITLE
BZ#1903408: lift ETP limitation from OVN-K

### DIFF
--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -7,9 +7,8 @@
 
 The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has the following limitations:
 
-* OVN-Kubernetes does not support setting the external traffic policy or internal traffic policy for a Kubernetes service to `local`.
-The default value, `cluster`, is supported for both parameters.
-This limitation can affect you when you add a service of type `LoadBalancer`, `NodePort`, or add a service with an external IP.
+* OVN-Kubernetes does not support setting the internal traffic policy for a Kubernetes service to `local`.
+This limitation can affect network communication to your application when you add a service of type `ClusterIP`, `LoadBalancer`, `NodePort`, or add a service with an external IP.
 
 // The foll limitation is also recorded in the installation section.
 * For clusters configured for dual-stack networking, both IPv4 and IPv6 traffic must use the same network interface as the default gateway.


### PR DESCRIPTION
Fixes the doc angle for https://bugzilla.redhat.com/show_bug.cgi?id=1903408.

----
Notice that the limitation for external traffic policy is no longer present in the [OVN-Kubernetes limitations](https://deploy-preview-40824--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html#nw-ovn-kubernetes-limitations_about-ovn-kubernetes).

For 4.9, the [limitation](https://docs.openshift.com/container-platform/4.9/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html#nw-ovn-kubernetes-limitations_about-ovn-kubernetes) (first bullet) is present.