### PR TITLE
[RHACS] Added missing resource definitions

### DIFF
--- a/modules/rbac-resource-definitions.adoc
+++ b/modules/rbac-resource-definitions.adoc
@@ -102,9 +102,9 @@ _(Local administrator only.)_
 | Create, edit, or delete image registry integrations.
 //TODO: Add link to image registry integrations
 
-| ImbuedLogs
-| _Internal use only_
-| _Internal use only_
+| ImageIntegration
+| View image registry integrations.
+| Add, edit, or delete image registry integrations.
 
 | Indicator
 | View process activity in deployments.
@@ -130,10 +130,18 @@ _(Local administrator only.)_
 | View existing Kubernetes namespaces in secured clusters.
 | N/A
 
+| NetworkBaseline
+| View the network baseline network results.
+| Modify network baselines.
+
 | NetworkGraph
 | View active and allowed network connections in secured clusters.
 | N/A
 //TODO: Add link to manage network policies
+
+| NetworkGraphConfig
+| View network graph configurations.
+| Modify network graph configurations.
 
 | NetworkPolicy
 | View existing network policies in secured clusters and simulate changes.
@@ -202,4 +210,22 @@ _(Local administrator only.)_
 | User
 | View users that have accessed your {product-title} instance, including the metadata that the authentication provider provides about them.
 | N/A
+
+| VulnerabilityManagementApprovals
+| View all pending deferral or false positive vulnerability management requests.
+| Approve or reject pending deferral or false positive vulnerability management requests.
+Change any previously approved requests back to the observed state.
+
+| VulnerabilityManagementRequests
+| View all pending deferral or false positive vulnerability management requests.
+| Request a deferral on a vulnerability or mark it as a false positive.
+Change the status of pending or previously approved requests that you have created.
+
+| VulnerabilityReports
+| View vulnerability report configurations.
+| Add, modify or delete vulnerability report configurations.
+
+| WatchedImage
+| View undeployed watched images monitored.
+| Configure watched images.
 |===


### PR DESCRIPTION
- Based on resource definitions from the `Admin` permissions set.

Applies to RHACS 3.68 only


---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
