### PR TITLE
RN-4.10: Added new default components for AWS installations

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -58,6 +58,14 @@ The `coreos-installer` utility now has `iso customize` and `pxe customize` subco
 [id="ocp-4-10-installation-and-upgrade"]
 === Installation and upgrade
 
+[id="ocp-4-10-AWS-default-components"]
+==== New default component types for AWS installations
+
+The {product-title} 4.10 installer uses new default component types for installations on AWS. The installer uses the following components by default:
+
+* AWS EC2 M6i instances for both control plane and compute nodes, where available
+* AWS EBS gp3 storage
+
 [id="ocp-4-10-OCP-on-ARM"]
 ==== {product-title} on ARM
 


### PR DESCRIPTION
From RN tracker: https://github.com/openshift/openshift-docs/issues/37586#issuecomment-1006059654

Preview: https://deploy-preview-41831--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-AWS-default-components

@mtulio How does this look to you?