### PR TITLE
OSDOCS-2922: Added a warning for deleting clusters.

### DIFF
--- a/modules/rosa-deleting-cluster.adoc
+++ b/modules/rosa-deleting-cluster.adoc
@@ -10,7 +10,7 @@ endif::[]
 [id="rosa-deleting-cluster_{context}"]
 = Deleting a cluster
 
-You can delete an {product-title} cluster using the `rosa` CLI. 
+You can delete an {product-title} cluster using the `rosa` CLI.
 
 ifdef::sts[]
 You can also use the `rosa` CLI to delete the AWS Identity and Access Management (IAM) account-wide roles, the cluster-specific Operator roles, and the OpenID Connect (OIDC) provider. The cluster deletion must complete before you remove the IAM resources, because the resources are used in the cluster deletion and clean-up processes.

--- a/rosa_getting_started/rosa-deleting-cluster.adoc
+++ b/rosa_getting_started/rosa-deleting-cluster.adoc
@@ -7,4 +7,13 @@ toc::[]
 
 Delete a {product-title} (ROSA) cluster using the `rosa` command-line.
 
+[id="prerequisites_rosa-deleting-cluster"]
+== Prerequisites
+
+* If {product-title} created a VPC, you must remove the following items from your cluster before you can successfully delete your cluster:
+** Network configurations, such as VPN configurations and VPC peering connections
+** Any additional services that were added to the VPC
+
+If these configurations and services remain, the cluster does not delete properly.
+
 include::modules/rosa-deleting-cluster.adoc[leveloffset=+1]

--- a/rosa_getting_started_sts/rosa-sts-deleting-cluster.adoc
+++ b/rosa_getting_started_sts/rosa-sts-deleting-cluster.adoc
@@ -7,5 +7,14 @@ toc::[]
 
 Delete a {product-title} (ROSA) cluster using the `rosa` command-line.
 
+[id="prerequisites_rosa-sts-deleting-cluster"]
+== Prerequisites
+
+* If {product-title} created a VPC, you must remove the following items from your cluster before you can successfully delete your cluster:
+** Network configurations, such as VPN configurations and VPC peering connections
+** Any additional services that were added to the VPC
+
+If these configurations and services remain, the cluster does not delete properly.
+
 include::modules/rosa-deleting-cluster.adoc[leveloffset=+1]
 include::modules/rosa-deleting-aws-resources-aws-console.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR adds a note to a few topics to warn users that they should remove all network configurations before they delete a cluster.

JIRA: https://issues.redhat.com/browse/OSDOCS-2922

PREVIEWS:

~~1. **Revoking access to ROSA (STS)** - https://deploy-preview-41128--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-deleting-access-cluster.html~~
2. **Deleting a cluster** - https://deploy-preview-41128--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-deleting-cluster.html
3. **Deleting cluster (STS)** - https://deploy-preview-41128--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-deleting-cluster.html