### PR TITLE
Adds a few deprecated features and one new feature to authentication …

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -181,6 +181,7 @@ The `ovnkube_master_resource_update_total` metric is removed for the 4.10 releas
 ==== Enhancement to must-gather to simplify network tracing
 
 The `oc adm must-gather` command is enhanced in a way that simplifies collecting network packet captures.
+
 Previously, `oc adm must-gather` could start a single debug pod only.
 With this enhancement, you can start a debug pod on multiple nodes at the same time.
 
@@ -275,6 +276,14 @@ In {product-title} 4.7, _Cluster Logging_ became _Red Hat OpenShift Logging_. Fo
 
 [id="ocp-4-10-auth"]
 === Authentication and authorization
+
+[id="ocp-4-10-oc-commands-obtain-credentials-from-podman-config"]
+==== oc commands now obtain credentials from Podman configuration locations
+
+Previously, `oc` commands that used the registry configuration, for example `oc login` or `oc image`, obtained credentials from Docker configuration locations. With {product-title} {product-version}, if a registry entry cannot be found in the default Docker configuration location, `oc` commands obtain the credentials from Podman configuration locations. You can set your preference to either `docker` or `podman` by using the `REGISTRY_AUTH_PREFERENCE` environment variable to prioritize the location.
+
+Users also have the option to use the `REGISTRY_AUTH_FILE` environment variable, which serves as an alternative to the existing `--registry-config` CLI flag. The `REGISTRY_AUTH_FILE` environment variable is also compatible with `podman`.
+
 
 [id="ocp-4-10-sandboxed-containers"]
 === {sandboxed-containers-first}
@@ -421,6 +430,15 @@ In the table, features are marked with the following statuses:
 ====
 AMD and Intel 64-bit architectures (x86-64-v2) will still be supported.
 ====
+
+[id="ocp-4-10-docker-config-location-deprecation"]
+==== Default Docker configuration location deprecation
+Previously, `oc` commands that used a registry configuration would obtain credentials from the Docker configuration location, which was `~/.docker/config.json` by default. This has been deprecated and will be replaced by a Podman configuration location in a future version of {product-title}.
+
+[id="ocp-4-10-empty-file-support-deprecation"]
+==== Empty file and stdout support deprecation in oc registry login
+
+Support for empty files using the `--registry-config` and `--to` flags in `oc registry login` has been deprecated. Support for `-` (standard output) has also been deprecated as an argument when using `oc registry login`. They will be removed in a future version of {product-title}.
 
 [id="ocp-4-10-removed-features"]
 === Removed features


### PR DESCRIPTION
RN entry at https://github.com/openshift/openshift-docs/issues/37586#issuecomment-983654990

Previews: 

* New feature: https://deploy-preview-41535--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-oc-commands-obtain-credentials-from-podman-config
* Deprecated features: https://deploy-preview-41535--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-docker-config-location-deprecation

Please do not merge until I confirm accuracy with devs.

Thanks! 