### PR TITLE
Adds 4.9.17 release notes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2421,3 +2421,27 @@ link:https://access.redhat.com/solutions/6644371[{product-title} 4.9.15 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-9-17"]
+=== RHBA-2022:0195 - {product-title} 4.9.17 bug fix update
+
+Issued: 2022-01-24
+
+{product-title} release 4.9.17 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0195[RHBA-2022:0195] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0194[RHBA-2022:0194] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6662631[{product-title} 4.9.17 container image list]
+
+[id="ocp-4-9-17-bug-fixes"]
+==== Bug fixes
+
+* Previously, csi-driver pod's `livenessProbe` had a low timeout. Consequently, the probe would fail on slower clouds causing the cluster to be degraded. With this update, timeout of `livenessProbe` is set to accommodate slower environments. As a result, the cluster is no longer degraded on clouds with slow cinder. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2037080[*BZ#2037080*])
+
+* Previously, {product-title} Jenkins Sync Plug-in did not synchronize config maps and image streams that have the label `role` set to `jenkins-agent`, intended to map into Jenkins Kubernetes plugin pod templates. Consequently, {product-title} Jenkins Sync Plug-in no longer imported pod templates from the config maps or image streams with the `jenkins-agent` label. With this update, the accepted label specification is corrected. As a result, {product-title} Jenkins Sync Plug-in imports pod templates from config maps or image streams with the `jenkins-agent` label. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2038961[*BZ#2038961*])
+
+
+[id="ocp-4-9-17-updating"]
+==== Updating
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

To be merged when the erratas are shipped live. I will send a reminder.

OCP version: **Applicable only to 4.9 only**

Direct Doc Preview Link: https://deploy-preview-40924--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-17