### PR TITLE
OSDOCS-2899 Update OCP mirror links for installations

### DIFF
--- a/modules/installation-gcp-user-infra-rhcos.adoc
+++ b/modules/installation-gcp-user-infra-rhcos.adoc
@@ -12,7 +12,7 @@ your {product-title} nodes.
 
 ifndef::openshift-origin[]
 . Obtain the {op-system} image from the
-link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/[{op-system} image mirror]
+link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/[{op-system} image mirror]
 page.
 +
 [IMPORTANT]

--- a/modules/installation-rhv-about-inventory-yml.adoc
+++ b/modules/installation-rhv-about-inventory-yml.adoc
@@ -26,7 +26,7 @@ all:
     # {op-system} section
     # ---
     rhcos:
-      image_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/latest/rhcos-openstack.x86_64.qcow2.gz"
+      image_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/latest/rhcos-openstack.x86_64.qcow2.gz"
       local_cmp_image_path: "/tmp/rhcos.qcow2.gz"
       local_image_path: "/tmp/rhcos.qcow2"
 

--- a/modules/installation-rhv-specifying-rhcos-image-settings.adoc
+++ b/modules/installation-rhv-specifying-rhcos-image-settings.adoc
@@ -14,16 +14,16 @@ Update the {op-system-first} image settings of the `inventory.yml` file. Later, 
 .Procedure
 
 ifndef::openshift-origin[]
-. Locate the {op-system} image download page for the version of {product-title} you are installing, such as link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/latest/[Index of /pub/openshift-v4/dependencies/rhcos/latest/latest].
+. Locate the {op-system} image download page for the version of {product-title} you are installing, such as link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/latest/[Index of /pub/openshift-v4/dependencies/rhcos/latest/latest].
 
-. From that download page, copy the URL of an OpenStack `qcow2` image, such as `\https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/latest/rhcos-openstack.x86_64.qcow2.gz`.
+. From that download page, copy the URL of an OpenStack `qcow2` image, such as `\https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/latest/rhcos-openstack.x86_64.qcow2.gz`.
 
 . Edit the `inventory.yml` playbook you downloaded earlier. In it, paste the URL as the value for `image_url`. For example:
 +
 [source,yaml]
 ----
 rhcos:
-  "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/latest/rhcos-openstack.x86_64.qcow2.gz"
+  "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/latest/rhcos-openstack.x86_64.qcow2.gz"
 ----
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -70,7 +70,7 @@ Replace `bootstrap.ign` with `master.ign` or `worker.ign` in the command to vali
 ifndef::openshift-origin[]
 . Obtain the {op-system} images that are required for your preferred method of installing operating system instances from the
 ifndef::ibm-power[]
-link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/[{op-system} image mirror]
+link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/[{op-system} image mirror]
 endif::ibm-power[]
 ifdef::ibm-power[]
 link:https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/[{op-system} image mirror]

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -77,7 +77,7 @@ Replace `bootstrap.ign` with `master.ign` or `worker.ign` in the command to vali
 ifndef::openshift-origin[]
 . Obtain the {op-system} `kernel`,
 `initramfs` and `rootfs` files from the
-link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/[{op-system} image mirror]
+link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/[{op-system} image mirror]
 page.
 +
 [IMPORTANT]

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -81,7 +81,7 @@ If you plan to add more compute machines to your cluster after you finish instal
 ====
 
 ifndef::openshift-origin[]
-. Obtain the {op-system} OVA image. Images are available from the link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/[{op-system} image mirror] page.
+. Obtain the {op-system} OVA image. Images are available from the link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/[{op-system} image mirror] page.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2899

Updates the same for all instances. The links will not be workable yet. Example preview:

https://deploy-preview-41157--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-gcp-user-infra-rhcos_installing-gcp-user-infra