### PR TITLE
OSSMDOC-456: Distributed tracing rebranding work in OSSM docs.

### DIFF
--- a/_attributes/distr-tracing-document-attributes.adoc
+++ b/_attributes/distr-tracing-document-attributes.adoc
@@ -12,6 +12,8 @@
 :product-dedicated: Red Hat OpenShift Dedicated
 :console-redhat-com: Red Hat OpenShift Cluster Manager
 
+:ProductName: Red Hat OpenShift Service Mesh
+
 :DTProductName: Red Hat OpenShift distributed tracing
 :DTShortName: distributed tracing
 :DTProductVersion: 2.1

--- a/distr_tracing/distr_tracing_install/distr-tracing-deploying-jaeger.adoc
+++ b/distr_tracing/distr_tracing_install/distr-tracing-deploying-jaeger.adoc
@@ -58,6 +58,11 @@ include::modules/distr-tracing-deploy-production-es.adoc[leveloffset=+1]
 
 include::modules/distr-tracing-deploy-streaming.adoc[leveloffset=+1]
 
+[id="validating-your-jaeger-deployment"]
+== Validating your deployment
+
+include::modules/distr-tracing-accessing-jaeger-console.adoc[leveloffset=+1]
+
 [id="customizing-your-deployment"]
 == Customizing your deployment
 

--- a/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
+++ b/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
@@ -11,3 +11,8 @@ The {OTELName} Operator uses a custom resource definition (CRD) file that define
 // The following include statements pull in the module files that comprise the assembly.
 
 include::modules/distr-tracing-config-otel-collector.adoc[leveloffset=+1]
+
+[id="validating-your-otel-deployment"]
+== Validating your deployment
+
+include::modules/distr-tracing-accessing-jaeger-console.adoc[leveloffset=+1]

--- a/modules/distr-tracing-accessing-jaeger-console.adoc
+++ b/modules/distr-tracing-accessing-jaeger-console.adoc
@@ -1,14 +1,12 @@
 ////
 Module included in the following assemblies:
-* service_mesh/v2x/ossm-observability.adoc
-* service_mesh/v2x/ossm-troubleshooting-istio.adoc
+
 ////
 
-:_content-type: PROCEDURE
-[id="ossm-accessing-jaeger-console_{context}"]
+[id="distr-tracing-accessing-jaeger-console_{context}"]
 = Accessing the Jaeger console
 
-To access the Jaeger console you must have {ProductName} installed, {JaegerName} installed and configured.
+To access the Jaeger console you must have either {ProductName} or {DTProductName} installed, and {JaegerName} installed, configured, and deployed.
 
 The installation process creates a route to access the Jaeger console.
 
@@ -19,7 +17,7 @@ If you know the URL for the Jaeger console, you can access it directly.  If you 
 
 . Navigate to *Networking* -> *Routes*.
 
-. On the *Routes* page, select the control plane project, for example `istio-system`, from the *Namespace* menu.
+. On the *Routes* page, select the control plane project, for example `tracing-system`, from the *Namespace* menu.
 +
 The *Location* column displays the linked address for each route.
 +
@@ -27,7 +25,7 @@ The *Location* column displays the linked address for each route.
 
 . Click *Log In With OpenShift*.
 
-
+////
 .Procedure from Kiali console
 
 . Launch the Kiali console.
@@ -35,7 +33,7 @@ The *Location* column displays the linked address for each route.
 . Click *Distributed Tracing* in the left navigation pane.
 
 . Click *Log In With OpenShift*.
-
+////
 
 .Procedure from the CLI
 
@@ -46,11 +44,11 @@ The *Location* column displays the linked address for each route.
 $ oc login https://<HOSTNAME>:6443
 ----
 +
-. To query for details of the route using the command line, enter the following command. In this example, `istio-system` is the control plane namespace.
+. To query for details of the route using the command line, enter the following command. In this example, `tracing-system` is the control plane namespace.
 +
 [source,terminal]
 ----
-$ export JAEGER_URL=$(oc get route -n istio-system jaeger -o jsonpath='{.spec.host}')
+$ export JAEGER_URL=$(oc get route -n tracing-system jaeger -o jsonpath='{.spec.host}')
 ----
 +
 . Launch a browser and navigate to ``\https://<JAEGER_URL>``, where `<JAEGER_URL>` is the route that you discovered in the previous step.

--- a/modules/distr-tracing-config-ingester.adoc
+++ b/modules/distr-tracing-config-ingester.adoc
@@ -42,7 +42,7 @@ The deadlock interval is disabled by default (set to `0`), to avoid terminating 
 |options:
   log-level:
 |Logging level for the Ingester.
-|Possible values: `trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
+|Possible values: `debug`, `info`, `warn`, `error`, `fatal`, `dpanic`, `panic`.
 |===
 
 .Streaming Collector and Ingester example

--- a/modules/distr-tracing-config-jaeger-collector.adoc
+++ b/modules/distr-tracing-config-jaeger-collector.adoc
@@ -62,5 +62,5 @@ The Collectors are stateless and thus many instances of Jaeger Collector can be 
 |options:
   log-level:
 |Logging level for the Collector.
-|Possible values: `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
+|Possible values: `debug`, `info`, `warn`, `error`, `fatal`, `panic`.
 |===

--- a/modules/distr-tracing-config-query.adoc
+++ b/modules/distr-tracing-config-query.adoc
@@ -39,14 +39,14 @@ Query is a service that retrieves traces from storage and hosts the user interfa
 |options:
   log-level:
 |Logging level for Query.
