### PR TITLE
Fixing asciibinder warning in 4.7 Release Notes

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -3001,7 +3001,7 @@ Space precluded documenting all of the container images for this release in the 
 link:https://access.redhat.com/solutions/6545871[{product-title} 4.7.38 container image list]
 
 [id="ocp-kubernetes-1-20-11-updates"]
-===== Updates from Kubernetes 1.20.11
+==== Updates from Kubernetes 1.20.11
 This update contains changes from Kubernetes 1.20.11. More information can be found in the following changelog: link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#v12011[1.20.11].
 
 [id="ocp-4-7-38-upgrading"]


### PR DESCRIPTION
This applies to `enterprise-4.7` only.

The PR resolves an `asciibinder build` warning in the 4.7 Release Notes.