### PR TITLE
THREESCALE-8071: Clarified the prerequisites about the usage of OIDC with WebAssembly and 3scale versions.

### DIFF
--- a/service_mesh/v2x/ossm-threescale-webassembly-module.adoc
+++ b/service_mesh/v2x/ossm-threescale-webassembly-module.adoc
@@ -32,8 +32,7 @@ Because of its self-contained design, it is possible to configure this module to
 [id="prerequisites_ossm-threescale-webassembly-module"]
 == Prerequisites
 
-* The module works with all supported 3scale releases except when configuring a service to use xref:../../authentication/identity_providers/configuring-oidc-identity-provider.adoc#configuring-oidc-identity-provider[OpenID Connect (OIDC)].
-* For this WebAssembly configuration, you will need 3scale 2.11 or later.
+* The module works with all supported 3scale releases, except when configuring a service to use xref:../../authentication/identity_providers/configuring-oidc-identity-provider.adoc#configuring-oidc-identity-provider[OpenID connect (OIDC)], which requires 3scale 2.11 or later.
 
 include::modules/ossm-configuring-the-threescale-wasm-auth-module.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Work done for Jira Issue [THREESCALE-8071](https://issues.redhat.com/browse/THREESCALE-8071)

Related GitHub Issue: https://github.com/openshift/openshift-docs/issues/40406

**Reviewers**

* @JStickler 
* @rahulanand16nov (3scale SME)
* @pehala (3scale QE)