### PR TITLE
GitHub 41621: adds \ to combine command that is separated on 2 lines  

### DIFF
--- a/modules/go-run-argo-cd-instance-on-infrastructure-nodes.adoc
+++ b/modules/go-run-argo-cd-instance-on-infrastructure-nodes.adoc
@@ -22,7 +22,7 @@ $ oc label node <node-name> node-role.kubernetes.io/infra=""
 +
 [source,terminal]
 ----
-$ oc adm taint nodes -l node-role.kubernetes.io/infra
+$ oc adm taint nodes -l node-role.kubernetes.io/infra \
 infra=reserved:NoSchedule infra=reserved:NoExecute
 ----
 . Add the `runOnInfra` toggle in the `GitOpsService` custom resource:


### PR DESCRIPTION
4.8+

GitHub issue #41621 

[Preview](https://deploy-preview-41852--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations)

Fixes a command that was broken into two lines by adding \ to combine the command into a single line.