### PR TITLE
BZ#2052372: Rm subresource:status marker step

### DIFF
--- a/modules/osdk-golang-define-api.adoc
+++ b/modules/osdk-golang-define-api.adoc
@@ -28,24 +28,6 @@ type MemcachedStatus struct {
 }
 ----
 
-. Add the `+kubebuilder:subresource:status` marker to add a `status` subresource to the CRD manifest:
-+
-[source,go]
-----
-// Memcached is the Schema for the memcacheds API
-// +kubebuilder:subresource:status <1>
-type Memcached struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec   MemcachedSpec   `json:"spec,omitempty"`
-	Status MemcachedStatus `json:"status,omitempty"`
-}
-----
-<1> Add this line.
-+
-This enables the controller to update the CR status without changing the rest of the CR object.
-
 . Update the generated code for the resource type:
 +
 [source,terminal]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2052372

Preview: https://deploy-preview-41807--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-golang-define-api_osdk-golang-tutorial