### PR TITLE
Missed z-stream WMCO 1.0.5 release

### DIFF
--- a/windows_containers/windows-containers-release-notes.adoc
+++ b/windows_containers/windows-containers-release-notes.adoc
@@ -17,6 +17,15 @@ The release notes for Red Hat OpenShift for Windows Containers tracks the develo
 
 You must have a subscription to receive support for the Red Hat WMCO. Deploying Windows container workloads in production clusters is not supported without a subscription. If you do not have a subscription, you can use the community WMCO, a distribution that lacks official support. Request support through the link:http://access.redhat.com/[Red Hat Customer Portal].
 
+[id="wmco-1-0-5"]
+== Release notes for Red Hat Windows Machine Config Operator 1.0.5
+
+Issued: 2021-06-14
+
+The WMCO 1.0.5 is now available with bug fixes. The components of the WMCO were released in link:https://access.redhat.com/errata/RHBA-2021:2142[RHBA-2021:2142].
+
+The support statements and known issues documented for the xref:../windows_containers/windows-containers-release-notes.adoc#wmco-1-0-2[WMCO 1.0.2] release also apply for this release of the WMCO.
+
 [id="wmco-1-0-4"]
 == Release notes for Red Hat Windows Machine Config Operator 1.0.4
 


### PR DESCRIPTION
Added generic release notes section for missed WINC 1.0.5 release.

Preview: https://deploy-preview-40971--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes.html#wmco-1-0-5