### PR TITLE
4.10 RN: Removed feature, Scheduler Policy

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -401,7 +401,7 @@ In the table, features are marked with the following statuses:
 |Scheduler policy
 |DEP
 |DEP
-|
+|REM
 
 |`ImageChangesInProgress` condition for Cluster Samples Operator
 |DEP


### PR DESCRIPTION
RN entry at https://github.com/openshift/openshift-docs/issues/37586#issuecomment-1032304319

Change to removed and deprecated feature table. Scheduler policy --> REM.

applies only to `enterprise-4.10`

https://deploy-preview-41562--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-deprecated-removed-features


CC @ingvagabund @kasturinarra 