### PR TITLE
Fixing typos for EUS-to-EUS update content

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -436,7 +436,7 @@ Topics:
   File: installing-update-service
 - Name: Understanding upgrade channels
   File: understanding-upgrade-channels-release
-- Name: Preparing to perform an EUS to EUS upgrade
+- Name: Preparing to perform an EUS-to-EUS update
   File: preparing-eus-eus-upgrade
 - Name: Updating a cluster within a minor version using the web console
   File: updating-cluster-within-minor

--- a/modules/updating-eus-to-eus-upgrade.adoc
+++ b/modules/updating-eus-to-eus-upgrade.adoc
@@ -4,24 +4,24 @@
 
 :_content-type: PROCEDURE
 [id="updating-eus-to-eus-upgrade_{context}"]
-= EUS to EUS upgrade
+= EUS-to-EUS update
 
-The following procedure pauses all non-master MachineConfigPools and performs upgrades from {product-title} 4.8 to 4.9 to 4.10, then unpauses the previously paused MachineConfigPools.
-Following this procedure reduces the total upgrade duration and the number of times worker nodes are restarted.
+The following procedure pauses all non-master MachineConfigPools and performs updates from {product-title} 4.8 to 4.9 to 4.10, then unpauses the previously paused MachineConfigPools.
+Following this procedure reduces the total update duration and the number of times worker nodes are restarted.
 
 .Prerequisites
 
 * Review the release notes for {product-title} 4.9 and 4.10
-* Review the release notes and product lifecycles for any layered products and OLM Operators. Some may require updates either before or during an EUS to EUS upgrade.
-* Ensure that you are familiar with version-specific prerequisites, such as link:https://docs.openshift.com/container-platform/4.9/updating/updating-cluster-prepare.html#update-preparing-migrate_updating-cluster-prepare[administrator acknowledgement] that is required prior to upgrading from {product-title} 4.8 to 4.9.
+* Review the release notes and product lifecycles for any layered products and OLM Operators. Some may require updates either before or during an EUS-to-EUS update.
+* Ensure that you are familiar with version-specific prerequisites, such as link:https://docs.openshift.com/container-platform/4.9/updating/updating-cluster-prepare.html#update-preparing-migrate_updating-cluster-prepare[administrator acknowledgement] that is required prior to updating from {product-title} 4.8 to 4.9.
 * Verify that your cluster is not running a version earlier than {product-title} 4.8.14.
-If your cluster is running a version than {product-title} 4.8.14, you must upgrade to a later 4.8.z version prior to upgrading to 4.9.
-The upgrade to 4.8.14 or later is necessary to fulfill the minimum version requirements that must be performed without pausing MachineConfigPools.
+If your cluster is running a version than {product-title} 4.8.14, you must update to a later 4.8.z version prior to updating to 4.9.
+The update to 4.8.14 or later is necessary to fulfill the minimum version requirements that must be performed without pausing MachineConfigPools.
 * Verify that MachineConfigPools is unpaused.
 
 .Procedure
 
-. Upgrade any OLM Operators to versions that are compatible with both versions you are upgrading to.
+. Upgrade any OLM Operators to versions that are compatible with both versions you are updating to.
 
 . Verify that all MachineConfigPools display a status of `UPDATED` and no MachineConfigPools display a status of `UPDATING`.
 To view the status of all MachineConfigPools, run the following command:
@@ -54,7 +54,7 @@ You cannot pause the master pool.
 $ oc patch mcp/worker --type merge --patch '{"spec":{"paused":true}}'
 ----
 
-. To change to the `eus-4.10` channel and upgrade to 4.9, run the following commands:
+. To change to the `eus-4.10` channel and update to 4.9, run the following commands:
 +
 [source,terminal]
 ----
@@ -69,7 +69,7 @@ $ oc adm upgrade --to-latest
 Updating to latest version 4.9.18
 ----
 
-. To ensure the 4.9 upgrades are completed successfully retrieve the cluster version, run the following command:
+. To ensure the 4.9 updates are completed successfully retrieve the cluster version, run the following command:
 +
 [source,terminal]
 ----
@@ -84,16 +84,16 @@ NAME  	  VERSION  AVAILABLE  PROGRESSING   SINCE   STATUS
 version   4.9.18   True       False         6m29s   Cluster version is 4.9.18
 ----
 
-. If necessary, upgrade OLM operators using the Administrator perspective on the web console.
+. If necessary, upgrade OLM Operators using the Administrator perspective on the web console.
 
-. To upgrade to 4.10, run the following command:
+. To update to 4.10, run the following command:
 +
 [source,terminal]
 ----
 $ oc adm upgrade --to-latest
 ----
 
-. To ensure the 4.10 upgrade is completed successfully retrieve the cluster version, run the following command:
+. To ensure the 4.10 update is completed successfully retrieve the cluster version, run the following command:
 +
 [source,terminal]
 ----
