### PR TITLE
OSDOCS-3210: Add Compliance Operator RNs

### DIFF
--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -12,6 +12,21 @@ These release notes track the development of the Compliance Operator in the {pro
 
 For an overview of the Compliance Operator, see xref:../../security/compliance_operator/compliance-operator-understanding.adoc#understanding-compliance-operator[Understanding the Compliance Operator].
 
+[id="compliance-operator-release-notes-0-1-48"]
+== OpenShift Compliance Operator 0.1.48
+
+The following advisory is available for the OpenShift Compliance Operator 0.1.48:
+
+* link:https://access.redhat.com/errata/RHBA-2022:0416[RHBA-2022:0416 - OpenShift Compliance Operator bug fix and enhancement update]
+
+[id="openshift-compliance-operator-0-1-48-bug-fixes"]
+
+=== Bug fixes
+
+* Previously, some rules associated with extended Open Vulnerability and Assessment Language (OVAL) definitions had a `checkType` of `None`. This was because the Compliance Operator was not processing extended OVAL definitions when parsing rules. With this update, content from extended OVAL definitions is parsed so that these rules now have a `checkType` of either `Node` or `Platform`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2040282[*BZ#2040282*])
+
+* Previously, a manually created `MachineConfig` object for `KubeletConfig` prevented a `KubeletConfig` object from being generated for remediation, leaving the remediation in the `Pending` state.  With this release, a `KubeletConfig`  object is created by the remediation, regardless if there is a manually created `MachineConfig` object for `KubeletConfig`. As a result, `KubeletConfig` remediations now work as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2040401[*BZ#2040401*])
+
 [id="compliance-operator-release-notes-0-1-47"]
 == OpenShift Compliance Operator 0.1.47
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3239
Applies to 4.6+

Note - The external advisory number is updated, the link is now live.
https://deploy-preview-41127--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-release-notes.html

