### PR TITLE
CNV-12571: New content to enable descheduler on VMs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3073,6 +3073,8 @@ Topics:
       File: virt-configuring-vgpu-passthrough
     - Name: Configuring a watchdog device
       File: virt-configuring-a-watchdog
+    - Name: Enabling descheduler evictions on virtual machines
+      File: virt-enabling-descheduler-evictions
 # Importing virtual machines
   - Name: Importing virtual machines
     Dir: importing_vms

--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -2,6 +2,14 @@
 //
 // * nodes/scheduling/nodes-descheduler.adoc
 
+ifeval::["{context}" == "nodes-descheduler"]
+:nodes:
+endif::[]
+
+ifeval::["{context}" == "virt-enabling-descheduler-evictions"]
+:virt:
+endif::[]
+
 :_content-type: PROCEDURE
 [id="nodes-descheduler-installing_{context}"]
 = Installing the descheduler
@@ -35,6 +43,17 @@ endif::[]
 .. From the *Operators* -> *Installed Operators* page, click the *Kube Descheduler Operator*.
 .. Select the *Kube Descheduler* tab and click *Create KubeDescheduler*.
 .. Edit the settings as necessary.
+ifdef::virt[]
+... Expand the *Profiles* section and select `DevPreviewLongLifecycle`. The `AffinityAndTaints` profile is enabled by default.
++
+[IMPORTANT]
+====
+The only profile currently available for {VirtProductName} is `DevPreviewLongLifecycle`.
+====
+
+You can also configure the profiles and settings for the descheduler later using the OpenShift CLI (`oc`).
+endif::virt[]
+ifdef::nodes[]
 ... Expand the *Profiles* section to select one or more profiles to enable. The `AffinityAndTaints` profile is enabled by default. Click *Add Profile* to select additional profiles.
 +
 [NOTE]
@@ -46,3 +65,12 @@ Do not enable both `TopologyAndDuplicates` and `SoftTopologyAndDuplicates`. Enab
 .. Click *Create*.
 
 You can also configure the profiles and settings for the descheduler later using the OpenShift CLI (`oc`). If you did not adjust the profiles when creating the descheduler instance from the web console, the `AffinityAndTaints` profile is enabled by default.
+endif::nodes[]
+
+ifeval::["{context}" == "nodes-descheduler"]
+:!nodes:
+endif::[]
+
+ifeval::["{context}" == "virt-enabling-descheduler-evictions"]
+:!virt:
+endif::[]

--- a/modules/nodes-descheduler-profiles.adoc
+++ b/modules/nodes-descheduler-profiles.adoc
@@ -2,9 +2,18 @@
 //
 // * nodes/scheduling/nodes-descheduler.adoc
 
+ifeval::["{context}" == "nodes-descheduler"]
+:nodes:
+endif::[]
+
+ifeval::["{context}" == "virt-enabling-descheduler-evictions"]
+:virt:
+endif::[]
+
+:_content-type: REFERENCE
 [id="nodes-descheduler-profiles_{context}"]
 = Descheduler profiles
-
+ifdef::nodes[]
 The following descheduler profiles are available:
 
 `AffinityAndTaints`:: This profile evicts pods that violate inter-pod anti-affinity, node affinity, and node taints.
@@ -52,3 +61,22 @@ Do not enable both `SoftTopologyAndDuplicates` and `TopologyAndDuplicates`. Enab
 `EvictPodsWithLocalStorage`:: This profile allows pods with local storage to be eligible for eviction.
 
 `EvictPodsWithPVC`:: This profile allows pods with persistent volume claims to be eligible for eviction.
+endif::nodes[]
+ifdef::virt[]
+Use the Technology Preview `DevPreviewLongLifecycle` profile to enable the descheduler on a virtual machine. This is the only descheduler profile currently available for {VirtProductName}. To ensure proper scheduling, create VMs with CPU and memory requests for the expected load.
+
+`DevPreviewLongLifecycle`:: This profile balances resource usage between nodes and enables the following strategies:
++
+* `RemovePodsHavingTooManyRestarts`: removes pods whose containers have been restarted too many times and pods where the sum of restarts over all containers (including Init Containers) is more than 100. Restarting the VM guest operating system does not increase this count.
+* `LowNodeUtilization`: evicts pods from overutilized nodes when there are any underutilized nodes. The destination node for the evicted pod will be determined by the scheduler.
+** A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
+** A node is considered overutilized if its usage is above 50% for any of the thresholds (CPU, memory, and number of pods).
+endif::virt[]
+
+ifeval::["{context}" == "nodes-descheduler"]
+:!nodes:
+endif::[]
+
+ifeval::["{context}" == "virt-enabling-descheduler-evictions"]
+:!virt:
+endif::[]

--- a/modules/virt-enabling-descheduler-evictions.adoc
+++ b/modules/virt-enabling-descheduler-evictions.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.adoc
+
+:_content-type: PROCEDURE
+[id="virt-enabling-descheduler-evictions_{context}"]
+= Enabling descheduler evictions on a virtual machine (VM)
+
+After the descheduler is installed, you can enable descheduler evictions on your VM by adding an annotation to the `VirtualMachine` custom resource (CR).
+
+.Prerequisites
+
+* Install the descheduler in the {product-title} web console or OpenShift CLI (`oc`).
+* Ensure that the VM is not running.
+
+.Procedure
+
+. Before starting the VM, add the `descheduler.alpha.kubernetes.io/evict` annotation to the `VirtualMachine` CR:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+  template:
+    metadata:
+      annotations:
+        descheduler.alpha.kubernetes.io/evict: "true"
+----
+
+. If you did not already set the `DevPreviewLongLifecycle` profile in the web console during installation, specify the `DevPreviewLongLifecycle` in the `spec.profile` section of the `KubeDescheduler` object:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  deschedulingIntervalSeconds: 3600
+  profiles:
+  - DevPreviewLongLifecycle
+----
+
+The descheduler is now enabled on the VM.

--- a/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.adoc
@@ -1,0 +1,19 @@
+:_content-type: ASSEMBLY
+[id="virt-enabling-descheduler-evictions"]
+= Enabling descheduler evictions on virtual machines
+include::modules/virt-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
+:context: virt-enabling-descheduler-evictions
+
+toc::[]
+
+:FeatureName: Descheduler eviction for virtual machines
+include::snippets/technology-preview.adoc[]
+
+The xref:../../../nodes/scheduling/nodes-descheduler.adoc#nodes-descheduler[descheduler] can be used to evict a running pod to allow the pod to be rescheduled onto a more suitable node. You must install the descheduler by using the {product-title} web console or OpenShift CLI (`oc`) before you can enable it on your virtual machine (VM).
+
+include::modules/nodes-descheduler-profiles.adoc[leveloffset=+1]
+
+include::modules/nodes-descheduler-installing.adoc[leveloffset=+1]
+
+include::modules/virt-enabling-descheduler-evictions.adoc[leveloffset=+1]


### PR DESCRIPTION
Re: [CNV-12571](https://issues.redhat.com/browse/CNV-12571)
For 4.10 and later

preview: https://deploy-preview-41805--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.html