### PR TITLE
BZ2045022: Remove requirement for 10GB nics on bare-metal IPI. 4.8 and earlier

### DIFF
--- a/modules/ipi-install-node-requirements.adoc
+++ b/modules/ipi-install-node-requirements.adoc
@@ -34,7 +34,7 @@ endif::[]
 
 * *Worker nodes:* While not required, a typical production cluster has one or more worker nodes. Smaller clusters are more resource efficient for administrators and developers during development, production, and testing.
 
-* *Network interfaces:* Each node must have at least one 10GB network interface for the routable `baremetal` network. Each node must have one 10GB network interface for a `provisioning` network when using the `provisioning` network for deployment. Using the `provisioning` network is the default configuration. Network interface names must follow the same naming convention across all nodes. For example, the first NIC name on a node, such as `eth0` or `eno1`, must be the same name on all of the other nodes. The same principle applies to the remaining NICs on each node.
+* *Network interfaces:* Each node must have at least one network interface for the routable `baremetal` network. Each node must have one network interface for a `provisioning` network when using the `provisioning` network for deployment. Using the `provisioning` network is the default configuration. Network interface naming must be consistent across control plane nodes for the provisioning network. For example, if a control plane node uses the `eth0` NIC for the provisioning network, the other control plane nodes must use it as well.
 
 ifeval::[{product-version} > 4.3]
 * *Unified Extensible Firmware Interface (UEFI):* Installer-provisioned installation requires UEFI boot on all {product-title} nodes when using IPv6 addressing on the `provisioning` network. In addition, UEFI Device PXE Settings must be set to use the IPv6 protocol on the `provisioning` network NIC, but omitting the `provisioning` network removes this requirement.


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2045022

Preview: https://deploy-preview-41833--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#node-requirements_ipi-install-prerequisites (scroll to Network Interfaces)

Versions: 4.8, 4.7, 4.6