### PR TITLE
Github-41810: fixes typo in adding infrastructure node

### DIFF
--- a/modules/go-add-infra-nodes.adoc
+++ b/modules/go-add-infra-nodes.adoc
@@ -12,7 +12,7 @@
 +
 [source,terminal]
 ----
-$ oc label node <node-name> node-role.kubernetes.io/infra
+$ oc label node <node-name> node-role.kubernetes.io/infra=
 ----
 . Edit the `GitOpsService` Custom Resource (CR) to add the infrastructure node selector:
 +
@@ -31,11 +31,11 @@ metadata:
 spec:
   runOnInfra: true
 ----
-. Optional: Apply taints and isolate the workloads on infrastructure nodes and prevent other workloads from scheduling on these nodes. 
+. Optional: Apply taints and isolate the workloads on infrastructure nodes and prevent other workloads from scheduling on these nodes.
 +
 [source,terminal]
 ----
-$ oc adm taint nodes -l node-role.kubernetes.io/infra 
+$ oc adm taint nodes -l node-role.kubernetes.io/infra
 infra=reserved:NoSchedule infra=reserved:NoExecute
 ----
 +
@@ -51,7 +51,7 @@ spec:
     value: reserved
   - effect: NoExecute
     key: infra
-    value: reserved 
+    value: reserved
 ----
 
 To verify that the workloads are scheduled on infrastructure nodes in the {gitops-title} namespace, click any of the pod names and ensure that the *Node selector* and *Tolerations* have been added.


### PR DESCRIPTION
4.8+

GitHub issue #41810 

[Preview](https://deploy-preview-41928--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/run-gitops-control-plane-workload-on-infra-nodes.html)

Fixes typo in command that returned an error message

PTAL: @lwan-wanglin and/or @jianping-shu for QE ack. Thank you.
