### PR TITLE
Marked Cluster Loader as REM for 4.10

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -304,7 +304,7 @@ In the table, features are marked with the following statuses:
 |Cluster Loader
 |DEP
 |DEP
-|
+|REM
 
 |Bring your own {op-system-base} 7 compute machines
 |DEP


### PR DESCRIPTION
Content removal was completed in https://github.com/openshift/openshift-docs/pull/41106