### PR TITLE
BZ2037519: 4.10 RN arches deprecation notice

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -114,7 +114,6 @@ For more information, see xref:../updating/understanding-upgrade-channels-releas
 [id="ocp-4-10-networking"]
 === Networking
 
-
 [id="ocp-4-10-redfish-events"]
 ==== Low-latency Redfish hardware event delivery (Technology Preview)
 
@@ -128,7 +127,6 @@ You can use a REST API to develop applications to consume and respond to events 
 ====
 This feature is supported for single node OpenShift clusters only.
 ====
-
 
 [id="ocp-4-10-networking-ovn-gateway-config"]
 ==== OVN-Kubernetes support for gateway configuration
@@ -390,6 +388,16 @@ In the table, features are marked with the following statuses:
 
 [id="ocp-4-10-deprecated-features"]
 === Deprecated features
+
+[id="ocp-4-10-arch-deprecations"]
+==== IBM POWER8, IBM z13 all models, LinuxONE Emperor, LinuxONE Rockhopper, and x86_64 v1 architectures will be deprecated
+
+{op-system} functionality in IBM POWER8, IBM z13 all models, LinuxONE Emperor, LinuxONE Rockhopper, and x86_64 v1 CPU architectures will be deprecated in an upcoming release. Additional details for when support will discontinue for these architectures will be announced in a future release.
+
+[NOTE]
+====
+AMD and Intel 64-bit architectures (x86-64-v2) will still be supported.
+====
 
 [id="ocp-4-10-removed-features"]
 === Removed features


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2037519

Draft preview link: https://deploy-preview-41265--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-arch-deprecations

Details are scant in the BZ, could use input on what to explicitly call out in OCP 4.10 Release Notes? 
Cc: @marrusl @control-d @miabbott 