### PR TITLE
BZ2011298: Missing information wrt cloud formation template in AWS installation of Openshift

### DIFF
--- a/modules/installation-aws-user-infra-requirements.adoc
+++ b/modules/installation-aws-user-infra-requirements.adoc
@@ -290,6 +290,66 @@ a `AWS::EC2::SecurityGroupIngress` resource.
 |`tcp`
 |`30000` - `32767`
 
+|`MasterIngressGeneve`
+|Geneve packets
+|`udp`
+|`6081`
+
+|`MasterIngressWorkerGeneve`
+|Geneve packets
+|`udp`
+|`6081`
+
+|`MasterIngressIpsecIke`
+|IPsec IKE packets
+|`udp`
+|`500`
+
+|`MasterIngressWorkerIpsecIke`
+|IPsec IKE packets
+|`udp`
+|`500`
+
+|`MasterIngressIpsecNat`
+|IPsec NAT-T packets
+|`udp`
+|`4500`
+
+|`MasterIngressWorkerIpsecNat`
+|IPsec NAT-T packets
+|`udp`
+|`4500`
+
+|`MasterIngressIpsecEsp`
+|IPsec ESP packets
+|`50`
+|`All`
+
+|`MasterIngressWorkerIpsecEsp`
+|IPsec ESP packets
+|`50`
+|`All`
+
+|`MasterIngressInternalUDP`
+|Internal cluster communication
+|`udp`
+|`9000` - `9999`
+
+|`MasterIngressWorkerInternalUDP`
+|Internal cluster communication
+|`udp`
+|`9000` - `9999`
+
+|`MasterIngressIngressServicesUDP`
+|Kubernetes Ingress services
+|`udp`
+|`30000` - `32767`
+
+|`MasterIngressWorkerIngressServicesUDP`
+|Kubernetes Ingress services
+|`udp`
+|`30000` - `32767`
+
 |===
 
 
@@ -345,6 +405,66 @@ a `AWS::EC2::SecurityGroupIngress` resource.
 |`WorkerIngressWorkerIngressServices`
 |Kubernetes Ingress services
 |`tcp`
+|`30000` - `32767`
+
+|`WorkerIngressGeneve`
+|Geneve packets
+|`udp`
+|`6081`
+
+|`WorkerIngressMasterGeneve`
+|Geneve packets
+|`udp`
+|`6081`
+
+|`WorkerIngressIpsecIke`
+|IPsec IKE packets
+|`udp`
+|`500`
+
+|`WorkerIngressMasterIpsecIke`
+|IPsec IKE packets
+|`udp`
+|`500`
+
+|`WorkerIngressIpsecNat`
+|IPsec NAT-T packets
+|`udp`
+|`4500`
+
+|`WorkerIngressMasterIpsecNat`
+|IPsec NAT-T packets
+|`udp`
+|`4500`
+
+|`WorkerIngressIpsecEsp`
+|IPsec ESP packets
+|`50`
+|`All`
+
+|`WorkerIngressMasterIpsecEsp`
+|IPsec ESP packets
+|`50`
+|`All`
+
+|`WorkerIngressInternalUDP`
+|Internal cluster communication
+|`udp`
+|`9000` - `9999`
+
+|`WorkerIngressMasterInternalUDP`
+|Internal cluster communication
+|`udp`
+|`9000` - `9999`
+
+|`WorkerIngressIngressServicesUDP`
+|Kubernetes Ingress services
+|`udp`
+|`30000` - `32767`
+
+|`WorkerIngressMasterIngressServicesUDP`
+|Kubernetes Ingress services
+|`udp`
 |`30000` - `32767`
 
 |===


### PR DESCRIPTION
Fixes: [BZ2011298](https://bugzilla.redhat.com/show_bug.cgi?id=2011298)
OCP version: 4.6+
QE contact: @yunjiang29 
[preview](https://deploy-preview-40854--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws.html#installation-aws-user-infra-other-infrastructure_installing-restricted-networks-aws)