### PR TITLE
[TELCODOCS-261] Hardware Event Proxy Operator Install and Config + RFHE API refererence

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2138,6 +2138,8 @@ Topics:
   File: managing-alerts
 - Name: Reviewing monitoring dashboards
   File: reviewing-monitoring-dashboards
+- Name: Monitoring Redfish hardware events
+  File: using-rfhe
 - Name: Accessing third-party monitoring UIs and APIs
   File: accessing-third-party-monitoring-uis-and-apis
 - Name: Troubleshooting monitoring issues

--- a/modules/cnf-rfhe-notifications-api-refererence.adoc
+++ b/modules/cnf-rfhe-notifications-api-refererence.adoc
@@ -1,0 +1,161 @@
+// Module included in the following assemblies:
+//
+// * networking/using-rfhe.adoc
+
+:_content-type: REFERENCE
+[id="cnf-rfhe-notifications-api-refererence_{context}"]
+= Subscribing applications to Redfish hardware event notifications REST API reference
+
+Use the Redfish event notifications REST API to subscribe an application to the Redfish hardware events that are generated on the parent node.
+
+Subscribe applications to Redfish events by using the resource address `/cluster/node/<node_name>/redfish/event`, where `<node_name>` is the cluster node running the application.
+
+Deploy your `cloud-event-consumer` application container and `cloud-event-proxy` sidecar container in a separate application pod. The `cloud-event-consumer` application subscribes to the `cloud-event-proxy` container in the application pod.
+
+Use the following API endpoints to subscribe the `cloud-event-consumer` application to Redfish events posted by the `cloud-event-proxy` container at [x-]`http://localhost:8089/api/cloudNotifications/v1/` in the application pod:
+
+* `/api/cloudNotifications/v1/subscriptions`
+- `POST`: Creates a new subscription
+- `GET`: Retrieves a list of subscriptions
+* `/api/cloudNotifications/v1/subscriptions/<subscription_id>`
+- `GET`: Returns details for the specified subscription ID
+* `api/cloudNotifications/v1/subscriptions/status/<subscription_id>`
+- `PUT`: Creates a new status ping request for the specified subscription ID
+* `/api/cloudNotifications/v1/health`
+- `GET`: Returns the health status of `cloudNotifications` API
+
+[NOTE]
+====
+`9089` is the default port for the `cloud-event-consumer` container deployed in the application pod. You can configure a different port for your application as required.
+====
+
+[discrete]
+== api/cloudNotifications/v1/subscriptions
+
+[discrete]
+=== HTTP method
+
+`GET api/cloudNotifications/v1/subscriptions`
+
+[discrete]
+==== Description
+
+Returns a list of subscriptions. If subscriptions exist, a `200 OK` status code is returned along with the list of subscriptions.
+
+.Example API response
+[source,json]
+----
+[
+ {
+  "id": "ca11ab76-86f9-428c-8d3a-666c24e34d32",
+  "endpointUri": "http://localhost:9089/api/cloudNotifications/v1/dummy",
+  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/subscriptions/ca11ab76-86f9-428c-8d3a-666c24e34d32",
+  "resource": "/cluster/node/openshift-worker-0.openshift.example.com/redfish/event"
+ }
+]
+----
+
+[discrete]
+=== HTTP method
+
+`POST api/cloudNotifications/v1/subscriptions`
+
+[discrete]
+==== Description
+
+Creates a new subscription. If a subscription is successfully created, or if it already exists, a `201 Created` status code is returned.
+
+.Query parameters
+|===
+| Parameter | Type
+
+| subscription
+| data
+|===
+
+.Example payload
+[source,json]
+----
+{
+  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/subscriptions",
+  "resource": "/cluster/node/openshift-worker-0.openshift.example.com/redfish/event"
+}
+----
+
+[discrete]
+== api/cloudNotifications/v1/subscriptions/<subscription_id>
+
+[discrete]
+=== HTTP method
+
+`GET api/cloudNotifications/v1/subscriptions/<subscription_id>`
+
+[discrete]
+==== Description
+
+Returns details for the subscription with ID `<subscription_id>`
+
+.Query parameters
+|===
+| Parameter | Type
+
+| `<subscription_id>`
+| string
+|===
+
+.Example API response
+[source,json]
+----
+{
+  "id":"ca11ab76-86f9-428c-8d3a-666c24e34d32",
+  "endpointUri":"http://localhost:9089/api/cloudNotifications/v1/dummy",
+  "uriLocation":"http://localhost:8089/api/cloudNotifications/v1/subscriptions/ca11ab76-86f9-428c-8d3a-666c24e34d32",
+  "resource":"/cluster/node/openshift-worker-0.openshift.example.com/redfish/event"
+}
+----
+
+[discrete]
+== api/cloudNotifications/v1/subscriptions/status/<subscription_id>
+
+[discrete]
+=== HTTP method
+
+`PUT api/cloudNotifications/v1/subscriptions/status/<subscription_id>`
+
+[discrete]
+==== Description
+
+Creates a new status ping request for subscription with ID `<subscription_id>`. If a subscription is present, the status request is successful and a `202 Accepted` status code is returned.
+
+.Query parameters
+|===
+| Parameter | Type
+
+| `<subscription_id>`
+| string
+|===
+
+.Example API response
+[source,json]
+----
+{"status":"ping sent"}
+----
+
+[discrete]
+== api/cloudNotifications/v1/health/
+
+[discrete]
+=== HTTP method
+
+`GET api/cloudNotifications/v1/health/`
+
+[discrete]
+==== Description
+
+Returns the health status for the `cloudNotifications` REST API.
+
+.Example API response
+[source,terminal]
+----
+OK
+----

