### PR TITLE
bz2046589: Fix inconsistency with mirror registry language

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -124,7 +124,7 @@ $ REMOVABLE_MEDIA_PATH=<path> <1>
 ----
 <1> Specify the full path, including the initial forward slash (/) character.
 
-. Mirror the version images to the internal container registry:
+. Mirror the version images to the mirror registry:
 ** If your mirror host does not have internet access, take the following actions:
 ... Connect the removable media to a system that is connected to the internet.
 ... Review the images and configuration manifests to mirror:

--- a/modules/update-mirror-repository.adoc
+++ b/modules/update-mirror-repository.adoc
@@ -95,7 +95,7 @@ $ REMOVABLE_MEDIA_PATH=<path> <1>
 ----
 $ oc adm release mirror -a ${LOCAL_SECRET_JSON} --to-dir=${REMOVABLE_MEDIA_PATH}/mirror quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE}-${ARCHITECTURE} --dry-run
 ----
-. Mirror the version images to the internal container registry.
+. Mirror the version images to the mirror registry.
 ** If your mirror host does not have internet access, take the following actions:
 ... Connect the removable media to a system that is connected to the internet.
 ... Mirror the images and configuration manifests to a directory on the removable media:

--- a/modules/update-service-mirror-release.adoc
+++ b/modules/update-service-mirror-release.adoc
@@ -119,7 +119,7 @@ $ REMOVABLE_MEDIA_PATH=<path> <1>
 ----
 <1> Specify the full path, including the initial forward slash (`/`) character.
 
-. Mirror the version images to the internal container registry:
+. Mirror the version images to the mirror registry:
 ** If your mirror host does not have internet access, take the following actions:
 ... Connect the removable media to a system that is connected to the internet.
 ... Review the images and configuration manifests to mirror:


### PR DESCRIPTION
- [BZ2046589](https://bugzilla.redhat.com/show_bug.cgi?id=2046589)
- [Preview](https://deploy-preview-41123--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster#update-mirror-repository_updating-restricted-network-cluster)
- [Preview](https://deploy-preview-41123--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-mirroring-installation-images.html#installation-mirror-repository_installing-mirroring-installation-images)
- [Preview](https://deploy-preview-41123--osdocs.netlify.app/openshift-enterprise/latest/updating/installing-update-service.html#update-service-mirror-release_update-service)

Reviewed/confirmed by QA: Applies to 4.6 and above