### PR TITLE
Updates the firewall configuration for Quay OpenShift installation docs

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -122,7 +122,7 @@ CDN hostnames, such as `cdn01.quay.io`, are covered when you add a wildcard entr
 |443, 80
 |Required to access the default cluster routes unless you set an ingress wildcard during installation.
 
-|`quay-registry.s3.amazonaws.com`
+|`quayio-production-s3.s3.amazonaws.com`
 |443, 80
 |Required to access Quay image content in AWS.
 

--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -47,7 +47,7 @@ If you are using a firewall and want to create your cluster using AWS PrivateLin
 |Required. Allows interactions between the cluster and OpenShift Console Manager (OCM) to enable functionality, such as scheduling upgrades.
 |443, 80
 
-|`quay-registry.s3.amazonaws.com`
+|`quayio-production-s3.s3.amazonaws.com`
 |Required. Used to access Quay image content in AWS.
 |443, 80
 |===
@@ -140,7 +140,7 @@ Review the link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS Ser
 |Required. Used to access the default cluster routes unless you set an ingress wildcard during installation.
 |443, 80
 
-|`quay-registry.s3.amazonaws.com`
+|`quayio-production-s3.s3.amazonaws.com`
 |Required. Used to access Quay image content in AWS.
 |443, 80
 


### PR DESCRIPTION
For 4.6+ 

Jira: https://issues.redhat.com/browse/PROJQUAY-1540

Preview: https://deploy-preview-41843--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html#configuring-firewall_configuring-firewall

ROSA: https://deploy-preview-41843--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites

Pending ack.