### PR TITLE
TELCODOCS-212: Adds release notes for TELCODOCS-212.

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -492,6 +492,15 @@ You can now set the maximum length of the syslog message in the Ingress Controll
 For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration parameters].
 
 
+[id="ocp-4-10-networking-ipi-nmstate"]
+==== Configuring host network interfaces with NMState on installer-provisioned clusters
+
+{product-title} now provides a `networkConfig` configuration setting for installer-provisioned clusters, which takes an NMState YAML configuration to configure host interfaces. During installer-provisioned installations, you can add the `networkConfig` configuration setting and the NMState YAML configuration to the `install-config.yaml` file. Additionally, you can add the `networkConfig` configuration setting and the NMState YAML configuration to the bare metal host resource when using the Bare Metal Operator.
+
+The most common use case for the `networkConfig` configuration setting is to set static IP addresses on a host's network interface during installation or while expanding the cluster.
+
+For more information, see xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-host-network-interfaces-in-the-install-config.yaml-file_ipi-install-installation-workflow[Configuring host network interfaces in the install-config.yaml file].
+
 [id="ocp-4-10-hardware"]
 === Hardware
 


### PR DESCRIPTION
This PR adds a release note for [TELCODOCS-212](https://issues.redhat.com/browse/TELCODOCS-212) for the 4.10 release. I also noticed a syntax error in the file and fixed that too.  

Fixes: [TELCODOCS-212](https://issues.redhat.com/browse/TELCODOCS-212)

Release: 4.10

Preview: https://deploy-preview-41444--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-networking-ipi-nmstate

Signed-off-by: John Wilkins <jowilkin@redhat.com>