-|Possible values: `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
+|Possible values: `debug`, `info`, `warn`, `error`, `fatal`, `panic`.
 |
 
 |options:
   query:
     base-path:
 |The base path for all jaeger-query HTTP routes can be set to a non-root value, for example, `/jaeger` would cause all UI URLs to start with `/jaeger`. This can be useful when running jaeger-query behind a reverse proxy.
-|/{path}
+|/<path>
 |
 |===
 

--- a/modules/jaeger-architecture.adoc
+++ b/modules/jaeger-architecture.adoc
@@ -6,9 +6,9 @@ This CONCEPT module included in the following assemblies:
 ////
 
 [id="jaeger-architecture_{context}"]
-= Jaeger architecture
+= Distributed tracing architecture
 
-Jaeger is made up of several components that work together to collect, store, and display tracing data.
+The {JaegerShortName} is based on the open source link:https://www.jaegertracing.io/[Jaeger project]. The {JaegerShortName} is made up of several components that work together to collect, store, and display tracing data.
 
 * *Jaeger Client* (Tracer, Reporter, instrumented application, client libraries)- Jaeger clients are language specific implementations of the OpenTracing API. They can be used to instrument applications for distributed tracing either manually or with a variety of existing open source frameworks, such as Camel (Fuse), Spring Boot (RHOAR), MicroProfile (RHOAR/Thorntail), Wildfly (EAP), and many more, that are already integrated with OpenTracing.
 

--- a/modules/jaeger-config-collector.adoc
+++ b/modules/jaeger-config-collector.adoc
@@ -62,5 +62,5 @@ The collectors are stateless and thus many instances of Jaeger Collector can be 
 |options:
   log-level:
 |Logging level for the collector.
-|`trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`
+|Possible values: `debug`, `info`, `warning`, `error`, `fatal`, `panic`
 |===

--- a/modules/jaeger-config-query.adoc
+++ b/modules/jaeger-config-query.adoc
@@ -40,7 +40,7 @@ Query is a service that retrieves traces from storage and hosts the user interfa
 |options:
   log-level:
 |Logging level for Query.
-|Possible values: `trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
+|Possible values: `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
 |
 
 |options:

--- a/modules/jaeger-deploy-default.adoc
+++ b/modules/jaeger-deploy-default.adoc
@@ -71,7 +71,7 @@ Follow this procedure to create an instance of Jaeger from the command line.
 +
 [source,terminal]
 ----
-$ oc login https://{HOSTNAME}:8443
+$ oc login https://<HOSTNAME>:8443
 ----
 
 . Create a new project named `jaeger-system`.

--- a/modules/jaeger-deploy-production-es.adoc
+++ b/modules/jaeger-deploy-production-es.adoc
@@ -90,7 +90,7 @@ Follow this procedure to create an instance of Jaeger from the command line.
 +
 [source,terminal]
 ----
-$ oc login https://{HOSTNAME}:8443
+$ oc login https:/<HOSTNAME>:8443
 ----
 
 . Create a new project named `jaeger-system`.

--- a/modules/jaeger-deploy-streaming.adoc
+++ b/modules/jaeger-deploy-streaming.adoc
@@ -102,7 +102,7 @@ Procedure
 +
 [source,terminal]
 ----
-$ oc login https://{HOSTNAME}:8443
+$ oc login https://<HOSTNAME>:8443
 ----
 
 . Create a new project named `jaeger-system`.
@@ -143,4 +143,3 @@ jaeger-streaming-kafka-0                                          2/2     Runnin
 jaeger-streaming-query-65bf5bb854-ncnc7                           3/3     Running   0          80s
 jaeger-streaming-zookeeper-0                                      2/2     Running   0          3m39s
 ----
-

--- a/modules/jaeger-product-overview.adoc
+++ b/modules/jaeger-product-overview.adoc
@@ -7,12 +7,12 @@ This CONCEPT module included in the following assemblies:
 
 :_content-type: CONCEPT
 [id="jaeger-product-overview_{context}"]
-= Jaeger overview
+= Distributed tracing platform overview
 
-As a service owner, you can use Jaeger to instrument your services to gather insights into your service architecture.
+As a service owner, you can use the {JaegerShortName} to instrument your services to gather insights into your service architecture.
 Jaeger is an open source distributed tracing platform that you can use for monitoring, network profiling, and troubleshooting the interaction between components in modern, cloud-native, microservices-based applications.
 
-Using Jaeger lets you perform the following functions:
+Using the {JaegerShortName} lets you perform the following functions:
 
 * Monitor distributed transactions
 
@@ -20,4 +20,4 @@ Using Jaeger lets you perform the following functions:
 
 * Perform root cause analysis
 
-Jaeger is based on the vendor-neutral link:https://opentracing.io/[OpenTracing] APIs and instrumentation.
+The {JaegerShortName} is based on the vendor-neutral link:https://opentracing.io/[OpenTracing] APIs and instrumentation.

--- a/modules/ossm-accessing-jaeger.adoc
+++ b/modules/ossm-accessing-jaeger.adoc
@@ -10,7 +10,7 @@ Networking > Routes> search Jaeger route (Location = Link)
 Kiali Console > Distributed Tracing tab
 ////
 
-The installation process creates a route to access the Jaeger console.
+The deployment process creates a route to access the Jaeger console.
 
 .Procedure
 . Log in to the {Product-title} console.
@@ -31,4 +31,4 @@ $ export JAEGER_URL=$(oc get route -n istio-system jaeger -o jsonpath='{.spec.ho
 
 . If you have added services to the service mesh and have generated traces, you can use the filters and *Find Traces* button to search your trace data.
 +
-If you are validating the console installation, there is no trace data to display.
+If you are validating the console installation, there is no data to display until you start collecting traces.

--- a/modules/ossm-accessing-kiali.adoc
+++ b/modules/ossm-accessing-kiali.adoc
@@ -11,7 +11,7 @@ Networking > Routes> search Kiali route (Location = Link)
 CLI = oc get routes
 ////
 
-The installation process creates a route to access the Kiali console.
+The deployment process creates a route to access the Kiali console.
 
 .Procedure
 

--- a/modules/ossm-architecture.adoc
+++ b/modules/ossm-architecture.adoc
@@ -36,16 +36,16 @@ The *control plane* manages and configures the proxies that make up the data pla
 
 {ProductName} also bundles the following Istio add-ons as part of the product:
 
-* *Kiali* - Kiali is the management console for {ProductName}. It provides dashboards, observability, and robust configuration and validation capabilities. It shows the structure of your service mesh by inferring traffic topology and displays the health of your mesh. Kiali provides detailed metrics, powerful validation, access to Grafana, and strong integration for distributed tracing with Jaeger.
+* *Kiali* - Kiali is the management console for {ProductName}. It provides dashboards, observability, and robust configuration and validation capabilities. It shows the structure of your service mesh by inferring traffic topology and displays the health of your mesh. Kiali provides detailed metrics, powerful validation, access to Grafana, and strong integration with the {JaegerShortName}.
 
 * *Prometheus* - {ProductName} uses Prometheus to store telemetry information from services. Kiali depends on Prometheus to obtain metrics, health status, and mesh topology.
 
-* *Jaeger* - {ProductName} supports Jaeger for distributed tracing. Jaeger is an open source traceability server that centralizes and displays traces associated with a single request between multiple services. Using Jaeger you can monitor and troubleshoot your microservices-based distributed systems.
+* *Jaeger* - {ProductName} supports the {JaegerShortName}. Jaeger is an open source traceability server that centralizes and displays traces associated with a single request between multiple services. Using the {JaegerShortName} you can monitor and troubleshoot your microservices-based distributed systems.
 
-* *Elasticsearch* - ElasticSearch is an open source, distributed, JSON-based search and analytics engine. Jaeger uses ElasticSearch for distributed storage and indexing for logging and tracing data.
+* *Elasticsearch* - Elasticsearch is an open source, distributed, JSON-based search and analytics engine. The {JaegerShortName} uses Elasticsearch for persistent storage.
 
 * *Grafana* - Grafana provides mesh administrators with advanced query and metrics analysis and dashboards for Istio data. Optionally, Grafana can be used to analyze service mesh metrics.
 
-The following Istio adapters are supported with {ProductName}:
+The following Istio integrations are supported with {ProductName}:
 
-* *3scale* - The 3scale Istio adapter is an optional component that integrates {ProductName} with Red Hat 3scale API Management solutions. The default {ProductName} installation does not include this component.
+* *3scale* - Istio provides an optional integration with Red Hat 3scale API Management solutions. For versions prior to 2.1, this integration was achieved via the 3scale Istio adapter. For version 2.1 and later, the 3scale integration is achieved via a WebAssembly module.

--- a/modules/ossm-configuring-jaeger.adoc
+++ b/modules/ossm-configuring-jaeger.adoc
@@ -6,6 +6,6 @@
 [id="ossm-specifying-jaeger-configuration_{context}"]
 = Specifying Jaeger configuration in the SMCP
 
-You can configure Jaeger under the `addons` section of the `ServiceMeshControlPlane` resource. However, there are some limitations to what you can configure in the SMCP.
+You configure Jaeger under the `addons` section of the `ServiceMeshControlPlane` resource. However, there are some limitations to what you can configure in the SMCP.
 
-When the SMCP passes configuration information to the Jaeger Operator, it triggers one of three deployment strategies: `allInOne`, `production`, or `streaming`.
+When the SMCP passes configuration information to the {JaegerName} Operator, it triggers one of three deployment strategies: `allInOne`, `production`, or `streaming`.

--- a/modules/ossm-control-plane-cli.adoc
+++ b/modules/ossm-control-plane-cli.adoc
@@ -20,7 +20,7 @@ You can deploy a basic `ServiceMeshControlPlane` from the command line.
 +
 [source,terminal]
 ----
-$ oc login https://{HOSTNAME}:6443
+$ oc login https://<HOSTNAME>:6443
 ----
 +
 . Create a project named `istio-system`.

--- a/modules/ossm-control-plane-deploy-1x.adoc
+++ b/modules/ossm-control-plane-deploy-1x.adoc
@@ -83,7 +83,7 @@ Follow this procedure to deploy the {ProductName} control plane the command line
 +
 [source,terminal]
 ----
-$ oc login https://{HOSTNAME}:6443
+$ oc login https://<HOSTNAME>:6443
 ----
 
 . Create a project named `istio-system`.

--- a/modules/ossm-deploying-jaeger.adoc
+++ b/modules/ossm-deploying-jaeger.adoc
@@ -3,13 +3,13 @@
 // * service_mesh/v2x/ossm-custom-resources.adoc
 
 [id="ossm-deploying-jaeger_{context}"]
-= Deploying Jaeger
+= Deploying the distributed tracing platform
 
-Jaeger has predefined deployment strategies. You specify a deployment strategy in the Jaeger custom resource (CR) file. When you create a Jaeger instance, the Operator uses this configuration file to create the objects necessary for the deployment.
+The {JaegerShortName} has predefined deployment strategies. You specify a deployment strategy in the Jaeger custom resource (CR) file. When you create an instance of the {JaegerShortName}, the {JaegerName} Operator uses this configuration file to create the objects necessary for the deployment.
 
-The Jaeger Operator currently supports the following deployment strategies:
+The {JaegerName} Operator currently supports the following deployment strategies:
 
-* *allInOne* (default) - This strategy is intended for development, testing, and demo purposes and it is not for production use. The main back-end components, Agent, Collector and Query service, are all packaged into a single executable, which is configured (by default) to use in-memory storage. You can configure this deployment strategy in the SMCP.
+* *allInOne* (default) - This strategy is intended for development, testing, and demo purposes and it is not for production use. The main back-end components, Agent, Collector, and Query service, are all packaged into a single executable, which is configured (by default) to use in-memory storage. You can configure this deployment strategy in the SMCP.
 +
 [NOTE]
 ====
@@ -26,7 +26,7 @@ The streaming strategy requires an additional Red Hat subscription for AMQ Strea
 ====
 
 [id="ossm-deploying-jaeger-default_{context}"]
-== Default Jaeger deployment
+== Default {JaegerShortName} deployment
 
 If you do not specify Jaeger configuration options, the `ServiceMeshControlPlane` resource will use the `allInOne` Jaeger deployment strategy by default. When using the default `allInOne` deployment strategy, set `spec.addons.jaeger.install.storage.type` to `Memory`. You can accept the defaults or specify additional configuration options under `install`.
 
@@ -51,7 +51,7 @@ spec:
 ----
 
 [id="ossm-deploying-jaeger-production-min_{context}"]
-== Production Jaeger deployment (minimal)
+== Production {JaegerShortName} deployment (minimal)
 
 To use the default settings for the `production` deployment strategy, set `spec.addons.jaeger.install.storage.type` to `Elasticsearch` and specify additional configuration options under `install`. Note that the SMCP only supports configuring Elasticsearch resources and image name.
 
@@ -69,7 +69,7 @@ spec:
     type: Jaeger
   addons:
     jaeger:
-      name: jaeger-production
+      name: jaeger  #name of Jaeger CR
       install:
         storage:
           type: Elasticsearch
@@ -84,11 +84,11 @@ spec:
 
 
 [id="ossm-deploying-jaeger-production_{context}"]
-== Production Jaeger deployment (fully customized)
+== Production {JaegerShortName} deployment (fully customized)
 
 The SMCP supports only minimal Elasticsearch parameters. To fully customize your production environment and access all of the Elasticsearch configuration parameters, use the Jaeger custom resource (CR) to configure Jaeger.
 
-Create and configure your Jaeger instance and set `spec.addons.jaeger.name` to the name of the Jaeger instance, in this example: `jaeger-production-cr`.
+Create and configure your Jaeger instance and set `spec.addons.jaeger.name` to the name of the Jaeger instance, in this example: `MyJaegerInstance`.
 
 .Control plane with linked Jaeger production CR
 [source,yaml]
@@ -104,7 +104,7 @@ spec:
     type: Jaeger
   addons:
     jaeger:
-      name: jaeger-production-cr #name of Jaeger CR
+      name: MyJaegerInstance #name of Jaeger CR
       install:
         storage:
           type: Elasticsearch
@@ -115,7 +115,7 @@ spec:
 [id="ossm-deploying-jaeger-streaming_{context}"]
 == Streaming Jaeger deployment
 
-To use the `streaming` deployment strategy, you create and configure your Jaeger instance first, then set `spec.addons.jaeger.name` to the name of the Jaeger instance, in this example: `jaeger-streaming-cr`.
+To use the `streaming` deployment strategy, you create and configure your Jaeger instance first, then set `spec.addons.jaeger.name` to the name of the Jaeger instance, in this example: `MyJaegerInstance`.
 
 .Control plane with linked Jaeger streaming CR
 [source,yaml]
@@ -131,5 +131,5 @@ spec:
     type: Jaeger
   addons:
     jaeger:
-      name: jaeger-streaming-cr  #name of Jaeger CR
+      name: MyJaegerInstance  #name of Jaeger CR
 ----

--- a/modules/ossm-federation-config-smcp.adoc
+++ b/modules/ossm-federation-config-smcp.adoc
@@ -323,7 +323,7 @@ Follow this procedure to create or edit the `ServiceMeshControlPlane` with the c
 +
 [source,terminal]
 ----
-$ oc login --username=NAMEOFUSER https://{HOSTNAME}:6443
+$ oc login --username=NAMEOFUSER https://<HOSTNAME>:6443
 ----
 +
 . Change to the project where you installed the control plane, for example red-mesh-system.

--- a/modules/ossm-federation-create-export.adoc
+++ b/modules/ossm-federation-create-export.adoc
@@ -49,7 +49,7 @@ Follow this procedure to create an `ExportServiceSet` from the command line.
 +
 [source,terminal]
 ----
-$ oc login --username=<NAMEOFUSER> <API token> https://{HOSTNAME}:6443
+$ oc login --username=<NAMEOFUSER> <API token> https://<HOSTNAME>:6443
 ----
 +
 . Change to the project where you installed the control plane; for example, `red-mesh-system`.

--- a/modules/ossm-federation-create-import.adoc
+++ b/modules/ossm-federation-create-import.adoc
@@ -50,7 +50,7 @@ Follow this procedure to create an `ImportServiceSet` from the command line.
 +
 [source,terminal]
 ----
-$ oc login --username=<NAMEOFUSER> <API token> https://{HOSTNAME}:6443
+$ oc login --username=<NAMEOFUSER> <API token> https://<HOSTNAME>:6443
 ----
 +
 . Change to the project where you installed the control plane; for example, `green-mesh-system`.

--- a/modules/ossm-federation-create-meshPeer.adoc
+++ b/modules/ossm-federation-create-meshPeer.adoc
@@ -42,7 +42,7 @@ Follow this procedure to create a `ServiceMeshPeer` resource from the command li
 +
 [source,terminal]
 ----
-$ oc login --username=<NAMEOFUSER> <API token> https://{HOSTNAME}:6443
+$ oc login --username=<NAMEOFUSER> <API token> https://<HOSTNAME>:6443
 ----
 +
 . Change to the project where you installed the control plane, for example, `red-mesh-system`.

--- a/modules/ossm-install-ossm-operator.adoc
+++ b/modules/ossm-install-ossm-operator.adoc
@@ -10,7 +10,7 @@
 To install {ProductName}, install following Operators in this order. Repeat the procedure for each Operator.
 
 * OpenShift Elasticsearch
-* Jaeger
+* {JaegerName}
 * Kiali
 * {ProductName}
 
@@ -28,15 +28,15 @@ To install {ProductName}, install following Operators in this order. Repeat the 
 ====
 If you have already installed the OpenShift Elasticsearch Operator as part of OpenShift
 Logging, you do not need to install the OpenShift Elasticsearch Operator again. The
-Jaeger Operator will create the Elasticsearch instance using the installed OpenShift
+{JaegerName} Operator will create the Elasticsearch instance using the installed OpenShift
 Elasticsearch Operator.
 ====
 
 . On the *Install Operator* page, select installation options.
-.. For the OpenShift Elasticsearch Operator, in the *Update Channel* section, select *stable-5.x*. The Elasticsearch installation requires the `openshift-operators-redhat` namespace for the OpenShift Elasticsearch Operator. The other Red Hat OpenShift Service Mesh operators are installed in the `openshift-operators` namespace.
-.. For the Jaeger, Kiali, and {ProductName} Operators, accept the defaults.
+.. For the OpenShift Elasticsearch Operator, in the *Update Channel* section, select *stable-5.x*.
+.. For the {JaegerName}, Kiali, and {ProductName} Operators, accept the defaults.
 +
-The Jaeger, Kiali and {ProductName} are installed in the `openshift-operators` namespace. The OpenShift Elasticsearch Operator is installed in the `openshift-operators-redhat` namespace.
+The {JaegerName}, Kiali and {ProductName} Operators are installed in the `openshift-operators` namespace. The OpenShift Elasticsearch Operator is installed in the `openshift-operators-redhat` namespace.
 
 . Click *Install*. Wait until the Operator has installed before repeating the steps for the next Operator in the list.
 

--- a/modules/ossm-installation-activities.adoc
+++ b/modules/ossm-installation-activities.adoc
@@ -10,7 +10,7 @@
 
 {ProductName} requires the following four Operators:
 
-* *OpenShift Elasticsearch* - (Optional) Provides database storage for tracing and logging with Jaeger. It is based on the open source link:https://www.elastic.co/[Elasticsearch] project.
-* *Jaeger* - Provides tracing to monitor and troubleshoot transactions in complex distributed systems. It is based on the open source link:https://www.jaegertracing.io/[Jaeger] project. 
-* *Kiali* - Provides observability for your service mesh. Allows you to view configurations, monitor traffic, and analyze traces in a single console. It is based on the open source link:https://www.kiali.io/[Kiali] project. 
+* *OpenShift Elasticsearch* - (Optional) Provides database storage for tracing and logging with the {JaegerShortName}. It is based on the open source link:https://www.elastic.co/[Elasticsearch] project.
+* *{JaegerName}* - Provides distributed tracing to monitor and troubleshoot transactions in complex distributed systems. It is based on the open source link:https://www.jaegertracing.io/[Jaeger] project.
+* *Kiali* - Provides observability for your service mesh. Allows you to view configurations, monitor traffic, and analyze traces in a single console. It is based on the open source link:https://www.kiali.io/[Kiali] project.
 * *{ProductName}* - Allows you to connect, secure, control, and observe the microservices that comprise your applications. The {ProductShortName} Operator defines and monitors the `ServiceMeshControlPlane` resources that manage the deployment, updating, and deletion of the {ProductShortName} components. It is based on the open source link:https://istio.io/[Istio] project.

--- a/modules/ossm-jaeger-service-mesh.adoc
+++ b/modules/ossm-jaeger-service-mesh.adoc
@@ -5,14 +5,14 @@ This CONCEPT module included in the following assemblies:
 ////
 
 [id="ossm-jaeger-service-mesh_{context}"]
-= Jaeger and service mesh
+= Distributed tracing and service mesh
 
-Installing Jaeger with the Service Mesh on {product-title} differs from community Jaeger installations in multiple ways. These modifications are sometimes necessary to resolve issues, provide additional features, or to handle differences when deploying on {product-title}.
+Installing the {JaegerShortName} with the Service Mesh on {product-title} differs from community Jaeger installations in multiple ways. These modifications are sometimes necessary to resolve issues, provide additional features, or to handle differences when deploying on {product-title}.
 
-* Jaeger has been enabled by default for {ProductShortName}.
+* Distributed tracing has been enabled by default for {ProductShortName}.
 * Ingress has been enabled by default for {ProductShortName}.
 * The name for the Zipkin port name has changed to `jaeger-collector-zipkin` (from `http`)
 * Jaeger uses Elasticsearch for storage by default when you select either the `production` or `streaming` deployment option.
-* The community version of Istio provides a generic "tracing" route. {ProductName} uses a "jaeger" route that is installed by the Jaeger Operator and is already protected by OAuth.
+* The community version of Istio provides a generic "tracing" route. {ProductName} uses a "jaeger" route that is installed by the {JaegerName} Operator and is already protected by OAuth.
 * {ProductName} uses a sidecar for the Envoy proxy, and Jaeger also uses a sidecar, for the Jaeger agent.
 These two sidecars are configured separately and should not be confused with each other. The proxy sidecar creates spans related to the pod's ingress and egress traffic. The agent sidecar receives the spans emitted by the application and sends them to the Jaeger Collector.

--- a/modules/ossm-kiali-architecture.adoc
+++ b/modules/ossm-kiali-architecture.adoc
@@ -7,7 +7,7 @@ This CONCEPT module included in the following assemblies:
 [id="ossm-kiali-architecture_{context}"]
 = Kiali architecture
 
-Kiali is composed of two components: the Kiali application and the Kiali console.
+Kiali is based on the open source link:https://kiali.io/[Kiali project]. Kiali is composed of two components: the Kiali application and the Kiali console.
 
 * *Kiali application* (back end) – This component runs in the container application platform and communicates with the service mesh components, retrieves and processes data, and exposes this data to the console. The Kiali application does not need storage. When deploying the application to a cluster, configurations are set in ConfigMaps and secrets.
 
@@ -21,6 +21,6 @@ In addition, Kiali depends on external services and components provided by the c
 
 * *Cluster API* - Kiali uses the API of the {product-title} (cluster API) to fetch and resolve service mesh configurations. Kiali queries the cluster API to retrieve, for example, definitions for namespaces, services, deployments, pods, and other entities. Kiali also makes queries to resolve relationships between the different cluster entities. The cluster API is also queried to retrieve Istio configurations like virtual services, destination rules, route rules, gateways, quotas, and so on.
 
-* *Jaeger* - Jaeger is optional, but is installed by default as part of the {ProductName} installation. When you install Jaeger as part of the default {ProductName} installation, the Kiali console includes a tab to display Jaeger's tracing data. Note that tracing data will not be available if you disable Istio's distributed tracing feature.  Also note that user must have access to the namespace where the control plane is installed to view Jaeger data.
+* *Jaeger* - Jaeger is optional, but is installed by default as part of the {ProductName} installation. When you install the {JaegerShortName} as part of the default {ProductName} installation, the Kiali console includes a tab to display distributed tracing data. Note that tracing data will not be available if you disable Istio's distributed tracing feature. Also note that user must have access to the namespace where the control plane is installed to view tracing data.
 
 * *Grafana* - Grafana is optional, but is installed by default as part of the {ProductName} installation. When available, the metrics pages of Kiali display links to direct the user to the same metric in Grafana. Note that user must have access to the namespace where the control plane is installed to view links to the Grafana dashboard and view Grafana data.

--- a/modules/ossm-member-roll-create.adoc
+++ b/modules/ossm-member-roll-create.adoc
@@ -63,14 +63,14 @@ You can add a project to the `ServiceMeshMemberRoll` from the command line.
 +
 [source,terminal]
 ----
-$ oc login https://{HOSTNAME}:6443
+$ oc login https://<HOSTNAME>:6443
 ----
 
 . If you do not already have services for your mesh, or you are starting from scratch, create a project for your applications. It must be different from the project where you installed the control plane.
 +
 [source,terminal]
 ----
-$ oc new-project {your-project}
+$ oc new-project <your-project>
 ----
 
 . To add your projects as members, modify the following example YAML. You can add any number of projects, but a project can only belong to *one* `ServiceMeshMemberRoll` resource. In this example, `istio-system` is the name of the control plane project.

--- a/modules/ossm-observability-addresses.adoc
+++ b/modules/ossm-observability-addresses.adoc
@@ -39,7 +39,7 @@ The *Location* column displays the linked address for each route.
 +
 [source,terminal]
 ----
-$ oc login https://{HOSTNAME}:6443
+$ oc login https://<HOSTNAME>:6443
 ----
 +
 . Switch to the control plane project. In this example, `istio-system` is the control plane project.  Run the following command:

--- a/modules/ossm-remove-cleanup.adoc
+++ b/modules/ossm-remove-cleanup.adoc
@@ -18,7 +18,7 @@ You can manually remove resources left behind after removing the {ProductName} O
 
 . Log in to the {product-title} CLI as a cluster administrator.
 
-. Run the following commands to clean up resources after uninstalling the Operators. If you intend to keep using Jaeger as a stand-alone service without service mesh, do not delete the Jaeger resources.
+. Run the following commands to clean up resources after uninstalling the Operators. If you intend to keep using {JaegerShortName} as a stand-alone service without service mesh, do not delete the Jaeger resources.
 +
 [NOTE]
 ====

--- a/modules/ossm-remove-operators.adoc
+++ b/modules/ossm-remove-operators.adoc
@@ -7,7 +7,7 @@
 [id="ossm-operatorhub-remove-operators_{context}"]
 = Removing the installed Operators
 
-You must remove the Operators to successfully remove {ProductName}. After you remove the {ProductName} Operator, you must remove the Kiali Operator, the Jaeger Operator, and the OpenShift Elasticsearch Operator.
+You must remove the Operators to successfully remove {ProductName}. After you remove the {ProductName} Operator, you must remove the Kiali Operator, the {JaegerName} Operator, and the OpenShift Elasticsearch Operator.
 
 [id="ossm-remove-operator-servicemesh_{context}"]
 == Removing the Operators
@@ -16,7 +16,7 @@ Follow this procedure to remove the Operators that make up {ProductName}. Repeat
 
 * {ProductName}
 * Kiali
-* Jaeger
+* {JaegerName}
 * OpenShift Elasticsearch
 
 .Procedure

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -19,7 +19,7 @@ These limitations exist in {ProductName}:
 
 * Graph layout - The layout for the Kiali graph can render differently, depending on your application architecture and the data to display (number of graph nodes and their interactions). Because it is difficult if not impossible to create a single layout that renders nicely for every situation, Kiali offers a choice of several different layouts. To choose a different layout, you can choose a different *Layout Schema* from the *Graph Settings* menu.
 
-* The first time you access related services such as Jaeger and Grafana, from the Kiali console, you must accept the certificate and re-authenticate using your {product-title} login credentials. This happens due to an issue with how the framework displays embedded pages in the console.
+* The first time you access related services such as {JaegerShortName} and Grafana, from the Kiali console, you must accept the certificate and re-authenticate using your {product-title} login credentials. This happens due to an issue with how the framework displays embedded pages in the console.
 
 * The Bookinfo sample application cannot be installed on IBM Z and IBM Power Systems.
 
@@ -37,16 +37,19 @@ These are the known issues in {ProductName}:
 For example, if you create a namespace called 'akube-a' and add it to the Service Mesh member roll, then the Kiali UI does not display the namespace. For defined exclusion patterns, the software excludes namespaces that start with or contain the pattern.
 +
 The workaround is to change the Kiali Custom Resource setting so it prefixes the setting with a carat (^). For example:
-
-  api:
-    namespaces:
-      exclude:
-      - "^istio-operator"
-      - "^kube-.*"
-      - "^openshift.*"
-      - "^ibm.*"
-      - "^kiali-operator"
-
++
+[source,yaml]
+----
+api:
+  namespaces:
+    exclude:
+    - "^istio-operator"
+    - "^kube-.*"
+    - "^openshift.*"
+    - "^ibm.*"
+    - "^kiali-operator"
+----
++
 * link:https://issues.redhat.com/browse/OSSM-285[OSSM-285] When trying to access the Kiali console, receive the following error message "Error trying to get OAuth Metadata". The workaround is to restart the Kiali pod.
 
 * link:https://issues.redhat.com/browse/MAISTRA-2735[MAISTRA-2735] The resources that the Service Mesh Operator deletes when reconciling the SMCP have changed. Previously, the Operator deleted a resource with the following labels:

--- a/modules/ossm-smcp-prod.adoc
+++ b/modules/ossm-smcp-prod.adoc
@@ -8,13 +8,13 @@
 
 If you have installed a basic `ServiceMeshControlPlane` resource to test {ProductShortName}, you must configure it to production specification before you use {ProductName} in production.
 
-You cannot change the `metadata.name` field of an existing `ServiceMeshControlPlane` resource. For production deployments, you must customize the default template. 
+You cannot change the `metadata.name` field of an existing `ServiceMeshControlPlane` resource. For production deployments, you must customize the default template.
 
 .Procedure
 
-. Configure Jaeger for production. 
+. Configure the {JaegerShortName} for production.
 +
-.. Edit the `ServiceMeshControlPlane` resource to use the `production` deployment strategy, by setting `spec.addons.jaeger.install.storage.type` to `Elasticsearch` and specify additional configuration options under `install`. You can create and configure your Jaeger instance and set `spec.addons.jaeger.name` to the name of the Jaeger instance, for example,  `jaeger-production`.
+.. Edit the `ServiceMeshControlPlane` resource to use the `production` deployment strategy, by setting `spec.addons.jaeger.install.storage.type` to `Elasticsearch` and specify additional configuration options under `install`. You can create and configure your Jaeger instance and set `spec.addons.jaeger.name` to the name of the Jaeger instance.
 +
 .Default Jaeger parameters including Elasticsearch
 [source,yaml]
@@ -30,7 +30,7 @@ spec:
     type: Jaeger
   addons:
     jaeger:
-      name: jaeger-production
+      name: MyJaeger
       install:
         storage:
           type: Elasticsearch

--- a/modules/ossm-troubleshooting-proxy.adoc
+++ b/modules/ossm-troubleshooting-proxy.adoc
@@ -19,7 +19,7 @@ To enable access logging for all istio-proxy containers, edit the `ServiceMeshCo
 +
 [source,terminal]
 ----
