### PR TITLE
[RHACS] Fixes for RHACS 3.66 docs

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -194,12 +194,12 @@ openshift-acs:
   site_name: Documentation
   site_url: https://docs.openshift.com/
   branches:
-    rhacs-docs:
-      name: '3.66'
-      dir: acs/3.66
     rhacs-docs-3.65:
       name: '3.65'
       dir: acs/3.65
+    rhacs-docs-3.66:
+      name: '3.66'
+      dir: acs/3.66
     rhacs-docs-3.67:
       name: '3.67'
       dir: acs/3.67


### PR DESCRIPTION
Instead of `rhacs-docs` branch the docs for 3.66 should be built from `rhacs-docs-3.66` branch. `rhacs-docs` branch is like the `main` branch for OpenShift docs.