### PR TITLE
CNV-13050: Live migrating VM on secondary network

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3117,6 +3117,8 @@ Topics:
     File: virt-live-migration-limits
   - Name: Migrating a virtual machine instance to another node
     File: virt-migrate-vmi
+  - Name: Migrating a virtual machine over a dedicated secondary network
+    File: virt-migrating-vm-on-secondary-network
   - Name: Monitoring live migration of a virtual machine instance
     File: virt-monitor-vmi-migration
   - Name: Cancelling the live migration of a virtual machine instance

--- a/modules/virt-configuring-secondary-network-vm-live-migration.adoc
+++ b/modules/virt-configuring-secondary-network-vm-live-migration.adoc
@@ -1,0 +1,86 @@
+// Module included in the following assemblies:
+//
+// * virt/live_migration/virt-migrating-vm-on-secondary-network.adoc
+
+:_content-type: PROCEDURE
+[id="virt-configuring-secondary-network-vm-live-migration_{context}"]
+= Configuring a dedicated secondary network for virtual machine live migration
+
+To configure a dedicated secondary network for live migration, you must first create a bridge network attachment definition for a namespace by using the CLI. Then, add the name of the `NetworkAttachmentDefinition` object to the `HyperConverged` custom resource (CR).
+
+.Prerequisites
+
+* You installed the OpenShift CLI (`oc`).
+* You logged in to the cluster as a user with the `cluster-admin` role.
+* The Multus Container Network Interface (CNI) plug-in is installed on the cluster.
+* Every node on the cluster has at least two Network Interface Cards (NICs), and the NICs to be used for live migration are connected to the same VLAN.
+* The virtual machine (VM) is running with the `LiveMigrate` eviction strategy.
+
+.Procedure
+
+. Create a `NetworkAttachmentDefinition` manifest.
++
+.Example configuration file
+[source,yaml]
+----
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: my-secondary-network <1>
+  namespace: openshift-cnv
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "name": "migration-bridge",
+    "type": "macvlan",
+    "master": "eth1", <2>
+    "mode": "bridge",
+    "ipam": {
+      "type": "whereabouts", <3>
+      "range": "10.200.5.0/24" <4>
+    }
+  }'
+----
+<1> The name of the `NetworkAttachmentDefinition` object.
+<2> The name of the NIC to be used for live migration.
+<3> The name of the CNI plug-in that provides the network for this network attachment definition.
+<4> The IP address range for the secondary network. This range must not have any overlap with the IP addresses of the main network.
+
+. Open the `HyperConverged` CR in your default editor by running the following command:
++
+[source,terminal]
+----
+oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+----
+
+. Add the name of the `NetworkAttachmentDefinition` object to the `spec.liveMigrationConfig` stanza of the `HyperConverged` CR. For example:
++
+.Example configuration file
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  liveMigrationConfig:
+    completionTimeoutPerGiB: 800
+    network: my-secondary-network  <1>
+    parallelMigrationsPerCluster: 5
+    parallelOutboundMigrationsPerNode: 2
+    progressTimeout: 150
+...
+----
+<1> The name of the Multus `NetworkAttachmentDefinition` object to be used for live migrations.
+
+
+. Save your changes and exit the editor. The `virt-handler` pods restart and connect to the secondary network.
+
+.Verification
+
+* When the node that the virtual machine runs on is placed into maintenance mode, the VM automatically migrates to another node in the cluster. You can verify that the migration occurred over the secondary network and not the default pod network by checking the target IP address in the virtual machine instance (VMI) metadata.
++
+[source,terminal]
+----
+oc get vmi <vmi_name> -o jsonpath='{.status.migrationState.targetNodeAddress}'
+----

--- a/virt/live_migration/virt-migrating-vm-on-secondary-network.adoc
+++ b/virt/live_migration/virt-migrating-vm-on-secondary-network.adoc
@@ -1,0 +1,17 @@
+:_content-type: ASSEMBLY
+[id="virt-migrating-vm-on-secondary-network"]
+= Migrating a virtual machine over a dedicated secondary network
+include::modules/virt-document-attributes.adoc[]
+:context: virt-migrating-vm-on-secondary-network
+
+toc::[]
+
+You can configure a dedicated xref:../../virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc#attaching-to-multiple-networks[secondary Multus network] for live migration. A dedicated network minimizes disruption to tenant workloads due to network saturation when virtual machine live migration is triggered.
+
+
+include::modules/virt-configuring-secondary-network-vm-live-migration.adoc[leveloffset=+1]
+
+[id="additional-resources_virt-migrating-vm-on-secondary-network"]
+== Additional resources
+
+* xref:../../virt/live_migration/virt-live-migration-limits.adoc#virt-live-migration-limits[Live migration limits and timeouts]


### PR DESCRIPTION
[CNV-13050](https://issues.redhat.com/browse/CNV-13050)

New assembly and procedure module to document live migration of VM over a dedicated Multus network

Preview: https://deploy-preview-41416--osdocs.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-migrating-vm-on-secondary-network.html