### PR TITLE
CNV-14273: Live migration restriction is no longer relevant in 4.10

### DIFF
--- a/modules/virt-about-live-migration.adoc
+++ b/modules/virt-about-live-migration.adoc
@@ -14,6 +14,4 @@ You can use live migration if the following conditions are met:
 
 * The pod network binding must not be of the bridge interface type `()`.
 
-* Ports `49152` and `49153` must be available in the `virt-launcher` pod. If these ports are specified in the `masquerade` interface, live migration does not function.
-
 * Live migration is supported for virtual machines that are attached to an SR-IOV network interface.


### PR DESCRIPTION
For 4.10 only.

Jira: https://issues.redhat.com/browse/CNV-14273

Tagging @davidvossel for Code Review.
Tagging @ousleyp for QE and Peer Review (as this is a simple change. Let me know if you think Oded should assign a QE).

Direct doc preview link: https://deploy-preview-41107--osdocs.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-live-migration.html