### PR TITLE
Change comment type to enable scripting

### DIFF
--- a/distr_tracing/distr_tracing_arch/distr-tracing-architecture.adoc
+++ b/distr_tracing/distr_tracing_arch/distr-tracing-architecture.adoc
@@ -25,23 +25,5 @@ include::modules/distr-tracing-features.adoc[leveloffset=+1]
 
 include::modules/distr-tracing-architecture.adoc[leveloffset=+1]
 
-////
-TODO
-WRITE more detailed component docs
-
-include::modules/distr-tracing-client-java.adoc[leveloffset=+1]
-
-include::modules/distr-tracing-agent.adoc[leveloffset=+1]
-
-include::modules/distr-tracing--jaeger-collector.adoc[leveloffset=+1]
-
-include::modules/distr-tracing-otel-collector.adoc[leveloffset=+1]
-
-include::modules/distr-tracing-data-store.adoc[leveloffset=+1]
-
-include::modules/distr-tracing-query.adoc[leveloffset=+1]
-
-include::modules/distr-tracing-ingester.adoc[leveloffset=+1]
-
-include::modules/distr-tracing-console.adoc[leveloffset=+1]
-////
+#TODO
+#WRITE more detailed component docs


### PR DESCRIPTION
This applies to `main`, `enterprise-4.6`, `enterprise-4.7`,  `enterprise-4.8`,  `enterprise-4.9` and `enterprise-4.10`.

This PR changes the comment type for some commented-out `include` statements. Currently all of the statements are commented out within a `////` to `////` comment that encapsulates several lines. The PR removes the `include` comments, because it is difficult otherwise to determine if the target modules are live or not in scripts.

If you comment each include line individually by using `#`, the build checks do not pick up that the line is inactive and then the build fails because the module targets are not present. I have subsequently removed the lines completely, to help with the scripting.