### PR TITLE
WIP: OSDOCS-2173: [4.8] Added Intel E810 NICs for SRIOV

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -10,7 +10,7 @@
 .Supported network interface controllers
 [cols="1,2,1,1"]
 |===
-|Manufacturer |Model |Vendor ID | Device ID 
+|Manufacturer |Model |Vendor ID | Device ID
 
 |Intel
 |X710
@@ -26,6 +26,21 @@
 |XXV710
 |8086
 |158b
+
+|Intel
+|E810-CQDA2
+|8088
+|1592
+
+|Intel
+|E810-XXVDA2
+|8088
+|159b
+
+|Intel
+|E810-XXVDA4
+|8088
+|1593
 
 |Mellanox
 |MT27700 Family [ConnectX&#8209;4]

--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -451,9 +451,9 @@ For more information, see xref:../networking/multiple_networks/configuring-multi
 [id="ocp-4-8-supported-hardware-sriov"]
 ==== Supported hardware for SR-IOV
 
-{product-title} {product-version} adds support for additional Intel and Mellanox hardware.
+{product-title} {product-version} adds support for additional Intel and Mellanox network interface controllers.
 
-* Intel X710 and XL710 controllers
+* Intel X710, XL710, and E810
 * Mellanox ConnectX-5 Ex
 
 For more information, see the xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[supported devices].


### PR DESCRIPTION
This PR adds support for the Intel E810 NICs.
It also adds a release note.

For information, see
https://issues.redhat.com/browse/OSDOCS-2173
https://bugzilla.redhat.com/show_bug.cgi?id=2019844

https://deploy-preview-41333--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov