### PR TITLE
SRVCOM-1524: universal clean up required before adding OSD docs

### DIFF
--- a/modules/specifying-sink-flag-kn.adoc
+++ b/modules/specifying-sink-flag-kn.adoc
@@ -12,7 +12,7 @@
 
 When you create an event-producing custom resource by using the Knative (`kn`) CLI, you can specify a sink where events are sent to from that resource, by using the `--sink` flag.
 
-The following example creates a sink binding that uses a service, `http://event-display.svc.cluster.local`, as the sink:
+The following example creates a sink binding that uses a service, `\http://event-display.svc.cluster.local`, as the sink:
 
 .Example command using the `--sink` flag
 [source,terminal]
@@ -24,4 +24,4 @@ $ kn source binding create bind-heartbeat \
   --ce-override "sink=bound"
 ----
 
-<1> `svc` in `http://event-display.svc.cluster.local` determines that the sink is a Knative service. Other default sink prefixes include `channel`, and `broker`.
+<1> `svc` in `\http://event-display.svc.cluster.local` determines that the sink is a Knative service. Other default sink prefixes include `channel`, and `broker`.

--- a/serverless/discover/about-serverless.adoc
+++ b/serverless/discover/about-serverless.adoc
@@ -13,11 +13,6 @@ Developers on {ServerlessProductName} can use the provided Kubernetes native API
 
 {ServerlessProductName} is based on the open source link:https://knative.dev/docs/[Knative project], which provides portability and consistency for hybrid and multi-cloud environments by enabling an enterprise-grade serverless platform.
 
-[id="about-serverless-supported-configs"]
-== Supported configurations
-
-The set of supported features, configurations, and integrations for {ServerlessProductName}, current and past versions, are available at the link:https://access.redhat.com/articles/4912821[Supported Configurations page].
-
 // Knative Serving
 include::modules/about-knative-serving.adoc[leveloffset=+1]
 
@@ -28,6 +23,13 @@ You can propagate an event from an xref:../../serverless/discover/knative-event-
 
 * xref:../../serverless/discover/serverless-channels.adoc#serverless-channels[channels] and subscriptions, or
 * xref:../../serverless/develop/serverless-using-brokers.adoc#serverless-using-brokers[brokers] and xref:../../serverless/develop/serverless-triggers.adoc#serverless-triggers[triggers].
+
+// add something about CLI tools?
+
+[id="about-serverless-supported-configs"]
+== Supported configurations
+
+The set of supported features, configurations, and integrations for {ServerlessProductName}, current and past versions, are available at the link:https://access.redhat.com/articles/4912821[Supported Configurations page].
 
 [id="additional-resources_about-serverless"]
 == Additional resources


### PR DESCRIPTION
Applies for OCP 4.6+

Related Jira: https://issues.redhat.com/browse/SRVCOM-1524

Direct previews:
- https://deploy-preview-42078--osdocs.netlify.app/openshift-enterprise/latest/serverless/discover/about-serverless.html
- https://deploy-preview-42078--osdocs.netlify.app/openshift-enterprise/latest/serverless/develop/serverless-event-sinks.html#specifying-sink-flag-kn_serverless-event-sinks