### PR TITLE
Adds first batch of 4.10 RN bug doc text

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -679,6 +679,18 @@ You cannot upgrade {op-system-base} 7 compute machines to {op-system-base} 8. Yo
 
 * Previously, editing a machine specification on {rh-openstack-first} would cause {product-title} to attempt to delete and recreate the machine. As a result, this caused an unrecoverable loss of the node it was hosting. With this fix, any edits made to the machine specification after creation are ignored. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1962066[*BZ#1962066*])
 
+* Previously, the check to ensure that the AWS machine was not updated before requeueing was removed. Consequently, problems arose when the AWS machine's virtual machine had been removed, but its object was still available. In the event that this happened, the AWS machine would requeue in an infinite loop and could not be deleted or updated. This update restores the check that was used to ensure that the AWS machine was not updated before requeueing. As a result, machines no longer requeue if they have been updated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2007802[*BZ#2007802*])
+
+* Previously, modifying a selector changed the list of machines that a machine set observed. As a result, leaks could occur because the machine set lost track of machines it had already created. This update ensures that the selector is immutable once created. As a result, machine sets now lists the correct machines. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2005052[*BZ#2005052*])
+
+* Previously, if a virtual machine template had snapshots, an incorrect disk size was picked due to an incorrect usage of the `linkedClone` operation. With this update, the default clone operation is changed to `fullClone` for all situations. `linkedClone` must now by specified by the user. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2001008[*BZ#2001008*])
+
+* Previously, the custom resource definition (CRD) schema requirements did not allow numeric values. Consequently, marshaling errors occurred during upgrades. This update corrects the schema requirements to allow both string and numeric values. As a result, marshaling errors are no longer reported by the API server conversion. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1999425[*BZ#1999425*])
+
+* Previously, if the Machine API Operator was moved, or the pods were deployed as a result of a name change, the `MachineNotYetDeleted` metric would reset for each monitored machine. This update changes the metric query to ignore the source pod label. As a result, the `MachineNotYetDeleted` metric now properly alerts in scenarios where the Machine API Operator pod has been renamed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1986237[*BZ#1986237*])
+
+* Previously, egress IPs on vSphere were picked up by the vSphere cloud provider within the kubelet. These were unexpected by the certificate signing requests (CSR) approver. Consequently, nodes with egress IPs would not have their CSR renewals approved. This update allows the CSR approver to account for egress IPs. As a result, nodes with egress IPs on vSphere SDN clusters now continue to function and have valid CSR renewals. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1860774[*BZ#1860774*])
+
 [discrete]
 [id="ocp-4-10-cluster-version-operator-bug-fixes"]
 ==== Cluster Version Operator
@@ -1056,7 +1068,7 @@ This script removes unauthenticated subjects from the following cluster role bin
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 
-* The assignment of egress IP addresses to control plane nodes with the EgressIP feature is not supported on a cluster provisioned on Amazon Web Services (AWS). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039656[*BZ#2039656*])
+* The assignment of egress IP addresses to control plane nodes with the egress IP feature is not supported on a cluster provisioned on Amazon Web Services (AWS). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039656[*BZ#2039656*])
 
 * Previously, there was a race condition between {rh-openstack-first} credentials secret creation and `kube-controller-manager` startup. As a result, {rh-openstack-first} cloud provider would not be configured with {rh-openstack} credentials and would break support when creating Octavia load balancers for `LoadBalancer` services. To work around this, you must restart the `kube-controller-manager` pods by deleting the pods manually from the manifests. When you use the workaround, the `kube-controller-manager` pods restart and {rh-openstack} credentials are properly configured. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2004542[*BZ#2004542*])
 


### PR DESCRIPTION
Adds first batch for 4.10 RN bug doc text.

Preview: https://deploy-preview-42076--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-bug-fixes

For 4.10

Can be merged upon approval 