### PR TITLE
BZ:2049053: fix crio annotation description and examples

### DIFF
--- a/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
+++ b/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
@@ -14,6 +14,28 @@ In the performance profile, `globallyDisableIrqLoadBalancing` is used to manage 
 
 To achieve low latency for workloads, some (but not all) pods require the CPUs they are running on to not process device interrupts. A pod annotation, `irq-load-balancing.crio.io`, is used to define whether device interrupts are processed or not. When configured, CRI-O disables device interrupts only as long as the pod is running.
 
+[id="disabling-cpu-cfs-quota_{context}"]
+== Disabling CPU CFS quota
+
+To reduce CPU throttling for individual guaranteed pods, create a pod specification with the annotation `cpu-quota.crio.io: "disable"`. This annotation disables the CPU completely fair scheduler (CFS) quota at the pod run time. The following pod specification contains this annotation:
+
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: Pod
+metadata:
+  annotations:
+      cpu-quota.crio.io: "disable"
+spec:
+    runtimeClassName: performance-<profile_name>
+...
+----
+
+[NOTE]
+====
+Only disable CPU CFS quota when the CPU manager static policy is enabled and for pods with guaranteed QoS that use whole CPUs. Otherwise, disabling CPU CFS quota can affect the performance of other containers in the cluster.
+====
+
 [id="configuring-global-device-interrupts-handling-for-isolated-cpus_{context}"]
 == Disabling global device interrupts handling in Performance Addon Operator
 
@@ -35,7 +57,7 @@ spec:
 [id="disabling_interrupt_processing_for_individual_pods_{context}"]
 == Disabling interrupt processing for individual pods
 
-To disable interrupt processing for individual pods, ensure that `globallyDisableIrqLoadBalancing` is set to `false` in the performance profile. Then, in the pod specification, set the `irq-load-balancing.crio.io` and `cpu-load-balancing.crio.io` pod annotations to `disable`. An example pod specification snippet that illustrates this is below:
+To disable interrupt processing for individual pods, ensure that `globallyDisableIrqLoadBalancing` is set to `false` in the performance profile. Then, in the pod specification, set the `irq-load-balancing.crio.io` pod annotation to `disable`. The following pod specification contains this annotation:
 
 [source,yaml]
 ----
@@ -44,7 +66,6 @@ kind: Pod
 metadata:
   annotations:
       irq-load-balancing.crio.io: "disable"
-      cpu-load-balancing.crio.io: "disable"
 spec:
     runtimeClassName: performance-<profile_name>
 ...


### PR DESCRIPTION
Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=2049053

Relevant for 4.10, 4.9 and 4.8

Preview updated content
https://deploy-preview-41282--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus_cnf-master

https://deploy-preview-41282--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#disabling_interrupt_processing_for_individual_pods_cnf-master

https://deploy-preview-41282--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#performance-addon-operator-disabling-cpu-load-balancing-for-dpdk_cnf-master

