### PR TITLE
adds notes for 4.8.28 release

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2993,3 +2993,19 @@ link:https://access.redhat.com/solutions/6643691[{product-title} 4.8.27 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-8-28"]
+=== RHBA-2022:0172 - {product-title} 4.8.28 bug fix update
+
+Issued: 2022-01-25
+
+{product-title} release 4.8.28 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0172[RHBA-2022:0172] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0171[RHBA-2022:0171] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6656881[{product-title} 4.8.28 container image list]
+
+[id="ocp-4-8-28-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Rel Notes for Tuesday 1/25 4.8.28 release

- Applies to `enterprise-4.8` only
- [Preview link](https://deploy-preview-40847--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-28)