### PR TITLE
modules/monitoring-support-considerations: Drop unnecessary comma

### DIFF
--- a/modules/monitoring-support-considerations.adoc
+++ b/modules/monitoring-support-considerations.adoc
@@ -7,7 +7,7 @@
 
 The following modifications are explicitly not supported:
 
-* *Creating additional `ServiceMonitor`, `PodMonitor`, and `PrometheusRule` objects in the `openshift-&#42;`, and `kube-&#42;` projects.*
+* *Creating additional `ServiceMonitor`, `PodMonitor`, and `PrometheusRule` objects in the `openshift-&#42;` and `kube-&#42;` projects.*
 * *Modifying any resources or objects deployed in the `openshift-monitoring` or `openshift-user-workload-monitoring` projects.* The resources created by the {product-title} monitoring stack are not meant to be used by any other resources, as there are no guarantees about their backward compatibility.
 +
 [NOTE]


### PR DESCRIPTION
The comma landed with this line in 754f5b796f (#24722), but no need for a comma in "A and B".