### PR TITLE
TELCODOCS-362: D/S Documentation & RN: SDN-2215/MPNETWORK-4:Track Kubernetes NMstate to be GA for the bare metal platform

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -152,18 +152,6 @@ Define a consistent clock date and time format in each cluster node's BIOS setti
 
 You can reconfigure the control plane nodes to act as NTP servers on disconnected clusters, and reconfigure worker nodes to retrieve time from the control plane nodes.
 
-[id='network-requirements-state-config_{context}']
-== State-driven network configuration requirements (Technology Preview)
-
-{product-title} supports additional post-installation state-driven network configuration on the secondary network interfaces of cluster nodes using `kubernetes-nmstate`. For example, system administrators might configure a secondary network interface on cluster nodes after installation for a storage network.
-
-[NOTE]
-====
-Configuration must occur before scheduling pods.
-====
-
-State-driven network configuration requires installing `kubernetes-nmstate`, and also requires Network Manager running on the cluster nodes. See *OpenShift Virtualization > Kubernetes NMState (Tech Preview)* for additional details.
-
 [id='network-requirements-out-of-band_{context}']
 == Port access for the out-of-band management IP address
 

--- a/modules/virt-creating-interface-on-nodes.adoc
+++ b/modules/virt-creating-interface-on-nodes.adoc
@@ -15,7 +15,7 @@ You can configure multiple nmstate-enabled nodes concurrently. The configuration
 
 .Procedure
 
-. Create the `NodeNetworkConfigurationPolicy` manifest. The following example configures a Linux bridge on all worker nodes:
+. Create the `NodeNetworkConfigurationPolicy` manifest. The following example configures a Linux bridge on all worker nodes and configures the DNS resolver:
 +
 [source,yaml]
 ----
@@ -36,18 +36,27 @@ spec:
         ipv4:
           dhcp: true
           enabled: true
+          auto-dns: false
         bridge:
           options:
             stp:
               enabled: false
           port:
             - name: eth1
+    dns-resolver: <6>
+      config:
+        search:
+        - example.com
+        - example.org
+        server:
+        - 8.8.8.8
 ----
 <1> Name of the policy.
 <2> Optional: If you do not include the `nodeSelector` parameter, the policy applies to all nodes in the cluster.
 <3> This example uses the `node-role.kubernetes.io/worker: ""` node selector to select all worker nodes in the cluster.
 <4> Optional: Specifies the maximum number of nmstate-enabled nodes that the policy configuration can be applied to concurrently. This parameter can be set to either a percentage value (string), for example, `"10%"`, or an absolute value (number), such as `3`.
 <5> Optional: Human-readable description for the interface.
+<6> Optional: Specifies the search and server settings for the DNS server.
 
 . Create the node network policy:
 +

--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -3,6 +3,7 @@
 // * virt/node_network/virt-updating-node-network-config.adoc
 // * networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
 
+:_content-type: REFERENCE
 [id="virt-example-nmstate-IP-management_{context}"]
 = Examples: IP management
 
@@ -90,13 +91,17 @@ The following snippet configures an Ethernet interface that uses a dynamic IP ad
 [id="virt-example-nmstate-IP-management-dns_{context}"]
 == DNS
 
-The following snippet sets DNS configuration on the host.
+Setting the DNS configuration is analagous to modifying the `/etc/resolv.conf` file. The following snippet sets the DNS configuration on the host.
 
 [source,yaml]
 ----
 ...
-    interfaces:
+    interfaces: <1>
        ...
+       ipv4:
+         ...
+         auto-dns: false
+         ...
     dns-resolver:
       config:
         search:
@@ -106,6 +111,12 @@ The following snippet sets DNS configuration on the host.
         - 8.8.8.8
 ...
 ----
+<1> You must configure an interface with `auto-dns: false` or you must use static IP configuration on an interface in order for Kubernetes NMState to store custom DNS settings.
+
+[IMPORTANT]
+====
+You cannot use `br-ex`, an OVNKubernetes-managed Open vSwitch bridge, as the interface when configuring DNS resolvers.
+====
 
 [id="virt-example-nmstate-IP-management-static-routing_{context}"]
 == Static routing

--- a/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -8,7 +8,12 @@ toc::[]
 
 The Kubernetes NMState Operator provides a Kubernetes API for performing state-driven network configuration across the {product-title} cluster's nodes with NMState. The Kubernetes NMState Operator provides users with functionality to configure various network interface types, DNS, and routing on cluster nodes. Additionally, the daemons on the cluster nodes periodically report on the state of each node's network interfaces to the API server.
 
-include::snippets/technology-preview.adoc[]
+[IMPORTANT]
+====
+Red Hat supports the Kubernetes NMState Operator in production environments on bare metal platform installations only. For other platforms, the Kubernetes NMState Operator is a Technology Preview. See the following Technology Preview statement for support limitations when using Kubernetes NMState on platforms other than bare metal.
+====
+
+include::modules/technology-preview.adoc[]
 
 Before you can use NMState with {product-title}, you must install the Kubernetes NMState Operator.
 


### PR DESCRIPTION
Removes Technology Preview admonishment for K8S NMState on bare metal platforms.

Fixes: [TELCODOCS-362](https://issues.redhat.com/browse/TELCODOCS-362)

See https://issues.redhat.com/browse/TELCODOCS-362 for additional details.

Preview URL: https://deploy-preview-41108--osdocs.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html

https://deploy-preview-41108--osdocs.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-creating-interface-on-nodes_k8s_nmstate-updating-node-network-config

For release(s): 4.10
Signed-off-by: John Wilkins <jowilkin@redhat.com>
