### PR TITLE
document an internal api annotation for CRDs

### DIFF
--- a/modules/api-support-tiers.adoc
+++ b/modules/api-support-tiers.adoc
@@ -30,3 +30,5 @@ Components and developer tools that receive continuous updates through the Opera
 No compatibility is provided. API and AOE can change at any point. These capabilities should not be used by applications needing long-term support.
 
 It is common practice for Operators to use custom resource definitions (CRDs) internally to accomplish a task.  These objects are not meant for use by actors external to the Operator and are intended to be hidden.  If any CRD is not meant for use by actors external to the Operator, the `operators.operatorframework.io/internal-objects` annotation in the Operators `ClusterServiceVersion` (CSV) must be specified, and that signals that the corresponding resource is internal use only.
+
+In addition, any CRD annotated with the key `internal.api.openshift.io` and value `true` is in this category, regardless of its group, version, or other tier category characteristics it may share.


### PR DESCRIPTION
The CSV annotation for olm operators:
1) only works for olm operators, not SLO operators
2) only translates into some console behavior, nothing is reflected on the CRD to warn a cli/api user that they should not consume this api directly.

So this PR proposes a mechanism that any CRD (whether owned by an olm operator or a CVO/SLO operator) can leverage.
