### PR TITLE
SRVCOM-1288 + SRVCOM-1664: Clean up attributes, prereqs

### DIFF
--- a/modules/knative-serving-CR-system-deployments.adoc
+++ b/modules/knative-serving-CR-system-deployments.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * /serverless/admin_guide/knative-serving-CR-config.adoc
+
+:_content-type: REFERENCE
 [id="knative-serving-CR-system-deployments_{context}"]
 = Overriding system deployment configurations
 

--- a/modules/serverless-activator-metrics.adoc
+++ b/modules/serverless-activator-metrics.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-admin-metrics.adoc
+
+:_content-type: REFERENCE
 [id="serverless-activator-metrics_{context}"]
 = Activator metrics
 

--- a/modules/serverless-admin-monitoring-eventing-channel.adoc
+++ b/modules/serverless-admin-monitoring-eventing-channel.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-admin-monitoring.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-admin-monitoring-eventing-channel_{context}"]
 = Monitoring Knative Eventing channels

--- a/modules/serverless-autoscaler-metrics.adoc
+++ b/modules/serverless-autoscaler-metrics.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-admin-metrics.adoc
+
+:_content-type: REFERENCE
 [id="serverless-autoscaler-metrics_{context}"]
 = Autoscaler metrics
 

--- a/modules/serverless-broker-filter-metrics.adoc
+++ b/modules/serverless-broker-filter-metrics.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-admin-metrics.adoc
+
+:_content-type: REFERENCE
 [id="serverless-broker-filter-metrics_{context}"]
 = Broker filter metrics
 

--- a/modules/serverless-broker-ingress-metrics.adoc
+++ b/modules/serverless-broker-ingress-metrics.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-admin-metrics.adoc
+
+:_content-type: REFERENCE
 [id="serverless-broker-ingress-metrics_{context}"]
 = Broker ingress metrics
 

--- a/modules/serverless-channel-default.adoc
+++ b/modules/serverless-channel-default.adoc
@@ -8,8 +8,7 @@
 
 The `default-ch-webhook` config map can be used to specify the default channel implementation for the cluster or for one or more namespaces.
 
-You can make changes to the `knative-eventing` namespace config maps, including the `default-ch-webhook` config map, by using the {ServerlessOperatorName} to propagate changes.
-To do this, you must modify the `KnativeEventing` custom resource.
+You can make changes to the `knative-eventing` namespace config maps, including the `default-ch-webhook` config map, by using the {ServerlessOperatorName} to propagate changes. To do this, you must modify the `KnativeEventing` custom resource.
 
 .Prerequisites
 

--- a/modules/serverless-config-emptydir.adoc
+++ b/modules/serverless-config-emptydir.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * /serverless/admin_guide/knative-serving-CR-config.adoc
+
+:_content-type: REFERENCE
 [id="serverless-config-emptydir_{context}"]
 = Configuring the EmptyDir extension
 

--- a/modules/serverless-config-replicas-eventing.adoc
+++ b/modules/serverless-config-replicas-eventing.adoc
@@ -1,14 +1,15 @@
-// Module is included in the following assemblies:
+// Module included in the following assemblies:
 //
-// serverless/serverless-ha.adoc
+// * /serverless/admin_guide/serverless-ha.adoc
 
 :_content-type: PROCEDURE
 [id="serverless-config-replicas-eventing_{context}"]
-= Configuring high availability replicas for Eventing
+= Configuring high availability replicas for Knative Eventing
 
 You can scale Knative Eventing components by modifying the `spec.high-availability.replicas` value in the KnativeEventing custom resource.
 
 .Prerequisites
+
 * You have access to an {product-title} cluster with cluster administrator permissions.
 * The {ServerlessOperatorName} and Knative Eventing are installed on your cluster.
 

--- a/modules/serverless-config-replicas-kafka.adoc
+++ b/modules/serverless-config-replicas-kafka.adoc
@@ -1,10 +1,15 @@
+// Module included in the following assemblies:
+//
+// * /serverless/admin_guide/serverless-ha.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-config-replicas-kafka_{context}"]
-= Configuring high availability replicas for Kafka
+= Configuring high availability replicas for Knative Kafka
 
 You can scale Knative Kafka components by modifying the `spec.high-availability.replicas` value in the KnativeKafka custom resource.
 
 .Prerequisites
