### PR TITLE
align tier 1 apis to k8s upstream GA api guidelines

### DIFF
--- a/modules/api-support-tiers.adoc
+++ b/modules/api-support-tiers.adoc
@@ -10,7 +10,7 @@ All commercially supported APIs, components, and features are associated under o
 [discrete]
 [id="api-tier-1_{context}"]
 == API tier 1
-APIs and application operating environments (AOEs) are stable within a major release for a minimum of 12 months or 3 minor releases from the announcement of deprecation, whichever is longer. The release that introduces a new or revised API or AOE, and the two following minor releases (n, n+1, n+2).
+APIs and application operating environments (AOEs) are stable within a major release. They may be deprecated within a major release, but they will not be removed until a subsequent major release.
 
 [discrete]
 [id="api-tier-2_{context}"]


### PR DESCRIPTION
see:
https://github.com/kubernetes/website/pull/31389
https://kubernetes.io/docs/reference/using-api/deprecation-policy/