### PR TITLE
OSDOCS-3282: Added an important note to the cluster-wide proxy documentation

### DIFF
--- a/networking/configuring-cluster-wide-proxy.adoc
+++ b/networking/configuring-cluster-wide-proxy.adoc
@@ -10,6 +10,11 @@ toc::[]
 
 You can configure a cluster-wide proxy during cluster installation.
 
+[IMPORTANT]
+====
+Cluster-wide proxy is a functionally-complete feature and suitable for production workloads. There are additional considerations that need to be added to documentation, and until then, this feature is considered a Technology Preview.
+====
+
 == Prerequisites
 [id="prerequisites_cluster-wide-proxy-configuration"]
 
@@ -18,11 +23,11 @@ You can configure a cluster-wide proxy during cluster installation.
 ifdef::openshift-dedicated[]
 * You must have a Customer Cloud Subscription (CCS) cluster with a VPC that the proxy can access.
 
-For more information, see xref:../osd_quickstart/osd-quickstart.adoc[Quick Start] for a basic cluster installation workflow.
+For more information, see xref:../../osd_quickstart/osd-quickstart.adoc[Quick Start] for a basic cluster installation workflow.
 endif::[]
 
 ifdef::openshift-rosa[]
-For information about standard installation prerequisites, see xref:../rosa_getting_started/rosa-aws-prereqs.adoc[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc[AWS prerequisites for ROSA with STS].
+For information about standard installation prerequisites, see xref:../../rosa_getting_started/rosa-aws-prereqs.adoc[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc[AWS prerequisites for ROSA with STS].
 endif::[]
 
 include::modules/cluster-wide-proxy.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR adds a new note to the clusterwide proxy information.

JIRA: https://issues.redhat.com/browse/OSDOCS-3282

PREVIEW: 

ROSA: https://deploy-preview-42038--osdocs.netlify.app/openshift-rosa/latest/networking/configuring-cluster-wide-proxy
OSD: https://people.redhat.com/eponvell/021622/OSDOCS-3282_ClusterwideProxyNote/networking/configuring-cluster-wide-proxy.html