### PR TITLE
ExternalTrafficPolicy support before 4.10

### DIFF
--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -8,8 +8,13 @@
 The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has the following limitations:
 
 * OVN-Kubernetes does not support setting the external traffic policy or internal traffic policy for a Kubernetes service to `local`.
-The default value, `local`, is set for ExternalTrafficPolicy, however the load is still distributed to available backends until the fix is available (BZ #1903408). The value, `cluster`, is supported for both the parameters.
-This limitation can affect you when you add a service of type `LoadBalancer`, `NodePort`, or add a service with an external IP.
+The default value `cluster` is supported for both parameters. This limitation can affect you when you add a service of type LoadBalancer, NodePort, or add a service with an external IP.
+
+[NOTE]
+====
+Openshift Installer provisioned infrastructure(IPI) on Azure cloud, installer create Loadbalancer service with `ExternalTrafficPolicy` pointing to local, however the load is still distributed to the available backends until the fix is available, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[BZ#1903408].
+====
+
 
 // The foll limitation is also recorded in the installation section.
 * For clusters configured for dual-stack networking, both IPv4 and IPv6 traffic must use the same network interface as the default gateway.

--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -8,7 +8,7 @@
 The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has the following limitations:
 
 * OVN-Kubernetes does not support setting the external traffic policy or internal traffic policy for a Kubernetes service to `local`.
-The default value, `cluster`, is supported for both parameters.
+The default value, `local`, is set for ExternalTrafficPolicy, however the load is still distributed to available backends until the fix is available (BZ #1903408). The value, `cluster`, is supported for both the parameters.
 This limitation can affect you when you add a service of type `LoadBalancer`, `NodePort`, or add a service with an external IP.
 
 // The foll limitation is also recorded in the installation section.

--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -7,8 +7,7 @@
 
 The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has the following limitations:
 
-* OVN-Kubernetes does not support setting the external traffic policy or internal traffic policy for a Kubernetes service to `local`.
-The default value `cluster` is supported for both parameters. This limitation can affect you when you add a service of type LoadBalancer, NodePort, or add a service with an external IP.
+* OVN-Kubernetes does not support setting the external traffic policy or internal traffic policy for a Kubernetes service to `local`. The default value `cluster` is supported for both parameters. This limitation can affect you when you add a service of type LoadBalancer, NodePort, or add a service with an external IP.
 
 [NOTE]
 ====


### PR DESCRIPTION
The clusters are by default set up with ETP=local, but as the patch for local is yet not exist, we still balance the traffic even with ETP set to local. 
Post the patch release (4.10), we will support local. 

spec:
  clusterIP: 172.30.64.132
  externalTrafficPolicy: Local
  healthCheckNodePort: 32424