### PR TITLE
RNs - RHEL 8.5 is now supported for OCP 4.10 compute machines

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -19,9 +19,9 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {cloud-redhat-com} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
 // Double check OP system versions
-{product-title} {product-version} is supported on {op-system-base-full} 8.4, as well as on {op-system-first} 4.10.
+{product-title} {product-version} is supported on {op-system-base-full} 8.4 and 8.5, as well as on {op-system-first} 4.10.
 
-You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base-full} 8.4 for compute machines.
+You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517
 
 //TODO: Add the line below for EUS releases.


### PR DESCRIPTION
Preview: https://deploy-preview-41151--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-about-this-release