### PR TITLE
OSDOCS-1694 Add mutable Ingress Controller endpoint publishing strategy release note

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -565,6 +565,13 @@ You can now create DNS records by using the Red Hat External DNS Operator on clo
 
 For more information, see xref:../networking/external_dns_operator/nw-installing-external-dns-operator.adoc#nw-installing-external-dns-operator[Installing the External DNS Operator].
 
+[id="ocp-4-10-ingress-controller-endpoint-publishing-strategies"]
+==== Mutable Ingress Controller endpoint publishing strategy enhancement
+
+Cluster administrators can now configure the Ingress Controller endpoint publishing strategy to change the load-balancer scope between `Internal` and `External` in {product-title}.
+
+For more information, see xref:../networking/nw-ingress-controller-endpoint-publishing-strategies.adoc#nw-ingress-controller-endpoint-publishing-strategies_nw-ingress-controller-endpoint-publishing-strategies[Ingress Controller endpoint publishing strategy].
+
 [id="ocp-4-10-networking-ipi-nmstate"]
 ==== Configuring host network interfaces with NMState on installer-provisioned clusters
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1694

Relates to https://github.com/openshift/openshift-docs/pull/39451.

Preview: https://deploy-preview-41323--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-ingress-controller-endpoint-publishing-strategies