### PR TITLE
RN 4.6.54: Added late-breaking security language for extras RHSA

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3445,11 +3445,11 @@ link:https://access.redhat.com/solutions/6635841[{product-title} 4.6.53 containe
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-6-54"]
-=== RHBA-2022:0180 - {product-title} 4.6.54 bug fix update
+=== RHBA-2022:0180 - {product-title} 4.6.54 bug fix and security update
 
 Issued: 2022-01-26
 
-{product-title} release 4.6.54 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0180[RHBA-2022:0180] advisory. There are no RPM packages for this release.
+{product-title} release 4.6.54, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0180[RHBA-2022:0180] advisory. There are no RPM packages for this release.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 


### PR DESCRIPTION
Adding security language for extras advisory that got changed to RHSA.

Applies only to `enterprise-4.6`