### PR TITLE
ROSA: update rosa docs for current roles/policies

### DIFF
--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -23,7 +23,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 
 |===
 
-.`sts_installer_trust_policy.json` for all versions
+.`sts_installer_trust_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -35,7 +35,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
-                    "arn:aws:iam::710019948333:role/RH-Managed-OpenShift-Installer"
+                    "arn:aws:iam::%{aws_account_id}:role/RH-Managed-OpenShift-Installer"
                 ]
             },
             "Action": [
@@ -47,200 +47,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 ----
 ====
 
-.`sts_installer_permission_policy.json` for 4.7
-[%collapsible]
-====
-[source,json]
-----
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:DescribeAutoScalingGroups",
-                "ec2:AllocateAddress",
-                "ec2:AssociateAddress",
-                "ec2:AssociateDhcpOptions",
-                "ec2:AssociateRouteTable",
-                "ec2:AttachInternetGateway",
-                "ec2:AttachNetworkInterface",
-                "ec2:AuthorizeSecurityGroupEgress",
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:CopyImage",
-                "ec2:CreateDhcpOptions",
-                "ec2:CreateInternetGateway",
-                "ec2:CreateNatGateway",
-                "ec2:CreateNetworkInterface",
-                "ec2:CreateRoute",
-                "ec2:CreateRouteTable",
-                "ec2:CreateSecurityGroup",
-                "ec2:CreateSubnet",
-                "ec2:CreateTags",
-                "ec2:CreateVolume",
-                "ec2:CreateVpc",
-                "ec2:CreateVpcEndpoint",
-                "ec2:DeleteDhcpOptions",
-                "ec2:DeleteInternetGateway",
-                "ec2:DeleteNatGateway",
-                "ec2:DeleteNetworkInterface",
-                "ec2:DeleteRoute",
-                "ec2:DeleteRouteTable",
-                "ec2:DeleteSecurityGroup",
-                "ec2:DeleteSnapshot",
-                "ec2:DeleteSubnet",
-                "ec2:DeleteTags",
-                "ec2:DeleteVolume",
-                "ec2:DeleteVpc",
-                "ec2:DeleteVpcEndpoints",
-                "ec2:DeregisterImage",
-                "ec2:DescribeAccountAttributes",
-                "ec2:DescribeAddresses",
-                "ec2:DescribeAvailabilityZones",
-                "ec2:DescribeDhcpOptions",
-                "ec2:DescribeImages",
-                "ec2:DescribeInstanceAttribute",
-                "ec2:DescribeInstanceCreditSpecifications",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceStatus",
-                "ec2:DescribeInstanceTypes",
-                "ec2:DescribeInternetGateways",
-                "ec2:DescribeKeyPairs",
-                "ec2:DescribeNatGateways",
-                "ec2:DescribeNetworkAcls",
-                "ec2:DescribeNetworkInterfaces",
-                "ec2:DescribePrefixLists",
-                "ec2:DescribeRegions",
-                "ec2:DescribeReservedInstancesOfferings",
-                "ec2:DescribeRouteTables",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeSubnets",
-                "ec2:DescribeTags",
-                "ec2:DescribeVolumes",
-                "ec2:DescribeVpcAttribute",
-                "ec2:DescribeVpcClassicLink",
-                "ec2:DescribeVpcClassicLinkDnsSupport",
-                "ec2:DescribeVpcEndpoints",
-                "ec2:DescribeVpcs",
-                "ec2:DetachInternetGateway",
-                "ec2:DisassociateRouteTable",
-                "ec2:GetEbsDefaultKmsKeyId",
-                "ec2:ModifyInstanceAttribute",
-                "ec2:ModifyNetworkInterfaceAttribute",
-                "ec2:ModifySubnetAttribute",
-                "ec2:ModifyVpcAttribute",
-                "ec2:ReleaseAddress",
-                "ec2:ReplaceRouteTableAssociation",
-                "ec2:RevokeSecurityGroupEgress",
-                "ec2:RevokeSecurityGroupIngress",
-                "ec2:RunInstances",
-                "ec2:StartInstances",
-                "ec2:StopInstances",
-                "ec2:TerminateInstances",
-                "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
-                "elasticloadbalancing:AttachLoadBalancerToSubnets",
-                "elasticloadbalancing:ConfigureHealthCheck",
-                "elasticloadbalancing:CreateListener",
-                "elasticloadbalancing:CreateLoadBalancer",
-                "elasticloadbalancing:CreateLoadBalancerListeners",
-                "elasticloadbalancing:CreateTargetGroup",
-                "elasticloadbalancing:DeleteLoadBalancer",
-                "elasticloadbalancing:DeleteTargetGroup",
-                "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-                "elasticloadbalancing:DeregisterTargets",
-                "elasticloadbalancing:DescribeInstanceHealth",
-                "elasticloadbalancing:DescribeListeners",
-                "elasticloadbalancing:DescribeLoadBalancerAttributes",
-                "elasticloadbalancing:DescribeLoadBalancers",
-                "elasticloadbalancing:DescribeTags",
-                "elasticloadbalancing:DescribeTargetGroupAttributes",
-                "elasticloadbalancing:DescribeTargetGroups",
-                "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:ModifyLoadBalancerAttributes",
-                "elasticloadbalancing:ModifyTargetGroup",
-                "elasticloadbalancing:ModifyTargetGroupAttributes",
-                "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-                "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
-                "iam:AddRoleToInstanceProfile",
-                "iam:CreateInstanceProfile",
-                "iam:DeleteInstanceProfile",
-                "iam:GetInstanceProfile",
-                "iam:GetRole",
-                "iam:GetRolePolicy",
-                "iam:GetUser",
-                "iam:ListAttachedRolePolicies",
-                "iam:ListInstanceProfiles",
-                "iam:ListInstanceProfilesForRole",
-                "iam:ListRolePolicies",
-                "iam:ListRoles",
-                "iam:ListUserPolicies",
-                "iam:ListUsers",
-                "iam:PassRole",
-                "iam:RemoveRoleFromInstanceProfile",
-                "iam:SimulatePrincipalPolicy",
-                "iam:TagRole",
-                "iam:UntagRole",
-                "route53:ChangeResourceRecordSets",
-                "route53:ChangeTagsForResource",
-                "route53:CreateHostedZone",
-                "route53:DeleteHostedZone",
-                "route53:GetChange",
-                "route53:GetHostedZone",
-                "route53:ListHostedZones",
-                "route53:ListHostedZonesByName",
-                "route53:ListResourceRecordSets",
-                "route53:ListTagsForResource",
-                "route53:UpdateHostedZoneComment",
-                "s3:CreateBucket",
-                "s3:DeleteBucket",
-                "s3:DeleteObject",
-                "s3:GetAccelerateConfiguration",
-                "s3:GetBucketAcl",
-                "s3:GetBucketCORS",
-                "s3:GetBucketLocation",
-                "s3:GetBucketLogging",
-                "s3:GetBucketObjectLockConfiguration",
-                "s3:GetBucketRequestPayment",
-                "s3:GetBucketTagging",
-                "s3:GetBucketVersioning",
-                "s3:GetBucketWebsite",
-                "s3:GetEncryptionConfiguration",
-                "s3:GetLifecycleConfiguration",
-                "s3:GetObject",
-                "s3:GetObjectAcl",
-                "s3:GetObjectTagging",
-                "s3:GetObjectVersion",
-                "s3:GetReplicationConfiguration",
-                "s3:ListBucket",
-                "s3:ListBucketVersions",
-                "s3:PutBucketAcl",
-                "s3:PutBucketTagging",
-                "s3:PutEncryptionConfiguration",
-                "s3:PutObject",
-                "s3:PutObjectAcl",
-                "s3:PutObjectTagging",
-                "sts:AssumeRole",
-                "sts:AssumeRoleWithWebIdentity",
-                "sts:GetCallerIdentity",
-                "tag:GetResources",
-                "tag:UntagResources",
-                "ec2:CreateVpcEndpointServiceConfiguration",
-                "ec2:DeleteVpcEndpointServiceConfigurations",
-                "ec2:DescribeVpcEndpointServiceConfigurations",
-                "ec2:DescribeVpcEndpointServicePermissions",
-                "ec2:DescribeVpcEndpointServices",
-                "ec2:ModifyVpcEndpointServicePermissions"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-----
-====
-
-.`sts_installer_permission_policy.json` for 4.8
+.`sts_installer_permission_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -447,7 +254,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 
 |===
 
