### PR TITLE
TELCODOCS-243: D/S Docs & RN: METAL-6 (MPHARDWARE-4/KNIDEPLOY-2108) BIOS Settings Configuration (set values)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -405,10 +405,13 @@ Dir: post_installation_configuration
 Distros: openshift-origin,openshift-enterprise
 Topics:
 - Name: Post-installation configuration overview
+  Distros: openshift-enterprise
   File: index
 - Name: Configuring a private cluster
   Distros: openshift-enterprise,openshift-origin
   File: configuring-private-cluster
+- Name: Bare metal configuration
+  File: bare-metal-configuration
 - Name: Machine configuration tasks
   File: machine-configuration-tasks
 - Name: Cluster tasks

--- a/modules/bmo-about-the-baremetalhost-resource.adoc
+++ b/modules/bmo-about-the-baremetalhost-resource.adoc
@@ -1,0 +1,316 @@
+// This is included in the following assemblies:
+//
+// post_installation_configuration/bare-metal-configuration.adoc
+
+:_content-type: REFERENCE
+[id="about-the-baremetalhost-resource_{context}"]
+= About the BareMetalHost resource
+
+Metal^3^ introduces the concept of the `BareMetalHost` resource, which defines a physical host and its properties. The `BareMetalHost` resource contains two sections:
+
+. The `BareMetalHost` spec
+. The `BareMetalHost` status
+
+== The BareMetalHost spec
+
+The `spec` section of the `BareMetalHost` resource defines the desired state of the host.
+
+.BareMetalHost spec
+[options="header"]
+|====
+|Parameters |Description
+
+| `automatedCleaningMode`
+| An interface to enable or disable automated cleaning during provisioning and de-provisioning. When set to `disabled`, it skips automated cleaning. When set to `metadata`, automated cleaning is enabled. The default setting is `metadata`.
+
+a|
+----
+bmc:
+  address:
+  credentialsName:
+  disableCertificateVerification:
+----
+a| The `bmc` configuration setting contains the connection information for the baseboard management controller (BMC) on the host. The fields are:
+
+* `address`: The URL for communicating with the host's BMC controller.
+
+* `credentialsName`: A reference to a secret containing the username and password for the BMC.
+
+* `disableCertificateVerification`: A boolean to skip certificate validation when set to `true`.
+
+| `bootMACAddress`
+| The MAC address of the NIC used for provisioning the host.
+
+| `bootMode`
+| The boot mode of the host. It defaults to `UEFI`, but it can also be set to `legacy` for BIOS boot, or `UEFISecureBoot`.
+
+| `consumerRef`
+| A reference to another resource that is using the host. It could be empty if another resource is not currently using the host. For example, a `Machine` resource might use the host when the the `machine-api` is using the host.
+
+| `description`
+| A human-provided string to help identify the host.
+
+| `externallyProvisioned`
+a| A boolean indicating whether the host provisioning and deprovisioning are managed externally. When set:
+
+* Power status can still be managed using the online field.
+* Hardware inventory will be monitored, but no provisioning or deprovisioning operations are performed on the host.
+
+| `firmware`
+a| Contains information about the BIOS configuration of bare metal hosts. Currently, `firmware` is only supported by iRMC, iDRAC, iLO4 and iLO5 BMCs. The sub fields are:
+
+** `simultaneousMultithreadingEnabled`: Allows a single physical processor core to appear as several logical processors. Valid settings are `true` or `false`.
+** `sriovEnabled`: SR-IOV support enables a hypervisor to create virtual instances of a PCI-express device, potentially increasing performance. Valid settings are `true` or `false`.
+** `virtualizationEnabled`: Supports the virtualization of platform hardware. Valid settings are `true` or `false`.
+
+a|
+----
+image:
+  url:
+  checksum:
+  checksumType:
+  format:
+----
+a| The `image` configuration setting holds the details for the image to be deployed on the host. Ironic requires the image fields. However, when the `externallyProvisioned` configuration setting is set to `true` and the external management doesn't require power control, the fields can be empty. The fields are:
+
+* `url`: The URL of an image to deploy to the host.
+* `checksum`: The actual checksum or a URL to a file containing the checksum for the image at `image.url`.
+* `checksumType`: You can specify checksum algorithms. Currently `image.checksumType` only supports `md5`, `sha256`, and `sha512`. The default checksum type is `md5`.
+* `format`: This is the disk format of the image. It can be one of `raw`, `qcow2`, `vdi`, `vmdk`, `live-iso` or be left unset. Setting it to `raw` enables raw image streaming in the Ironic agent for that image. Setting it to `live-iso` enables iso images to live boot without deploying to disk, and it ignores the `checksum` fields.
+
+| `networkData`
+| A reference to the secret containing the network configuration data and its namespace, so that it can be attached to the host before the host boots to set up the network.
+
+| `online`
+| A boolean indicating whether the host should be powered on (`true`) or off (`false`). Changing this value will trigger a change in the power state of the physical host.
+
+a|
+----
+raid:
+  hardwareRAIDVolumes:
+  softwareRAIDVolumes:
+----
+a|  (Optional) Contains the information about the RAID configuration for bare metal hosts. If not specified, it retains the current configuration. Currently, `raid` is only supported by iRMC, iDRAC, and iLO5 BMCs. The fields are:
+
+* `hardwareRAIDVolumes`: Contains the list of logical drives for hardware RAID, and defines the desired volume configuration in the hardware RAID. If you don't specify `rootDeviceHints`, the first volume is the root volume. The sub-fields are:
+
+** `level`: The RAID level for the logical drive. The following levels are supported: `0`,`1`,`2`,`5`,`6`,`1+0`,`5+0`,`6+0`.
+** `name`: The name of the volume as a string. It should be unique within the server. If not specified, the volume name will be auto-generated.
+** `numberOfPhysicalDisks`: The number of physical drives as an integer to use for the logical drove. Defaults to the minimum number of disk drives required for the particular RAID level.
+** `physicalDisks`: The list of names of physical disk drives as a string. This is an optional field. If specified, the controller field must be specified too.
+** `controller`: (Optional) The name of the RAID controller as a string to use in the hardware RAID volume.
+** `rotational`: If set to `true`, it will only select rotational disk drives. If set to `false`, it will only select solid-state and NVMe drives. If not set, it selects any drive types, which is the default behavior.
+** `sizeGibibytes`: The size of the logical drive as an integer to create in GiB. If unspecified or set to `0`, it will use the maximum capacity of physical drive for the logical drive.
+
+* `softwareRAIDVolumes`: Contains the list of logical disks for software RAID. If you don't specify `rootDeviceHints`, the first volume is the root volume. If you set `HardwareRAIDVolumes`, this item will be invalid. Software RAIDs will always be deleted. The number of created software RAID devices must be `1` or `2`. If there is only one software RAID device, it must be `RAID-1`. If there are two RAID devices, the first device must be `RAID-1`, while the RAID level for the second device can be `0`, `1`, or `1+0`. The first RAID device will be the deployment device. Therefore, enforcing `RAID-1` reduces the risk of a non-booting node in case of a device failure. The `softwareRAIDVolume` field defines the desired configuration of the volume in the software RAID. The sub-fields are:
+
+** `level`: The RAID level for the logical drive. The following levels are supported: `0`,`1`,`1+0`.
+** `physicalDisks`: A list of device hints. The number of items should be greater than or equal to `2`.
+** `sizeGibibytes`: The size of the logical disk drive as an integer to be created in GiB. If unspecified or set to `0`, it will use the maximum capacity of physical drive for logical drive.
+
+You can set the `hardwareRAIDVolume` as an empty slice to clear the hardware RAID configuration. For example:
+
+----
+spec:
+   raid:
+     hardwareRAIDVolume: []
+----
+
+If you receive an error message indicating that the driver does not support RAID, set the `raid`, `hardwareRAIDVolumes` or `softwareRAIDVolumes` to nil. You might need to ensure the host has a RAID controller.
+
+a|
+----
+rootDeviceHints:
+  deviceName:
+  hctl:
+  model:
+  vendor:
+  serialNumber:
+  minSizeGigabytes:
+  wwn:
+  wwnWithExtension:
+  wwnVendorExtension:
+  rotational:
+----
+a| The `rootDeviceHints` parameter enables provisioning of the {op-system} image to a particular device. It examines the devices in the order it discovers them, and compares the discovered values with the hint values. It uses the first discovered device that matches the hint value. The configuration can combine multiple hints, but a device must match all hints to get selected. The fields are:
+
+* `deviceName`: A string containing a Linux device name like `/dev/vda`. The hint must match the actual value exactly.
+
+* `hctl`: A string containing a SCSI bus address like `0:0:0:0`. The hint must match the actual value exactly.
+
+* `model`: A string containing a vendor-specific device identifier. The hint can be a substring of the actual value.
+
+* `vendor`: A string containing the name of the vendor or manufacturer of the device. The hint can be a sub-string of the actual value.
+
+* `serialNumber`: A string containing the device serial number. The hint must match the actual value exactly.
+
+* `minSizeGigabytes`: An integer representing the minimum size of the device in gigabytes.
+
+* `wwn`: A string containing the unique storage identifier. The hint must match the actual value exactly.
+
+* `wwnWithExtension`: A string containing the unique storage identifier with the vendor extension appended. The hint must match the actual value exactly.
+
+* `wwnVendorExtension`: A string containing the unique vendor storage identifier. The hint must match the actual value exactly.
+
+* `rotational`: A boolean indicating whether the device should be a rotating disk (true) or not (false).
+
+|====
+
+== The BareMetalHost status
+
+The `BareMetalHost` status represents the host's current state, and includes tested credentials, current hardware details, and other information.
+
+
+.BareMetalHost status
+[options="header"]
+|====
+|Parameters |Description
+
+| `goodCredentials`
+| A reference to the secret and its namespace holding the last set of baseboard management controller (BMC) credentials the system was able to validate as working.
+
+| `errorMessage`
+| Details of the last error reported by the provisioning backend, if any.
+
+| `errorType`
+a| Indicates the class of problem that has caused the host to enter an error state. The error types are:
+
+* `provisioned registration error`: Occurs when the controller is unable to re-register an already provisioned host.
+* `registration error`: Occurs when the controller is unable to connect to the host's baseboard management controller.
+* `inspection error`: Occurs when an attempt to obtain hardware details from the host fails.
+* `preparation error`: Occurs when cleaning fails.
+* `provisioning error`: Occurs when the controller fails to provision or deprovision the host.
+* `power management error`: Occurs when the controller is unable to modify the power state of the host.
+* `detach error`: Occurs when the controller is unable to detatch the host from the provisioner.
+
+a|
+----
+hardware:
+  cpu
+    arch:
+    model:
+    clockMegahertz:
+    flags:
+    count:
+----
+a| The `hardware.cpu` field details of the CPU(s) in the system. The fields include:
+
+* `arch`: The architecture of the CPU.
+* `model`: The CPU model as a string.
+* `clockMegahertz`: The speed in MHz of the CPU.
+* `flags`: The list of CPU flags. For example, `'mmx','sse','sse2','vmx'` etc.
+* `count`: The number of CPUs available in the system.
+
+a|
+----
+hardware:
+  firmware:
+----
+| Contains BIOS firmware information. For example, the hardware vendor and version.
+
+a|
+----
+hardware:
+  nics:
+  - ip:
+    name:
+    mac:
+    speedGbps:
+    vlans:
+    vlanId:
+    pxe:
+----
+a| The `hardware.nics` field contains a list of network interfaces for the host. The fields include:
+
+* `ip`: The IP address of the NIC, if one was assigned when the discovery agent ran.
+* `name`: A string identifying the network device. For example, `nic-1`.
+* `mac`: The MAC address of the NIC.
+* `speedGbps`: The speed of the device in Gbps.
+* `vlans`: A list holding all the VLANs available for this NIC.
+* `vlanId`: The untagged VLAN ID.
+* `pxe`: Whether the NIC is able to boot using PXE.
+
+a|
+----
+hardware:
+  ramMebibytes:
+----
+| The host's amount of memory in Mebibytes (MiB).
+
+a|
+----
+hardware:
+  storage:
+  - name:
+    rotational:
+    sizeBytes:
+    serialNumber:
+----
+a| The `hardware.storage` field contains a list of storage devices available to the host. The fields include:
+
+* `name`: A string identifying the storage device. For example, `disk 1 (boot)`.
+* `rotational`: Indicates whether the disk is rotational, and returns either `true` or `false`.
+* `sizeBytes`: The size of the storage device.
+* `serialNumber`: The device's serial number.
+
+a|
+----
+hardware:
+  systemVendor:
+    manufacturer:
+    productName:
+    serialNumber:
+----
+| Contains information about the host's `manufacturer`, the `productName`, and the `serialNumber`.
+
+
+| `lastUpdated`
+| The timestamp of the last time the status of the host was updated.
+
+| `operationalStatus`
+a| The status of the server. The status is one of the following:
+
+* `OK`: Indicates all the details for the host are known, correctly configured, working, and manageable.
+* `discovered`: Implies some of the host's details are either not working correctly or missing. For example, the BMC address is known but the login credentials are not.
+* `error`: Indicates the system found some sort of irrecoverable error. Refer to the `errorMessage` field in the status section for more details.
+* `delayed`: Indicates that provisioning is delayed to limit simultaneous provisioning of multiple hosts.
+* `detached`: Indicates the host is marked `unmanaged`.
+
+| `poweredOn`
+| Boolean indicating whether the host is powered on.
+
+a|
+----
+provisioning:
+  state:
+  id:
+  image:
+  raid:
+  firmware:
+  rootDeviceHints:
+----
+a| The `provisioning` field contains values related to deploying an image to the host. The sub-fields include:
+
+* `state`: The current state of any ongoing provisioning operation. The states include:
+** `<empty string>`: There is no provisioning happening at the moment.
+** `unmanaged`: There is insufficient information available to register the host.
+** `registering`: The agent is checking the host's BMC details.
+** `match profile`: The agent is comparing the discovered hardware details on the host against known profiles.
+** `available`: The host is available for provisioning. This state was previously known as `ready`.
+** `preparing`: The existing configuration will be removed, and the new configuration will be set on the host.
+** `provisioning`: The provisioner is writing an image to the host's storage.
+** `provisioned`: The provisioner wrote an image to the host's storage.
+** `externally provisioned`: Metal^3^ does not manage the image on the host.
+** `deprovisioning`: The provisioner is wiping the image from the host's storage.
+** `inspecting`: The agent is collecting hardware details for the host.
+** `deleting`: The agent is deleting the from the cluster.
+* `id`: The unique identifier for the service in the underlying provisioning tool.
+* `image`: The image most recently provisioned to the host.
+* `raid`: The list of hardware or software RAID volumes recently set.
+* `firmware`: The BIOS configuration for the bare metal server.
+* `rootDeviceHints`: The root device selection instructions used for the most recent provisioning operation.
+
+| `triedCredentials`
+| A reference to the secret and its namespace holding the last set of BMC credentials that were sent to the provisioning backend.
+
+|====

--- a/modules/bmo-about-the-firmwareschema-resource.adoc
+++ b/modules/bmo-about-the-firmwareschema-resource.adoc
@@ -1,0 +1,45 @@
+// This is included in the following assemblies:
+//
+// post_installation_configuration/bare-metal-configuration.adoc
+
+:_content-type: REFERENCE
+[id="about-the-firmwareschema-resource_{context}"]
+= About the FirmwareSchema resource
+
+BIOS settings vary among hardware vendors and host models. A `FirmwareSchema` resource is a read-only resource that contains the types and limits for each BIOS setting on each host model. The data comes directly from the BMC through Ironic. The `FirmwareSchema` prevents you from sending invalid values to a host when specifying values in the `spec` field of the `HostFirmwareSettings` resource. The `FirmwareSchema` resource has a unique identifier derived from its settings and limits. Identical host models use the same `FirmwareSchema` identifier. It is likely that multiple instances of `HostFirmwareSettings` use the same `FirmwareSchema`.
+
+
+.FirmwareSchema specification
+[options="header"]
+|====
+|Parameters|Description
+
+a|
+----
+<BIOS_setting_name>
+  attribute_type:
+  allowable_values:
+  lower_bound:
+  upper_bound:
+  min_length:
+  max_length:
+  read_only:
+  unique:
+----
+
+a| The `spec` is a simple map consisting of the BIOS setting name and the limits of the setting. The fields include:
+
+* `attribute_type`: The type of setting. The supported types are:
+** `Enumeration`
+** `Integer`
+** `String`
+** `Boolean`
+* `allowable_values`: A list of allowable values when the `attribute_type` is `Enumeration`.
+* `lower_bound`: The lowest allowed value when `attribute_type` is `Integer`.
+* `upper_bound`: The highest allowed value when `attribute_type` is `Integer`.
+* `min_length`: The shortest string length that the value can have when `attribute_type` is `String`.
+* `max_length`: The longest string length that the value can have when `attribute_type` is `String`.
+* `read_only`: The setting is read only and cannot be modified.
+* `unique`: The setting is specific to this host.
+
+|====

