### PR TITLE
BZ2042497: Fixed typos in Running the latency tests section

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
+++ b/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
@@ -346,10 +346,10 @@ For example, to change the `CNF_TESTS_IMAGE` with a custom registry run the foll
 $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh
 ----
 
-[id="cnf-performing-end-to-end-tests-ginko-parameters_{context}"]
+[id="cnf-performing-end-to-end-tests-ginkgo-parameters_{context}"]
 === Ginkgo parameters
 
-The test suite is built upon the ginkgo BDD framework. This means that it accepts parameters for filtering or skipping tests.
+The Ginkgo BDD (Behavior-Driven Development) framework serves as the base for the test suite. This means that it accepts parameters for filtering or skipping tests.
 
 You can use the `-ginkgo.focus` parameter to filter a set of tests:
 
@@ -360,7 +360,7 @@ $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registr
 
 You can run only the latency test using the `-ginkgo.focus` parameter.
 
-To run only the latency test, you must provide the `-ginkgo.focus` parameter and the `PERF_TEST_PROFILE` environment variable that contains the name of the performance profile that needs to be tested. For example:
+To run only the latency test, you must provide the `-ginkgo.focus` parameter and the `PERF_TEST_PROFILE` environment variable that has the name of the `PerformanceProfile` that needs to be tested. For example:
 
 [source,terminal]
 ----
@@ -522,21 +522,23 @@ CLEAN_PERFORMANCE_PROFILE="false" registry.redhat.io/openshift-kni/cnf-tests /us
 
 [id="cnf-performing-end-to-end-tests-running-the-tests_{context}"]
 == Running the latency tests
-Assuming the `kubeconfig` file is in the current folder, the command for running the test suite is:
 
-[source,terminal]
+If the `kubeconfig` file is in the current folder, you can run the test suite by using the following command:
+
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh
+$ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
+-e DISCOVERY_MODE=true registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 ----
 
-This allows your `kubeconfig` file to be consumed from inside the running container.
+This allows the running container to use the `kubeconfig` file from inside the container.
 
 [WARNING]
 ====
 You must run the latency tests in Discovery mode. The latency tests can change the configuration of your cluster if you do not run in Discovery mode.
 ====
 
-In {product-title} {product-version}, you can also run latency tests from the CNF-test container. The latency test allows the to validate that node tuning is sufficient for your workload.
+In {product-title} {product-version}, you can also run latency tests from the CNF-test container. The latency test allows you to validate node tuning for your workload.
 
 Three tools measure the latency of the system:
 
@@ -546,9 +548,9 @@ Three tools measure the latency of the system:
 
 Each tool has a specific use. Use the tools in sequence to achieve reliable test results.
 
-. The `hwlatdetect` tool measures the baseline that the bare hardware can achieve. Before proceeding with the next latency test, ensure that the number measured by `hwlatdetect` meets the required threshold because hardware latency spikes cannot be fixed by operating system tuning.
+. The `hwlatdetect` tool measures the baseline that the bare metal hardware can achieve. Before proceeding with the next latency test, ensure that the number measured by `hwlatdetect` meets the required threshold because you cannot fix hardware latency spikes by operating system tuning.
 
-.  The `cyclictest` tool verifies the timer latency after `hwlatdetect` passes validation. The `cyclictest` tool schedules a repeated timer and measures the difference between the desired and the actual trigger times. The difference can uncover basic issues with the tuning caused by interrupts or process priorities.
+.  The `cyclictest` tool verifies the real-time kernel scheduler latency after `hwlatdetect` passes validation. The `cyclictest` tool schedules a repeated timer and measures the difference between the desired and the actual trigger times. The difference can uncover basic issues with the tuning caused by interrupts or process priorities. The tool must run on a real-time kernel.
 
 . The `oslat` tool behaves similarly to a CPU-intensive DPDK application and measures all the interruptions and disruptions to the busy loop that simulates CPU heavy data processing.
 
@@ -556,57 +558,176 @@ By default, the latency tests are disabled. To enable the latency test, you must
 
 The test introduces the following environment variables:
 
