### PR TITLE
OSDOCS-3155 OSD/Rosa: Scaling/Autoscaling additions

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -148,6 +148,8 @@ Distros: openshift-dedicated
 Topics:
 - Name: About machine pools
   File: nodes-machinepools-about
+- Name: Managing worker nodes
+  File: rosa-managing-worker-nodes
 - Name: About autoscaling nodes on a cluster
   File: nodes-about-autoscaling-nodes
 ---

--- a/modules/cluster-autoscaler-about.adoc
+++ b/modules/cluster-autoscaler-about.adoc
@@ -2,6 +2,7 @@
 //
 // * machine_management/applying-autoscaling.adoc
 // * post_installation_configuration/cluster-tasks.adoc
+// * nodes/nodes-about-autoscaling-nodes.adoc
 
 :_content-type: CONCEPT
 [id="cluster-autoscaler-about_{context}"]
@@ -11,7 +12,14 @@ The cluster autoscaler adjusts the size of an {product-title} cluster to meet it
 
 The cluster autoscaler increases the size of the cluster when there are pods that fail to schedule on any of the current worker nodes due to insufficient resources or when another node is necessary to meet deployment needs. The cluster autoscaler does not increase the cluster resources beyond the limits that you specify.
 
-The cluster autoscaler computes the total memory, CPU, and GPU on all nodes the cluster, even though it does not manage the control plane nodes. These values are not single-machine oriented. They are an aggregation of all the resources in the entire cluster. For example, if you set the maximum memory resource limit, the cluster autoscaler includes all the nodes in the cluster when calculating the current memory usage. That calculation is then used to determine if the cluster autoscaler has the capacity to add more worker resources.
+The cluster autoscaler computes the total
+ifndef::openshift-dedicated,openshift-rosa[]
+memory, CPU, and GPU
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+memory and CPU
+endif::[]
+on all nodes the cluster, even though it does not manage the control plane nodes. These values are not single-machine oriented. They are an aggregation of all the resources in the entire cluster. For example, if you set the maximum memory resource limit, the cluster autoscaler includes all the nodes in the cluster when calculating the current memory usage. That calculation is then used to determine if the cluster autoscaler has the capacity to add more worker resources.
 
 [IMPORTANT]
 ====

--- a/modules/rosa-adding-instance-types.adoc
+++ b/modules/rosa-adding-instance-types.adoc
@@ -1,6 +1,3 @@
-
-
-
 // Module included in the following assemblies:
 //
 // * nodes/nodes/rosa-managing-worker-nodes.adoc
@@ -14,6 +11,7 @@ After a machine pool is created, the instance type cannot be changed. To add a d
 
 .Procedure
 
+ifdef::openshift-rosa[]
 . To add an instance type with a new machine pool, enter the following command:
 +
 [source,terminal]
@@ -48,3 +46,16 @@ default             No            2           m5.xlarge                         
 db-nodes-mp         No            2           m5.xlarge      app=db, tier=backend            us-east-1a
 db-nodes-large-mp   No            2           m5.2xlarge     app=db, tier=backend            us-east-1a
 ----
+endif::[]
+
+
+ifdef::openshift-dedicated[]
+
+. From the {cluster-manager-url}, navigate to the *Clusters* page and select the cluster that you want to configure.
+. On the selected cluster, select the *Machine pools* tab.
+. Click *Add a machine pool*.
+. Select a *Worker node instance type*.
+. Select the number nodes you want to add to the machine pool using the *Worker node count* field.
+. Optional. Under *Node labels*, add labels to the *Key* and *Value* fields.
+. Select *Add machine pool* to create a machine pool and save these changes.
+endif::[]

--- a/modules/rosa-adding-node-labels.adoc
+++ b/modules/rosa-adding-node-labels.adoc
@@ -18,7 +18,8 @@ Currently, adding node labels on an existing machine pool adds the labels to onl
 
 .Procedure
 
-. To create a new machine pool, add the node labels, and create replica worker nodes, enter the following command:
+ifdef::openshift-rosa[]
+* To create a new machine pool, add the node labels, and create replica worker nodes, enter the following command:
 +
 [source,terminal]
 ----
@@ -40,7 +41,7 @@ I: Machine pool 'db-nodes-mp' created successfully on cluster 'mycluster'
 
 .Verification
 
-. To verify that the machine pool, labels, and replicas were created, enter the following command:
+* To verify that the machine pool, labels, and replicas were created, enter the following command:
 +
 [source,terminal]
 ----
@@ -54,3 +55,18 @@ ID            AUTOSCALING   REPLICAS    INSTANCE TYPE  LABELS                 TA
 default       No            2           m5.xlarge                                      us-east-1a
 db-nodes-mp   No            2           m5.xlarge      app=db, tier=backend            us-east-1a
 ----
