### PR TITLE
[enterprise-4.10] CCXDEV-6341 Insights Operator 4.10 Release Notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -304,6 +304,31 @@ In {product-title} 4.7, _Cluster Logging_ became _Red Hat OpenShift Logging_. Fo
 [id="ocp-4-10-insights-operator"]
 === Insights Operator
 
+[id="ocp-4-10-insights-operator-sca"]
+==== Importing simple content access certificates 
+
+In {product-title} 4.10, Insights Operator now imports your simple content access certificates from {console-redhat-com} by default.
+
+For more information, see xref:../support/remote_health_monitoring/insights-operator-simple-access.adoc[Importing simple content access certificates with Insights Operator].
+
+[id="ocp-4-10-insights-operator-data-collection-enhancements"]
+==== Insights Operator data collection enhancements
+
+To reduce the amount of data sent to Red Hat, Insights Operator only gathers information when certain conditions are met. For example, Insights Operator only gathers the Alertmanager logs when Alertmanager fails to send alert notifications.
+
+
+In {product-title} 4.10, the Insights Operator collects the following additional information:
+
+* (Conditional) The logs from pods where the `KubePodCrashlooping` and `KubePodNotReady` alerts are firing
+* (Conditional) The Alertmanager logs when the `AlertmanagerClusterFailedToSendAlerts` or `AlertmanagerFailedToSendAlerts` alerts are firing
+* Silenced alerts from Alertmanager
+* The node logs from the journal unit (kubelet)
+* The `CostManagementMetricsConfig` from clusters with `costmanagement-metrics-operator` installed
+* The time series database status from the monitoring stack Prometheus instance
+* Additional information about the {product-title} scheduler 
+
+With this additional information, Red Hat improves {product-title} functionality and enhances Insights Advisor recommendations.
+
 [id="ocp-4-10-auth"]
 === Authentication and authorization
 


### PR DESCRIPTION
Update to the 4.10 Release Notes for Insights Operator
https://issues.redhat.com/browse/CCXDEV-6341

Versions: enterprise-4.10 

Preview:
https://deploy-preview-40931--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-insights-operator

SME: tremes, radekvokal 
QE: JoaoFula