### PR TITLE
BZ2029511: Documentation update for Volumes with high file counts delay pod creation due to recursive SELinux file context relabeling 3.11

### DIFF
--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -101,6 +101,12 @@ for as long as you need it. You can schedule pods and access claimed
 PVs by including `persistentVolumeClaim` in the pod's volumes block. See
 xref:pvc-claims-as-volumes[below] for syntax details.
 
+[NOTE]
+====
+When attaching persistent volumes that have a high file count to pods, those pods can fail or take an excessive amount of time to start. For
+more information, see link:https://access.redhat.com/solutions/6221251[When using Persistent Volumes with high file counts in OpenShift, why do pods fail to start or take an excessive amount of time to achieve "Ready" state?].
+====
+
 ifdef::openshift-origin,openshift-enterprise[]
 
 [[pvcprotection]]

--- a/install_config/persistent_storage/index.adoc
+++ b/install_config/persistent_storage/index.adoc
@@ -37,6 +37,13 @@ Persistent Disk]
 - xref:../../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[Dynamic Provisioning and Creating Storage Classes]
 - xref:../../install_config/persistent_storage/pod_security_context.adoc#install-config-persistent-storage-pod-security-context[Volume Security]
 - xref:../../install_config/persistent_storage/selector_label_binding.adoc#selector-label-volume-binding[Selector-Label Volume Binding]
+
+[NOTE]
+====
+When attaching persistent volumes that have a high file count to pods, those pods can fail or take an excessive amount of time to start. For
+more information, see link:https://access.redhat.com/solutions/6221251[When using Persistent Volumes with high file counts in OpenShift, why do pods fail to start or take an excessive amount of time to achieve "Ready" state?].
+====
+
 ////
 The following section provides useful troubleshooting methods when working with persistent volumes:
 - xref:../../install_config/persistent_storage/storage_troubleshooting.adoc#install-config-persistent-storage-storage-troubleshooting[Persistent Volume Troubleshooting].

--- a/install_config/storage_examples/index.adoc
+++ b/install_config/storage_examples/index.adoc
@@ -22,3 +22,9 @@ against the volumes as a user of the system.
 - xref:../../install_config/storage_examples/storage_classes_dynamic_provisioning.adoc#install-config-storage-examples-storage-classes-dynamic-provisioning[Using StorageClasses for Dynamic Provisioning]
 - xref:../../install_config/storage_examples/storage_classes_legacy.adoc#install-config-storage-examples-storage-classes-legacy[Using StorageClasses for Existing Legacy Storage]
 - xref:../../install_config/storage_examples/azure_blob_docker_registry_example.adoc#azure-blob-docker-registry[Configuring Azure Blob Storage for Integrated Container Image Registry]
+
+[NOTE]
+====
+When attaching persistent volumes that have a high file count to pods, those pods can fail or take an excessive amount of time to start. For
+more information, see link:https://access.redhat.com/solutions/6221251[When using Persistent Volumes with high file counts in OpenShift, why do pods fail to start or take an excessive amount of time to achieve "Ready" state?].
+====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2029511

Previews:
[Use pods and claimed PVs](https://deploy-preview-41174--osdocs.netlify.app/openshift-enterprise/latest/architecture/additional_concepts/storage.html#using)
[Configuring Persistent Storage Overview](https://deploy-preview-41174--osdocs.netlify.app/openshift-enterprise/latest/install_config/persistent_storage/index.html)
 [Persistent Storage Examples Overview](https://deploy-preview-41174--osdocs.netlify.app/openshift-enterprise/latest/install_config/storage_examples/index.html) 
