### PR TITLE
BZ-1896679: Moving content to the right location

### DIFF
--- a/modules/update-mirror-repository.adoc
+++ b/modules/update-mirror-repository.adoc
@@ -114,6 +114,17 @@ $ oc image mirror  -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mi
 +
 <1> For `REMOVABLE_MEDIA_PATH`, you must use the same path that you specified when you mirrored the images.
 
+... Use `oc` command-line interface (CLI) to log in to the cluster that you are upgrading.
+
+... Apply the mirrored release image signature config map to the connected cluster:
++
+[source,terminal]
+----
+$ oc apply -f ${REMOVABLE_MEDIA_PATH}/mirror/config/<image_signature_file> <1>
+----
++
+<1> For `<image_signature_file>`, specify the path and name of the file, for example, `signature-sha256-81154f5c03294534.yaml`.
+
 ** If the local container registry and the cluster are connected to the mirror host, directly push the release images to the local registry and apply the config map  to the cluster by using following command:
 +
 [source,terminal]

--- a/updating/updating-restricted-network-cluster.adoc
+++ b/updating/updating-restricted-network-cluster.adoc
@@ -22,7 +22,7 @@ See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permis
 * Have a recent xref:../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[etcd backup] in case your upgrade fails and you must xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restore your cluster to a previous state].
 * Ensure that all machine config pools (MCPs) are running and not paused. Nodes associated with a paused MCP are skipped during the update process. You can pause the MCPs if you are performing a canary rollout update strategy.
 * If your cluster uses manually maintained credentials, ensure that the Cloud Credential Operator (CCO) is in an upgradeable state. For more information, see _Upgrading clusters with manually maintained credentials_ for xref:../installing/installing_aws/manually-creating-iam.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-aws[AWS], xref:../installing/installing_azure/manually-creating-iam-azure.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-azure[Azure], or xref:../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-gcp[GCP].
-//STS is not currently supported in a restricted network environment, but the following bullet can be uncommented when that changes. 
+//STS is not currently supported in a restricted network environment, but the following bullet can be uncommented when that changes.
 //* If your cluster uses manually maintained credentials with the AWS Secure Token Service (STS), obtain a copy of the `ccoctl` utility from the release image being upgraded to and use it to process any updated credentials. For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-upgrading[_Upgrading an OpenShift Container Platform cluster configured for manual mode with STS_].
 
 [IMPORTANT]
@@ -51,7 +51,7 @@ Before you update your cluster, you must manually create a config map that conta
 
 If you are upgrading from version 4.4.8 or later, you can use the `oc` CLI to create the config map. If you are upgrading from an earlier version, you must use the manual method.
 
-include::modules/update-oc-configmap-signature-verification.adoc[leveloffset=+2]
+//include::modules/update-oc-configmap-signature-verification.adoc[leveloffset=+2]
 
 include::modules/update-configuring-image-signature.adoc[leveloffset=+2]
 


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1896679
Applies to 4.6+
SME and QE ack required (@wking and @jiajliu)
Preview: [Mirroring the OpenShift Container Platform image repository](https://deploy-preview-41550--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster#update-mirror-repository_updating-restricted-network-cluster) Step 4, first bullet, first sub-bullet.