### PR TITLE
OSDOCS-2859: Add Ansible Operator metrics

### DIFF
--- a/modules/osdk-ansible-inside-operator-local.adoc
+++ b/modules/osdk-ansible-inside-operator-local.adoc
@@ -15,8 +15,8 @@ You can customize the roles path by setting the environment variable `ANSIBLE_RO
 
 .Prerequisites
 
-- link:https://ansible-runner.readthedocs.io/en/latest/install.html[Ansible Runner] version v1.1.0+
-- link:https://github.com/ansible/ansible-runner-http[Ansible Runner HTTP Event Emitter plug-in] version v1.0.0+
+- link:https://ansible-runner.readthedocs.io/en/latest/install.html[Ansible Runner] v2.0.2+
+- link:https://github.com/ansible/ansible-runner-http[Ansible Runner HTTP Event Emitter plug-in] v1.0.0+
 - Performed the previous steps for testing the Kubernetes Collection locally
 
 .Procedure

--- a/modules/osdk-ansible-metrics.adoc
+++ b/modules/osdk-ansible-metrics.adoc
@@ -1,0 +1,240 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-monitoring-prometheus.adoc
+
+:_content-type: PROCEDURE
+[id="osdk-ansible-metrics_{context}"]
+= Exposing custom metrics for Ansible-based Operators
+
+As an Operator author creating Ansible-based Operators, you can use the Operator SDK's `osdk_metrics` module to expose custom Operator and Operand metrics, emit events, and support logging.
+
+.Prerequisites
+
+* Ansible-based Operator generated using the Operator SDK
+* Prometheus Operator, which is deployed by default on {product-title} clusters
+
+.Procedure
+
+. Generate an Ansible-based Operator. This example uses a `testmetrics.com` domain:
++
+[source,terminal]
+----
+$ operator-sdk init \
+    --plugins=ansible \
+    --domain=testmetrics.com
+----
+
+. Create a `metrics` API. This example uses a `kind` named `Testmetrics`:
++
+[source,terminal]
+----
+$ operator-sdk create api \
+    --group metrics \
+    --version v1 \
+    --kind Testmetrics \
+    --generate-role
+----
+
+. Edit the `roles/testmetrics/tasks/main.yml` file and use the `osdk_metrics` module to create custom metrics for your Operator project:
++
+.Example `roles/testmetrics/tasks/main.yml` file
+[%collapsible]
+====
+[source,yaml]
+----
+---
+# tasks file for Memcached
+- name: start k8sstatus
+  k8s:
+    definition:
+      kind: Deployment
+      apiVersion: apps/v1
+      metadata:
+        name: '{{ ansible_operator_meta.name }}-memcached'
+        namespace: '{{ ansible_operator_meta.namespace }}'
+      spec:
+        replicas: "{{size}}"
+        selector:
+          matchLabels:
+            app: memcached
+        template:
+          metadata:
+            labels:
+              app: memcached
+          spec:
+            containers:
+            - name: memcached
+              command:
+              - memcached
+              - -m=64
+              - -o
+              - modern
+              - -v
+              image: "docker.io/memcached:1.4.36-alpine"
+              ports:
+                - containerPort: 11211
+
+- osdk_metric:
+    name: my_thing_counter
+    description: This metric counts things
+    counter: {}
+
+- osdk_metric:
+    name: my_counter_metric
+    description: Add 3.14 to the counter
+    counter:
+      increment: yes
+
+- osdk_metric:
+    name: my_gauge_metric
+    description: Create my gauge and set it to 2.
+    gauge:
+      set: 2
+
+- osdk_metric:
+    name: my_histogram_metric
+    description: Observe my histogram
+    histogram:
+      observe: 2
+
+- osdk_metric:
+    name: my_summary_metric
+    description: Observe my summary
+    summary:
+      observe: 2
+----
+====
+
+.Verification
+
+. Run your Operator on a cluster. For example, to use the "run as a deployment" method:
+
+
+.. Build the Operator image and push it to a registry:
++
+[source,terminal]
+----
+$ make docker-build docker-push IMG=<registry>/<user>/<image_name>:<tag>
+----
+
+.. Install the Operator on a cluster:
++
+[source,terminal]
+----
+$ make install
+----
+
+.. Deploy the Operator:
++
+[source,terminal]
+----
+$ make deploy IMG=<registry>/<user>/<image_name>:<tag>
+----
+
+. Create a `Testmetrics` custom resource (CR):
+
+.. Define the CR spec:
++
+.Example `config/samples/metrics_v1_testmetrics.yaml` file
+[%collapsible]
+====
+[source,yaml]
+----
+apiVersion: metrics.testmetrics.com/v1
+kind: Testmetrics
+metadata:
+  name: testmetrics-sample
+spec:
+  size: 1
+----
+====
+
+.. Create the object:
++
+[source,terminal]
+----
+$ oc create -f config/samples/metrics_v1_testmetrics.yaml
+----
+
+. Get the pod details:
++
+[source,terminal]
+----
+$ oc get pods
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                    READY   STATUS    RESTARTS   AGE
+ansiblemetrics-controller-manager-<id>  2/2     Running   0          149m
+testmetrics-sample-memcached-<id>       1/1     Running   0          147m
+----
+
+. Get the endpoint details:
++
+[source,terminal]
+----
+$ oc get ep
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                ENDPOINTS          AGE
+ansiblemetrics-controller-manager-metrics-service   10.129.2.70:8443   150m
+----
+
+. Get the custom metrics token:
++
+[source,terminal]
+----
+$ token=`oc sa get-token prometheus-k8s -n openshift-monitoring`
+----
+
+. Check the metrics values:
+
+.. Check the `my_counter_metric` value:
++
+[source,terminal]
+----
+$ oc exec ansiblemetrics-controller-manager-<id> -- curl -k -H "Authoriza
+tion: Bearer $token" 'https://10.129.2.70:8443/metrics' | grep  my_counter
+----
++
+.Example output
+[source,terminal]
+----
+HELP my_counter_metric Add 3.14 to the counter
+TYPE my_counter_metric counter
+my_counter_metric 2
+----
+
+.. Check the `my_gauge_metric` value:
++
+[source,terminal]
+----
+$ oc exec ansiblemetrics-controller-manager-<id> -- curl -k -H "Authoriza
+tion: Bearer $token" 'https://10.129.2.70:8443/metrics' | grep  gauge
+----
++
+.Example output
+[source,terminal]
+----
+HELP my_gauge_metric Create my gauge and set it to 2.
+----
+
+.. Check the `my_histogram_metric` and `my_summary_metric` values:
++
+[source,terminal]
+----
+$ oc exec ansiblemetrics-controller-manager-<id> -- curl -k -H "Authoriza
+tion: Bearer $token" 'https://10.129.2.70:8443/metrics' | grep  Observe
+----
++
+.Example output
+[source,terminal]
+----
+HELP my_histogram_metric Observe my histogram
+HELP my_summary_metric Observe my summary
+----

--- a/modules/osdk-common-prereqs.adoc
+++ b/modules/osdk-common-prereqs.adoc
@@ -26,10 +26,10 @@ ifdef::golang[]
 - link:https://www.mercurial-scm.org/downloads[Mercurial] v3.9+
 endif::[]
 ifdef::ansible[]
-- link:https://docs.ansible.com/ansible/latest/index.html[Ansible] version v2.9.0+
-- link:https://ansible-runner.readthedocs.io/en/latest/install.html[Ansible Runner] version v2.0.2+
-- link:https://github.com/ansible/ansible-runner-http[Ansible Runner HTTP Event Emitter plug-in] version v1.0.0+
-- link:https://pypi.org/project/openshift/[OpenShift Python client] version v0.12.0+
+- link:https://docs.ansible.com/ansible/latest/index.html[Ansible] v2.9.0+
+- link:https://ansible-runner.readthedocs.io/en/latest/install.html[Ansible Runner] v2.0.2+
+- link:https://github.com/ansible/ansible-runner-http[Ansible Runner HTTP Event Emitter plug-in] v1.0.0+
+- link:https://pypi.org/project/openshift/[OpenShift Python client] v0.11.2+
 endif::[]
 - Logged into an {product-title} {product-version} cluster with `oc` with an account that has `cluster-admin` permissions
 - To allow the cluster to pull the image, the repository where you push your image must be set as public, or you must configure an image pull secret

--- a/modules/osdk-monitoring-custom-metrics.adoc
+++ b/modules/osdk-monitoring-custom-metrics.adoc
@@ -4,14 +4,14 @@
 
 :_content-type: PROCEDURE
 [id="osdk-monitoring-custom-metrics_{context}"]
-= Exposing custom metrics
+= Exposing custom metrics for Go-based Operators
 
 As an Operator author, you can publish custom metrics by using the global Prometheus registry from the `controller-runtime/pkg/metrics` library.
 
 .Prerequisites
 
 * Go-based Operator generated using the Operator SDK
-* Prometheus Operator (deployed by default on {product-title} clusters)
+* Prometheus Operator, which is deployed by default on {product-title} clusters
 
 .Procedure
 

--- a/operators/operator_sdk/osdk-monitoring-prometheus.adoc
+++ b/operators/operator_sdk/osdk-monitoring-prometheus.adoc
@@ -6,8 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This guide describes the built-in monitoring support provided by the Operator SDK using the Prometheus Operator and details usage for Operator authors.
+This guide describes the built-in monitoring support provided by the Operator SDK using the Prometheus Operator and details usage for authors of Go-based and Ansible-based Operators.
 
 include::modules/osdk-monitoring-prometheus-operator-support.adoc[leveloffset=+1]
 
 include::modules/osdk-monitoring-custom-metrics.adoc[leveloffset=+1]
+include::modules/osdk-ansible-metrics.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2859 

Preview: [Exposing custom metrics for Ansible-based Operators](https://deploy-preview-41171--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-monitoring-prometheus.html#osdk-ansible-metrics_osdk-monitoring-prometheus)