### PR TITLE
Marked Cluster Loader as RM in 4.10

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -309,7 +309,7 @@ In the table, features are marked with the following statuses:
 |Cluster Loader
 |DEP
 |DEP
-|
+|REM
 
 |Bring your own {op-system-base} 7 compute machines
 |DEP


### PR DESCRIPTION
This release note update reflects the changes in https://github.com/openshift/openshift-docs/pull/41106. Cluster Loader content is now removed in 4.10.