### PR TITLE
Fixes a small typo in the 4.9 RNs

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1538,6 +1538,14 @@ conditions:
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1939788[*BZ#1939788*])
 
 [discrete]
+[id="ocp-4-9-performance-addon-operator-bug-fixes"]
+==== Performance Addon Operator
+
+The following update for the Performance Addon Operator is now available for {product-title} 4.9:
+
+* Previously, the Performance Addon Operator could not restart properly in environments with a bandwidth-limited connection. It also could not restart properly when single node clusters, or any other edge nodes, lost connection to the image registry. With this update, the issue is resolved by ensuring the image is not pulled from `registry.redhat.io` if the image is already available on the node. This fix ensures that the Performance Addon Operator restarts correctly using the image from the local image cache. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2055019[*BZ#2055019*])
+
+[discrete]
 [id="ocp-4-9-rhcos-bug-fixes"]
 ==== {op-system-first}
 
@@ -2496,11 +2504,16 @@ To update an existing {product-title} 4.9 cluster to this latest release, see xr
 
 Issued: 2022-02-14
 
-{product-title} release 4.9.21, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0488[RHBA-2022:0488] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0487[RHSA-2022:0487] advisory.
+{product-title} release 4.9.21, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0488[RHBA-2022:0488] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0487[RHBA-2022:0487] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/6727301[{product-title} 4.9.21 container image list]
+
+[id="ocp-4-9-21-bug-fixes"]
+==== Bug fixes
+
+* The Performance Addon Operator has received an update that fixes link:https://bugzilla.redhat.com/show_bug.cgi?id=2055019[BZ#2055019]. For more information, see the "Performance Addon Operator" section of xref:../release_notes/ocp-4-9-release-notes#ocp-4-9-bug-fixes[Bug fixes].
 
 [id="ocp-4-9-21-known-issues"]
 ==== Known Issues


### PR DESCRIPTION
No BZ.

Fixes a small typo and adds a bug fix to the Performance Addon Operator

No QE needed. 

Preview: https://deploy-preview-41993--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-21