### PR TITLE
Alternative patch command to update the storage configuration

### DIFF
--- a/modules/registry-configuring-storage-azure-gov-cloud.adoc
+++ b/modules/registry-configuring-storage-azure-gov-cloud.adoc
@@ -36,4 +36,17 @@ storage:
     container: <container-name>
     cloudName: AzureUSGovernmentCloud <1>
 ----
+
+Alternative command for the above configuration:
+
+----
+$ oc patch configs.imageregistry.operator.openshift.io/cluster \
+--type=merge \
+--patch '{"spec":{"storage":{"azure":{"accountName":"storage-account-name","container":"container-name","cloudName":"AzureUSGovernmentCloud"}}}}' <1>
+
+$ oc patch configs.imageregistry.operator.openshift.io/cluster \
+--type=json \
+--patch '[{"op":"remove", "path":"/spec/storage/emptyDir: {}"}]'"}]'
+----
+
 <1> `cloudName` is the name of the Azure cloud environment, which can be used to configure the Azure SDK with the appropriate Azure API endpoints. Defaults to `AzurePublicCloud`. You can also set `cloudName` to `AzureUSGovernmentCloud`, `AzureChinaCloud`, or `AzureGermanCloud` with sufficient credentials. 


### PR DESCRIPTION
Updated the document with "oc patch" command to fill the storage configuration for image registry w/o using "oc edit".