### PR TITLE
[WIP] OSDOCS-3222 - Adding redirects for updating cluster URLS

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -157,6 +157,10 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform\/4\.(.+)\/release_notes\/ocp-4-((?!\1).+)-release-notes.html /container-platform/4.$1/release_notes/ocp-4-$1-release-notes.html [NE,R=301]
     RewriteRule ^container-platform\/3\.(.+)\/release_notes\/ocp_3_((?!\1).+)_release_notes.html /container-platform/3.$1/release_notes/ocp_3_$1_release_notes.html [NE,R=301]
 
+    # Redirects for the Updating book
+    RewriteRule ^container-platform/(4\.6|4\.7|4\.8|4\.9)/updating/updating-cluster-between-minor.html /container-platform/$1/updating/updating-cluster-within-minor.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.6|4\.7|4\.8|4\.9)/updating/updating-cluster.html /container-platform/$1/updating/updating-cluster-within-minor.html [NE,R=302]
+
     # CNV scenarios based redirect
     RewriteRule ^container-platform/4\.8/virt/learn_more_about_ov.html /container-platform/4.8/virt/virt-learn-more-about-openshift-virtualization.html [NE,R=301]
 


### PR DESCRIPTION
This applies to `main`. I am in the process of confirming which branches this needs to be cherry picked to.

This relates to https://issues.redhat.com/browse/OSDOCS-3222. The PR adds temporary (302) redirect rules for two pages in the Updating book for OCP 4.6 to 4.9 that have been relocated. The rules will be changed to permanent (301) redirects after the temporary rules are applied and verified.