### PR TITLE
Fix typo in 4.9.18 errata number

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2448,11 +2448,11 @@ link:https://access.redhat.com/solutions/6662631[{product-title} 4.9.17 containe
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-9-18"]
-=== RHBA-2022:2079 - {product-title} 4.9.18 bug fix update
+=== RHBA-2022:0279 - {product-title} 4.9.18 bug fix update
 
 Issued: 2022-01-31
 
-{product-title} release 4.9.18 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:2079[RHBA-2022:2079] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0276[RHBA-2022:0276] advisory.
+{product-title} release 4.9.18 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0279[RHBA-2022:0279] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0276[RHBA-2022:0276] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 


### PR DESCRIPTION
There is a typo in 4.9.18 release notes, the errata is https://access.redhat.com/errata/RHBA-2022:0279