### PR TITLE
Direct Access to Monitoring Service API

### DIFF
--- a/monitoring/accessing-third-party-service-apis.adoc
+++ b/monitoring/accessing-third-party-service-apis.adoc
@@ -1,0 +1,23 @@
+[id="accessing-third-party-service-apis"]
+= Accessing third-party Service APIs
+include::modules/common-attributes.adoc[]
+:context: accessing-third-party-service-apis
+
+toc::[]
+
+{product-title} provides direct access to third-party web service APIs for components in the Monitoring stack, such as Prometheus, Alertmanager, or Thanos Querier, using a Bearer Token for authentification.
+
+For example, the code snippet below queries the service API "receivers" of AlertManager.
+
+```shell
+host=$(oc -n openshift-monitoring get route alertmanager-main -ojsonpath={.spec.host})
+token=$(oc whoami -t)
+curl -H "Authorization: Bearer $token" -k "https://$host/api/v2/receivers"
+```
+
+.Additional resources
+
+* xref:../monitoring/accessing-third-party-uis.adoc#accessing-third-party-uis[Accessing third party UIs]
+* xref:../monitoring/managing-metrics.adoc#managing-metrics[Managing metrics]
+* xref:../monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]
+* xref:../monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards[Reviewing monitoring dashboards]


### PR DESCRIPTION
Mention Openshift provides direct access to API endpoints in 3rd party monitoring components. 
