### PR TITLE
Github-39655: fixes typo in table

### DIFF
--- a/modules/rosa-policy-identity-access-management.adoc
+++ b/modules/rosa-policy-identity-access-management.adoc
@@ -36,7 +36,7 @@ Each of these access types have different levels of access to components:
 
 | OpenShift Cluster Manager (OCM) | R/W | No access | No access | No access
 | OpenShift console | No access | R/W | R/W | No access
-| Node Operatiing  system | No access | A specific list of elevated OS and network permissions. | A specific list of elevated OS and network permissions. | No access
+| Node Operating  system | No access | A specific list of elevated OS and network permissions. | A specific list of elevated OS and network permissions. | No access
 | AWS Console | No access | No access, but this is the account used to request cloud provider access. | No access | All cloud provider permissions using the SRE identity.
 
 |===


### PR DESCRIPTION
4.9+

Github issue #39655

[Preview](https://deploy-preview-42084--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-policy-process-security)

Fixes a small typo in the table under the heading "Privileged access controls in Red Hat OpenShift Service on AWS" on the right "Node Operatiing"