-.`sts_instance_controlplane_trust_policy.json` for all versions
+.`sts_instance_controlplane_trust_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -471,64 +278,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 ----
 ====
 
-.`sts_instance_controlplane_permission_policy.json` for 4.7
-[%collapsible]
-====
-[source,json]
-----
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:AttachVolume",
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:CreateSecurityGroup",
-                "ec2:CreateTags",
-                "ec2:CreateVolume",
-                "ec2:DeleteSecurityGroup",
-                "ec2:DeleteVolume",
-                "ec2:Describe*",
-                "ec2:DetachVolume",
-                "ec2:ModifyInstanceAttribute",
-                "ec2:ModifyVolume",
-                "ec2:RevokeSecurityGroupIngress",
-                "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:AttachLoadBalancerToSubnets",
-                "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
-                "elasticloadbalancing:CreateListener",
-                "elasticloadbalancing:CreateLoadBalancer",
-                "elasticloadbalancing:CreateLoadBalancerPolicy",
-                "elasticloadbalancing:CreateLoadBalancerListeners",
-                "elasticloadbalancing:CreateTargetGroup",
-                "elasticloadbalancing:ConfigureHealthCheck",
-                "elasticloadbalancing:DeleteListener",
-                "elasticloadbalancing:DeleteLoadBalancer",
-                "elasticloadbalancing:DeleteLoadBalancerListeners",
-                "elasticloadbalancing:DeleteTargetGroup",
-                "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-                "elasticloadbalancing:DeregisterTargets",
-                "elasticloadbalancing:Describe*",
-                "elasticloadbalancing:DetachLoadBalancerFromSubnets",
-                "elasticloadbalancing:ModifyListener",
-                "elasticloadbalancing:ModifyLoadBalancerAttributes",
-                "elasticloadbalancing:ModifyTargetGroup",
-                "elasticloadbalancing:ModifyTargetGroupAttributes",
-                "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-                "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
-                "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
-                "kms:DescribeKey"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-----
-====
-
-.`sts_instance_controlplane_permission_policy.json` for 4.8
+.`sts_instance_controlplane_permission_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -599,7 +349,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 
 |===
 
