### PR TITLE
Updating ROSA getting started intro

### DIFF
--- a/rosa_getting_started/rosa-getting-started.adoc
+++ b/rosa_getting_started/rosa-getting-started.adoc
@@ -6,7 +6,7 @@ include::modules/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-Follow this getting started document to quickly create a {product-title} (ROSA) cluster, add users, deploy your first application, and learn how to scale and delete your cluster.
+Follow this getting started document to quickly create a {product-title} (ROSA) cluster, grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.
 
 You can create a ROSA cluster either with or without the AWS Security Token Service (STS). The procedures in this document enable you to create a cluster that uses AWS STS. For more information about using AWS STS with ROSA clusters, see xref:../rosa_architecture/rosa-understanding.adoc#rosa-using-sts_rosa-understanding[Using the AWS Security Token Service].
 


### PR DESCRIPTION
This applies to `main`, `enterprise-4.9` and `enterprise-4.10`.

This PR updates the intro sentence in the ROSA getting started assembly by removing the reference to scaling clusters and adding a reference to deleting users. The updated sentence accurately reflects what is currently included in the page.

The preview is [here](https://deploy-preview-41245--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-getting-started).