+
 * You have access to an {product-title} cluster with cluster administrator permissions.
 * The {ServerlessOperatorName} and Knative Kafka are installed on your cluster.
 

--- a/modules/serverless-config-replicas-serving.adoc
+++ b/modules/serverless-config-replicas-serving.adoc
@@ -1,6 +1,10 @@
+// Module included in the following assemblies:
+//
+// * /serverless/admin_guide/serverless-ha.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-config-replicas-serving_{context}"]
-= Configuring high availability replicas for Serving
+= Configuring high availability replicas for Knative Serving
 
 You can scale Knative Serving components by modifying the `spec.high-availability.replicas` value in the KnativeServing custom resource.
 

--- a/modules/serverless-controller-metrics.adoc
+++ b/modules/serverless-controller-metrics.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-admin-metrics.adoc
+
+:_content-type: REFERENCE
 [id="serverless-controller-metrics_{context}"]
 = Controller metrics
 

--- a/modules/serverless-event-source-metrics.adoc
+++ b/modules/serverless-event-source-metrics.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-admin-metrics.adoc
+
+:_content-type: REFERENCE
 [id="serverless-event-source-metrics_{context}"]
 = Event source metrics
 

--- a/modules/serverless-go-metrics.adoc
+++ b/modules/serverless-go-metrics.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-admin-metrics.adoc
+
+:_content-type: REFERENCE
 [id="serverless-go-metrics_{context}"]
 = Go runtime metrics
 

--- a/modules/serverless-https-redirect-global.adoc
+++ b/modules/serverless-https-redirect-global.adoc
@@ -1,7 +1,8 @@
-// Module is included in the following assemblies:
+// Module included in the following assemblies:
 //
-// * serverless/admin_guide/knative-serving-CR-config.adoc
+// * /serverless/admin_guide/knative-serving-CR-config.adoc
 
+:_content-type: REFERENCE
 [id="serverless-https-redirect-global_{context}"]
 = HTTPS redirection global settings
 

--- a/modules/serverless-inmemory-dispatch-metrics.adoc
+++ b/modules/serverless-inmemory-dispatch-metrics.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-admin-metrics.adoc
+
+:_content-type: REFERENCE
 [id="serverless-inmemory-dispatch-metrics_{context}"]
 = InMemoryChannel dispatcher metrics
 

--- a/modules/serverless-install-kafka-odc.adoc
+++ b/modules/serverless-install-kafka-odc.adoc
@@ -44,7 +44,7 @@ The `replicationFactor` value must be less than or equal to the number of nodes 
 
 .Prerequisites
 
-* You have installed {ServerlessProductName}, including Knative Eventing, in your {product-title} cluster.
+* You have installed the {ServerlessOperatorName} and Knative Eventing on your cluster.
 * You have access to a Red Hat AMQ Streams cluster.
 * You have cluster administrator permissions on {product-title}.
 * You are logged in to the {product-title} web console.

--- a/modules/serverless-kafka-broker-sasl-default-config.adoc
+++ b/modules/serverless-kafka-broker-sasl-default-config.adoc
@@ -10,6 +10,7 @@ As a cluster administrator, you can set up _Simple Authentication and Security L
 
 .Prerequisites
 