-* `LATENCY_TEST_CPUS` variable specifies the number of CPUs that the pod running the latency tests uses.
-* `LATENCY_TEST_RUNTIME` variable specifies the amount of time in seconds that the latency test must run.
-* `CYCLICTEST_MAXIMUM_LATENCY` variable specifies the maximum latency in microseconds that all threads expect before waking up during the `cyclictest` run.
-* `HWLATDETECT_MAXIMUM_LATENCY` variable specifies the maximum acceptable hardware latency in microseconds for the workload and operating system.
-* `OSLAT_MAXIMUM_LATENCY` variable specifies the maximum acceptable latency in microseconds for the `oslat` test results.
-* `MAXIMUM_LATENCY` is a unified variable you can apply for all tests.
+`LATENCY_TEST_DELAY`:: The variable specifies the amount of time in seconds after which the test starts running. You can use the variable to allow the CPU manager reconcile loop to update the default CPU pool. The default value is 0.
+`LATENCY_TEST_CPUS`:: The variable specifies the number of CPUs that the pod running the latency tests uses. If you do not set the variable, the default configuration includes all isolated CPUs.
+`LATENCY_TEST_RUNTIME`:: The variable specifies the amount of time in seconds that the latency test must run. The default value is 300 seconds.
+`HWLATDETECT_MAXIMUM_LATENCY`:: The variable specifies the maximum acceptable hardware latency in microseconds for the workload and operating system. If you do not set the value of `HWLATDETECT_MAXIMUM_LATENCY` or `MAXIMUM_LATENCY`, the tool compares the default expected threshold (20μs) and the actual maximum latency in the tool itself. Then, the test fails or succeeds accordingly.
+`CYCLICTEST_MAXIMUM_LATENCY`:: The variable specifies the maximum latency in microseconds that all threads expect before waking up during the `cyclictest` run. If you do not set the value of `CYCLICTEST_MAXIMUM_LATENCY` or `MAXIMUM_LATENCY`, the tool skips the comparison of the expected and the actual maximum latency.
+`OSLAT_MAXIMUM_LATENCY`:: The variable specifies the maximum acceptable latency in microseconds for the `oslat` test results. If you do not set the value of `OSLAT_MAXIMUM_LATENCY` or `MAXIMUM_LATENCY`, the tool skips the comparison of the expected and the actual maximum latency.
+`MAXIMUM_LATENCY`:: This is a unified variable you can apply for all tests.
 
 [NOTE]
 ====
 A variable that is specific to certain tests has precedence over the unified variable.
 ====
 
-You can use the `ginkgo.focus` flag to run a specific test.
+You can use the `-ginkgo.v` flag to run the tests with verbosity.
+
+You can use the `-ginkgo.focus` flag to run a specific test.
 
 [id="cnf-performing-end-to-end-tests-running-hwlatdetect"]
 === Running hwlatdetect
 
-To perform the `hwlatdetect`, run the following command:
+.Prerequisites:
 
-[source, terminal]
+* You installed the real-time kernel
+* You run the tool on bare metal hardware
+* You logged into registry.redhat.io with your Customer Portal credentials
+
+.Procedure
+
+. Run the following command:
+
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=worker-cnf -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20  registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh -ginko.focus=”hwladetect”
+$ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e \
+LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=worker-cnf -e \
+LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20  registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
+/usr/bin/test-run.sh -ginkgo.focus="hwlatdetect"
 ----
 
-The above command runs the `hwlatdetect` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs), and the command line displays `SUCCESS!`.
+The command runs the `hwlatdetect` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs), and the command line displays `SUCCESS!` when this test is completed.
+
+[NOTE]
+====
+For valid results, the test should run for at least 12 hours.
+====
 
 .Example failure output
