### PR TITLE
Release notes for oc adm prune deployments --replica-sets flag

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -341,6 +341,13 @@ The Special Resource Operator (SRO) now exposes metrics to help you watch the he
 [id="ocp-4-10-dev-exp"]
 === Developer experience
 
+[id="ocp-4-10-dev-exp-prune-deployments"]
+==== Pruning deployment replica sets (Technology Preview)
+
+This release introduces a Technology Preview flag `--replica-sets` to the `oc adm prune deployments` command. By default, only replication controllers are pruned with the `oc adm prune deployments` command. When you set `--replica-sets` to `true`, replica sets are also included in the pruning process.
+
+For more information, see xref:../applications/pruning-objects.adoc#pruning-deployments_pruning-objects[Pruning deployment resources].
+
 [id="ocp-4-10-insights-operator"]
 === Insights Operator
 
@@ -919,6 +926,11 @@ In the table below, features are marked with the following statuses:
 |
 
 | Low-latency Redfish hardware events
+|-
+|-
+|TP
+
+|Pruning replica sets using the `--replica-sets` flag
 |-
 |-
 |TP


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2892

Previews:
* https://deploy-preview-41942--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-dev-exp-prune-deployments
* https://deploy-preview-41942--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-technology-preview