### PR TITLE
OSDOCS-2461: Fixed the TOC for OSD

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -54,6 +54,13 @@ Topics:
 - Name: Quickstart for OpenShift Dedicated
   File: osd-quickstart
 ---
+Name: Red Hat OpenShift Cluster Manager (OCM)
+Dir: ocm
+Distros: openshift-dedicated
+Topics:
+- Name: Red Hat OpenShift Cluster Manager (OCM)
+  File: ocm-overview
+---
 Name: Creating a cluster
 Dir: osd_cluster_create
 Distros: openshift-dedicated


### PR DESCRIPTION
Fixed the TOC for OSD that was missing the new OCM book.