--- a/modules/bmo-about-the-hostfirmwaresettings-resource.adoc
+++ b/modules/bmo-about-the-hostfirmwaresettings-resource.adoc
@@ -1,0 +1,83 @@
+// This is included in the following assemblies:
+//
+// post_installation_configuration/bare-metal-configuration.adoc
+
+:_content-type: REFERENCE
+[id="about-the-hostfirmwaresettings-resource_{context}"]
+= About the HostFirmwareSettings resource
+
+You can use the `HostFirmwareSettings` resource to retrieve and manage the BIOS settings for a host. When a host moves to the `Available` state, Ironic reads the host's BIOS settings and creates the `HostFirmwareSettings` resource. The resource contains the complete BIOS configuration returned from the baseboard management controller (BMC). Whereas, the `firmware` field in the `BareMetalHost` resource returns three vendor-independent fields, the `HostFirmwareSettings` resource typically comprises many BIOS settings of vendor-specific fields per host.
+
+The `HostFirmwareSettings` resource contains two sections:
+
+. The `HostFirmwareSettings` spec.
+. The `HostFirmwareSettings` status.
+
+== The `HostFirmwareSettings` spec
+
+The `spec` section of the `HostFirmwareSettings` resource defines the desired state of the host's BIOS, and it is empty by default. Ironic uses the settings in the `spec.settings` section to update the baseboard management controller (BMC) when the host is in the `Preparing` state. The `spec.settings` section uses the `FirmwareSchema` resource schema to ensure that you do not send invalid name/value pairs to hosts. See "About the FirmwareSchema resource" for additional details.
+
+.Example
+[source,terminal]
+----
+spec:
+  settings:
+    ProcTurboMode: Disabled<1>
+----
+<1> In the foregoing example, the `spec.settings` section contains a name/value pair that will set the `ProcTurboMode` BIOS setting to `Disabled`.
+
+[NOTE]
+====
+Integer parameters listed in the `status` section appear as strings. For example, `"1"`. When setting integers in the `spec.settings` section, the values should be set as integers without quotes. For example, `1`.
+====
+
+== The `HostFirmwareSettings` status
+
+The `status` represents the current state of the host's BIOS.
+
+.HostFirmwareSettings
+[options="header"]
+|====
+|Parameters|Description
+a|
+----
+status:
+  conditions:
+  - lastTransitionTime:
+    message:
+    observedGeneration:
+    reason:
+    status:
+    type:
+----
+a| The `conditions` field contains a list of state changes. The sub-fields include:
+
+* `lastTransitionTime`: The last time the state changed.
+* `message`: A description of the state change.
+* `observedGeneration`: The current generation of the `status`. If `metadata.generation` and this field are not the same, the `status.conditions` might be out of date.
+* `reason`: The reason for the state change.
+* `status`: The status of the state change. The status can be `True`, `False` or `Unknown`.
+* `type`: The type of state change. The types are `Valid` and `ChangeDetected`.
+
+a|
+----
+status:
+  schema:
+    name:
+    namespace:
+    lastUpdated:
+----
+a| The `FirmwareSchema` for the firmware settings. The fields include:
+
+* `name`: The name or unique identifier referencing the schema.
+* `namespace`: The namespace where the schema is stored.
+* `lastUpdated`: The last time the resource was updated.
+
+a|
+----
+status:
+  settings:
+----
+| The `settings` field contains a list of name/value pairs of a host's current BIOS settings.
+
+|====

