### PR TITLE
OSDOCS-3164: Copies the HIPAA compliance table to ROSA

### DIFF
--- a/modules/rosa-policy-security-regulation-compliance.adoc
+++ b/modules/rosa-policy-security-regulation-compliance.adoc
@@ -50,19 +50,18 @@ Any issues that may be discovered are prioritized based on severity. Any issues 
 == Compliance
 {product-title} follows common industry best practices for security and controls. The certifications are outlined in the following table.
 
-
 .Security and control certifications for {product-title}
-[cols= "3,3",options="header"]
+[cols= "3,3,3",options="header"]
 |===
-| Certification | {product-title}
+| Certification | {product-title} on AWS | {product-title} on GCP
 
-| ISO 27001 | Yes
+| ISO 27001 | Yes | Yes
 
-| PCI DSS | Yes
+| PCI DSS | Yes | Yes
 
-| SOC 2 Type 2 | Yes
+| SOC 2 Type 2 | Yes | Yes
 
-| HIPAA | Yes
+| HIPAA | Yes | Yes
 
 |===
 


### PR DESCRIPTION
This PR copies a table from OSD to ROSA for the HIPAA compliance info.

JIRA: https://issues.redhat.com/browse/OSDOCS-3164

PREVIEW:
* **ROSA**: https://deploy-preview-41383--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-policy-process-security#rosa-policy-compliance_rosa-policy-process-security