-[source, terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $KUBECONFIG:/root/kubeconfig:Z -e KUBECONFIG=/root/kubeconfig -e PERF_TEST_PROFILE=performance -e ROLE_WORKER_CNF=worker-cnf -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=40 -e MAXIMUM_LATENCY=1 -e LATENCY_TEST_CPUS=10 -e DISCOVERY_MODE=true quay.io/titzhak/cnf-tests:latest usr/bin/test-run.sh -ginkgo.focus="hwlatdetect" <1>
-running /usr/bin//validationsuite -ginkgo.focus=hwlatdetect
-...
+$ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e \
+LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=worker-cnf -e \
+LATENCY_TEST_RUNTIME=10 -e MAXIMUM_LATENCY=1  registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 \
+/usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="hwlatdetect" <1>
+
+running /usr/bin/validationsuite -ginkgo.v -ginkgo.focus=hwlatdetect
+I0210 17:08:38.607699       7 request.go:668] Waited for 1.047200253s due to client-side throttling, not priority and fairness, request: GET:https://api.ocp.demo.lab:6443/apis/apps.openshift.io/v1?timeout=32s
+Running Suite: CNF Features e2e validation
+==========================================
+Random Seed: 1644512917
+Will run 0 of 48 specs
+
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+Ran 0 of 48 Specs in 0.001 seconds
+SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 48 Skipped
+
+PASS
 Discovery mode enabled, skipping setup
-running /usr/bin//cnftests -ginkgo.focus=hwlatdetect
-I0812 09:53:57.108148      19 request.go:668] Waited for 1.049207747s due to client-side throttling, not priority and fairness, request: GET:https://api.cnfdc8.t5g.lab.eng.bos.redhat.com:6443/apis/autoscaling/v1?timeout=32s
+running /usr/bin/cnftests -ginkgo.v -ginkgo.focus=hwlatdetect
+I0210 17:08:41.179269      40 request.go:668] Waited for 1.046001096s due to client-side throttling, not priority and fairness, request: GET:https://api.ocp.demo.lab:6443/apis/storage.k8s.io/v1beta1?timeout=32s
 Running Suite: CNF Features e2e integration tests
 =================================================
-Random Seed: 1628762033
-Will run 1 of 138 specs
+Random Seed: 1644512920
+Will run 1 of 151 specs
 
-SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+SSSSSSS
 ------------------------------
-• [SLOW TEST:26.144 seconds]
+[performance] Latency Test with the hwlatdetect image 
+  should succeed
+  /remote-source/app/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:221
+STEP: Waiting two minutes to download the latencyTest image
+STEP: Waiting another two minutes to give enough time for the cluster to move the pod to Succeeded phase
+Feb 10 17:10:56.045: [INFO]: found mcd machine-config-daemon-dzpw7 for node ocp-worker-0.demo.lab
+Feb 10 17:10:56.259: [INFO]: found mcd machine-config-daemon-dzpw7 for node ocp-worker-0.demo.lab
+Feb 10 17:11:56.825: [ERROR]: timed out waiting for the condition
+
+• Failure [193.903 seconds]
 [performance] Latency Test
-/go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:84
+/remote-source/app/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:60
   with the hwlatdetect image