--- a/modules/hw-installing-amq-interconnect-messaging-bus.adoc
+++ b/modules/hw-installing-amq-interconnect-messaging-bus.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * networking/using-rfhe.adoc
+
+:_content-type: PROCEDURE
+[id="hw-installing-amq-interconnect-messaging-bus_{context}"]
+= Installing the AMQ messaging bus
+
+To pass Redfish hardware event notifications between publisher and subscriber on a node, you must install and configure an AMQ messaging bus to run locally on the node. You do this by installing the AMQ Interconnect Operator for use in the cluster.
+
+.Prerequisites
+
+* Install the {product-title} CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+* Install the AMQ Interconnect Operator to its own `amq-interconnect` namespace. See link:https://access.redhat.com/documentation/en-us/red_hat_amq/2021.q1/html/deploying_amq_interconnect_on_openshift/adding-operator-router-ocp[Installing the AMQ Interconnect Operator].
+
+.Verification
+
+. Check that the AMQ Interconnect Operator is available and the required pods are running:
++
+[source,terminal]
+----
+$ oc get pods -n amq-interconnect
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                    READY   STATUS    RESTARTS   AGE
+amq-interconnect-645db76c76-k8ghs       1/1     Running   0          23h
+interconnect-operator-5cb5fc7cc-4v7qm   1/1     Running   0          23h
+----
+
+. Check that the required `hw-event-proxy` hardware event producer pod is running in the `openshift-hw-events` namespace.
++
+[source,terminal]
+----
+$ oc get pods -n openshift-hw-events
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                         				 READY   STATUS    RESTARTS   AGE
+baremetal-hardware-event-proxy-operator-controller-manager-b889bb8d5-qwhvs   2/2     Running   0          25s
+----
+
+
+

