### PR TITLE
Added a step to extract iso com openshift-install command

### DIFF
--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -87,8 +87,19 @@ ISO file names resemble the following example:
 `rhcos-<version>-live.<architecture>.iso`
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-. Obtain the {op-system} images from the
-link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system} Downloads] page
+. Obtain the {op-system} images from the output of `openshift-install` command:
++
+[source,terminal]
+----
+openshift-install coreos print-stream-json | grep '\.iso[^.]'
+----
++
+.Example output
+[source,terminal]
+----
+"location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live.x86_64.iso",
+----
++
 endif::openshift-origin[]
 
 . Use the ISO to start the {op-system} installation. Use one of the following installation options:


### PR DESCRIPTION
Added a missing step telling to use the FCOS image from `openshift-install coreos print-stream-json`.

Without this, users will be lead to download the latest stable version from https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable.