### PR TITLE
[RHACS] Add Liveness Probe, Readiness Probe, Replicas (for 3.69)

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -479,6 +479,30 @@ For example `oc`, or `kubectl`.
 | ✓
 | Deploy
 
+| Liveness Probe
+| Whether the container defines a liveness probe.
+| 3.69 and newer
+| ✕
+| ✕
+| ✕
+| Deploy
+
+| Readiness Probe
+| Whether the container defines a readiness probe.
+| 3.69 and newer
+| ✕
+| ✕
+| ✕
+| Deploy
+
+| Replicas
+| The number of deployment replicas.
+| 3.69 and newer
+| ✕
+| ✓
+| ✓
+| Deploy
+
 |===
 
 [NOTE]


### PR DESCRIPTION
Added three new policy criteria as described in [RHACS-69](https://issues.redhat.com/browse/RHACS-69).

Applies to 3.69


<hr>

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
