### PR TITLE
BZ1975509: Added cpu and memory reservation when Latency Sensitivity is set to High

### DIFF
--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -156,7 +156,9 @@ $ export IPCFG="ip=192.168.100.101::192.168.100.254:255.255.255.0:::none nameser
 $ govc vm.change -vm "<vm_name>" -e "guestinfo.afterburn.initrd.network-kargs=${IPCFG}"
 ----
 +
-*** Optional: In the event of cluster performance issues, from the *Latency Sensitivity* list, select *High*.
+*** Optional: In the event of cluster performance issues, from the *Latency Sensitivity* list, select *High*. Ensure that your VM's CPU and memory reservation have the following values:
+**** Memory reservation value must be equal to its configured memory size.
+**** CPU reservation value must be at least the number of low latency virtual CPUs multiplied by the measured physical CPU speed.
 *** Click *Edit Configuration*, and on the *Configuration Parameters* window, click *Add Configuration Params*. Define the following parameter names and values:
 **** `guestinfo.ignition.config.data`: Locate the base-64 encoded files that you created previously in this procedure, and paste the contents of the base64-encoded Ignition config file for this machine type.
 **** `guestinfo.ignition.config.data.encoding`: Specify `base64`.


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1975509

OCP version: **4.7 and 4.6**

Direct Doc Preview link: https://deploy-preview-41684--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-user-infra.html#installation-vsphere-machines_installing-vmc-user-infra

Peer-review-squad: back-port this PR to 4.6 as well.

@jinyunma PTAL and let me know your feedback.