### PR TITLE
[OSASINFRA-2769] Add information that Kuryr doesn't support unidling

### DIFF
--- a/modules/idle-unidling-applications.adoc
+++ b/modules/idle-unidling-applications.adoc
@@ -25,3 +25,7 @@ $ oc scale --replicas=1 dc <dc_name>
 Automatic unidling by a router is currently only supported by the default
 HAProxy router.
 ====
+[NOTE]
+====
+Services do not support automatic unidling if you configure Kuryr-Kubernetes as an SDN.
+====

--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -40,6 +40,8 @@ use the Amphora driver. They are subject to the same resource concerns as earlie
 same port. Services that expose the same port to different protocols, like TCP
 and UDP, are not supported.
 
+* Kuryr SDN does not support automatic unidling by a service.
+
 [discrete]
 [id="openstack-go-limitations_{context}"]
 == {rh-openstack} environment limitations


### PR DESCRIPTION
Due to technical limitations of Octavia it is not possible to implement
automatic unidling with Kuryr when a Service gets called. This commit
adds note about this to the documentation.
