### PR TITLE
Only one H1 heading per file

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -172,6 +172,8 @@ Do not use "Overview" as a heading.
 
 Do not use backticks or other markup in assembly or module headings.
 
+Use only one level 1 heading (`=`) in any file.
+
 === Discrete headings
 
 If you have a section heading that you do not want to appear in the TOC (like if you think that some section is not worth showing up or if there are already too many nested levels), you can use a discrete (or floating) heading:


### PR DESCRIPTION
The asciidoctorj build fails whenever an `.adoc` file contains more than one H1, or `=`, level heading.