### PR TITLE
NE753: Docs work for External DNS Operator

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -925,6 +925,19 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
 - Name: Using PTP hardware
   File: using-ptp
+- Name: External DNS Operator
+  Dir: external_dns_operator
+  Topics:
+  - Name: Installing the External DNS Operator
+    File: nw-installing-external-dns-operator
+  - Name: External DNS Operator configuration parameters
+    File: nw-external-dns-operator-configuration-parameters
+  - Name: Creating DNS records on an public hosted zone for AWS
+    File: nw-control-dns-records-public-hosted-zone-aws
+  - Name: Creating DNS records on an public zone for Azure
+    File: nw-control-dns-records-public-hosted-zone-azure
+  - Name: Creating DNS records on an public managed zone for GCP
+    File: nw-control-dns-records-public-managed-zone-gcp
 - Name: Network policy
   Dir: network_policy
   Topics:

--- a/networking/external_dns_operator/nw-configuration-parameters.adoc
+++ b/networking/external_dns_operator/nw-configuration-parameters.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="external-dns-operator-configuration-parameters"]
+= External DNS Operator configuration parameters
+include::modules/common-attributes.adoc[]
+:context: external-dns-operator-configuration-parameters
+
+toc::[]
+
+The External DNS Operators includes the following configuration parameters:
+
+include::modules/nw-external-dns-operator-configuration-parameters.adoc[leveloffset=+1]

--- a/networking/external_dns_operator/nw-control-dns-records-public-hosted-zone-aws.adoc
+++ b/networking/external_dns_operator/nw-control-dns-records-public-hosted-zone-aws.adoc
@@ -1,0 +1,95 @@
+// Module included in the following assemblies:
+//
+// * networking/external_dns_operator/nw-creating-dns-records-on-aws.adoc
+
+:_content-type: PROCEDURE
+[id="nw-control-dns-records-public-hosted-zone-aws_{context}"]
+= Creating DNS records on an public hosted zone for AWS by using Red Hat External DNS Operator
+
+You can create DNS records on a public hosted zone for AWS by using the Red Hat External DNS Operator.
+
+.Procedure
+
+. Check the user. The user must have access to the `kube-system` namespace. If you don’t have the credentials, as you can fetch the credentials from the `kube-system` namespace to use the cloud provider client:
++
+[source,terminal]
+----
+$ oc whoami
+----
++
+.Example output
+[source,terminal]
+----
+system:admin
+----
+
+. Fetch the values from aws-creds secret present in `kube-system` namespace.
++
+[source,terminal]
+----
+$ export AWS_ACCESS_KEY_ID=$(oc get secrets aws-creds -n kube-system  --template={{.data.aws_access_key_id}} | base64 -d)
+$ export AWS_SECRET_ACCESS_KEY=$(oc get secrets aws-creds -n kube-system  --template={{.data.aws_secret_access_key}} | base64 -d)
+----
+
+. Get the routes to check the domain:
++
+[source,terminal]
+----
+$ oc get routes --all-namespaces | grep console
+----
++
+.Example output
+[source,terminal]
+----
+openshift-console          console             console-openshift-console.apps.testextdnsoperator.apacshift.support                       console             https   reencrypt/Redirect     None
+openshift-console          downloads           downloads-openshift-console.apps.testextdnsoperator.apacshift.support                     downloads           http    edge/Redirect          None
+----
+
+. Get the list of dns zones to find the one which corresponds to the previously found route's domain:
++
+[source,terminal]
+----
+$ aws route53 list-hosted-zones | grep testextdnsoperator.apacshift.support
+----
++
+.Example output
+[source,terminal]
+----
+HOSTEDZONES	terraform	/hostedzone/Z02355203TNN1XXXX1J6O	testextdnsoperator.apacshift.support.	5
+----
+
+. Create `ExternalDNS` CR for `route` source:
++
+[source,yaml]
+----
+apiVersion: externaldns.olm.openshift.io/v1alpha1
+kind: ExternalDNS
+metadata:
+  name: sample-aws <1>
+spec:
+  domains:
+  - filterType: Include   <2>
+    matchType: Exact   <3>
+    name: testextdnsoperator.apacshift.support <4>
+    provider:
+      type: AWS <5>
+    source:  <6>
+      type: OpenShiftRoute <7>
+      openshiftRouteOptions:
+        routerName: default <8>
+----
+<1> Defines the name of external DNS CR.
+<2> By default all hosted zones are selected as potential targets. You can include a hosted zone that you need.
+<3> The matching of the target zone's domain has to be exact (as opposed to regular expression match).
+<4> Specify the exact domain of the zone you want to update. The hostname of the routes must be subdomains of the specified domain.
+<5> Defines the `AWS Route53` DNS provider.
+<6> Defines options for the source of DNS records.
+<7> Defines OpenShift `route` resource as the source for the DNS records which gets created in the previously specified DNS provider.
+<8> If the source is `OpenShiftRoute`, then you can pass the OpenShift ingress controller name. External DNS Operator selects the canonical hostname of that router as the target while creating CNAME record.
+
+. Check the records created for OCP routes using the following command:
++
+[source,terminal]
+----
+$ aws route53 list-resource-record-sets --hosted-zone-id Z02355203TNN1XXXX1J6O --query "ResourceRecordSets[?Type == 'CNAME']" | grep console
+----

--- a/networking/external_dns_operator/nw-control-dns-records-public-hosted-zone-azure.adoc
+++ b/networking/external_dns_operator/nw-control-dns-records-public-hosted-zone-azure.adoc
@@ -1,0 +1,100 @@
+// Module included in the following assemblies:
+//
+// * networking/external_dns_operator/nw-creating-dns-records-on-azure.adoc
+
+:_content-type: PROCEDURE
+[id="nw-control-dns-records-public-hosted-zone-azure_{context}"]
+= Creating DNS records on an public DNS zone for Azure by using Red Hat External DNS Operator
+
+You can create DNS records on a public DNS zone for Azure by using Red Hat External DNS Operator.
+
+.Procedure
+
+. Check the user. The user must have access to the `kube-system` namespace. If you don’t have the credentials, as you can fetch the credentials from the `kube-system` namespace to use the cloud provider client:
++
+[source,terminal]
+----
+$ oc whoami
+----
++
+.Example output
+[source,terminal]
+----
+system:admin
+----
+
+. Fetch the values from azure-credentials secret present in `kube-system` namespace.
++
+[source,terminal]
+----
+$ CLIENT_ID=$(oc get secrets azure-credentials  -n kube-system  --template={{.data.azure_client_id}} | base64 -d)
+$ CLIENT_SECRET=$(oc get secrets azure-credentials  -n kube-system  --template={{.data.azure_client_secret}} | base64 -d)
+$ RESOURCE_GROUP=$(oc get secrets azure-credentials  -n kube-system  --template={{.data.azure_resourcegroup}} | base64 -d)
+$ SUBSCRIPTION_ID=$(oc get secrets azure-credentials  -n kube-system  --template={{.data.azure_subscription_id}} | base64 -d)
+$ TENANT_ID=$(oc get secrets azure-credentials  -n kube-system  --template={{.data.azure_tenant_id}} | base64 -d)
+----
+
+. Login to azure with base64 decoded values:
++
+[source,terminal]
+----
+$ az login --service-principal -u "${CLIENT_ID}" -p "${CLIENT_SECRET}" --tenant "${TENANT_ID}"
+----
+
+. Get the routes to check the domain:
++
+[source,terminal]
+----
+$ oc get routes --all-namespaces | grep console
+----
++
+.Example output
+[source,terminal]
+----
+openshift-console          console             console-openshift-console.apps.test.azure.example.com                       console             https   reencrypt/Redirect     None
+openshift-console          downloads           downloads-openshift-console.apps.test.azure.example.com                     downloads           http    edge/Redirect          None
+----
+
+. Get the list of dns zones to find the one which corresponds to the previously found route's domain:
++
+[source,terminal]
+----
+$ az network dns zone list --resource-group "${RESOURCE_GROUP}"
+----
+
+. Create `ExternalDNS` CR for `route` source:
++
+[source,yaml]
+----
+apiVersion: externaldns.olm.openshift.io/v1alpha1
+kind: ExternalDNS
+metadata:
+  name: sample-azure <1>
+spec:
+  zones:
+  - "/subscriptions/1234567890/resourceGroups/test-azure-xxxxx-rg/providers/Microsoft.Network/dnszones/test.azure.example.com" <2>
+  provider:
+    type: Azure <3>
+  source:
+    openshiftRouteOptions: <4>
+      routerName: default <5>
+    type: OpenShiftRoute <6>
+----
+<1> defines the name of External DNS CR.
+<2> Define the zone ID.
+<3> defines the Azure DNS provider.
+<4> You can define options for the source of DNS records.
+<5> If the source is `OpenShiftRoute` then you can pass the OpenShift ingress controller name. External DNS selects the canonical hostname of that router as the target while creating CNAME record.
+<6> Defines OpenShift `route` resource as the source for the DNS records which gets created in the previously specified DNS provider.
+
+. Check the records created for OCP routes using the following command:
++
+[source,terminal]
+----
+$ az network dns record-set list -g "${RESOURCE_GROUP}"  -z test.azure.example.com | grep console
+----
+
+[NOTE]
+====
+To create records on private hosted zones on private Azure dns, you need to specify the private zone under `zones` which populates the provider type to `azure-private-dns` in the `ExternalDNS` container args.
+====

