### PR TITLE
Fix build warning caused by OSP legacy cert scan module

### DIFF
--- a/modules/security-osp-validating-certificates.adoc
+++ b/modules/security-osp-validating-certificates.adoc
@@ -26,7 +26,7 @@ Beginning with {product-title} 4.10, HTTPS certificates must contain subject alt
 
 . Save the following script to your machine: 
 +
-[%collapsible%]
+[%collapsible]
 ====
 [source,bash]
 ----


### PR DESCRIPTION
This commit removes an extraneous percent sign from the
'collapsible' block in the module.