### PR TITLE
RHDEVDOCS-3701 - Remove warning in monitoring scalability topic

### DIFF
--- a/scalability_and_performance/scaling-cluster-monitoring-operator.adoc
+++ b/scalability_and_performance/scaling-cluster-monitoring-operator.adoc
@@ -6,12 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} exposes metrics that the Cluster Monitoring Operator collects and stores in the Prometheus-based monitoring stack. As an administrator, you can view system resources, containers and components metrics in one dashboard interface, Grafana.
-
-[IMPORTANT]
-====
-If you are running cluster monitoring with an attached PVC for Prometheus, you might experience OOM kills during cluster upgrade. When persistent storage is in use for Prometheus, Prometheus memory usage doubles during cluster upgrade and for several hours after upgrade is complete. To avoid the OOM kill issue, allow worker nodes with double the size of memory that was available prior to the upgrade. For example, if you are running monitoring on the minimum recommended nodes, which is 2 cores with 8 GB of RAM, increase memory to 16 GB. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1925061[BZ#1925061].
-====
+{product-title} exposes metrics that the Cluster Monitoring Operator collects and stores in the Prometheus-based monitoring stack. As an administrator, you can view system resources, containers, and components metrics in one dashboard interface, Grafana.
 
 include::modules/prometheus-database-storage-requirements.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Removes a warning from the monitoring scalability topic because the related BZ issue has been fixed in OCP 4.8+

- Aligned team: Dev Tools
- For branches: 4.8+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3701
- Direct link to doc preview: https://deploy-preview-42081--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/scaling-cluster-monitoring-operator.html
- SME review: n/a
- QE review: @juzhao 
- Peer review: @rolfedh 
- <All reviews complete. Please merge now>