### PR TITLE
BZ1965154: Removed CSI version support

### DIFF
--- a/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
@@ -95,7 +95,7 @@ For more information, see xref:../storage/persistent_storage/persistent-storage-
 [discrete]
 ==== Container Storage Interface (CSI) persistent storage
 
-Persistent storage using the Container Storage Interface (CSI) was link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] in {product-title} 3.11. {product-title} {product-version} fully supports CSI version 1.1.0 and ships with xref:../storage/container_storage_interface/persistent-storage-csi.adoc#csi-drivers-supported_persistent-storage-csi[several CSI drivers]. You can also install your own driver.
+Persistent storage using the Container Storage Interface (CSI) was link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] in {product-title} 3.11. {product-title} {product-version} ships with xref:../storage/container_storage_interface/persistent-storage-csi.adoc#csi-drivers-supported_persistent-storage-csi[several CSI drivers]. You can also install your own driver.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-using-csi[Persistent storage using the Container Storage Interface (CSI)].
 


### PR DESCRIPTION
[BZ2023197](https://bugzilla.redhat.com/show_bug.cgi?id=2023197) will add the CSI spec version for each version (from 4.6 onward) in [Configuring CSI volumes](https://docs.openshift.com/container-platform/4.9/storage/container_storage_interface/persistent-storage-csi.html) assembly. So removed CSI version support in Storage migration considerations. 

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1965154

OCP version: 4.6 +

Direct Doc Preview Link: https://deploy-preview-40989--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/planning-migration-3-4.html#migration-preparing-storage

@duanwei33 Please review and let me know your feedback.
