### PR TITLE
added release notes 1.2.2

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -27,6 +27,8 @@ include::modules/gitops-release-notes-1-3-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-0.adoc[leveloffset=+1]
 
+include::modules/gitops-release-notes-1-2-2.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-2-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-2.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-2-2.adoc
+++ b/modules/gitops-release-notes-1-2-2.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-2-2_{context}"]
+= Release notes for {gitops-title} 1.2.2
+
+{gitops-title} 1.2.2 is now available on {product-title} 4.8.
+
+[id="fixed-issues-1-2-2_{context}"]
+== Fixed issues
+The following issue was resolved in the current release:
+
+* All versions of Argo CD are vulnerable to a path traversal bug that allows to pass arbitrary values to be consumed by Helm charts. This update fixes the CVE-2022-24348 gitops error, path traversal and dereference of symlinks when passing Helm value files.
+link:https://issues.redhat.com/browse/GITOPS-1756[GITOPS-1756]


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.8
JIRA issue: https://issues.redhat.com/browse/RHDEVDOCS-3798
Preview pages: https://deploy-preview-42045--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes

SME+QE review:
Peer-review: