### PR TITLE
Replaced *.quay.io allowlist wildcard with discrete list of subdomains

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -26,19 +26,34 @@ There are no special configuration considerations for services running on only c
 |443, 80
 |Provides core container images
 
-|`*.quay.io`
+|`cdn.quay.io`
 |443, 80
 |Provides core container images
 
-|`*.openshiftapps.com`
+|`cdn01.quay.io`
+|443, 80
+|Provides core container images
+
+|`cdn02.quay.io`
+|443, 80
+|Provides core container images
+
+|`cdn03.quay.io`
+|443, 80
+|Provides core container images
+
+|`sso.redhat.com`
+|443, 80
+|The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`
+
+|`rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com`
 |443, 80
 |Provides {op-system-first} images
 
 |===
 +
+You can use the wildcards `\*.quay.io` and `*.openshiftapps.com` instead of `cdn0[1-3].quay.io` and `rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com` in your allowlist.
 When you add a site, such as `quay.io`, to your allowlist, do not add a wildcard entry, such as `*.quay.io`, to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a hostname such as `cdn01.quay.io`.
-+
-CDN hostnames, such as `cdn01.quay.io`, are covered when you add a wildcard entry, such as `*.quay.io`, in your allowlist.
 
 . Allowlist any site that provides resources for a language or framework that your builds require.
 


### PR DESCRIPTION
RFE: https://issues.redhat.com/browse/RFE-995
Applicable for 4.7+. 

Doc preview: https://deploy-preview-41850--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html#configuring-firewall_configuring-firewall