### PR TITLE
SRVCOM-1288 + SRVCOM-1664: Clean up attributes, prereqs

### DIFF
--- a/modules/serverless-build-func-kn.adoc
+++ b/modules/serverless-build-func-kn.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-getting-started.adoc
+
+:_content-type: REFERENCE
 [id="serverless-build-func-kn_{context}"]
 = Building functions
 

--- a/modules/serverless-create-func-kn.adoc
+++ b/modules/serverless-create-func-kn.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-getting-started.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-create-func-kn_{context}"]
 = Creating functions
@@ -5,6 +9,11 @@
 You can create a basic serverless function using the `kn` CLI.
 
 You can specify the path, runtime, template, and repository with the template as flags on the command line, or use the `-c` flag to start the interactive experience in the terminal.
+
+.Prerequisites
+
+* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the `kn` CLI.
 
 .Procedure
 

--- a/modules/serverless-deploy-func-kn.adoc
+++ b/modules/serverless-deploy-func-kn.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-getting-started.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-deploy-func-kn_{context}"]
 = Deploying functions
@@ -8,7 +12,10 @@ If the targeted function is already deployed, it is updated with a new container
 
 .Prerequisites
 
-* You must have already initialized the function that you want to deploy.
+* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the `kn` CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* You must have already created and initialized the function that you want to deploy.
 
 .Procedure
 

--- a/modules/serverless-functions-podman.adoc
+++ b/modules/serverless-functions-podman.adoc
@@ -2,6 +2,7 @@
 //
 // * serverless/serverless-functions-setup.adoc
 
+:_content-type: PROCEDURE
 [id="serverless-functions-podman_{context}"]
 = Using podman
 

--- a/modules/serverless-functions-quarkus-return-value-types.adoc
+++ b/modules/serverless-functions-quarkus-return-value-types.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-quarkus-functions.adoc
+// * serverless/functions/serverless-developing-quarkus-functions.adoc
 
+:_content-type: REFERENCE
 [id="serverless-functions-quarkus-return-value-types_{context}"]
 = Permitted types
 

--- a/modules/serverless-functions-using-integrated-registry.adoc
+++ b/modules/serverless-functions-using-integrated-registry.adoc
@@ -1,12 +1,19 @@
 // Module included in the following assemblies:
 //
-// * serverless/serverless-functions-setup.adoc
+// * serverless/functions/serverless-functions-getting-started.adoc
 
 :_content-type: PROCEDURE
 [id="serverless-functions-using-integrated-registry_{context}"]
 = Building and deploying functions with OpenShift Container Registry
 
 When building and deploying functions, the resulting container image is stored in an image registry. Usually this will be a public registry, such as Quay. However, you can use the integrated OpenShift Container Registry instead if it has been exposed by a cluster administrator.
+
+.Prerequisites
+
+* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* OpenShift Container Registry has been exposed by a cluster administrator.
+* You have installed the `kn` CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure
 

--- a/modules/serverless-go-function-return-values.adoc
+++ b/modules/serverless-go-function-return-values.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-go-functions.adoc
+// * serverless/functions/serverless-developing-go-functions.adoc
 
+:_content-type: REFERENCE
 [id="serverless-go-function-return-values_{context}"]
 = Golang function return values
 

--- a/modules/serverless-go-template.adoc
+++ b/modules/serverless-go-template.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-go-functions.adoc
+// * serverless/functions/serverless-developing-go-functions.adoc
 
+:_content-type: REFERENCE
 [id="serverless-go-template_{context}"]
 = Golang function template structure
 

--- a/modules/serverless-invoking-go-functions-cloudevent.adoc
+++ b/modules/serverless-invoking-go-functions-cloudevent.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies
+//
+// * serverless/functions/serverless-developing-go-functions.adoc
+
+:_content-type: REFERENCE
 [id="serverless-invoking-go-functions-cloudevent_{context}"]
 = Functions triggered by a cloud event
 

--- a/modules/serverless-invoking-go-functions-http.adoc
+++ b/modules/serverless-invoking-go-functions-http.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies
+//
+// * serverless/functions/serverless-developing-go-functions.adoc
+
+:_content-type: REFERENCE
 [id="serverless-invoking-go-functions-http_{context}"]
 = Functions triggered by an HTTP request
 