--- a/modules/nw-rfhe-creating-hardware-event.adoc
+++ b/modules/nw-rfhe-creating-hardware-event.adoc
@@ -1,0 +1,78 @@
+// Module included in the following assemblies:
+//
+// * networking/using-rfhe.adoc
+
+:_content-type: PROCEDURE
+[id="nw-rfhe-creating-hardware-event_{context}"]
+= Creating the Redfish HardwareEvent and Secret CRs
+
+To start using baremetal hardware events, create the a `HardwareEvent` custom resource (CR) for the host where the Redfish hardware is present. Hardware events and faults are reported in the `hw-event-proxy` logs.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* Install the Baremetal Hardware Event Proxy Operator.
+* Create a `BMCEventSubscription` CR for the BMC Redfish hardware.
+
+[NOTE]
+====
+Create a single instance of the `HardwareEvent` resource. Multiple `HardwareEvent` resources are not permitted.
+====
+
+.Procedure
+
+. Create the `HardwareEvent` custom resource (CR):
+
+.. Save the following YAML in the `hw-event.yaml` file:
++
+[source,yaml]
+----
+apiVersion: "event.redhat-cne.org/v1alpha1"
+kind: "HardwareEvent"
+metadata:
+  name: "hardware-event"
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/hw-event: "" <1>
+  transportHost: "amqp://amq-router-service-name.amq-namespace.svc.cluster.local" <2>
+  logLevel: "debug" <3>
+  msgParserTimeout: "10" <4>
+----
+<1> Mandatory. Use the `nodeSelector` field to target nodes with the specified label, for example, `node-role.kubernetes.io/hw-event: ""`.
+<2> Mandatory. AMQP host that delivers the events at the transport layer using the AMQP protocol.
+<3> Optional. The default value is `debug`. Sets the log level in hw-event-proxy logs. The following log levels are available: `fatal`, `error`, `warning`, `info`, `debug`, `trace`.
+<4> Optional. Sets the timeout value in milliseconds for the Message Parser. If a message parsing request is not responded to within the timeout duration, the original hardware event message is passed to the cloud native event framework. The default value is 10.
+
+.. Create the `HardwareEvent` CR:
++
+[source,terminal]
+----
+$ oc create -f hardware-event.yaml
+----
+
+. Create a BMC username and password `Secret` CR that allows the hardware events proxy to access the Redfish message registry for the bare-metal host.
++
+.. Save the following YAML in the `hw-event-bmc-secret.yaml` file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redfish-basic-auth
+type: Opaque
+stringData: <1>
+  username: <bmc_username>
+  password: <bmc_password>
+  # BMC host DNS or IP address
+  hostaddr: <bmc_host_ip_address>
+----
+<1> Enter plain text values for the various items under `stringData`.
++
+.. Create the `Secret` CR:
++
+[source,terminal]
+----
+$ oc create -f hw-event-bmc-secret.yaml
+----

--- a/modules/nw-rfhe-creating_bmc_event_sub.adoc
+++ b/modules/nw-rfhe-creating_bmc_event_sub.adoc
@@ -1,0 +1,126 @@
+// Module included in the following assemblies:
+//
+// * networking/using-rfhe.adoc
+
+:_content-type: PROCEDURE
+[id="nw-rfhe-creating_bmc_event_sub_{context}"]
+= Subscribing to Redfish hardware events
+
+You can configure the baseboard management controller (BMC) to send Redfish hardware events to subscribed applications running in {product-title} cluster. Example Redfish events include an increase in device temperature, or removal of a device. Applications subscribe to Redfish hardware events using a REST API.
+
+[IMPORTANT]
+====
+You can only create a `BMCEventSubscription` CR for physical hardware that supports Redfish and has a vendor interface set to `redfish` or `idrac-redfish`.
+====
+
+[NOTE]
+====
+Use the `BMCEventSubscription` CR to subscribe to pre-defined Redfish events. The Redfish standard does not provide an option to create specific alerts and thresholds. For example, to receive an alert event when an enclosure's temperature exceeds 40° Celsius, you need to manually configure the event according to the vendor's recommendations.
+====
+
+To subscribe to Redfish hardware events for the node using a `BMCEventSubscription` custom resource (CR), perform the following procedure:
+
+.Prerequisites
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* Get the user name and password for the BMC.
+* Deploy a bare-metal node with Redfish hardware in your cluster, and enable Redfish events on the BMC.
++
+[NOTE]
+====
+Enabling Redfish events on specific hardware is outside the scope of this information. For more information about enabling Redfish events for your specific hardware, consult the BMC manufacturer documentation.
+====
+
+.Procedure
+. Confirm the node hardware has the Redfish `EventService` enabled using the following `curl` command:
++
+[source,terminal]
+----
+curl https://<bmc_ip_address>/redfish/v1/EventService --insecure -H 'Content-Type: application/json' -u "<user_name>:<password>"
+----
++
+where:
++
+--
+bmc_ip_address:: is the IP address of the BMC controller.
+--
++
+.Example output
+[source,terminal]
+----
+{
+   "@odata.context": "/redfish/v1/$metadata#EventService.EventService",
+   "@odata.id": "/redfish/v1/EventService",
+   "@odata.type": "#EventService.v1_0_2.EventService",
+   "Actions": {
+      "#EventService.SubmitTestEvent": {
+         "EventType@Redfish.AllowableValues": ["StatusChange", "ResourceUpdated", "ResourceAdded", "ResourceRemoved", "Alert"],
+         "target": "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent"
+      }
+   },
+   "DeliveryRetryAttempts": 3,
+   "DeliveryRetryIntervalSeconds": 30,
+   "Description": "Event Service represents the properties for the service",
+   "EventTypesForSubscription": ["StatusChange", "ResourceUpdated", "ResourceAdded", "ResourceRemoved", "Alert"],
+   "EventTypesForSubscription@odata.count": 5,
+   "Id": "EventService",
+   "Name": "Event Service",
+   "ServiceEnabled": true,
+   "Status": {
+      "Health": "OK",
+      "HealthRollup": "OK",
+      "State": "Enabled"
+   },
+   "Subscriptions": {
+      "@odata.id": "/redfish/v1/EventService/Subscriptions"
+   }
+}
+----
+
+. Get the hardware event proxy service route for the cluster:
++
+[source,terminal]
+----
+$ oc get route -n openshift-hw-events
+----
++
+.Example output
+[source,terminal]
+----
+NAME                      HOST/PORT                                                                            PATH   SERVICES                  PORT    TERMINATION            WILDCARD
+hw-event-proxy            hw-event-proxy-cloud-native-events.apps.compute-1.example.com                               hw-event-proxy-service    9087    edge                   None
+----
+
+. Create a `BMCEventSubscription` resource to subscribe to the Redfish events:
+
+.. Save the following YAML in the `bmc_sub.yaml` file:
++
+[source,yaml]
+----
+apiVersion: metal3.io/v1alpha1
+kind: BMCEventSubscription
+metadata:
+  name: sub-01
+  namespace: openshift-machine-api
+spec:
+   hostName: <hostname> <1>
+   destination: <proxy_service_url> <2>
+   context: ''
+----
+<1> Specifies the name or UUID of the worker node where the Redfish events are generated.
+<2> Specifies the baremetal hardware event proxy service, for example, `https://hw-event-proxy-cloud-native-events.apps.compute-1.example.com/webhook`.
++
+
+.. Create the `BMCEventSubscription` CR:
++
+[source,terminal]
+----
+$ oc create -f bmc_sub.yaml
+----
+
+. Optional: To delete the BMC event subscription, run the following command:
++
+[source,terminal]
+----
+$ oc delete -f bmc_sub.yaml
+----

