### PR TITLE
RHEVDOCS-3660 - Correcting supported versions table for RHOL

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -8,7 +8,14 @@ toc::[]
 [id="openshift-logging-supported-versions"]
 == Supported versions
 
-OpenShift Logging 5.0, 5.1, and 5.2 run on {product-title} 4.7 and 4.8.
+.{product-title} version support for Red Hat OpenShift Logging (RHOL)
+[options="header"]
+|====
+|        |4.7          |4.8          |4.9
+|RHOL 5.1|X            |X            |
+|RHOL 5.2|X            |X            |X
+|RHOL 5.3|             |X             |X
+|====
 
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 

--- a/logging/cluster-logging-upgrading.adoc
+++ b/logging/cluster-logging-upgrading.adoc
@@ -5,7 +5,14 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} 4.7 and 4.8 support OpenShift Logging 5.0, 5.1, and 5.2.
+.{product-title} version support for Red Hat OpenShift Logging (RHOL)
+[options="header"]
+|====
+|        |4.7          |4.8          |4.9
+|RHOL 5.1|X            |X            |
+|RHOL 5.2|X            |X            |X
+|RHOL 5.3|             |X             |X
+|====
 
 To upgrade from cluster logging in {product-title} version 4.6 and earlier to OpenShift Logging 5.x, you update the {product-title} cluster to version 4.7 or 4.8. Then, you update the following operators:
 


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.8
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3660 / subtask of https://issues.redhat.com/browse/RHDEVDOCS-3513
- Direct link to doc preview: https://deploy-preview-40897--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html 
- SME review: @alanconway 
- QE review: @anpingli
- Peer review: @jc-berger 
Please merge. 

