### PR TITLE
OSDOCS-2478: Adds procedure for enabling the multicluster console

### DIFF
--- a/modules/enabling-multi-cluster-console.adoc
+++ b/modules/enabling-multi-cluster-console.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * assemblies/web-console.adoc
+
+:_content-type: PROCEDURE
+[id="enable-multi-cluster-console_{context}"]
+= Enabling multicluster in the web console
+
+:FeatureName: Multicluster console
+include::snippets/technology-preview.adoc[leveloffset=+1]
+//
+
+.Prerequisites
+* You must have link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/install/index[Red Hat Advanced Cluster Management (ACM) for Kubernetes 2.5] installed.
+* You must have upgraded to the latest version of {product-title}.
+* You must have administrator privileges.
+
+WARNING: This should not be set on production clusters. You will not be able to upgrade your cluster after applying the feature gate, and it cannot be undone.
+
+.Procedure
+
+. Log in to the {product-title} web console using your credentials.
+
+. Enable ACM in the administrator perspective by following *Admin* -> *ClusterSettings* -> *Configuration* -> *Console Details* -> *Console Plugins* and click `enable`.
+
+. Click *Refresh the web console* in the pop-up window that states that a web console update is available.
+
+. *local-cluster* and *All Clusters* is visible above the perspectives in the navigation section.
+
+. Enable the feature gate from *Administration* -> *Cluster Settings* -> *Configuration* -> *FeatureGate*, and edit the YAML.
++
+[source,yaml]
+
+----
+spec:
+    featureSet: TechPreviewNoUpgrade
+----
+
+. Click save. This enables for all clusters.
+IMPORTANT: Once you save, this cannot be undone.

--- a/modules/multi-cluster-about.adoc
+++ b/modules/multi-cluster-about.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * assemblies/web-console.adoc
+
+:_content-type: CONCEPT
+[id="multi-cluster-about_{context}"]
+= Multicluster console
+
+The multicluster console provides a simplified hybrid cloud console that provides a single interface. You can switch between Advanced Cluster Managment (ACM) and the cluster Console in the same browser tab. It provides a consistent design that allows for shared components.

--- a/web_console/web-console.adoc
+++ b/web_console/web-console.adoc
@@ -21,3 +21,8 @@ Platform 4.x Tested Integrations] page before you create the supporting
 infrastructure for your cluster.
 
 include::modules/web-console-overview.adoc[leveloffset=+1]
+include::modules/multi-cluster-about.adoc[leveloffset=+1]
+include::modules/enabling-multi-cluster-console.adoc[leveloffset=+2]
+
+.Additional resources
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc[Enabling feature sets using the web console]


### PR DESCRIPTION
Related to [OSDOCS:2478](https://issues.redhat.com/browse/OSDOCS-2478)

- Applicable to `enterprise-4.10` 
- Link to ACM 2.5 will not work at the moment. They do not release the same date as OCP 4.10. 

- [Preview link](https://deploy-preview-42063--osdocs.netlify.app/openshift-enterprise/latest/web_console/web-console.html#enable-multi-cluster-console_web-console)