### PR TITLE
CNV-13661: Added example for inheriting static IP from NIC

### DIFF
--- a/modules/virt-example-inherit-static-ip-from-nic.adoc
+++ b/modules/virt-example-inherit-static-ip-from-nic.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * virt/node_network/virt-updating-node-network-config.adoc
+
+:_content-type: REFERENCE
+[id="virt-example-inherit-static-ip-from-nic_{context}"]
+= Example: Linux bridge interface node network configuration policy to inherit static IP address from the NIC attached to the bridge
+
+Create a Linux bridge interface on nodes in the cluster and transfer the static IP configuration of the NIC to the bridge by applying a single `NodeNetworkConfigurationPolicy` manifest to the cluster.
+
+The following YAML file is an example of a manifest for a Linux bridge interface. It includes sample values that you must replace with your own information.
+
+
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: br1-eth1-copy-ipv4-policy <1>
+spec:
+  nodeSelector: <2>
+    node-role.kubernetes.io/worker: ""
+  capture:
+    eth1-nic: interfaces.name=="eth1" <3>
+    eth1-routes: routes.running.next-hop-interface=="eth1"
+    br1-routes: capture.eth1-routes | routes.running.next-hop-interface := "br1"
+  desiredState:
+    interfaces:
+      - name: br1
+        description: Linux bridge with eth1 as a port
+        type: linux-bridge <4>
+        state: up
+        ipv4: "{{ capture.eth1-nic.interfaces.0.ipv4 }}" <5>
+        bridge:
+          options:
+            stp:
+              enabled: false
+          port:
+            - name: eth1 <6>
+     routes:
+        config: "{{ capture.br1-routes.routes.running }}"
+----
+<1> The name of the policy.
+<2> Optional: If you do not include the `nodeSelector` parameter, the policy applies to all nodes in the cluster. This example uses the `node-role.kubernetes.io/worker: ""` node selector to select all worker nodes in the cluster.
+<3> The reference to the node NIC to which the bridge attaches.
+<4> The type of interface. This example creates a bridge.
+<5> The IP address of the bridge interface. This value matches the IP address of the NIC which is referenced by the `spec.capture.eth1-nic` entry.
+<6> The node NIC to which the bridge attaches.

--- a/virt/node_network/virt-updating-node-network-config.adoc
+++ b/virt/node_network/virt-updating-node-network-config.adoc
@@ -2,7 +2,7 @@
 [id="virt-updating-node-network-config"]
 = Updating node network configuration
 include::modules/virt-document-attributes.adoc[]
-:context: virt-updating-node-network-config 
+:context: virt-updating-node-network-config
 
 toc::[]
 
@@ -36,6 +36,18 @@ include::modules/virt-example-ethernet-nncp.adoc[leveloffset=+2]
 
 include::modules/virt-example-nmstate-multiple-interfaces.adoc[leveloffset=+2]
 
+[id="capturing-nic-static-ip_virt-updating-node-network-config"]
+== Capturing the static IP of a NIC attached to a bridge
+
+ifdef::openshift-enterprise[]
+:FeatureName: Capturing the static IP of a NIC
+include::snippets/technology-preview.adoc[leveloffset=+2]
+endif::[]
+
+include::modules/virt-example-inherit-static-ip-from-nic.adoc[leveloffset=+2]
+
+.Additional resources
+* link:https://nmstate.io/nmpolicy/user-guide/102-policy-syntax.html[The NMPolicy project - Policy syntax]
+
 // Dropping offset by one again
 include::modules/virt-example-nmstate-IP-management.adoc[leveloffset=+1]
-


### PR DESCRIPTION
[CNV-13661](https://issues.redhat.com/browse/CNV-13661)

New module with code example to showcase how to transfer static IP address from a NIC to the bridge that it is attached to.

Preview: https://deploy-preview-40886--osdocs.netlify.app/openshift-enterprise/latest/virt/node_network/virt-updating-node-network-config.html#capturing-nic-static-ip_virt-updating-node-network-config