### PR TITLE
BZ#2051835 - fix typo in DHCP note

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -110,7 +110,7 @@ Some administrators prefer to use static IP addresses so that each node's IP add
 [IMPORTANT]
 .Ensuring that your DHCP server can provide infinite leases
 ====
-Your DHCP server must provide a DHCP expiration time of 4294967295 seconds to properly set an infinite lease as specified by link:https://datatracker.ietf.org/doc/html/rfc2131[rfc2131]. If a lesser value is returned for the DHCP infinite lease time, the node reports an error and a static IP is not set for the node. In RHEL 8, `dhcpd` does not provides infinite leases. If you want to use the provisioner node to serve dynamic IP addresses with infinite lease times, use `dnsmasq` rather than `dhcpd`.
+Your DHCP server must provide a DHCP expiration time of 4294967295 seconds to properly set an infinite lease as specified by link:https://datatracker.ietf.org/doc/html/rfc2131[rfc2131]. If a lesser value is returned for the DHCP infinite lease time, the node reports an error and a permanent IP is not set for the node. In RHEL 8, `dhcpd` does not provide infinite leases. If you want to use the provisioner node to serve dynamic IP addresses with infinite lease times, use `dnsmasq` rather than `dhcpd`.
 ====
 
 [IMPORTANT]


### PR DESCRIPTION
Merge to enterprise-4.8 only 

Fixes typo introduced in https://github.com/openshift/openshift-docs/pull/41781

Preview: https://deploy-preview-42008--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html