### PR TITLE
BZ1752683 - Adding missing command switch in cli operations

### DIFF
--- a/cli_reference/basic_cli_operations.adoc
+++ b/cli_reference/basic_cli_operations.adoc
@@ -795,7 +795,7 @@ Retrieve the log output for a specific build, deployment, or pod. This command
 works for builds, build configurations, deployment configurations, and pods.
 [source,terminal]
 ----
-$ oc logs -f <pod>
+$ oc logs -f <pod> -c <container_name>
 ----
 
 === exec


### PR DESCRIPTION
For Version 3.11
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1752683

No QE required

Preview: https://deploy-preview-41797--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/basic_cli_operations.html#logs