### PR TITLE
BZ2044701 - Fixing doc gap for installing Cluster samples operator install

### DIFF
--- a/modules/installation-images-samples-disconnected-mirroring-assist.adoc
+++ b/modules/installation-images-samples-disconnected-mirroring-assist.adoc
@@ -11,7 +11,11 @@ During installation, {product-title} creates a config map named `imagestreamtag-
 
 The format of the key for each entry in the data field in the config map is `<image_stream_name>_<image_stream_tag_name>`.
 
-During a disconnected installation of {product-title}, the status of the Cluster Samples Operator is set to `Removed`. If you choose to change it to `Managed`, it installs samples. 
+During a disconnected installation of {product-title}, the status of the Cluster Samples Operator is set to `Removed`. If you choose to change it to `Managed`, it installs samples.
+[NOTE]
+====
+The use of samples in a network-restricted or discontinued environment may require access to services external to your network. Some example services include: Github, Maven Central, npm, RubyGems, PyPi and others. There might be additional steps to take that allow the cluster samples operators's objects to reach the services they require.
+====
 
 You can use this config map as a reference for which images need to be mirrored for your image streams to import.
 


### PR DESCRIPTION
For versions 4.7+
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2044701

Preview: https://deploy-preview-41133--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/configuring-samples-operator.html#installation-images-samples-disconnected-mirroring-assist_configuring-samples-operator