--- a/modules/bmo-editing-the-hostfirmwaresettings-resource.adoc
+++ b/modules/bmo-editing-the-hostfirmwaresettings-resource.adoc
@@ -1,0 +1,39 @@
+// This is included in the following assemblies:
+//
+// post_installation_configuration/bare-metal-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="editing-the-hostfirmwaresettings-resource_{context}"]
+= Editing the HostFirmwareSettings resource
+
+You can edit the `HostFirmwareSettings` of provisioned hosts.
+
+.Procedure
+
+. Get the list of hosts:
++
+[source,terminal]
+----
+$ oc get hfs -n openshift-machine-api
+----
+
+. Edit a host's `HostFirmwareSettings` resource:
++
+[source,terminal]
+----
+$ oc edit hfs -n openshift-machine-api/<host_name>
+----
++
+Where `<host_name>` is the name of a provisioned host. The `HostFirmwareSettings` resource will open in the default editor for your terminal.
+
+. Add name/value pairs to the `spec.settings` section:
++
+.Example
+[source,terminal]
+----
+spec:
+  settings:
+    name: value
+----
+
+. Save the changes and exit the editor.

--- a/modules/bmo-getting-the-baremetalhost-resource.adoc
+++ b/modules/bmo-getting-the-baremetalhost-resource.adoc
@@ -1,0 +1,136 @@
+// This is included in the following assemblies:
+//
+// post_installation_configuration/bare-metal-configuration.adoc
+:_content-type: PROCEDURE
+[id="getting-the-baremetalhost-resource_{context}"]
+= Getting the BareMetalHost resource
+
+The `BareMetalHost` resource contains the properties of a physical host. You must get the `BareMetalHost` resource for a physical host to review its properties.
+
+.Procedure
+
+. Get the `BareMetalHost` resource for all hosts:
++
+[source,terminal]
+----
+$ oc get bmh -n openshift-machine-api -o yaml
+----
++
+[NOTE]
+====
+You can use `baremetalhost` as the long form of `bmh` with `oc get` command.
+====
+
+. Get the list of hosts:
++
+[source,terminal]
+----
+$ oc get bmh -n openshift-machine-api
+----
+
+. Get the `BareMetalHost` resource for a specific host
++
+[source,terminal]
+----
+$ oc get bmh -n openshift-machine-api/<host_name> -o yaml
+----
++
+Where `<host_name>` is the name of the host.
++
+.Example output
+[source,yaml]
+----
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  creationTimestamp: "2019-09-20T06:33:35Z"
+  finalizers:
+  - baremetalhost.metal3.io
+  generation: 2
+  name: bmo-controlplane-0
+  namespace: bmo-project
+  resourceVersion: "22642"
+  selfLink: /apis/metal3.io/v1alpha1/namespaces/bmo-project/baremetalhosts/bmo-controlplane-0
+  uid: 92b2f77a-db70-11e9-9db1-525400764849
+spec:
+  bmc:
+    address: ipmi://10.10.57.19
+    credentialsName: bmo-controlplane-0-bmc-secret
+  bootMACAddress: 98:03:9b:61:80:48
+  consumerRef:
+    apiVersion: machine.openshift.io/v1beta1
+    kind: Machine
+    name: bmo-controlplane-0
+    namespace: bmo-project
+  externallyProvisioned: true
+  hardwareProfile: default
+  image:
+    checksum: http://172.16.1.100/images/myOSv1/myOS.qcow2.md5sum
+    url: http://172.16.1.100/images/myOSv1/myOS.qcow2
+  online: true
+  raid:
+    hardwareRAIDVolumes:
+    - level: "1"
+      sizeGibibytes: 200
+      rotational: true
+  firmware:
+    virtualizationEnabled: true
+  userData:
+    name: bmo-controlplane-user-data
+    namespace: bmo-project
+  networkData:
+    name: bmo-controlplane-network-data
+    namespace: bmo-project
+  metaData:
+    name: bmo-controlplane-meta-data
+    namespace: bmo-project
+status:
+  errorMessage: ""
+  goodCredentials:
+    credentials:
+      name: bmo-controlplane-0-bmc-secret
+      namespace: bmo-project
+    credentialsVersion: "5562"
+  hardware:
+    cpu:
+      arch: x86_64
+      clockMegahertz: 2000
+      count: 40
+      flags: []
+      model: Intel(R) Xeon(R) Gold 6138 CPU @ 2.00GHz
+    firmware:
+      bios:
+        date: 12/17/2018
+        vendor: Dell Inc.
+        version: 1.6.13
+    hostname: bmo-controlplane-0.localdomain
+    nics:
+    - ip: 172.22.135.105
+      mac: "00:00:00:00:00:00"
+      model: unknown
+      name: eno1
+      pxe: true
+      speedGbps: 25
+      vlanId: 0
+    ramMebibytes: 0
+    storage: []
+    systemVendor:
+      manufacturer: Dell Inc.
+      productName: PowerEdge r460
+      serialNumber: ""
+  hardwareProfile: ""
+  lastUpdated: "2019-09-20T07:03:23Z"
+  operationalStatus: OK
+  poweredOn: true
+  provisioning:
+    ID: a4438010-3fc6-4c5c-b570-900bbe85da57
+    image:
+      checksum: ""
+      url: ""
+    state: externally provisioned
+  triedCredentials:
+    credentials:
+      name: bmo-controlplane-0-bmc-secret
+      namespace: bmo-project
+    credentialsVersion: "5562"
+----