--- a/modules/serverless-invoking-python-functions.adoc
+++ b/modules/serverless-invoking-python-functions.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies
+//
+// * serverless/functions/serverless-developing-python-functions.adoc
+
 :_content-type: CONCEPT
 [id="serverless-invoking-python-functions_{context}"]
 = About invoking Python functions

--- a/modules/serverless-invoking-quarkus-functions.adoc
+++ b/modules/serverless-invoking-quarkus-functions.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-quarkus-functions.adoc
+// * serverless/functions/serverless-developing-quarkus-functions.adoc
 
 :_content-type: CONCEPT
 [id="serverless-invoking-quarkus-functions_{context}"]

--- a/modules/serverless-kafka-sasl-public-certs.adoc
+++ b/modules/serverless-kafka-sasl-public-certs.adoc
@@ -1,7 +1,8 @@
-// Module is included in the following assemblies:
+// Module included in the following assemblies:
 //
-// * serverless/knative_eventing/serverless-kafka.adoc
+// * serverless/security/serverless-kafka-security.adoc
 
+:_content-type: REFERENCE
 [id="serverless-kafka-sasl-public-certs_{context}"]
 = Configuring SASL authentication using public CA certificates
 
@@ -15,7 +16,3 @@ $ oc create secret --namespace <namespace> generic <kafka_auth_secret> \
   --from-literal=saslType="SCRAM-SHA-512" \
   --from-literal=user="my-sasl-user"
 ----
-
-.Additional resources
-
-* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka]

--- a/modules/serverless-kafka-sasl.adoc
+++ b/modules/serverless-kafka-sasl.adoc
@@ -1,15 +1,17 @@
-// Module is included in the following assemblies:
+// Module included in the following assemblies:
 //
-// * serverless/knative_eventing/serverless-kafka.adoc
+// * serverless/security/serverless-kafka-security.adoc
 
 :_content-type: PROCEDURE
 [id="serverless-kafka-sasl_{context}"]
 = Configuring SASL authentication
 
+You can use the following procedure to configure SASL authentication for a Kafka channel.
+
 .Prerequisites
 
-* A username and password for the Kafka cluster.
-* Choose the SASL mechanism to use, for example `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
+* You have a username and password for the Kafka cluster.
+* You have chosen the SASL mechanism to use, for example `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
 * If TLS is enabled, you also need the `ca.crt` certificate file for the Kafka cluster.
 
 [NOTE]
@@ -84,7 +86,3 @@ spec:
   source:
     enabled: true
 ----
-
-.Additional resources
-
-* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka]

--- a/modules/serverless-kafka-tls.adoc
+++ b/modules/serverless-kafka-tls.adoc
@@ -1,15 +1,17 @@
-// Module is included in the following assemblies:
+// Module included in the following assemblies:
 //
-// serverless/knative_eventing/serverless-kafka.adoc
+// * serverless/security/serverless-kafka-security.adoc
 
 :_content-type: PROCEDURE
 [id="serverless-configuring-tls-authentication-against-an-apache-kafka_{context}"]
 = Configuring TLS authentication
 
+You can use the following procedure to configure TLS authentication for a Kafka channel.
+
 .Prerequisites
 
-* A Kafka cluster CA certificate as a `.pem` file.
-* A Kafka cluster client certificate and key as `.pem` files.
+* You have a Kafka cluster CA certificate stored as a `.pem` file.
+* You have a Kafka cluster client certificate and a key stored as `.pem` files.
 
 .Procedure
 
@@ -77,7 +79,3 @@ spec:
   source:
     enabled: true
 ----
-
-.Additional resources
-
-* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka]

--- a/modules/serverless-kn-func-emit-reference.adoc
+++ b/modules/serverless-kn-func-emit-reference.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-getting-started.adoc
+
+:_content-type: REFERENCE
 [id="serverless-kn-func-emit-reference_{context}"]
 = kn func emit optional parameters
 

--- a/modules/serverless-kn-func-emit.adoc
+++ b/modules/serverless-kn-func-emit.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-getting-started.adoc
+
+:_content-type: REFERENCE
 [id="serverless-kn-func-emit_{context}"]
 = Emitting a test event to a deployed function
 