@@ -117,10 +117,10 @@ $ oc patch mcp/worker --type merge --patch '{"spec":{"paused":false}}'
 +
 [NOTE]
 ====
-If pools are not unpaused, the cluster is not permitted to upgrade to any future minors and maintenance tasks such as certificate rotation are inhibited. This puts the cluster at risk for future degradation.
+If pools are not unpaused, the cluster is not permitted to update to any future minors and maintenance tasks such as certificate rotation are inhibited. This puts the cluster at risk for future degradation.
 ====
 
-. To verify that your previously paused pools have updated and your cluster completed the upgrade to 4.10, run the following command:
+. To verify that your previously paused pools have updated and your cluster completed the update to 4.10, run the following command:
 +
 [source,terminal]
 ----

--- a/updating/preparing-eus-eus-upgrade.adoc
+++ b/updating/preparing-eus-eus-upgrade.adoc
@@ -1,23 +1,23 @@
 :_content-type: ASSEMBLY
 [id="preparing-eus-eus-upgrade"]
-= Preparing to perform an EUS to EUS upgrade
+= Preparing to perform an EUS-to-EUS update
 include::modules/common-attributes.adoc[]
 :context: eus-to-eus-upgrade
 
 toc::[]
 
-Due to fundamental Kubernetes design, all {product-title} upgrades between minor versions must be serialized.
-You must upgrade from {product-title} 4.8 to 4.9 and then to 4.10. You cannot upgrade from {product-title} 4.8 to 4.10 directly.
-However, beginning with the upgrade from {product-title} 4.8 to 4.9 to 4.10, administrators who wish to upgrade between two Extended Update Support (EUS) versions can do so incurring only a single reboot of non-master hosts.
+Due to fundamental Kubernetes design, all {product-title} updates between minor versions must be serialized.
+You must update from {product-title} 4.8 to 4.9 and then to 4.10. You cannot update from {product-title} 4.8 to 4.10 directly.
+However, beginning with the update from {product-title} 4.8 to 4.9 to 4.10, administrators who wish to update between two Extended Update Support (EUS) versions can do so incurring only a single reboot of non-master hosts.
 
-There are a number of caveats to consider when attempting an EUS to EUS upgrade.
+There are a number of caveats to consider when attempting an EUS-to-EUS update.
 
-* EUS to EUS upgrades are only offered after upgrades between all versions involved have been made available in `stable` channels.
-* If you encounter issues during or after upgrading to the odd-numbered minor version but before upgrading to the next even-numbered version, then remediation of those issues may require that non-master hosts complete the upgrade to the odd-numbered version before moving forward.
-* You can complete the upgrade process during multiple maintenance windows by pausing at intermediate steps. However, plan to complete the entire upgrade within 60 days. This is critical to ensure that normal cluster automation processes are completed including those associated with certificate rotation.
-* You must be running at least {product-title} 4.8.14 before starting the EUS-to-EUS upgrade procedure. If you do not meet this minimum requirement, upgrade to a later 4.8.z before attempting the EUS-to-EUS upgrade.
-* Support for RHEL7 workers was removed in {product-title} 4.10 and replaced with RHEL8 workers, therefore EUS to EUS upgrades are not available for clusters with RHEL7 workers.
-* Node components are not updated to {product-title} 4.9. Do not expect all features and bugs fixed in {product-title} 4.9 to be made available until you complete the upgrade to {product-title} 4.10 and enable all MachineConfigPools to update.
+* EUS-to-EUS updates are only offered after updates between all versions involved have been made available in `stable` channels.
+* If you encounter issues during or after upgrading to the odd-numbered minor version but before upgrading to the next even-numbered version, then remediation of those issues may require that non-master hosts complete the update to the odd-numbered version before moving forward.
+* You can complete the update process during multiple maintenance windows by pausing at intermediate steps. However, plan to complete the entire update within 60 days. This is critical to ensure that normal cluster automation processes are completed including those associated with certificate rotation.
+* You must be running at least {product-title} 4.8.14 before starting the EUS-to-EUS update procedure. If you do not meet this minimum requirement, update to a later 4.8.z before attempting the EUS-to-EUS update.
+* Support for RHEL7 workers was removed in {product-title} 4.10 and replaced with RHEL8 workers, therefore EUS-to-EUS updates are not available for clusters with RHEL7 workers.
+* Node components are not updated to {product-title} 4.9. Do not expect all features and bugs fixed in {product-title} 4.9 to be made available until you complete the update to {product-title} 4.10 and enable all MachineConfigPools to update.
 
 
 include::modules/updating-eus-to-eus-upgrade.adoc[leveloffset=+1]


### PR DESCRIPTION
Applies to 4.8+
No relevant JIRAs
SME/QE not required as typos are outside of the code. Also changed upgrade -> update (https://github.com/openshift/openshift-docs/pull/40525).
Preview Link: [Performing an EUS-to-EUS update](https://deploy-preview-41549--osdocs.netlify.app/openshift-enterprise/latest/updating/preparing-eus-eus-upgrade.html)