### PR TITLE
OSDOCS-2726: Reorganizing the restricted network cluster content

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -432,10 +432,6 @@ Distros: openshift-origin,openshift-enterprise
 Topics:
 - Name: Understanding OpenShift updates
   File: understanding-openshift-updates
-- Name: Understanding the OpenShift Update Service
-  File: understanding-the-update-service
-- Name: Installing and configuring the OpenShift Update Service
-  File: installing-update-service
 - Name: Understanding upgrade channels
   File: understanding-upgrade-channels-release
 - Name: Preparing to perform an EUS-to-EUS update

--- a/modules/update-service-mirror-release.adoc
+++ b/modules/update-service-mirror-release.adoc
@@ -147,6 +147,16 @@ $ oc image mirror -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mir
 +
 <1> For `REMOVABLE_MEDIA_PATH`, you must use the path where you mounted the removable media.
 +
+... Use `oc` command-line interface (CLI) to log in to the cluster that you are upgrading.
+
+... Apply the mirrored release image signature config map to the disconnected cluster:
++
+[source,terminal]
+----
+$ oc apply -f ${REMOVABLE_MEDIA_PATH}/mirror/config/<image_signature_file> <1>
+----
+<1> For `<image_signature_file>`, specify the path and name of the file, for example, `signature-sha256-81154f5c03294534.yaml`.
+
 ... Mirror the release image to a separate repository:
 +
 [source,terminal]

--- a/security/container_security/security-hosts-vms.adoc
+++ b/security/container_security/security-hosts-vms.adoc
@@ -29,7 +29,7 @@ ifndef::openshift-origin[]
 endif::[]
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-encrypt-disk_installing-customizing[Disk encryption]
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Chrony time service]
-* xref:../../updating/understanding-the-update-service.adoc#update-service-overview_understanding-the-update-service[{product-title} cluster updates]
+* xref:../../updating/updating-restricted-network-cluster.adoc#update-service-overview_updating-restricted-network-cluster[{product-title} cluster updates]
 
 // Virtualization versus containers
 include::modules/security-hosts-vms-vs-containers.adoc[leveloffset=+1]

--- a/updating/updating-restricted-network-cluster.adoc
+++ b/updating/updating-restricted-network-cluster.adoc
@@ -6,13 +6,15 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can upgrade a restricted network {product-title} cluster by using the `oc` command-line interface (CLI).
+You can upgrade a restricted network {product-title} cluster by using the `oc` command-line interface (CLI) or using the OpenShift Update Service.
+
+== Updating a restricted network cluster using the CLI
 
 A restricted network environment is the one in which your cluster nodes cannot access the internet. For this reason, you must populate a registry with the installation images. If your registry host cannot access both the internet and the cluster, you can mirror the images to a file system that disconnected from that environment and then bring that host or removable media across that gap. If the local container registry and the cluster are connected to the mirror registry's host, you can directly push the release images to the local registry.
 
 If multiple clusters are present within the restricted network, mirror the required release images to a single container image registry and use that registry to update all the clusters.
 
-== Prerequisites
+=== Prerequisites
 
 * Have access to the internet to obtain the necessary container images.
 * Have write access to a container registry in the restricted-network environment to push and pull images. The container registry must be compatible with Docker registry API v2.
@@ -31,21 +33,21 @@ If you are running cluster monitoring with an attached PVC for Prometheus, you m
 ====
 
 [id="updating-restricted-network-mirror-host"]
-== Preparing your mirror host
+=== Preparing your mirror host
 
 Before you perform the mirror procedure, you must prepare the host to retrieve content
 and push it to the remote location.
 
-include::modules/cli-installing-cli.adoc[leveloffset=+2]
+include::modules/cli-installing-cli.adoc[leveloffset=+3]
 
 // this file doesn't exist, so I'm including the one that should pick up more changes from Clayton's PR - modules/installation-adding-mirror-registry-pull-secret.adoc[leveloffset=+1]
 
-include::modules/installation-adding-registry-pull-secret.adoc[leveloffset=+1]
+include::modules/installation-adding-registry-pull-secret.adoc[leveloffset=+2]
 
-include::modules/update-mirror-repository.adoc[leveloffset=+1]
+include::modules/update-mirror-repository.adoc[leveloffset=+2]
 
 [id="updating-restricted-network-image-signature-configmap"]
-== Creating the image signature config map
+=== Creating the image signature config map
 
 Before you update your cluster, you must manually create a config map that contains the signatures of the release images that you use. This signature allows the Cluster Version Operator (CVO) to verify that the release images have not been modified by comparing the expected and actual image signatures.
 
@@ -55,19 +57,122 @@ If you are upgrading from version 4.4.8 or later, you can use the `oc` CLI to cr
 
 include::modules/update-configuring-image-signature.adoc[leveloffset=+2]
 
-include::modules/machine-health-checks-pausing.adoc[leveloffset=+1]
+include::modules/machine-health-checks-pausing.adoc[leveloffset=+3]
 
-include::modules/update-restricted.adoc[leveloffset=+1]
+include::modules/update-restricted.adoc[leveloffset=+2]
 
-include::modules/images-configuration-registry-mirror.adoc[leveloffset=+1]
+include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
 
-include::modules/generating-icsp-object-scoped-to-a-registry.adoc[leveloffset=+1]
+include::modules/generating-icsp-object-scoped-to-a-registry.adoc[leveloffset=+2]
 
 [id="additional-resources_security-container-signature"]
-== Additional resources
+=== Additional resources
 
 * xref:../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
 
 * xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-overview-post-install-machine-configuration-tasks[Machine Config Overview]
 
-* xref:../updating/installing-update-service.adoc#installing-update-service[Installing and configuring the OpenShift Update Service]
+[id="update-restricted-network-cluster-update-service"]
+== Updating a restricted network cluster using the OpenShift Update Service
+
+include::modules/update-service-overview.adoc[leveloffset=+2]
+
+.Additional resources
+
+* xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Understanding upgrade channels and releases]
+
+For clusters with internet accessibility, Red Hat provides over-the-air updates through an {product-title} update service as a hosted service located behind public APIs. However, clusters in a restricted network have no way to access public APIs for update information.
+
+To provide a similar upgrade experience in a restricted network, you can install and configure the OpenShift Update Service locally so that it is available within a disconnected environment.
+
+The following sections describe how to provide over-the-air updates for your disconnected cluster and its underlying operating system.
+
+[id="update-service-prereqs"]
+=== Prerequisites
+
+* For more information on installing Operators, see xref:../operators/user/olm-installing-operators-in-namespace.adoc#olm-installing-operators-in-namespace[Installing Operators in your namespace].
+
+[id="registry-configuration-for-update-service"]
+=== Configuring access to a secured registry for the OpenShift update service
+
+If the release images are contained in a secure registry, complete the steps in xref:../registry/configuring-registry-operator.adoc#images-configuration-cas_configuring-registry-operator[Configuring additional trust stores for image registry access] along with following changes for the update service.
+
+The OpenShift Update Service Operator needs the config map key name `updateservice-registry` in the registry CA cert.
+
+.Image registry CA config map example for the update service
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-registry-ca
+data:
+  updateservice-registry: | <1>
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+  registry-with-port.example.com..5000: | <2>
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+----
+<1> The OpenShift Update Service Operator requires the config map key name updateservice-registry in the registry CA cert.
+<2>  If the registry has the port, such as `registry-with-port.example.com:5000`, `:` should be replaced with `..`.
+
+[id="update-service-install"]
+=== Installing the OpenShift Update Service Operator
+
+To install the OpenShift Update Service, you must first install the OpenShift Update Service Operator by using the {product-title} web console or CLI.
+
+[NOTE]
+====
+For clusters that are installed on restricted networks, also known as disconnected clusters, Operator Lifecycle Manager by default cannot access the Red Hat-provided OperatorHub sources hosted on remote registries because those remote sources require full internet connectivity. For more information, see xref:../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+====
+
+include::modules/update-service-install-web-console.adoc[leveloffset=+2]
+
+include::modules/update-service-install-cli.adoc[leveloffset=+2]
+
+include::modules/update-service-graph-data.adoc[leveloffset=+2]
+
+include::modules/update-service-mirror-release.adoc[leveloffset=+2]
+
+[id="update-service-create-service"]
+=== Creating an OpenShift Update Service application
+
+You can create an OpenShift Update Service application by using the {product-title} web console or CLI.
+
+include::modules/update-service-create-service-web-console.adoc[leveloffset=+3]
+
+include::modules/update-service-create-service-cli.adoc[leveloffset=+3]
+
+[NOTE]
+====
+The policy engine route name must not be more than 63 characters based on RFC-1123. If you see `ReconcileCompleted` status as `false`  with the reason `CreateRouteFailed` caused by `host must conform to DNS 1123 naming convention
+and must be no more than 63 characters`, try creating the Update Service with a shorter name.
+====
+
+include::modules/update-service-configure-cvo.adoc[leveloffset=+3]
+
+[NOTE]
+====
+See xref:../networking/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object[Enabling the cluster-wide proxy] to configure the CA to trust the update server.
+====
+
+[id="update-service-delete-service"]
+=== Deleting an OpenShift Update Service application
+
+You can delete an OpenShift Update Service application by using the {product-title} web console or CLI.
+
+include::modules/update-service-delete-service-web-console.adoc[leveloffset=+3]
+
+include::modules/update-service-delete-service-cli.adoc[leveloffset=+3]
+
+[id="update-service-uninstall"]
+=== Uninstalling the OpenShift Update Service Operator
+
+To uninstall the OpenShift Update Service, you must first delete all OpenShift Update Service applications by using the {product-title} web console or CLI.
+
+include::modules/update-service-uninstall-web-console.adoc[leveloffset=+3]
+
+include::modules/update-service-uninstall-cli.adoc[leveloffset=+3]

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -276,7 +276,7 @@ There is a separate process for
 xref:../updating/updating-disconnected-cluster.adoc#updating-disconnected-cluster[updating a cluster on a restricted network].
 ////
 
-- **xref:../updating/installing-update-service.adoc#installing-update-service[Understanding the OpenShift Update Service]**: Learn about installing and managing a local OpenShift Update Service for recommending {product-title} updates in restricted network environments.
+- **xref:../updating/updating-restricted-network-cluster.adoc#update-service-overview_updating-restricted-network-cluster[Understanding the OpenShift Update Service]**: Learn about installing and managing a local OpenShift Update Service for recommending {product-title} updates in restricted network environments.
 
 === Monitor the cluster
 


### PR DESCRIPTION
Applies to 4.8+
JIRA: https://issues.redhat.com/browse/OSDOCS-2726
QE and/or SME ack required
Preview Link: [Updating a restricted network cluster](https://deploy-preview-41224--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster.html). I reorganized everything into 1 chapter named "Updating a restricted network cluster". I combined the content from the previous [Updating a restricted network cluster](https://docs.openshift.com/container-platform/4.9/updating/updating-restricted-network-cluster.html) with [Installing and configuring the OpenShift Update Service](https://docs.openshift.com/container-platform/4.9/updating/installing-update-service.html) and [Understanding the OpenShift Update Service](https://docs.openshift.com/container-platform/4.9/updating/understanding-the-update-service.html). 