### PR TITLE
Release note for Poison Pill 4.9

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -734,6 +734,12 @@ When configuring the `docker/config.json` file to allow pods to pull images from
 
 Node-related metrics and alerts have been enhanced to give you an earlier indication of when the stability of a node is compromised.
 
+[id="ocp-4-9-poison-pill-operator"]
+==== Enhanced remediation with the Poison Pill Operator 
+
+You can use the Poison Pill Operator regardless of the cluster installation type, such as Installer Provisioned Infrastructure (IPI) or User Provisioned Infrastructure (UPI). 
+The Operator now provides enhanced remediation with the use of watchdog devices. For more information, see xref:../nodes/nodes/eco-poison-pill-operator.adoc#about-watchdog-devices_poison-pill-operator-remediate-nodes[About watchdog devices].
+
 [id="ocp-4-9-node-health-check-operator"]
 ==== Deploy node health checks with the Node Health Check Operator (Technology Preview)
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-343: RN for Poison Pill Operator 

Preview: https://deploy-preview-41180--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-poison-pill-operator
 
 Note: The link in the release note will be active after the [main docs PR for Poison Pill 4.9](https://github.com/openshift/openshift-docs/pull/40380) is merged.