### PR TITLE
Release note for NHC 4.10

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -376,6 +376,14 @@ For more information on configuration drift, see xref:../post_installation_confi
 
 You can now enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control groups version 2] (cgroups v2) on specific nodes in your cluster. The {product-title} process for enabling cgroups v2 disables all cgroups version 1 controllers and hierarchies. The {product-title} cgroups version 2 feature is in Developer Preview and is not supported by Red Hat at this time.
 
+[id="ocp-4-10-node-health-check-operator"]
+==== Node Health Check Operator enhancements
+
+The Node Health Check Operator provides these new enhancements:
+
+* Support for running in disconnected mode
+* Prevent conflicts with machine health check. For more information, see xref:../nodes/nodes/eco-node-health-check-operator.adoc#how-nhc-prevent-conflict-with-mhc_node-health-check-operator[About how node health checks prevent conflicts with machine health checks]
+
 [id="ocp-4-10-logging"]
 === Red Hat OpenShift Logging
 


### PR DESCRIPTION
[TELCODOCS-344](https://issues.redhat.com/browse/TELCODOCS-344): Release note for Node Health Operator for OCP 4.10 (ECOPROJECT-250)

Preview: [Node Health Check Operator enhancements](https://deploy-preview-41743--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-node-health-check-operator)

Note: The link in the release note will resolve correctly after the  https://github.com/openshift/openshift-docs/pull/41724 is merged.