### PR TITLE
BZ2044242: Fix path in RHCOS images cache section

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -49,7 +49,7 @@ $ sudo semanage fcontext -a -t httpd_sys_content_t "/home/kni/rhcos_image_cache(
 +
 [source,terminal]
 ----
-$ sudo restorecon -Rv rhcos_image_cache/
+$ sudo restorecon -Rv /home/kni/rhcos_image_cache/
 ----
 
 


### PR DESCRIPTION
Fixing the path when setting the appropriate SELinux context in RHCOS images cache section.

Signed-off-by: Leo Ochoa <lochoa@redhat.com>