### PR TITLE
BZ2044242 corrected path for SELinux context

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -54,7 +54,7 @@ $ sudo semanage fcontext -a -t httpd_sys_content_t "/home/kni/rhcos_image_cache(
 +
 [source,terminal]
 ----
-$ sudo restorecon -Rv rhcos_image_cache/
+$ sudo restorecon -Rv /home/kni/rhcos_image_cache/
 ----
 
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2044242

For releases 
- 4.9
- 4.10

Preview: https://deploy-preview-41489--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-creating-an-rhcos-images-cache_ipi-install-installation-workflow