-  /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:224
-    should succeed
-    /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:232
+  /remote-source/app/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:213
+    should succeed [It]
+    /remote-source/app/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:221
+
+    Log file created at: 2022/02/10 17:08:45
+    Running on machine: hwlatdetect-cd8b6
+    Binary: Built with gc go1.16.6 for linux/amd64
+    Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
+    I0210 17:08:45.716288       1 node.go:37] Environment information: /proc/cmdline: BOOT_IMAGE=(hd0,gpt3)/ostree/rhcos-56fabc639a679b757ebae30e5f01b2ebd38e9fde9ecae91c41be41d3e89b37f8/vmlinuz-4.18.0-305.34.2.rt7.107.el8_4.x86_64 random.trust_cpu=on console=tty0 console=ttyS0,115200n8 ignition.platform.id=qemu ostree=/ostree/boot.0/rhcos/56fabc639a679b757ebae30e5f01b2ebd38e9fde9ecae91c41be41d3e89b37f8/0 root=UUID=56731f4f-f558-46a3-85d3-d1b579683385 rw rootflags=prjquota skew_tick=1 nohz=on rcu_nocbs=3-5 tuned.non_isolcpus=ffffffc7 intel_pstate=disable nosoftlockup tsc=nowatchdog intel_iommu=on iommu=pt isolcpus=managed_irq,3-5 systemd.cpu_affinity=0,1,2,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31 + +
+    I0210 17:08:45.716782       1 node.go:44] Environment information: kernel version 4.18.0-305.34.2.rt7.107.el8_4.x86_64
+    I0210 17:08:45.716861       1 main.go:50] running the hwlatdetect command with arguments [/usr/bin/hwlatdetect --threshold 1 --hardlimit 1 --duration 10 --window 10000000us --width 950000us]
+    F0210 17:08:56.815204       1 main.go:53] failed to run hwlatdetect command; out: hwlatdetect:  test duration 10 seconds
+       detector: tracer
+       parameters:
+            Latency threshold: 1us <2>
+            Sample window:     10000000us
+            Sample width:      950000us
+         Non-sampling period:  9050000us
+            Output File:       None
+    
+    Starting test
+    test finished
+    Max Latency: 24us <3>
+    Samples recorded: 1
+    Samples exceeding threshold: 1
+    ts: 1644512927.163556381, inner:20, outer:24
+    ; err: exit status 1
+    goroutine 1 [running]:
+    k8s.io/klog.stacks(0xc000010001, 0xc00012e000, 0x25b, 0x2710)
+    	/remote-source/app/vendor/k8s.io/klog/klog.go:875 +0xb9
+    k8s.io/klog.(*loggingT).output(0x5bed00, 0xc000000003, 0xc0000121c0, 0x53ea81, 0x7, 0x35, 0x0)
+    	/remote-source/app/vendor/k8s.io/klog/klog.go:829 +0x1b0
+    k8s.io/klog.(*loggingT).printf(0x5bed00, 0x3, 0x5082da, 0x33, 0xc000113f58, 0x2, 0x2)
+    	/remote-source/app/vendor/k8s.io/klog/klog.go:707 +0x153
+    k8s.io/klog.Fatalf(...)
+    	/remote-source/app/vendor/k8s.io/klog/klog.go:1276
+    main.main()
+    	/remote-source/app/cnf-tests/pod-utils/hwlatdetect-runner/main.go:53 +0x897
+    
+    goroutine 6 [chan receive]:
+    k8s.io/klog.(*loggingT).flushDaemon(0x5bed00)
+    	/remote-source/app/vendor/k8s.io/klog/klog.go:1010 +0x8b
+    created by k8s.io/klog.init.0
+    	/remote-source/app/vendor/k8s.io/klog/klog.go:411 +0xd8
+    
+    goroutine 7 [chan receive]:
+    k8s.io/klog/v2.(*loggingT).flushDaemon(0x5bede0)
+    	/remote-source/app/vendor/k8s.io/klog/v2/klog.go:1169 +0x8b
+    created by k8s.io/klog/v2.init.0
+    	/remote-source/app/vendor/k8s.io/klog/v2/klog.go:420 +0xdf
+    Unexpected error:
+        <*errors.errorString | 0xc000418ed0>: {
+            s: "timed out waiting for the condition",
+        }
+        timed out waiting for the condition
+    occurred
+
+    /remote-source/app/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:433
 ------------------------------
-SSSSSSSSSSSSSSSSSSSSSS
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+JUnit report was created: /junit.xml/cnftests-junit.xml
+
+
+Summarizing 1 Failure:
+
+[Fail] [performance] Latency Test with the hwlatdetect image [It] should succeed 
+/remote-source/app/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:433
+
+Ran 1 of 151 Specs in 222.254 seconds
+FAIL! -- 0 Passed | 1 Failed | 0 Pending | 150 Skipped
+
+--- FAIL: TestTest (222.45s)
+FAIL
+----
+<1> The `podman` arguments you provided.
+<2> You can configure the latency threshold by using the `MAXIMUM_LATENCY` or the `HWLATDETECT_MAXIMUM_LATENCY` environment variables.
+<3> The maximum latency value measured during the test.
+
+[id="cnf-performing-end-to-end-tests-capturing-results-hwlatdetect"]
+==== Capturing the results
+
+You can capture the following types of results: 
 
 detector: tracer
    parameters:
@@ -636,37 +757,57 @@ k8s.io/klog.Fatalf(...)
 main.main()
 	/remote-source/app/cnf-tests/pod-utils/hwlatdetect-runner/main.go:51 +0x897
 ----
-<1> The docker arguments provided by the user.
-<2> The latency threshold configured by the user using the `MAX_LATENCY` or the `HWLATDETECT_MAX_LATENCY` environment variables.
+<1> The `podman` arguments provided by the user.
+<2> The latency threshold configured by the user using the `MAXIMUM_LATENCY` or the `HWLATDETECT_MAXIMUM_LATENCY` environment variables.
 <3> The maximum latency value measured during the test.
 
 [id="cnf-performing-end-to-end-tests-running-cyclictest"]
 === Running cyclictest
 
+.Prerequisites
+
+* You installed the real-time kernel
+* You installed the Performance Add-on Operator and you applied performance profile
+
+.Procedure
+
 To perform the `cyclictest`, run the following command:
 
-[source, terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=worker-cnf -e LATENCY_TEST_CPUS=10 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20  registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh -ginkgo.focus="cyclictest"
+$ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e \
+LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=worker-cnf -e \
+LATENCY_TEST_CPUS=10 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
+registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh -ginkgo.focus="cyclictest"
 ----
 
-The above command runs the `cyclictest` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs), and the command line displays `SUCCESS!`.
+The command runs the `cyclictest` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs), and the command line displays `SUCCESS!` when this test is completed.
+
+[NOTE]
+====
+For valid results, the test should run for at least 12 hours.
+====
 
 .Example failure output
-[source, terminal]
+[source,terminal,subs="attributes+"]
 ----
-$docker run -v $KUBECONFIG:/root/kubeconfig:Z -e KUBECONFIG=/root/kubeconfig -e PERF_TEST_PROFILE=performance -e ROLE_WORKER_CNF=worker-cnf -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 -e LATENCY_TEST_CPUS=10 -e DISCOVERY_MODE=true quay.io/titzhak/cnf-tests:latest usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="cyclictest" <1>
+$ podman run -v $KUBECONFIG:/root/kubeconfig:Z -e KUBECONFIG=/root/kubeconfig -e \
+PERF_TEST_PROFILE=performance -e ROLE_WORKER_CNF=worker-cnf -e LATENCY_TEST_RUN=true -e \
+LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 -e LATENCY_TEST_CPUS=10 -e DISCOVERY_MODE=true \
+registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} usr/bin/test-run.sh \
+-ginkgo.v -ginkgo.focus="cyclictest" <1>
+
 
 Discovery mode enabled, skipping setup
 running /usr/bin//cnftests -ginkgo.v -ginkgo.focus=cyclictest
 I0811 15:02:36.350033      20 request.go:668] Waited for 1.049965918s due to client-side throttling, not priority and fairness, request: GET:https://api.cnfdc8.t5g.lab.eng.bos.redhat.com:6443/apis/machineconfiguration.openshift.io/v1?timeout=32s
 Running Suite: CNF Features e2e integration tests
-=================================================
+
 Random Seed: 1628694153
 Will run 1 of 138 specs
 
 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-------------------------------
+
 [performance] Latency Test with the cyclictest image
   should succeed
   /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:200
