### PR TITLE
BZ1977793: Fix ICSP steps for mirrored

### DIFF
--- a/modules/olm-mirroring-catalog-airgapped.adoc
+++ b/modules/olm-mirroring-catalog-airgapped.adoc
@@ -83,6 +83,24 @@ $ oc adm catalog mirror \
 Red Hat Quay does not support nested repositories. As a result, running the `oc adm catalog mirror` command will fail with a `401` unauthorized error. As a workaround, you can use the `--max-components=2` option when running the `oc adm catalog mirror` command to disable the creation of nested repositories. For more information on this workaround, see the link:https://access.redhat.com/solutions/5440741[Unauthorized error thrown while using catalog mirror command with Quay registry] Knowledgebase Solution.
 ====
 
+. Run the `oc adm catalog mirror` command again. Use the newly mirrored index image as the source and the same mirror registry namespace used in the previous step as the target:
++
+[source,terminal]
+----
+$ oc adm catalog mirror \
+    <mirror_registry>:<port>/<index_image> \
+    <mirror_registry>:<port>/<namespace> \
+    --manifests-only \//<1>
+    [-a ${REG_CREDS}] \
+    [--insecure]
+----
+<1> The `--manifests-only` flag is required for this step so that the command does not copy all of the mirrored content again.
++
+[IMPORTANT]
+====
+This step is required because the image mappings in the `imageContentSourcePolicy.yaml` file generated during the previous step must be updated from local paths to valid mirror locations. Failure to do so will cause errors when you create the `ImageContentSourcePolicy` object in a later step.
+====
+
 After you mirror the catalog, you can continue with the remainder of your cluster installation. After your cluster installation has finished successfully, you must specify the manifests directory from this procedure to create the `ImageContentSourcePolicy` and `CatalogSource` objects. These objects are required to enable installation of Operators from OperatorHub.
 
 :!index-image-pullspec:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1977793

Preview: Step 6 in https://deploy-preview-41633--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-mirroring-installation-images.html#olm-mirror-catalog-airgapped_installing-mirroring-installation-images

This file was in a different location for 4.7 and 4.8, so different PRs for them: https://github.com/openshift/openshift-docs/pull/40716 and https://github.com/openshift/openshift-docs/pull/41668.