### PR TITLE
Enterprise-4.9 BZ2049854: Correct GCP CSI Driver in table to GA

### DIFF
--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -18,8 +18,8 @@ The following table describes the CSI drivers that are installed with {product-t
 
 |AWS EBS | ✅ | - | ✅
 |AWS EFS (Tech Preview) | - | - | -
-|Google Cloud Platform (GCP) persistent disk (PD) (Tech Preview)| ✅ | - | ✅
-|Microsoft Azure Disk (Tech Preview) | ✅ | ✅ | ✅
+|Google Cloud Platform (GCP) persistent disk (PD)| ✅ | - | ✅
+|Microsoft Azure Disk | ✅ | ✅ | ✅
 |Microsoft Azure Stack Hub | ✅ | ✅ | ✅
 |OpenStack Cinder | ✅ | ✅ | ✅
 |OpenShift Container Storage | ✅ | ✅ | ✅


### PR DESCRIPTION
Cherry Picked from [a0a44f4d639d62f2da5cbb411b6e49a5000aeb18](https://github.com/openshift/openshift-docs/pull/41315)