### PR TITLE
RHACS 3.68 - Docs release

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -138,9 +138,9 @@ AddType text/vtt                            vtt
     # ACS Redirects to go to the latest version - change here when a new version drops
     # it should probably be best to combine the next few lines in one reg exp but for clarity keeping them separate
     # the first one redirects
-    RewriteRule ^acs/?$ /acs/3.67/welcome/index.html [R=301]
-    RewriteRule ^acs/(\D.*)$ /acs/3.67/$1 [NE,R=301]
-    RewriteRule ^acs/(3\.65|3\.66|3\.67)/?$ /acs/$1/welcome/index.html [L,R=301]
+    RewriteRule ^acs/?$ /acs/3.68/welcome/index.html [R=301]
+    RewriteRule ^acs/(\D.*)$ /acs/3.68/$1 [NE,R=301]
+    RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68)/?$ /acs/$1/welcome/index.html [L,R=301]
 
     # this pipeline redirect has to come before the latest kicks in generically
     RewriteRule ^container-platform/latest/pipelines/creating-applications-with-cicd-pipelines.html /container-platform/4.7/cicd/pipelines/creating-applications-with-cicd-pipelines.html [NE,R=302]

--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -203,3 +203,6 @@ openshift-acs:
     rhacs-docs-3.67:
       name: '3.67'
       dir: acs/3.67
+    rhacs-docs-3.68:
+      name: '3.68'
+      dir: acs/3.68

--- a/index-commercial.html
+++ b/index-commercial.html
@@ -263,6 +263,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
               <div class="btn-group">
                 <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">Select version<span class="caret"></span></button>
                 <ul class="dropdown-menu" role="menu">
+                  <li><a href="acs/3.68/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> RHACS 3.68</a></li>
                   <li><a href="acs/3.67/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> RHACS 3.67</a></li>
                   <li><a href="acs/3.66/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> RHACS 3.66</a></li>
                   <li><a href="acs/3.65/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> RHACS 3.65</a></li>


### PR DESCRIPTION
Docs release PR for RHACS 3.68
- Based on https://github.com/openshift/openshift-docs/pull/39460