### PR TITLE
OSDOCS-2986: Remove mention of Azure Gen2 VM support

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -45,11 +45,6 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-10-rhcos"]
 === {op-system-first}
 
-[id="ocp-4-10-azure-gen2-vm"]
-==== Support for Azure generation 2 VMs
-
-{product-title} 4.10 introduces support for provisioning virtual machines (VMs) with disk sizes that exceed 2000 GB by using a VM with Azure generation 2 support. For more information, see link:https://docs.microsoft.com/en-us/azure/virtual-machines/generation-2[Support for generation 2 VMs on Azure].
-
 [id="ocp-4-10-installation-and-upgrade"]
 === Installation and upgrade
 


### PR DESCRIPTION
Based on [feedback from product manager](https://github.com/openshift/openshift-docs/pull/41111#issuecomment-1029528329), the pieces of this feature aren't all in place yet and is not ready to be documented.

JIRA: https://issues.redhat.com/browse/OSDOCS-2987

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2025868

Direct doc preview link (though it's a removal): https://deploy-preview-41474--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-rhcos