### PR TITLE
Update the Dockerfile to use Fedora

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile
-FROM centos:8
-RUN dnf install git python3 python3-devel ruby rubygems -y
+FROM fedora:35
+RUN yum install -y git python3 python3-pip ruby
 RUN gem install asciidoctor asciidoctor-diagram
 COPY . $HOME/src/
 RUN pip3 install pyyaml /src/aura.tar.gz


### PR DESCRIPTION
Existing `Dockerfile` doesn't run and gives the following error:
```
❯ git checkout main

Switched to branch 'main'
Your branch is up to date with 'upstream/main'.

❯ docker build -t localdocs .

[+] Building 5.2s (7/10)
 => [internal] load build definition from Dockerfile                                     0.0s
 => => transferring dockerfile: 237B                                                     0.0s
 => [internal] load .dockerignore                                                        0.0s
 => => transferring context: 2B                                                          0.0s
 => [internal] load metadata for docker.io/library/centos:8                              3.0s
 => [auth] library/centos:pull token for registry-1.docker.io                            0.0s
 => CACHED [1/5] FROM docker.io/library/centos:8@sha256:a27fd8080b517143cbbbab9dfb7c857  0.0s
 => [internal] load build context                                                        0.9s
 => => transferring context: 2.14MB                                                      0.9s
 => ERROR [2/5] RUN dnf install git python3 python3-devel ruby rubygems -y               2.1s
------
 > [2/5] RUN dnf install git python3 python3-devel ruby rubygems -y:
#6 1.974 CentOS Linux 8 - AppStream                       81  B/s |  38  B     00:00
#6 1.991 Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
------
executor failed running [/bin/sh -c dnf install git python3 python3-devel ruby rubygems -y]: exit code: 1
```

Fix the centos image requires extra commands, switching to a fedora image solves the issue. 