### PR TITLE
[OSDOCS-3065] Enable OVS Hardware offload

### DIFF
--- a/modules/nw-osp-enabling-ovs-offload.adoc
+++ b/modules/nw-osp-enabling-ovs-offload.adoc
@@ -1,0 +1,136 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/network-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="nw-osp-enabling-ovs-offload_{context}"]
+= Enabling OVS hardware offloading
+
+For clusters that run on {rh-openstack-first}, you can enable link:https://www.openvswitch.org/[Open vSwitch (OVS)] hardware offloading. 
+
+OVS is a multi-layer virtual switch that enables large-scale, multi-server network virtualization. 
+
+.Prerequisites
+
+* You installed a cluster on {rh-openstack} that is configured for single-root input/output virtualization (SR-IOV).
+* You installed the SR-IOV Network Operator on your cluster. 
+* You created two `hw-offload` type virtual function (VF) interfaces on your cluster.
+
+.Procedure
+
+. From a command line, enter the following command to disable the admission webhook:
++
+[source,terminal]
+----
+$ oc patch sriovoperatorconfig default --type=merge -n openshift-sriov-network-operator --patch '{ "spec": { "enableOperatorWebhook": false } }'
+----
+
+. Create an `SriovNetworkNodePolicy` policy for the two `hw-offload` type VF interfaces that are on your cluster:
++
+.The first virtual function interface
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy <1>
+metadata:
+  name: "hwoffload9"
+  namespace: openshift-sriov-network-operator
+spec:
+  deviceType: netdevice
+  isRdma: true
+  nicSelector:
+    pfNames: <2>
+    - ens6
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: 'true'
+  numVfs: 1
+  priority: 99
+  resourceName: "hwoffload9"
+----
+<1> Insert the `SriovNetworkNodePolicy` value here.
+<2> Both interfaces must include physical function (PF) names.
++
+.The second virtual function interface
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy <1>
+metadata:
+  name: "hwoffload10"
+  namespace: openshift-sriov-network-operator
+spec:
+  deviceType: netdevice
+  isRdma: true
+  nicSelector:
+    pfNames: <2>
+    - ens5
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: 'true'
+  numVfs: 1
+  priority: 99
+  resourceName: "hwoffload10"
+----
+<1> Insert the `SriovNetworkNodePolicy` value here.
+<2> Both interfaces must include physical function (PF) names.
+
+. Create `NetworkAttachmentDefinition` resources for the two interfaces:
++
+.A `NetworkAttachmentDefinition` resource for the first interface
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/hwoffload9
+  name: hwoffload9
+  namespace: default
+spec:
+    config: '{ "cniVersion":"0.3.1", "name":"hwoffload9","type":"host-device","device":"ens6"
+    }'
+----
++
+.A `NetworkAttachmentDefinition` resource for the second interface
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/hwoffload10
+  name: hwoffload10
+  namespace: default
+spec:
+    config: '{ "cniVersion":"0.3.1", "name":"hwoffload10","type":"host-device","device":"ens5"
+    }'
+----
+ 
+. Use the interfaces that you created with a pod. For example:
++
+.A pod that uses the two OVS offload interfaces
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dpdk-testpmd
+  namespace: default
+  annotations:
+    irq-load-balancing.crio.io: disable
+    cpu-quota.crio.io: disable
+    k8s.v1.cni.cncf.io/networks: '[
+      {
+       "name": "hwoffload9",
+       "namespace": "default"
+      },
+      {
+       "name": "hwoffload10",
+       "namespace": "default"
+      }
+    ]'
+spec:
+  restartPolicy: Never
+  containers:
+  - name: dpdk-testpmd
+    image: quay.io/krister/centos8_nfv-container-dpdk-testpmd:latest
+----

--- a/post_installation_configuration/network-configuration.adoc
+++ b/post_installation_configuration/network-configuration.adoc
@@ -106,3 +106,4 @@ You can configure some aspects of an {product-title} on {rh-openstack-first} clu
 include::modules/installation-osp-configuring-api-floating-ip.adoc[leveloffset=+2]
 include::modules/installation-osp-kuryr-port-pools.adoc[leveloffset=+2]
 include::modules/installation-osp-kuryr-settings-active.adoc[leveloffset=+2]
+include::modules/nw-osp-enabling-ovs-offload.adoc[leveloffset=+2]


### PR DESCRIPTION
Context: https://issues.redhat.com/browse/OSDOCS-3065

Scheduled for ~~4.11~~4.10 at the moment

Preview: https://deploy-preview-41247--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/network-configuration.html#nw-osp-enabling-ovs-offload_post-install-network-configuration