### PR TITLE
BZ2036296: Removed storage class annotations for Azure and GCP

### DIFF
--- a/modules/dynamic-provisioning-annotations.adoc
+++ b/modules/dynamic-provisioning-annotations.adoc
@@ -28,7 +28,7 @@ metadata:
 
 This enables any persistent volume claim (PVC) that does not specify a
 specific storage class to automatically be provisioned through the
-default storage class.
+default storage class. However, your cluster can have more than one storage class, but only one of them can be the default storage class.
 
 [NOTE]
 ====

--- a/modules/dynamic-provisioning-azure-disk-definition.adoc
+++ b/modules/dynamic-provisioning-azure-disk-definition.adoc
@@ -13,8 +13,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: managed-premium
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/azure-disk
 volumeBindingMode: WaitForFirstConsumer <1>
 allowVolumeExpansion: true

--- a/modules/dynamic-provisioning-gce-definition.adoc
+++ b/modules/dynamic-provisioning-gce-definition.adoc
@@ -13,8 +13,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: standard
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-standard <1>


### PR DESCRIPTION
The following fixes are included in this PR:

- When cluster is installed, by default storageClass is installed. Removed `is-default-class` annotations in Azure and GCP object definition topics.

- Added cluster support for more than one StorageClass in Storage class annotations topic.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2036296

OCP version: 4.6+

Direct Doc Preview Link: 
https://deploy-preview-40925--osdocs.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html#azure-disk-definition_dynamic-provisioning

https://deploy-preview-40925--osdocs.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html#gce-persistentdisk-storage-class_dynamic-provisioning

https://deploy-preview-40925--osdocs.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html#storage-class-annotations_dynamic-provisioning

@duanwei33 PTAL at the PR and let me know your feedback.