### PR TITLE
BZ2029511: Documentation update for Volumes with high file counts delay pod creation due to recursive SELinux file context relabeling

### DIFF
--- a/modules/nodes-pods-using-example.adoc
+++ b/modules/nodes-pods-using-example.adoc
@@ -111,7 +111,10 @@ status:
 <6> Specify the volumes to provide for the pod. Volumes mount at the specified path. Do not mount to the container root, `/`, or any path that is the same in the host and the container. This can corrupt your host system if the container is sufficiently privileged, such as the host `/dev/pts` files. It is safe to mount the host by using `/host`.
 <7> Each container in the pod is instantiated from its own container image.
 <8> Pods making requests against the {product-title} API is a common enough pattern that there is a `serviceAccount` field for specifying which service account user the pod should authenticate as when making the requests. This enables fine-grained access control for custom infrastructure components.
-<9> The pod defines storage volumes that are available to its container(s) to use. In this case, it provides an ephemeral volume for a `secret` volume containing the default service account tokens.
+<9> The pod defines storage volumes that are available to its container(s) to use. In this case, it provides an ephemeral volume for a `secret` volume containing the default service account tokens. 
++
+If you attach persistent volumes that have high file counts to pods, those pods can fail or can take a long time to start. For
+more information, see link:https://access.redhat.com/solutions/6221251[When using Persistent Volumes with high file counts in OpenShift, why do pods fail to start or take an excessive amount of time to achieve "Ready" state?].
 
 [NOTE]
 ====

--- a/modules/storage-persistent-storage-lifecycle.adoc
+++ b/modules/storage-persistent-storage-lifecycle.adoc
@@ -54,6 +54,12 @@ Once you have a claim and that claim is bound, the bound PV belongs to you
 for as long as you need it. You can schedule pods and access claimed
 PVs by including `persistentVolumeClaim` in the pod's volumes block.
 
+[NOTE]
+====
+If you attach persistent volumes that have high file counts to pods, those pods can fail or can take a long time to start. For
+more information, see link:https://access.redhat.com/solutions/6221251[When using Persistent Volumes with high file counts in OpenShift, why do pods fail to start or take an excessive amount of time to achieve "Ready" state?].
+==== 
+
 ifdef::openshift-origin,openshift-enterprise,openshift-webscale[]
 
 [id="pvcprotection_{context}"]

--- a/nodes/pods/nodes-pods-using.adoc
+++ b/nodes/pods/nodes-pods-using.adoc
@@ -17,3 +17,7 @@ deployed, and managed.
 include::modules/nodes-pods-using-about.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-using-example.adoc[leveloffset=+1]
+
+== Additional resources
+
+* For more information on pods and storage see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage] and xref:../../storage/understanding-persistent-storage.adoc#understanding-ephemeral-storage[Understanding ephemeral storage].


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2029511

Previews: 
[Use pods and claimed PVs](https://deploy-preview-41173--osdocs.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html#using-pods_understanding-persistent-storage)[
Example pod configurations](https://deploy-preview-41173--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-using.html#nodes-pods-using-example_nodes-pods-using-ssy) in callout 9
