### PR TITLE
Fixing asciibinder errors and warnings

### DIFF
--- a/monitoring/monitoring-overview.adoc
+++ b/monitoring/monitoring-overview.adoc
@@ -19,6 +19,7 @@ The {product-title} web console provides xref:../monitoring/accessing-third-part
 
 After installing {product-title} {product-version}, cluster administrators can optionally enable monitoring for user-defined projects. By using this feature, cluster administrators, developers, and other users can specify how services and pods are monitored in their own projects.
 As a cluster administrator, you can find answers to common problems such as user metrics unavailability and Prometheus consuming a lot of disk space in xref:../monitoring/troubleshooting-monitoring-issues.adoc#troubleshooting-monitoring-issues[troubleshooting monitoring issues].
+
 // Understanding the monitoring stack
 include::modules/monitoring-understanding-the-monitoring-stack.adoc[leveloffset=+1]
 include::modules/monitoring-default-monitoring-components.adoc[leveloffset=+2]


### PR DESCRIPTION
This applies to `enterprise-4.8` only.

The PR fixes `asciibinder build` errors and warnings relating to the monitoring overview assembly.