### PR TITLE
BZ1947814:VPA Operator uninstall doesn't document manual cleanups

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
@@ -12,13 +12,15 @@ You can remove the Vertical Pod Autoscaler Operator (VPA) from your {product-tit
 You can remove a specific VPA using the `oc delete vpa <vpa-name>` command. The same actions apply for resource requests as uninstalling the vertical pod autoscaler.
 ====
 
+After removing the VPA Operator, it is recommended that you remove other components associated with the Operator to avoid potential issues. 
+
 .Prerequisites
 
 * The Vertical Pod Autoscaler Operator must be installed.
 
 .Procedure
 
-. In the {product-title} web console, click *Operators* → *Installed Operators*.
+. In the {product-title} web console, click *Operators* -> *Installed Operators*.
 
 . Switch to the *openshift-vertical-pod-autoscaler* project.
 
@@ -27,3 +29,105 @@ You can remove a specific VPA using the `oc delete vpa <vpa-name>` command. The 
 . Optional: To remove all operands associated with the Operator, in the dialog box, select *Delete all operand instances for this operator* checkbox.
 
 . Click *Uninstall*.
+
+. Optional: Use the OpenShift CLI to remove the VPA components:
+
+.. Delete the VPA mutating webhook configuration: 
++
+[source,terminal]
+----
+$ oc delete mutatingwebhookconfigurations/vpa-webhook-config
+----
+
+.. List any VPA custom resources: 
++
+[source,terminal]
+----
+$ oc get verticalpodautoscalercheckpoints.autoscaling.k8s.io,verticalpodautoscalercontrollers.autoscaling.openshift.io,verticalpodautoscalers.autoscaling.k8s.io -o wide --all-namespaces
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE      NAME                                                                       AGE
+my-project     verticalpodautoscalercheckpoint.autoscaling.k8s.io/vpa-recommender-httpd   5m46s
+
+NAMESPACE                           NAME                                                               AGE
+openshift-vertical-pod-autoscaler   verticalpodautoscalercontroller.autoscaling.openshift.io/default   11m
+
+NAMESPACE      NAME                                                       MODE   CPU   MEM       PROVIDED   AGE
+my-project     verticalpodautoscaler.autoscaling.k8s.io/vpa-recommender   Auto   93m   262144k   True       9m15s
+----
+
+.. Delete the listed VPA custom resources. For example:
++
+[source,terminal]
+----
+$ oc delete verticalpodautoscalercheckpoint.autoscaling.k8s.io/vpa-recommender-httpd -n my-project
+----
++
+[source,terminal]
+----
+$ oc delete verticalpodautoscalercontroller.autoscaling.openshift.io/default -n openshift-vertical-pod-autoscaler
+----
++
+[source,terminal]
+----
+$ oc delete verticalpodautoscaler.autoscaling.k8s.io/vpa-recommender -n my-project
+----
+
+.. List any VPA custom resource definitions (CRDs):
++
+[source,terminal]
+----
+$ oc get crd
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                              CREATED AT
+ ...
+verticalpodautoscalercheckpoints.autoscaling.k8s.io               2022-02-07T14:09:20Z
+verticalpodautoscalercontrollers.autoscaling.openshift.io         2022-02-07T14:09:20Z
+verticalpodautoscalers.autoscaling.k8s.io                         2022-02-07T14:09:20Z
+ ...
+----
+
+.. Delete the listed VPA CRDs: 
++
+[source,terminal]
+----
+$ oc delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io verticalpodautoscalercontrollers.autoscaling.openshift.io verticalpodautoscalers.autoscaling.k8s.io
+----
++
+Deleting the CRDs removes the associated roles, cluster roles, and role bindings. However, there might be a few cluster roles that must be manually deleted.
+
+.. List any VPA cluster roles: 
++
+[source,terminal]
+----
+$ oc get clusterrole | grep openshift-vertical-pod-autoscaler
+----
++
+.Example output
+[source,terminal]
+----
+openshift-vertical-pod-autoscaler-6896f-admin        2022-02-02T15:29:55Z
+openshift-vertical-pod-autoscaler-6896f-edit         2022-02-02T15:29:55Z
+openshift-vertical-pod-autoscaler-6896f-view         2022-02-02T15:29:55Z
+----
+
+.. Delete the listed VPA cluster roles. For example:
++
+[source,terminal]
+----
+$ oc delete clusterrole openshift-vertical-pod-autoscaler-6896f-admin openshift-vertical-pod-autoscaler-6896f-edit openshift-vertical-pod-autoscaler-6896f-view
+----
+
+.. Delete the VPA Operator:
++
+[source,terminal]
+----
+$ oc delete operator/vertical-pod-autoscaler.openshift-vertical-pod-autoscaler
+----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1947814

Preview:  [Uninstalling the Vertical Pod Autoscaler Operator]( https://deploy-preview-41349--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-uninstall_nodes-pods-vertical-autoscaler)