### PR TITLE
TELCODOCS-386: Send SRO metrics as telemetry data

### DIFF
--- a/hardware_enablement/psap-special-resource-operator.adoc
+++ b/hardware_enablement/psap-special-resource-operator.adoc
@@ -29,6 +29,9 @@ include::modules/psap-special-resource-operator-using-manifests.adoc[leveloffset
 
 include::modules/psap-special-resource-operator-using-configmaps.adoc[leveloffset=+2]
 
+
+include::modules/psap-special-resource-operator-metrics.adoc[leveloffset=+1]
+
 [id="additional-resources_special-resource-operator"]
 == Additional resources
 

--- a/modules/psap-special-resource-operator-metrics.adoc
+++ b/modules/psap-special-resource-operator-metrics.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/psap-special-resource-operator.adoc
+
+:_content-type: REFERENCE
+[id="special-resource-operator-metrics_{context}"]
+= Prometheus Special Resource Operator metrics
+
+
+The Special Resource Operator (SRO) exposes the following Prometheus metrics through the `metrics` service:
+
+|===
+|Metric Name |Description
+
+|`sro_used_nodes`
+|Returns the nodes that are running pods created by a SRO custom resource (CR). This metric is available for `DaemonSet` and `Deployment` objects only. 
+
+|`sro_kind_completed_info`
+|Represents whether a `kind` of an object defined by the Helm Charts in a SRO CR has been successfully uploaded in the cluster (value `1`) or not (value `0`). Examples of objects are `DaemonSet`, `Deployment` or `BuildConfig`.
+
+|`sro_states_completed_info`
+|Represents whether the SRO has finished processing a CR successfully (value `1`) or the SRO has not processed the CR yet (value `0`).
+
+|`sro_managed_resources_total`
+|Returns the number of SRO CRs in the cluster, regardless of their state.
+|===

--- a/modules/psap-special-resource-operator-using-configmaps.adoc
+++ b/modules/psap-special-resource-operator-using-configmaps.adoc
@@ -2,10 +2,11 @@
 //
 // * hardware_enablement/psap-special-resource-operator.adoc
 
+:_content-type: PROCEDURE
 [id="deploy-simple-kmod-using-configmap-chart"]
 = Building and running the simple-kmod SpecialResource by using a config map
 
-In this example, the simple-kmod kernel module is used to show how the SRO can manage a driver container which is defined in Helm chart templates stored in a config map.
+In this example, the simple-kmod kernel module shows how the Special Resource Operator (SRO) manages a driver container. The container is defined in the Helm chart templates that are stored in a config map.
 
 .Prerequisites
 
@@ -14,7 +15,7 @@ In this example, the simple-kmod kernel module is used to show how the SRO can m
 * You installed the OpenShift CLI (`oc`).
 * You are logged into the OpenShift CLI as a user with `cluster-admin` privileges.
 * You installed the Node Feature Discovery (NFD) Operator.
-* You installed the Special Resource Operator.
+* You installed the SRO.
 * You installed the Helm CLI (`helm`).
 
 .Procedure
@@ -270,7 +271,15 @@ spec:
 ----
 $ oc create -f simple-kmod-configmap.yaml
 ----
-+
+
+[NOTE]
+====
+To remove the simple-kmod kernel module from the node, delete the simple-kmod `SpecialResource` API object using the `oc delete` command. The kernel module is unloaded when the driver container pod is deleted.
+====
+
+
+.Verification
+
 The `simple-kmod` resources are deployed in the `simple-kmod` namespace as specified in the object manifest. After a short time, the build pod for the `simple-kmod` driver container starts running. The build completes after a few minutes, and then the driver container pods start running. 
 
 . Use `oc get pods` command to display the status of the build pods:
@@ -310,7 +319,7 @@ simple_procfs_kmod     16384  0
 simple_kmod            16384  0
 ----
 
-[NOTE]
+[TIP]
 ====
-If you want to remove the simple-kmod kernel module from the node, delete the simple-kmod `SpecialResource` API object using the `oc delete` command. The kernel module is unloaded when the driver container pod is deleted.
+The `sro_kind_completed_info` SRO Prometheus metric provides information about the status of the different objects being deployed, which can be useful to troubleshoot SRO CR installations. The SRO also provides other types of metrics that you can use to watch the health of your environment.
 ====

--- a/modules/psap-special-resource-operator-using-manifests.adoc
+++ b/modules/psap-special-resource-operator-using-manifests.adoc
@@ -2,10 +2,11 @@
 //
 // * hardware_enablement/psap-special-resource-operator.adoc
 
+:_content-type: PROCEDURE
 [id="deploy-simple-kmod-using-local-chart_{context}"]
 = Building and running the simple-kmod SpecialResource by using the templates from the SRO image
 
-The SRO image contains a local repository of Helm charts including the templates for deploying the simple-kmod kernel module. In this example, the simple-kmod kernel module is used to show how the SRO can manage a driver container that is defined in the internal SRO repository.
+The Special Resource Operator(SRO) image contains a local repository of Helm charts, including the templates for deploying the simple-kmod kernel module. In this example, the simple-kmod kernel module shows how the SRO can manage a driver container that is defined in the internal SRO repository.
 
 .Prerequisites
 
@@ -53,10 +54,17 @@ spec:
 ----
 $ oc create -f simple-kmod-local.yaml
 ----
-+
+
+[NOTE]
+====
+To remove the simple-kmod kernel module from the node, delete the simple-kmod `SpecialResource` API object using the `oc delete` command. The kernel module is unloaded when the driver container pod is deleted.
+====
+
+.Verification
+
+
 The `simple-kmod` resources are deployed in the `simple-kmod` namespace as specified in the object manifest. After a short time, the build pod for the `simple-kmod` driver container starts running. The build completes after a few minutes, and then the driver container pods start running.
 
-+
 . Use the `oc get pods` command to display the status of the pods:
 
 +
@@ -95,7 +103,7 @@ simple_procfs_kmod     16384  0
 simple_kmod            16384  0
 ----
 
-[NOTE]
+[TIP]
 ====
-If you want to remove the simple-kmod kernel module from the node, delete the simple-kmod `SpecialResource` API object using the `oc delete` command. The kernel module is unloaded when the driver container pod is deleted.
+The `sro_kind_completed_info` SRO Prometheus metric provides information about the status of the different objects being deployed, which can be useful to troubleshoot SRO CR installations. The SRO also provides other types of metrics that you can use to watch the health of your environment.
 ====


### PR DESCRIPTION
Adds a module with the new metrics. Split 2 procedures to provide verification steps, and added a tip to explain reader metrics could be useful when installing.

Documents: https://issues.redhat.com/browse/TELCODOCS-386

Preview links:

The new module --> https://deploy-preview-41158--osdocs.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-special-resource-operator.html#special-resource-operator-metrics_special-resource-operator

Modules slightly edited --> 
https://deploy-preview-41158--osdocs.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-special-resource-operator.html#deploy-simple-kmod-using-configmap-chart

https://deploy-preview-41158--osdocs.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-special-resource-operator.html#deploy-simple-kmod-using-local-chart_special-resource-operator

https://deploy-preview-41327--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected#ztp-checking-the-managed-cluster-status_ztp-deploying-disconnected

Versions:  4.10