### PR TITLE
OSDOCS-3261: Fix title for ocp4-nerc-cip-node in the Supported Profiles table

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -47,7 +47,7 @@ The Compliance Operator provides the following compliance profiles:
 |link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
 
 |ocp4-nerc-cip-node
-|North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Platform level
+|North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Node level
 |0.1.44+
 |link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3261

Applies to 4.6+

https://deploy-preview-41593--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-supported-profiles.html
