### PR TITLE
Release note for Poison Pill 4.10

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -321,6 +321,14 @@ For more information on configuration drift, see xref:../post_installation_confi
 
 You can now enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control groups version 2] (cgroups v2) on specific nodes in your cluster. The {product-title} process for enabling cgroups v2 disables all cgroups version 1 controllers and hierarchies. The {product-title} cgroups version 2 feature is in Developer Preview and is not supported by Red Hat at this time.
 
+[id="ocp-4-10-poison-pill-operator"]
+==== Poison Pill Operator enhancements
+
+The Poison Pill Operator uses `NodeDeletion` as its default remediation strategy. The `NodeDeletion` remediation strategy removes the `node` object. 
+
+In {product-title} 4.10, the Poison Pill Operator introduces a new remediation strategy called `ResourceDeletion`. The `ResourceDeletion` remediation strategy removes the pods and associated volume attachments on the node rather than the `node` object. This strategy helps to recover workloads faster. 
+
+
 [id="ocp-4-10-logging"]
 === Red Hat OpenShift Logging
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-451: Release note for Poison Pill 4.10

Applies to OpenShift 4.10 release note (when ready, merge to enterprise_4.10 only)

Preview: https://deploy-preview-41754--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-poison-pill-operator 