### PR TITLE
Adds 4.9.19 release notes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2469,3 +2469,24 @@ link:https://access.redhat.com/solutions/6682531[{product-title} 4.9.18 containe
 ==== Updating
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-9-19"]
+=== RHBA-2022:0340 - {product-title} 4.9.19 bug fix and security update
+
+Issued: 2022-02-09
+
+{product-title} release 4.9.19, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0340[RHBA-2022:0340] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0339[RHSA-2022:0339] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6713251[{product-title} 4.9.19 container image list]
+
+
+[id="ocp-4-9-19-preparing-upgrade-next-release"]
+==== Preparing to upgrade to the next {product-title} release
+Due to the removal of the scheduler Policy API, {product-title} 4.9.19 introduces a blocking conditional that blocks upgrading from {product-title} 4.9 to {product-title} 4.10. In order to upgrade from {product-title} 4.9 to {product-title} 4.10, you must clear the scheduler Policy API configuration and ensure it is no longer in use. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2037665[*BZ#2037665*])
+
+[id="ocp-4-9-19-updating"]
+==== Updating
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

To be merged on 09-02.

OCP version: **Applicable only to 4.9**

Direct Doc Preview Link: https://deploy-preview-41561--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-19

@ctauchen and @stevsmit PTAL and let me know your feedback.