--- a/modules/bmo-getting-the-firmwareschema-resource.adoc
+++ b/modules/bmo-getting-the-firmwareschema-resource.adoc
@@ -1,0 +1,27 @@
+// This is included in the following assemblies:
+//
+// post_installation_configuration/bare-metal-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="getting-the-firmwareschema-resource_{context}"]
+= Getting the FirmwareSchema resource
+
+Each host model from each vendor has different BIOS settings. When editing the `HostFirmwareSettings` resource's `spec` section, the name/value pairs you set must conform to that host's firmware schema. To ensure you are setting valid name/value pairs, get the `FirmwareSchema` for the host and review it.
+
+.Procedure
+
+. To get a list of `FirmwareSchema` resource instances, execute the following:
++
+[source,terminal]
+----
+$ oc get firmwareschema -n openshift-machine-api
+----
+
+. To get a particular `FirmwareSchema` instance, execute:
++
+[source,terminal]
+----
+$ oc get firmwareschema -n openshift-machine-api/<instance_name> -o yaml
+----
++
+Where `<instance_name>` is the name of the schema instance.

--- a/modules/bmo-getting-the-hostfirmwaresettings-resource.adoc
+++ b/modules/bmo-getting-the-hostfirmwaresettings-resource.adoc
@@ -1,0 +1,38 @@
+// This is included in the following assemblies:
+//
+// post_installation_configuration/bare-metal-configuration.adoc
+
+[id="getting-the-hostfirmwaresettings-resource_{context}"]
+= Getting the HostFirmwareSettings resource
+
+The `HostFirmwareSettings` resource contains the vendor-specific BIOS properties of a physical host. You must get the `HostFirmwareSettings` resource for a physical host to review its BIOS properties.
+
+.Procedure
+
+. Get the detailed list of the `HostFirmwareSettings` resource settings:
++
+[source,terminal]
+----
+$ oc get hfs -n openshift-machine-api -o yaml
+----
++
+[NOTE]
+====
+You can use `hostfirmwaresettings` as the long form of `hfs` with the `oc get` command.
+====
+
+. Get the list of hosts:
++
+[source,terminal]
+----
+$ oc get hfs -n openshift-machine-api
+----
+
+. Get the `HostFirmwareSettings` resource for a particular host
++
+[source,terminal]
+----
+$ oc get hfs -n openshift-machine-api/<host_name> -o yaml
+----
++
+Where `<host_name>` is the name of the host.

