### PR TITLE
SRVCOM-1667: Fix the mTLS entry in the feature matrix

### DIFF
--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -28,7 +28,7 @@ In the table, features are marked with the following statuses:
 |TP
 |TP
 
-|mTLS
+|Service Mesh mTLS
 |GA
 |GA
 |GA


### PR DESCRIPTION
For versions 4.6+

https://issues.redhat.com/browse/SRVCOM-1667

Preview: https://deploy-preview-41735--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-deprecated-removed-features_serverless-release-notes