### PR TITLE
OSDOCS-2828: CCO in manual mode for Alibaba Cloud in 4.10

### DIFF
--- a/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
+++ b/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
@@ -32,12 +32,18 @@ Mint mode is the default and recommended best practice setting for the CCO to us
 [cols="<.^2,^.^1,^.^1,^.^1"]
 |====
 |Cloud provider |Mint |Passthrough |Manual
+////
+//removing until later work merges
+|{alibaba}
+|
+|
+|X
+////
 
 |Amazon Web Services (AWS)
 |X
 |X
 |X
-
 
 |Microsoft Azure
 |

--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -1,6 +1,14 @@
 // Module included in the following assemblies:
 //
 // * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+// * installing/installing_alibaba/manually-creating-alibaba-ram.adoc
+
+ifeval::["{context}" == "cco-mode-sts"]
+:aws:
+endif::[]
+ifeval::["{context}" == "manually-creating-alibaba-ram"]
+:alibaba:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="cco-ccoctl-configuring_{context}"]
@@ -51,29 +59,27 @@ $ chmod 775 ccoctl
 +
 [source,terminal]
 ----
-$ ccoctl aws --help
+$ ccoctl --help
 ----
 +
-.Output of `ccoctl aws --help`:
+.Output of `ccoctl --help`:
 +
 [source,terminal]
 ----
-Creating/updating/deleting cloud credentials objects for AWS cloud
-
+OpenShift credentials provisioning tool
 
 Usage:
-  ccoctl aws [command]
-
+  ccoctl [command]
 
 Available Commands:
-  create-all               Create all the required credentials objects
-  create-iam-roles         Create IAM roles
-  create-identity-provider Create IAM identity provider
-  create-key-pair          Create a key pair
-  delete                   Delete credentials objects
+  alibabacloud Manage credentials objects for alibaba cloud
+  aws          Manage credentials objects for AWS cloud
+  gcp          Manage credentials objects for Google cloud
+  help         Help about any command
+  ibmcloud     Manage credentials objects for IBM Cloud
 
 Flags:
-  -h, --help   help for aws
+  -h, --help   help for ccoctl
 
-Use "ccoctl aws [command] --help" for more information about a command.
+Use "ccoctl [command] --help" for more information about a command.
 ----

--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -1,8 +1,17 @@
 // Module included in the following assemblies:
 //
 // * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+// * installing/installing_alibaba/manually-creating-alibaba-ram.adoc
+
+ifeval::["{context}" == "cco-mode-sts"]
+:aws:
+endif::[]
+ifeval::["{context}" == "manually-creating-alibaba-ram"]
+:alibaba:
+endif::[]
 
 :_content-type: PROCEDURE
+ifdef::aws[]
 [id="cco-ccoctl-creating-at-once_{context}"]
 = Creating AWS resources with a single command
 
@@ -11,52 +20,106 @@ If you do not need to review the JSON files that the `ccoctl` tool creates befor
 Otherwise, you can create the AWS resources individually.
 
 //to-do if possible: xref to modules/cco-ccoctl-creating-individually.adoc for `create the AWS resources individually`
+endif::aws[]
+ifdef::alibaba[]
+[id="cco-ccoctl-creating-at-once_{context}"]
+= Creating Alibaba Cloud RAM users with ccoctl
+
+You can use the `ccoctl alibabacloud create-ram-users` command to automate the creation of Alibaba Cloud RAM users and policies for each in-cluster component.
+endif::alibaba[]
 
 [NOTE]
 ====
-By default, `ccoctl` creates objects in the directory in which the commands are run. To specify a directory, use the `--output-dir` flag. This procedure uses `_<path_to_ccoctl_output_dir>_` to refer to this location.
+By default, `ccoctl` creates objects in the directory in which the commands are run. To specify a directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this location.
 ====
 
 .Prerequisites
 
 * Extract and prepare the `ccoctl` binary.
+ifdef::alibaba[]
+* Obtain the AccessKey (AK) of the RAM user you wish to use.
+* Use the AK of the chosen RAM user to configure the {alibaba} SDK client's credential provider chain for link:https://github.com/aliyun/alibaba-cloud-sdk-go/blob/master/docs/2-Client-EN.md#1-environment-credentials[Environment Credentials] mode or through link:https://github.com/aliyun/alibaba-cloud-sdk-go/blob/master/docs/2-Client-EN.md#2-credentials-file[Credentials File] mode.
+//Note: those Alibaba Cloud docs links are officially intended for user consumption (https://github.com/openshift/cloud-credential-operator/pull/412/files#r764509590). We would prefer not to link to GitHub like this, but an alternative has not yet presented itself.
+endif::alibaba[]
 
 .Procedure
 
 . Extract the list of `CredentialsRequest` objects from the {product-title} release image:
 +
 [source,terminal,subs="+quotes"]
