### PR TITLE
Fixing OSD and ROSA cross-references

### DIFF
--- a/networking/configuring-cluster-wide-proxy.adoc
+++ b/networking/configuring-cluster-wide-proxy.adoc
@@ -18,11 +18,11 @@ You can configure a cluster-wide proxy during cluster installation.
 ifdef::openshift-dedicated[]
 * You must have a Customer Cloud Subscription (CCS) cluster with a VPC that the proxy can access.
 
-For more information, see xref:../../osd_quickstart/osd-quickstart.adoc[Quick Start] for a basic cluster installation workflow.
+For more information, see xref:../osd_quickstart/osd-quickstart.adoc[Quick Start] for a basic cluster installation workflow.
 endif::[]
 
 ifdef::openshift-rosa[]
-For information about standard installation prerequisites, see xref:../../rosa_getting_started/rosa-aws-prereqs.adoc[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc[AWS prerequisites for ROSA with STS].
+For information about standard installation prerequisites, see xref:../rosa_getting_started/rosa-aws-prereqs.adoc[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc[AWS prerequisites for ROSA with STS].
 endif::[]
 
 include::modules/cluster-wide-proxy.adoc[leveloffset=+1]


### PR DESCRIPTION
This applies to `main`, `enterprise-4.10` and `enterprise-4.9`.

This pull request relates to https://github.com/openshift/openshift-docs/issues/41611 and https://github.com/openshift/openshift-docs/issues/41612.