### PR TITLE
Adds a second batch of the 4.10 RN bug doc text

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -615,6 +615,8 @@ You cannot upgrade {op-system-base} 7 compute machines to {op-system-base} 8. Yo
 [id="ocp-4-10-cloud-compute-bug-fixes"]
 ==== Cloud Compute
 
+* Previously, editing a machine specification on {rh-openstack-first} would cause {product-title} to attempt to delete and recreate the machine. As a result, this caused an unrecoverable loss of the node it was hosting. With this fix, any edits made to the machine specification after creation are ignored. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1962066[*BZ#1962066*])
+
 [discrete]
 [id="ocp-4-10-cluster-version-operator-bug-fixes"]
 ==== Cluster Version Operator
@@ -630,6 +632,10 @@ You cannot upgrade {op-system-base} 7 compute machines to {op-system-base} 8. Yo
 [discrete]
 [id="ocp-4-10-installer-bug-fixes"]
 ==== Installer
+
+* Previously, RAM validation for {rh-openstack-first} checked for values using a wrong unit, and as a result the validation accepted flavors that did not meet minimum RAM requirements. With this fix, RAM validation now rejects flavors with insufficient RAM. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2009699[*BZ#2009699*])
+
+* Previously, {product-title} master nodes were missing Ingress security group rules when they were schedulable and deployed on {rh-openstack}. As a result, {product-title} deployments on {rh-openstack} failed for compact clusters with no dedicated workers. This fix adds Ingress security group rules on {rh-openstack-first} when masters are schedulable. Now, you can deploy compact three-node clusters on {rh-openstack}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1955544[*BZ#1955544*])
 
 [discrete]
 [id="ocp-4-10-kube-api-server-bug-fixes"]
@@ -984,6 +990,9 @@ This script removes unauthenticated subjects from the following cluster role bin
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 
 * The assignment of egress IP addresses to control plane nodes with the EgressIP feature is not supported on a cluster provisioned on Amazon Web Services (AWS). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039656[*BZ#2039656*])
+
+* Previously, there was a race condition between {rh-openstack-first} credentials secret creation and `kube-controller-manager` startup. As a result, {rh-openstack-first} cloud provider would not be configured with {rh-openstack} credentials and would break support when creating Octavia load balancers for `LoadBalancer` services. To work around this, you must restart the `kube-controller-manager` pods by deleting the pods manually from the manifests. When you use the workaround, the `kube-controller-manager` pods restart and {rh-openstack} credentials are properly configured. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2004542[*BZ#2004542*])
+
 
 [id="ocp-4-10-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Preview: https://deploy-preview-42085--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-bug-fixes

No QE needed.

Can be merged upon approval 