### PR TITLE
RHDEVDOCS-3546 - Added environment and health check details

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1489,6 +1489,8 @@ Topics:
     File: configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations
   - Name: Deploying a Spring Boot application with Argo CD
     File: deploying-a-spring-boot-application-with-argo-cd
+  - Name: Monitoring application health status
+    File: health-information-for-resources-deploment 
   - Name: Configuring SSO for Argo CD using Dex
     File: configuring-sso-on-argo-cd-using-dex
   - Name: Configuring SSO for Argo CD using Keycloak

--- a/cicd/gitops/health-information-for-resources-deploment.adoc
+++ b/cicd/gitops/health-information-for-resources-deploment.adoc
@@ -1,11 +1,11 @@
 include::modules/gitops-document-attributes.adoc[]
 [id="health-information-for-resources-deploments"]
-= Monitoring health information for application reources and deployments
+= Monitoring health information for application resources and deployments
 :context: health-information-for-resources-deploment
 include::modules/common-attributes.adoc[]
 
 toc::[]
 
-The environment details page in the dev console displays the health status of the resources, such as routes, sync status, deployment config, deployment history.
+The environment details page displays the health status of the application resources, such as routes, synchronization status, deployment configuration and deployment history.
 
 include::modules/go-health-monitoring.adoc[leveloffset=+1]

--- a/cicd/gitops/health-information-for-resources-deploment.adoc
+++ b/cicd/gitops/health-information-for-resources-deploment.adoc
@@ -1,0 +1,11 @@
+include::modules/gitops-document-attributes.adoc[]
+[id="health-information-for-resources-deploments"]
+= Monitoring health information for application reources and deployments
+:context: health-information-for-resources-deploment
+include::modules/common-attributes.adoc[]
+
+toc::[]
+
+The environment details page in the dev console displays the health status of the resources, such as routes, sync status, deployment config, deployment history.
+
+include::modules/go-health-monitoring.adoc[leveloffset=+1]

--- a/modules/go-health-monitoring.adoc
+++ b/modules/go-health-monitoring.adoc
@@ -1,19 +1,22 @@
 [id="health-information-resources_{context}"]
 = Checking health information
 
+The {gitops-title} Operator will install the GitOps backend service in the `openshift-gitops` namespace.
+
 .Prerequisites
 
-* {gitops-title} Operator installed from *OperatorHub*.
+* The {gitops-title} Operator is installed from *OperatorHub*.
 * Argo CD applications are in sync.
 
 .Procedure
 
-* The Operator will install the backend service in `openshift-gitops` namespace. Click *Environments* under the *Developer* perspective. 
+. Click *Environments* under the *Developer* perspective. The *Environments* page shows the list of applications along with their *Environment status*.
 
-*  The *Environments* page shows the list of applications along with their *Environment status*.
+. Hover over the icons under the *Environment status* column to see the synchronization status of all the environments.
 
-* Hover over the icons under the *Environment status* column to see the sync status of all the environments.
+. Click on the application to view the details of the application.
 
-* Click on the application to view the details of the application.
+. If the application is `out of sync` or `degraded` applications the respecting icons are displayed under the *Resources*. Hover over the icons to see the health status and the sync status. The icons are:
 
-* If the application is out of sync or not healthy the corresponding icon is displayed under *Resources*. Hover over the icons to see the health status and the sync status. 
+.. For `degraded`, the broken heart icon is displayed.
+.. For `out of sync`, the yellow yield icon is displayed.

--- a/modules/go-health-monitoring.adoc
+++ b/modules/go-health-monitoring.adoc
@@ -14,7 +14,7 @@ The {gitops-title} Operator will install the GitOps backend service in the `open
 
 . Hover over the icons under the *Environment status* column to see the synchronization status of all the environments.
 
-. Click on the application to view the details of the application.
+. Click on the application name from the list to view the details of a specific application.
 
 . If the application is `out of sync` or `degraded` applications the respecting icons are displayed under the *Resources*. Hover over the icons to see the health status and the sync status. The icons are:
 

--- a/modules/go-health-monitoring.adoc
+++ b/modules/go-health-monitoring.adoc
@@ -1,0 +1,19 @@
+[id="health-information-resources_{context}"]
+= Checking health information
+
+.Prerequisites
+
+* {gitops-title} Operator installed from *OperatorHub*.
+* Argo CD applications are in sync.
+
+.Procedure
+
+* The Operator will install the backend service in `openshift-gitops` namespace. Click *Environments* under the *Developer* perspective. 
+
+*  The *Environments* page shows the list of applications along with their *Environment status*.
+
+* Hover over the icons under the *Environment status* column to see the sync status of all the environments.
+
+* Click on the application to view the details of the application.
+
+* If the application is out of sync or not healthy the corresponding icon is displayed under *Resources*. Hover over the icons to see the health status and the sync status. 


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.8, enterprise-4.9
JIRA issues: https://issues.redhat.com/browse/RHDEVDOCS-3546

Preview pages: https://deploy-preview-40988--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/health-information-for-resources-deploment.html

SME+QE review:

Peer-review: