### PR TITLE
RN_NE743_NE768: Release Notes for upstream resolvers and syslog maxsize

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -249,6 +249,19 @@ This enhancement adds the ability to configure global HTTP traffic compression o
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-configuring-router-compression_configuring-ingress[Using router compression].
 
+[id="ocp-4-10-ne-coredns-customization"]
+==== Support for CoreDNS customization
+A cluster administrator can now configure DNS servers to allow DNS name resolution through the configured servers for the default domain. A DNS forwarding configuration can have both the default servers specified in the `/etc/resolv.conf` file and the upstream DNS servers.
+
+For more information, see xref:../networking/dns-operator.adoc#nw-dns-forward_dns-operator[Using DNS forwarding].
+
+[id="ocp-4-10-ne-syslog-maxlength"]
+==== Support for configuring the maximum length of the syslog message in the Ingress Controller
+You can now set the maximum length of the syslog message in the Ingress Controller to any value between 480 and 4096 bytes.
+
+For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration parameters].
+
+
 [id="ocp-4-10-hardware"]
 === Hardware
 


### PR DESCRIPTION
For 4.10+

https://issues.redhat.com/browse/NE-743
https://issues.redhat.com/browse/NE-768

[Docs preview](https://deploy-preview-41812--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-networking)