### PR TITLE
OSDOCS-3275: 4.10 RN RHCOS PXE install using --ignition-ca

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -71,6 +71,8 @@ For more information, see xref:../getting_started/openshift-overview.adoc[Gettin
 
 The `coreos-installer` utility now has `iso customize` and `pxe customize` subcommands for more flexible customization when installing {op-system} on bare metal from the live ISO and PXE images.
 
+This includes the ability to customize the installation to fetch Ignition configs from HTTPS servers that use a custom certificate authority or self-signed certificate.
+
 [id="ocp-4-10-installation-and-upgrade"]
 === Installation and upgrade
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3275

Adds a 4.10 release for RHCOS PXE install. This is the Release Note for the product docs being tracked in https://issues.redhat.com/browse/OSDOCS-3144. Once the feature doc is merged, the link to the --ignition-ca flag could be added to this RN.

Original request: https://github.com/openshift/openshift-docs/issues/37586#issuecomment-1024996962

**Preview link:** https://deploy-preview-41849--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-coreos-installer-customize-ignition-ca