### PR TITLE
TELCODOCS:485 - Bare-metal support on AWS - tech-preview

### DIFF
--- a/modules/sandboxed-containers-preparing-openshift-cluster.adoc
+++ b/modules/sandboxed-containers-preparing-openshift-cluster.adoc
@@ -8,13 +8,23 @@
 
 Before you install {sandboxed-containers-first}, ensure that your {product-title} cluster meets the following requirements:
 
-* Your cluster must be installed on bare-metal infrastructure, on premise with {op-system-first} workers.
+* Your cluster must be installed on on-premise bare-metal infrastructure with {op-system-first} workers. You can use any installation method including user-provisioned, installer-provisioned, or assisted installer to deploy your cluster.
 +
-[IMPORTANT]
+[NOTE]
 ====
-* {sandboxed-containers-first} only supports {op-system} worker nodes. RHEL 7 or RHEL  8 nodes are not supported.
+* {sandboxed-containers-first} only supports {op-system} worker nodes. RHEL 7 or RHEL 8 nodes are not supported.
 * Nested virtualization is not supported.
 ====
+
+* You can install {sandboxed-containers-first} on Amazon Web Services (AWS) bare-metal instances. Bare-metal instances offered by other cloud providers are not supported.
++
+--
+ifdef::openshift-enterprise[]
+:FeatureName: Installing OpenShift sandboxed containers on AWS bare-metal instances
+include::snippets/technology-preview.adoc[leveloffset=+2]
+endif::[]
+--
+
 
 [id="sandboxed-containers-resource-requirements_{context}"]
 == Resource requirements for {sandboxed-containers-first}

--- a/sandboxed_containers/understanding-sandboxed-containers.adoc
+++ b/sandboxed_containers/understanding-sandboxed-containers.adoc
@@ -21,9 +21,16 @@ toc::[]
 
 You can use the {sandboxed-containers-operator} to perform tasks such as installation and removal, updates, and status monitoring.
 
-Sandboxed containers are only supported on bare metal.
+You can install {sandboxed-containers-first} on Amazon Web Services (AWS) bare-metal instances. Bare-metal instances offered by other cloud providers are not supported.
 
-{op-system-first} is the only supported operating system for {sandboxed-containers-first} 1.0.0.
+--
+ifdef::openshift-enterprise[]
+:FeatureName: Installing OpenShift sandboxed containers on AWS bare metal instances
+include::snippets/technology-preview.adoc[leveloffset=+2]
+endif::[]
+--
+
+{op-system-first} is the only supported operating system for {sandboxed-containers-first} {sandboxed-containers-version}.
 
 include::modules/sandboxed-containers-common-terms.adoc[leveloffset=+1]
 include::modules/sandboxed-containers-building-blocks.adoc[leveloffset=+1]


### PR DESCRIPTION
Update for 4.10: [TELCODOCS-485](https://issues.redhat.com/browse/TELCODOCS-485).

Preview link: https://deploy-preview-41933--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html#sandboxed-containers-prerequisites_deploying-sandboxed-containers

Acked by QE and PM.