+ifdef::aws[]
 ----
-$ oc adm release extract --credentials-requests --cloud=aws --to=__<path_to_directory_with_list_of_credentials_requests>__/credrequests quay.io/__<path_to>__/ocp-release:__<version>__
+$ oc adm release extract --credentials-requests --cloud=aws --to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
 ----
+endif::aws[]
+ifdef::alibaba[]
+----
+$ oc adm release extract --credentials-requests --cloud=alibabacloud --to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
+----
+endif::alibaba[]
 
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 +
 [source,terminal,subs="+quotes"]
+ifdef::aws[]
 ----
-$ ccoctl aws create-all --name=__<name>__ --region=__<aws_region>__ --credentials-requests-dir=__<path_to_directory_with_list_of_credentials_requests>__/credrequests
+$ ccoctl aws create-all --name=<name> --region=<aws_region> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
 ----
++
+where:
++
+** `<name>` is the name used to tag any cloud resources that are created for tracking.
+** `<aws-region>` is the AWS region in which cloud resources will be created.
+** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files for the component `CredentialsRequest` objects.
+endif::aws[]
+ifdef::alibaba[]
+----
+$ ccoctl alibabacloud create-ram-users --name <name> --region=<alibaba-region> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
+----
++
+where:
++
+** `<name>` is the name used to tag any cloud resources that are created for tracking.
+** `<alibaba-region>` is the Alibaba Cloud region in which cloud resources will be created.
+** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files for the component `CredentialsRequest` objects.
++
+[NOTE]
+====
+A RAM user can have up to two AccessKeys at the same time. If you run `ccoctl alibabacloud create-ram-users` more than twice, the previous generated manifests secret becomes stale and you must reapply the newly generated secrets.
+====
+endif::alibaba[]
 
 .Verification
 
-* To verify that the {product-title} secrets are created, list the files in the `_<path_to_ccoctl_output_dir>_/manifests` directory:
+* To verify that the {product-title} secrets are created, list the files in the `<path_to_ccoctl_output_dir>/manifests` directory:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ ll __<path_to_ccoctl_output_dir>__/manifests
+$ ls <path_to_ccoctl_output_dir>/manifests
 ----
 +
 .Example output:
 +
 [source,terminal,subs="+quotes"]
+ifdef::aws[]
 ----
-total 24
--rw-------. 1 __<user>__ __<user>__ 161 Apr 13 11:42 cluster-authentication-02-config.yaml
--rw-------. 1 __<user>__ __<user>__ 379 Apr 13 11:59 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 353 Apr 13 11:59 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 355 Apr 13 11:59 openshift-image-registry-installer-cloud-credentials-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 339 Apr 13 11:59 openshift-ingress-operator-cloud-credentials-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 337 Apr 13 11:59 openshift-machine-api-aws-cloud-credentials-credentials.yaml
+cluster-authentication-02-config.yaml
+openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
+openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
+openshift-image-registry-installer-cloud-credentials-credentials.yaml
+openshift-ingress-operator-cloud-credentials-credentials.yaml
+openshift-machine-api-aws-cloud-credentials-credentials.yaml
 ----
 
 You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.
+endif::aws[]
+ifdef::alibaba[]
+----
+openshift-cluster-csi-drivers-alibaba-disk-credentials-credentials.yaml
+openshift-image-registry-installer-cloud-credentials-credentials.yaml
+openshift-ingress-operator-cloud-credentials-credentials.yaml
+openshift-machine-api-alibabacloud-credentials-credentials.yaml
+----
+
+You can verify that the RAM users and policies are created by querying Alibaba Cloud. For more information, refer to Alibaba Cloud documentation on listing RAM users and policies.
+endif::alibaba[]


### PR DESCRIPTION
For [OSDOCS-2828](https://issues.redhat.com/browse/OSDOCS-2828), which documents [CCO-81](https://issues.redhat.com/browse/CCO-81)

Notes: 
This PR adds some conditions to the ccoctl steps that were created for AWS STS so that they will also work for Alibaba Cloud. Added Alibaba content as needed, and cleaned up a couple style issues as well. The `{alibaba}` attribute won't render without #41083, and the new assembly that these should go in for Alibaba is also in that PR.

Previews:
- ~~Support matrix~~: removing this for now so this can be merged as-is, will add back later.
- [Configuring the Cloud Credential Operator utility](https://deploy-preview-41309--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-configuring_cco-mode-sts)
- [Creating AWS resources with a single command](https://deploy-preview-41309--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-at-once_cco-mode-sts)