### PR TITLE
[WIP] move elements in DOM to fix copy/select issues

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -534,7 +534,7 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
     flex-flow: column;
     top: 165px;
     bottom: 1px;
-    margin-left: 780px;
+    margin-left: 1350px;
     height: auto;
     max-height: 800px;
     overflow-y: auto;

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -19,7 +19,7 @@
   <link href="https://assets.openshift.net/content/subdomain/touch-icon-precomposed.png" rel="apple-touch-icon-precomposed" type="image/png">
   <link href="https://assets.openshift.net/content/subdomain/favicon32x32.png" rel="shortcut icon" type="text/css">
   <link href="https://assets.openshift.net/content/osh-nav-footer.css" rel="stylesheet" type="text/css" media="screen, print" />
-  <link href="https://docs.openshift.com/container-platform/4.1/_stylesheets/docs.css" rel="stylesheet" />
+  <link href="http://file.emea.redhat.com/aireilly/move-toc-dom/_stylesheets/docs.css" rel="stylesheet" />
   <!--[if IE]><link rel="shortcut icon" href="https://assets.openshift.net/content/subdomain/favicon.ico"><![endif]-->
   <!-- or, set /favicon.ico for IE10 win -->
   <meta content="OpenShift" name="application-name">
@@ -538,6 +538,18 @@
           document.querySelector('#support-alert').style.removeProperty('zIndex');
         }
       }
+    })
+  </script>
+
+  <!-- move toc above page header div when DOM is inserted -->
+  <script type="text/javascript">
+    window.addEventListener('DOMContentLoaded', () => {
+      var toc = document.querySelector('#toc');
+      var main = document.querySelector("#main");
+      //clone the elements to be moved
+      var toc_clone = toc.cloneNode(true);
+      main.parentNode.insertBefore(toc_clone, main);
+      toc.remove();
     })
   </script>
 


### PR DESCRIPTION
In the current docs.openshift build, you can't select text in the right hand TOC. This can be frustrating to users. This PR addresses this by moving elements in DOM after page load.

Preview: http://file.emea.redhat.com/aireilly/move-toc-dom/updating/installing-update-service.html