### PR TITLE
RHDEVDOCS-3667 - Improve tlsConfig monitoring docs

### DIFF
--- a/modules/monitoring-specifying-how-a-service-is-monitored.adoc
+++ b/modules/monitoring-specifying-how-a-service-is-monitored.adoc
@@ -6,12 +6,8 @@
 [id="specifying-how-a-service-is-monitored_{context}"]
 = Specifying how a service is monitored
 
+[role="_abstract"]
 To use the metrics exposed by your service, you must configure {product-title} monitoring to scrape metrics from the `/metrics` endpoint. You can do this using a `ServiceMonitor` custom resource definition (CRD) that specifies how a service should be monitored, or a `PodMonitor` CRD that specifies how a pod should be monitored. The former requires a `Service` object, while the latter does not, allowing Prometheus to directly scrape metrics from the metrics endpoint exposed by a pod.
-
-[NOTE]
-====
-In {product-title} {product-version}, you can use the `tlsConfig` property for a `ServiceMonitor` resource to specify the TLS configuration to use when scraping metrics from an endpoint. The `tlsConfig` property is not yet available for `PodMonitor` resources. If you need to use a TLS configuration when scraping metrics, you must use `ServiceMonitor` resource.
-====
 
 This procedure shows you how to create a `ServiceMonitor` resource for a service in a user-defined project.
 
@@ -20,6 +16,11 @@ This procedure shows you how to create a `ServiceMonitor` resource for a service
 * You have access to the cluster as a user with the `cluster-admin` role or the `monitoring-edit` role.
 * You have enabled monitoring for user-defined projects.
 * For this example, you have deployed the `prometheus-example-app` sample service in the `ns1` project.
++
+[NOTE]
+====
+The `prometheus-example-app` sample service does not support TLS authentication.
+====
 
 .Procedure
 
@@ -75,7 +76,3 @@ $ oc -n ns1 get servicemonitor
 NAME                         AGE
 prometheus-example-monitor   81m
 ----
-
-.Additional resources
-
-* See the link:https://github.com/openshift/prometheus-operator/blob/release-4.5/Documentation/api.md[Prometheus Operator API documentation] for more information on `ServiceMonitor` and `PodMonitor` resources.

--- a/modules/monitoring-understanding-metrics.adoc
+++ b/modules/monitoring-understanding-metrics.adoc
@@ -6,11 +6,12 @@
 [id="understanding-metrics_{context}"]
 = Understanding metrics
 
-In {product-title} {product-version}, cluster components are monitored by scraping metrics exposed through service endpoints. You can also configure metrics collection for user-defined projects. Metrics enable you to monitor how cluster components and your own workloads are performing.
+[role="_abstract"]
+In {product-title} {product-version}, cluster components are monitored by scraping metrics exposed through service endpoints. You can also configure metrics collection for user-defined projects.
 
 You can define the metrics that you want to provide for your own workloads by using Prometheus client libraries at the application level.
 
-In {product-title}, metrics are exposed through an HTTP service endpoint under the `/metrics` canonical name. You can list all available metrics for a service by running a `curl` query against `\http://<endpoint>/metrics`. For instance, you can expose a route to the `prometheus-example-app` example application and then run the following to view all of its available metrics:
+In {product-title}, metrics are exposed through an HTTP service endpoint under the `/metrics` canonical name. You can list all available metrics for a service by running a `curl` query against `\http://<endpoint>/metrics`. For instance, you can expose a route to the `prometheus-example-app` example service and then run the following to view all of its available metrics:
 
 [source,terminal]
 ----

--- a/monitoring/managing-metrics.adoc
+++ b/monitoring/managing-metrics.adoc
@@ -6,6 +6,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can collect metrics to monitor how cluster components and your own workloads are performing.
+
 // Understanding metrics
 include::modules/monitoring-understanding-metrics.adoc[leveloffset=+1]
 
@@ -14,7 +17,12 @@ include::modules/monitoring-setting-up-metrics-collection-for-user-defined-proje
 include::modules/monitoring-deploying-a-sample-service.adoc[leveloffset=+2]
 include::modules/monitoring-specifying-how-a-service-is-monitored.adoc[leveloffset=+2]
 
+.Additional resources
+
 * xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
+* link:https://access.redhat.com/articles/6675491[How to scrape metrics using TLS in a ServiceMonitor configuration in a user-defined project]
+* xref:../rest_api/monitoring_apis/podmonitor-monitoring-coreos-com-v1.adoc[PodMonitor API]
+* xref:../rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.adoc[ServiceMonitor API]
 
 // Querying metrics
 include::modules/monitoring-querying-metrics.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR removes the Note admonition regarding TLS configuration for configuring metrics for user-defined projects. 

It also adds a Note admonition informing the user that the `prometheus-example-app` does not support TLS authentication and adds a link to a RH KCS article about how to scrape metrics using TLS in a `ServiceMonitor` configuration.

Applies to OCP 4.7+ versions

- Aligned team: Dev Tools
- For branches: 4.7+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3667
- Direct link to doc preview: https://deploy-preview-41472--osdocs.netlify.app/openshift-enterprise/latest/monitoring/managing-metrics.html#specifying-how-a-service-is-monitored_managing-metrics
- SME review: @PhilipGough
- Peer review: Srivaralakshmi
- <All reviews complete. Please merge now>