-.`sts_instance_worker_trust_policy.json` for all versions
+.`sts_instance_worker_trust_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -623,7 +373,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 ----
 ====
 
-.`sts_instance_worker_permission_policy.json` for 4.7
+.`sts_instance_worker_permission_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -634,29 +384,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
         {
             "Effect": "Allow",
             "Action": [
-                "ec2:DescribeInstances",
-                "ec2:DescribeRegions"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-----
-====
-
-.`sts_instance_worker_permission_policy.json` for 4.8
-[%collapsible]
-====
-[source,json]
-----
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:DescribeInstances",
-                "ec2:DescribeRegions"
+                "ec2:DescribeInstances"
             ],
             "Resource": "*"
         }
@@ -679,7 +407,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 
 |===
 
-.`sts_support_trust_policy.json` for all versions
+.`sts_support_trust_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -691,7 +419,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
-                    "arn:aws:iam::710019948333:role/RH-Technical-Support-Access"
+                    "arn:aws:iam::%{aws_account_id}:role/RH-Technical-Support-Access"
                 ]
             },
             "Action": [
@@ -703,7 +431,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 ----
 ====
 
-.`sts_support_permission_policy.json` for 4.7
+.`sts_support_permission_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -814,163 +542,9 @@ The account-wide roles and policies are specific to an OpenShift minor release v
                 "ec2:SearchLocalGatewayRoutes",
                 "ec2:SearchTransitGatewayMulticastGroups",
                 "ec2:SearchTransitGatewayRoutes",
+                "ec2:RunInstances",
                 "ec2:StartInstances",