+* You have cluster administrator permissions on {product-title}.
 * The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR are installed on your {product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 * You have a username and password for a Kafka cluster.

--- a/modules/serverless-kafka-broker-tls-default-config.adoc
+++ b/modules/serverless-kafka-broker-tls-default-config.adoc
@@ -10,6 +10,7 @@ As a cluster administrator, you can set up _Transport Layer Security_ (TLS) auth
 
 .Prerequisites
 
+* You have cluster administrator permissions on {product-title}.
 * The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR are installed on your {product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 * You have a Kafka cluster CA certificate stored as a `.pem` file.

--- a/modules/serverless-ossm-enabling-serving-metrics.adoc
+++ b/modules/serverless-ossm-enabling-serving-metrics.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * /serverless/admin_guide/serverless-ossm-setup.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-ossm-enabling-serving-metrics_{context}"]
 = Enabling Knative Serving metrics when using Service Mesh with mTLS
@@ -6,9 +10,11 @@ If Service Mesh is enabled with mTLS, metrics for Knative Serving are disabled b
 
 .Prerequisites
 
-* You have installed the {ServerlessOperatorName} on your {product-title} cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on your cluster.
 * You have installed {ProductName} with the mTLS functionality enabled.
-* You have installed Knative Serving.
+* You have access to an {product-title} account with cluster administrator access.
+* You have installed the `oc` CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure
 
@@ -24,6 +30,7 @@ spec:
   config:
     observability:
       metrics.backend-destination: "prometheus"
+...
 ----
 +
 This step prevents metrics from being disabled by default.
@@ -44,12 +51,14 @@ spec:
         matchLabels:
           name: "openshift-monitoring"
   podSelector: {}
+...
 ----
 
 . Modify and reapply the default Service Mesh control plane in the `istio-system` namespace, so that it includes the following spec:
 +
 [source,yaml]
 ----
+...
 spec:
   proxy:
     networking:
@@ -57,4 +66,5 @@ spec:
         inbound:
           excludedPorts:
           - 8444
+...
 ----

--- a/modules/serverless-ossm-setup-with-kourier.adoc
+++ b/modules/serverless-ossm-setup-with-kourier.adoc
@@ -1,12 +1,18 @@
+// Module included in the following assemblies:
+//
+// * /serverless/admin_guide/serverless-ossm-setup.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-ossm-setup-with-kourier_{context}"]
 = Integrating {ProductShortName} with {ServerlessProductName} when Kourier is enabled
 
 .Prerequisites
 
-* You have installed the {ServerlessOperatorName} on your {product-title} cluster.
+* You have access to an {product-title} account with cluster administrator access.
+* You have installed the `oc` CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* You have installed the {ServerlessOperatorName} and Knative Serving on your cluster.
 * You have installed {ProductName}. {ServerlessProductName} with {ProductShortName} and Kourier is supported for use with both {ProductName} versions 1.x and 2.x.
-* You have installed Knative Serving.
 
 .Procedure
 
@@ -22,6 +28,7 @@ metadata:
 spec:
   members:
     - <namespace> <1>
+...
 ----
 <1> A list of namespaces to be integrated with {ProductShortName}.
 . Apply the `ServiceMeshMemberRoll` resource:
@@ -30,6 +37,7 @@ spec:
 ----
 $ oc apply -f <filename>
 ----
+
 . Create a network policy that permits traffic flow from Knative system pods to Knative services:
 .. Add the `serving.knative.openshift.io/system-namespace=true` label to the `knative-serving` namespace:
 +
@@ -61,6 +69,7 @@ spec:
   podSelector: {}
   policyTypes:
   - Ingress
+...
 ----
 <1> Add the namespace that you want to integrate with {ProductShortName}.
 .. Apply the `NetworkPolicy` resource:

--- a/modules/serverless-ossm-setup.adoc
+++ b/modules/serverless-ossm-setup.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * /serverless/admin_guide/serverless-ossm-setup.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-ossm-setup_{context}"]
 = Integrating {ProductShortName} with {ServerlessProductName}
@@ -6,17 +10,21 @@ You can integrate {ProductShortName} with {ServerlessProductName} without using 
 
 .Prerequisites
 
-* You have installed the {ServerlessOperatorName} on your {product-title} cluster.
 * You have installed {ProductName}. {ServerlessProductName} with {ProductShortName} only is supported for use with {ProductName} version 2.0.5 or higher.
-
+* You have access to an {product-title} account with cluster administrator access.
+* You have installed the {ServerlessOperatorName}.
++
 [IMPORTANT]
 ====
 Do not install the Knative Serving component before completing the following procedures. There are additional steps required when creating the `KnativeServing` custom resource defintion (CRD) to integrate Knative Serving with {ProductShortName}, which are not covered in the general Knative Serving installation procedure of the _Administration guide_.
 ====
+* You have installed the `oc` CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure
 
 . Create a `ServiceMeshControlPlane` object in the `istio-system` namespace. If you want to use the mTLS functionality, this must be enabled for the `istio-system` namespace.
+
 . Add the namespaces that you would like to integrate with {ProductShortName} to the `ServiceMeshMemberRoll` object as members:
 +
 [source,yaml]

--- a/modules/serverless-webhook-metrics.adoc
+++ b/modules/serverless-webhook-metrics.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-admin-metrics.adoc
+
+:_content-type: REFERENCE
 [id="serverless-webhook-metrics_{context}"]
 = Webhook metrics
 

--- a/modules/serverlesss-ossm-external-certs.adoc
+++ b/modules/serverlesss-ossm-external-certs.adoc
@@ -1,8 +1,19 @@
+// Module included in the following assemblies:
+//
+// * /serverless/admin_guide/serverless-ossm-setup.adoc
+
 :_content-type: PROCEDURE
 [id="serverlesss-ossm-external-certs_{context}"]
 = Creating a certificate to encrypt incoming external traffic
 
 By default, the {ProductShortName} mTLS feature only secures traffic inside of the {ProductShortName} itself, between the ingress gateway and individual pods that have sidecars. To encrypt traffic as it flows into the {product-title} cluster, you must generate a certificate before you enable the {ServerlessProductName} and {ProductShortName} integration.
+
+.Prerequisites
+
+* You have access to an {product-title} account with cluster administrator access.
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have installed the `oc` CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure
 

--- a/serverless/admin_guide/serverless-configuring-eventing-defaults.adoc
+++ b/serverless/admin_guide/serverless-configuring-eventing-defaults.adoc
@@ -1,7 +1,7 @@
-include::modules/serverless-document-attributes.adoc[]
 [id="serverless-configuring-eventing-defaults"]
 = Configuring Knative Eventing defaults
 include::modules/common-attributes.adoc[]
+include::modules/serverless-document-attributes.adoc[]
 :context: serverless-configuring-eventing-defaults
 
 toc::[]

--- a/serverless/admin_guide/serverless-ha.adoc
+++ b/serverless/admin_guide/serverless-ha.adoc
@@ -16,6 +16,7 @@ When using a leader election HA pattern, instances of controllers are already sc
 These controller instances compete to use a shared resource, known as the leader election lock.
 The instance of the controller that has access to the leader election lock resource at any given time is referred to as the leader.
 
+[id="serverless-ha-configuring-replicas"]
 == Configuring high availability replicas on {ServerlessProductName}
 
 High availability (HA) functionality is available by default on {ServerlessProductName} for Knative Serving, Knative Eventing, and Knative Kafka. These are the components scaled for each of them:
@@ -29,7 +30,6 @@ These components are configured with two replicas by default.
 For Knative Eventing, the `mt-broker-filter` and `mt-broker-ingress` deployments are not scaled by HA. If multiple deployments are needed, scale these components manually.
 
 You modify the number of replicas that are created per component by changing the configuration of `spec.high-availability.replicas` in the KnativeServing custom resource (CR), the KnativeEventing CR, or the KnativeKafka CR.
-// This field also specifies the minimum number of _activators_ if you are using the horizontal pod autoscaler (HPA). For more information about HPA, see
 
 include::modules/serverless-config-replicas-serving.adoc[leveloffset=+2]
 include::modules/serverless-config-replicas-eventing.adoc[leveloffset=+2]


### PR DESCRIPTION
Jiras: https://issues.redhat.com/browse/SRVCOM-1288 + https://issues.redhat.com/browse/SRVCOM-1664

Applies for OCP 4.6+

Preview links:
- https://deploy-preview-41839--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-ossm-setup.html#serverless-ossm-enabling-serving-metrics_serverless-ossm-setup
- https://deploy-preview-41839--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-ossm-setup.html#serverless-ossm-setup-with-kourier_serverless-ossm-setup
- https://deploy-preview-41839--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-ossm-setup.html#serverlesss-ossm-external-certs_serverless-ossm-setup
- https://deploy-preview-41839--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-ossm-setup.html#serverless-ossm-setup_serverless-ossm-setup

(not much to see, just adding / updating prereqs)