### PR TITLE
BZ1999000: Adds build configs and secrets objects maximum values

### DIFF
--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -56,6 +56,14 @@ Tested Cloud Platforms for {product-title} 4.x: Amazon Web Services, Microsoft A
 | 2,000
 | 2,000
 
+| Number of build configs
+| 12,000
+| 12,000
+
+| Number of secrets
+| 40,000
+| 40,000
+
 |===
 [.small]
 --
@@ -68,5 +76,5 @@ Tested Cloud Platforms for {product-title} 4.x: Amazon Web Services, Microsoft A
 --
 [NOTE]
 ====
-Red Hat does not provide direct guidance on sizing your {product-title} cluster. This is because determining whether your cluster is within the supported bounds of {product-title} requires careful consideration of all the multidimensional factors that limit the cluster scale. 
+Red Hat does not provide direct guidance on sizing your {product-title} cluster. This is because determining whether your cluster is within the supported bounds of {product-title} requires careful consideration of all the multidimensional factors that limit the cluster scale.
 ====


### PR DESCRIPTION
Adds 4K cluster-density * 10 = 40,000 secrets per iteration and 4K cluster-density * 3 = 12,000 build Configs. 
Reference doc: https://github.com/cloud-bulldozer/e2e-benchmarking/tree/master/workloads/kube-burner#cluster-density-variables

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1999000

OCP version: 4.6+

Direct Doc Preview Link: https://deploy-preview-40908--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html#cluster-maximums-major-releases_object-limits