### PR TITLE
[BZ2035505]: Increase the shutting down time for large-scale clusters

### DIFF
--- a/modules/graceful-shutdown.adoc
+++ b/modules/graceful-shutdown.adoc
@@ -42,8 +42,9 @@ $ oc -n openshift-kube-apiserver-operator get secret kube-apiserver-to-kubelet-s
 +
 [source,terminal]
 ----
-$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1; done
+$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1 <1>; done
 ----
+<1> Indicates how long, in minutes, this process lasts before the control-plane nodes are shut down. For large-scale clusters with 10 nodes or more, set to 10 minutes or longer to make sure all the compute nodes have time to shut down first.
 +
 .Example output
 ----
@@ -58,6 +59,15 @@ Shutdown scheduled for Mon 2021-09-13 09:36:29 UTC, use 'shutdown -c' to cancel.
 ----
 +
 Shutting down the nodes using one of these methods allows pods to terminate gracefully, which reduces the chance for data corruption.
++
+[NOTE]
+====
+Adjust the shut down time to be longer for large-scale clusters:
+[source,terminal]
+----
+$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 10; done
+----
+====
 +
 [NOTE]
 ====


### PR DESCRIPTION
OCP version: 4.6+
[Preview](https://deploy-preview-41606--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-shutdown.html#graceful-shutdown_graceful-shutdown-cluster)
QA contact: @sunilcio 
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2035505)