### PR TITLE
BZ2028496: add disconnected option in the IPI infrastructure options table

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -238,6 +238,20 @@ endif::openshift-origin[]
 |
 |
 
+
+|Disconnected
+|
+|
+|
+|
+|
+|
+|xref:../installing/installing-mirroring-installation-images#installing-mirroring-installation-images[X]
+|
+|
+|
+|
+|
 |===
 
 .User-provisioned infrastructure options


### PR DESCRIPTION
For 4.9+
https://bugzilla.redhat.com/show_bug.cgi?id=2028496

[Docs preview](https://deploy-preview-41973--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#supported-installation-methods-for-different-platforms)