### PR TITLE
BZ1906725: Added an assembly for managing CLI profiles from 3.11

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -562,6 +562,8 @@ Topics:
     File: getting-started-cli
   - Name: Configuring the OpenShift CLI
     File: configuring-cli
+  - Name: Managing CLI profiles
+    File: managing-cli-profiles  
   - Name: Extending the OpenShift CLI with plug-ins
     File: extending-cli-plugins
     Distros: openshift-enterprise,openshift-origin

--- a/cli_reference/openshift_cli/managing-cli-profiles.adoc
+++ b/cli_reference/openshift_cli/managing-cli-profiles.adoc
@@ -1,0 +1,15 @@
+:_content-type: ASSEMBLY
+[id="managing-cli-profiles"]
+= Managing CLI profiles
+include::modules/common-attributes.adoc[]
+:context: managing-cli-profiles
+
+toc::[]
+
+A CLI configuration file allows you to configure different profiles, or contexts, for use with the xref:../../cli_reference/index.adoc#cli-tools-overview[CLI tools overview]. A context consists of xref:../../authentication/understanding-authentication.adoc#understanding-authentication[user authentication] and {product-title} server information associated with a _nickname_.
+
+include::modules/about-cli-profiles-switch.adoc[leveloffset=+1]
+
+include::modules/manual-configuration-of-cli-profiles.adoc[leveloffset=+1]
+
+include::modules/load-and-merge-rules.adoc[leveloffset=+1]

--- a/modules/about-cli-profiles-switch.adoc
+++ b/modules/about-cli-profiles-switch.adoc
@@ -1,0 +1,114 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/openshift_cli/managing-cli-profiles.adoc
+
+:_content-type: CONCEPT
+[id="about-switches-between-cli-profiles_{context}"]
+= About switches between CLI profiles
+
+Contexts allow you to easily switch between multiple users across multiple {product-title} servers, or clusters, when using CLI operations. Nicknames make managing CLI configurations easier by providing short-hand references to contexts, user credentials, and cluster details.
+After logging in with the CLI for the first time, {product-title} creates a `~/.kube/config` file if one does not already exist. As more authentication and connection details are provided to the CLI, either automatically during an `oc login` operation or by manually configuring CLI profiles, the updated information is stored in the configuration file:
+
+.CLI config file
+
+[source,yaml]
+----
+apiVersion: v1
+clusters: <1>
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://openshift1.example.com:8443
+  name: openshift1.example.com:8443
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://openshift2.example.com:8443
+  name: openshift2.example.com:8443
+contexts: <2>
+- context:
+    cluster: openshift1.example.com:8443
+    namespace: alice-project
+    user: alice/openshift1.example.com:8443
+  name: alice-project/openshift1.example.com:8443/alice
+- context:
+    cluster: openshift1.example.com:8443
+    namespace: joe-project
+    user: alice/openshift1.example.com:8443
+  name: joe-project/openshift1/alice
+current-context: joe-project/openshift1.example.com:8443/alice <3>
+kind: Config
+preferences: {}
+users: <4>
+- name: alice/openshift1.example.com:8443
+  user:
+    token: xZHd2piv5_9vQrg-SKXRJ2Dsl9SceNJdhNTljEKTb8k
+----
+
+<1> The `clusters` section defines connection details for {product-title} clusters, including the address for their master server. In this example, one cluster is nicknamed `openshift1.example.com:8443` and another is nicknamed `openshift2.example.com:8443`.
+<2> This `contexts` section defines two contexts: one nicknamed `alice-project/openshift1.example.com:8443/alice`, using the `alice-project` project, `openshift1.example.com:8443` cluster, and `alice` user, and another nicknamed `joe-project/openshift1.example.com:8443/alice`, using the `joe-project` project, `openshift1.example.com:8443` cluster and `alice` user.
+<3> The `current-context` parameter shows that the `joe-project/openshift1.example.com:8443/alice` context is currently in use, allowing the `alice` user to work in the `joe-project` project on the `openshift1.example.com:8443` cluster.
+<4> The `users` section defines user credentials. In this example, the user nickname `alice/openshift1.example.com:8443` uses an access token.
+
+The CLI can support multiple configuration files which are loaded at runtime and merged together along with any override options specified from the command line. After you are logged in, you can use the `oc status` or `oc project` command to verify your current working environment:
+
+.Verify the current working environment
+
+[source,terminal,options="nowrap"]
+----
+$ oc status
+----
+
+.Example output
+[source,terminal]
+----
+oc status
+In project Joe's Project (joe-project)
+
+service database (172.30.43.12:5434 -> 3306)
+  database deploys docker.io/openshift/mysql-55-centos7:latest
+    #1 deployed 25 minutes ago - 1 pod
+
+service frontend (172.30.159.137:5432 -> 8080)
+  frontend deploys origin-ruby-sample:latest <-
+    builds https://github.com/openshift/ruby-hello-world with joe-project/ruby-20-centos7:latest
+    #1 deployed 22 minutes ago - 2 pods
+
+To see more information about a service or deployment, use 'oc describe service <name>' or 'oc describe dc <name>'.
+You can use 'oc get all' to see lists of each of the types described in this example.
+----
+
+.List the current project
+[source,terminal,options="nowrap"]
+----
+$ oc project
+----
+
+.Example output
+[source,terminal]
+----
+Using project "joe-project" from context named "joe-project/openshift1.example.com:8443/alice" on server "https://openshift1.example.com:8443".
+----
+
+You can run the `oc login` command again and supply the required information during the interactive process, to log in using any other combination of user credentials and cluster details. A context is constructed based on the supplied information if one does not already exist. If you are already logged in and want to switch to another project the current user already has access to, use the `oc project` command and enter the name of the project:
+
+[source,terminal,options="nowrap"]
+----
+$ oc project alice-project
+----
+
+.Example output
+[source,terminal]
+----
+Now using project "alice-project" on server "https://openshift1.example.com:8443".
+----
+
+At any time, you can use the `oc config view` command to view your current CLI configuration, as seen in the output. Additional CLI configuration commands are also available for more advanced usage.
+
+[NOTE]
+====
+If you have access to administrator credentials but are no longer logged in as the default system user `system:admin`, you can log back in as this user at any time as long as the credentials are still present in your CLI config file. The following command logs in and switches to the default project:
+
+[source,terminal]
+----
+$ oc login -u system:admin -n default
+----
+====

