### PR TITLE
BZ1933928: Updates verification command of dynamically provisioned storage class

### DIFF
--- a/modules/persistent-storage-local-discovery.adoc
+++ b/modules/persistent-storage-local-discovery.adoc
@@ -135,7 +135,7 @@ $ oc apply -f local-volume-set.yaml
 +
 [source,terminal]
 ----
-$ oc -n get pv
+$ oc get pv
 ----
 +
 .Example output


### PR DESCRIPTION
Updated verification command from `oc -n get pv` to `oc get pv`.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1933928

OCP version: 4.6+

Direct Doc Preview Link: https://deploy-preview-40922--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local.html#local-storage-discovery_persistent-storage-local

@duanwei33 Please review and let me know your feedback.