-                "ec2:TerminateInstances",
-                "elasticloadbalancing:ConfigureHealthCheck",
-                "elasticloadbalancing:DescribeAccountLimits",
-                "elasticloadbalancing:DescribeInstanceHealth",
-                "elasticloadbalancing:DescribeListenerCertificates",
-                "elasticloadbalancing:DescribeListeners",
-                "elasticloadbalancing:DescribeLoadBalancerAttributes",
-                "elasticloadbalancing:DescribeLoadBalancerAttributes",
-                "elasticloadbalancing:DescribeLoadBalancerPolicies",
-                "elasticloadbalancing:DescribeLoadBalancerPolicyTypes",
-                "elasticloadbalancing:DescribeLoadBalancers",
-                "elasticloadbalancing:DescribeLoadBalancers",
-                "elasticloadbalancing:DescribeRules",
-                "elasticloadbalancing:DescribeSSLPolicies",
-                "elasticloadbalancing:DescribeTags",
-                "elasticloadbalancing:DescribeTags",
-                "elasticloadbalancing:DescribeTargetGroupAttributes",
-                "elasticloadbalancing:DescribeTargetGroups",
-                "elasticloadbalancing:DescribeTargetHealth",
-                "route53:GetHostedZone",
-                "route53:GetHostedZoneCount",
-                "route53:ListHostedZones",
-                "route53:ListHostedZonesByName",
-                "route53:ListResourceRecordSets",
-                "s3:GetBucketTagging",
-                "s3:GetObjectAcl",
-                "s3:GetObjectTagging",
-                "s3:ListAllMyBuckets"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": "s3:ListBucket",
-            "Resource": [
-                "arn:aws:s3:::managed-velero*",
-                "arn:aws:s3:::*image-registry*"
-            ]
-        }
-    ]
-}
-----
-====
-
-.`sts_support_permission_policy.json` for 4.8
-[%collapsible]
-====
-[source,json]
-----
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "cloudtrail:DescribeTrails",
-                "cloudtrail:LookupEvents",
-                "cloudwatch:GetMetricData",
-                "cloudwatch:GetMetricStatistics",
-                "cloudwatch:ListMetrics",
-                "ec2:CopySnapshot",
-                "ec2:CreateSnapshot",
-                "ec2:CreateSnapshots",
-                "ec2:DescribeAccountAttributes",
-                "ec2:DescribeAddresses",
-                "ec2:DescribeAddressesAttribute",
-                "ec2:DescribeAggregateIdFormat",
-                "ec2:DescribeAvailabilityZones",
-                "ec2:DescribeByoipCidrs",
-                "ec2:DescribeCapacityReservations",
-                "ec2:DescribeCarrierGateways",
-                "ec2:DescribeClassicLinkInstances",
-                "ec2:DescribeClientVpnAuthorizationRules",
-                "ec2:DescribeClientVpnConnections",
-                "ec2:DescribeClientVpnEndpoints",
-                "ec2:DescribeClientVpnRoutes",
-                "ec2:DescribeClientVpnTargetNetworks",
-                "ec2:DescribeCoipPools",
-                "ec2:DescribeCustomerGateways",
-                "ec2:DescribeDhcpOptions",
-                "ec2:DescribeEgressOnlyInternetGateways",
-                "ec2:DescribeIamInstanceProfileAssociations",
-                "ec2:DescribeIdFormat",
-                "ec2:DescribeIdentityIdFormat",
-                "ec2:DescribeImageAttribute",
-                "ec2:DescribeImages",
-                "ec2:DescribeInstanceAttribute",
-                "ec2:DescribeInstanceStatus",
-                "ec2:DescribeInstanceTypeOfferings",
-                "ec2:DescribeInstanceTypes",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInternetGateways",
-                "ec2:DescribeIpv6Pools",
-                "ec2:DescribeKeyPairs",
-                "ec2:DescribeLaunchTemplates",
-                "ec2:DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations",
-                "ec2:DescribeLocalGatewayRouteTableVpcAssociations",
-                "ec2:DescribeLocalGatewayRouteTables",
-                "ec2:DescribeLocalGatewayVirtualInterfaceGroups",
-                "ec2:DescribeLocalGatewayVirtualInterfaces",
-                "ec2:DescribeLocalGateways",
-                "ec2:DescribeNatGateways",
-                "ec2:DescribeNetworkAcls",
-                "ec2:DescribeNetworkInterfaces",
-                "ec2:DescribePlacementGroups",
-                "ec2:DescribePrefixLists",
-                "ec2:DescribePrincipalIdFormat",
-                "ec2:DescribePublicIpv4Pools",
-                "ec2:DescribeRegions",
-                "ec2:DescribeReservedInstances",
-                "ec2:DescribeRouteTables",
-                "ec2:DescribeScheduledInstances",
-                "ec2:DescribeSecurityGroupReferences",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeSnapshotAttribute",
-                "ec2:DescribeSnapshots",
-                "ec2:DescribeSpotFleetInstances",
-                "ec2:DescribeStaleSecurityGroups",
-                "ec2:DescribeSubnets",
-                "ec2:DescribeTags",
-                "ec2:DescribeTransitGatewayAttachments",
-                "ec2:DescribeTransitGatewayConnectPeers",
-                "ec2:DescribeTransitGatewayConnects",
-                "ec2:DescribeTransitGatewayMulticastDomains",
-                "ec2:DescribeTransitGatewayPeeringAttachments",
-                "ec2:DescribeTransitGatewayRouteTables",
-                "ec2:DescribeTransitGatewayVpcAttachments",
-                "ec2:DescribeTransitGateways",
-                "ec2:DescribeVolumeAttribute",
-                "ec2:DescribeVolumeStatus",
-                "ec2:DescribeVolumes",
-                "ec2:DescribeVolumesModifications",
-                "ec2:DescribeVpcAttribute",
-                "ec2:DescribeVpcClassicLink",
-                "ec2:DescribeVpcClassicLinkDnsSupport",
-                "ec2:DescribeVpcEndpointConnectionNotifications",
-                "ec2:DescribeVpcEndpointConnections",
-                "ec2:DescribeVpcEndpointServiceConfigurations",
-                "ec2:DescribeVpcEndpointServicePermissions",
-                "ec2:DescribeVpcEndpointServices",
-                "ec2:DescribeVpcEndpoints",
-                "ec2:DescribeVpcPeeringConnections",
-                "ec2:DescribeVpcs",
-                "ec2:DescribeVpnConnections",
-                "ec2:DescribeVpnGateways",
-                "ec2:GetAssociatedIpv6PoolCidrs",
-                "ec2:GetTransitGatewayAttachmentPropagations",
-                "ec2:GetTransitGatewayMulticastDomainAssociations",
-                "ec2:GetTransitGatewayPrefixListReferences",
-                "ec2:GetTransitGatewayRouteTableAssociations",
-                "ec2:GetTransitGatewayRouteTablePropagations",
-                "ec2:RebootInstances",
-                "ec2:SearchLocalGatewayRoutes",
-                "ec2:SearchTransitGatewayMulticastGroups",
-                "ec2:SearchTransitGatewayRoutes",
-                "ec2:StartInstances",
+                "ec2:StopInstances",
                 "ec2:TerminateInstances",
                 "elasticloadbalancing:ConfigureHealthCheck",
                 "elasticloadbalancing:DescribeAccountLimits",
