### PR TITLE
[WIP] OSDOCS-2935: Notable tech change: OSDK version bump to v1.16.0

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -265,6 +265,19 @@ In {product-title} 4.7, _Cluster Logging_ became _Red Hat OpenShift Logging_. Fo
 
 // Note: use [discrete] for these sub-headings.
 
+[discrete]
+[id="ocp-4-10-operator-sdk-v-1-16-0"]
+==== Operator SDK v1.16.0
+
+{product-title} 4.10 supports Operator SDK v1.16.0. See xref:../cli_reference/osdk/cli-osdk-install.adoc#cli-osdk-install[Installing the Operator SDK CLI] to install or update to this latest version.
+
+[NOTE]
+====
+Operator SDK v1.16.0 supports Kubernetes 1.22.
+====
+
+If you have any Operator projects that were previously created or maintained with Operator SDK v1.10.1, see xref:../operators/operator_sdk/osdk-upgrading-projects.adoc#osdk-upgrading-projects[Upgrading projects for newer Operator SDK versions] to ensure your projects are upgraded to maintain compatibility with Operator SDK v1.16.0.
+
 [id="ocp-4-10-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
- OCP 4.10
- [OSDOCS-2935](https://issues.redhat.com/browse/OSDOCS-2935)
- [Docs preview](https://deploy-preview-41443--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-operator-sdk-v-1-16-0)

This PR adds the version update to the OpenShift 4.10 Release notes as a notable technical change. The note mentions OSDK v1.16.0's support of Kubernetes 1.22, but not the deprecated APIs removed in k8s 1.22. That will be discussed in a follow up PR. 

See [OSDOCS-2858](https://issues.redhat.com/browse/OSDOCS-2858) for details.

Related PRs:
- https://github.com/openshift/openshift-docs/pull/41388
- https://github.com/openshift/openshift-docs/pull/41029