### PR TITLE
BuildConfig uses the Jenkins Kubernetes Plug-in

### DIFF
--- a/modules/images-other-jenkins-kubernetes-plugin.adoc
+++ b/modules/images-other-jenkins-kubernetes-plugin.adoc
@@ -56,7 +56,7 @@ items:
 
 It is also possible to override the specification of the dynamically created Jenkins agent pod. The following is a modification to the preceding example, which overrides the container memory and specifies an environment variable.
 
-.Sample `BuildConfig` that the Jenkins Kubernetes Plug-in, specifying memory limit and environment variable
+.Sample `BuildConfig` that uses the Jenkins Kubernetes Plug-in, specifying memory limit and environment variable
 [source,yaml]
 ----
 kind: BuildConfig


### PR DESCRIPTION
Like in the previous header (above at line 10) The BuildConfig uses the Jenkins Kubernetes Plug-in.
This PR adds the missing uses.

Additionally, maybe you want to cherry pick it into the other branches.
