### PR TITLE
SRVCOM-1288 + SRVCOM-1664: Clean up attributes, prereqs

### DIFF
--- a/modules/cluster-logging-deploying-about.adoc
+++ b/modules/cluster-logging-deploying-about.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * logging/cluster-logging-deploying-about.adoc
+// * serverless/monitor/cluster-logging-serverless.adoc
 
 :_content-type: CONCEPT
 [id="cluster-logging-deploying-about_{context}"]

--- a/modules/serverless-autoscaling-dashboard-activator-metrics.adoc
+++ b/modules/serverless-autoscaling-dashboard-activator-metrics.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/monitor/serverless-autoscaling-dashboard.adoc
+
+:_content-type: REFERENCE
 [id="serverless-autoscaling-dashboard-activator-metrics_{context}"]
 = Activator metrics
 

--- a/modules/serverless-autoscaling-dashboard-navigating.adoc
+++ b/modules/serverless-autoscaling-dashboard-navigating.adoc
@@ -1,9 +1,20 @@
+// Module included in the following assemblies:
+//
+// * serverless/monitor/serverless-autoscaling-dashboard.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-autoscaling-dashboard-navigating_{context}"]
 = Navigating to the autoscaling dashboard
 
+You can use the following steps to navigate to the autoscaling dashboard in the the {product-title} web console.
+
+.Prerequisites
+
+* You have logged in to the {product-title} web console.
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+
 .Procedure
 
-. In the {product-title} Web UI, go to the *Monitoring -> Dashboards* page.
+. In the *Developer* perspective, navigate to the *Monitoring -> Dashboards* page.
 . In the *Dashboard* field, select the *Knative Serving - Scaling Debugging* dashboard.
 . Use the *Namespace*, *Configuration*, and *Revision* fields to specify the workload you want to examine.

--- a/modules/serverless-autoscaling-dashboard-observed-concurrency.adoc
+++ b/modules/serverless-autoscaling-dashboard-observed-concurrency.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/monitor/serverless-autoscaling-dashboard.adoc
+
+:_content-type: REFERENCE
 [id="serverless-autoscaling-dashboard-observed-concurrency_{context}"]
 = Observed concurrency
 

--- a/modules/serverless-autoscaling-dashboard-observed-rps.adoc
+++ b/modules/serverless-autoscaling-dashboard-observed-rps.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/monitor/serverless-autoscaling-dashboard.adoc
+
+:_content-type: REFERENCE
 [id="serverless-autoscaling-dashboard-observed-rps_{context}"]
 = Requests per second
 

--- a/modules/serverless-autoscaling-dashboard-panic-mode.adoc
+++ b/modules/serverless-autoscaling-dashboard-panic-mode.adoc
@@ -1,6 +1,11 @@
+// Module included in the following assemblies:
+//
+// * serverless/monitor/serverless-autoscaling-dashboard.adoc
+
+:_content-type: REFERENCE
 [id="serverless-autoscaling-dashboard-panic-mode_{context}"]
 = Panic mode
 
-The *Panic Mode* graph shows the timeline of times when the Knative service faces a bursty load, which causes the autoscaler to quickly adapt the Service pod number.
+The *Panic Mode* graph shows the timeline of times when the Knative service faces a bursty load, which causes the autoscaler to quickly adapt the service pod number.
 
 image::serverless-autoscaling-dashboard-panic-mode.png[Panic mode]

--- a/modules/serverless-autoscaling-dashboard-pod-information.adoc
+++ b/modules/serverless-autoscaling-dashboard-pod-information.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/monitor/serverless-autoscaling-dashboard.adoc
+
+:_content-type: REFERENCE
 [id="serverless-autoscaling-dashboard-pod-information_{context}"]
 = Pod information
 

--- a/modules/serverless-autoscaling-dashboard-scrape-time.adoc
+++ b/modules/serverless-autoscaling-dashboard-scrape-time.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/monitor/serverless-autoscaling-dashboard.adoc
+
+:_content-type: REFERENCE
 [id="serverless-autoscaling-dashboard-scrape-time_{context}"]
 = Scrape time
 

--- a/modules/serverless-create-domain-mapping-kn.adoc
+++ b/modules/serverless-create-domain-mapping-kn.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * serverless/security/serverless-custom-domains.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-create-domain-mapping-kn_{context}"]
 = Creating a custom domain mapping by using the Knative CLI

--- a/modules/serverless-create-domain-mapping.adoc
+++ b/modules/serverless-create-domain-mapping.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * serverless/security/serverless-custom-domains.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-create-domain-mapping_{context}"]
 = Creating a custom domain mapping
