### PR TITLE
OSDOCS-3219 ASH UPI now supports internal CAs

### DIFF
--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc
@@ -15,11 +15,6 @@ Several link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/templ
 The steps for performing a user-provisioned infrastructure installation are provided as an example only. Installing a cluster with infrastructure you provide requires knowledge of the cloud provider and the installation process of {product-title}. Several ARM templates are provided to assist in completing these steps or to help model your own. You are also free to create the required resources through other methods; the templates are just an example.
 ====
 
-[IMPORTANT]
-====
-You can only install {product-title} on Azure Stack Hub with public endpoints, such as the ARM endpoint, that are secured with certificates signed by a publicly trusted certificate authority (CA). Support for internal CAs will be added in a future z-stream release of {product-title}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2012173[*BZ#2012173*])
-====
-
 [id="prerequisites_installing-azure-stack-hub-user-infra"]
 == Prerequisites
 

--- a/modules/installation-azure-stack-hub-config-yaml.adoc
+++ b/modules/installation-azure-stack-hub-config-yaml.adoc
@@ -50,10 +50,18 @@ platform:
 pullSecret: '{"auths": ...}' <8>
 ifndef::openshift-origin[]
 fips: false <9>
-sshKey: ssh-ed25519 AAAA... <10>
+additionalTrustBundle: | <10>
+    -----BEGIN CERTIFICATE-----
+    <MY_TRUSTED_CA_CERT>
+    -----END CERTIFICATE-----
+sshKey: ssh-ed25519 AAAA... <11>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <9>
+additionalTrustBundle: | <9>
+    -----BEGIN CERTIFICATE-----
+    <MY_TRUSTED_CA_CERT>
+    -----END CERTIFICATE-----
+sshKey: ssh-ed25519 AAAA... <10>
 endif::openshift-origin[]
 ----
 <1> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
@@ -71,10 +79,12 @@ ifndef::openshift-origin[]
 ====
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
-<10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<10> If your Azure Stack Hub environment uses an internal certificate authority (CA), add the necessary certificate bundle in `.pem` format.
+<11> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<9> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<9> If your Azure Stack Hub environment uses an internal certificate authority (CA), add the necessary certificate bundle in `.pem` format.
+<10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 +
 [NOTE]

--- a/modules/installation-creating-azure-bootstrap.adoc
+++ b/modules/installation-creating-azure-bootstrap.adoc
@@ -41,7 +41,7 @@ support with your installation logs.
 this topic and save it as `04_bootstrap.json` in your cluster's installation directory. This template
 describes the bootstrap machine that your cluster requires.
 
-. Export the bootstrap ignition variable:
+. Export the bootstrap URL variable:
 +
 [source,terminal]
 ----
@@ -52,11 +52,35 @@ $ bootstrap_url_expiry=`date -u -d "10 hours" '+%Y-%m-%dT%H:%MZ'`
 ----
 $ export BOOTSTRAP_URL=`az storage blob generate-sas -c 'files' -n 'bootstrap.ign' --https-only --full-uri --permissions r --expiry $bootstrap_url_expiry --account-name ${CLUSTER_NAME}sa --account-key ${ACCOUNT_KEY} -o tsv`
 ----
+
+. Export the bootstrap ignition variable:
+ifdef::azure[]
 +
 [source,terminal]
 ----
 $ export BOOTSTRAP_IGNITION=`jq -rcnM --arg v "3.2.0" --arg url ${BOOTSTRAP_URL} '{ignition:{version:$v,config:{replace:{source:$url}}}}' | base64 | tr -d '\n'`
 ----
+endif::azure[]
+ifdef::ash[]
+.. If your environment uses a public certificate authority (CA), run this command:
++
+[source,terminal]
+----
+$ export BOOTSTRAP_IGNITION=`jq -rcnM --arg v "3.2.0" --arg url ${BOOTSTRAP_URL} '{ignition:{version:$v,config:{replace:{source:$url}}}}' | base64 | tr -d '\n'`
+----
+
+.. If your environment uses an internal CA, you must add your PEM encoded bundle to the bootstrap ignition stub so that your bootstrap virtual machine can pull the bootstrap ignition from the storage account. Run the following commands, which assume your CA is in a file called `CA.pem`:
++
+[source,terminal]
+----
+$ export CA="data:text/plain;charset=utf-8;base64,$(cat CA.pem |base64 |tr -d '\n')"
+----
++
+[source,terminal]
+----
+$ export BOOTSTRAP_IGNITION=`jq -rcnM --arg v "3.2.0" --arg url "$BOOTSTRAP_URL" --arg cert "$CA" '{ignition:{version:$v,security:{tls:{certificateAuthorities:[{source:$cert}]}},config:{replace:{source:$url}}}}' | base64 | tr -d '\n'`
+----
+endif::ash[]
 
 . Create the deployment by using the `az` CLI:
 +

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -311,6 +311,21 @@ status:
 
 endif::user-infra-vpc[]
 
+ifdef::ash[]
+. Optional: If your Azure Stack Hub environment uses an internal certificate authority (CA), you must update the `.spec.trustedCA.name` field in the `<installation_directory>/manifests/cluster-proxy-01-config.yaml` file to use `user-ca-bundle`:
++
+[source,yaml]
+----
+...
+spec:
+  trustedCA:
+    name: user-ca-bundle
+...
+----
++
+Later, you must update your bootstrap ignition to include the CA.
+endif::ash[]
+
 ifdef::azure-user-infra[]
 . When configuring Azure on user-provisioned infrastructure, you must export
 some common variables defined in the manifest files to use later in the Azure


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3219

Preview: https://deploy-preview-41308--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.html