### PR TITLE
[BZ2050107]: Add fields to subscription config when installing Operators using CLI 

### DIFF
--- a/modules/olm-installing-from-operatorhub-using-cli.adoc
+++ b/modules/olm-installing-from-operatorhub-using-cli.adoc
@@ -116,12 +116,44 @@ spec:
   name: <operator_name> <3>
   source: redhat-operators <4>
   sourceNamespace: openshift-marketplace <5>
+  config:
+    env: <6>
+    - name: ARGS
+      value: "-v=10"
+    envFrom: <7>
+    - secretRef:
+        name: license-secret
+    volumes: <8>
+    - name: <volume_name>
+      configMap:
+        name: <configmap_name>
+    volumeMounts: <9>
+    - mountPath: <directory_name>
+      name: <volume_name>
+    tolerations: <10>
+    - operator: "Exists"
+    resources: <11>
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    nodeSelector: <12>
+      foo: bar
 ----
 <1> For `AllNamespaces` install mode usage, specify the `openshift-operators` namespace. Otherwise, specify the relevant single namespace for `SingleNamespace` install mode usage.
 <2> Name of the channel to subscribe to.
 <3> Name of the Operator to subscribe to.
 <4> Name of the catalog source that provides the Operator.
 <5> Namespace of the catalog source. Use `openshift-marketplace` for the default OperatorHub catalog sources.
+<6> The `env` parameter defines a list of Environment Variables that must exist in all containers in the pod created by OLM.
+<7> The `envFrom` parameter defines a list of sources to populate Environment Variables in the container.
+<8> The `volumes` parameter defines a list of Volumes that must exist on the pod created by OLM.
+<9> The `volumeMounts` parameter defines a list of VolumeMounts that must exist in all containers in the pod created by OLM. If a `volumeMount` references a `volume` that does not exist, OLM fails to deploy the Operator.
+<10> The `tolerations` parameter defines a list of Tolerations for the pod created by OLM.
+<11> The `resources` parameter defines resource constraints for all the containers in the pod created by OLM.
+<12> The `nodeSelector` parameter defines a `NodeSelector` for the pod created by OLM.
 
 . Create the `Subscription` object:
 +


### PR DESCRIPTION
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2050107)
OCP version: 4.6+
[Preview](https://deploy-preview-41607--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-adding-operators-to-cluster.html#olm-installing-operator-from-operatorhub-using-cli_olm-adding-operators-to-a-cluster)
QA contact: @bandrade 
