### PR TITLE
OSDOCS-3139: IBM Cloud machine management

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1726,6 +1726,8 @@ Topics:
     File: creating-machineset-azure-stack-hub
   - Name: Creating a machine set on GCP
     File: creating-machineset-gcp
+  - Name: Creating a machine set on IBM Cloud
+    File: creating-machineset-ibm-cloud
   - Name: Creating a machine set on OpenStack
     File: creating-machineset-osp
   - Name: Creating a machine set on RHV

--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -42,6 +42,8 @@ include::modules/machineset-yaml-azure-stack-hub.adoc[leveloffset=+3]
 Machine sets running on Azure Stack Hub do not support non-guaranteed Spot VMs.
 ====
 
+include::modules/machineset-yaml-ibm-cloud.adoc[leveloffset=+3]
+
 include::modules/machineset-yaml-gcp.adoc[leveloffset=+3]
 
 Machine sets running on GCP support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-non-guaranteed-instance_creating-machineset-gcp[preemptible VM instances]. You can save on costs by using preemptible VM instances at a lower price

--- a/machine_management/creating_machinesets/creating-machineset-ibm-cloud.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-ibm-cloud.adoc
@@ -1,0 +1,21 @@
+:_content-type: ASSEMBLY
+[id="creating-machineset-ibm-cloud"]
+= Creating a machine set on IBM Cloud
+include::modules/common-attributes.adoc[]
+:context: creating-machineset-ibm-cloud
+
+toc::[]
+
+You can create a different machine set to serve a specific purpose in your {product-title} cluster on IBM Cloud. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//Machine API overview
+include::modules/machine-api-overview.adoc[leveloffset=+1]
+
+//Sample YAML for a machine set custom resource on IBM Cloud
+include::modules/machineset-yaml-ibm-cloud.adoc[leveloffset=+1]
+
+//Creating a machine set
+include::modules/machineset-creating.adoc[leveloffset=+1]

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -2,15 +2,12 @@
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
 // * machine_management/creating_machinesets/creating-machineset-aws.adoc
-// * post_installation_configuration/cluster-tasks.adoc
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :infra:
 endif::[]
-ifeval::["{context}" == "post-install-cluster-tasks"]
-:infra:
-endif::[]
 
+:_content-type: REFERENCE
 [id="machineset-yaml-aws_{context}"]
 =  Sample YAML for a machine set custom resource on AWS
 
