### PR TITLE
Reorganizing CCO manual upgrade requirements

### DIFF
--- a/installing/installing_aws/manually-creating-iam.adoc
+++ b/installing/installing_aws/manually-creating-iam.adoc
@@ -24,9 +24,11 @@ include::modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc[level
 
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 
-include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
+.Additional references
+* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster within a minor version using the web console]
+* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster within a minor version using the CLI]
 
-include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
+include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
 
 include::modules/mint-mode.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/manually-creating-iam-azure.adoc
+++ b/installing/installing_azure/manually-creating-iam-azure.adoc
@@ -16,9 +16,11 @@ For a detailed description of all available CCO credential modes and their suppo
 
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 
-include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
+.Additional references
+* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster within a minor version using the web console]
+* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster within a minor version using the CLI]
 
-include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
+include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
 
 [id="manually-creating-iam-azure-next-steps"]
 == Next steps

--- a/installing/installing_gcp/manually-creating-iam-gcp.adoc
+++ b/installing/installing_gcp/manually-creating-iam-gcp.adoc
@@ -18,9 +18,11 @@ For a detailed description of all available CCO credential modes and their suppo
 
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 
-include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
+.Additional references
+* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster within a minor version using the web console]
+* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster within a minor version using the CLI]
 
-include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
+include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
 
 include::modules/mint-mode.adoc[leveloffset=+1]
 

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -173,7 +173,7 @@ $ openshift-install create cluster --dir <installation_directory>
 +
 [IMPORTANT]
 ====
-Before upgrading a cluster that uses manually maintained credentials, you must ensure that the CCO is in an upgradeable state. For details, see the "Upgrading clusters with manually maintained credentials" section of the installation content for your cloud provider.
+Before upgrading a cluster that uses manually maintained credentials, you must ensure that the CCO is in an upgradeable state. For details, see the "Upgrading clusters with manually maintained credentials" section of the update procedure you are using.
 ====
 
 ifeval::["{context}" == "manually-creating-iam-aws"]

--- a/modules/manually-maintained-credentials-upgrade.adoc
+++ b/modules/manually-maintained-credentials-upgrade.adoc
@@ -1,10 +1,9 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_aws/manually-creating-iam.adoc
-// * installing/installing_azure/manually-creating-iam-azure.adoc
-// * installing/installing_gcp/manually-creating-iam-gcp.adoc
 // * authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc
 // * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+// * updating/updating-cluster-within-minor.adoc
+// * updating/updating-cluster-cli.adoc
 
 :_content-type: PROCEDURE
 [id="manually-maintained-credentials-upgrade_{context}"]
