### PR TITLE
Adds 4.7.43 release notes

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -3079,3 +3079,28 @@ link:https://access.redhat.com/solutions/6683011[{product-title} 4.7.42 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-7-43"]
+=== RHSA-2022:0492 - {product-title} 4.7.43 bug fix and security update
+
+Issued: 2022-02-16
+
+{product-title} release 4.7.43, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:0492[RHSA-2022:0492] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0491[RHSA-2022:0491] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6732681[{product-title} 4.7.43 container image list]
+
+[id="ocp-4-7-43-features"]
+==== Features
+
+[id="ocp-4-7-43-features-ip-reconciler"]
+===== IP reconciliation for Whereabouts CNI plug-in
+
+A new enhancement to the Whereabouts CNI plug-in adds an IP reconciliation job, `ip-reconciler`, which runs as a Kubernetes cronjob. Previously, if a `CNI DEL` request did not finish for a pod, the pod's IP addresses remained allocated even though they were not used. Now these IP addresses are periodically collected and made available to be reallocated. (https://bugzilla.redhat.com/show_bug.cgi?id=2028966[*BZ#2028967*])
+
+
+[id="ocp-4-7-43-updating"]
+==== Updating
+
+To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

OCP version: **Applicable to 4.7 only**

Direct Doc Link Preview: https://deploy-preview-41974--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes

peer-review-squad: It can be merged if looks good.