### PR TITLE
[BZ2047742]: Apply label to MCP

### DIFF
--- a/modules/compliance-apply-remediation-for-customized-mcp.adoc
+++ b/modules/compliance-apply-remediation-for-customized-mcp.adoc
@@ -1,0 +1,67 @@
+:_content-type: PROCEDURE
+[id="complianc-operator-apply-remediation-for-customized-mcp"]
+= Applying remediation when using customized machine config pools
+
+When you create a custom `MachineConfigPool`, add a label to the `MachineConfigPool` so that `machineConfigPoolSelector` present in the `KubeletConfig` can match the label with `MachineConfigPool`.
+
+.Procedure
+
+. List the nodes.
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                                       STATUS  ROLES  AGE    VERSION
+ip-10-0-128-92.us-east-2.compute.internal  Ready   master 5h21m  v1.23.3+d99c04f
+ip-10-0-158-32.us-east-2.compute.internal  Ready   worker 5h17m  v1.23.3+d99c04f
+ip-10-0-166-81.us-east-2.compute.internal  Ready   worker 5h17m  v1.23.3+d99c04f
+ip-10-0-171-170.us-east-2.compute.internal Ready   master 5h21m  v1.23.3+d99c04f
+ip-10-0-197-35.us-east-2.compute.internal  Ready   master 5h22m  v1.23.3+d99c04f
+----
+
+. Add a label to nodes.
++
+[source,terminal]
+----
+$ oc label node ip-10-0-166-81.us-east-2.compute.internal node-role.kubernetes.io/<machine_config_pool_name>=
+----
++
+.Example output
++
+[source,terminal]
+----
+node/ip-10-0-166-81.us-east-2.compute.internal labeled
+----
+
+. Create custom `MachineConfigPool` CR.
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: <machine_config_pool_name>
+  labels:
+    pools.operator.machineconfiguration.openshift.io/<machine_config_pool_name>: '' <1>
+spec:
+  machineConfigSelector:
+  matchExpressions:
+  - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,<machine_config_pool_name>]}
+  nodeSelector:
+  matchLabels:
+    node-role.kubernetes.io/<machine_config_pool_name>: ""
+----
+<1> The `labels` field defines label name to add for Machine config pool(MCP).
+
+. Verify MCP created successfully.
++
+[source,terminal]
+----
+$ oc get mcp -w
+----

--- a/security/compliance_operator/compliance-operator-remediation.adoc
+++ b/security/compliance_operator/compliance-operator-remediation.adoc
@@ -10,6 +10,8 @@ Each `ComplianceCheckResult` represents a result of one compliance rule check. I
 
 include::modules/compliance-review.adoc[leveloffset=+1]
 
+include::modules/compliance-apply-remediation-for-customized-mcp.adoc[leveloffset=+1]
+
 include::modules/compliance-applying.adoc[leveloffset=+1]
 
 include::modules/compliance-manual.adoc[leveloffset=+1]


### PR DESCRIPTION
OCP version: 4.6+
[Preview](https://deploy-preview-41903--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-remediation.html#complianc-operator-apply-remediation-for-customized-mcp)
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2047742)
QE contact: @pdhamdhe - LGTMed
