### PR TITLE
OSDOCS-2461: Added OCM book to ROSA

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -52,7 +52,7 @@ Topics:
 Name: Getting started
 Dir: rosa_getting_started
 Distros: openshift-rosa
-Topics: 
+Topics:
 - Name: Getting started with ROSA
   File: rosa-getting-started
 ---
@@ -87,6 +87,13 @@ Topics:
   File: rosa-sts-deleting-access-cluster
 - Name: Deleting a ROSA cluster
   File: rosa-sts-deleting-cluster
+---
+Name: Red Hat OpenShift Cluster Manager
+Dir: ocm
+Distros: openshift-rosa
+Topics:
+- Name: Red Hat OpenShift Cluster Manager
+  File: ocm-overview
 ---
 Name: Setting up accounts and clusters
 Dir: rosa_getting_started


### PR DESCRIPTION
Added the OCM book to ROSA since users will use the cluster manager to manage their clusters.

PREVIEW:

* https://deploy-preview-41070--osdocs.netlify.app/openshift-rosa/latest/ocm/ocm-overview.html