@@ -1026,30 +600,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 
 |===
 
-.`openshift_ingress_operator_cloud_credentials_policy.json` for 4.7
-[%collapsible]
-====
-[source,json]
-----
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "elasticloadbalancing:DescribeLoadBalancers",
-        "route53:ListHostedZones",
-        "route53:ChangeResourceRecordSets",
-        "tag:GetResources"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-----
-====
-
-.`openshift_ingress_operator_cloud_credentials_policy.json` for 4.8
+.`openshift_ingress_operator_cloud_credentials_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -1083,40 +634,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 
 |===
 
-.`openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json` for 4.7
-[%collapsible]
-====
-[source,json]
-----
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:AttachVolume",
-        "ec2:CreateSnapshot",
-        "ec2:CreateTags",
-        "ec2:CreateVolume",
-        "ec2:DeleteSnapshot",
-        "ec2:DeleteTags",
-        "ec2:DeleteVolume",
-        "ec2:DescribeInstances",
-        "ec2:DescribeSnapshots",
-        "ec2:DescribeTags",
-        "ec2:DescribeVolumes",
-        "ec2:DescribeVolumesModifications",
-        "ec2:DetachVolume",
-        "ec2:ModifyVolume"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-----
-====
-
-.`openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json` for 4.8
+.`openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -1160,7 +678,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 
 |===
 
