### PR TITLE
Github-41808: fixes small typo

### DIFF
--- a/modules/virt-about-vm-snapshots.adoc
+++ b/modules/virt-about-vm-snapshots.adoc
@@ -9,7 +9,7 @@
 A _snapshot_ represents the state and data of a virtual machine (VM) at a specific point in time. You can use a snapshot to restore an existing VM to a previous state (represented by
 the snapshot) for backup and disaster recovery or to rapidly roll back to a previous development version.
 
-A VM snapshot is created from a VM that is powered off (Stopped state) or powred on (Running state).
+A VM snapshot is created from a VM that is powered off (Stopped state) or powered on (Running state).
 
 When taking a snapshot of a running VM, the controller checks that the QEMU guest agent is installed and running. If so, it freezes the VM file system before taking the snapshot, and thaws the file system after the snapshot is taken.
 


### PR DESCRIPTION
4.9+ 

GitHub issue #41808 

[Preview](https://deploy-preview-42082--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-managing-vm-snapshots.html)

Fixes small typo in description "powred". 