### PR TITLE
Fixing tech preview includes in Serverless book

### DIFF
--- a/serverless/admin_guide/serverless-kafka-admin.adoc
+++ b/serverless/admin_guide/serverless-kafka-admin.adoc
@@ -21,7 +21,7 @@ The `KnativeKafka` CR provides users with additional options, such as:
 * Kafka broker
 
 :FeatureName: Kafka broker
-include::modules/technology-preview.adoc[leveloffset=+1]
+include::snippets/technology-preview.adoc[leveloffset=+1]
 
 include::modules/serverless-install-kafka-odc.adoc[leveloffset=+1]
 

--- a/serverless/develop/serverless-kafka-developer.adoc
+++ b/serverless/develop/serverless-kafka-developer.adoc
@@ -21,7 +21,7 @@ Knative Kafka provides additional options, such as:
 * Kafka broker
 
 :FeatureName: Kafka broker
-include::modules/technology-preview.adoc[leveloffset=+1]
+include::snippets/technology-preview.adoc[leveloffset=+1]
 
 include::modules/serverless-kafka-event-delivery.adoc[leveloffset=+1]
 
@@ -44,7 +44,7 @@ include::modules/serverless-kafka-source-yaml.adoc[leveloffset=+2]
 == Kafka broker
 
 :FeatureName: Kafka broker
-include::modules/technology-preview.adoc[leveloffset=+2]
+include::snippets/technology-preview.adoc[leveloffset=+2]
 
 If a cluster administrator has configured your {ServerlessProductName} deployment to use Kafka broker as the default broker type, xref:../../serverless/develop/serverless-using-brokers.adoc#serverless-using-brokers-creating-brokers[creating a broker by using the default settings] creates a Kafka-based `Broker` object. If your {ServerlessProductName} deployment is not configured to use Kafka broker as the default broker type, you can still use the following procedure to create a Kafka-based broker.
 

--- a/serverless/develop/serverless-using-brokers.adoc
+++ b/serverless/develop/serverless-using-brokers.adoc
@@ -16,7 +16,7 @@ Events can be sent from an event source to a broker as an HTTP `POST` request. A
 include::modules/serverless-broker-types.adoc[leveloffset=+1]
 
 :FeatureName: Kafka broker
-include::modules/technology-preview.adoc[leveloffset=+2]
+include::snippets/technology-preview.adoc[leveloffset=+2]
 
 .Additional resources
 

--- a/serverless/reference/kn-event-ref.adoc
+++ b/serverless/reference/kn-event-ref.adoc
@@ -7,7 +7,7 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 :FeatureName: The `kn event` plug-in
-include::modules/technology-preview.adoc[leveloffset=+2]
+include::snippets/technology-preview.adoc[leveloffset=+2]
 
 You can use the `kn event` set of commands to manage cloud events from the command line.
 


### PR DESCRIPTION
This applies to `main` only.

This PR updates some Technology Preview `include` statements in the Serverless book, to resolve the errors seen when building the OCP library in `main`.

`modules/technology-preview.adoc` was moved to `snippets/technology-preview.adoc` in https://github.com/openshift/openshift-docs/pull/39854.