### PR TITLE
Bug 2041940: Fix enablePortPoolsPrepopulation setting definition

### DIFF
--- a/modules/installation-osp-kuryr-port-pools.adoc
+++ b/modules/installation-osp-kuryr-port-pools.adoc
@@ -17,7 +17,7 @@ Because Kuryr keeps each namespace in a separate subnet, a separate ports pool i
 
 Prior to installing a cluster, you can set the following parameters in the `cluster-network-03-config.yml` manifest file to configure ports pool behavior:
 
-* The `enablePortPoolsPrepopulation` parameter controls pool prepopulation, which forces Kuryr to add ports to the pool when it is created, such as when a new host is added, or a new namespace is created. The default value is `false`.
+* The `enablePortPoolsPrepopulation` parameter controls pool prepopulation, which forces Kuryr to add Neutron ports to the pools when the first pod that is configured to use the dedicated network for pods is created in a namespace. The default value is `false`.
 * The `poolMinPorts` parameter is the minimum number of free ports that are kept in the pool. The default value is `1`.
 * The `poolMaxPorts` parameter is the maximum number of free ports that are kept in the pool. A value of `0` disables that upper bound. This is the default setting.
 +

--- a/modules/installation-osp-kuryr-settings-active.adoc
+++ b/modules/installation-osp-kuryr-settings-active.adoc
@@ -39,7 +39,7 @@ spec:
       poolBatchPorts: 3 <3>
       poolMaxPorts: 5 <4>
 ----
-<1> Set `enablePortPoolsPrepopulation` to `true` to make Kuryr create new Neutron ports after a namespace is created or a new node is added to the cluster. This setting raises the Neutron ports quota but can reduce the time that is required to spawn pods. The default value is `false`.
+<1> Set `enablePortPoolsPrepopulation` to `true` to make Kuryr create Neutron ports when the first pod that is configured to use the dedicated network for pods is created in a namespace. This setting raises the Neutron ports quota but can reduce the time that is required to spawn pods. The default value is `false`.
 <2> Kuryr creates new ports for a pool if the number of free ports in that pool is lower than the value of `poolMinPorts`. The default value is `1`.
 <3> `poolBatchPorts` controls the number of new ports that are created if the number of free ports is lower than the value of `poolMinPorts`. The default value is `3`.
 <4> If the number of free ports in a pool is higher than the value of `poolMaxPorts`, Kuryr deletes them until the number matches that value. Setting the value to `0` disables this upper bound, preventing pools from shrinking. The default value is `0`.

--- a/modules/installation-osp-kuryr-settings-installing.adoc
+++ b/modules/installation-osp-kuryr-settings-installing.adoc
@@ -80,7 +80,7 @@ spec:
       poolMaxPorts: 5 <4>
       openstackServiceNetwork: 172.30.0.0/15 <5>
 ----
-<1> Set the value of `enablePortPoolsPrepopulation` to `true` to make Kuryr create new Neutron ports after a namespace is created or a new node is added to the cluster. This setting raises the Neutron ports quota but can reduce the time that is required to spawn pods. The default value is `false`.
+<1> Set `enablePortPoolsPrepopulation` to `true` to make Kuryr create new Neutron ports when the first pod on the network for pods is created in a namespace. This setting raises the Neutron ports quota but can reduce the time that is required to spawn pods. The default value is `false`.
 <2> Kuryr creates new ports for a pool if the number of free ports in that pool is lower than the value of `poolMinPorts`. The default value is `1`.
 <3> `poolBatchPorts` controls the number of new ports that are created if the number of free ports is lower than the value of `poolMinPorts`. The default value is `3`.
 <4> If the number of free ports in a pool is higher than the value of  `poolMaxPorts`, Kuryr deletes them until the number matches that value. Setting this value to `0` disables this upper bound, preventing pools from shrinking. The default value is `0`.


### PR DESCRIPTION
As part of the work to reduce OpenStack resource usage[1]
the Namespace is only now handled when a Pod on Pods
Network is created in it. This new behavior also affects when
the ports pool prepopulation happens requiring update to
the docs.

[1] https://issues.redhat.com/browse/OSASINFRA-2590