### PR TITLE
OSDOCS-2935: Bump OCP and OSDK version

### DIFF
--- a/modules/osdk-common-prereqs.adoc
+++ b/modules/osdk-common-prereqs.adoc
@@ -26,9 +26,9 @@ ifdef::golang[]
 endif::[]
 ifdef::ansible[]
 - link:https://docs.ansible.com/ansible/latest/index.html[Ansible] version v2.9.0+
-- link:https://ansible-runner.readthedocs.io/en/latest/install.html[Ansible Runner] version v1.1.0+
+- link:https://ansible-runner.readthedocs.io/en/latest/install.html[Ansible Runner] version v2.0.2+
 - link:https://github.com/ansible/ansible-runner-http[Ansible Runner HTTP Event Emitter plug-in] version v1.0.0+
-- link:https://pypi.org/project/openshift/[OpenShift Python client] version v0.11.2+
+- link:https://pypi.org/project/openshift/[OpenShift Python client] version v0.12.0+
 endif::[]
 - Logged into an {product-title} {product-version} cluster with `oc` with an account that has `cluster-admin` permissions
 - To allow the cluster pull the image, the repository where you push your image must be set as public, or you must configure an image pull secret

--- a/modules/osdk-installing-cli-linux-macos.adoc
+++ b/modules/osdk-installing-cli-linux-macos.adoc
@@ -3,8 +3,8 @@
 // * cli_reference/osdk/cli-osdk-install.adoc
 // * operators/operator_sdk/osdk-installing-cli.adoc
 
-:ocp_ver: 4.9
-:osdk_ver: v1.10.1
+:ocp_ver: 4.10
+:osdk_ver: v1.16.0
 
 [id="osdk-installing-cli-linux-macos_{context}"]
 = Installing the Operator SDK CLI
@@ -13,12 +13,12 @@ You can install the OpenShift SDK CLI tool on Linux.
 
 .Prerequisites
 
-- link:https://golang.org/dl/[Go] v1.16+
+* link:https://golang.org/dl/[Go] v1.16+
 ifdef::openshift-origin[]
-- link:https://docs.docker.com/install/[`docker`] v17.03+, link:https://github.com/containers/libpod/blob/master/install.md[`podman`] v1.2.0+, or link:https://github.com/containers/buildah/blob/master/install.md[`buildah`] v1.7+
+* link:https://docs.docker.com/install/[`docker`] v17.03+, link:https://github.com/containers/libpod/blob/master/install.md[`podman`] v1.2.0+, or link:https://github.com/containers/buildah/blob/master/install.md[`buildah`] v1.7+
 endif::[]
 ifndef::openshift-origin[]
-- `docker` v17.03+, `podman` v1.9.3+, or `buildah` v1.7+
+* `docker` v17.03+, `podman` v1.9.3+, or `buildah` v1.7+
 endif::[]
 
 .Procedure

--- a/modules/osdk-scorecard-config.adoc
+++ b/modules/osdk-scorecard-config.adoc
@@ -2,7 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
-:osdk_ver: v1.10.1
+:osdk_ver: v1.16.0
 
 [id="osdk-scorecard-config_{context}"]
 = Scorecard configuration

--- a/modules/osdk-scorecard-output.adoc
+++ b/modules/osdk-scorecard-output.adoc
@@ -2,7 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
-:osdk_ver: v1.10.1
+:osdk_ver: v1.16.0
 
 [id="osdk-scorecard-output_{context}"]
 = Scorecard output

--- a/modules/osdk-scorecard-parallel.adoc
+++ b/modules/osdk-scorecard-parallel.adoc
@@ -2,7 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
-:osdk_ver: v1.10.1
+:osdk_ver: v1.16.0
 
 [id="osdk-scorecard-parallel_{context}"]
 = Enabling parallel testing

--- a/operators/operator_sdk/osdk-installing-cli.adoc
+++ b/operators/operator_sdk/osdk-installing-cli.adoc
@@ -3,7 +3,7 @@
 include::modules/common-attributes.adoc[]
 :context: osdk-installing-cli
 
-:osdk_ver: v1.10.1
+:osdk_ver: v1.16.0
 
 toc::[]
 


### PR DESCRIPTION
- OCP version: 4.10
- [OSDOCS-2935](https://issues.redhat.com/browse/OSDOCS-2935)

This PR updates the downstream Operator SDK version to v1.16.0 and updates various SDK-related prerequisites. Very small changes, despite the large number of preview links.

**Docs preview links:**
1. [OSDK CLI Installation](https://deploy-preview-41388--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-installing-cli.html)
1. [Ansible tutorial](https://deploy-preview-41388--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html)
2. [Ansible quickstart](https://deploy-preview-41388--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-quickstart.html)
3. [Go tutorial](https://deploy-preview-41388--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html)
4. [Go quickstart](https://deploy-preview-41388--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-quickstart.html)
9. [Scorecard output](https://deploy-preview-41388--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-scorecard.html#osdk-scorecard-output_osdk-scorecard)
10. [Scorecard config](https://deploy-preview-41388--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-scorecard.html#osdk-scorecard-config_osdk-scorecard)
11. [Scorecard parallel testing](https://deploy-preview-41388--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-scorecard.html#osdk-scorecard-parallel_osdk-scorecard)

Related PRs:
- Updating OSDK projects to a newer version: https://github.com/openshift/openshift-docs/pull/41029
- OSDK v1.16.0 release note: https://github.com/openshift/openshift-docs/pull/41710