@@ -695,7 +836,8 @@ Binary: Built with gc go1.16.6 for linux/amd64
 Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
 I0811 15:02:51.092254       1 node.go:37] Environment information: /proc/cmdline: BOOT_IMAGE=(hd0,gpt3)/ostree/rhcos-612d89f4519a53ad0b1a132f4add78372661bfb3994f5fe115654971aa58a543/vmlinuz-4.18.0-305.10.2.rt7.83.el8_4.x86_64 ip=dhcp random.trust_cpu=on console=tty0 console=ttyS0,115200n8 ostree=/ostree/boot.1/rhcos/612d89f4519a53ad0b1a132f4add78372661bfb3994f5fe115654971aa58a543/0 ignition.platform.id=openstack root=UUID=5a4ddf16-9372-44d9-ac4e-3ee329e16ab3 rw rootflags=prjquota skew_tick=1 nohz=on rcu_nocbs=1-3 tuned.non_isolcpus=000000ff,ffffffff,ffffffff,fffffff1 intel_pstate=disable nosoftlockup tsc=nowatchdog intel_iommu=on iommu=pt isolcpus=managed_irq,1-3 systemd.cpu_affinity=0,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103 default_hugepagesz=1G hugepagesz=2M hugepages=128 nmi_watchdog=0 audit=0 mce=off processor.max_cstate=1 idle=poll intel_idle.max_cstate=0
 I0811 15:02:51.092427       1 node.go:44] Environment information: kernel version 4.18.0-305.10.2.rt7.83.el8_4.x86_64
-I0811 15:02:51.092450       1 main.go:48] running the cyclictest command with arguments [-D 600 -p 1 -t 10 -a 2,4,6,8,10,54,56,58,60,62 -h 30 -i 1000 --quiet] <3>
+I0811 15:02:51.092450       1 main.go:48] running the cyclictest command with arguments \
+[-D 600 -95 1 -t 10 -a 2,4,6,8,10,54,56,58,60,62 -h 30 -i 1000 --quiet] <3>
 I0811 15:03:06.147253       1 main.go:54] succeeded to run the cyclictest command: # /dev/cpu_dma_latency set to 0us
 # Histogram
 000000 000000	000000	000000	000000	000000	000000	000000	000000	000000	000000
@@ -721,41 +863,132 @@ More histogram entries ...
 # Thread 8: 45766 56169 56171 ...# 00015 others
 # Thread 9: 02974 08094 13214 ... # 00090 others
 ----
-<1> The docker arguments provided by the user.
-<2> The user is notified about the measured latency and the configured latency.
+<1> The `podman` arguments you provided.
+<2> You can see the measured latency and the configured latency.
 <3> The arguments for the `cyclictest` command.
 <4> The maximum latencies measured on each thread.
+
+[id="cnf-performing-end-to-end-tests-capturing-results-cyclictest"]
+==== Capturing the results
+
+The same output can indicate different results for different workloads. For example, spikes up to 18μs is acceptable for 4G DU workloads but not for 5G DU workloads. Spikes above 20μs are not acceptable in any case.
+
+.Example of good results
+
+[source, terminal]
+----
+running cmd: cyclictest -q -D 10m -p 1 -t 16 -a 2,4,6,8,10,12,14,16,54,56,58,60,62,64,66,68 -h 30 -i 1000 -m 
+# Histogram
+000000 000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000
+000001 000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000
+000002 579506	535967	418614	573648	532870	529897	489306	558076	582350	585188	583793	223781	532480	569130	472250	576043
+More histogram entries ...
+# Total: 000600000 000600000 000600000 000599999 000599999 000599999 000599998 000599998 000599998 000599997 000599997 000599996 000599996 000599995 000599995 000599995
+# Min Latencies: 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002
+# Avg Latencies: 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002
+# Max Latencies: 00005 00005 00004 00005 00004 00004 00005 00005 00006 00005 00004 00005 00004 00004 00005 00004
+# Histogram Overflows: 00000 00000 00000 00000 00000 00000 00000 00000 00000 00000 00000 00000 00000 00000 00000 00000
+# Histogram Overflow at cycle number:
+# Thread 0:
+# Thread 1:
+# Thread 2:
+# Thread 3:
+# Thread 4:
+# Thread 5:
+# Thread 6:
+# Thread 7:
+# Thread 8:
+# Thread 9:
+# Thread 10:
+# Thread 11:
+# Thread 12:
+# Thread 13:
+# Thread 14:
+# Thread 15:
+----
+
+.Example of bad results
+
+[source, terminal]
+----
+running cmd: cyclictest -q -D 10m -p 1 -t 16 -a 2,4,6,8,10,12,14,16,54,56,58,60,62,64,66,68 -h 30 -i 1000 -m 
+# Histogram
+000000 000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000
+000001 000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000
+000002 564632	579686	354911	563036	492543	521983	515884	378266	592621	463547	482764	591976	590409	588145	589556	353518
+More histogram entries ...
+# Total: 000599999 000599999 000599999 000599997 000599997 000599998 000599998 000599997 000599997 000599996 000599995 000599996 000599995 000599995 000599995 000599993
+# Min Latencies: 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002
+# Avg Latencies: 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002 00002
+# Max Latencies: 00493 00387 00271 00619 00541 00513 00009 00389 00252 00215 00539 00498 00363 00204 00068 00520
+# Histogram Overflows: 00001 00001 00001 00002 00002 00001 00000 00001 00001 00001 00002 00001 00001 00001 00001 00002
+# Histogram Overflow at cycle number:
+# Thread 0: 155922
+# Thread 1: 110064
+# Thread 2: 110064
+# Thread 3: 110063 155921
+# Thread 4: 110063 155921
+# Thread 5: 155920
+# Thread 6:
+# Thread 7: 110062
+# Thread 8: 110062
+# Thread 9: 155919
+# Thread 10: 110061 155919
+# Thread 11: 155918
+# Thread 12: 155918
+# Thread 13: 110060
+# Thread 14: 110060
+# Thread 15: 110059 155917
+----
 
 [id="cnf-performing-end-to-end-tests-running-oslat"]
 === Running oslat
 
