### PR TITLE
BZ2036297: Updated storage class name object and added callout

### DIFF
--- a/modules/dynamic-provisioning-aws-definition.adoc
+++ b/modules/dynamic-provisioning-aws-definition.adoc
@@ -12,33 +12,34 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: slow
+  name: <storage-class-name> <1>
 provisioner: kubernetes.io/aws-ebs
 parameters:
-  type: io1 <1>
-  iopsPerGB: "10" <2>
-  encrypted: "true" <3>
-  kmsKeyId: keyvalue <4>
-  fsType: ext4 <5>
+  type: io1 <2>
+  iopsPerGB: "10" <3>
+  encrypted: "true" <4>
+  kmsKeyId: keyvalue <5>
+  fsType: ext4 <6>
 ----
-<1> (required) Select from `io1`, `gp2`, `sc1`, `st1`. The default is `gp2`.
+<1> (required) Name of the storage class. The persistent volume claim uses this storage class for provisioning the associated persistent volumes.
+<2> (required) Select from `io1`, `gp2`, `sc1`, `st1`. The default is `gp2`.
 See the
 link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation]
 for valid Amazon Resource Name (ARN) values.
-<2> Optional: Only for *io1* volumes. I/O operations per second per GiB.
+<3> Optional: Only for *io1* volumes. I/O operations per second per GiB.
 The AWS volume plug-in multiplies this with the size of the requested
 volume to compute IOPS of the volume. The value cap is 20,000 IOPS, which
 is the maximum supported by AWS. See the
 link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation]
 for further details.
-<3> Optional: Denotes whether to encrypt the EBS volume. Valid values
+<4> Optional: Denotes whether to encrypt the EBS volume. Valid values
 are `true` or `false`.
-<4> Optional: The full ARN of the key to use when encrypting the volume.
+<5> Optional: The full ARN of the key to use when encrypting the volume.
 If none is supplied, but `encypted` is set to `true`, then AWS generates a
 key. See the
 link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation]
 for a valid ARN value.
-<5> Optional: File system that is created on dynamically provisioned
+<6> Optional: File system that is created on dynamically provisioned
 volumes. This value is copied to the `fsType` field of dynamically
 provisioned persistent volumes and the file system is created when the
 volume is mounted for the first time. The default value is `ext4`.

--- a/modules/dynamic-provisioning-azure-disk-definition.adoc
+++ b/modules/dynamic-provisioning-azure-disk-definition.adoc
@@ -12,17 +12,18 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: managed-premium
+  name: <storage-class-name> <1>
 provisioner: kubernetes.io/azure-disk
-volumeBindingMode: WaitForFirstConsumer <1>
+volumeBindingMode: WaitForFirstConsumer <2>
 allowVolumeExpansion: true
 parameters:
-  kind: Managed <2>
-  storageaccounttype: Premium_LRS <3>
+  kind: Managed <3>
+  storageaccounttype: Premium_LRS <4>
 reclaimPolicy: Delete
 ----
-<1> Using `WaitForFirstConsumer` is strongly recommended. This provisions the volume while allowing enough storage to schedule the pod on a free worker node from an available zone.
-<2> Possible values are `Shared` (default), `Managed`, and `Dedicated`.
+<1> Name of the storage class. The persistent volume claim uses this storage class for provisioning the associated persistent volumes.
+<2> Using `WaitForFirstConsumer` is strongly recommended. This provisions the volume while allowing enough storage to schedule the pod on a free worker node from an available zone.
+<3> Possible values are `Shared` (default), `Managed`, and `Dedicated`.
 +
 [IMPORTANT]
 ====
@@ -31,7 +32,7 @@ Red Hat only supports the use of `kind: Managed` in the storage class.
 With `Shared` and `Dedicated`, Azure creates unmanaged disks, while {product-title} creates a managed disk for machine OS (root) disks. But because Azure Disk does not allow the use of both managed and unmanaged disks on a node, unmanaged disks created with `Shared` or `Dedicated` cannot be attached to {product-title} nodes.
 ====
 
-<3> Azure storage account SKU tier. Default is empty. Note that Premium VMs can attach both `Standard_LRS` and `Premium_LRS` disks, Standard VMs can only attach `Standard_LRS` disks, Managed VMs can only attach managed disks, and unmanaged VMs can only attach unmanaged disks.
+<4> Azure storage account SKU tier. Default is empty. Note that Premium VMs can attach both `Standard_LRS` and `Premium_LRS` disks, Standard VMs can only attach `Standard_LRS` disks, Managed VMs can only attach managed disks, and unmanaged VMs can only attach unmanaged disks.
 +
 .. If `kind` is set to `Shared`, Azure creates all unmanaged disks in a few shared storage accounts in the same resource group as the cluster.
 .. If `kind` is set to `Managed`, Azure creates new managed disks.

