### PR TITLE
BZ2019366: Adding note about hostpath provisioner directory disk pressure

### DIFF
--- a/modules/virt-configuring-selinux-hpp-on-rhcos8.adoc
+++ b/modules/virt-configuring-selinux-hpp-on-rhcos8.adoc
@@ -15,7 +15,11 @@ You must configure SELinux before you create the `HostPathProvisioner` custom re
 ====
 The backing directory must not be located in the filesystem's root directory because the `/` partition is read-only on {op-system}. For example, you can use `/var/<directory_name>` but not `/<directory_name>`.
 ====
-
++
+[WARNING]
+====
+If you select a directory that shares space with your operating system, you might exhaust the space on that partition and your node might become non-functional. Create a separate partition and point the hostpath provisioner to the separate partition to avoid interference with your operating system.
+====
 
 .Procedure
 

--- a/modules/virt-using-hostpath-provisioner.adoc
+++ b/modules/virt-using-hostpath-provisioner.adoc
@@ -15,6 +15,11 @@ To deploy the hostpath provisioner and enable your virtual machines to use local
 ====
 The backing directory must not be located in the filesystem's root directory because the `/` partition is read-only on {op-system-first}. For example, you can use `/var/<directory_name>` but not `/<directory_name>`.
 ====
++
+[WARNING]
+====
+If you select a directory that shares space with your operating system, you might exhaust the space on that partition and your node becomes non-functional. Create a separate partition and point the hostpath provisioner to the separate partition to avoid interference with your operating system.
+====
 
 * Apply the SELinux context `container_file_t` to the PV backing directory on each node. For example:
 +


### PR DESCRIPTION
This PR relates to [BZ2019366](https://bugzilla.redhat.com/show_bug.cgi?id=2019366) and its associated JIRA story [CNV-14730](https://issues.redhat.com/browse/CNV-14730).

The bugs asks for a note to be added to [Configuring SELinux for the hostpath provisioner](https://docs.openshift.com/container-platform/4.9/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.html#virt-configuring-selinux-hpp-on-rhcos8_virt-configuring-local-storage-for-vms) and [Using the hostpath provisioner to enable local storage](https://docs.openshift.com/container-platform/4.9/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.html#virt-using-hostpath-provisioner_virt-configuring-local-storage-for-vms) warning users to not use a directory that shares space with the OS to avoid excessive disk usage.

CP: 4.8, 4.9, 4.10

Preview:
* [Configuring SELinux for the hostpath provisioner](https://deploy-preview-42091--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.html#virt-configuring-selinux-hpp-on-rhcos8_virt-configuring-local-storage-for-vms)
* [Using the hostpath provisioner to enable local storage](https://deploy-preview-42091--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.html#virt-using-hostpath-provisioner_virt-configuring-local-storage-for-vms)