### PR TITLE
Adding the content type to the two autogenerated CLI files

### DIFF
--- a/modules/oc-adm-by-example-content.adoc
+++ b/modules/oc-adm-by-example-content.adoc
@@ -2,6 +2,7 @@
 // This template is for admin ('oc adm ...') commands
 // Uses 'source,bash' for proper syntax highlighting for comments in examples
 
+:_content-type: REFERENCE
 [id="openshift-cli-admin_{context}"]
 = OpenShift CLI (oc) administrator commands
 

--- a/modules/oc-by-example-content.adoc
+++ b/modules/oc-by-example-content.adoc
@@ -2,6 +2,7 @@
 // This template is for non-admin (not 'oc adm ...') commands
 // Uses 'source,bash' for proper syntax highlighting for comments in examples
 
+:_content-type: REFERENCE
 [id="openshift-cli-developer_{context}"]
 = OpenShift CLI (oc) developer commands
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2906

No new CLI updates to pull in after code freeze, but just adding in the content types to the generated files.

Nothing visible to verify in the preview, other than making sure I didn't typo/accidentally make something appear visibly:
* https://deploy-preview-41924--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/developer-cli-commands.html
* https://deploy-preview-41924--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/administrator-cli-commands.html