### PR TITLE
OSDOCS-2934: OSDK resource pruning for Operators

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1401,6 +1401,8 @@ Topics:
     File: osdk-monitoring-prometheus
   - Name: Configuring leader election
     File: osdk-leader-election
+  - Name: Object pruning utility
+    File: osdk-pruning-utility
   - Name: Migrating package manifest projects to bundle format
     File: osdk-pkgman-to-bundle
   - Name: Operator SDK CLI reference

--- a/modules/osdk-pruning-utility-about.adoc
+++ b/modules/osdk-pruning-utility-about.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-pruning-utility.adoc
+
+:_content-type: CONCEPT
+[id="osdk-about-pruning-utility_{context}"]
+= About the operator-lib pruning utility
+
+Objects, such as jobs or pods, are created as a normal part of the Operator life cycle. If the cluster administrator or the Operator does not remove these object, they can stay in the cluster and consume resources.
+
+Previously, the following options were available for pruning unnecessary objects:
+
+* Operator authors had to create a unique pruning solution for their Operators.
+* Cluster administrators had to clean up objects on their own.
+
+The `operator-lib` link:https://github.com/operator-framework/operator-lib/tree/main/prune[pruning utility] removes objects from a Kubernetes cluster for a given namespace. The library was added in version `0.9.0` of the link:https://github.com/operator-framework/operator-lib/releases/tag/v0.9.0[`operator-lib` library] as part of the Operator Framework.

--- a/modules/osdk-pruning-utility-config.adoc
+++ b/modules/osdk-pruning-utility-config.adoc
@@ -1,0 +1,86 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-pruning-utility.adoc
+
+:_content-type: REFERENCE
+[id="osdk-pruning-utility-config_{context}"]
+= Pruning utility configuration
+
+The `operator-lib` pruning utility is written in Go and includes common pruning strategies for Go-based Operators.
+
+.Example configuration
+[source,go]
+----
+cfg = Config{
+        log:           logf.Log.WithName("prune"),
+        DryRun:        false,
+        Clientset:     client,
+        LabelSelector: "app=<operator_name>",
+        Resources: []schema.GroupVersionKind{
+                {Group: "", Version: "", Kind: PodKind},
+        },
+        Namespaces: []string{"default"},
+        Strategy: StrategyConfig{
+                Mode:            MaxCountStrategy,
+                MaxCountSetting: 1,
+        },
+        PreDeleteHook: myhook,
+}
+----
+
+The pruning utility configuration file defines pruning actions by using the following fields:
+
+[cols="3,7",options="header"]
+|===
+|Configuration field |Description
+
+|`log`
+|Logger used to handle library log messages.
+
+|`DryRun`
+|Boolean that determines whether resources should be removed. If set to `true`, the utility runs but does not to remove resources.
+
+|`Clientset`
+|Client-go Kubernetes ClientSet used for Kubernetes API calls.
+
+|`LabelSelector`
+|Kubernetes label selector expression used to find resources to prune.
+
+|`Resources`
+|Kubernetes resource kinds. `PodKind` and `JobKind` are currently supported.
+
+|`Namespaces`
+|List of Kubernetes namespaces to search for resources.
+
+|`Strategy`
+|Pruning strategy to run.
+
+|`Strategy.Mode`
+|`MaxCountStrategy`, `MaxAgeStrategy`, or `CustomStrategy` are currently supported.
+
+|`Strategy.MaxCountSetting`
+|Integer value for `MaxCountStrategy` that specifies how many resources should remain after the pruning utility run.
+
+|`Strategy.MaxAgeSetting`
+|Go `time.Duration` string value, such as `48h`, that specifies the age of resources to prune.
+
+|`Strategy.CustomSettings`
+|Go map of values that can be passed into a custom strategy function.
+
+|`PreDeleteHook`
+|Optional: Go function to call before pruning a resource.
+
+|`CustomStrategy`
+|Optional: Go function that implements a custom pruning strategy
+|===
+
+.Pruning execution
+
+You can call the pruning action by running the execute function on the pruning configuration.
+
+[source,go]
+----
+err := cfg.Execute(ctx)
+----
+
+You can also call a pruning action by using a cron package or by calling the pruning utility with a triggering event.

--- a/operators/operator_sdk/osdk-pruning-utility.adoc
+++ b/operators/operator_sdk/osdk-pruning-utility.adoc
@@ -1,0 +1,12 @@
+:_content-type: ASSEMBLY
+[id="osdk-pruning-utility"]
+= Object pruning utility for Go-based Operators
+include::modules/common-attributes.adoc[]
+:context: osdk-pruning-utility
+
+toc::[]
+
+The `operator-lib` pruning utility lets Go-based Operators clean up, or prune, objects when they are no longer needed. Operator authors can also use the utility to create custom hooks and strategies.
+
+include::modules/osdk-pruning-utility-about.adoc[leveloffset=+1]
+include::modules/osdk-pruning-utility-config.adoc[leveloffset=+1]


### PR DESCRIPTION
- enterprise-4.10
- [OSDOCS-2934](https://issues.redhat.com/browse/OSDOCS-2934)
- [Doc preview link](https://deploy-preview-42106--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-pruning-utility.html)