### PR TITLE
OSDOCS-3227: Adding warning about changing URL

### DIFF
--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -6,6 +6,11 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+////
+All OpenShift advisories link directly to this assembly. If you are doing work that changes the URL, DON'T!
+But if you really need to, please contact the release notes team so they can change the advisory templates. These templates are not part of the openshift-docs repo.
+////
+
 You can update, or upgrade, an {product-title} cluster within a minor version by using the OpenShift CLI (`oc`).
 
 == Prerequisites


### PR DESCRIPTION
Writers need to know that we link directly to this assembly from the advisories. New structures or title changes break links in the advisory templates, which aren't stored in this repository.

https://issues.redhat.com/browse/OSDOCS-3227

Applies to 4.6+

No preview, comments only.

