### PR TITLE
Adding single-node OpenShift and three-node OpenShift terms to glossary

### DIFF
--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -636,6 +636,24 @@ A service account binds together:
 * a set of secrets
 
 ''''
+=== single-node OpenShift
+
+Usage: single-node OpenShift
+
+Single-node OpenShift (or {product-title} on a single-node cluster) is a deployment footprint that provides control plane and worker node capabilities in a single server for deployments in constrained environments.
+
+Do not use: Single Node Openshift (SNO).
+
+''''
+=== three-node OpenShift
+
+Usage: three-node OpenShift
+
+Three-node OpenShift is a compact cluster deployment footprint on three nodes for deployments in constrained environments. It provides three control plane nodes that you configure as schedulable for workloads.
+
+Do not use: Three Node Openshift.
+
+''''
 === SkyDNS
 
 Usage: SkyDNS


### PR DESCRIPTION
Adding _single-node OpenShift_ and _three-node Openshift_ terms to glossary. Merge to main.