### PR TITLE
BZ-1941940 4.7: Updated Image Cache Name to Use Quay.io

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -111,5 +111,5 @@ $ ls -Z /home/kni/rhcos_image_cache
 $ podman run -d --name rhcos_image_cache \
 -v /home/kni/rhcos_image_cache:/var/www/html \
 -p 8080:8080/tcp \
-registry.centos.org/centos/httpd-24-centos7:latest
+quay.io/centos7/httpd-24-centos7:latest
 ----


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1941940

For: Version 4.7

Doc Preview: https://deploy-preview-41098--osdocs.netlify.app

Signed-off-by: Katie Tothill ktothill@redhat.com