### PR TITLE
BZ2049854: Correct GCP CSI Driver in table to GA

### DIFF
--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -18,7 +18,7 @@ The following table describes the CSI drivers that are installed with {product-t
 
 |AWS EBS | ✅ | - | ✅
 |AWS EFS (Tech Preview) | - | - | -
-|Google Cloud Platform (GCP) persistent disk (PD) (Tech Preview)| ✅ | - | ✅
+|Google Cloud Platform (GCP) persistent disk (PD)| ✅ | - | ✅
 |Microsoft Azure Disk | ✅ | ✅ | ✅
 |Microsoft Azure Stack Hub | ✅ | ✅ | ✅
 |OpenStack Cinder | ✅ | ✅ | ✅


### PR DESCRIPTION
4.8+

[BZ2049854](https://bugzilla.redhat.com/show_bug.cgi?id=2049854) Corrects GCP CSI Driver in table to GA.

**Preview**: https://deploy-preview-41315--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi.html#csi-drivers-supported_persistent-storage-csi

**PTAL**: @jsafrane @duanwei33 