--- a/modules/nw-rfhe-installing-operator-cli.adoc
+++ b/modules/nw-rfhe-installing-operator-cli.adoc
@@ -1,0 +1,103 @@
+// Module included in the following assemblies:
+//
+// * networking/using-rfhe.adoc
+
+:_content-type: PROCEDURE
+[id="nw-rfhe-installing-operator-cli_{context}"]
+= Installing the Baremetal Hardware Event Proxy Operator using the CLI
+
+As a cluster administrator, you can install the Operator by using the CLI.
+
+.Prerequisites
+
+* A cluster installed on bare-metal hardware with nodes that have Redfish hardware.
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a namespace for the Baremetal Hardware Event Proxy Operator.
+
+.. Save the following YAML in the `hw-events-namespace.yaml` file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-hw-events
+  annotations:
+    workload.openshift.io/allowed: management
+  labels:
+    name: openshift-hw-events
+    openshift.io/cluster-monitoring: "true"
+----
+
+.. Create the `Namespace` CR:
++
+[source,terminal]
+----
+$ oc create -f hw-events-namespace.yaml
+----
+
+. Create an Operator group for the Baremetal Hardware Event Proxy Operator.
+
+.. Save the following YAML in the `hw-events-operatorgroup.yaml` file:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: baremetal-hardware-event-proxy-operator-group
+  namespace: openshift-hw-events
+spec:
+  targetNamespaces:
+  - openshift-hw-events
+----
+
+.. Create the `OperatorGroup` CR:
++
+[source,terminal]
+----
+$ oc create -f hw-events-operatorgroup.yaml
+----
+
+. Subscribe to the Baremetal Hardware Event Proxy Operator.
+
+.. Save the following YAML in the `hw-events-sub.yaml` file:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: baremetal-hardware-event-proxy-operator-subscription
+  namespace: openshift-hw-events
+spec:
+  channel: "stable"
+  name: baremetal-hardware-event-proxy-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+----
+
+.. Create the `Subscription` CR:
++
+[source,terminal]
+----
+$ oc create -f hw-events-sub.yaml
+----
+
+. To verify that the Operator is installed, enter the following command:
++
+[source,terminal]
+----
+$ oc get csv -n openshift-hw-events -o custom-columns=Name:.metadata.name,Phase:.status.phase
+----
++
+.Example output
+[source,terminal]
+----
+Name                         Phase
+4.10.0-202201261535          Succeeded
+----

