### PR TITLE
OSDOCS-2694:AWS PrivateLink arch diagram incorrect

### DIFF
--- a/images/156_OpenShift_ROSA_Arch_0621_privatelink.svg
+++ b/images/156_OpenShift_ROSA_Arch_0621_privatelink.svg
@@ -1,322 +1,258 @@
-<svg id="f5cfb119-cfa8-41f9-b78e-2055b3581bdd" data-name="artwork" xmlns="http://www.w3.org/2000/svg" width="760" height="519.507" viewBox="0 0 760 519.507">
+<svg id="a7fa9573-abe2-4a40-ae64-fae5bf205cc4" data-name="artwork" xmlns="http://www.w3.org/2000/svg" width="760" height="519.507" viewBox="0 0 760 519.507">
   <defs>
     <style>
-      .bb5f9692-c442-4f77-8e1f-31b32f9f74a1 {
+      .b1b4035f-3ce4-42a7-bc3e-b94360fb930d {
         fill: #c4c4c4;
       }
 
-      .a948e394-64b4-4607-b904-a70986052a79, .e8f26476-521b-4e4e-b8c3-76ba7d6beee8 {
+      .b7c84ee7-c086-42d9-93ee-26d53bfb781f, .e7efa073-ee49-4805-a810-fbb8987e49b0 {
         font-size: 11px;
       }
 
-      .a948e394-64b4-4607-b904-a70986052a79, .ab397ba8-d1d1-4b0d-ba40-67e404985571, .bb93582a-a6e4-4638-b989-1021dcc30a88, .e8f26476-521b-4e4e-b8c3-76ba7d6beee8 {
+      .b7c84ee7-c086-42d9-93ee-26d53bfb781f, .b85634e9-8401-4824-b3f9-43f8b7f4c31d, .e3f0e370-4c82-46bf-ba70-3fba369fa8db, .e7efa073-ee49-4805-a810-fbb8987e49b0 {
         fill: #151515;
       }
 
-      .e8f26476-521b-4e4e-b8c3-76ba7d6beee8 {
+      .b7c84ee7-c086-42d9-93ee-26d53bfb781f {
         font-family: RedHatText-Medium, Red Hat Text;
         font-weight: 500;
       }
 
-      .a481feb1-ac3d-49c0-ad32-c2b68a878cf4, .a903d9f8-1d04-44eb-ad3c-0f0e36b3c27c, .ae1dc0d1-0e51-4325-96d3-4af8d85c97ef, .ae79de5f-81dc-4b8d-8816-bdbcb289734b, .b0c10438-7c46-4a1b-86d5-4f7562fc2e35, .b0c9a5dd-c504-4dc3-9be8-1d186441537c, .b5f900cf-2522-4961-b6fc-a9d64a96a482, .b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9, .b7cdd690-62a1-4e5a-9e83-ab5f2946c9ce, .f5d99c62-387f-4dc9-af57-1070360f6ec8 {
+      .b1f7e056-e611-4777-80a2-a65a28cb0821, .b3fb0424-c963-40cb-9f46-075ec073efa1, .b418bf25-9744-4ab9-b65b-f320f7318127, .b7f18908-c244-4e26-81e8-4de98e875cf5, .bd0843c9-21b4-4b81-9c52-8a9f27180b8d, .f2a6a062-2134-43e7-8296-436a2fa25740, .f3fdb182-0969-4fc9-953e-d5263db0d50f, .f69dd7fb-6bbf-4ca0-aca9-665a506b8919 {
         fill: none;
       }
 
-      .b5f900cf-2522-4961-b6fc-a9d64a96a482 {
+      .bd0843c9-21b4-4b81-9c52-8a9f27180b8d {
         stroke: #06c;
       }
 
-      .a903d9f8-1d04-44eb-ad3c-0f0e36b3c27c, .ae1dc0d1-0e51-4325-96d3-4af8d85c97ef, .ae79de5f-81dc-4b8d-8816-bdbcb289734b, .b0c10438-7c46-4a1b-86d5-4f7562fc2e35, .b0c9a5dd-c504-4dc3-9be8-1d186441537c, .b5f900cf-2522-4961-b6fc-a9d64a96a482, .b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9, .b7cdd690-62a1-4e5a-9e83-ab5f2946c9ce, .e053b0c2-d938-42b5-816c-b4c118ba5c66, .f5d99c62-387f-4dc9-af57-1070360f6ec8 {
+      .b3fb0424-c963-40cb-9f46-075ec073efa1, .b418bf25-9744-4ab9-b65b-f320f7318127, .b7f18908-c244-4e26-81e8-4de98e875cf5, .bd0843c9-21b4-4b81-9c52-8a9f27180b8d, .f2a6a062-2134-43e7-8296-436a2fa25740, .f3fdb182-0969-4fc9-953e-d5263db0d50f, .f69dd7fb-6bbf-4ca0-aca9-665a506b8919, .fbc04b7e-7692-4d2e-8e80-0337122aab34 {
         stroke-linecap: round;
         stroke-linejoin: round;
       }
 
-      .a903d9f8-1d04-44eb-ad3c-0f0e36b3c27c, .b0c9a5dd-c504-4dc3-9be8-1d186441537c, .b5f900cf-2522-4961-b6fc-a9d64a96a482 {
+      .b418bf25-9744-4ab9-b65b-f320f7318127, .bd0843c9-21b4-4b81-9c52-8a9f27180b8d {
         stroke-width: 2px;
       }
 
-      .f85db5a8-1a3c-4965-b275-fe819a4d9263 {
+      .b9a814cc-2dba-4cfb-885b-03db17853ad3 {
         fill: #06c;
       }
 
-      .a6f07811-5c79-4ff3-a4a5-db1bc58639ea, .e053b0c2-d938-42b5-816c-b4c118ba5c66 {
+      .ac1a4e9a-8a92-46a2-91ec-3546765ddb62, .fbc04b7e-7692-4d2e-8e80-0337122aab34 {
         fill: #fff;
       }
 
-      .ae1dc0d1-0e51-4325-96d3-4af8d85c97ef, .b0c9a5dd-c504-4dc3-9be8-1d186441537c, .e053b0c2-d938-42b5-816c-b4c118ba5c66 {
+      .b418bf25-9744-4ab9-b65b-f320f7318127, .f2a6a062-2134-43e7-8296-436a2fa25740, .fbc04b7e-7692-4d2e-8e80-0337122aab34 {
         stroke: #5b5b5b;
       }
 
-      .ae1dc0d1-0e51-4325-96d3-4af8d85c97ef, .e053b0c2-d938-42b5-816c-b4c118ba5c66 {
+      .f2a6a062-2134-43e7-8296-436a2fa25740, .fbc04b7e-7692-4d2e-8e80-0337122aab34 {
         stroke-width: 1.5px;
       }
 
-      .ae79de5f-81dc-4b8d-8816-bdbcb289734b {
+      .b7f18908-c244-4e26-81e8-4de98e875cf5 {
         stroke: #151515;
       }
 
-      .a7a0f9a2-dd10-49d7-b01d-32958b8424b4 {
+      .af5f7c8b-59be-4f9c-9020-57fe5f2aacc6 {
         fill: #5b5b5b;
       }
 
-      .b0c10438-7c46-4a1b-86d5-4f7562fc2e35, .b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9, .f5d99c62-387f-4dc9-af57-1070360f6ec8 {
+      .b3fb0424-c963-40cb-9f46-075ec073efa1, .f3fdb182-0969-4fc9-953e-d5263db0d50f, .f69dd7fb-6bbf-4ca0-aca9-665a506b8919 {
         stroke: #c4c4c4;
       }
 
-      .b0c10438-7c46-4a1b-86d5-4f7562fc2e35 {
+      .f3fdb182-0969-4fc9-953e-d5263db0d50f {
         stroke-dasharray: 2.981 2.981;
       }
 
-      .f5d99c62-387f-4dc9-af57-1070360f6ec8 {
+      .b3fb0424-c963-40cb-9f46-075ec073efa1 {
         stroke-dasharray: 3 3;
       }
 
-      .ae616477-1e09-46cd-85c1-0b4280cab686 {
+      .fdb956ea-1dce-4b0b-a7c0-7a46fd063796 {
         fill: #e8e8e8;
       }
 
-      .a948e394-64b4-4607-b904-a70986052a79, .bb93582a-a6e4-4638-b989-1021dcc30a88 {
+      .b85634e9-8401-4824-b3f9-43f8b7f4c31d, .e7efa073-ee49-4805-a810-fbb8987e49b0 {
         font-family: RedHatText-Bold, Red Hat Text;
         font-weight: 700;
       }
 
-      .b7cdd690-62a1-4e5a-9e83-ab5f2946c9ce {
-        stroke: #fff;
-        stroke-width: 8px;
-      }
-
-      .a903d9f8-1d04-44eb-ad3c-0f0e36b3c27c {
-        stroke: #4cb6d6;
-      }
-
-      .b63cdd79-fc3f-464e-bf73-ea7cae83db70 {
-        fill: #4cb6d6;
-      }
-
-      .bb93582a-a6e4-4638-b989-1021dcc30a88 {
+      .b85634e9-8401-4824-b3f9-43f8b7f4c31d {
         font-size: 12px;
       }
 
-      .a96f75ea-9a46-4516-8393-41822b208052 {
+      .a2005cac-254a-463a-9c1a-e3f760590dca {
         font-size: 10px;
         fill: #ececec;
         font-family: RedHatText-Regular, Red Hat Text;
       }
     </style>
   </defs>
-  <path class="bb5f9692-c442-4f77-8e1f-31b32f9f74a1" d="M759,108.732V478.507H227.5V108.732H759m1-1H226.5V479.507H760V107.732Z"/>
-  <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(0 207.113)">Private network</text>
-  <line class="b5f900cf-2522-4961-b6fc-a9d64a96a482" x1="740" y1="192.352" x2="1" y2="193.852"/>
+  <path class="b1b4035f-3ce4-42a7-bc3e-b94360fb930d" d="M759,178.732V478.507H227.5V178.732H759m1-1H226.5V479.507H760V177.732Z"/>
+  <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(0 207.113)">Private network</text>
+  <line class="bd0843c9-21b4-4b81-9c52-8a9f27180b8d" x1="740" y1="192.352" x2="1" y2="193.852"/>
   <g>
-    <line class="b5f900cf-2522-4961-b6fc-a9d64a96a482" x1="104.094" y1="159.356" x2="104.094" y2="183.18"/>
-    <polygon class="f85db5a8-1a3c-4965-b275-fe819a4d9263" points="99.107 181.721 104.094 190.356 109.08 181.721 99.107 181.721"/>
+    <line class="bd0843c9-21b4-4b81-9c52-8a9f27180b8d" x1="104.094" y1="159.356" x2="104.094" y2="183.18"/>
+    <polygon class="b9a814cc-2dba-4cfb-885b-03db17853ad3" points="99.107 181.721 104.094 190.356 109.08 181.721 99.107 181.721"/>
   </g>
   <g>
-    <line class="b5f900cf-2522-4961-b6fc-a9d64a96a482" x1="184.258" y1="171.356" x2="184.258" y2="183.18"/>
-    <polygon class="f85db5a8-1a3c-4965-b275-fe819a4d9263" points="179.272 181.721 184.258 190.356 189.245 181.721 179.272 181.721"/>
+    <line class="bd0843c9-21b4-4b81-9c52-8a9f27180b8d" x1="184.258" y1="171.356" x2="184.258" y2="183.18"/>
+    <polygon class="b9a814cc-2dba-4cfb-885b-03db17853ad3" points="179.272 181.721 184.258 190.356 189.245 181.721 179.272 181.721"/>
   </g>
   <g>
-    <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(162.055 154.659)">Route53<tspan x="10.433" y="12">DNS</tspan></text>
+    <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(162.055 154.659)">Route53<tspan x="10.433" y="12">DNS</tspan></text>
     <g>
-      <rect class="e053b0c2-d938-42b5-816c-b4c118ba5c66" x="156.758" y="124.314" width="55" height="13.75"/>
-      <line class="b0c9a5dd-c504-4dc3-9be8-1d186441537c" x1="205.879" y1="130.211" x2="205.879" y2="130.211"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="162.651" y1="129.176" x2="162.651" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="168.544" y1="129.176" x2="168.544" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="174.437" y1="129.176" x2="174.437" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="180.33" y1="129.176" x2="180.33" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="186.223" y1="129.176" x2="186.223" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="192.115" y1="129.176" x2="192.115" y2="133.141"/>
+      <rect class="fbc04b7e-7692-4d2e-8e80-0337122aab34" x="156.758" y="124.314" width="55" height="13.75"/>
+      <line class="b418bf25-9744-4ab9-b65b-f320f7318127" x1="205.879" y1="130.211" x2="205.879" y2="130.211"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="162.651" y1="129.176" x2="162.651" y2="133.141"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="168.544" y1="129.176" x2="168.544" y2="133.141"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="174.437" y1="129.176" x2="174.437" y2="133.141"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="180.33" y1="129.176" x2="180.33" y2="133.141"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="186.223" y1="129.176" x2="186.223" y2="133.141"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="192.115" y1="129.176" x2="192.115" y2="133.141"/>
     </g>
   </g>
   <g>
-    <line class="ae79de5f-81dc-4b8d-8816-bdbcb289734b" x1="104.094" y1="101.864" x2="104.094" y2="82.54"/>
-    <polygon class="ab397ba8-d1d1-4b0d-ba40-67e404985571" points="109.08 100.405 104.094 109.04 99.107 100.405 109.08 100.405"/>
+    <line class="b7f18908-c244-4e26-81e8-4de98e875cf5" x1="104.094" y1="101.864" x2="104.094" y2="82.54"/>
+    <polygon class="e3f0e370-4c82-46bf-ba70-3fba369fa8db" points="109.08 100.405 104.094 109.04 99.107 100.405 109.08 100.405"/>
   </g>
   <g>
-    <line class="ae79de5f-81dc-4b8d-8816-bdbcb289734b" x1="26.713" y1="183.18" x2="26.713" y2="69.41"/>
-    <polygon class="ab397ba8-d1d1-4b0d-ba40-67e404985571" points="31.699 181.721 26.713 190.357 21.726 181.721 31.699 181.721"/>
+    <line class="b7f18908-c244-4e26-81e8-4de98e875cf5" x1="26.713" y1="183.18" x2="26.713" y2="69.41"/>
+    <polygon class="e3f0e370-4c82-46bf-ba70-3fba369fa8db" points="31.699 181.721 26.713 190.357 21.726 181.721 31.699 181.721"/>
   </g>
   <g>
-    <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(0 64.096)">Developer</text>
+    <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(0 64.096)">Developer</text>
     <g>
-      <path class="e053b0c2-d938-42b5-816c-b4c118ba5c66" d="M45.162,47.529a18.451,18.451,0,0,0-36.9,0Z"/>
-      <ellipse class="e053b0c2-d938-42b5-816c-b4c118ba5c66" cx="26.713" cy="20.175" rx="9.262" ry="9.148"/>
+      <path class="fbc04b7e-7692-4d2e-8e80-0337122aab34" d="M45.162,47.529a18.451,18.451,0,0,0-36.9,0Z"/>
+      <ellipse class="fbc04b7e-7692-4d2e-8e80-0337122aab34" cx="26.713" cy="20.175" rx="9.262" ry="9.148"/>
     </g>
   </g>
   <g>
-    <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(83.249 64.097)">Red Hat<tspan x="-13.25" y="12">Management</tspan></text>
+    <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(83.249 64.097)">Red Hat<tspan x="-13.25" y="12">Management</tspan></text>
     <g>
-      <path class="e053b0c2-d938-42b5-816c-b4c118ba5c66" d="M122.544,47.529a18.451,18.451,0,0,0-36.9,0Z"/>
-      <ellipse class="e053b0c2-d938-42b5-816c-b4c118ba5c66" cx="104.095" cy="20.175" rx="9.262" ry="9.148"/>
+      <path class="fbc04b7e-7692-4d2e-8e80-0337122aab34" d="M122.544,47.529a18.451,18.451,0,0,0-36.9,0Z"/>
+      <ellipse class="fbc04b7e-7692-4d2e-8e80-0337122aab34" cx="104.095" cy="20.175" rx="9.262" ry="9.148"/>
     </g>
   </g>
   <g>
-    <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(74.378 154.659)">PrivateLink</text>
+    <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(74.378 154.659)">PrivateLink</text>
     <g>
-      <path class="e053b0c2-d938-42b5-816c-b4c118ba5c66" d="M125.361,128.967a6.694,6.694,0,0,0-6.207-4.156A13.4,13.4,0,0,0,94.119,118.3a10.22,10.22,0,0,0-1.726-.157,9.968,9.968,0,1,0,0,19.936h19.486"/>
-      <path class="a7a0f9a2-dd10-49d7-b01d-32958b8424b4" d="M125.625,131.975,121.031,131a.949.949,0,0,0-.4,0l-4.594.976a.959.959,0,0,0-.758.937V138.2a5.551,5.551,0,1,0,11.1,0v-5.287A.959.959,0,0,0,125.625,131.975Z"/>
+      <path class="fbc04b7e-7692-4d2e-8e80-0337122aab34" d="M125.361,128.967a6.694,6.694,0,0,0-6.207-4.156A13.4,13.4,0,0,0,94.119,118.3a10.22,10.22,0,0,0-1.726-.157,9.968,9.968,0,1,0,0,19.936h19.486"/>
+      <path class="af5f7c8b-59be-4f9c-9020-57fe5f2aacc6" d="M125.625,131.975,121.031,131a.949.949,0,0,0-.4,0l-4.594.976a.959.959,0,0,0-.758.937V138.2a5.551,5.551,0,1,0,11.1,0v-5.287A.959.959,0,0,0,125.625,131.975Z"/>
     </g>
   </g>
   <g>
-    <polyline class="ae79de5f-81dc-4b8d-8816-bdbcb289734b" points="485.25 271.834 485.25 220.477 445.426 220.477"/>
-    <polygon class="ab397ba8-d1d1-4b0d-ba40-67e404985571" points="446.885 215.49 438.25 220.477 446.885 225.463 446.885 215.49"/>
+    <polyline class="b7f18908-c244-4e26-81e8-4de98e875cf5" points="485.25 271.834 485.25 220.477 445.426 220.477"/>
+    <polygon class="e3f0e370-4c82-46bf-ba70-3fba369fa8db" points="446.885 215.49 438.25 220.477 446.885 225.463 446.885 215.49"/>
   </g>
   <g>
-    <polyline class="ae79de5f-81dc-4b8d-8816-bdbcb289734b" points="664 271.834 664 220.477 500.25 220.477 500.25 262.158"/>
-    <polygon class="ab397ba8-d1d1-4b0d-ba40-67e404985571" points="495.263 260.699 500.25 269.334 505.236 260.699 495.263 260.699"/>
+    <polyline class="b7f18908-c244-4e26-81e8-4de98e875cf5" points="614 271.834 614 220.477 500.25 220.477 500.25 262.158"/>
+    <polygon class="e3f0e370-4c82-46bf-ba70-3fba369fa8db" points="495.263 260.699 500.25 269.334 505.236 260.699 495.263 260.699"/>
   </g>
   <g>
-    <polyline class="ae79de5f-81dc-4b8d-8816-bdbcb289734b" points="321.5 262.158 321.5 220.477 385.125 220.477"/>
-    <polygon class="ab397ba8-d1d1-4b0d-ba40-67e404985571" points="326.486 260.699 321.5 269.334 316.513 260.699 326.486 260.699"/>
+    <line class="b7f18908-c244-4e26-81e8-4de98e875cf5" x1="664.5" y1="249.372" x2="664.5" y2="262.158"/>
+    <polygon class="e3f0e370-4c82-46bf-ba70-3fba369fa8db" points="659.514 260.699 664.5 269.334 669.486 260.699 659.514 260.699"/>
   </g>
   <g>
-    <polyline class="b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9" points="402.5 450.334 402.5 451.834 401 451.834"/>
-    <line class="b0c10438-7c46-4a1b-86d5-4f7562fc2e35" x1="398.019" y1="451.834" x2="244.491" y2="451.834"/>
-    <polyline class="b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9" points="243 451.834 241.5 451.834 241.5 450.334"/>
-    <line class="f5d99c62-387f-4dc9-af57-1070360f6ec8" x1="241.5" y1="447.334" x2="241.5" y2="274.834"/>
-    <polyline class="b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9" points="241.5 273.334 241.5 271.834 243 271.834"/>
-    <line class="b0c10438-7c46-4a1b-86d5-4f7562fc2e35" x1="245.981" y1="271.834" x2="399.509" y2="271.834"/>
-    <polyline class="b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9" points="401 271.834 402.5 271.834 402.5 273.334"/>
-    <line class="f5d99c62-387f-4dc9-af57-1070360f6ec8" x1="402.5" y1="276.334" x2="402.5" y2="448.834"/>
+    <polyline class="b7f18908-c244-4e26-81e8-4de98e875cf5" points="329.568 262.158 329.568 220.477 385.125 220.477"/>
+    <polygon class="e3f0e370-4c82-46bf-ba70-3fba369fa8db" points="334.554 260.699 329.568 269.334 324.581 260.699 334.554 260.699"/>
   </g>
-  <rect class="ae616477-1e09-46cd-85c1-0b4280cab686" x="251.5" y="281.834" width="141" height="155"/>
-  <text class="a948e394-64b4-4607-b904-a70986052a79" transform="translate(261.5 301.938)">Control plane nodes <tspan x="0" y="12">(x3)</tspan></text>
-  <rect class="a6f07811-5c79-4ff3-a4a5-db1bc58639ea" x="261.5" y="326.834" width="120" height="30"/>
-  <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(297.487 344.881)">apiserver</text>
-  <rect class="a6f07811-5c79-4ff3-a4a5-db1bc58639ea" x="261.5" y="361.834" width="120" height="30"/>
-  <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(309.839 379.881)">etcd</text>
-  <rect class="a6f07811-5c79-4ff3-a4a5-db1bc58639ea" x="261.5" y="396.834" width="120" height="30"/>
-  <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(296.321 414.881)">controller</text>
   <g>
-    <polyline class="b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9" points="573.75 450.334 573.75 451.834 572.25 451.834"/>
-    <line class="b0c10438-7c46-4a1b-86d5-4f7562fc2e35" x1="569.269" y1="451.834" x2="415.741" y2="451.834"/>
-    <polyline class="b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9" points="414.25 451.834 412.75 451.834 412.75 450.334"/>
-    <line class="f5d99c62-387f-4dc9-af57-1070360f6ec8" x1="412.75" y1="447.334" x2="412.75" y2="274.834"/>
-    <polyline class="b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9" points="412.75 273.334 412.75 271.834 414.25 271.834"/>
-    <line class="b0c10438-7c46-4a1b-86d5-4f7562fc2e35" x1="417.231" y1="271.834" x2="570.759" y2="271.834"/>
-    <polyline class="b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9" points="572.25 271.834 573.75 271.834 573.75 273.334"/>
-    <line class="f5d99c62-387f-4dc9-af57-1070360f6ec8" x1="573.75" y1="276.334" x2="573.75" y2="448.834"/>
+    <polyline class="f69dd7fb-6bbf-4ca0-aca9-665a506b8919" points="402.5 450.334 402.5 451.834 401 451.834"/>
+    <line class="f3fdb182-0969-4fc9-953e-d5263db0d50f" x1="398.019" y1="451.834" x2="244.491" y2="451.834"/>
+    <polyline class="f69dd7fb-6bbf-4ca0-aca9-665a506b8919" points="243 451.834 241.5 451.834 241.5 450.334"/>
+    <line class="b3fb0424-c963-40cb-9f46-075ec073efa1" x1="241.5" y1="447.334" x2="241.5" y2="274.834"/>
+    <polyline class="f69dd7fb-6bbf-4ca0-aca9-665a506b8919" points="241.5 273.334 241.5 271.834 243 271.834"/>
+    <line class="f3fdb182-0969-4fc9-953e-d5263db0d50f" x1="245.981" y1="271.834" x2="399.509" y2="271.834"/>
+    <polyline class="f69dd7fb-6bbf-4ca0-aca9-665a506b8919" points="401 271.834 402.5 271.834 402.5 273.334"/>
+    <line class="b3fb0424-c963-40cb-9f46-075ec073efa1" x1="402.5" y1="276.334" x2="402.5" y2="448.834"/>
   </g>
-  <rect class="ae616477-1e09-46cd-85c1-0b4280cab686" x="422.75" y="281.834" width="141" height="155"/>
-  <text class="a948e394-64b4-4607-b904-a70986052a79" transform="translate(432.75 301.938)">Worker nodes <tspan x="0" y="12">(xN)</tspan></text>
-  <rect class="a6f07811-5c79-4ff3-a4a5-db1bc58639ea" x="432.75" y="326.834" width="120" height="30"/>
-  <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(455.762 344.881)">Compute (xN)</text>
-  <rect class="a6f07811-5c79-4ff3-a4a5-db1bc58639ea" x="432.75" y="361.834" width="120" height="30"/>
-  <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(445.016 379.881)">Persistent storage</text>
+  <rect class="fdb956ea-1dce-4b0b-a7c0-7a46fd063796" x="251.5" y="281.834" width="141" height="155"/>
+  <text class="e7efa073-ee49-4805-a810-fbb8987e49b0" transform="translate(261.5 301.938)">Control plane nodes <tspan x="0" y="12">(x3)</tspan></text>
+  <rect class="ac1a4e9a-8a92-46a2-91ec-3546765ddb62" x="261.5" y="326.834" width="120" height="30"/>
+  <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(297.487 344.881)">apiserver</text>
+  <rect class="ac1a4e9a-8a92-46a2-91ec-3546765ddb62" x="261.5" y="361.834" width="120" height="30"/>
+  <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(309.839 379.881)">etcd</text>
+  <rect class="ac1a4e9a-8a92-46a2-91ec-3546765ddb62" x="261.5" y="396.834" width="120" height="30"/>
+  <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(296.321 414.881)">controller</text>
   <g>
-    <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(387.698 243.945)">Internal<tspan x="-6.407" y="12">(API) NLB</tspan></text>
+    <polyline class="f69dd7fb-6bbf-4ca0-aca9-665a506b8919" points="573.75 450.334 573.75 451.834 572.25 451.834"/>
+    <line class="f3fdb182-0969-4fc9-953e-d5263db0d50f" x1="569.269" y1="451.834" x2="415.741" y2="451.834"/>
+    <polyline class="f69dd7fb-6bbf-4ca0-aca9-665a506b8919" points="414.25 451.834 412.75 451.834 412.75 450.334"/>
+    <line class="b3fb0424-c963-40cb-9f46-075ec073efa1" x1="412.75" y1="447.334" x2="412.75" y2="274.834"/>
+    <polyline class="f69dd7fb-6bbf-4ca0-aca9-665a506b8919" points="412.75 273.334 412.75 271.834 414.25 271.834"/>
+    <line class="f3fdb182-0969-4fc9-953e-d5263db0d50f" x1="417.231" y1="271.834" x2="570.759" y2="271.834"/>
+    <polyline class="f69dd7fb-6bbf-4ca0-aca9-665a506b8919" points="572.25 271.834 573.75 271.834 573.75 273.334"/>
+    <line class="b3fb0424-c963-40cb-9f46-075ec073efa1" x1="573.75" y1="276.334" x2="573.75" y2="448.834"/>
+  </g>
+  <rect class="fdb956ea-1dce-4b0b-a7c0-7a46fd063796" x="422.75" y="281.834" width="141" height="155"/>
+  <text class="e7efa073-ee49-4805-a810-fbb8987e49b0" transform="translate(432.75 301.938)">Worker nodes <tspan x="0" y="12">(xN)</tspan></text>
+  <rect class="ac1a4e9a-8a92-46a2-91ec-3546765ddb62" x="432.75" y="326.834" width="120" height="30"/>
+  <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(455.762 344.881)">Compute (xN)</text>
+  <rect class="ac1a4e9a-8a92-46a2-91ec-3546765ddb62" x="432.75" y="361.834" width="120" height="30"/>
+  <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(445.016 379.881)">Persistent storage</text>
+  <g>
+    <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(385.845 243.945)">API NLB</text>
     <g>
-      <rect class="e053b0c2-d938-42b5-816c-b4c118ba5c66" x="380.125" y="213.602" width="55" height="13.75"/>
-      <line class="b0c9a5dd-c504-4dc3-9be8-1d186441537c" x1="429.246" y1="219.498" x2="429.246" y2="219.498"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="386.018" y1="218.464" x2="386.018" y2="222.429"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="391.911" y1="218.464" x2="391.911" y2="222.429"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="397.804" y1="218.464" x2="397.804" y2="222.429"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="403.696" y1="218.464" x2="403.696" y2="222.429"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="409.589" y1="218.464" x2="409.589" y2="222.429"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="415.482" y1="218.464" x2="415.482" y2="222.429"/>
+      <rect class="fbc04b7e-7692-4d2e-8e80-0337122aab34" x="380.125" y="213.602" width="55" height="13.75"/>
+      <line class="b418bf25-9744-4ab9-b65b-f320f7318127" x1="429.246" y1="219.498" x2="429.246" y2="219.498"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="386.018" y1="218.464" x2="386.018" y2="222.429"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="391.911" y1="218.464" x2="391.911" y2="222.429"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="397.804" y1="218.464" x2="397.804" y2="222.429"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="403.696" y1="218.464" x2="403.696" y2="222.429"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="409.589" y1="218.464" x2="409.589" y2="222.429"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="415.482" y1="218.464" x2="415.482" y2="222.429"/>
     </g>
   </g>
   <g>
-    <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(684.689 154.659)">Red Hat<tspan x="-16.665" y="12">(Console) ELB</tspan></text>
+    <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(641.917 243.947)">App ELB</text>
     <g>
-      <rect class="e053b0c2-d938-42b5-816c-b4c118ba5c66" x="678.034" y="124.314" width="55" height="13.75"/>
-      <line class="b0c9a5dd-c504-4dc3-9be8-1d186441537c" x1="727.155" y1="130.211" x2="727.155" y2="130.211"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="683.927" y1="129.176" x2="683.927" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="689.82" y1="129.176" x2="689.82" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="695.713" y1="129.176" x2="695.713" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="701.605" y1="129.176" x2="701.605" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="707.498" y1="129.176" x2="707.498" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="713.391" y1="129.176" x2="713.391" y2="133.141"/>
+      <rect class="fbc04b7e-7692-4d2e-8e80-0337122aab34" x="637" y="213.602" width="55" height="13.75"/>
+      <line class="b418bf25-9744-4ab9-b65b-f320f7318127" x1="686.121" y1="219.498" x2="686.121" y2="219.498"/>
+      <line class="f2a6a062-2134-43e7-8296-436a2fa25740" x1="643.735" y1="221.459" x2="651.985" y2="221.459"/>
     </g>
   </g>
   <g>
-    <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(573.348 154.659)">External/internal<tspan x="21.603" y="12">App ELB</tspan></text>
-    <g>
-      <rect class="e053b0c2-d938-42b5-816c-b4c118ba5c66" x="594.966" y="124.314" width="55" height="13.75"/>
-      <line class="b0c9a5dd-c504-4dc3-9be8-1d186441537c" x1="644.087" y1="130.211" x2="644.087" y2="130.211"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="601.701" y1="132.171" x2="609.951" y2="132.171"/>
-    </g>
+    <line class="bd0843c9-21b4-4b81-9c52-8a9f27180b8d" x1="407.625" y1="193.019" x2="407.625" y2="203.16"/>
+    <polygon class="b9a814cc-2dba-4cfb-885b-03db17853ad3" points="402.638 201.701 407.625 210.336 412.611 201.701 402.638 201.701"/>
   </g>
   <g>
-    <g>
-      <line class="b5f900cf-2522-4961-b6fc-a9d64a96a482" x1="610.034" y1="180.528" x2="610.034" y2="192.352"/>
-      <polygon class="f85db5a8-1a3c-4965-b275-fe819a4d9263" points="605.048 181.987 610.034 173.352 615.02 181.987 605.048 181.987"/>
-    </g>
-    <line class="b7cdd690-62a1-4e5a-9e83-ab5f2946c9ce" x1="625.034" y1="173.352" x2="625.034" y2="235.334"/>
-    <g>
-      <line class="a903d9f8-1d04-44eb-ad3c-0f0e36b3c27c" x1="625.034" y1="180.528" x2="625.034" y2="262.158"/>
-      <polygon class="b63cdd79-fc3f-464e-bf73-ea7cae83db70" points="620.048 181.987 625.034 173.352 630.02 181.987 620.048 181.987"/>
-      <polygon class="b63cdd79-fc3f-464e-bf73-ea7cae83db70" points="620.048 260.699 625.034 269.334 630.02 260.699 620.048 260.699"/>
-    </g>
-  </g>
-  <line class="b7cdd690-62a1-4e5a-9e83-ab5f2946c9ce" x1="705.534" y1="173.352" x2="705.534" y2="235.334"/>
-  <line class="b7cdd690-62a1-4e5a-9e83-ab5f2946c9ce" x1="363.534" y1="215.775" x2="363.534" y2="252.161"/>
-  <g>
-    <line class="a903d9f8-1d04-44eb-ad3c-0f0e36b3c27c" x1="705.534" y1="180.528" x2="705.534" y2="262.158"/>
-    <polygon class="b63cdd79-fc3f-464e-bf73-ea7cae83db70" points="700.548 181.987 705.534 173.352 710.52 181.987 700.548 181.987"/>
-    <polygon class="b63cdd79-fc3f-464e-bf73-ea7cae83db70" points="700.548 260.699 705.534 269.334 710.52 260.699 700.548 260.699"/>
+    <line class="bd0843c9-21b4-4b81-9c52-8a9f27180b8d" x1="664.5" y1="193.019" x2="664.5" y2="203.16"/>
+    <polygon class="b9a814cc-2dba-4cfb-885b-03db17853ad3" points="659.514 201.701 664.5 210.336 669.486 201.701 659.514 201.701"/>
   </g>
   <g>
-    <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(342.689 154.659)">Red Hat<tspan x="-4.829" y="12">(API) ELB</tspan></text>
-    <g>
-      <rect class="e053b0c2-d938-42b5-816c-b4c118ba5c66" x="336.034" y="124.314" width="55" height="13.75"/>
-      <line class="b0c9a5dd-c504-4dc3-9be8-1d186441537c" x1="385.155" y1="130.211" x2="385.155" y2="130.211"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="341.927" y1="129.176" x2="341.927" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="347.82" y1="129.176" x2="347.82" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="353.713" y1="129.176" x2="353.713" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="359.605" y1="129.176" x2="359.605" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="365.498" y1="129.176" x2="365.498" y2="133.141"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="371.391" y1="129.176" x2="371.391" y2="133.141"/>
-    </g>
+    <polyline class="f69dd7fb-6bbf-4ca0-aca9-665a506b8919" points="745 450.334 745 451.834 743.5 451.834"/>
+    <line class="f3fdb182-0969-4fc9-953e-d5263db0d50f" x1="740.519" y1="451.834" x2="586.991" y2="451.834"/>
+    <polyline class="f69dd7fb-6bbf-4ca0-aca9-665a506b8919" points="585.5 451.834 584 451.834 584 450.334"/>
+    <line class="b3fb0424-c963-40cb-9f46-075ec073efa1" x1="584" y1="447.334" x2="584" y2="274.834"/>
+    <polyline class="f69dd7fb-6bbf-4ca0-aca9-665a506b8919" points="584 273.334 584 271.834 585.5 271.834"/>
+    <line class="f3fdb182-0969-4fc9-953e-d5263db0d50f" x1="588.481" y1="271.834" x2="742.009" y2="271.834"/>
+    <polyline class="f69dd7fb-6bbf-4ca0-aca9-665a506b8919" points="743.5 271.834 745 271.834 745 273.334"/>
+    <line class="b3fb0424-c963-40cb-9f46-075ec073efa1" x1="745" y1="276.334" x2="745" y2="448.834"/>
   </g>
+  <rect class="fdb956ea-1dce-4b0b-a7c0-7a46fd063796" x="594" y="281.834" width="141" height="155"/>
+  <text class="e7efa073-ee49-4805-a810-fbb8987e49b0" transform="translate(604 301.938)">Infra nodes <tspan x="0" y="12">(x2, x3)</tspan></text>
+  <rect class="ac1a4e9a-8a92-46a2-91ec-3546765ddb62" x="604" y="326.834" width="120" height="30"/>
+  <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(643.925 344.881)">registry</text>
+  <rect class="ac1a4e9a-8a92-46a2-91ec-3546765ddb62" x="604" y="361.834" width="120" height="30"/>
+  <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(647.758 379.881)">router</text>
+  <rect class="ac1a4e9a-8a92-46a2-91ec-3546765ddb62" x="604" y="396.834" width="120" height="30"/>
+  <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(635.642 414.881)">monitoring</text>
   <g>
-    <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(236.348 154.659)">External/internal<tspan x="17.853" y="12">(API) NLB</tspan></text>
-    <g>
-      <rect class="e053b0c2-d938-42b5-816c-b4c118ba5c66" x="252.966" y="124.314" width="55" height="13.75"/>
-      <line class="b0c9a5dd-c504-4dc3-9be8-1d186441537c" x1="302.087" y1="130.211" x2="302.087" y2="130.211"/>
-      <line class="ae1dc0d1-0e51-4325-96d3-4af8d85c97ef" x1="259.701" y1="132.171" x2="267.951" y2="132.171"/>
-    </g>
+    <text class="b85634e9-8401-4824-b3f9-43f8b7f4c31d" transform="translate(702.797 162.732)">AWS VPC</text>
+    <line class="b7f18908-c244-4e26-81e8-4de98e875cf5" x1="699.599" y1="158.204" x2="676.735" y2="177.732"/>
   </g>
+  <rect class="ac1a4e9a-8a92-46a2-91ec-3546765ddb62" x="274.429" y="444.078" width="95.143" height="14.513"/>
+  <rect class="ac1a4e9a-8a92-46a2-91ec-3546765ddb62" x="445.679" y="444.078" width="95.143" height="14.513"/>
+  <rect class="ac1a4e9a-8a92-46a2-91ec-3546765ddb62" x="616.929" y="444.078" width="95.143" height="14.513"/>
+  <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(280.085 454.381)">Availability zone<tspan x="23.683" y="12">(x1, x3)</tspan></text>
+  <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(451.336 454.381)">Availability zone<tspan x="23.683" y="12">(x1, x3)</tspan></text>
+  <text class="b7c84ee7-c086-42d9-93ee-26d53bfb781f" transform="translate(622.585 454.381)">Availability zone<tspan x="23.683" y="12">(x1, x3)</tspan></text>
   <g>
-    <line class="b5f900cf-2522-4961-b6fc-a9d64a96a482" x1="280.534" y1="180.528" x2="280.534" y2="262.158"/>
-    <polygon class="f85db5a8-1a3c-4965-b275-fe819a4d9263" points="275.548 181.987 280.534 173.352 285.52 181.987 275.548 181.987"/>
-    <polygon class="f85db5a8-1a3c-4965-b275-fe819a4d9263" points="275.548 260.699 280.534 269.334 285.52 260.699 275.548 260.699"/>
-  </g>
-  <g>
-    <line class="b5f900cf-2522-4961-b6fc-a9d64a96a482" x1="363.534" y1="180.528" x2="363.534" y2="262.158"/>
-    <polygon class="f85db5a8-1a3c-4965-b275-fe819a4d9263" points="358.548 181.987 363.534 173.352 368.52 181.987 358.548 181.987"/>
-    <polygon class="f85db5a8-1a3c-4965-b275-fe819a4d9263" points="358.548 260.699 363.534 269.334 368.52 260.699 358.548 260.699"/>
-  </g>
-  <g>
-    <polyline class="b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9" points="745 450.334 745 451.834 743.5 451.834"/>
-    <line class="b0c10438-7c46-4a1b-86d5-4f7562fc2e35" x1="740.519" y1="451.834" x2="586.991" y2="451.834"/>
-    <polyline class="b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9" points="585.5 451.834 584 451.834 584 450.334"/>
-    <line class="f5d99c62-387f-4dc9-af57-1070360f6ec8" x1="584" y1="447.334" x2="584" y2="274.834"/>
-    <polyline class="b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9" points="584 273.334 584 271.834 585.5 271.834"/>
-    <line class="b0c10438-7c46-4a1b-86d5-4f7562fc2e35" x1="588.481" y1="271.834" x2="742.009" y2="271.834"/>
-    <polyline class="b727e749-6ba8-4a9b-9699-1ac7a3f2c5e9" points="743.5 271.834 745 271.834 745 273.334"/>
-    <line class="f5d99c62-387f-4dc9-af57-1070360f6ec8" x1="745" y1="276.334" x2="745" y2="448.834"/>
-  </g>
-  <rect class="ae616477-1e09-46cd-85c1-0b4280cab686" x="594" y="281.834" width="141" height="155"/>
-  <text class="a948e394-64b4-4607-b904-a70986052a79" transform="translate(604 301.938)">Infra nodes <tspan x="0" y="12">(x2, x3)</tspan></text>
-  <rect class="a6f07811-5c79-4ff3-a4a5-db1bc58639ea" x="604" y="326.834" width="120" height="30"/>
-  <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(643.925 344.881)">registry</text>
-  <rect class="a6f07811-5c79-4ff3-a4a5-db1bc58639ea" x="604" y="361.834" width="120" height="30"/>
-  <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(647.758 379.881)">router</text>
-  <rect class="a6f07811-5c79-4ff3-a4a5-db1bc58639ea" x="604" y="396.834" width="120" height="30"/>
-  <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(635.642 414.881)">monitoring</text>
-  <g>
-    <text class="bb93582a-a6e4-4638-b989-1021dcc30a88" transform="translate(702.797 92.732)">AWS VPC</text>
-    <line class="ae79de5f-81dc-4b8d-8816-bdbcb289734b" x1="699.599" y1="88.204" x2="676.735" y2="107.732"/>
-  </g>
-  <rect class="a6f07811-5c79-4ff3-a4a5-db1bc58639ea" x="274.429" y="444.078" width="95.143" height="14.513"/>
-  <rect class="a6f07811-5c79-4ff3-a4a5-db1bc58639ea" x="445.679" y="444.078" width="95.143" height="14.513"/>
-  <rect class="a6f07811-5c79-4ff3-a4a5-db1bc58639ea" x="616.929" y="444.078" width="95.143" height="14.513"/>
-  <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(280.085 454.381)">Availability zone<tspan x="23.683" y="12">(x1, x3)</tspan></text>
-  <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(451.336 454.381)">Availability zone<tspan x="23.683" y="12">(x1, x3)</tspan></text>
-  <text class="e8f26476-521b-4e4e-b8c3-76ba7d6beee8" transform="translate(622.585 454.381)">Availability zone<tspan x="23.683" y="12">(x1, x3)</tspan></text>
-  <g>
-    <text class="a96f75ea-9a46-4516-8393-41822b208052" transform="translate(668.082 502.524)">156_OpenShift_0621</text>
-    <rect class="a481feb1-ac3d-49c0-ad32-c2b68a878cf4" y="479.507" width="760" height="40"/>
+    <text class="a2005cac-254a-463a-9c1a-e3f760590dca" transform="translate(672.322 502.524)">156_OpenShift_1221</text>
+    <rect class="b1f7e056-e611-4777-80a2-a65a28cb0821" y="479.507" width="760" height="40"/>
   </g>
 </svg>


### PR DESCRIPTION
4.9+

[OSDOCS-2694](https://issues.redhat.com/browse/OSDOCS-2694)
Fixes ROSA-specific diagram

**Preview**:https://deploy-preview-41253--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-architecture-models#osd-aws-privatelink-architecture.adoc_rosa-architecture-models

**PTAL**: @okashi18 