-$ oc login https://{HOSTNAME}:6443
+$ oc login https://<HOSTNAME>:6443
 ----
 +
 . Change to the project where you installed the control plane, for example `istio-system`.

--- a/modules/ossm-troubleshooting-smcp.adoc
+++ b/modules/ossm-troubleshooting-smcp.adoc
@@ -10,6 +10,6 @@ If you are experiencing issues while deploying the Service Mesh control plane,
 
 * Ensure that the `ServiceMeshControlPlane` and `Jaeger` custom resources are deployed in the same project. For example, use the `istio-system` project for both.
 
-//* If you selected to install the Elasticsearch Operator in a specific namespace in the cluster instead of selecting *All namespaces in on the cluster (default)*, then OpenShift could not automatically copy the Operator to the istio-system namespace and the Jaeger Operator could not call the Elasticsearch Operator during the installation?
+//* If you selected to install the Elasticsearch Operator in a specific namespace in the cluster instead of selecting *All namespaces in on the cluster (default)*, then OpenShift could not automatically copy the Operator to the istio-system namespace and the {JaegerName} Operator could not call the Elasticsearch Operator during the installation?
 
 //The steps for deploying the service mesh control plane (SMCP) include verifying the deployment in the OpenShift console.

--- a/modules/ossm-updating-smcp.adoc
+++ b/modules/ossm-updating-smcp.adoc
@@ -14,7 +14,7 @@ You can create or edit the `ServiceMeshControlPlane` with the command line.
 +
 [source,terminal]
 ----
