### PR TITLE
RHDEVDOCS-3747 - Added 1.4.2 release notes

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,7 +23,13 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-4-2.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-4-1.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-4-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-3-3.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-2.adoc[leveloffset=+1]
 

--- a/modules/gitops-release-notes-1-3-3.adoc
+++ b/modules/gitops-release-notes-1-3-3.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-3-3_{context}"]
+= Release notes for {gitops-title} 1.3.3
+
+{gitops-title} 1.3.3 is now available on {product-title} 4.7, 4.8, and 4.9.
+
+[id="fixed-issues-1-3-3_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* All versions of Argo CD are vulnerable to a path traversal bug that allows to pass arbitrary values to be consumed by Helm charts. This update fixes the `CVE-2022-24348 gitops` error, path traversal and dereference of symlinks when passing Helm value files. link:https://issues.redhat.com/browse/GITOPS-1756[GITOPS-1756]

--- a/modules/gitops-release-notes-1-4-1.adoc
+++ b/modules/gitops-release-notes-1-4-1.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-4-1_{context}"]
+= Release notes for {gitops-title} 1.4.1
+
+{gitops-title} 1.4.1 is now available on {product-title} 4.7, 4.8, and 4.9.
+
+[id="fixed-issues-1-4-1_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* {gitops-title} Operator v1.4.0 introduced a regression which removes the description fields from `spec` for the following CRDs:
+
+** `argoproj.io_applications.yaml`
+** `argoproj.io_appprojects.yaml`
+** `argoproj.io_argocds.yaml`
+
+Before this update, if you created an `AppProject` resource using the `kubectl create`, it failed to synchronize. This update restores the missing description fields in `CustomResourceDefinitions: ArgoCD, AppProject, Application` that caused `kubectl create` to fail. link:https://issues.redhat.com/browse/GITOPS-1721[GITOPS-1721]

--- a/modules/gitops-release-notes-1-4-2.adoc
+++ b/modules/gitops-release-notes-1-4-2.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-4-2_{context}"]
+= Release notes for {gitops-title} 1.4.2
+
+{gitops-title} 1.4.2 is now available on {product-title} 4.7, 4.8, and 4.9.
+
+[id="fixed-issues-1-4-2_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* All versions of Argo CD are vulnerable to a path traversal bug that allows to pass arbitrary values to be consumed by Helm charts. This update fixes the `CVE-2022-24348 gitops` error, path traversal and dereference of symlinks when passing Helm value files. link:https://issues.redhat.com/browse/GITOPS-1756[GITOPS-1756]
+
+* Before this update, the *Route* resources got stuck in `Progressing` Health status if more than one `Ingress` is attached to the route.  This update fixes the health check and reports the correct health status of *Route* resource. link:https://issues.redhat.com/browse/GITOPS-1751[GITOPS-1751]


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.9
JIRA issues: https://issues.redhat.com/browse/RHDEVDOCS-3747

Preview pages: https://deploy-preview-41758--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes#gitops-release-notes-1-4-2_gitops-release-notes

SME+QE review: @iam-veeramalla 

Peer-review: @rolfedh 