### PR TITLE
Updating the TechPreviewNoUpdate list in 4.8

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -8,23 +8,15 @@
 
 You can use the `FeatureGate` custom resource (CR) to enable specific feature sets in your cluster. A feature set is a collection of {product-title} features that are not enabled by default.
 
-For example, the `TechPreviewNoUpgrade` feature set allows you to enable a subset of the current Technology Preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters.
-
 You can activate any of the following feature sets by using the `FeatureGate` CR:
 
-[options="header"]
-|===
-| Feature Set| Description
+* `TechPreviewNoUpgrade`. This featrue set a subset of the current Technology Preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents upgrades. This feature set is not recommended on production clusters. The following Technology Preview features are enabled by this feature set:
 
-|`TechPreviewNoUpgrade`
-a|Enables Technology Preview features that are not part of the default features. Enabling this feature set cannot be undone and prevents upgrades. This feature set is not recommended on production clusters. 
-
-The following Technology Preview features are enabled by this feature set:
-
-* link:https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#certificate-rotation[RotateKubeletServerCertificate]. Enables the rotation of the server TLS certificate on the kubelet.
-* link:https://kubernetes.io/docs/concepts/policy/pid-limiting/#pod-pid-limits[Pod PID limits (SupportPodPidsLimit)]. Enables limiting process IDs (PIDs) in pods.
-
-|===
+** Azure Disk CSI Driver Operator. Enables the provisioning of persistent volumes (PVs) by using the Container Storage Interface (CSI) driver for Microsoft Azure Disk Storage.
+** VMware vSphere CSI Driver Operator. Enables the provisioning of persistent volumes (PVs) by using the Container Storage Interface (CSI) VMware vSphere driver for Virtual Machine Disk (VMDK) volumes.
+** CSI automatic migration. Enables the automatic migration of supported in-tree volume plug-ins to their equivalent Container Storage Interface (CSI) drivers. Available as a Technology Preview for:
+*** Amazon Web Services (AWS) Elastic Block Storage (EBS)
+*** OpenStack Cinder
 
 //// 
 Do not document per Derek Carr: https://github.com/openshift/api/pull/370#issuecomment-510632939

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 :context: nodes-cluster-enabling
 [id="nodes-cluster-enabling"]
-= Enabling {product-title} features using FeatureGates
+= Enabling features using feature gates
 include::modules/common-attributes.adoc[]
 
 toc::[]
@@ -10,9 +10,14 @@ As an administrator, you can use feature gates to enable features that are not p
 
 include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+1]
 
+.Additional resources
+
+* For more information on the features activated by the `TechPreviewNoUpdate` feature gate, see the following topics:
+
+** xref:../../storage/container_storage_interface/persistent-storage-csi-azure.adoc#persistent-storage-csi-azure-disk[Azure Disk CSI Driver Operator]
+** xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-vsphere[VMware vSphere CSI Driver Operator]
+** xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration]
+
 include::modules/nodes-cluster-enabling-features-console.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-enabling-features-cli.adoc[leveloffset=+1]
-
-// modules/nodes-cluster-disabling-features-list.adoc[leveloffset=+1]
-


### PR DESCRIPTION
Updated the list to match: https://github.com/openshift/api/blob/release-4.8/config/v1/types_feature.go#L108

Preview: [Understanding feature gates](https://deploy-preview-41641--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling) 