### PR TITLE
[virt] removing blank lines in attributes file

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -12,11 +12,11 @@
 :VirtProductName: OpenShift Virtualization
 :ProductRelease:
 :ProductVersion:
-
+//
 :VirtVersion: 4.10
 :KubeVirtVersion: v0.49.0
 :HCOVersion: 4.10.0
-
+//
 // :LastHCOVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com
@@ -33,7 +33,7 @@
 :Install_BookName: Installing OpenShift Virtualization
 :Using_BookName: Using OpenShift Virtualization
 :RN_BookName: OpenShift Virtualization release notes
-
+//
 // OKD branding
 ifdef::openshift-origin[]
 :product-title: OKD


### PR DESCRIPTION
@bergerhoffer noticed that our `{RN_BookName}` attribute was not being replaced with its value. It appears that removing blank lines from the attributes file fixes it, so I'm commenting them out with this PR.

Cherrypick to enterprise-4.9 and 4.10

Preview build TBD