### PR TITLE
BZ-2022831 Clarified unique domain requirements for Ingress Controller

### DIFF
--- a/modules/nw-aws-nlb-existing-cluster.adoc
+++ b/modules/nw-aws-nlb-existing-cluster.adoc
@@ -50,7 +50,7 @@ spec:
           type: NLB
 ----
 <1> Replace `$my_ingress_controller` with a unique name for the Ingress Controller.
-<2> Replace `$my_unique_ingress_domain` with a domain name that is unique among all Ingress Controllers in the cluster.
+<2> Replace `$my_unique_ingress_domain` with a domain name that is unique among all Ingress Controllers in the cluster. This variable must be a subdomain of the DNS name `<clustername>.<domain>`.
 <3> You can replace `External` with `Internal` to use an internal NLB.
 
 . Create the resource in the cluster:


### PR DESCRIPTION
CP to 4.9+
Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=2022831
Doc preview: https://deploy-preview-41148--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-aws-network-load-balancer.html#nw-aws-nlb-existing-cluster_configuring-ingress-cluster-traffic-aws-network-load-balancer

QE approval ✅