-[source, terminal]
+.Prerequisites
+
+* You installed the Performance Add-on Operator and you applied a performance profile
+
+.Procedure
+
+* To perform the `oslat`, run the following command: 
+
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=worker-cnf -e LATENCY_TEST_CPUS=7 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20  registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh -ginkgo.focus="oslat"
+$ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e \
+LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=worker-cnf -e \
+LATENCY_TEST_CPUS=7 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
+registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh -ginkgo.focus="oslat"
 ----
 
-The above command runs the `cyclictest` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs), and the command line displays `SUCCESS!`.
+The command runs the `oslat` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs), and the command line displays `SUCCESS!` when this test is completed.
 
 .Example failure output
-[source, terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $KUBECONFIG:/root/kubeconfig:Z -e KUBECONFIG=/root/kubeconfig -e IMAGE_REGISTRY=quay.io/titzhak -e CNF_TESTS_IMAGE=cnf-tests:latest -e PERF_TEST_PROFILE=performance -e ROLE_WORKER_CNF=worker-cnf -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e DISCOVERY_MODE=true -e MAXIMUM_LATENCY=20 -e LATENCY_TEST_CPUS=7 quay.io/titzhak/cnf-tests:latest usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="oslat" <1>
+$ podman run -v $KUBECONFIG:/root/kubeconfig:Z -e KUBECONFIG=/root/kubeconfig -e \
+IMAGE_REGISTRY="registry.redhat.io" -e CNF_TESTS_IMAGE=cnf-tests:latest -e \
+PERF_TEST_PROFILE=<performance_profile_name> -e ROLE_WORKER_CNF=worker-cnf -e \
+LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e DISCOVERY_MODE=true -e \
+MAXIMUM_LATENCY=20 -e LATENCY_TEST_CPUS=7 \
+registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
+usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="oslat" <1>
+
 
 running /usr/bin//validationsuite -ginkgo.v -ginkgo.focus=oslat
 I0829 12:36:55.386776       8 request.go:668] Waited for 1.000303471s due to client-side throttling, not priority and fairness, request: GET:https://api.cnfdc8.t5g.lab.eng.bos.redhat.com:6443/apis/authentication.k8s.io/v1?timeout=32s
 Running Suite: CNF Features e2e validation
