### PR TITLE
RHDEVDOCS-3703 Pipelines 1.6.2 Release Notes

### DIFF
--- a/modules/op-release-notes-1-6.adoc
+++ b/modules/op-release-notes-1-6.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assembly:
 //
 // * cicd/pipelines/op-release-notes.adoc
-
+:_content-type: REFERENCE
 [id="op-release-notes-1-6_{context}"]
 = Release notes for {pipelines-title} General Availability 1.6
 
@@ -275,3 +275,35 @@ Error from server (InternalError): Internal error occurred: failed calling webho
 
 * The pod serving the `tkn` CLI will now be scheduled on nodes, based on the node selector and toleration limits specified in the `TektonConfig` custom resource.
 // https://issues.redhat.com/browse/SRVKP-1804
+
+
+[id="release-notes-1-6-2_{context}"]
+== Release notes for {pipelines-title} General Availability 1.6.2
+
+[id="known-issues-1-6-2_{context}"]
+=== Known issues
+
+* When you create a new project, the creation of the `pipeline` service account is delayed, and removal of existing cluster tasks and pipeline templates takes more than 10 minutes.
+// https://issues.redhat.com/browse/SRVKP-2043  
+
+[id="fixed-issues-1-6-2_{context}"]
+=== Fixed issues
+
+* Before this update, multiple instances of Tekton installer sets were created for a pipeline after upgrading to Red Hat OpenShift Pipelines 1.6.1 from an older version. With this update, the Operator ensures that only one instance of each type of `TektonInstallerSet` exists after an upgrade.
+// https://issues.redhat.com/browse/SRVKP-1926
+
+* Before this update, all the reconcilers in the Operator used the component version to decide resource recreation during an upgrade to Red Hat OpenShift Pipelines 1.6.1 from an older version. As a result, those resources were not recreated whose component versions did not change in the upgrade. With this update, the Operator uses the Operator version instead of the component version to decide resource recreation during an upgrade.
+// https://issues.redhat.com/browse/SRVKP-1928
+
+* Before this update, the pipelines webhook service was missing in the cluster after an upgrade. This was due to an upgrade deadlock on the config maps. With this update, a mechanism is added to disable webhook validation if the config maps are absent in the cluster. As a result, the pipelines webhook service persists in the cluster after an upgrade.
+// https://issues.redhat.com/browse/SRVKP-1939
+
+* Before this update, cron jobs for auto-pruning got recreated after any configuration change to the namespace. With this update, cron jobs for auto-pruning get recreated only if there is a relevant annotation change in the namespace.
+// https://issues.redhat.com/browse/SRVKP-1826
+
+* The upstream version of Tekton Pipelines is revised to `v0.28.3`, which has the following fixes:
+** Fix `PipelineRun` or `TaskRun` objects to allow label or annotation propagation.
+** For implicit params:
+*** Do not apply the `PipelineSpec` parameters to the `TaskRefs` object.
+*** Disable implicit param behavior for the `Pipeline` objects.
+// https://github.com/tektoncd/pipeline/releases/tag/v0.28.3


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`
- **JIRA issues**: [RHDEVDOCS-3703 Release Notes for Pipelines 1.6.2 Z stream release](https://issues.redhat.com/browse/RHDEVDOCS-3703)
- **Preview pages**: [Release notes for Red Hat OpenShift Pipelines General Availability 1.6.2](https://deploy-preview-41822--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes#release-notes-1-6-2_op-release-notes)
- **SME review**: @concaf ([engineering draft](https://docs.google.com/document/d/195d0TvQY17Z0MriLHh0aJE9u3HQxjqIR2FtpulWEjKo/edit#))    
- **Peer-review**: @Srivaralakshmi 

Old closed PR with review comments: https://github.com/openshift/openshift-docs/pull/41326