### PR TITLE
CNV-12692: Live migration of VMs to nodes that support the VM's host model CPU

### DIFF
--- a/modules/virt-about-live-migration.adoc
+++ b/modules/virt-about-live-migration.adoc
@@ -16,3 +16,5 @@ You can use live migration if the following conditions are met:
 * The pod network binding must not be of the bridge interface type `()`.
 
 * Live migration is supported for virtual machines that are attached to an SR-IOV network interface.
+
+* If the virtual machine uses a host model CPU, live migration is supported only between nodes that support the virtual machine's host model CPU.

--- a/virt/live_migration/virt-migrate-vmi.adoc
+++ b/virt/live_migration/virt-migrate-vmi.adoc
@@ -9,6 +9,11 @@ toc::[]
 
 Manually initiate a live migration of a virtual machine instance to another node using either the web console or the CLI.
 
+[NOTE]
+====
+If a virtual machine uses a host model CPU, you can perform live migration of that virtual machine only between nodes that support its host CPU model.
+====
+
 include::modules/virt-initiating-vm-migration-web.adoc[leveloffset=+1]
 include::modules/virt-initiating-vm-migration-cli.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR is associated with https://issues.redhat.com/browse/CNV-12692 and it applies to the CNV 4.10 release.