### PR TITLE
OSDOCS-3009: RN for Ingress router compression

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -212,6 +212,12 @@ If you use the OpenShift SDN cluster network provider, you can now use egress ru
 
 For more information, refer to xref:../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy].
 
+[id="ocp-4-10-ne-router-compression"]
+==== Ingress Controller router compression
+This enhancement adds the ability to configure global HTTP traffic compression on the Ingress Controller to specify router for specific MIME types. This update enables gzip-compression of your ingress workloads when there are large amounts of compressible routed traffic.
+
+For more information, see xref:../networking/ingress-operator.adoc#nw-configuring-router-compression_configuring-ingress[Using router compression].
+
 [id="ocp-4-10-hardware"]
 === Hardware
 


### PR DESCRIPTION
RN for [Using router compression](https://docs.openshift.com/container-platform/4.10/networking/ingress-operator.html#nw-configuring-router-compression_configuring-ingress) #37586(release note tracker)

Jira: https://issues.redhat.com/browse/OSDOCS-3009

For 4.10 only

Preview: https://deploy-preview-41461--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-ne-router-compression