--- a/modules/load-and-merge-rules.adoc
+++ b/modules/load-and-merge-rules.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/openshift_cli/managing-cli-profiles.adoc
+
+:_content-type: CONCEPT
+[id="load-and-merge-rules_{context}"]
+= Load and merge rules
+
+You can follow these rules, when issuing CLI operations for the loading and merging order for the CLI configuration:
+
+* CLI config files are retrieved from your workstation, using the following hierarchy and merge rules:
+
+** If the `--config` option is set, then only that file is loaded. The flag is set once and no merging takes place.
+** If the `$KUBECONFIG` environment variable is set, then it is used. The variable can be a list of paths, and if so the paths are merged together. When a value is modified, it is modified in the file that defines the stanza. When a value is created, it is created in the first file that exists. If no files in the chain exist, then it creates the last file in the list.
+** Otherwise, the `_~/.kube/config_` file is used and no merging takes place.
+
+* The context to use is determined based on the first match in the following flow:
+
+** The value of the `--context` option.
+** The `current-context` value from the CLI config file.
+** An empty value is allowed at this stage.
+
+* The user and cluster to use is determined. At this point, you may or may not have a context; they are built based on the first match in the following flow, which is run once for the user and once for the cluster:
+** The value of the `--user` for user name and  `--cluster` option for
+cluster name.
+** If the `--context` option is present, then use the context's value.
+** An empty value is allowed at this stage.
+* The actual cluster information to use is determined. At this point, you may or may not have cluster information. Each piece of the cluster information is built based on the first match in the following flow:
+** The values of any of the following command line options:
+*** `--server`,
+*** `--api-version`
+*** `--certificate-authority`
+*** `--insecure-skip-tls-verify`
+** If cluster information and a value for the attribute is present, then use it.
+** If you do not have a server location, then there is an error.
+* The actual user information to use is determined. Users are built using the same rules as clusters, except that you can only have one authentication technique per user; conflicting techniques cause the operation to fail. Command line options take precedence over config file values. Valid command line options are:
+** `--auth-path`
+** `--client-certificate`
+** `--client-key`
+** `--token`
+* For any information that is still missing, default values are used and prompts are given for additional information.

