### PR TITLE
[enterprise-4.8] Deleting module in assembly to fix broken builds.

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -27,11 +27,7 @@ include::modules/gitops-release-notes-1-4-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-4-1.adoc[leveloffset=+1]
 
-include::modules/gitops-release-notes-1-4-0.adoc[leveloffset=+1]
-
 include::modules/gitops-release-notes-1-3-3.adoc[leveloffset=+1]
-
-include::modules/gitops-release-notes-1-3-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-1.adoc[leveloffset=+1]
 


### PR DESCRIPTION
xref:#41776 broke the builds for the 4.8 branch because the module for the 1-4-0 release notes doesn't exist on this branch.

Deleting that line as a temporary fix until @[DebarghoGhosh](https://github.com/DebarghoGhosh) is back online.

(I suspect the permanent fix is to add the missing modules and restore the includes in the assembly.
Modules missing on this branch:

- gitops-release-notes-1-3-2.adoc
- gitops-release-notes-1-4-0.adoc