### PR TITLE
[enterprise-4.7] Removing redundant OSD conditional

### DIFF
--- a/support/managing-cluster-resources.adoc
+++ b/support/managing-cluster-resources.adoc
@@ -2,9 +2,6 @@
 [id="managing-cluster-resources"]
 = Managing your cluster resources
 include::modules/common-attributes.adoc[]
-ifdef::openshift-dedicated[]
-include::modules/attributes-openshift-dedicated.adoc[]
-endif::[]
 :context: managing-cluster-resources
 
 toc::[]


### PR DESCRIPTION
This applies to `enterprise-4.7` only.

This PR removes a redundant conditional for OSD, which is not published from the `enterprise-4.7` branch. The conditional is being removed primarily because it contains an `include` statement that is showing up in some scripting that searches for live module files by collection.