### PR TITLE
OSDOCS-2852: out-of-tree providers added in 4.10 (rel notes)

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -369,6 +369,20 @@ Users also have the option to use the `REGISTRY_AUTH_FILE` environment variable,
 
 // Note: use [discrete] for these sub-headings.
 
+[discrete]
+[id="ocp-4-10-cluster-cloud-controller-manager-operator"]
+==== Cloud controller managers for additional cloud providers
+
+The Kubernetes community plans to deprecate the Kubernetes controller manager in favor of using cloud controller managers to interact with underlying cloud platforms. As a result, there is no plan to add Kubernetes controller manager support for any new cloud platforms. The Alibaba Cloud and IBM Cloud implementations that are added in this release of {product-title} use cloud controller managers.
+
+In addition, this release supports using cloud controller managers for Google Cloud Platform (GCP) and VMware vSphere as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview].
+
+To learn more about the cloud controller manager, see the link:https://kubernetes.io/docs/concepts/architecture/cloud-controller/[Kubernetes Cloud Controller Manager documentation].
+
+To manage the cloud controller manager and cloud node manager deployments and lifecycles, use the Cluster Cloud Controller Manager Operator.
+
+For more information, see the xref:../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_platform-operators-ref[Cluster Cloud Controller Manager Operator] entry in the _Platform Operators reference_.
+
 [id="ocp-4-10-deprecated-removed-features"]
 == Deprecated and removed features
 
@@ -816,20 +830,45 @@ In the table below, features are marked with the following statuses:
 |GA
 |GA
 
-|Cloud controller manager for AWS
+|Cloud controller manager for Alibaba Cloud
 |-
-|TP
-|
+|-
+|GA
 
-|Cloud controller manager for Azure
+|Cloud controller manager for Amazon Web Services
 |-
 |TP
-|
+|TP
 
-|Cloud controller manager for OpenStack
+|Cloud controller manager for Google Cloud Platform
+|-
 |-
 |TP
-|
+
+|Cloud controller manager for IBM Cloud
+|-
+|-
+|GA
+
+|Cloud controller manager for Microsoft Azure
+|-
+|TP
+|TP
+
+|Cloud controller manager for Microsoft Azure Stack Hub
+|-
+|GA
+|GA
+
+|Cloud controller manager for {rh-openstack-first}
+|-
+|TP
+|TP
+
+|Cloud controller manager for VMware vSphere
+|-
+|-
+|TP
 
 |Driver Toolkit
 |TP


### PR DESCRIPTION
For [OSDOCS-2852](https://issues.redhat.com/browse/OSDOCS-2852), which covers OCPCLOUD-976, OCPCLOUD-1122, and OCPCLOUD-1160. 

Note: this PR covers the Rel Notes announcement. #41577 updates the CCCMO entry in the Platform Operators reference space for new clouds.

Previews:
- [Implementation of cloud controller managers for cloud providers](https://deploy-preview-41575--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-cluster-cloud-controller-manager-operator) in _Notable technical changes_
- [Technology Preview tracker](https://deploy-preview-41575--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-technology-preview) table