### PR TITLE
Add snippets symlink in modules dir

### DIFF
--- a/modules/snippets
+++ b/modules/snippets
@@ -1,0 +1,1 @@
+../snippets/


### PR DESCRIPTION
Text snippets are allowed in modules, but they need a symlink from the `modules/` directory to the `snippets/` directory if they're going to be included with a relative reference in the following form:

```
include::snippets/technology-preview.adoc[]
```

~~Also update the Tech Preview example in the guidelines since the old PR-link example was using the former `modules/` directory and showing a `leveloffset` that I don't think we need.~~

^ Actually gonna do this in a separate PR (https://github.com/openshift/openshift-docs/pull/41477) because of branch drift for the guidelines file.