--- a/modules/serverless-nodejs-function-return-values.adoc
+++ b/modules/serverless-nodejs-function-return-values.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-nodejs-functions.adoc
+// * serverless/functions/serverless-developing-nodejs-functions.adoc
 
+:_content-type: REFERENCE
 [id="serverless-nodejs-function-return-values_{context}"]
 = Node.js function return values
 

--- a/modules/serverless-nodejs-functions-context-objects.adoc
+++ b/modules/serverless-nodejs-functions-context-objects.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-nodejs-functions.adoc
+// * serverless/functions/serverless-developing-nodejs-functions.adoc
 
+:_content-type: REFERENCE
 [id="serverless-nodejs-functions-context-objects_{context}"]
 = Node.js context objects
 

--- a/modules/serverless-nodejs-template.adoc
+++ b/modules/serverless-nodejs-template.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-nodejs-functions.adoc
+// * serverless/functions/serverless-developing-nodejs-functions.adoc
 
+:_content-type: REFERENCE
 [id="serverless-nodejs-template_{context}"]
 = Node.js function template structure
 

--- a/modules/serverless-python-function-return-values.adoc
+++ b/modules/serverless-python-function-return-values.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-python-functions.adoc
+// * serverless/functions/serverless-developing-python-functions.adoc
 
+:_content-type: REFERENCE
 [id="serverless-python-function-return-values_{context}"]
 = Python function return values
 

--- a/modules/serverless-python-template.adoc
+++ b/modules/serverless-python-template.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-python-functions.adoc
+// * serverless/functions/serverless-developing-python-functions.adoc
 
+:_content-type: REFERENCE
 [id="serverless-python-template_{context}"]
 = Python function template structure
 

--- a/modules/serverless-quarkus-cloudevent-attributes.adoc
+++ b/modules/serverless-quarkus-cloudevent-attributes.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-quarkus-functions.adoc
+// * serverless/functions/serverless-developing-quarkus-functions.adoc
 
+:_content-type: CONCEPT
 [id="serverless-quarkus-cloudevent-attributes_{context}"]
 = CloudEvent attributes
 

--- a/modules/serverless-quarkus-function-return-values.adoc
+++ b/modules/serverless-quarkus-function-return-values.adoc
@@ -1,18 +1,21 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-quarkus-functions.adoc
+// * serverless/functions/serverless-developing-quarkus-functions.adoc
 
+:_content-type: CONCEPT
 [id="serverless-quarkus-function-return-values_{context}"]
 = Quarkus function return values
 
 Functions can return an instance of:
 
 * Any type from the list of permitted types.
+
 * The `Uni<T>` type, where the `<T>` type parameter can be of any type from the permitted types.
 
 The `Uni<T>` type is useful if a function calls asynchronous APIs, because the returned object is serialized in the same format as the received object. For example:
 
 * If a function receives an HTTP request, then the returned object is sent in the body of an HTTP response.
+
 * If a function receives a `CloudEvent` object in binary encoding, then the returned object is sent in the data property of a binary-encoded `CloudEvent` object.
 
 The following example shows a function that fetches a list of purchases:
@@ -29,4 +32,5 @@ public class Functions {
 ----
 
 * Invoking this function through an HTTP request produces an HTTP response that contains a list of purchases in the body of the response.
+
 * Invoking this function through an incoming `CloudEvent` object produces a `CloudEvent` response with a list of purchases in the `data` property.

--- a/modules/serverless-quarkus-template.adoc
+++ b/modules/serverless-quarkus-template.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-quarkus-functions.adoc
+// * serverless/functions/serverless-developing-quarkus-functions.adoc
 
+:_content-type: REFERENCE
 [id="serverless-quarkus-template_{context}"]
 = Quarkus function template structure
 

--- a/modules/serverless-testing-go-functions.adoc
+++ b/modules/serverless-testing-go-functions.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-go-functions.adoc
+// * serverless/functions/serverless-developing-typescript-functions.adoc
 
 :_content-type: PROCEDURE
 [id="serverless-testing-go-functions_{context}"]
@@ -8,9 +8,17 @@
 
 Golang functions can be tested locally on your computer. In the default project that is created when you create a function using `kn func create`, there is a `handle_test.go` file which contains some basic tests. These tests can be extended as needed.
 
+.Prerequisites
+
+* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the `kn` CLI.
+* You have created a function by using `kn func create`.
+
 .Procedure
 
-* Run the tests:
+. Navigate to the *test* folder for your function.
+
+. Run the tests:
 +
 [source,terminal]
 ----

--- a/modules/serverless-testing-nodejs-functions.adoc
+++ b/modules/serverless-testing-nodejs-functions.adoc
@@ -6,11 +6,18 @@
 [id="serverless-testing-nodejs-functions_{context}"]
 = Testing Node.js functions
 
-Node.js functions can be tested locally on your computer. In the default project that is created when you create a function using `kn func create`, there is a *test* folder that contains some simple unit and integration tests.
+Node.js functions can be tested locally on your computer. In the default project that is created when you create a function by using `kn func create`, there is a *test* folder that contains some simple unit and integration tests.
+
+.Prerequisites
+
+* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the `kn` CLI.
+* You have created a function by using `kn func create`.
 
 .Procedure
 
-* Run the tests:
+. Navigate to the *test* folder for your function.
+. Run the tests:
 +
 [source,terminal]
 ----

--- a/modules/serverless-testing-python-functions.adoc
+++ b/modules/serverless-testing-python-functions.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-python-functions.adoc
+// * serverless/functions/serverless-developing-python-functions.adoc
 
 :_content-type: PROCEDURE
 [id="serverless-testing-python-functions_{context}"]
@@ -24,7 +24,9 @@ $ pip install -r requirements.txt
 
 .Procedure
 
-* After you have installed the dependencies, run the tests:
+. Navigate to the folder for your function that contains the `test_func.py` file.
+
+. Run the tests:
 +
 [source,terminal]
 ----

--- a/modules/serverless-testing-quarkus-functions.adoc
+++ b/modules/serverless-testing-quarkus-functions.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies
 //
-// * /serverless/functions/serverless-developing-quarkus-functions.adoc
+// * serverless/functions/serverless-developing-quarkus-functions.adoc
 
 :_content-type: PROCEDURE
 [id="serverless-testing-quarkus-functions_{context}"]
@@ -8,9 +8,15 @@
 
 You can test Quarkus functions locally on your computer by running the Maven tests that are included in the project template.
 
+.Prerequisites
+
+* You have created a Quarkus function.
+
 .Procedure
 
-* Run the Maven tests:
+. Navigate to the project folder for your function.
+
+. Run the Maven tests:
 +
 [source,terminal]
 ----

--- a/modules/serverless-testing-typescript-functions.adoc
+++ b/modules/serverless-testing-typescript-functions.adoc
@@ -1,8 +1,18 @@
+// Module included in the following assemblies
+//
+// * serverless/functions/serverless-developing-typescript-functions.adoc
+
 :_content-type: PROCEDURE
 [id="serverless-testing-typescript-functions_{context}"]
 = Testing TypeScript functions
 
 TypeScript functions can be tested locally on your computer. In the default project that is created when you create a function using `kn func create`, there is a *test* folder that contains some simple unit and integration tests.
+
+.Prerequisites
+
+* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the `kn` CLI.
+* You have created a function by using `kn func create`.
 
 .Procedure
 
@@ -12,6 +22,8 @@ TypeScript functions can be tested locally on your computer. In the default proj
 ----
 $ npm install
 ----
+
+. Navigate to the *test* folder for your function.
 
 . Run the tests:
 +

--- a/modules/serverless-typescript-function-return-values.adoc
+++ b/modules/serverless-typescript-function-return-values.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies
+//
+// * serverless/functions/serverless-developing-typescript-functions.adoc
+
+:_content-type: REFERENCE
 [id="serverless-typescript-function-return-values_{context}"]
 = TypeScript function return values
 

--- a/modules/serverless-typescript-functions-context-objects.adoc
+++ b/modules/serverless-typescript-functions-context-objects.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies
+//
+// * serverless/functions/serverless-developing-typescript-functions.adoc
+
+:_content-type: REFERENCE
 [id="serverless-typescript-functions-context-objects_{context}"]
 = TypeScript context objects
 

--- a/modules/serverless-typescript-template.adoc
+++ b/modules/serverless-typescript-template.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies
+//
+// * serverless/functions/serverless-developing-typescript-functions.adoc
+
+:_content-type: REFERENCE
 [id="serverless-typescript-template_{context}"]
 = TypeScript function template structure
 

--- a/serverless/functions/serverless-functions-getting-started.adoc
+++ b/serverless/functions/serverless-functions-getting-started.adoc
@@ -20,13 +20,12 @@ Before you can complete the following procedures, you must ensure that you have 
 include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]
