### PR TITLE
Backport of enterprise-4.10 SCA headings for user continuity

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -486,7 +486,7 @@ Topics:
     File: using-insights-to-identify-issues-with-your-cluster
   - Name: Using remote health reporting in a restricted network
     File: remote-health-reporting-from-restricted-network
-  - Name: Configuring RHEL Simple Content Access
+  - Name: Importing simple content access certificates with Insights Operator
     File: insights-operator-simple-access
 - Name: Gathering data about your cluster
   File: gathering-cluster-data

--- a/modules/insights-operator-configuring-sca.adoc
+++ b/modules/insights-operator-configuring-sca.adoc
@@ -5,7 +5,7 @@
 
 :_content-type: PROCEDURE
 [id="insights-operator-configuring-sca_{context}"]
-= Configuring Simple Content Access import interval
+= Configuring simple content access import interval
 
 You can configure how often the Insights Operator imports the RHEL Simple Content Access (SCA) certificates using the `support` secret in the `openshift-config` namespace. The certificate import normally occurs every 8 hours, but you may want to shorten this interval if you update your SCA configuration in Red Hat Subscription Management.
 

--- a/modules/insights-operator-disabling-sca.adoc
+++ b/modules/insights-operator-disabling-sca.adoc
@@ -5,7 +5,7 @@
 
 :_content-type: PROCEDURE
 [id="insights-operator-disabling-sca_{context}"]
-= Disabling Simple Content Access import
+= Disabling simple content access import
 
 You can disable the import of RHEL Simple Content Access certificates using the `support` secret in the `openshift-config` namespace.
 

--- a/support/remote_health_monitoring/insights-operator-simple-access.adoc
+++ b/support/remote_health_monitoring/insights-operator-simple-access.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="insights-operator-simple-access"]
-= Importing RHEL Simple Content Access certificates with Insights Operator
+= Importing simple content access certificates with Insights Operator
 include::modules/common-attributes.adoc[]
 :context: remote-health-reporting-from-restricted-network
 :FeatureName: `InsightsOperatorPullingSCA`


### PR DESCRIPTION
This PR is a backport of the heading changes in this merged 4.10 PR: https://github.com/openshift/openshift-docs/pull/40689 

No content was changed due to differences in this feature from 4.9 -> 4.10 


Preview: https://deploy-preview-41677--osdocs.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/insights-operator-simple-access.html 


