### PR TITLE
[RHACS] Add missing policy criteria

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -479,6 +479,14 @@ For example `oc`, or `kubectl`.
 | ✓
 | Deploy
 
+| Automount Service Account Token
+| Check if the deployment configuration automatically mounts the service account token.
+| 3.68 and newer
+| ✕
+| ✕
+| ✕
+| Deploy
+
 |===
 
 [NOTE]

--- a/release_notes/368-release-notes.adoc
+++ b/release_notes/368-release-notes.adoc
@@ -29,6 +29,13 @@ For more details, see xref:../integration/integrate-with-image-registries.adoc#u
 [id="output-format-enhancements"]
 === Enhancements for CI outputs
 Red Hat has improved the usability of {product-title} CI integrations. CI outputs now show additional detailed information about the vulnerabilities and the security policies responsible for broken builds.
+For more details, see xref:../cli/getting-started-cli.adoc#configuring-output-format[Configuring output format].
+
+[id="automount-service-account-token-policy-criteria"]
+=== Automount Service Account Token policy criteria
+Kubernetes automatically provisions a service account during pod creation and mounts the account's secret token within the pod at runtime.
+Many containerized applications do not require direct access to the service account. If a threat actor compromises an application, they might obtain the account token to further compromise the server.
+Therefore, when an application does not need to access the service account directly, administrators must ensure that the pod specifications disable the default behaviour. You can now use the *Automount Service Account Token* policy criteria to find the pods that have the service account mounted.
 
 [id="known-issue"]
 == Known issue


### PR DESCRIPTION
Adds the missing policy criteria for *Automount Service Account Token*

Applies to 3.68

<hr>

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
