### PR TITLE
Network Observability: Policy admonitions

### DIFF
--- a/modules/nw-networkpolicy-create.adoc
+++ b/modules/nw-networkpolicy-create.adoc
@@ -159,7 +159,5 @@ endif::multi[]
 
 [NOTE]
 ====
-If you log in with a user with the `cluster-admin` role in the console, then you
-have a choice of creating a network policy in any namespace in the cluster
-directly from the YAML view or from a form in the web console. 
+If you log in to the web console with `cluster-admin` privileges, you have a choice of creating a network policy in any namespace in the cluster directly in YAML or from a form in the web console.
 ====

--- a/modules/nw-networkpolicy-delete.adoc
+++ b/modules/nw-networkpolicy-delete.adoc
@@ -75,3 +75,8 @@ ifdef::multi[]
 endif::multi[]
 :!name:
 :!role:
+
+[NOTE]
+====
+If you log in to the web console with `cluster-admin` privileges, you have a choice of deleting a network policy in any namespace in the cluster directly in YAML or from the policy in the web console through the *Actions* menu.
+====

--- a/modules/nw-networkpolicy-edit.adoc
+++ b/modules/nw-networkpolicy-edit.adoc
@@ -106,3 +106,8 @@ ifdef::multi[]
 endif::multi[]
 :!name:
 :!role:
+
+[NOTE]
+====
+If you log in to the web console with `cluster-admin` privileges, you have a choice of editing a network policy in any namespace in the cluster directly in YAML or from the policy in the web console through the *Actions* menu.
+====

--- a/modules/nw-networkpolicy-view.adoc
+++ b/modules/nw-networkpolicy-view.adoc
@@ -87,3 +87,9 @@ ifdef::multi[]
 endif::multi[]
 :!name:
 :!role:
+
+
+[NOTE]
+====
+If you log in to the web console with `cluster-admin` privileges, you have a choice of viewing a network policy in any namespace in the cluster directly in YAML or from a form in the web console.
+====


### PR DESCRIPTION
This replaces [PR 41161](https://github.com/openshift/openshift-docs/pull/41161/files), which was QE, SME, and Peer Reviewed approved. Old PR got buried in unexpected commits.

For Main and 4.10
Jira: [issues.redhat.com/browse/OSDOCS-2657](https://issues.redhat.com/browse/OSDOCS-2657)

New content: adding Note about the web console to:

- [Viewing a network policy](https://deploy-preview-41381--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/viewing-network-policy.html)
- [Editing a network policy](https://deploy-preview-41381--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/editing-network-policy.html)
- [Deleting a network policy](https://deploy-preview-41381--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/deleting-network-policy.html)
- [Creating a network policy](https://deploy-preview-41381--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/creating-network-policy.html)
