### PR TITLE
OSSMDOC-472: Make NetworkPolicy optional.

### DIFF
--- a/modules/ossm-auto-route-enable.adoc
+++ b/modules/ossm-auto-route-enable.adoc
@@ -1,9 +1,9 @@
 // Module is included in the following assemblies:
 // * service_mesh/v2x/ossm-traffic-manage.adoc
 //
-
+:_content-type: REFERENCE
 [id="ossm-auto-route-enable_{context}"]
-= Disabling automatic {ProductName} route creation
+= Disabling automatic creation of routes
 
 By default, the `ServiceMeshControlPlane` resource automatically synchronizes the Gateway resources with OpenShift routes. Disabling the automatic route creation allows you more flexibility to control routes if you have a special case or prefer to control routes manually.
 

--- a/modules/ossm-config-disable-networkpolicy.adoc
+++ b/modules/ossm-config-disable-networkpolicy.adoc
@@ -1,25 +1,28 @@
 ////
 This module included in the following assemblies:
--v2x/servicemesh-release-notes.adoc
+-service_mesh/v2x/ossm-traffic-manage.adoc
 ////
-
+:_content-type: PROCEDURE
 [id="ossm-config-disable-networkpolicy_{context}"]
-= Disabling network policies
+= Disabling automatic creation of network policies
 
-{ProductName} automatically creates and manages a number of `NetworkPolicies` resources in the control plane and application namespaces. This is to ensure that applications and the control plane can communicate with each other.
-
-If you want to disable the automatic creation and management of `NetworkPolicies` resources, for example to enforce company security policies, you can do so.  You can edit the `ServiceMeshControlPlane` to set the `spec.security.manageNetworkPolicy` setting to `false`
+If you want to disable the automatic creation and management of `NetworkPolicy` resources, for example to enforce company security policies, or to allow direct access to pods in the mesh, you can do so.  You can edit the `ServiceMeshControlPlane` and set `spec.security.manageNetworkPolicy` to `false`.
 
 [NOTE]
 ====
 When you disable `spec.security.manageNetworkPolicy` {ProductName} will not create *any* `NetworkPolicy` objects.  The system administrator is responsible for managing the network and fixing any issues this might cause.
 ====
 
+.Prerequisites
+
+* {ProductName} Operator version 2.1.1 or higher installed.
+* `ServiceMeshControlPlane` resource updated to version 2.1 or higher.
+
 .Procedure
 
 . In the {product-title} web console, click *Operators* -> *Installed Operators*.
 
-. Select the project where you installed the control plane, for example `istio-system`, from the Project menu.
+. Select the project where you installed the control plane, for example `istio-system`, from the *Project* menu.
 
 . Click the {ProductName} Operator. In the *Istio Service Mesh Control Plane* column, click the name of your `ServiceMeshControlPlane`, for example `basic-install`.
 
@@ -33,7 +36,6 @@ apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 spec:
   security:
-      trust:
       manageNetworkPolicy: false
 ----
 +

--- a/modules/ossm-networkpolicy-overview.adoc
+++ b/modules/ossm-networkpolicy-overview.adoc
@@ -1,0 +1,11 @@
+////
+This module included in the following assemblies:
+-service_mesh/v2x/ossm-traffic-manage.adoc
+////
+:_content-type: CONCEPT
+[id="ossm-understanding-networkpolicy_{context}"]
+= Understanding network policies
+
+{ProductName} automatically creates and manages a number of `NetworkPolicies` resources in the control plane and application namespaces. This is to ensure that applications and the control plane can communicate with each other.
+
+For example, if you have configured your {product-title} cluster to use the SDN plug-in, {ProductName} creates a `NetworkPolicy` resource in each member project. This enables ingress to all pods in the mesh from the other mesh members and the control plane. This also restricts ingress to only member projects. If you require ingress from non-member projects, you need to create a `NetworkPolicy` to allow that traffic through. If you remove a namespace from {ProductShortName}, this `NetworkPolicy` resource is deleted from the project.

--- a/service_mesh/v2x/ossm-traffic-manage.adoc
+++ b/service_mesh/v2x/ossm-traffic-manage.adoc
@@ -35,8 +35,13 @@ OpenShift routes for Istio Gateways are automatically managed in {ProductShortNa
 {ProductName} creates the route with the subdomain, but {product-title} must be configured to enable it. Subdomains, for example `*.domain.com`, are supported but not by default. Configure an {product-title} wildcard policy before configuring a wildcard host Gateway. For more information, see xref:../../networking/ingress-operator.adoc#using-wildcard-routes_configuring-ingress[Using wildcard routes].
 
 include::modules/ossm-auto-route.adoc[leveloffset=+2]
+
 include::modules/ossm-auto-route-annotations.adoc[leveloffset=+2]
+
 include::modules/ossm-auto-route-enable.adoc[leveloffset=+2]
 
-
 include::modules/ossm-routing-sc.adoc[leveloffset=+2]
+
+include::modules/ossm-networkpolicy-overview.adoc[leveloffset=+1]
+
+include::modules/ossm-config-disable-networkpolicy.adoc[leveloffset=+2]


### PR DESCRIPTION
This PR adds two new topics to the Traffic Management assembly.

Preview is here ->https://deploy-preview-41402--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-traffic-manage.html#ossm-understanding-networkpolicy_routing-traffic

Eng review - rcernich, jwendell
QE review - yxun
Peer review - ahardin-rh