--- a/modules/nw-rfhe-installing-operator-web-console.adoc
+++ b/modules/nw-rfhe-installing-operator-web-console.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * networking/using-rfhe.adoc
+:_content-type: PROCEDURE
+[id="nw-rfhe-installing-operator-web-console_{context}"]
+= Installing the Baremetal Hardware Event Proxy Operator using the web console
+
+As a cluster administrator, you can install the Baremetal Hardware Event Proxy Operator using the web console.
+
+.Prerequisites
+
+* A cluster installed on bare-metal hardware with nodes that have Redfish hardware.
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Install the Baremetal Hardware Event Proxy Operator using the {product-title} web console:
+
+.. In the {product-title} web console, click *Operators* -> *OperatorHub*.
+
+.. Choose  *Baremetal Hardware Event Proxy Operator* from the list of available Operators, and then click *Install*.
+
+.. On the *Install Operator* page, select or create a *Namespace* and then select *baremetal-hardware-event-proxy-operator*. Then, click *Install*.
+
+. Optional: Verify that the Baremetal Hardware Event Proxy Operator installed successfully:
+
+.. Switch to the *Operators* -> *Installed Operators* page.
+
+.. Ensure that *Baremetal Hardware Event Proxy Operator* is listed in the project with a *Status* of *InstallSucceeded*.
++
+[NOTE]
+====
+During installation an Operator might display a *Failed* status. If the installation later succeeds with an *InstallSucceeded* message, you can ignore the *Failed* message.
+====
+
+If the operator does not appear as installed, to troubleshoot further:
+
+* Go to the *Operators* -> *Installed Operators* page and inspect the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors under *Status*.
+* Go to the *Workloads* -> *Pods* page and check the logs for pods in the project namespace.

--- a/monitoring/using-rfhe.adoc
+++ b/monitoring/using-rfhe.adoc
@@ -1,0 +1,32 @@
+:_content-type: ASSEMBLY
+[id="using-rfhe"]
+= Monitoring Redfish hardware events
+include::_attributes/common-attributes.adoc[]
+:context: using-rfhe
+
+toc::[]
+
+:FeatureName: Redfish hardware events
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+[id="installing-hw-events"]
+== Installing the Baremetal Hardware Event Proxy Operator
+
+Install the Baremetal Hardware Event Proxy Operator using the {product-title} CLI or the web console.
+
+include::modules/nw-rfhe-installing-operator-cli.adoc[leveloffset=+2]
+
+include::modules/nw-rfhe-installing-operator-web-console.adoc[leveloffset=+2]
+
+include::modules/hw-installing-amq-interconnect-messaging-bus.adoc[leveloffset=+1]
+
+[id="subscribing-hw-events"]
+== Subscribing to Redfish BMC hardware events for a cluster node
+
+As a cluster administrator, you can subscribe to Redfish BMC events generated on a node in your cluster by creating a `BMCEventSubscription` custom resource (CR) for the node, creating a `HardwareEvent` CR for the event, and a `Secret` CR for the BMC.
+
+include::modules/nw-rfhe-creating_bmc_event_sub.adoc[leveloffset=+2]
+
+include::modules/nw-rfhe-creating-hardware-event.adoc[leveloffset=+2]
+
+include::modules/cnf-rfhe-notifications-api-refererence.adoc[leveloffset=+1]


### PR DESCRIPTION
Documents HW events Operator install + API reference for https://issues.redhat.com/browse/TELCODOCS-261

Related: 
* RFHE Operator overview: https://github.com/openshift/openshift-docs/pull/41289

Merge to main, enterprise-4.10, 4.11.

Preview: https://deploy-preview-41832--osdocs.netlify.app/openshift-enterprise/latest/monitoring/using-rfhe.html