### PR TITLE
MULTIARCH-1480, 1481 - Multus add new step and fix typos

### DIFF
--- a/modules/nw-multus-create-network.adoc
+++ b/modules/nw-multus-create-network.adoc
@@ -24,6 +24,13 @@ network.
 
 .Procedure
 
+. Optional: Create the namespace for the additional networks:
++
+[source,terminal]
+----
+$ oc create namespace <namespace_name>
+----
+
 . To edit the CNO configuration, enter the following command:
 +
 [source,terminal]
@@ -44,7 +51,7 @@ spec:
   # ...
   additionalNetworks:
   - name: tertiary-net
-    namespace: project2
+    namespace: namespace2
     type: Raw
     rawCNIConfig: |-
       {
@@ -68,7 +75,7 @@ spec:
 
 .Verification
 
-* Confirm that the CNO created the NetworkAttachmentDefinition object by running the following command. There might be a delay before the CNO creates the object.
+* Confirm that the CNO created the `NetworkAttachmentDefinition` object by running the following command. There might be a delay before the CNO creates the object.
 +
 [source,terminal]
 ----

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -13,6 +13,7 @@ ifeval::["{context}" == "configuring-sriov-net-attach"]
 :sr-iov:
 endif::[]
 
+:_content-type: CONCEPT
 [id="nw-multus-ipam-object_{context}"]
 = Configuration of IP address assignment for an additional network
 
@@ -96,7 +97,7 @@ The `addresses` array requires objects with the following fields:
 
 |`nameservers`
 |`array`
-|An of array of one or more IP addresses for to send DNS queries to.
+|An array of one or more IP addresses for to send DNS queries to.
 
 |`domain`
 |`array`
@@ -210,7 +211,7 @@ The following table describes the configuration for dynamic IP address assignmen
 
 |`exclude`
 |`array`
-|Optional: A list of zero ore more IP addresses and ranges in CIDR notation. IP addresses within an excluded address range are not assigned.
+|Optional: A list of zero or more IP addresses and ranges in CIDR notation. IP addresses within an excluded address range are not assigned.
 
 |====
 


### PR DESCRIPTION
Feedback from IBM Z test: To create an additional network , the new network needs a pod to run in. 

OCP version for cherry-picking: enterprise-4.10 and later

Jira:
- IBM Z [MULTIARCH-1481](https://issues.redhat.com/browse/MULTIARCH-1481)
- IBM P [MULTIARCH-1480](https://issues.redhat.com/browse/MULTIARCH-1480)

Preview: 

- [Creating an additional network attachment with the Cluster Network Operator](https://deploy-preview-41686--osdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-create-network_configuring-additional-network)

QE review: 
- IBM Z - Christian laPolt
- IBM Power - Mick Tarsel
- x86 - Doug Smith