### PR TITLE
ISSUE-41270: Fixing typo on heading

### DIFF
--- a/updating/preparing-eus-eus-upgrade.adoc
+++ b/updating/preparing-eus-eus-upgrade.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="preparing-eus-eus-upgrade"]
-= Performing to perform an EUS to EUS upgrade
+= Preparing to perform an EUS to EUS upgrade
 include::modules/common-attributes.adoc[]
 :context: eus-to-eus-upgrade
 


### PR DESCRIPTION
4.8+
Fixing issue https://github.com/openshift/openshift-docs/issues/41270 
Typo on heading, SME/QE not required.
Preview: [Preparing to perform an EUS to EUS upgrade](https://deploy-preview-41290--osdocs.netlify.app/openshift-enterprise/latest/updating/preparing-eus-eus-upgrade.html)