### PR TITLE
Adding content type attributes to IBM P/Z install modules / also to modules shared with other platforms 

### DIFF
--- a/modules/cluster-entitlements.adoc
+++ b/modules/cluster-entitlements.adoc
@@ -109,7 +109,7 @@ ifeval::["{context}" == "installing-restricted-networks-gcp"]
 :restricted:
 endif::[]
 
-
+:_content-type: CONCEPT
 [id="cluster-entitlements_{context}"]
 ifndef::openshift-origin[]
 = Internet access for {product-title}

--- a/modules/cluster-telemetry.adoc
+++ b/modules/cluster-telemetry.adoc
@@ -65,6 +65,7 @@
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 
+:_content-type: CONCEPT
 [id="cluster-telemetry_{context}"]
 ifndef::openshift-origin[]
 = Telemetry access for {product-title}

--- a/modules/csr-management.adoc
+++ b/modules/csr-management.adoc
@@ -27,6 +27,7 @@
 // machine_management/more-rhel-compute.adoc
 // post_installation_configuration/node-tasks.adoc
 
+:_content-type: CONCEPT
 [id="csr-management_{context}"]
 = Certificate signing requests management
 

--- a/modules/ibm-z-choose-networking-setup.adoc
+++ b/modules/ibm-z-choose-networking-setup.adoc
@@ -2,6 +2,7 @@
 //
 // * scalability_and_performance/ibm-z-recommended-host-practices.adoc
 
+:_content-type: CONCEPT
 [id="ibm-z-choose-networking-setup_{context}"]
 = Choose your networking setup
 

--- a/modules/ibm-z-managing-cpu-overcommitment.adoc
+++ b/modules/ibm-z-managing-cpu-overcommitment.adoc
@@ -2,6 +2,7 @@
 //
 // * scalability_and_performance/ibm-z-recommended-host-practices.adoc
 
+:_content-type: CONCEPT
 [id="ibm-z-managing-cpu-overcommitment_{context}"]
 = Managing CPU overcommitment
 

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -43,7 +43,8 @@ ifeval::["{context}" == "installing-rhv-restricted-network"]
 :rhv:
 endif::[]
 
-
+:_content-type: CONCEPT
+// Assumption is that attribute once outside ifdef works for several level one headings.
 [id="installation-bare-metal-config-yaml_{context}"]
 ifndef::ibm-z,ibm-z-kvm,ibm-power,agnostic,rhv[]
 = Sample `install-config.yaml` file for bare metal

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -182,6 +182,7 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :ibm-power:
 endif::[]
 
+:_content-type: CONCEPT
 [id="installation-configuration-parameters_{context}"]
 = Installation configuration parameters
 

--- a/modules/installation-dns-user-infra.adoc
+++ b/modules/installation-dns-user-infra.adoc
@@ -35,6 +35,7 @@ endif::[]
 
 :prewrap!:
 
+:_content-type: CONCEPT
 [id="installation-dns-user-infra_{context}"]
 = User-provisioned DNS requirements
 

--- a/modules/installation-ibm-z-kvm-user-infra-installing-rhcos.adoc
+++ b/modules/installation-ibm-z-kvm-user-infra-installing-rhcos.adoc
@@ -3,6 +3,7 @@
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
 
+:_content-type: CONCEPT
 [id="installation-ibm-z-kvm-user-infra-installing-rhcos_{context}"]
 = Installing {op-system} and starting the {product-title} bootstrap process
 

--- a/modules/installation-load-balancing-user-infra.adoc
+++ b/modules/installation-load-balancing-user-infra.adoc
@@ -48,6 +48,7 @@ ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :restricted:
 endif::[]
 
+:_content-type: CONCEPT
 [id="installation-load-balancing-user-infra_{context}"]
 = Load balancing requirements for user-provisioned infrastructure
 

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -77,6 +77,7 @@ ifeval::["{context}" == "installing-rhv-restricted-network"]
 endif::[]
 
 
+:_content-type: CONCEPT
 [id="installation-network-user-infra_{context}"]
 = Networking requirements for user-provisioned infrastructure
 

--- a/modules/installation-registry-storage-config.adoc
+++ b/modules/installation-registry-storage-config.adoc
@@ -33,6 +33,7 @@ ifeval::["{context}" == "installing-restricted-networks-aws"]
 :aws:
 endif::[]
 
+:_content-type: CONCEPT
 [id="installation-registry-storage-config_{context}"]
 = Image registry storage configuration
 

--- a/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
+++ b/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
@@ -3,6 +3,7 @@
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
 
 
+:_content-type: CONCEPT
 [id="installation-requirements-user-infra_{context}"]
 = Machine requirements for a cluster with user-provisioned infrastructure
 

--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -49,6 +49,7 @@ ifeval::["{context}" == "installing-platform-agnostic"]
 :agnostic:
 endif::[]
 
+:_content-type: CONCEPT
 [id="installation-requirements-user-infra_{context}"]
 = Requirements for a cluster with user-provisioned infrastructure
 

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -33,6 +33,7 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :restricted:
 endif::[]
 
+:_content-type: REFERENCE
 [id="installation-user-infra-machines-static-network_{context}"]
 = Advanced {op-system} installation reference
 

--- a/modules/minimum-ibm-power-system-requirements.adoc
+++ b/modules/minimum-ibm-power-system-requirements.adoc
@@ -3,6 +3,7 @@
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 
+:_content-type: CONCEPT
 [id="minimum-ibm-power-system-requirements_{context}"]
 = Minimum IBM Power requirements
 

--- a/modules/minimum-ibm-z-system-requirements.adoc
+++ b/modules/minimum-ibm-z-system-requirements.adoc
@@ -3,6 +3,7 @@
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
 
+:_content-type: CONCEPT
 [id="minimum-ibm-z-system-requirements_{context}"]
 = Minimum IBM Z system environment
 

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -27,6 +27,7 @@ ifeval::["{context}" == "post-install-network-configuration"]
 :post-install-network-configuration:
 endif::[]
 
+:_content-type: CONCEPT
 [id="nw-operator-cr_{context}"]
 = Cluster Network Operator configuration
 

--- a/modules/preferred-ibm-z-system-requirements.adoc
+++ b/modules/preferred-ibm-z-system-requirements.adoc
@@ -3,6 +3,7 @@
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
 
+:_content-type: CONCEPT
 [id="preferred-ibm-z-system-requirements_{context}"]
 = Preferred IBM Z system environment
 

--- a/modules/recommended-ibm-power-system-requirements.adoc
+++ b/modules/recommended-ibm-power-system-requirements.adoc
@@ -3,6 +3,7 @@
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 
+:_content-type: CONCEPT
 [id="recommended-ibm-power-system-requirements_{context}"]
 = Recommended IBM Power system requirements
 


### PR DESCRIPTION
This PR adds content type attributes to IBM Z and IBM Power modules that were missed by Pauls scripts.

After discussion in install docs meeting(02/08)  "Requirements" are also `:_content-type: CONCEPT` 

Applies to 4.9 and later. 
Earlier release will be covered in separate PRs. 