--- a/networking/external_dns_operator/nw-control-dns-records-public-managed-zone-gcp.adoc
+++ b/networking/external_dns_operator/nw-control-dns-records-public-managed-zone-gcp.adoc
@@ -1,0 +1,111 @@
+
+// Module included in the following assemblies:
+//
+// * networking/external_dns_operator/nw-creating-dns-records-on-gc.adoc
+
+:_content-type: PROCEDURE
+[id="nw-control-dns-records-public-hosted-zone-gcp_{context}"]
+= Creating DNS records on an public managed zone for GCP by using Red Hat External DNS Operator
+
+You can create DNS records on a public managed zone for GCP by using Red Hat External DNS Operator.
+
+.Procedure
+
+. Check the user. The user must have access to the `kube-system` namespace. If you don’t have the credentials, as you can fetch the credentials from the `kube-system` namespace to use the cloud provider client:
++
+[source,terminal]
+----
+$ oc whoami
+----
++
+.Example output
+[source,terminal]
+----
+system:admin
+----
+
+. Copy the value of service_account.json in gcp-credentials secret in a file encoded-gcloud.json by running the following command:
++
+[source,terminal]
+----
+$ oc get secret gcp-credentials -n kube-system --template='{{$v := index .data "service_account.json"}}{{$v}}' | base64 -d - > decoded-gcloud.json
+----
+
+. Export Google credentials by running the following command:
++
+[source,terminal]
+----
+$ export GOOGLE_CREDENTIALS=decoded-gcloud.json
+----
+
+. Activate your account by using the following command:
++
+[source,terminal]
+----
+$ gcloud auth activate-service-account  <client_email as per decoded-gcloud.json> --key-file=decoded-gcloud.json
+----
+
+. Set your project by running the following command:
++
+[source,terminal]
+----
+$ gcloud config set project <project_id as per decoded-gcloud.json>
+----
+
+. Get the routes to check the domain by running the following command:
++
+[source,terminal]
+----
+$ oc get routes --all-namespaces | grep console
+----
++
+.Example output
+[source,terminal]
+----
+openshift-console          console             console-openshift-console.apps.test.gcp.example.com                       console             https   reencrypt/Redirect     None
+openshift-console          downloads           downloads-openshift-console.apps.test.gcp.example.com                     downloads           http    edge/Redirect          None
+----
+
+. Get the list of managed zones to find the zone which corresponds to the previously found route’s domain:
++
+[source,terminal]
+----
+$ gcloud dns managed-zones list | grep test.gcp.example.com
+qe-cvs4g-private-zone test.gcp.example.com
+----
+
+. Create `ExternalDNS` CR for `route` source:
++
+[source,yaml]
+----
+apiVersion: externaldns.olm.openshift.io/v1alpha1
+kind: ExternalDNS
+metadata:
+  name: sample-gcp <1>
+spec:
+  domains:
+    - filterType: Include <2>
+      matchType: Exact <3>
+      name: test.gcp.example.com <4>
+  provider:
+    type: GCP <5>
+  source:
+    openshiftRouteOptions: <6>
+      routerName: default <7>
+    type: OpenShiftRoute <8>
+----
+<1> Defines the name of External DNS CR.
+<2> By default all hosted zones are selected as potential targets. You can include a hosted zone that you need.
+<3> The matching of the target zone's domain has to be exact (as opposed to regular expression match).
+<4> Specify the exact domain of the zone you want to update. The hostname of the routes must be subdomains of the specified domain.
+<5> Defines Google Cloud DNS provider.
+<6> You can define options for the source of DNS records.
+<7> If the source is `OpenShiftRoute` then you can pass the OpenShift ingress controller name. External DNS selects the canonical hostname of that router as the target while creating CNAME record.
+<8> Defines OpenShift `route` resource as the source for the DNS records which gets created in the previously specified DNS provider.
+
+. Check the records created for OCP routes using the following command:
++
+[source,terminal]
+----
+$ gcloud dns record-sets list --zone=qe-cvs4g-private-zone | grep console
+----

