### PR TITLE
Noting that PodSecurity is not available in 4.10

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -411,6 +411,12 @@ To manage the cloud controller manager and cloud node manager deployments and li
 
 For more information, see the xref:../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_platform-operators-ref[Cluster Cloud Controller Manager Operator] entry in the _Platform Operators reference_.
 
+[discrete]
+[id="ocp-4-10-pod-security-not-available"]
+==== PodSecurity admission not available
+
+The PodSecurity admission controller is available as a beta feature in Kubernetes 1.23, but is not available in {product-title} 4.10. This feature is currently planned for a future {product-title} release.
+
 [id="ocp-4-10-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3258

Addresses https://github.com/openshift/openshift-docs/issues/37586#issuecomment-1022037348

Preview: https://deploy-preview-41945--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-pod-security-not-available