### PR TITLE
NE768: Document syslog maxLength parameter support for an Ingress Controller

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * ingress/configure-ingress-operator.adoc
-
+:_content-type: REFERENCE
 [id="nw-ingress-controller-configuration-parameters_{context}"]
 = Ingress Controller configuration parameters
 
@@ -138,6 +138,7 @@ The `AllowedSubjectPatterns` is an optional value that specifies a list of regul
 *** `syslog` describes parameters for the `Syslog` logging destination type:
 **** `address` is the IP address of the syslog endpoint that receives log messages.
 **** `port` is the UDP port number of the syslog endpoint that receives log messages.
+**** `maxLength` is the maximum length of the syslog message. It must be between `480` and `4096` bytes. If this field is empty, the maximum length is set to the default value of `1024` bytes.
 **** `facility` specifies the syslog facility of log messages. If this field is empty, the facility is `local1`. Otherwise, it must specify a valid syslog facility: `kern`, `user`, `mail`, `daemon`, `auth`, `syslog`, `lpr`, `news`, `uucp`, `cron`, `auth2`, `ftp`, `ntp`, `audit`, `alert`, `cron2`, `local0`, `local1`, `local2`, `local3`. `local4`, `local5`, `local6`, or `local7`.
 ** `httpLogFormat` specifies the format of the log message for an HTTP request. If this field is empty, log messages use the implementation's default HTTP log format. For HAProxy's default HTTP log format, see link:http://cbonte.github.io/haproxy-dconv/2.0/configuration.html#8.2.3[the HAProxy documentation].
 


### PR DESCRIPTION
For 4.10+

https://issues.redhat.com/browse/NE-768

[Doc preview](https://deploy-preview-41138--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress)

Requires ack from @melvinjoseph86 @sairameshv @Miciah 