### PR TITLE
BZ-2045576: Add dual stack breaking API change

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -139,6 +139,13 @@ For more information, see xref:../updating/understanding-upgrade-channels-releas
 [id="ocp-4-10-networking"]
 === Networking
 
+[id="ocp-4-10-networking-dual-stack-api-change"]
+==== Dual-stack services require that ipFamilyPolicy is specified
+
+When you create a service that uses multiple IP address families, you must explicitly specify `ipFamilyPolicy: PreferDualStack` or `ipFamilyPolicy: RequireDualStack` in your Service object definition. This change breaks backwards compatibility with earlier releases of {product-title}.
+
+For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2045576[BZ#2045576].
+
 [id="ocp-4-10-redfish-events"]
 ==== Low-latency Redfish hardware event delivery (Technology Preview)
 


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=2045576

This is a breaking API change that needs to be documented in the release notes.

Preview: https://deploy-preview-41568--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-networking-dual-stack-api-change