### PR TITLE
Adding ROSA getting started next steps

### DIFF
--- a/modules/rosa-getting-started-create-cluster-admin-user.adoc
+++ b/modules/rosa-getting-started-create-cluster-admin-user.adoc
@@ -9,7 +9,7 @@ Before configuring an identity provider, you can create a user with `cluster-adm
 
 [NOTE]
 ====
-The cluster administrator user is useful when you need quick access to a newly deployed cluster. However, Red Hat recommends that you configure an identity provider and grant cluster administrator privileges to the identity provider users as required. For more information about setting up an identity provider for your ROSA cluster, see _Configuring an identity provider and granting cluster access_.
+The cluster administrator user is useful when you need quick access to a newly deployed cluster. However, consider configuring an identity provider and granting cluster administrator privileges to the identity provider users as required. For more information about setting up an identity provider for your ROSA cluster, see _Configuring an identity provider and granting cluster access_.
 ====
 
 .Prerequisites

--- a/modules/rosa-getting-started-enable-rosa.adoc
+++ b/modules/rosa-getting-started-enable-rosa.adoc
@@ -13,7 +13,7 @@ Use the steps in this procedure to enable {product-title} (ROSA) in your AWS acc
 +
 [NOTE]
 ====
-Red Hat recommends the use of a dedicated AWS account to run production clusters. If you are using AWS Organizations, you can use an AWS account within your organization or link:https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_create.html#orgs_manage_accounts_create-new[create a new one].
+Consider using a dedicated AWS account to run production clusters. If you are using AWS Organizations, you can use an AWS account within your organization or link:https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_create.html#orgs_manage_accounts_create-new[create a new one].
 ====
 
 .Procedure

--- a/rosa_getting_started/rosa-getting-started.adoc
+++ b/rosa_getting_started/rosa-getting-started.adoc
@@ -38,6 +38,14 @@ include::modules/rosa-getting-started-revoke-admin-privileges.adoc[leveloffset=+
 include::modules/rosa-getting-started-revoke-user-access.adoc[leveloffset=+2]
 include::modules/rosa-getting-started-deleting-a-cluster.adoc[leveloffset=+1]
 
+[id="next-steps_{context}"]
+== Next steps
+
+* xref:../adding_service_cluster/adding-service.adoc#adding-service[Adding services to a cluster using the OCM console]
+* xref:../nodes/rosa-managing-worker-nodes.adoc#rosa-managing-worker-nodes[Managing compute nodes]
+* xref:../monitoring/osd-configuring-the-monitoring-stack.adoc#osd-configuring-the-monitoring-stack[Configuring the monitoring stack]
+* xref:../logging/rosa-install-logging.adoc#rosa-install-logging[Installing logging add-on services]
+
 [id="additional-resources_{context}"]
 == Additional resources
 


### PR DESCRIPTION
This applies to `main`, `enterprise-4.9` and `enterprise-4.10`.

This PR adds a "Next steps" section to the recently added "Getting started with Red Hat OpenShift Service on AWS" page.

The preview is [here](https://deploy-preview-41139--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-getting-started#next-steps_rosa-getting-started).