### PR TITLE
BZ#2051835 - adding clarification for DHCP infinite lease - OCP 4.7 docs

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -81,6 +81,12 @@ ifeval::[{product-version} > 4.6]
 ====
 Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To use static IP addresses in the {product-title} cluster, reserve the IP addresses with an infinite lease. During deployment, the installer will reconfigure the NICs from DHCP assigned addresses to static IP addresses. NICs with DHCP leases that are not infinite will remain configured to use DHCP.
 ====
+
+[IMPORTANT]
+.Ensuring that your DHCP server can provide infinite leases
+====
+Your DHCP server must provide a DHCP expiration time of 4294967295 seconds to properly set an infinite lease as specified by link:https://datatracker.ietf.org/doc/html/rfc2131[rfc2131]. If a lesser value is returned for the DHCP infinite lease time, the node reports an error and a static IP is not set for the node. In RHEL 8, `dhcpd` does not provides infinite leases. If you want to use the provisioner node to serve dynamic IP addresses with infinite lease times, use `dnsmasq` rather than `dhcpd`.
+====
 endif::[]
 
 The following table provides an exemplary embodiment of fully qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The hostnames of the control plane and worker nodes are exemplary, so you can use any host naming convention you prefer.


### PR DESCRIPTION
manual PR for failed cherrypick to 4.7 for https://github.com/openshift/openshift-docs/pull/41781