### PR TITLE
Updating content type labels in ifdefs

### DIFF
--- a/modules/nw-sriov-network-attachment.adoc
+++ b/modules/nw-sriov-network-attachment.adoc
@@ -23,8 +23,8 @@ ifeval::["{context}" == "virt-defining-an-sriov-network"]
 :object: pods or virtual machines
 endif::[]
 
-ifdef::ocp-sriov-net[]
 :_content-type: PROCEDURE
+ifdef::ocp-sriov-net[]
 [id="nw-sriov-network-attachment_{context}"]
 = Configuring SR-IOV additional network
 

--- a/modules/rbac-creating-cluster-role.adoc
+++ b/modules/rbac-creating-cluster-role.adoc
@@ -3,8 +3,8 @@
 // * authentication/using-rbac.adoc
 // * post_installation_configuration/preparing-for-users.adoc
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 :_content-type: PROCEDURE
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 [id="creating-cluster-role_{context}"]
 = Creating a cluster role
 

--- a/modules/rbac-creating-local-role.adoc
+++ b/modules/rbac-creating-local-role.adoc
@@ -3,8 +3,8 @@
 // * authentication/using-rbac.adoc
 // * post_installation_configuration/preparing-for-users.adoc
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 :_content-type: PROCEDURE
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 [id="creating-local-role_{context}"]
 = Creating a local role
 

--- a/modules/security-context-constraints-pre-allocated-values.adoc
+++ b/modules/security-context-constraints-pre-allocated-values.adoc
@@ -2,8 +2,8 @@
 //
 // * authentication/managing-security-context-constraints.adoc
 
-ifdef::openshift-origin,openshift-enterprise,openshift-dedicated,openshift-rosa[]
 :_content-type: CONCEPT
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated,openshift-rosa[]
 [id="security-context-constraints-pre-allocated-values_{context}"]
 = About pre-allocated security context constraints values
 


### PR DESCRIPTION
This applies to `main`, `enterprise-4.10`, `enterprise-4.9`, `enterprise-4.8`, `enterprise-4.7` and `enterprise-4.6`.

This pull request relocates the content type label in files that embed the H1 anchor within an `ifdef` statement. In the PR, the labels are relocated before the respective `ifdef` statement.

The updates relate only to the content type labels that were added through the automation scripts.