### PR TITLE
BZ#2034410: Adding a note for namespace label

### DIFF
--- a/modules/nw-metallb-installing-operator-cli.adoc
+++ b/modules/nw-metallb-installing-operator-cli.adoc
@@ -41,6 +41,13 @@ metadata:
 EOF
 ----
 
+. Optional: To ensure BGP and BFD metrics appear in Prometheus, you can label the namespace as in the following command:
++
+[source,terminal]
+----
+$ oc label ns metallb-system "openshift.io/cluster-monitoring=true"
+----
+
 . Create an Operator group custom resource in the namespace:
 +
 [source,terminal]
@@ -128,4 +135,3 @@ $ oc get clusterserviceversion -n metallb-system \
 Name                                  Phase
 metallb-operator.{product-version}.0-nnnnnnnnnnnn   Succeeded
 ----
-


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2034410

Adding a note with command for creating a namespace label so that BGP and BFD metrics appear in Prometheus. 

4.10 only

Doc preview: https://deploy-preview-41169--osdocs.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-operator-install.html

Request for note: https://coreos.slack.com/archives/C01EH16NFPZ/p1643280373208200