-$ oc login https://{HOSTNAME}:6443
+$ oc login https://<HOSTNAME>:6443
 ----
 +
 . Change to the project where you installed the control plane, for example `istio-system`.

--- a/modules/ossm-validating-smcp.adoc
+++ b/modules/ossm-validating-smcp.adoc
@@ -19,11 +19,11 @@ When you create the Service Mesh control plane, the {ProductShortName} Operator 
 You view the Kiali components under the Kiali Operator, not the {ProductShortName} Operator.
 ====
 +
-* Calls the Jaeger Operator to create Jaeger components based on configuration in either the SMCP or the Jaeger custom resource.
+* Calls the {JaegerName} Operator to create {JaegerShortName} components based on configuration in either the SMCP or the Jaeger custom resource.
 +
 [NOTE]
 ====
-You view the Jaeger components under the Jaeger Operator and the Elasticsearch components under the Elasticsearch Operator, not the {ProductShortName} Operator.
+You view the Jaeger components under the {JaegerName} Operator and the Elasticsearch components under the Elasticsearch Operator, not the {ProductShortName} Operator.
 ====
 +
 .From the {product-title} console

--- a/modules/ossm-vs-istio.adoc
+++ b/modules/ossm-vs-istio.adoc
@@ -73,7 +73,7 @@ spec:
 
 * A _maistra-version_ label has been added to all resources.
 * All Ingress resources have been converted to OpenShift Route resources.
