### PR TITLE
BZ-1941940: Updated image cache name to use quay.io

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -123,7 +123,7 @@ $ ls -Z /home/kni/rhcos_image_cache
 $ podman run -d --name rhcos_image_cache \
 -v /home/kni/rhcos_image_cache:/var/www/html \
 -p 8080:8080/tcp \
-registry.centos.org/centos/httpd-24-centos7:latest
+quay.io/centos7/httpd-24-centos7:latest
 ----
 ifndef::upstream[]
 +


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1941940

For: 4.6, 4.8, 4.9, 4.10 
(4.7 is in [PR 41098](https://github.com/openshift/openshift-docs/pull/41098))

Doc Preview: https://deploy-preview-41099--osdocs.netlify.app

Signed-off-by: Katie Tothill ktothill@redhat.com