### PR TITLE
OSDOCS-2852: out-of-tree providers added in 4.10 (op ref)

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -10,9 +10,9 @@
 
 [NOTE]
 ====
-This Operator is only fully supported for Azure Stack Hub.
+This Operator is only fully supported for Alibaba Cloud, Microsoft Azure Stack Hub, and IBM Cloud.
 
-It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Amazon Web Services (AWS), Microsoft Azure, and {rh-openstack-first}.
+It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, {rh-openstack-first}, and VMware vSphere.
 ====
 
 The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).


### PR DESCRIPTION
For [OSDOCS-2852](https://issues.redhat.com/browse/OSDOCS-2852), which covers OCPCLOUD-976, OCPCLOUD-1122, and OCPCLOUD-1160.

Note: This PR updates the CCCMO entry in the Platform Operators reference space for new clouds. #41575 covers the Rel Notes announcement.

Preview:
[Cluster Cloud Controller Manager Operator](https://deploy-preview-41577--osdocs.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-cloud-controller-manager-operator_platform-operators-ref) in _Platform Operators reference_
