### PR TITLE
Added notes for release 4.8.29

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -3010,3 +3010,28 @@ link:https://access.redhat.com/solutions/6656881[{product-title} 4.8.28 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-8-29"]
+=== RHBA-2022:0278 - {product-title} 4.8.29 bug fix update
+
+Issued: 2022-02-01
+
+{product-title} release 4.8.29 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0278[RHBA-2022:0278] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0277[RHBA-2022:0277] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6681391[{product-title} 4.8.29 container image list]
+
+[id="ocp-4-8-29-bug-fixes"]
+==== Bug fixes
+
+* An updated Jenkins plugin, OpenShift Sync 1.0.48, wrongly specified which ConfigMap and ImageStream labels would apply to pod templates for the Kubernetes plugin for Jenkins. As a result, OpenShift Sync stopped importing pod templates from config maps and image streams that had the 'jenkins-agent' label. This update corrects the label specification, and pod templates are imported as expected.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2038960[*BZ#2038960*])
+
+* Previously, the Local Storage Operator looked for newly added block devices every 5 seconds, which caused high CPU usage. This update reduces CPU usage by increasing the interval to 60 seconds.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2006698[*BZ#2006698*])
+
+[id="ocp-4-8-29-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Notes for release 4.8.29.

Applies only to `enterprise-4.8`

https://deploy-preview-41214--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-29