### PR TITLE
uncomment OADP for 1.0 GA

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2099,37 +2099,37 @@ Topics:
   File: graceful-cluster-shutdown
 - Name: Restarting a cluster gracefully
   File: graceful-cluster-restart
-# - Name: Application backup and restore
-#   Dir: application_backup_and_restore
-#   Topics:
-#   - Name: OADP features and plugins
-#     File: oadp-features-plugins
-#   - Name: Installing and configuring OADP
-#     Dir: installing
-#     Topics:
-#     - Name: About installing OADP
-#       File: about-installing-oadp
-#     - Name: Installing and configuring OADP with AWS
-#       File: installing-oadp-aws
-#     - Name: Installing and configuring OADP with Azure
-#       File: installing-oadp-azure
-#     - Name: Installing and configuring OADP with GCP
-#       File: installing-oadp-gcp
-#     - Name: Installing and configuring OADP with MCG
-#       File: installing-oadp-mcg
-#     - Name: Installing and configuring OADP with OCS
-#       File: installing-oadp-ocs
-#     - Name: Uninstalling OADP
-#       File: uninstalling-oadp
-#   - Name: Backing up and restoring
-#     Dir: backing_up_and_restoring
-#     Topics:
-#     - Name: Backing up applications
-#       File: backing-up-applications
-#     - Name: Restoring applications
-#       File: restoring-applications
-#   - Name: Troubleshooting
-#     File: troubleshooting
+- Name: Application backup and restore
+  Dir: application_backup_and_restore
+  Topics:
+  - Name: OADP features and plugins
+    File: oadp-features-plugins
+  - Name: Installing and configuring OADP
+    Dir: installing
+    Topics:
+    - Name: About installing OADP
+      File: about-installing-oadp
+    - Name: Installing and configuring OADP with AWS
+      File: installing-oadp-aws
+    - Name: Installing and configuring OADP with Azure
+      File: installing-oadp-azure
+    - Name: Installing and configuring OADP with GCP
+      File: installing-oadp-gcp
+    - Name: Installing and configuring OADP with MCG
+      File: installing-oadp-mcg
+    - Name: Installing and configuring OADP with OCS
+      File: installing-oadp-ocs
+    - Name: Uninstalling OADP
+      File: uninstalling-oadp
+  - Name: Backing up and restoring
+    Dir: backing_up_and_restoring
+    Topics:
+    - Name: Backing up applications
+      File: backing-up-applications
+    - Name: Restoring applications
+      File: restoring-applications
+  - Name: Troubleshooting
+    File: troubleshooting
 - Name: Control plane backup and restore
   Dir: control_plane_backup_and_restore
   Topics:

--- a/backup_and_restore/index.adoc
+++ b/backup_and_restore/index.adoc
@@ -4,7 +4,7 @@
 include::modules/common-attributes.adoc[]
 :context: backup-restore-overview
 :backup-restore-overview:
-:velero-domain: velero.netlify.app
+:velero-domain: velero.io
 
 toc::[]
 
@@ -30,52 +30,52 @@ You might run into several situations where {product-title}  does not work as ex
 
 You can always recover from a disaster situation by xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restoring your cluster to its previous state] using the saved etcd snapshots.
 