--- a/modules/bmo-verifying-the-hostfirmware-settings-resource-is-valid.adoc
+++ b/modules/bmo-verifying-the-hostfirmware-settings-resource-is-valid.adoc
@@ -1,0 +1,41 @@
+// This is included in the following assemblies:
+//
+// post_installation_configuration/bare-metal-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="verifying-the-hostfirmware-settings-resource-is-valid_{context}"]
+= Verifying the HostFirmware Settings resource is valid
+
+When the user edits the `spec.settings` section to make a change to the `HostFirmwareSetting`(HFS) resource, the Bare Metal Operator (BMO) validates the change against the `FimwareSchema` resource, which is a read-only resource. If the setting is invalid, the BMO will set the `Type` value of the `status.Condition` setting to `False` and also generate an event and store it in the HFS resource. Use the following procedure to verify that the resource is valid.
+
+.Procedure
+
+. Get a list of hosts:
++
+[source,terminal]
+----
+$ oc get hfs -n openshift-machine-api
+----
+
+. Verify that the `HostFirmwareSettings` resource for a particular host is valid:
++
+[source,terminal]
+----
+$ oc describe hfs/<host_name> -n openshift-machine-api
+----
++
+Where `<host_name>` is the name of the host.
++
+.Example output
+[source,terminal]
+----
+Events:
+  Type    Reason            Age    From                                    Message
+  ----    ------            ----   ----                                    -------
+  Normal  ValidationFailed  2m49s  metal3-hostfirmwaresettings-controller  Invalid BIOS setting: Setting ProcTurboMode is invalid, unknown enumeration value - Foo
+----
++
+[IMPORTANT]
+====
+If the response returns `ValidationFailed`, there is an error in the resource configuration and you must update the values to conform to the `FirmwareSchema` resource.
+====

