### PR TITLE
BZ2048180: add a note to capture a limitation with respect to image streams and the internal registry

### DIFF
--- a/modules/images-allow-pods-to-reference-images-across-projects.adoc
+++ b/modules/images-allow-pods-to-reference-images-across-projects.adoc
@@ -7,6 +7,11 @@
 
 When using the internal registry, to allow pods in `project-a` to reference images in `project-b`, a service account in `project-a` must be bound to the `system:image-puller` role in `project-b`.
 
+[NOTE]
+====
+When you create a pod service account or a namespace, wait until the service account is provisioned with a docker pull secret; if you create a pod before its service account is fully provisioned, the pod fails to access the {product-title} internal registry.
+====
+
 .Procedure
 
 . To allow pods in `project-a` to reference images in `project-b`, bind a service account in `project-a` to the `system:image-puller` role in `project-b`:


### PR DESCRIPTION
For 4.6+
https://bugzilla.redhat.com/show_bug.cgi?id=2048180

[Doc preview](https://deploy-preview-41488--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/managing_images/using-image-pull-secrets.html)

Requires ack from @xiuwang 