### PR TITLE
paragraph re-phrase

### DIFF
--- a/monitoring/monitoring-overview.adoc
+++ b/monitoring/monitoring-overview.adoc
@@ -13,11 +13,9 @@ toc::[]
 
 A cluster administrator can xref:../monitoring/configuring-the-monitoring-stack.adoc#configuring-the-monitoring-stack[configure the monitoring stack] with the supported configurations. {product-title} delivers monitoring best practices out of the box.
 
-A set of alerts are included by default that immediately notify cluster administrators about issues with a cluster. Default dashboards in the {product-title} web console include visual representations of cluster metrics to help you to quickly understand the state of your cluster.
+A set of alerts are included by default that immediately notify cluster administrators about issues with a cluster. Default dashboards in the {product-title} web console include visual representations of cluster metrics to help you to quickly understand the state of your cluster. With the {product-title} web console, you can xref:../monitoring/managing-metrics.adoc#managing-metrics[view and manage metrics], xref:../monitoring/managing-alerts.adoc#managing-alerts[alerts], and xref:../monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards[review monitoring dashboards]. 
 
-The {product-title} web console provides xref:../monitoring/accessing-third-party-uis.adoc#accessing-third-party-uis[third-party integrated UIs] such as xref:../monitoring/managing-metrics.adoc#managing-metrics[metrics], xref:../monitoring/managing-alerts.adoc#managing-alerts[alerts], and xref:../monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards[review of monitoring dashboards]. You can access these third-party user interfaces (UIs) either through the web console or the CLI.
-
-After installing {product-title} {product-version}, cluster administrators can optionally enable monitoring for user-defined projects. By using this feature, cluster administrators, developers, and other users can specify how services and pods are monitored in their own projects. 
+After installing {product-title} {product-version}, cluster administrators can optionally enable monitoring for user-defined projects. By using this feature, cluster administrators, developers, and other users can specify how services and pods are monitored in their own projects.
 As a cluster administrator, you can find answers to common problems such as user metrics unavailability and Prometheus consuming a lot of disk space in xref:../monitoring/troubleshooting-monitoring-issues.adoc#troubleshooting-monitoring-issues[troubleshooting monitoring issues].
 
 // Understanding the monitoring stack


### PR DESCRIPTION
- Applies to 4.10versions and above. 
- [Preview](https://deploy-preview-41921--osdocs.netlify.app/openshift-enterprise/latest/monitoring/monitoring-overview.html)

[4.9and below Preview ](https://github.com/openshift/openshift-docs/pull/41930)
**NOTE**
The overview page mentions third-party UIs in 4.10 , since we are not supporting anymore, have removed the mention of third-party UIs. 

**For 4.9 and below versions:**
Rephrase of existing content based on a discussion with Paul. We want to encourage users to use our web console.

`The OpenShift Container Platform web console provides third-party integrated UI such as metrics, alerts, and review of monitoring dashboards.You can access these third-party user interfaces (UIs) either through the web console or the CLI.`
TO
`With the OpenShift Container Platform web console, you can view and manage metrics, alerts, and review monitoring dashboards. OpenShift Container Platform also provides access to third-party interfaces, such as Prometheus, Alertmanager, and Grafana. `

