### PR TITLE
[TELCODOCS-323] [OpenShift 4.10 release notes] - CNF-2772 PTP updates

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -550,6 +550,24 @@ The most common use case for the `networkConfig` configuration setting is to set
 
 For more information, see xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-host-network-interfaces-in-the-install-config.yaml-file_ipi-install-installation-workflow[Configuring host network interfaces in the install-config.yaml file].
 
+[id="ocp-4-10-networking-linuxptp"]
+==== Boundary clock and PTP enhancements to linuxptp services
+
+You can now specify multiple network interfaces in a `PtpConfig` profile to allow nodes running RAN vDU applications to serve as a Precision Time Protocol Telecom Boundary Clock (PTP T-BC). Interfaces configured as boundary clocks now also support PTP fast events.
+
+For more information, see xref:../networking/using-ptp.adoc#configuring-linuxptp-services-as-boundary-clock_using-ptp[Configuring linuxptp services as boundary clock].
+
+[id="ocp-4-10-networking-columbiaville"]
+==== Support for Intel 800-Series Columbiaville NICs
+
+Intel 800-Series Columbiaville NICs are now fully supported for interfaces configured as boundary clocks or ordinary clocks. Columbiaville NICs are supported in the following configurations:
+
+* Ordinary clock
+* Boundary clock synced to the Grandmaster clock
+* Boundary clock with one port synchronizing from an upstream source clock, and three ports providing downstream timing to destination clocks
+
+For more information, see xref:../networking/using-ptp.adoc#configuring-ptp-devices[Configuring PTP devices].
+
 [id="ocp-4-10-hardware"]
 === Hardware
 


### PR DESCRIPTION
Release note for https://issues.redhat.com/browse/TELCODOCS-323. 

Merge to enterprise-4.10

Preview: 
* [Boundary clock and PTP enhancements to linuxptp services](https://deploy-preview-41279--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-networking-linuxptp)
* [Support for Intel 800-Series Columbiaville NICs
](https://deploy-preview-41279--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-networking-columbiaville)