-* Grafana, Tracing (Jaeger), and Kiali are enabled by default and exposed through OpenShift routes.
+* Grafana, distributed tracing (Jaeger), and Kiali are enabled by default and exposed through OpenShift routes.
 * Godebug has been removed from all templates
 * The `istio-multi` ServiceAccount and ClusterRoleBinding have been removed, as well as the `istio-reader` ClusterRole.
 
@@ -92,7 +92,7 @@ spec:
 
 OpenShift routes for Istio Gateways are automatically managed in {ProductName}. Every time an Istio Gateway is created, updated or deleted inside the service mesh, an OpenShift route is created, updated or deleted.
 
-A {ProductName} control plane component called Istio OpenShift Routing (IOR) synchronizes the gateway route.  For more information, see Automatic route creation.
+A {ProductName} control plane component called Istio OpenShift Routing (IOR) synchronizes the gateway route. For more information, see Automatic route creation.
 
 [id="ossm-catch-all-domains_{context}"]
 === Catch-all domains
@@ -110,4 +110,4 @@ Transport Layer Security (TLS) is supported. This means that, if the Gateway con
 [id="ossm-wasm_{context}"]
 === WebAssembly Extensions
 
-{ProductName} 2.0 introduces WebAssembly extensions to Envoy Proxy as a link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview].  Note that WASM extensions are not included in the proxy binary and that WASM filters from the upstream Istio community are not supported in {ProductName} 2.0.
+{ProductName} 2.0 introduces WebAssembly extensions to Envoy Proxy as a link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview]. Note that WASM extensions are not included in the proxy binary and that WASM filters from the upstream Istio community are not supported in {ProductName} 2.0.

