### PR TITLE
SRVCOM-1619: Add a note that Serverless does not support multi-tenancy

### DIFF
--- a/serverless/install/install-serverless-operator.adoc
+++ b/serverless/install/install-serverless-operator.adoc
@@ -13,6 +13,11 @@ This guide walks cluster administrators through installing the {ServerlessOperat
 {ServerlessProductName} is supported for installation in a restricted network environment. For more information, see xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
 ====
 
+[NOTE]
+====
+{ServerlessProductName} currently cannot be used in a multi-tenant configuration on a single cluster.
+====
+
 include::modules/serverless-cluster-sizing-req.adoc[leveloffset=+1]
 
 If you have high availability (HA) enabled on your cluster, this requires between 0.5 - 1.5 cores and between 200MB - 2GB of memory for each replica of the Knative Serving control plane.


### PR DESCRIPTION
For versions 4.6+

https://issues.redhat.com/browse/SRVCOM-1619

Preview: https://deploy-preview-40881--osdocs.netlify.app/openshift-enterprise/latest/serverless/install/install-serverless-operator.html