### PR TITLE
ECOPROJECT-250- Documentation changes for NHC 4.10

### DIFF
--- a/modules/eco-node-health-check-operator-about.adoc
+++ b/modules/eco-node-health-check-operator-about.adoc
@@ -1,16 +1,16 @@
 // Module included in the following assemblies:
 //
-// * nodes/nodes/node-health-check-operator-installation.adoc
+// * nodes/nodes/eco-node-health-check-operator.adoc
 
 :_content-type: CONCEPT
 [id="about-node-health-check-operator_{context}"]
 = About the Node Health Check Operator
 
-The Node Health Check Operator deploys the `NodeHealthCheck` controller, which in turn creates the `NodeHealthCheck` custom resource (CR). The Node Health Check Operator also installs the Poison Pill Operator as a default remediation provider.
+The Node Health Check Operator deploys the `NodeHealthCheck` controller to detect the health of a node in the cluster. The `NodeHealthCheck` controller creates the `NodeHealthCheck` custom resource (CR), which defines a set of criteria and thresholds to determine the node's health. 
 
-The Operator uses the controller to detect the health of a node in the cluster. The controller creates a `NodeHealthCheck` custom resource (CR), which defines a set of criteria and thresholds to determine the node's health. 
+The Node Health Check Operator also installs the Poison Pill Operator as a default remediation provider.
 
-When node health check detects an unhealthy node, it creates a remediation CR that triggers the remediation provider. For example, the node health check creates the `PoisonPillRemediation` CR, which triggers the Poison Pill Operator to remediate the unhealthy node. 
+When the Node Health Check Operator detects an unhealthy node, it creates a remediation CR that triggers the remediation provider. For example, the controller creates the `PoisonPillRemediation` CR, which triggers the Poison Pill Operator to remediate the unhealthy node. 
 
 The `NodeHealthCheck` CR resembles the following YAML file:
 
@@ -43,7 +43,7 @@ spec:
       duration: 300s <6>
 ----
 
-<1> Specifies the amount (in percentage) of nodes allowed to be concurrently remediated in the targeted pool. If the number of healthy nodes equals to or exceeds the limit set by `minHealthy`, remediation occurs. The default value is 51%.
+<1> Specifies the amount of healthy nodes(in percentage or number) required for a remediation provider to concurrently remediate nodes in the targeted pool. If the number of healthy nodes equals to or exceeds the limit set by `minHealthy`, remediation occurs. The default value is 51%.
 <2> Prevents any new remediation from starting, while allowing any ongoing remediations to persist. The default value is empty. However, you can enter an array of strings that identify the cause of pausing the remediation. For example, `pause-test-cluster`.
 +
 [NOTE]
@@ -58,7 +58,40 @@ During the upgrade process, nodes in the cluster might become temporarily unavai
 [id="understanding-nhc-operator-workflow_{context}"]
 == Understanding the Node Health Check Operator workflow
 
-When a node is identified as unhealthy, the Operator checks how many other nodes are unhealthy. If the number of healthy nodes exceeds the amount that is specified in the `minHealthy` field of the `NodeHealthCheck` CR, the controller creates a remediation CR from the details that are provided in the external remediation template by the remediation provider. After remediation, the node's health status is updated accordingly.
+When a node is identified as unhealthy, the Node Health Check Operator checks how many other nodes are unhealthy. If the number of healthy nodes exceeds the amount that is specified in the `minHealthy` field of the `NodeHealthCheck` CR, the controller creates a remediation CR from the details that are provided in the external remediation template by the remediation provider. After remediation, the kubelet updates the node's health status.
 
-When the node turns healthy, the controller deletes the external remediation template
-and updates the node's health status.
+When the node turns healthy, the controller deletes the external remediation template.
+
+[id="how-nhc-prevent-conflict-with-mhc_{context}"]
+== About how node health checks prevent conflicts with machine health checks 
+
+When both, node health checks and machine health checks are deployed, the node health check avoids conflict with the machine health check.
+
+[NOTE]
+====
+{product-title} deploys `machine-api-termination-handler` as the default `MachineHealthCheck` resource.
+====
+
+The following list summarizes the system behavior when node health checks and machine health checks are deployed:
+
+* If only the default machine health check exists, the node health check continues to identify unhealthy nodes. However, the node health check ignores unhealthy nodes in a Terminating state. The default machine health check handles the unhealthy nodes with a Terminating state.
++
+.Example log message
+[source,terminal]
+----
+INFO MHCChecker	ignoring unhealthy Node, it is terminating and will be handled by MHC	{"NodeName": "node-1.example.com"}
+----
+
+* If the default machine health check is modified (for example, the `unhealthyConditions` is  `Ready`), or if additional machine health checks are created, the node health check is disabled.
++
+.Example log message
+----
+INFO controllers.NodeHealthCheck disabling NHC in order to avoid conflict with custom MHCs configured in the cluster {"NodeHealthCheck": "/nhc-worker-default"}
+----
+
+* When, again, only the default machine health check exists, the node health check is re-enabled.
++
+.Example log message
+----
+INFO controllers.NodeHealthCheck re-enabling NHC, no conflicting MHC configured in the cluster {"NodeHealthCheck": "/nhc-worker-default"}
+----

