### PR TITLE
Shared VPC support is intended for GCP

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -293,8 +293,8 @@ endif::openshift-origin[]
 |Shared VPC hosted outside of cluster project
 |
 |
-|xref:../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[X]
 |
+|xref:../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[X]
 |
 |
 |


### PR DESCRIPTION
This shifts the support mark for shared VPC back to GCP UPI (was incorrectly marked for ASH UPI). See the current live docs for the mistake: https://docs.openshift.com/container-platform/4.9/installing/installing-preparing.html#supported-installation-methods-for-different-platforms

Fix preview: https://deploy-preview-41019--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#supported-installation-methods-for-different-platforms