--- a/post_installation_configuration/bare-metal-configuration.adoc
+++ b/post_installation_configuration/bare-metal-configuration.adoc
@@ -1,0 +1,25 @@
+:_content-type: ASSEMBLY
+:context: post-install-bare-metal-configuration
+[id="post-install-bare-metal-configuration"]
+= Bare metal configuration
+include::modules/common-attributes.adoc[]
+
+toc::[]
+
+When deploying {product-title} on bare metal hosts, there are times when you need to make changes to the host either before or after provisioning. This can include inspecting the host's hardware, firmware, and BIOS details. It can also include formatting disks or changing modifiable BIOS settings. There are two resources that you can use with the Bare Metal Operator (BMO):
+
+* `BareMetalHost`
+* `HostFirmwareSettings`
+
+There is also a read-only `FirmwareSchema` resource, which you can use to validate that you are sending correct values to a host when making changes to host firmware settings.
+
+include::modules/bmo-about-the-baremetalhost-resource.adoc[leveloffset=+1]
+include::modules/bmo-getting-the-baremetalhost-resource.adoc[leveloffset=+1]
+
+include::modules/bmo-about-the-hostfirmwaresettings-resource.adoc[leveloffset=+1]
+include::modules/bmo-getting-the-hostfirmwaresettings-resource.adoc[leveloffset=+1]
+include::modules/bmo-editing-the-hostfirmwaresettings-resource.adoc[leveloffset=+1]
+include::modules/bmo-verifying-the-hostfirmware-settings-resource-is-valid.adoc[leveloffset=+1]
+
+include::modules/bmo-about-the-firmwareschema-resource.adoc[leveloffset=+1]
+include::modules/bmo-getting-the-firmwareschema-resource.adoc[leveloffset=+1]

