### PR TITLE
BZ2012677: Deleted two node events

### DIFF
--- a/modules/nodes-containers-events-list.adoc
+++ b/modules/nodes-containers-events-list.adoc
@@ -103,12 +103,6 @@ This section describes the events of {product-title}.
 |`HostPortConflict`
 |Host/port conflict.
 
-|`InsufficientFreeCPU`
-|Insufficient free CPU.
-
-|`InsufficientFreeMemory`
-|Insufficient free memory.
-
 |`KubeletSetupFailed`
 |Kubelet setup failed.
 


### PR DESCRIPTION
For versions 4.6 and beyond. 

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2012677

Direct link to doc preview: https://deploy-preview-41078--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-containers-events.html#nodes-containers-events-list_nodes-containers-events

Ready for QA: @sunilcio 