@@ -73,7 +70,7 @@ ifndef::infra[]
           node-role.kubernetes.io/<role>: "" <3>
 endif::infra[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <3>      
+          node-role.kubernetes.io/infra: "" <3>
       taints: <4>
         - key: node-role.kubernetes.io/infra
           effect: NoSchedule

--- a/modules/machineset-yaml-azure-stack-hub.adoc
+++ b/modules/machineset-yaml-azure-stack-hub.adoc
@@ -2,15 +2,12 @@
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
 // * machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc
-// * post_installation_configuration/cluster-tasks.adoc
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :infra:
 endif::[]
-ifeval::["{context}" == "post-install-cluster-tasks"]
-:infra:
-endif::[]
 
+:_content-type: REFERENCE
 [id="machineset-yaml-azure-stack-hub_{context}"]
 = Sample YAML for a machine set custom resource on Azure Stack Hub
 

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -2,15 +2,12 @@
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
 // * machine_management/creating-machineset-azure.adoc
-// * post_installation_configuration/cluster-tasks.adoc
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :infra:
 endif::[]
-ifeval::["{context}" == "post-install-cluster-tasks"]
-:infra:
-endif::[]
 
+:_content-type: REFERENCE
 [id="machineset-yaml-azure_{context}"]
 = Sample YAML for a machine set custom resource on Azure
 

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -2,15 +2,12 @@
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
 // * machine_management/creating-machineset-gcp.adoc
-// * post_installation_configuration/cluster-tasks.adoc
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :infra:
 endif::[]
-ifeval::["{context}" == "post-install-cluster-tasks"]
-:infra:
-endif::[]
 
+:_content-type: REFERENCE
 [id="machineset-yaml-gcp_{context}"]
 =  Sample YAML for a machine set custom resource on GCP
 

--- a/modules/machineset-yaml-ibm-cloud.adoc
+++ b/modules/machineset-yaml-ibm-cloud.adoc
@@ -1,0 +1,128 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating-infrastructure-machinesets.adoc
+// * machine_management/creating_machinesets/creating-machineset-ibm-cloud.adoc
+
+ifeval::["{context}" == "creating-infrastructure-machinesets"]
+:infra:
+endif::[]
+
+:_content-type: REFERENCE
+[id="machineset-yaml-ibm-cloud_{context}"]
+= Sample YAML for a machine set custom resource on IBM Cloud
+
+This sample YAML defines a machine set that runs in a specified IBM Cloud zone in a region and creates nodes that are labeled with
+ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
+ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
+
+In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
+ifndef::infra[`<role>`]
+ifdef::infra[`<infra>`]
+is the node label to add.
+
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+ifndef::infra[]
+    machine.openshift.io/cluster-api-machine-role: <role> <2>
+    machine.openshift.io/cluster-api-machine-type: <role> <2>
+  name: <infrastructure_id>-<role>-<region> <3>
+endif::infra[]
+ifdef::infra[]
+    machine.openshift.io/cluster-api-machine-role: <infra> <2>
+    machine.openshift.io/cluster-api-machine-type: <infra> <2>
+  name: <infrastructure_id>-<infra>-<region> <3>
+endif::infra[]
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+ifndef::infra[]
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+endif::infra[]
+ifdef::infra[]
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<region> <3>
+endif::infra[]
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+ifndef::infra[]
+        machine.openshift.io/cluster-api-machine-role: <role> <2>
+        machine.openshift.io/cluster-api-machine-type: <role> <2>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+endif::infra[]
+ifdef::infra[]
+        machine.openshift.io/cluster-api-machine-role: <infra> <2>
+        machine.openshift.io/cluster-api-machine-type: <infra> <2>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<region> <3>
+endif::infra[]
+    spec:
+      metadata:
+        labels:
+ifndef::infra[]
+          node-role.kubernetes.io/<role>: ""
+endif::infra[]
+ifdef::infra[]
+          node-role.kubernetes.io/infra: ""
+endif::infra[]
+      providerSpec:
+        value:
+          apiVersion: ibmcloudproviderconfig.openshift.io/v1beta1
+          credentialsSecret:
+            name: ibmcloud-credentials
+          image: <infrastructure_id>-rhcos <4>
+          kind: IBMCloudMachineProviderSpec
+          primaryNetworkInterface:
+              securityGroups:
+              - <infrastructure_id>-sg-cluster-wide
+              - <infrastructure_id>-sg-openshift-net
+              subnet: <infrastructure_id>-subnet-compute-<zone> <5>
+          profile: <instance_profile> <6>
+          region: <region> <7>
+          resourceGroup: <resource_group> <8>
+          userDataSecret:
+              name: <role>-user-data <2>
+          vpc: <vpc_name> <9>
+          zone: <zone> <10>
+ifdef::infra[]
+        taints: <11>
+        - key: node-role.kubernetes.io/infra
+          effect: NoSchedule
+endif::infra[]
+----
+<1> The infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
+ifndef::infra[]
+<2> The node label to add.
+<3> The infrastructure ID, node label, and region.
+endif::infra[]
+ifdef::infra[]
+<2> The `<infra>` node label.
+<3> The infrastructure ID, `<infra>` node label, and region.
+endif::infra[]
+<4> The custom {op-system-first} image that was used for cluster installation.
+<5> The infrastructure ID and zone within your region to place machines on. Be sure that your region supports the zone that you specify.
+<6> Specify the link:https://cloud.ibm.com/docs/vpc?topic=vpc-profiles&interface=ui[IBM Cloud instance profile].
+<7> Specify the region to place machines on.
+<8> The resource group that machine resources are placed in. This is either an existing resource group specified at installation time, or an installer-created resource group named based on the infrastructure ID.
+<9> The VPC name.
+<10> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
+ifdef::infra[]
+<11> The taint to prevent user workloads from being scheduled on infra nodes.
+endif::infra[]
+
+
+ifeval::["{context}" == "creating-infrastructure-machinesets"]
+:!infra:
+endif::[]

--- a/modules/machineset-yaml-osp.adoc
+++ b/modules/machineset-yaml-osp.adoc
@@ -2,15 +2,12 @@
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
 // * machine_management/creating_machinesets/creating-machineset-osp.adoc
-// * post_installation_configuration/cluster-tasks.adoc
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :infra:
 endif::[]
-ifeval::["{context}" == "post-install-cluster-tasks"]
-:infra:
-endif::[]
 
+:_content-type: REFERENCE
 [id="machineset-yaml-osp_{context}"]
 =  Sample YAML for a machine set custom resource on {rh-openstack}
 

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -2,15 +2,12 @@
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
 // * machine_management/creating_machinesets/creating-machineset-vsphere.adoc
-// * post_installation_configuration/cluster-tasks.adoc
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :infra:
 endif::[]
-ifeval::["{context}" == "post-install-cluster-tasks"]
-:infra:
-endif::[]
 
+:_content-type: REFERENCE
 [id="machineset-yaml-vsphere_{context}"]
 = Sample YAML for a machine set custom resource on vSphere
 

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -558,32 +558,6 @@ include::modules/infrastructure-moving-monitoring.adoc[leveloffset=+2]
 
 include::modules/infrastructure-moving-logging.adoc[leveloffset=+2]
 
-////
-Added a link to reduce the size of this file
-[id="post-install-creating-infrastructure-machinesets-clouds"]
-=== Creating machine sets for different clouds
-
-Use the sample machine set for your cloud.
-
-include::modules/machineset-yaml-aws.adoc[leveloffset=+3]
-
-Machine sets running on AWS support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances]. You can save on costs by using Spot Instances at a lower price compared to
-On-Demand Instances on AWS. xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-aws[Configure Spot Instances] by adding `spotMarketOptions` to the `MachineSet` YAML file.
-
-include::modules/machineset-yaml-azure.adoc[leveloffset=+3]
-
-Machine sets running on Azure support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-non-guaranteed-instance_creating-machineset-azure[Spot VMs]. You can save on costs by using Spot VMs at a lower price compared to standard VMs on Azure. You can xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-azure[configure Spot VMs] by adding `spotVMOptions` to the `MachineSet` YAML file.
-
-include::modules/machineset-yaml-gcp.adoc[leveloffset=+3]
-
-Machine sets running on GCP support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-non-guaranteed-instance_creating-machineset-gcp[preemptible VM instances]. You can save on costs by using preemptible VM instances at a lower price
-compared to normal instances on GCP. You can xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-gcp[configure preemptible VM instances] by adding `preemptible` to the `MachineSet` YAML file.
-
-include::modules/machineset-yaml-osp.adoc[leveloffset=+3]
-
-include::modules/machineset-yaml-vsphere.adoc[leveloffset=+3]
-////
-
 include::modules/cluster-autoscaler-about.adoc[leveloffset=+1]
 include::modules/cluster-autoscaler-cr.adoc[leveloffset=+2]
 :FeatureName: cluster autoscaler


### PR DESCRIPTION
For [OSDOCS-3139](https://issues.redhat.com/browse/OSDOCS-3139), which covers [OCPCLOUD-1229](https://issues.redhat.com/browse/OCPCLOUD-1229)

Notes: 
- Adds IBM machineset info
- (non-content change) Fixes documentation metadata for AWS, ASH, Azure, GCP, OpenStack, and vSphere YAML reference files
- (non-content change) Removes obsolete and previously commented-out section from `post_installation_configuration/cluster-tasks.adoc`

Previews:
- [Creating a machine set on IBM Cloud](https://deploy-preview-41804--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-ibm-cloud.html)
- [Sample YAML for a machine set custom resource on IBM Cloud](https://deploy-preview-41804--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-ibm-cloud_creating-infrastructure-machinesets) (for infrastructure machine sets)

Approvals:
- [x] [IBM Cloud](https://github.com/openshift/openshift-docs/pull/41804#pullrequestreview-893058161)
- [x] [Cluster Infra](https://github.com/openshift/openshift-docs/pull/41804#pullrequestreview-893098570)
- [x] [QE](https://github.com/openshift/openshift-docs/pull/41804#pullrequestreview-893209118)