--- a/networking/external_dns_operator/nw-creating-dns-records-on-aws.adoc
+++ b/networking/external_dns_operator/nw-creating-dns-records-on-aws.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="creating-dns-records-on-aws"]
+= Creating DNS records on AWS
+include::modules/common-attributes.adoc[]
+:context: creating-dns-records-on-aws
+
+toc::[]
+
+You can create DNS records on AWS using External DNS Operator.
+
+include::modules/nw-control-dns-records-public-hosted-zone-aws.adoc[leveloffset=+1]

--- a/networking/external_dns_operator/nw-creating-dns-records-on-azure.adoc
+++ b/networking/external_dns_operator/nw-creating-dns-records-on-azure.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="creating-dns-records-on-azure"]
+= Creating DNS records on Azure
+include::modules/common-attributes.adoc[]
+:context: creating-dns-records-on-azure
+
+toc::[]
+
+You can create DNS records on Azure using External DNS Operator.
+
+include::modules/nw-control-dns-records-public-hosted-zone-azure.adoc[leveloffset=+1]

--- a/networking/external_dns_operator/nw-creating-dns-records-on-gcp.adoc
+++ b/networking/external_dns_operator/nw-creating-dns-records-on-gcp.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="creating-dns-records-on-gcp"]
+= Creating DNS records on GCP
+include::modules/common-attributes.adoc[]
+:context: creating-dns-records-on-gcp
+
+toc::[]
+
+You can create DNS records on GCP using External DNS Operator.
+
+include::modules/nw-control-dns-records-public-hosted-zone-gcp.adoc[leveloffset=+1]

