### PR TITLE
OSDOCS-3302: Updating the TechPreviewNoUpdate list in 4.10

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -8,22 +8,27 @@
 
 You can use the `FeatureGate` custom resource (CR) to enable specific feature sets in your cluster. A feature set is a collection of {product-title} features that are not enabled by default.
 
-You can activate any of the following feature sets by using the `FeatureGate` CR:
+You can activate the following feature set by using the `FeatureGate` CR:
 
-* `TechPreviewNoUpgrade`. This featrue set a subset of the current Technology Preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents upgrades. This feature set is not recommended on production clusters. The following Technology Preview features are enabled by this feature set:
-
-** Azure Disk CSI Driver Operator. Enables the provisioning of persistent volumes (PVs) by using the Container Storage Interface (CSI) driver for Microsoft Azure Disk Storage.
-** VMware vSphere CSI Driver Operator. Enables the provisioning of persistent volumes (PVs) by using the Container Storage Interface (CSI) VMware vSphere driver for Virtual Machine Disk (VMDK) volumes.
-** CSI automatic migration. Enables the automatic migration of supported in-tree volume plug-ins to their equivalent Container Storage Interface (CSI) drivers. Available as a Technology Preview for:
+* `TechPreviewNoUpgrade`. This feature set is a subset of the current Technology Preview features. This feature set allows you to enable these tech preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents updates. This feature set is not recommended on production clusters. 
++
+The following Technology Preview features are enabled by this feature set:
++
+** Microsoft Azure File CSI Driver Operator. Enables the provisioning of persistent volumes (PVs) by using the Container Storage Interface (CSI) driver for Microsoft Azure File Storage.
+** CSI automatic migration. Enables automatic migration for supported in-tree volume plug-ins to their equivalent Container Storage Interface (CSI) drivers. Supported for:
 *** Amazon Web Services (AWS) Elastic Block Storage (EBS)
 *** OpenStack Cinder
 *** Azure Disk
-*** Google Cloud Platform Persistent Disk.
+*** Azure File
+*** Google Cloud Platform Persistent Disk (CSI)
+*** VMware vSphere
 ** Cluster Cloud Controller Manager Operator. Enables the Cluster Cloud Controller Manager Operator rather than the in-tree cloud controller. Available as a Technology Preview for: 
 *** Amazon Web Services (AWS)
 *** Microsoft Azure
 *** Red Hat OpenStack Platform (RHOSP)
-** Insights Operator. Enables the importing of RHEL Simple Content Access (SCA) certificates from {console-redhat-com}.
+** Shared resource CSI driver
+** CSI volume support for the {product-title} build system
+** Swap memory on nodes
 
 ////
 Do not document per Derek Carr: https://github.com/openshift/api/pull/370#issuecomment-510632939

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -13,12 +13,11 @@ include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+1]
 .Additional resources
 
 * For more information on the features activated by the `TechPreviewNoUpdate` feature gate, see the following topics:
-
-** xref:../../storage/container_storage_interface/persistent-storage-csi-azure.adoc#persistent-storage-csi-azure-disk[Azure Disk CSI Driver Operator]
-** xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-vsphere[VMware vSphere CSI Driver Operator]
+** xref:../../storage/container_storage_interface/persistent-storage-csi-azure-file.adoc#persistent-storage-csi-azure-file[Azure File CSI Driver Operator]
 ** xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration]
 ** xref:../../operators/operator-reference.html#cluster-cloud-controller-manager-operator_platform-operators-ref[Cluster Cloud Controller Manager Operator]
-** xref:../../support/remote_health_monitoring/insights-operator-simple-access.adoc#insights-operator-simple-access[Importing simple content access certificates with Insights Operator ]
+** xref:../../cicd/builds/build-strategies.html#builds-using-build-volumes_build-strategies-s2i[Source-to-image (S2I) build volumes] and xref:../../cicd/builds/build-strategies.html#builds-using-build-volumes_build-strategies-docker[Docker build volumes]
+** xref:../../nodes/nodes/nodes-nodes-working.html#nodes-nodes-swap-memory_nodes-nodes-working[Swap memory on nodes]
 
 include::modules/nodes-cluster-enabling-features-console.adoc[leveloffset=+1]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3302

Updated the list to match: https://github.com/openshift/api/blob/release-4.10/config/v1/types_feature.go#L113

Preview: [Understanding feature gates](https://deploy-preview-41695--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html)