### PR TITLE
OSDOCS-2691 Release Notes for 4.10

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -42,6 +42,27 @@ The scope of support for layered and dependent components of {product-title} cha
 
 This release adds improvements related to the following components and concepts.
 
+[id="ocp-4-10-documentation"]
+=== Documentation
+
+[id="ocp-4-10-getting-started"]
+==== Getting started with {product-title}
+
+{product-title} 4.10 now includes a getting started guide. Getting Started with {product-title} defines basic terminology and provides role-based next steps for developers and administrators.
+
+The tutorials walk new users through the web console and the OpenShift CLI (`oc`) interfaces. New users can accomplish the following tasks through the Getting Started:
+
+* Create a project
+* Grant view permissions
+* Deploy a container image from Quay
+* Examine and scale an application
+* Deploy a Python application from GitHub
+* Connect to a database from Quay
+* Create a secret
+* Load and view your application
+
+For more information, see xref:../getting_started/openshift-overview.adoc[Getting Started with {product-title}].
+
 [id="ocp-4-10-rhcos"]
 === {op-system-first}
 


### PR DESCRIPTION
Release notes for the new Getting Started section that is documented per JIRA: https://issues.redhat.com/browse/OSDOCS-2691. 
Once related PR(https://github.com/openshift/openshift-docs/pull/39254) is merged, we'll add the link to the Getting Started and merge the PR. 

SME: @sjstout needs to sign off before merging. 
No QE is needed. 

Preview: [Getting Started with OpenShift Container Platform](https://deploy-preview-41964--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-documentation).