--- a/service_mesh/v2x/ossm-architecture.adoc
+++ b/service_mesh/v2x/ossm-architecture.adoc
@@ -24,25 +24,24 @@ include::modules/ossm-kiali-architecture.adoc[leveloffset=+2]
 
 include::modules/ossm-kiali-features.adoc[leveloffset=+2]
 
-== Understanding Jaeger
+== Understanding distributed tracing
 
 Every time a user takes an action in an application, a request is executed by the architecture that may require dozens of different services to participate to produce a response.
-The path of this request is a distributed transaction.
-Jaeger lets you perform distributed tracing, which follows the path of a request through various microservices that make up an application.
+The path of this request is a distributed transaction. The {JaegerShortName} lets you perform distributed tracing, which follows the path of a request through various microservices that make up an application.
 
 *Distributed tracing* is a technique that is used to tie the information about different units of work together—usually executed in different processes or hosts—to understand a whole chain of events in a distributed transaction.
 Distributed tracing lets developers visualize call flows in large service oriented architectures.
 It can be invaluable in understanding serialization, parallelism, and sources of latency.
 
-Jaeger records the execution of individual requests across the whole stack of microservices, and presents them as traces. A *trace* is a data/execution path through the system. An end-to-end trace comprises one or more spans.
+The {JaegerShortName} records the execution of individual requests across the whole stack of microservices, and presents them as traces. A *trace* is a data/execution path through the system. An end-to-end trace comprises one or more spans.
 
