### PR TITLE
OSDOCS-2461: Updated the OCP topic map to not include the OCM book.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -426,13 +426,6 @@ Topics:
 - Name: Converting a connected cluster to a disconnected cluster
   File: connected-to-disconnected
 ---
-Name: Red Hat OpenShift Cluster Manager (OCM)
-Dir: ocm
-Distros: openshift-dedicated
-Topics:
-- Name: Red Hat OpenShift Cluster Manager overview
-  File: ocm-overview
----
 Name: Updating clusters
 Dir: updating
 Distros: openshift-origin,openshift-enterprise


### PR DESCRIPTION
This removes a needless entry in the OCP Topic map. This is an extension of [OSDOCS-2461](https://issues.redhat.com/browse/OSDOCS-2461).