### PR TITLE
BZ2029858: Removed es_util tool from prerequisites

### DIFF
--- a/modules/cluster-logging-manual-rollout-rolling.adoc
+++ b/modules/cluster-logging-manual-rollout-rolling.adoc
@@ -13,8 +13,6 @@ Also, a rolling restart is recommended if the nodes on which an Elasticsearch po
 
 * OpenShift Logging and Elasticsearch must be installed.
 
-* Install the {product-title} link:https://github.com/openshift/origin-aggregated-logging/tree/master/elasticsearch#es_util[*es_util*] tool
-
 .Procedure
 
 To perform a rolling cluster restart:


### PR DESCRIPTION
Removed `es_util tool` from the prerequisites list because `es_util tool` is installed inside Elasticsearch pods.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2029858

OCP version: 4.6+

Direct Doc Preview Link: https://deploy-preview-40907--osdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-log-store.html#cluster-logging-manual-rollout-rolling_cluster-logging-store