-A *span* represents a logical unit of work in Jaeger that has an operation name, the start time of the operation, and the duration. Spans may be nested and ordered to model causal relationships.
+A *span* represents a logical unit of work that has an operation name, the start time of the operation, and the duration. Spans may be nested and ordered to model causal relationships.
 
 include::modules/jaeger-product-overview.adoc[leveloffset=+2]
 
 include::modules/jaeger-architecture.adoc[leveloffset=+2]
 
-include::modules/jaeger-features.adoc[leveloffset=+2]
+include::modules/distr-tracing-features.adoc[leveloffset=+2]
 
 == Next steps
 

--- a/service_mesh/v2x/ossm-distr-tracing.adoc
+++ b/service_mesh/v2x/ossm-distr-tracing.adoc
@@ -6,9 +6,12 @@ include::_attributes/ossm-document-attributes.adoc[]
 
 toc::[]
 
+#DRAFT ASSEMBLY - Not currently listed on the Topic Map#
+//All of this content currently resides in the Observability Assembly
+
 Distributed Tracing is the process of tracking the performance of individual services in an application by tracing the path of the service calls in the application. Each time a user takes action in an application, a request is executed that might require many services to interact to produce a response. The path of this request is called a distributed transaction.
 
-As a developer, you can use Jaeger to visualize call flows in a microservice application with {ProductName}.
+As a developer, you can use the {JaegerShortName} to visualize call flows in a microservice application with {ProductName}.
 
 include::modules/ossm-config-sampling.adoc[leveloffset=+1]
 