@@ -7,6 +11,8 @@ To map a custom domain name to a custom resource (CR), you must create a `Domain
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on your cluster.
+* You have installed the `oc` CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 * You have created a Knative service and control a custom domain that you want to map to that service.
 +
 [NOTE]
@@ -65,6 +71,7 @@ spec:
    kind: Route
    apiVersion: serving.knative.dev/v1
 ----
+
 . Apply the `DomainMapping` CR as a YAML file:
 +
 [source,terminal]

--- a/modules/serverless-getting-support.adoc
+++ b/modules/serverless-getting-support.adoc
@@ -1,8 +1,8 @@
-////
-Module included in the following assemblies:
-- /serverless/serverless-release-notes.adoc
-////
+// Module included in the following assemblies:
+//
+// * serverless/serverless-support.adoc
 
+:_content-type: CONCEPT
 [id="serverless-getting-support_{context}"]
 = Getting support
 

--- a/modules/serverless-jaeger-config.adoc
+++ b/modules/serverless-jaeger-config.adoc
@@ -6,13 +6,15 @@
 [id="serverless-jaeger-config_{context}"]
 = Configuring Jaeger for use with {ServerlessProductName}
 
+You can use the following procedure to set up Jaeger for use with {ServerlessProductName}.
+
 .Prerequisites
 
-To configure Jaeger for use with {ServerlessProductName}, you will need:
-
-* Cluster administrator permissions on an {product-title} cluster.
-* A current installation of {ServerlessOperatorName} and Knative Serving.
-* A current installation of the Jaeger Operator.
+* You have access to an {product-title} account with cluster administrator access.
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have installed the Jaeger Operator.
+* You have installed the `oc` CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure
 

--- a/modules/serverless-monitoring-services-configuration-scraping.adoc
+++ b/modules/serverless-monitoring-services-configuration-scraping.adoc
@@ -2,6 +2,7 @@
 //
 // * serverless/monitor/serverless-service-monitoring.adoc
 
+:_content-type: REFERENCE
 [id="serverless-monitoring-services-configuration-scraping_{context}"]
 = Configuration for scraping custom metrics
 

--- a/modules/serverless-monitoring-services-custom-metrics.adoc
+++ b/modules/serverless-monitoring-services-custom-metrics.adoc
@@ -2,6 +2,7 @@
 //
 // * serverless/monitor/serverless-service-monitoring.adoc
 
+:_content-type: REFERENCE
 [id="serverless-monitoring-services-custom-metrics_{context}"]
 = Knative service with custom application metrics
 

--- a/modules/serverless-monitoring-services-default-metrics.adoc
+++ b/modules/serverless-monitoring-services-default-metrics.adoc
@@ -2,6 +2,7 @@
 //
 // * serverless/monitor/serverless-service-monitoring.adoc
 
+:_content-type: REFERENCE
 [id="serverless-monitoring-services-default-metrics_{context}"]
 = Knative service metrics exposed by default
 

--- a/modules/serverless-monitoring-services-examining-metrics-dashboard.adoc
+++ b/modules/serverless-monitoring-services-examining-metrics-dashboard.adoc
@@ -8,6 +8,11 @@
 
 You can examine the metrics using a dedicated dashboard that aggregates queue proxy metrics by namespace.
 
+.Prerequisites
+
+* You have logged in to the {product-title} web console.
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+
 .Procedure
 
 . In the web console, navigate to the *Observe* -> *Metrics* interface.

--- a/modules/serverless-monitoring-services-examining-metrics.adoc
+++ b/modules/serverless-monitoring-services-examining-metrics.adoc
@@ -8,6 +8,11 @@
 
 After you have configured the application to export the metrics and the monitoring stack to scrape them, you can examine the metrics in the web console.
 
+.Prerequisites
+
+* You have logged in to the {product-title} web console.
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+
 .Procedure
 
 . Optional: Run requests against your application that you will be able to see in the metrics:

--- a/modules/serverless-ossm-enable-sidecar-injection-with-kourier.adoc
+++ b/modules/serverless-ossm-enable-sidecar-injection-with-kourier.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * serverless/security/serverless-ossm-with-kourier-jwt.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-ossm-enable-sidecar-injection-with-kourier_{context}"]
 = Enabling sidecar injection for a Knative service
@@ -10,7 +14,12 @@ Adding sidecar injection to pods in system namespaces, such as `knative-serving`
 
 If you require sidecar injection for pods in these namespaces, see the {ServerlessProductName} documentation on _Integrating {ProductShortName} with {ServerlessProductName} natively_.
 ====
-// Add an xref here once it's enabled for modules
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have installed the `oc` CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure
 

--- a/modules/serverless-ossm-v1x-jwt.adoc
+++ b/modules/serverless-ossm-v1x-jwt.adoc
@@ -1,6 +1,18 @@
+// Module included in the following assemblies:
+//
+// * serverless/security/serverless-ossm-with-kourier-jwt.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-ossm-v1x-jwt_{context}"]
 = Using JSON Web Token authentication with {ProductShortName} 1.x and {ServerlessProductName}
+
+You can use the following procedure to enable using JSON Web Token authentication with {ProductShortName} 1.x and {ServerlessProductName}.
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have installed the `oc` CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure
 

--- a/modules/serverless-ossm-v2x-jwt.adoc
+++ b/modules/serverless-ossm-v2x-jwt.adoc
@@ -1,6 +1,18 @@
+// Module included in the following assemblies:
+//
+// * serverless/security/serverless-ossm-with-kourier-jwt.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-ossm-v2x-jwt_{context}"]
 = Using JSON Web Token authentication with {ProductShortName} 2.x and {ServerlessProductName}
+
+You can use the following procedure to enable using JSON Web Token authentication with {ProductShortName} 2.x and {ServerlessProductName}.
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have installed the `oc` CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure
 

--- a/modules/serverless-queue-proxy-metrics.adoc
+++ b/modules/serverless-queue-proxy-metrics.adoc
@@ -2,6 +2,7 @@
 //
 // * serverless/monitor/serverless-serving-metrics.adoc
 
+:_content-type: REFERENCE
 [id="serverless-queue-proxy-metrics_{context}"]
 = Queue proxy metrics
 

--- a/serverless/monitor/serverless-service-monitoring.adoc
+++ b/serverless/monitor/serverless-service-monitoring.adoc
@@ -19,24 +19,23 @@ You can use the {product-title} monitoring stack to record and view health check
 Scraping the metrics does not affect autoscaling of a Knative service, because scraping requests do not go through the activator. Consequently, no scraping takes place if no pods are running.
 ====
 
-.Additional resources
-
-* For more information on {product-title} monitoring stack, see xref:../../monitoring/monitoring-overview.adoc#monitoring-overview[Monitoring overview].
-
-* For information on monitoring the components of Serverless itself, as opposed to Knative services, see xref:../../serverless/admin_guide/serverless-admin-monitoring.adoc#serverless-admin-monitoring[Monitoring serverless components].
-
 include::modules/serverless-monitoring-services-default-metrics.adoc[leveloffset=+1]
 
 include::modules/serverless-monitoring-services-custom-metrics.adoc[leveloffset=+1]
 
 include::modules/serverless-monitoring-services-configuration-scraping.adoc[leveloffset=+1]
 
-.Additional resources
-
-* See also xref:../../monitoring/managing-metrics.adoc#specifying-how-a-service-is-monitored[Enabling monitoring for user-defined projects].
-
-* See also xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Specifying how a service is monitored].
-
 include::modules/serverless-monitoring-services-examining-metrics.adoc[leveloffset=+1]
 
 include::modules/serverless-monitoring-services-examining-metrics-dashboard.adoc[leveloffset=+1]
+
+[id="additional-resources_serverless-service-monitoring"]
+== Additional resources
+
+* For more information on {product-title} monitoring stack, see xref:../../monitoring/monitoring-overview.adoc#monitoring-overview[Monitoring overview].
+
+* For information on monitoring the components of Serverless itself, as opposed to Knative services, see xref:../../serverless/admin_guide/serverless-admin-monitoring.adoc#serverless-admin-monitoring[Monitoring serverless components].
+
+* xref:../../monitoring/managing-metrics.adoc#specifying-how-a-service-is-monitored[Enabling monitoring for user-defined projects]
+
+* xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Specifying how a service is monitored]


### PR DESCRIPTION
Jiras: https://issues.redhat.com/browse/SRVCOM-1288 + https://issues.redhat.com/browse/SRVCOM-1664

Applies for OCP 4.6+

Direct previews:
- https://deploy-preview-41860--osdocs.netlify.app/openshift-enterprise/latest/serverless/monitor/serverless-autoscaling-dashboard.html
- https://deploy-preview-41860--osdocs.netlify.app/openshift-enterprise/latest/serverless/security/serverless-custom-domains.html
- https://deploy-preview-41860--osdocs.netlify.app/openshift-enterprise/latest/serverless/monitor/serverless-tracing.html
- https://deploy-preview-41860--osdocs.netlify.app/openshift-enterprise/latest/serverless/monitor/serverless-service-monitoring.html
- https://deploy-preview-41860--osdocs.netlify.app/openshift-enterprise/latest/serverless/security/serverless-ossm-with-kourier-jwt.html
(not much to see, just updating prereqs, minor clean up)