-// [id="application-backup-restore-operations-overview"]
-// == Application backup and restore operations
-//
-// As a cluster administrator, you can back up and restore applications running on {product-title} by using the OpenShift API for Data Protection (OADP).
-//
-// xref links are broken so that the PR will build. Travis tries to verify commented out xrefs.
-// OADP backs up and restores Kubernetes resources and internal images, at the granularity of a namespace, by using link:https://{velero-domain}/[Velero 1.7]. OADP backs up and restores persistent volumes (PVs) by using snapshots or Restic. For details, see xref:  ../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-features_oadp-features-plugins[OADP features].
-//
-// [id="oadp-requirements"]
-// === OADP requirements
-//
-// OADP has the following requirements:
-//
-// * You must be logged in as a user with a `cluster-admin` role.
-// * You must have object storage for storing backups, such as one of the following storage types:
-//
-// ** Amazon Web Services
-// ** Microsoft Azure
-// ** Google Cloud Platform
-// ** Multicloud Object Gateway
-// ** S3-compatible object storage, such as Noobaa or Minio
-//
-// :FeatureName: The `CloudStorage` API for S3 storage
-// include::snippets/technology-preview.adoc[]
-//
-// * To back up PVs with snapshots, you must have cloud storage that has a native snapshot API or supports Container Storage Interface (CSI) snapshots, such as the following providers:
-//
-// ** Amazon Web Services
-// ** Microsoft Azure
-// ** Google Cloud Platform
-// ** CSI snapshot-enabled cloud storage, such as Ceph RBD or Ceph FS
-//
-// [NOTE]
-// ====
-// If you do not want to back up PVs by using snapshots, you can use link:https://restic.net/[Restic], which is installed by the OADP Operator by default.
-// ====
-//
-// [id="backing-up-and-restoring-applications"]
-// === Backing up and restoring applications
-//
-// You back up applications by creating a xref:  ../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#oadp-creating-backup-cr_backing-up-applications[`Backup`]  custom resource (CR). You can configure the following backup options:
-//
-// * xref:  ../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#oadp-creating-backup-hooks_backing-up-applications[Backup hooks] to run commands before or after the backup operation
-// * xref:  ../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#oadp-scheduling-backups_backing-up-applications[Scheduled backups]
-// * xref:  ../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#oadp-backing-up-applications-restic_backing-up-applications[Restic backups]
-//
-// You restore applications by creating a xref:  ../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#oadp-creating-restore-cr_restoring-applications[`Restore`] CR. You can configure xref:  ../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#oadp-creating-restore-hooks_restoring-applications[restore hooks] to run commands in init containers or in the application container during the restore operation.
+[id="application-backup-restore-operations-overview"]
+== Application backup and restore operations
+
+As a cluster administrator, you can back up and restore applications running on {product-title} by using the OpenShift API for Data Protection (OADP).
+
+// Velero 1.7 is no longer latest version. However, it is the officially supported version, so do not change the version number without confirmation from PM.
+OADP backs up and restores Kubernetes resources and internal images, at the granularity of a namespace, by using link:https://{velero-domain}/docs/v1.7/[Velero 1.7]. OADP backs up and restores persistent volumes (PVs) by using snapshots or Restic. For details, see xref:../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-features_oadp-features-plugins[OADP features].
+
+[id="oadp-requirements"]
+=== OADP requirements
+
+OADP has the following requirements:
+
+* You must be logged in as a user with a `cluster-admin` role.
+* You must have object storage for storing backups, such as one of the following storage types:
+
+** Amazon Web Services
+** Microsoft Azure
+** Google Cloud Platform
+** Multicloud Object Gateway
+** S3-compatible object storage, such as Noobaa or Minio
+
+:FeatureName: The `CloudStorage` API for S3 storage
+include::snippets/technology-preview.adoc[]
+
+* To back up PVs with snapshots, you must have cloud storage that has a native snapshot API or supports Container Storage Interface (CSI) snapshots, such as the following providers:
+
+** Amazon Web Services
+** Microsoft Azure
+** Google Cloud Platform
+** CSI snapshot-enabled cloud storage, such as Ceph RBD or Ceph FS
+
+[NOTE]
+====
+If you do not want to back up PVs by using snapshots, you can use link:https://restic.net/[Restic], which is installed by the OADP Operator by default.
+====
+
+[id="backing-up-and-restoring-applications"]
+=== Backing up and restoring applications
+
+You back up applications by creating a xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#oadp-creating-backup-cr_backing-up-applications[`Backup`] custom resource (CR). You can configure the following backup options:
+
+* xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#oadp-creating-backup-hooks_backing-up-applications[Backup hooks] to run commands before or after the backup operation
+* xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#oadp-scheduling-backups_backing-up-applications[Scheduled backups]
+* xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#oadp-backing-up-applications-restic_backing-up-applications[Restic backups]
+
+You restore applications by creating a xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#oadp-creating-restore-cr_restoring-applications[`Restore`] CR. You can configure xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#oadp-creating-restore-hooks_restoring-applications[restore hooks] to run commands in init containers or in the application container during the restore operation.
 
 :backup-restore-overview!:


### PR DESCRIPTION
No Jira or BZ.

Note: Velero 1.7 is no longer the latest version but it is the version used by OADP 1.0.

Previews:
https://deploy-preview-41614--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/index.html#application-backup-restore-operations-overview

Everything in "Application backup and restore."

No QE required. Ready for peer review.