--- a/service_mesh/v2x/ossm-observability.adoc
+++ b/service_mesh/v2x/ossm-observability.adoc
@@ -22,6 +22,8 @@ include::modules/ossm-distr-tracing.adoc[leveloffset=+1]
 
 include::modules/ossm-config-external-jaeger.adoc[leveloffset=+2]
 
+include::modules/ossm-config-sampling.adoc[leveloffset=+2]
+
 include::modules/ossm-jaeger-accessing-console.adoc[leveloffset=+1]
 
 For more information about configuring Jaeger, see the xref:../../distr_tracing/distr_tracing_install/distr-tracing-deploying-jaeger.adoc#distr-tracing-deploy-default_deploying-distributed-tracing-platform[distributed tracing documentation].

--- a/service_mesh/v2x/ossm-reference-jaeger.adoc
+++ b/service_mesh/v2x/ossm-reference-jaeger.adoc
@@ -16,20 +16,20 @@ include::modules/ossm-deploying-jaeger.adoc[leveloffset=+1]
 
 include::modules/ossm-configuring-external-jaeger.adoc[leveloffset=+1]
 
-include::modules/jaeger-deployment-best-practices.adoc[leveloffset=+2]
+include::modules/distr-tracing-deployment-best-practices.adoc[leveloffset=+2]
 
-include::modules/jaeger-config-default.adoc[leveloffset=+2]
+include::modules/distr-tracing-config-default.adoc[leveloffset=+2]
 
-include::modules/jaeger-config-collector.adoc[leveloffset=+2]
+include::modules/distr-tracing-config-jaeger-collector.adoc[leveloffset=+2]
 
-include::modules/jaeger-config-sampling.adoc[leveloffset=+2]
+include::modules/distr-tracing-config-sampling.adoc[leveloffset=+2]
 
-include::modules/jaeger-config-storage.adoc[leveloffset=+2]
+include::modules/distr-tracing-config-storage.adoc[leveloffset=+2]
 
 For more information about configuring Elasticsearch with {product-title}, see xref:../../logging/config/cluster-logging-log-store.adoc[Configuring the log store] or xref:../../distr_tracing/distr_tracing_install/distr-tracing-deploying-jaeger.adoc[Configuring and deploying distributed tracing].
 
 //TO DO For information about connecting to an external Elasticsearch instance, see xref:../../distr_tracing/distr_tracing_install/distr-tracing-deploying-jaeger.adoc#jaeger-config-external-es_jaeger-deploying[Connecting to an existing Elasticsearch instance].
 
-include::modules/jaeger-config-query.adoc[leveloffset=+2]
+include::modules/distr-tracing-config-query.adoc[leveloffset=+2]
 
-include::modules/jaeger-config-ingester.adoc[leveloffset=+2]
+include::modules/distr-tracing-config-ingester.adoc[leveloffset=+2]


### PR DESCRIPTION
This PR updates the service mesh docs for the rebranding of Jaeger to distributed tracing.
* Updates the Architecture assembly to point to the distributed tracing modules.  Preview available here -> https://deploy-preview-40980--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-architecture.html
* Updates the Configuration Reference to point to the distributed tracing modules.  Preview available here -> https://deploy-preview-40980--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-reference-jaeger.html
* Adds the Adjusting the sampling rate topic to the Observability assembly (and marks the distributed tracing assembly as an unused DRAFT for now).  Preview available here -> https://deploy-preview-40980--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-observability.html
* Adds variables where the word "Jaeger" refers to the Operator or to the distributed tracing platform (that is, Jaeger as a whole).
* Adds the Accessing the Jaeger Console topic to two distributed tracing deployment assemblies.

Work that was NOT included in this PR:
* Does not change the word "Jaeger/jaeger" where it refers to the Jaeger custom resource or Jaeger configuration options.
* Architecture topic NOT updated as OpenTelemetry is not yet supported on service mesh.
* Configuration topics that are specific to Service Mesh (vs standalone Jaeger) were left unchanged.

Work that was previously done in #39643:
* New variables were added to the document attributes file.
* Cross-references to the Jaeger docs were updated to point to distributed tracing.

PM review - Maltron
Eng review - pavolloffay
QE review - iblancasa, jkandasa
Peer review - lpettyjo