@@ -56,12 +55,12 @@ Where `<version_number>` is the version you are upgrading to, in the format `x.y
 +
 It may take several minutes after adding the annotation for the upgradeable status to change.
 
-. Verify that the CCO is upgradeable:
+.Verification
 
-.. In the *Administrator* perspective of the web console, navigate to *Administration* -> *Cluster Settings*.
+. In the *Administrator* perspective of the web console, navigate to *Administration* -> *Cluster Settings*.
 
-.. To view the CCO status details, click *cloud-credential* in the *Cluster Operators* list.
+. To view the CCO status details, click *cloud-credential* in the *Cluster Operators* list.
 
-.. If the *Upgradeable* status in the *Conditions* section is *False*, verify that the `upgradeable-to` annotation is free of typographical errors.
+. If the *Upgradeable* status in the *Conditions* section is *False*, verify that the `upgradeable-to` annotation is free of typographical errors.
 
 When the *Upgradeable* status in the *Conditions* section is *True*, you can begin the {product-title} upgrade.

--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -20,8 +20,8 @@ See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permis
 * Have a recent xref:../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[etcd backup] in case your upgrade fails and you must xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restore your cluster to a previous state].
 * Ensure all Operators previously installed through Operator Lifecycle Manager (OLM) are updated to their latest version in their latest channel. Updating the Operators ensures they have a valid upgrade path when the default OperatorHub catalogs switch from the current minor version to the next during a cluster upgrade. See xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Upgrading installed Operators] for more information.
 * Ensure that all machine config pools (MCPs) are running and not paused. Nodes associated with a paused MCP are skipped during the update process. You can pause the MCPs if you are performing a canary rollout update strategy.
-* If your cluster uses manually maintained credentials, ensure that the Cloud Credential Operator (CCO) is in an upgradeable state. For more information, see _Upgrading clusters with manually maintained credentials_ for xref:../installing/installing_aws/manually-creating-iam.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-aws[AWS], xref:../installing/installing_azure/manually-creating-iam-azure.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-azure[Azure], or xref:../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-gcp[GCP].
-* If your cluster uses manually maintained credentials with the AWS Secure Token Service (STS), obtain a copy of the `ccoctl` utility from the release image being upgraded to and use it to process any updated credentials. For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-upgrading[_Upgrading an OpenShift Container Platform cluster configured for manual mode with STS_].
+* If your cluster uses manually maintained credentials, ensure that the Cloud Credential Operator (CCO) is in an upgradeable state. For more information, see xref:../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Upgrading clusters with manually maintained credentials].
+* If your cluster uses manually maintained credentials with the AWS Secure Token Service (STS), obtain a copy of the `ccoctl` utility from the release image being upgraded to and use it to process any updated credentials. For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-upgrading[Upgrading an OpenShift Container Platform cluster configured for manual mode with STS].
 * Ensure that you address all `Upgradeable=False` conditions so the cluster allows an upgrade to the next minor version. You can run the `oc adm upgrade` command for an output of all `Upgradeable=False` conditions and the condition reasoning to help you prepare for a minor version upgrade.
 
 
@@ -38,6 +38,13 @@ If you are running cluster monitoring with an attached PVC for Prometheus, you m
 .Additional resources
 
 * xref:../architecture/architecture-installation.adoc#unmanaged-operators_architecture-installation[Support policy for unmanaged Operators]
+
+include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
+
+.Additional resources
+* xref:../installing/installing_aws/manually-creating-iam.adoc[Manually creating IAM for AWS]
+* xref:../installing/installing_azure/manually-creating-iam-azure.adoc[Manually creating IAM for Azure]
+* xref:../installing/installing_gcp/manually-creating-iam-gcp.adoc[Manually creating IAM for GCP]
 
 include::modules/machine-health-checks-pausing.adoc[leveloffset=+1]
 

--- a/updating/updating-cluster-within-minor.adoc
+++ b/updating/updating-cluster-within-minor.adoc
@@ -20,8 +20,8 @@ See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permis
 * Have a recent xref:../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[etcd backup] in case your upgrade fails and you must xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restore your cluster to a previous state].
 * Ensure all Operators previously installed through Operator Lifecycle Manager (OLM) are updated to their latest version in their latest channel. Updating the Operators ensures they have a valid upgrade path when the default OperatorHub catalogs switch from the current minor version to the next during a cluster upgrade. See xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Upgrading installed Operators] for more information.
 * Ensure that all machine config pools (MCPs) are running and not paused. Nodes associated with a paused MCP are skipped during the update process. You can pause the MCPs if you are performing a canary rollout update strategy.
-* If your cluster uses manually maintained credentials, ensure that the Cloud Credential Operator (CCO) is in an upgradeable state. For more information, see _Upgrading clusters with manually maintained credentials_ for xref:../installing/installing_aws/manually-creating-iam.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-aws[AWS], xref:../installing/installing_azure/manually-creating-iam-azure.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-azure[Azure], or xref:../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-gcp[GCP].
-* If your cluster uses manually maintained credentials with the AWS Secure Token Service (STS), obtain a copy of the `ccoctl` utility from the release image being upgraded to and use it to process any updated credentials. For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-upgrading[_Upgrading an OpenShift Container Platform cluster configured for manual mode with STS_].
+* If your cluster uses manually maintained credentials, ensure that the Cloud Credential Operator (CCO) is in an upgradeable state. For more information, see xref:../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Upgrading clusters with manually maintained credentials].
+* If your cluster uses manually maintained credentials with the AWS Secure Token Service (STS), obtain a copy of the `ccoctl` utility from the release image being upgraded to and use it to process any updated credentials. For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-upgrading[Upgrading an OpenShift Container Platform cluster configured for manual mode with STS].
 
 [IMPORTANT]
 ====
@@ -40,6 +40,13 @@ If you are running cluster monitoring with an attached PVC for Prometheus, you m
 include::modules/update-using-custom-machine-config-pools-canary.adoc[leveloffset=+1]
 
 If you want to use the canary rollout update process, see xref:../updating/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools[Performing a canary rollout update].
+
+include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
+
+.Additional resources
+* xref:../installing/installing_aws/manually-creating-iam.adoc[Manually creating IAM for AWS]
+* xref:../installing/installing_azure/manually-creating-iam-azure.adoc[Manually creating IAM for Azure]
+* xref:../installing/installing_gcp/manually-creating-iam-gcp.adoc[Manually creating IAM for GCP]
 
 include::modules/machine-health-checks-pausing.adoc[leveloffset=+1]
 


### PR DESCRIPTION
No Jira or BZ, groundwork for making related content better/possible.

Note: The titles "within a minor version" may seem in conflict with the caveat on this content that it is for upgrades "between minor versions", but this is the place users would go to find this, and phrasing will be covered as a part of later work on this book.

Previews:
- [Manually creating IAM for AWS](https://deploy-preview-41645--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/manually-creating-iam.html#manually-create-iam_manually-creating-iam-aws): Upgrade steps removed, _Additional resources_ links to upgrade steps added
- [Manually creating IAM for Azure](https://deploy-preview-41645--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/manually-creating-iam-azure.html#manually-create-iam_manually-creating-iam-azure): same
- [Manually creating IAM for GCP](https://deploy-preview-41645--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/manually-creating-iam-gcp.html#manually-create-iam_manually-creating-iam-gcp): same
- [Updating a cluster within a minor version using the web console](https://deploy-preview-41645--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-within-minor.html#manually-maintained-credentials-upgrade_updating-cluster-within-minor): Added upgrade steps and _Additional resources_ links to all three _Manually creating IAM_ procedures. Updated procedure to use `.Verification` heading.
- [Updating a cluster within a minor version using the CLI](https://deploy-preview-41645--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-cli.html#manually-maintained-credentials-upgrade_updating-cluster-cli): same