### PR TITLE
TELCODOCS-475: Update channel to read stable for 4.9 and 4.10

### DIFF
--- a/modules/psap-installing-node-feature-discovery-operator.adoc
+++ b/modules/psap-installing-node-feature-discovery-operator.adoc
@@ -64,19 +64,6 @@ spec:
 $ oc create -f nfd-operatorgroup.yaml
 ----
 
-.. Run the following command to get the `channel` value required for the next step.
-+
-[source,terminal]
-----
-$ oc get packagemanifest nfd -n openshift-marketplace -o jsonpath='{.status.defaultChannel}'
-----
-+
-.Example output
-[source,terminal]
-----
-4.10
-----
-
 .. Create the following `Subscription` CR and save the YAML in the `nfd-sub.yaml` file:
 +
 .Example Subscription
@@ -88,7 +75,7 @@ metadata:
   name: nfd
   namespace: openshift-nfd
 spec:
-  channel: "4.10"
+  channel: "stable"
   installPlanApproval: Automatic
   name: nfd
   source: redhat-operators

--- a/modules/psap-special-resource-operator-installing-using-cli.adoc
+++ b/modules/psap-special-resource-operator-installing-using-cli.adoc
@@ -60,19 +60,6 @@ spec:
 $ oc create -f sro-operatorgroup.yaml
 ----
 
-.. Run the following `oc get` command to get the `channel` value required for the next step:
-+
-[source,terminal]
-----
-$ oc get packagemanifest openshift-special-resource-operator -n openshift-marketplace -o jsonpath='{.status.defaultChannel}'
-----
-+
-.Example output
-[source,terminal]
-----
-4.9
-----
-
 .. Create the following `Subscription` CR and save the YAML in the `sro-sub.yaml` file:
 +
 .Example Subscription CR
@@ -84,13 +71,12 @@ metadata:
   name: openshift-special-resource-operator
   namespace: openshift-special-resource-operator
 spec:
-  channel: "4.9" <1>
+  channel: "stable"
   installPlanApproval: Automatic
   name: openshift-special-resource-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ----
-<1> Replace the channel value with the output from the previous command.
 
 .. Create the subscription object by running the following command:
 +
@@ -119,7 +105,8 @@ $ oc get pods
 [source,terminal]
 ----
 NAME                                                   READY   STATUS    RESTARTS   AGE
-special-resource-controller-manager-7bfb544d45-xx62r   2/2     Running   0          2m28s
+nfd-controller-manager-7f4c5f5778-4lvvk                2/2     Running   0          89s
+special-resource-controller-manager-6dbf7d4f6f-9kl8h   2/2     Running   0          81s
 ----
 +
 A successful deployment shows a `Running` status.


### PR DESCRIPTION
Addresses: https://issues.redhat.com/browse/TELCODOCS-475
This change needs to be made in 4.10 and 4.9. 
The original dev JIRA ticket is https://issues.redhat.com/browse/ART-3107 

**SRO Section**: https://deploy-preview-41437--osdocs.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-special-resource-operator.html

**NFD Section**: https://deploy-preview-41437--osdocs.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-node-feature-discovery-operator.html

