### PR TITLE
OSDOCS-3260:fixes typo in egress specification example

### DIFF
--- a/modules/nw-egress-router-cr.adoc
+++ b/modules/nw-egress-router-cr.adoc
@@ -69,7 +69,7 @@ metadata:
 spec:
   networkInterface: {
     macvlan: {
-      mode: "bridge"
+      mode: "Bridge"
     }
   }
   addresses: [


### PR DESCRIPTION
4.8+

[JIRA 3260](https://issues.redhat.com/browse/OSDOCS-3260?jql=project%20%3D%20OSDOCS%20AND%20issuetype%20%3D%20Bug%20AND%20resolution%20%3D%20Unresolved%20AND%20assignee%20in%20(currentUser())%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)

**[Preview](https://deploy-preview-41534--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/deploying-egress-router-ovn-redirection.html)**

Fixes [Issue](https://github.com/openshift/openshift-docs/issues/37180)