--- a/modules/eco-node-health-check-operator-installation-cli.adoc
+++ b/modules/eco-node-health-check-operator-installation-cli.adoc
@@ -7,6 +7,10 @@
 = Installing the Node Health Check Operator by using the CLI
 You can use the OpenShift CLI (`oc`) to install the Node Health Check Operator.
 
+To install the Operator in your own namespace, follow the steps in the procedure. 
+
+To install the Operator in the `openshift-operators` namespace, skip to step 3 of the procedure because the steps to create a new `Namespace` custom resource (CR) and an `OperatorGroup` CR are not required.
+
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).
@@ -22,7 +26,7 @@ You can use the OpenShift CLI (`oc`) to install the Node Health Check Operator.
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-operators
+  name: node-health-check
 ----
 .. To create the `Namespace` CR, run the following command:
 +
@@ -40,10 +44,7 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: node-health-check-operator
-  namespace: openshift-operators
-spec:
-  targetNamespaces:
-  - openshift-operators
+  namespace: node-health-check
 ----
 .. To create the `OperatorGroup` CR, run the following command:
 +
@@ -61,14 +62,19 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
     name: node-health-check-operator
-    namespace: openshift-operators
+    namespace: node-health-check <1>
 spec:
-    channel: alpha
+    channel: candidate <2>
+    installPlanApproval: Manual <3>
     name: node-healthcheck-operator
     source: redhat-operators
     sourceNamespace: openshift-marketplace
-    package: node-health-check-operator
+    package: node-healthcheck-operator
 ----
+<1> Specify the `Namespace` where you want to install the Node Health Check Operator. To install the Node Health Check Operator in the `openshift-operators` namespace, specify `openshift-operators` in the `Subscription` CR.
+<2> Specify the channel name for your subscription. To upgrade to the latest version of the Node Health Check Operator, you must manually change the channel name for your subscription from `alpha` to `candidate`.
+<3> Set the approval strategy to Manual in case your specified version is superseded by a later version in the catalog. This plan prevents an automatic upgrade to a later version and requires manual approval before the starting CSV can complete the installation.
+
 .. To create the `Subscription` CR, run the following command:
 +
 [source,terminal]
@@ -89,8 +95,8 @@ $ oc get csv -n openshift-operators
 
 [source,terminal]
 ----
-NAME                               DISPLAY                      VERSION   REPLACES   PHASE
-node-health-check-operator.v0.1.1  Node Health Check Operator   0.1.1                Succeeded
+NAME                              DISPLAY                     VERSION  REPLACES PHASE
+node-healthcheck-operator.v0.2.0. Node Health Check Operator  0.2.0             Succeeded
 ----
 . Verify that the Node Health Check Operator is up and running:
 +

--- a/nodes/nodes/eco-node-health-check-operator.adoc
+++ b/nodes/nodes/eco-node-health-check-operator.adoc
@@ -22,3 +22,8 @@ include::modules/eco-node-health-check-operator-about.adoc[leveloffset=+1]
 include::modules/eco-node-health-check-operator-installation-web-console.adoc[leveloffset=+1]
 
 include::modules/eco-node-health-check-operator-installation-cli.adoc[leveloffset=+1]
+
+[id="additional-resources-nhc-operator-installation"]
+== Additional resources
+* xref:../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Changing the update channel for an Operator]
+* The Node Health Check Operator is supported in a restricted network environment. For more information, see xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].


### PR DESCRIPTION
[TELCODOCS-344](https://issues.redhat.com/browse/TELCODOCS-344): This ticket documents enhancements to the Node Health Operator for OCP 4.10

Applies to OpenShift version 4.10+ 

Preview (new section for 4.10): [About how node health checks prevent conflicts with machine health checks ](https://deploy-preview-41724--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/eco-node-health-check-operator.html#how-nhc-prevent-conflict-with-mhc_node-health-check-operator)

Note: Some additional changes that were out of the cope of this ticket were requested in peer review to clarify the context of the new section in this PR.