+
+endif::[]
+
+
+ifdef::openshift-dedicated[]
+
+. From the {cluster-manager-url}, navigate to the *Clusters* page and select the cluster that you want to configure.
+. On the selected cluster, select the *Machine pools* tab.
+. Click *Add a machine pool*.
+. Select a *Worker node instance type*.
+. Select the number nodes you want to add to the machine pool using the *Worker node count* field.
+. Expand the *Edit node labels and taints* menu.
+. Under *Node labels*, add labels to the *Key* and *Value* fields.
+. Select *Add machine pool* to create a machine pool and save these changes.
+endif::[]

--- a/modules/rosa-scaling-worker-nodes.adoc
+++ b/modules/rosa-scaling-worker-nodes.adoc
@@ -11,6 +11,8 @@ Worker nodes can be scaled manually if you do not want to configure node autosca
 
 .Procedure
 
+ifdef::openshift-rosa[]
+
 . To get a list of the machine pools in a cluster, enter the following command. Each cluster has a default machine pool that is created when you create a cluster.
 +
 [source,terminal]
@@ -48,3 +50,22 @@ The response output shows the number of worker nodes, or replicas, as `Compute` 
 . Optional: To view this change in {cluster-manager-url}:
 .. Select the cluster.
 .. From the *Overview* tab, in the `Details` pane, review the `Compute` node number.
+
+endif::[]
+
+
+ifdef::openshift-dedicated[]
+
+. From the {cluster-manager-url}, navigate to the *Clusters* page and select the cluster that you want to scale worker nodes manually for.
+. On the selected cluster, select the *Machine pools* tab.
+. Click the Options menu {kebab} at the end of the machine pool that you want to manually scale, and select *Scale*.
+. On the *Edit node count* dialog, edit the node count.
++
+[NOTE]
+====
+Your subscription determines the number of nodes you can select.
+====
++
+. Select *Apply* to save these changes.
+
+endif::[]

--- a/nodes/nodes-about-autoscaling-nodes.adoc
+++ b/nodes/nodes-about-autoscaling-nodes.adoc
@@ -70,6 +70,15 @@ ifdef::openshift-rosa[]
 include::modules/rosa-disabling-autoscaling-nodes.adoc[leveloffset=+2]
 endif::[]
 
+Applying autoscaling to an {product-title} cluster involves deploying a cluster autoscaler and then deploying machine autoscalers for each machine type in your cluster.
+
+[IMPORTANT]
+====
+You can configure the cluster autoscaler only in clusters where the Machine API is operational.
+====
+
+include::modules/cluster-autoscaler-about.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="nodes-about-autoscaling-nodes-additional-resources"]
 == Additional resources

--- a/nodes/rosa-managing-worker-nodes.adoc
+++ b/nodes/rosa-managing-worker-nodes.adoc
@@ -5,7 +5,14 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-managing-worker-nodes
 toc::[]
 
-This section describes how to manage worker nodes with {product-title} (ROSA).
+This section describes how to manage worker nodes with
+ifndef::openshift-rosa[]
+{product-title}.
+endif::[]
+ifdef::openshift-rosa[]
+{product-title} (ROSA).
+endif::[]
+
 
 The majority of changes for worker nodes are configured on machine pools. A _machine pool_ is a group of worker nodes in a cluster that have the same configuration, providing ease of management. You can edit the configuration of worker nodes for options such as scaling, instance type, labels, and taints.
 
@@ -19,4 +26,6 @@ include::modules/rosa-adding-instance-types.adoc[leveloffset=+1]
 * xref:../nodes/nodes-about-autoscaling-nodes.adoc#nodes-about-autoscaling-nodes[About autoscaling]
 * xref:../nodes/nodes-about-autoscaling-nodes.adoc#nodes-enabling-autoscaling-nodes[Enabling autoscaling]
 * xref:../nodes/nodes-about-autoscaling-nodes.adoc#nodes-disabling-autoscaling-nodes[Disabling autoscaling]
+ifdef::openshift-rosa[]
 * xref:../rosa_policy/rosa-service-definition.adoc#rosa-service-definition[ROSA Service Definition]
+endif::[]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3155

Preview builds: 
OSD: Managing worker nodes: https://deploy-preview-40901--osdocs.netlify.app/openshift-dedicated/latest/nodes/rosa-managing-worker-nodes.html
OSD About autoscaling nodes on a cluster: https://deploy-preview-40901--osdocs.netlify.app/openshift-dedicated/latest/nodes/nodes-about-autoscaling-nodes.html#cluster-autoscaler-about_nodes-about-autoscaling-nodes
ROSA About autoscaling nodes on a cluster: https://deploy-preview-40901--osdocs.netlify.app/openshift-rosa/latest/nodes/nodes-about-autoscaling-nodes.html#cluster-autoscaler-about_nodes-about-autoscaling-nodes