### PR TITLE
Update TP guideline re: snippets

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -92,7 +92,7 @@ Example:
 
 [id="snippet-file-metadata"]
 == Text snippet file metadata
-Every text snippet should be placed in the snippets folder and should contain the following metadata at the top:
+Every text snippet should be placed in the `snippets/` folder and should contain the following metadata at the top:
 
 ----
 // Text snippet included in the following assemblies: <1>
@@ -107,7 +107,7 @@ Every text snippet should be placed in the snippets folder and should contain th
 ----
 <1> List of assemblies in which this text snippet is included.
 <2> List of modules in which this text snippet is included.
-<1> The content type for the file. For snippets, always use `:_content-type: SNIPPET`. Place this attribute before the anchor ID, the conditional that contains the anchor ID, or the first line of body text.
+<3> The content type for the file. For snippets, always use `:_content-type: SNIPPET`. Place this attribute before the anchor ID, the conditional that contains the anchor ID, or the first line of body text.
 
 [NOTE]
 ====
@@ -690,15 +690,17 @@ You must get approval from the Engineering, QE, and Docs teams before embedding 
 
 == Indicating Technology Preview features
 
-To indicate that a feature is in Technology Preview, include the
-`snippets/technology-preview.adoc` file in the feature's assembly to keep the
-supportability wording consistent across Technology Preview features and provide a value for the :FeatureName: variable before you include this module.
+To indicate that a feature is in Technology Preview, include the `snippets/technology-preview.adoc` file in the feature's assembly or module to keep the supportability wording consistent across Technology Preview features. Provide a value for the `:FeatureName:` variable before you include this module.
 
-See link:https://github.com/openshift/openshift-docs/pull/13878/files#diff-615ba1bf3b09d11a9c2604b775aa32f2[an example] of how this is applied.
+[source,text]
+----
+:FeatureName: The XYZ plug-in
+\include::snippets/technology-preview.adoc[]
+----
 
 == Indicating deprecated features
 
-To indicate that a feature is deprecated, include the `modules/deprecated-feature.adoc` file in the feature's assembly, or to each relevant assembly such as for a deprecated Operator, to keep the supportability wording consistent across deprecated features. Provide a value for the :FeatureName: variable before you include this module.
+To indicate that a feature is deprecated, include the `modules/deprecated-feature.adoc` file in the feature's assembly, or to each relevant assembly such as for a deprecated Operator, to keep the supportability wording consistent across deprecated features. Provide a value for the `:FeatureName:` variable before you include this module.
 
 See link:https://github.com/openshift/openshift-docs/pull/31776/files[an example] of how this is applied.
 


### PR DESCRIPTION
Update the Tech Preview example in the repo guidelines since the old PR-link example was using the former `modules/` directory and showing a `leveloffset` that I don't think we need.

Got review for these changes in https://github.com/openshift/openshift-docs/pull/41466#pullrequestreview-873578286.