### PR TITLE
BZ#2051835 - adding clarification for DHCP infinite lease

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -9,7 +9,7 @@ Installer-provisioned installation of {product-title} involves several network r
 
 image::210_OpenShift_Baremetal_IPI_Deployment_updates_0122_2.png[Installer-provisioned networking]
 
-[discrete]
+[id='network-requirements-config-nics_{context}']
 == Configuring NICs
 
 {product-title} deploys with two networks:
@@ -27,7 +27,7 @@ The `provisioning` network is optional, but it is required for PXE booting. If y
 When using a VLAN, each NIC must be on a separate VLAN corresponding to the appropriate network.
 ====
 
-[discrete]
+[id='network-requirements-dns_{context}']
 == DNS requirements
 
 Clients access the {product-title} cluster nodes over the `baremetal` network. A network administrator must configure a subdomain or subzone where the canonical name extension is the cluster name.
@@ -80,14 +80,14 @@ For example, `console-openshift-console.apps.<cluster_name>.<base_domain>` is us
 You can use the `dig` command to verify DNS resolution.
 ====
 
-[discrete]
+[id='network-requirements-dhcp-reqs_{context}']
 == Dynamic Host Configuration Protocol (DHCP) requirements
 
 By default, installer-provisioned installation deploys `ironic-dnsmasq` with DHCP enabled for the `provisioning` network. No other DHCP servers should be running on the `provisioning` network when the `provisioningNetwork` configuration setting is set to `managed`, which is the default value. If you have a DHCP server running on the `provisioning` network, you must set the `provisioningNetwork` configuration setting to `unmanaged` in the `install-config.yaml` file.
 
 Network administrators must reserve IP addresses for each node in the {product-title} cluster for the `baremetal` network on an external DHCP server.
 
-[discrete]
+[id='network-requirements-reserving-ip-addresses_{context}']
 == Reserving IP addresses for nodes with the DHCP server
 
 For the `baremetal` network, a network administrator must reserve a number of IP addresses, including:
@@ -105,6 +105,12 @@ For the `baremetal` network, a network administrator must reserve a number of IP
 .Reserving IP addresses so they become static IP addresses
 ====
 Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To use static IP addresses in the {product-title} cluster, reserve the IP addresses with an infinite lease. During deployment, the installer will reconfigure the NICs from DHCP assigned addresses to static IP addresses. NICs with DHCP leases that are not infinite will remain configured to use DHCP.
+====
+
+[IMPORTANT]
+.Ensuring that your DHCP server can provide infinite leases
+====
+Your DHCP server must provide a DHCP expiration time of 4294967295 seconds to properly set an infinite lease as specified by link:https://datatracker.ietf.org/doc/html/rfc2131[rfc2131]. If a lesser value is returned for the DHCP infinite lease time, the node reports an error and a static IP is not set for the node. In RHEL 8, `dhcpd` does not provides infinite leases. If you want to use the provisioner node to serve dynamic IP addresses with infinite lease times, use `dnsmasq` rather than `dhcpd`.
 ====
 
 [IMPORTANT]
@@ -134,7 +140,7 @@ The following table provides an exemplary embodiment of fully qualified domain n
 If you do not create DHCP reservations, the installer requires reverse DNS resolution to set the hostnames for the Kubernetes API node, the provisioner node, the control plane nodes, and the worker nodes.
 ====
 
-[discrete]
+[id='network-requirements-ntp_{context}']
 == Network Time Protocol (NTP)
 
 Each {product-title} node in the cluster must have access to an NTP server. {product-title} nodes use NTP to synchronize their clocks. For example, cluster nodes use SSL certificates that require validation, which might fail if the date and time between the nodes are not in sync.
@@ -146,7 +152,7 @@ Define a consistent clock date and time format in each cluster node's BIOS setti
 
 You can reconfigure the control plane nodes to act as NTP servers on disconnected clusters, and reconfigure worker nodes to retrieve time from the control plane nodes.
 
-[discrete]
+[id='network-requirements-state-config_{context}']
 == State-driven network configuration requirements (Technology Preview)
 
 {product-title} supports additional post-installation state-driven network configuration on the secondary network interfaces of cluster nodes using `kubernetes-nmstate`. For example, system administrators might configure a secondary network interface on cluster nodes after installation for a storage network.
@@ -158,7 +164,7 @@ Configuration must occur before scheduling pods.
 
 State-driven network configuration requires installing `kubernetes-nmstate`, and also requires Network Manager running on the cluster nodes. See *OpenShift Virtualization > Kubernetes NMState (Tech Preview)* for additional details.
 
-[discrete]
+[id='network-requirements-out-of-band_{context}']
 == Port access for the out-of-band management IP address
 
 The out-of-band management IP address is on a separate network from the node. To ensure that the out-of-band management can communicate with the `baremetal` node during installation, the out-of-band management IP address address must be granted access to the TCP 6180 port.


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=2051835

Preview: https://deploy-preview-41781--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-reserving-ip-addresses_ipi-install-prerequisites

Merge to main, enterprise-4.7+