--- a/post_installation_configuration/index.adoc
+++ b/post_installation_configuration/index.adoc
@@ -9,6 +9,7 @@ toc::[]
 After installing {product-title}, a cluster administrator can configure and customize the following components:
 
 * Machine
+* Bare metal
 * Cluster
 * Node
 * Network
@@ -26,6 +27,13 @@ Machine Config Operator (MCO) manages `MachineConfig` objects. By using MCO, you
 
 ** Configure nodes by using `MachineConfig` objects
 ** Configure MCO-related custom resources
+
+* xref:../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Configure bare metal nodes]: The Bare Metal Operator (BMO) implements a Kubernetes API for managing bare metal hosts. It maintains an inventory of available bare metal hosts as instances of the BareMetalHost Custom Resource Definition (CRD). The Bare Metal Operator can:
+
+** Inspect the host's hardware details and report them on the corresponding BareMetalHost. This includes information about CPUs, RAM, disks, NICs, and more.
+** Inspect the host's firmware and configure BIOS settings.
+** Provision hosts with a desired image.
+** Clean a host's disk contents before or after provisioning.
 
 * xref:../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[Configure cluster features]:
 As a cluster administrator, you can modify the configuration resources of the major features of an {product-title} cluster. These features include:


### PR DESCRIPTION
Creates content for BareMetalHost and HostFirmwareSettings custom resource definitions.

Fixes: [TELCODOCS-243](https://issues.redhat.com/browse/TELCODOCS-243)

See https://issues.redhat.com/browse/TELCODOCS-243 for additional details.

Preview URL: https://deploy-preview-41947--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/bare-metal-configuration.html

For release(s): 4.10
Signed-off-by: John Wilkins <jowilkin@redhat.com>