+include::modules/serverless-kn-func-emit.adoc[leveloffset=+1]
 include::modules/serverless-functions-using-integrated-registry.adoc[leveloffset=+1]
 
 == Additional resources
 
 * See xref:../../registry/securing-exposing-registry.adoc#securing-exposing-registry[Exposing a default registry manually].
-
-include::modules/serverless-kn-func-emit.adoc[leveloffset=+1]
 
 [id="next-steps_serverless-functions-getting-started"]
 == Next steps

--- a/serverless/functions/serverless-functions-setup.adoc
+++ b/serverless/functions/serverless-functions-setup.adoc
@@ -17,11 +17,21 @@ Before you can develop functions on {ServerlessProductName}, you must complete t
 
 To enable the use of {FunctionsProductName} on your cluster, you must complete the following steps:
 
-* {ServerlessProductName} is installed on your cluster.
+* The {ServerlessOperatorName} and Knative Serving are installed on your cluster.
++
+[NOTE]
+====
+Functions are deployed as a Knative service. If you want to use event-driven architecture with your functions, you must also install Knative Eventing.
+====
+
 * The xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[`oc` CLI] is installed on your cluster.
+
 * The xref:../../serverless/cli_tools/installing-kn.adoc#installing-kn[Knative (`kn`) CLI] is installed on your cluster. Installing the `kn` CLI enables the use of `kn func` commands which you can use to create and manage functions.
+
 * You have installed Docker Container Engine or podman version 3.3 or higher, and have access to an available image registry.
+
 * If you are using link:https://quay.io/[Quay.io] as the image registry, you must ensure that either the repository is not private, or that you have followed the {product-title} documentation on xref:../../openshift_images/managing_images/using-image-pull-secrets.adoc#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets[Allowing pods to reference images from other secured registries].
+
 * If you are using the OpenShift Container Registry, a cluster administrator must xref:../../registry/securing-exposing-registry.adoc#securing-exposing-registry[expose the registry].
 
 include::modules/serverless-functions-podman.adoc[leveloffset=+1]
@@ -30,4 +40,5 @@ include::modules/serverless-functions-podman.adoc[leveloffset=+1]
 == Next steps
 
 * For more information about Docker Container Engine or podman, see xref:../../architecture/understanding-development.adoc#container-build-tool-options[Container build tool options].
+
 * See xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-functions-getting-started[Getting started with functions].

--- a/serverless/security/serverless-kafka-security.adoc
+++ b/serverless/security/serverless-kafka-security.adoc
@@ -17,3 +17,8 @@ If you choose to enable SASL, Red Hat recommends to also enable TLS.
 include::modules/serverless-kafka-tls.adoc[leveloffset=+1]
 include::modules/serverless-kafka-sasl.adoc[leveloffset=+1]
 include::modules/serverless-kafka-sasl-public-certs.adoc[leveloffset=+1]
+
+[id="additional-resources_serverless-kafka-security"]
+== Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka]


### PR DESCRIPTION
Jiras: https://issues.redhat.com/browse/SRVCOM-1288 + https://issues.redhat.com/browse/SRVCOM-1664

Applies for OCP 4.6+

Direct previews:
- https://deploy-preview-41939--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-getting-started.html
- https://deploy-preview-41939--osdocs.netlify.app/openshift-enterprise/latest/serverless/security/serverless-kafka-security.html
- https://deploy-preview-41939--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-developing-typescript-functions.html#serverless-testing-typescript-functions_serverless-developing-typescript-functions
- https://deploy-preview-41939--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-developing-nodejs-functions.html#serverless-testing-nodejs-functions_serverless-developing-nodejs-functions
- https://deploy-preview-41939--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-developing-python-functions.html#serverless-testing-python-functions_serverless-developing-python-functions
- https://deploy-preview-41939--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-developing-quarkus-functions.html#serverless-testing-quarkus-functions_serverless-developing-quarkus-functions
- https://deploy-preview-41939--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-setup.html

**(not much to see, mostly just updating prereqs)**