--- a/networking/external_dns_operator/nw-external-dns-operator-configuration-parameters.adoc
+++ b/networking/external_dns_operator/nw-external-dns-operator-configuration-parameters.adoc
@@ -1,0 +1,104 @@
+// Module included in the following assemblies:
+//
+// * networking/external_dns_operator/nw-configuration-parameters.adoc
+
+:_content-type: CONCEPT
+[id="nw-external-dns-operator-configuration-parameters_{context}"]
+= External DNS Operator configuration parameters
+
+The External DNS Operator includes the following configuration parameters:
+
+[cols="3a,8a",options="header"]
+|===
+|Parameter |Description
+
+|`spec`
+|Enables the type of a cloud provider.
+
+[source,yaml]
+----
+spec:
+  provider:
+    type: AWS <1>
+    aws:
+      credentials:
+        name: aws-access-key <2>
+----
+<1> Defines available options such as AWS, GCP and Azure.
+<2> Defines a name of the `secret` which contains credentials for your cloud provider.
+
+|`zones`
+|Enables you to specify DNS zones by their domains. If you do not specify zones, `ExternalDNS` discovers all the zones present in your cloud provider account.
+
+[source,yaml]
+----
+zones:
+- "myzoneid" <1>
+----
+
+<1> Specifies the IDs of DNS zones.
+
+|`domains`
+|Enables you to specify AWS zones by their domains. If you do not specify domains, `ExternalDNS` discovers all the zones present in your cloud provider account.
+
+[source,yaml]
+----
+domains:
+- filterType: Include <1>
+  matchType: Exact <2>
+  name: "myzonedomain1.com" <3>
+- filterType: Include
+  matchType: Pattern <4>
+  pattern: ".*\\.otherzonedomain\\.com" <5>
+----
+<1> Instructs `ExternalDNS` to include the domain specified.
+<2> Instructs `ExtrnalDNS` that the domain matching has to be exact as opposed to regular expression match.
+<3> Defines the exact domain name by which `ExternalDNS` filters.
+<4> Sets `regex-domain-filter` flag in `ExternalDNS`. You can limit possible domains by using a Regex filter.
+<5> Defines the regex pattern to be used by `ExternalDNS` to filter the domains of the target zones.
+
+|`source`
+|Enables you to specify the source for the DNS records, `Service` or `Route`.
+
+[source,yaml]
+----
+source: <1>
+  type: Service <2>
+  service:
+    serviceType:<3>
+      - LoadBalancer
+      - ClusterIP
+  labelFilter: <4>
+    matchLabels:
+      external-dns.mydomain.org/publish: "yes"
+  hostnameAnnotation: "Allow" <5>
+  fqdnTemplate:
+  - "{{.Name}}.myzonedomain.com" <6>
+----
+<1> Defines the settings for the source of DNS records.
+<2> `ExternalDNS` uses `Service` type as source for creating dns records.
+<3> Sets `service-type-filter` flag in `ExternalDNS`. The `serviceType` contains the following fields:
+* `default`: `LoadBalancer`
+* `expected`: `ClusterIP`
+* `NodePort`
+* `LoadBalancer`
+* `ExternalName`
+<4> Ensures that the controller considers only those resources which matches with label filter.
+<5> The default value for `hostnameAnnotation` is `Ignore` which instructs `ExternalDNS` to generate DNS records using the templates specified in the field `fqdnTemplates`. When the value is `Allow` the DNS records get generated based on the value specified in the `external-dns.alpha.kubernetes.io/hostname` annotation.
+<6> External DNS Operator uses a string to generate DNS names from sources that don't define a hostname, or to add a hostname suffix when paired with the fake source.
+
+[source,yaml]
+----
+source:
+  type: OpenShiftRoute <1>
+  openshiftRouteOptions:
+    routerName: default <2>
+    labelFilter:
+      matchLabels:
+        external-dns.mydomain.org/publish: "yes"
+----
+
+<1> ExternalDNS` uses type `route` as source for creating dns records.
+<2> If the source is `OpenShiftRoute`, then you can pass the ingress controller name. The `ExternalDNS` uses canonical name of ingress controller as the target for CNAME record.
+
+|===

--- a/networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.adoc
+++ b/networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="installing-external-dns-on-cloud-providers"]
+= Installing External DNS Operator on cloud providers
+include::modules/common-attributes.adoc[]
+:context: installing-external-dns-on-cloud-providers
+
+toc::[]
+
+You can install External DNS Operator on cloud providers such as AWS, Azure and GCP.
+
+include::modules/nw-installing-external-dns-operator.adoc[leveloffset=+1]

--- a/networking/external_dns_operator/nw-installing-external-dns-operator.adoc
+++ b/networking/external_dns_operator/nw-installing-external-dns-operator.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.adoc
+
+:_content-type: PROCEDURE
+[id="nw-installing-external-dns-operator_{context}"]
+= Installing the External DNS Operator
+
+You can install the External DNS Operator using the Red Hat OpenShift Container Platform Operator Hub.
+
+.Prerequisites
+
+* You have logged in to the {product-title} web console as a user with `cluster-admin` permissions.
+* You have created the operand `external-dns` namespace by running `oc create ns external-dns` command.
+* You have granted the operator access to manage operand resources by running `oc apply -f https://raw.githubusercontent.com/openshift/external-dns-operator/main/config/rbac/extra-roles.yaml` command.
+
+.Procedure
+
+. Click *Operators* → *OperatorHub* in the OpenShift Web Console.
+. Click *External DNS Operator*.
+  You can use the Filter by keyword text box or the filter list to search for External DNS Operator from the list of operators.
+. Select `external-dns-operator` namespace.
+. On the External DNS Operator page, click *Install*.
+. On the Install Operator page, ensure that you selected the following options:
+.. Update the channel as *stable-{product-version}*.
+.. Installation mode as *A specific name on the cluster*.
+.. Installed namespace as `external-dns-operator`. If Namespace `external-dns-operator` does not exist, it will be created during the operator installation.
+.. Select *Approval Strategy* as *Automatic* or *Manual*. Approval Strategy is set to Automatic by default.
+.. Click *Install*.
+
+If you select Automatic updates, the Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your operator without any intervention.
+
+If you select Manual updates, the OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the operator updated to the new version.
+
+
+.Verification step
+
+Verify that External DNS Operator shows the Status as Succeeded on the Installed Operators dashboard.


### PR DESCRIPTION
OCP version: 4.10 only
Please cherry-pick to 4.10 branch
[Preview](https://deploy-preview-41811--osdocs.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-installing-external-dns-operator.html)
QE contact: @lihongan ==> LGTMed
SME: @alebedev87  ==> LGTMed
[NE-753](https://issues.redhat.com/browse/NE-753)
