### PR TITLE
BZ1977217 Corrected verbiage in Throttling logs in Fluentd

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -1942,10 +1942,10 @@ test-project:
 ----
 
 
-When you make changes to any part of the EFK stack, specifically Elasticsearch
-or Fluentd, you should first scale Elasticsearch down to zero and scale Fluentd
-so it does not match any other nodes. Then, make the changes and scale
-Elasticsearch and Fluentd back.
+To make changes to Fluentd, change the configuration and restart the Fluentd pods to apply the changes.
+To make changes to Elasticsearch, you must first scale down Fluentd and then
+scale down Elasticsearch to zero. After making your changes, scale Elasticsearch first and
+then scale Fluentd back to its original setting.
 
 To scale Elasticsearch to zero:
 ----


### PR DESCRIPTION
For only version 3.11

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1977217

Direct link to doc preview: https://deploy-preview-41732--osdocs.netlify.app/openshift-enterprise/latest/install_config/aggregate_logging.html#aggregated-fluentd

QA: @anpingli 