### PR TITLE
Github-34518: fixes 2 broken links

### DIFF
--- a/openshift_images/managing_images/using-image-pull-secrets.adoc
+++ b/openshift_images/managing_images/using-image-pull-secrets.adoc
@@ -12,7 +12,7 @@ However, for other scenarios, such as referencing images across {product-title} 
 
 You can obtain the image pull secret, `pullSecret`, from the link:https://console.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {console-redhat-com} site.
 
-You use this pull secret to authenticate with the services that are provided by the included authorities, including link:quay.io[Quay.io] and link:registry.redhat.io[registry.redhat.io], which serve the container images for {product-title} components.
+You use this pull secret to authenticate with the services that are provided by the included authorities, link:https://quay.io/[Quay.io] and link:https://registry.redhat.io[registry.redhat.io], which serve the container images for {product-title} components.
 
 include::modules/images-allow-pods-to-reference-images-across-projects.adoc[leveloffset=+1]
 


### PR DESCRIPTION
4.6+ 

Github issue #34518

[Preview](https://deploy-preview-41655--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/managing_images/using-image-pull-secrets.html)

Fixes broken links that returned 404 error