### PR TITLE
Added notes for release 4.6.54

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3443,3 +3443,19 @@ link:https://access.redhat.com/solutions/6635841[{product-title} 4.6.53 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-6-54"]
+=== RHBA-2022:0180 - {product-title} 4.6.54 bug fix update
+
+Issued: 2022-01-26
+
+{product-title} release 4.6.54 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0180[RHBA-2022:0180] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6663261[{product-title} 4.6.54 container image list]
+
+[id="ocp-4-6-54-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
These are the notes for release 4.6.54.

We expect this to ship on 26 January 2022.

Applies only to `enterprise-4.6`.

https://deploy-preview-40944--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-54