--- a/modules/manual-configuration-of-cli-profiles.adoc
+++ b/modules/manual-configuration-of-cli-profiles.adoc
@@ -1,0 +1,133 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/openshift_cli/managing-cli-profiles.adoc
+
+:_content-type: CONCEPT
+[id="manual-configuration-of-cli-profiles_{context}"]
+= Manual configuration of CLI profiles
+
+[NOTE]
+====
+This section covers more advanced usage of CLI configurations. In most situations, you can use the `oc login` and `oc project` commands to log in and switch between contexts and projects.
+====
+
+If you want to manually configure your CLI config files, you can use the `oc config` command instead of directly modifying the files. The `oc config` command includes a number of helpful sub-commands for this purpose:
+
+.CLI configuration subcommands
+[cols="1,8",options="header"]
+|===
+
+|Subcommand |Usage
+
+a|`set-cluster`
+a|Sets a cluster entry in the CLI config file. If the referenced cluster
+nickname already exists, the specified information is merged in.
+[source,terminal,options="nowrap"]
+----
+$ oc config set-cluster <cluster_nickname> [--server=<master_ip_or_fqdn>]
+[--certificate-authority=<path/to/certificate/authority>]
+[--api-version=<apiversion>] [--insecure-skip-tls-verify=true]
+----
+
+a|`set-context`
+a|Sets a context entry in the CLI config file. If the referenced context
+nickname already exists, the specified information is merged in.
+[source,terminal,options="nowrap"]
+----
+$ oc config set-context <context_nickname> [--cluster=<cluster_nickname>]
+[--user=<user_nickname>] [--namespace=<namespace>]
+----
+
+a|`use-context`
+a|Sets the current context using the specified context nickname.
+[source,terminal,options="nowrap"]
+----
+$ oc config use-context <context_nickname>
+----
+
+a|`set`
+a|Sets an individual value in the CLI config file.
+[source,terminal,options="nowrap"]
+----
+$ oc config set <property_name> <property_value>
+----
+The `<property_name>` is a dot-delimited name where each token represents either an attribute name or a map key. The `<property_value>` is the new value being set.
+
+a|`unset`
+a|Unsets individual values in the CLI config file.
+[source,terminal,options="nowrap"]
+----
+$ oc config unset <property_name>
+----
+The `<property_name>` is a dot-delimited name where each token represents either an attribute name or a map key.
+
+a|`view`
+a|Displays the merged CLI configuration currently in use.
+[source,terminal,options="nowrap"]
+----
+$ oc config view
+----
+
+Displays the result of the specified CLI config file.
+[source,terminal,options="nowrap"]
+----
+$ oc config view --config=<specific_filename>
+----
+|===
+
+.Example usage
+
+* Log in as a user that uses an access token.
+This token is used by the `alice` user:
+
+[source,terminal,options="nowrap"]
+----
+$ oc login https://openshift1.example.com --token=ns7yVhuRNpDM9cgzfhhxQ7bM5s7N2ZVrkZepSRf4LC0
+----
+
+* View the cluster entry automatically created:
+
+[source,terminal,options="nowrap"]
+----
+$ oc config view
+----
+
+.Example output
+[source,terminal]
+----
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://openshift1.example.com
+  name: openshift1-example-com
+contexts:
+- context:
+    cluster: openshift1-example-com
+    namespace: default
+    user: alice/openshift1-example-com
+  name: default/openshift1-example-com/alice
+current-context: default/openshift1-example-com/alice
+kind: Config
+preferences: {}
+users:
+- name: alice/openshift1.example.com
+  user:
+    token: ns7yVhuRNpDM9cgzfhhxQ7bM5s7N2ZVrkZepSRf4LC0
+----
+
+* Update the current context to have users log in to the desired namespace:
+
+[source,terminal]
+----
+$ oc config set-context `oc config current-context` --namespace=<project_name>
+----
+
+* Examine the current context, to confirm that the changes are implemented:
+
+[source,terminal]
+----
+$ oc whoami -c
+----
+
+All subsequent CLI operations uses the new context, unless otherwise specified by overriding CLI options or until the context is switched.


### PR DESCRIPTION
- Applies to 4.6+ versions
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1906725)
- [Preview](https://deploy-preview-40994--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/managing-cli-profiles.html)
- @kasturinarra ptal