--- a/modules/dynamic-provisioning-cinder-definition.adoc
+++ b/modules/dynamic-provisioning-cinder-definition.adoc
@@ -12,18 +12,19 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: gold
+  name: <storage-class-name> <1>
 provisioner: kubernetes.io/cinder
 parameters:
-  type: fast  <1>
-  availability: nova <2>
-  fsType: ext4 <3>
+  type: fast  <2>
+  availability: nova <3>
+  fsType: ext4 <4>
 ----
-<1> Volume type created in Cinder. Default is empty.
-<2> Availability Zone. If not specified, volumes are generally
+<1> Name of the storage class. The persistent volume claim uses this storage class for provisioning the associated persistent volumes.
+<2> Volume type created in Cinder. Default is empty.
+<3> Availability Zone. If not specified, volumes are generally
 round-robined across all active zones where the {product-title} cluster
 has a node.
-<3> File system that is created on dynamically provisioned volumes. This
+<4> File system that is created on dynamically provisioned volumes. This
 value is copied to the `fsType` field of dynamically provisioned
 persistent volumes and the file system is created when the volume is
 mounted for the first time. The default value is `ext4`.

--- a/modules/dynamic-provisioning-gce-definition.adoc
+++ b/modules/dynamic-provisioning-gce-definition.adoc
@@ -12,13 +12,14 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: standard
+  name: <storage-class-name> <1>
 provisioner: kubernetes.io/gce-pd
 parameters:
-  type: pd-standard <1>
+  type: pd-standard <2>
   replication-type: none
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 ----
-<1> Select either `pd-standard` or `pd-ssd`. The default is `pd-standard`.
+<1> Name of the storage class. The persistent volume claim uses this storage class for provisioning the associated persistent volumes.
+<2> Select either `pd-standard` or `pd-ssd`. The default is `pd-standard`.

--- a/modules/dynamic-provisioning-storage-class-definition.adoc
+++ b/modules/dynamic-provisioning-storage-class-definition.adoc
@@ -17,7 +17,7 @@ ElasticBlockStore (EBS) object definition.
 kind: StorageClass <1>
 apiVersion: storage.k8s.io/v1 <2>
 metadata:
-  name: gp2 <3>
+  name: <storage-class-name> <3>
   annotations: <4>
     storageclass.kubernetes.io/is-default-class: 'true'
     ...

--- a/modules/dynamic-provisioning-vsphere-definition.adoc
+++ b/modules/dynamic-provisioning-vsphere-definition.adoc
@@ -13,14 +13,15 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: slow
-provisioner: kubernetes.io/vsphere-volume <1>
+  name: <storage-class-name> <1>
+provisioner: kubernetes.io/vsphere-volume <2>
 parameters:
-  diskformat: thin <2>
+  diskformat: thin <3>
 ----
-<1> For more information about using VMware vSphere with {product-title},
+<1> Name of the storage class. The persistent volume claim uses this storage class for provisioning the associated persistent volumes.
+<2> For more information about using VMware vSphere with {product-title},
 see the
 link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/index.html[VMware vSphere documentation].
-<2>  `diskformat`: `thin`, `zeroedthick` and `eagerzeroedthick` are all
+<3>  `diskformat`: `thin`, `zeroedthick` and `eagerzeroedthick` are all
 valid disk formats. See vSphere docs for additional details regarding the
 disk format types. The default value is `thin`.


### PR DESCRIPTION
 Updated storage class `name` object and added callout to RHSOP, Azure, AWS, GCP, and vsphere object definitions.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2036297

OCP version: 4.6+

Direct Doc Preview Link:
https://deploy-preview-40990--osdocs.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html#openstack-cinder-storage-class_dynamic-provisioning

https://deploy-preview-40990--osdocs.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html#aws-definition_dynamic-provisioning

https://deploy-preview-40990--osdocs.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html#azure-disk-definition_dynamic-provisioning

https://deploy-preview-40990--osdocs.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html#gce-persistentdisk-storage-class_dynamic-provisioning

https://deploy-preview-40990--osdocs.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html#vsphere-definition_dynamic-provisioning

https://deploy-preview-40990--osdocs.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html#basic-storage-class-definition_dynamic-provisioning
 
@duanwei33 Please review and let me know your feedback