### PR TITLE
CNV-15796: UI for MAC spoof filtering

### DIFF
--- a/modules/virt-creating-bridge-nad-web.adoc
+++ b/modules/virt-creating-bridge-nad-web.adoc
@@ -21,4 +21,5 @@ to provide existing layer-2 networking to pods and virtual machines.
 . Click the *Network Type* list and select *CNV Linux bridge*.
 . Enter the name of the bridge in the *Bridge Name* field.
 . Optional: If the resource has VLAN IDs configured, enter the ID numbers in the *VLAN Tag Number* field.
+. Optional: Select the *MAC Spoof Check* checkbox to enable MAC spoof filtering. This feature provides security against a MAC spoofing attack by allowing only a single MAC address to exit the pod.
 . Click *Create*.


### PR DESCRIPTION
[CNV-15796](https://issues.redhat.com/browse/CNV-15796)

Added a step in the "Creating a Linux bridge network attachment definition in the web console" procedure about a new checkbox to enable MAC spoof filtering.

Preview: https://deploy-preview-41082--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-bridge-nad-web_virt-attaching-multiple-networks