-.`openshift_machine_api_aws_cloud_credentials_policy.json` for 4.7
+.`openshift_machine_api_aws_cloud_credentials_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -1176,6 +694,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
         "ec2:DescribeDhcpOptions",
         "ec2:DescribeImages",
         "ec2:DescribeInstances",
+        "ec2:DescribeInternetGateways",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeVpcs",
@@ -1183,66 +702,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
         "ec2:TerminateInstances",
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeTargetGroups",
-        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-        "elasticloadbalancing:RegisterTargets",
-        "iam:PassRole",
-        "iam:CreateServiceLinkedRole"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "kms:Decrypt",
-        "kms:Encrypt",
-        "kms:GenerateDataKey",
-        "kms:GenerateDataKeyWithoutPlainText",
-        "kms:DescribeKey"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "kms:RevokeGrant",
-        "kms:CreateGrant",
-        "kms:ListGrants"
-      ],
-      "Resource": "*",
-      "Condition": {
-        "Bool": {
-          "kms:GrantIsForAWSResource": true
-        }
-      }
-    }
-  ]
-}
-----
-====
-
-.`openshift_machine_api_aws_cloud_credentials_policy.json` for 4.8
-[%collapsible]
-====
-[source,json]
-----
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateTags",
-        "ec2:DescribeAvailabilityZones",
-        "ec2:DescribeDhcpOptions",
-        "ec2:DescribeImages",
-        "ec2:DescribeInstances",
-        "ec2:DescribeSecurityGroups",
-        "ec2:DescribeSubnets",
-        "ec2:DescribeVpcs",
-        "ec2:RunInstances",
-        "ec2:TerminateInstances",
-        "elasticloadbalancing:DescribeLoadBalancers",
-        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetHealth",
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:DeregisterTargets",
@@ -1292,29 +752,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 
 |===
 
-.`openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy.json` for 4.7
-[%collapsible]
-====
-[source,json]
-----
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iam:GetUser",
-        "iam:GetUserPolicy",
-        "iam:ListAccessKeys"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-----
-====
-
-.`openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy.json` for 4.8
+.`openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -1347,7 +785,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
 
 |===
 
-.`openshift_image_registry_installer_cloud_credentials_policy.json` for 4.7
+.`openshift_image_registry_installer_cloud_credentials_policy.json`
 [%collapsible]
 ====
 [source,json]
@@ -1361,56 +799,14 @@ The account-wide roles and policies are specific to an OpenShift minor release v
         "s3:CreateBucket",
         "s3:DeleteBucket",
         "s3:PutBucketTagging",
-        "s3:GetBucketTagging",
         "s3:PutBucketPublicAccessBlock",
-        "s3:GetBucketPublicAccessBlock",
         "s3:PutEncryptionConfiguration",
-        "s3:GetEncryptionConfiguration",
         "s3:PutLifecycleConfiguration",
-        "s3:GetLifecycleConfiguration",
         "s3:GetBucketLocation",
         "s3:ListBucket",
         "s3:GetObject",
         "s3:PutObject",
         "s3:DeleteObject",
-        "s3:ListBucketMultipartUploads",
-        "s3:AbortMultipartUpload",
-        "s3:ListMultipartUploadParts"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-----
-====
-
-.`openshift_image_registry_installer_cloud_credentials_policy.json` for 4.8
-[%collapsible]
-====
-[source,json]
-----
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:CreateBucket",
-        "s3:DeleteBucket",
-        "s3:PutBucketTagging",
-        "s3:GetBucketTagging",
-        "s3:PutBucketPublicAccessBlock",
-        "s3:GetBucketPublicAccessBlock",
-        "s3:PutEncryptionConfiguration",
-        "s3:GetEncryptionConfiguration",
-        "s3:PutLifecycleConfiguration",
-        "s3:GetLifecycleConfiguration",
-        "s3:GetBucketLocation",
-        "s3:ListBucket",
-        "s3:GetObject",
-        "s3:PutObject",
-        "s3:DeleteObject",
-        "s3:ListBucketMultipartUploads",
         "s3:AbortMultipartUpload",
         "s3:ListMultipartUploadParts"
       ],


### PR DESCRIPTION
This applies to `main`, `enterprise-4.9` and `enterprise-4.10`.

This relates to https://issues.redhat.com/browse/OSDOCS-3016. This (static) update lists 4.9 roles, policies and removes 4.7 and 4.8 reference. This PR is an interim step toward automating inclusion of json files from github.

[Preview](https://deploy-preview-40829--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-about-iam-resources)