### PR TITLE
removed versions

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,12 +23,6 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
-include::modules/gitops-release-notes-1-4-2.adoc[leveloffset=+1]
-
-include::modules/gitops-release-notes-1-4-1.adoc[leveloffset=+1]
-
-include::modules/gitops-release-notes-1-3-3.adoc[leveloffset=+1]
-
 include::modules/gitops-release-notes-1-3-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-0.adoc[leveloffset=+1]


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.8
JIRA issues: 

Preview pages: https://deploy-preview-41820--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html

SME Review:
Peer Review