### PR TITLE
OSDOCS-3217: Add logLevel and operatorLogLevel APIs documentation

### DIFF
--- a/modules/nw-dns-loglevel.adoc
+++ b/modules/nw-dns-loglevel.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+// * networking/dns-operator.adoc
+
+:_content-type: PROCEDURE
+[id="nw-dns-loglevel_{context}"]
+= Setting the CoreDNS log level
+
+You can configure the CoreDNS log level to determine the amount of detail in logged error messages. The valid values for CoreDNS log level are `Normal`, `Debug`, and `Trace`. The default `logLevel` is `Normal`.
+
+[NOTE]
+====
+The errors plug-in is always enabled. The following `logLevel` settings report different error responses:
+
+* `logLevel`: `Normal` enables the "errors" class: `log . { class error }`.
+
+* `logLevel`: `Debug` enables the "denial" class: `log . { class denial error }`.
+
+* `logLevel`: `Trace` enables the "all" class: `log . { class all }`.
+====
+
+.Procedure
+
+* To set `logLevel` to `Debug`, enter the following command:
++
+[source,terminal]
+----
+$ oc patch dnses.operator.openshift.io/default -p '{"spec":{"logLevel":"Debug"}}' --type=merge
+----
+
+* To set `logLevel` to `Trace`, enter the following command:
++
+[source,terminal]
+----
+$ oc patch dnses.operator.openshift.io/default -p '{"spec":{"logLevel":"Trace"}}' --type=merge
+----
+
+.Verification
+
+* To ensure the desired log level was set, check the config map:
++
+[source,terminal]
+----
+$ oc get configmap/dns-default -n openshift-dns -o yaml
+----

--- a/modules/nw-dns-operatorloglevel.adoc
+++ b/modules/nw-dns-operatorloglevel.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+// * networking/dns-operator.adoc
+
+:_content-type: PROCEDURE
+[id="nw-dns-operatorloglevel_{context}"]
+= Setting the CoreDNS Operator log level
+
+Cluster administrators can configure the Operator log level to more quickly track down OpenShift DNS issues. The valid values for `operatorLogLevel` are `Normal`, `Debug`, and `Trace`. `Trace` has the most detailed information. The default `operatorlogLevel` is `Normal`. There are seven logging levels for issues: Trace, Debug, Info, Warning, Error, Fatal and Panic. After the logging level is set, log entries with that severity or anything above it will be logged.
+
+* `operatorLogLevel: "Normal"` sets `logrus.SetLogLevel("Info")`.
+
+* `operatorLogLevel: "Debug"` sets `logrus.SetLogLevel("Debug")`.
+
+* `operatorLogLevel: "Trace"` sets  `logrus.SetLogLevel("Trace")`.
+
+.Procedure
+
+* To set `operatorLogLevel` to `Debug`, enter the following command:
++
+[source,terminal]
+----
+$ oc patch dnses.operator.openshift.io/default -p '{"spec":{"operatorLogLevel":"Debug"}}' --type=merge
+----
+
+* To set `operatorLogLevel` to `Trace`, enter the following command:
++
+[source,terminal]
+----
+$ oc patch dnses.operator.openshift.io/default -p '{"spec":{"operatorLogLevel":"Trace"}}' --type=merge
+----

--- a/networking/dns-operator.adoc
+++ b/networking/dns-operator.adoc
@@ -25,3 +25,7 @@ include::modules/nw-dns-operator-status.adoc[leveloffset=+1]
 
 include::modules/nw-dns-operator-logs.adoc[leveloffset=+1]
 endif::[]
+
+include::modules/nw-dns-loglevel.adoc[leveloffset=+1]
+
+include::modules/nw-dns-operatorloglevel.adoc[levelofset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3217

@miheer CoreDNS section draft done, please check, want more detail after the title if possible.

@ShudiLi QE please

https://deploy-preview-41719--osdocs.netlify.app/openshift-enterprise/latest/networking/dns-operator.html#nw-dns-loglevel_dns-operator

4.10 only