### PR TITLE
Add TrustArc to landing page

### DIFF
--- a/index-commercial.html
+++ b/index-commercial.html
@@ -353,7 +353,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2022 Red Hat, Inc.</span></p>
+                <p class="text-nowrap">Copyright © 2022 Red Hat, Inc.</p>
             </div>
 
             <div class="col">
@@ -361,11 +361,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                     <a target="_blank" href="https://www.redhat.com/en/about/privacy-policy" class="nav-link">Privacy statement</a>
                     <a target="_blank" href="https://www.openshift.com/legal/terms/" class="nav-link">Terms of use</a>
                     <a target="_blank" href="https://www.redhat.com/en/about/all-policies-guidelines" class="nav-link">All policies and guidelines</a>
+                    <a id="teconsent"></a>
                 </nav>
             </div>
         </div>
     </div>
 </footer>
+<div id="consent_blackbar" style="z-index: 100; position: fixed"></div>
 
 <script src="https://assets.openshift.net/content/modernizr.js" type="text/javascript"></script>
 <script src="https://assets.openshift.net/content/subdomain.js" type="text/javascript"></script>
@@ -378,5 +380,9 @@ if (("undefined" !== typeof _satellite) && ("function" === typeof _satellite.pag
 }
 </script>
 <!-- End Adobe DTM -->
+
+<!-- TrustArc -->
+<!-- content: 9481187406 -->
+<script src="//static.redhat.com/libs/redhat/marketing/latest/trustarc/trustarc.js"></script>
 </body>
 </html>


### PR DESCRIPTION
A follow up PR to the original TrustArc work that adds this to the landing page as well.

Refs https://github.com/openshift/openshift-docs/pull/40708.