### PR TITLE
BZ1951535: Adds note on disable of SSH access for openshift nodes

### DIFF
--- a/modules/manually-gathering-logs-with-ssh.adoc
+++ b/modules/manually-gathering-logs-with-ssh.adoc
@@ -8,6 +8,11 @@
 Manually gather logs in situations where `must-gather` or automated collection
 methods do not work.
 
+[IMPORTANT]
+====
+By default, SSH access to the {product-title} nodes is disabled on the {rh-openstack-first} based installations.
+====
+
 .Prerequisites
 
 * You must have SSH access to your host(s).


### PR DESCRIPTION
Added note on disable of SSH access for openshift nodes based on OpenStack based installations.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1951535

OCP version: 4.7+

Doc Preview Link: https://deploy-preview-40825--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-troubleshooting.html#installation-manually-gathering-logs-with-SSH_installing-troubleshooting