-==========================================
+
 
 Discovery mode enabled, skipping setup
 running /usr/bin//cnftests -ginkgo.v -ginkgo.focus=oslat
 I0829 12:37:01.219077      20 request.go:668] Waited for 1.050010755s due to client-side throttling, not priority and fairness, request: GET:https://api.cnfdc8.t5g.lab.eng.bos.redhat.com:6443/apis/snapshot.storage.k8s.io/v1beta1?timeout=32s
 Running Suite: CNF Features e2e integration tests
-=================================================
+
 Random Seed: 1630240617
 Will run 1 of 142 specs
 
 SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
-------------------------------
+
 [performance] Latency Test with the oslat image
   should succeed
   /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:134
@@ -783,7 +1016,8 @@ Binary: Built with gc go1.16.6 for linux/amd64
 Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
 I0829 13:25:21.569182       1 node.go:37] Environment information: /proc/cmdline: BOOT_IMAGE=(hd0,gpt3)/ostree/rhcos-612d89f4519a53ad0b1a132f4add78372661bfb3994f5fe115654971aa58a543/vmlinuz-4.18.0-305.10.2.rt7.83.el8_4.x86_64 ip=dhcp random.trust_cpu=on console=tty0 console=ttyS0,115200n8 ostree=/ostree/boot.0/rhcos/612d89f4519a53ad0b1a132f4add78372661bfb3994f5fe115654971aa58a543/0 ignition.platform.id=openstack root=UUID=5a4ddf16-9372-44d9-ac4e-3ee329e16ab3 rw rootflags=prjquota skew_tick=1 nohz=on rcu_nocbs=1-3 tuned.non_isolcpus=000000ff,ffffffff,ffffffff,fffffff1 intel_pstate=disable nosoftlockup tsc=nowatchdog intel_iommu=on iommu=pt isolcpus=managed_irq,1-3 systemd.cpu_affinity=0,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103 default_hugepagesz=1G hugepagesz=2M hugepages=128 nmi_watchdog=0 audit=0 mce=off processor.max_cstate=1 idle=poll intel_idle.max_cstate=0
 I0829 13:25:21.569345       1 node.go:44] Environment information: kernel version 4.18.0-305.10.2.rt7.83.el8_4.x86_64
-I0829 13:25:21.569367       1 main.go:53] Running the oslat command with arguments [--duration 600 --rtprio 1 --cpu-list 4,6,52,54,56,58 --cpu-main-thread 2] <1>
+I0829 13:25:21.569367       1 main.go:53] Running the oslat command with arguments \
+[--duration 600 --rtprio 1 --cpu-list 4,6,52,54,56,58 --cpu-main-thread 2] <1>
 I0829 13:35:22.632263       1 main.go:59] Succeeded to run the oslat command: oslat V 2.00
 Total runtime: 		600 seconds
 Thread priority: 	SCHED_FIFO:1
@@ -816,9 +1050,9 @@ Test completed.
      Max-Min:	 36 37 48 27 27 18 (us)
     Duration:	 599.667 599.667 599.667 599.667 599.667 599.667 (sec)
 ----
-<1> The list of CPUs running the `oslat` command. Seven CPUs are provided through the `LATENCY_TEST_CPUS` variable. Only six CPUs are displayed in total because one is used to run the `oslat` tool.
-<2> The user is notified about the measured latency and the configured latency.
-<3> The maximum latency values in microseconds that are measured on each CPU.
+<1> The list of CPUs running the `oslat` command. The `LATENCY_TEST_CPUS` variable providessSeven CPUs. You can only see six CPUs in total because one runs the `oslat` tool.
+<2> You can see the measured latency and the configured latency.
+<3> The maximum latency values in microseconds that each CPU measures.
 
 [id="cnf-performing-end-to-end-tests-troubleshooting_{context}"]
 == Troubleshooting


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2042497

Changes requested by @novacain1 (SME)

Running the latency tests:
https://deploy-preview-40932--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#cnf-performing-end-to-end-tests-running-the-tests_cnf-master

Running hwlatdetect:
https://deploy-preview-40932--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#cnf-performing-end-to-end-tests-running-hwlatdetect

For release(s): 4.9, 4.10