### PR TITLE
BZ2045022: Remove requirement for 10GB nics on bare-metal IPI

### DIFF
--- a/modules/ipi-install-node-requirements.adoc
+++ b/modules/ipi-install-node-requirements.adoc
@@ -33,7 +33,7 @@ endif::[]
 Do not deploy a cluster with only one worker node, because the cluster will deploy with routers and ingress traffic in a degraded state.
 ====
 
-* *Network interfaces:* Each node must have at least one 10GB network interface for the routable `baremetal` network. Each node must have one 10GB network interface for a `provisioning` network when using the `provisioning` network for deployment. Using the `provisioning` network is the default configuration. Network interface names must follow the same naming convention across all nodes. For example, the first NIC name on a node, such as `eth0` or `eno1`, must be the same name on all of the other nodes. The same principle applies to the remaining NICs on each node.
+* *Network interfaces:* Each node must have at least one network interface for the routable `baremetal` network. Each node must have one network interface for a `provisioning` network when using the `provisioning` network for deployment. Using the `provisioning` network is the default configuration.
 
 * *Unified Extensible Firmware Interface (UEFI):* Installer-provisioned installation requires UEFI boot on all {product-title} nodes when using IPv6 addressing on the `provisioning` network. In addition, UEFI Device PXE Settings must be set to use the IPv6 protocol on the `provisioning` network NIC, but omitting the `provisioning` network removes this requirement.
 


### PR DESCRIPTION
Fixes:  https://bugzilla.redhat.com/show_bug.cgi?id=2045022


Preview:  https://deploy-preview-41490--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#node-requirements_ipi-install-prerequisites  (scroll to Network Interfaces)


Versions: 4.9, 4.10