### PR TITLE
ECOPROJECT-5: Documentation for the standalone Node Maintenance Operator

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1886,6 +1886,8 @@ Topics:
     File: eco-poison-pill-operator
   - Name: Deploying node health checks by using the Node Health Check Operator
     File: eco-node-health-check-operator
+  - Name: Using the Node Maintenance Operator to place nodes in maintenance mode
+    File: eco-node-maintenance-operator  
   - Name: Understanding node rebooting
     File: nodes-nodes-rebooting
   - Name: Freeing node resources using garbage collection

--- a/modules/eco-about-node-maintenance-standalone.adoc
+++ b/modules/eco-about-node-maintenance-standalone.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+// nodes/nodes/eco-node-maintenance-operator.adoc
+
+:_content-type: CONCEPT
+[id="eco-about-node-maintenance-operator_{context}"]
+= About the Node Maintenance Operator
+
+You can place nodes into maintenance mode using the `oc adm` utility, or using `NodeMaintenance` custom resources (CRs).
+
+The Node Maintenance Operator watches for new or deleted `NodeMaintenance` CRs. When a new `NodeMaintenance` CR is detected, no new workloads are scheduled and the node is cordoned off from the rest of the cluster. All pods that can be evicted are evicted from the node. When a `NodeMaintenance` CR is deleted, the node that is referenced in the CR is made available for new workloads.
+
+[NOTE]
+====
+Using a `NodeMaintenance` CR for node maintenance tasks achieves the same results as the `oc adm cordon` and `oc adm drain` commands using standard {product-title} CR processing.
+====

--- a/modules/eco-checking_status_of_node_maintenance_cr_tasks.adoc
+++ b/modules/eco-checking_status_of_node_maintenance_cr_tasks.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+//nodes/nodes/eco-node-maintenance-operator.adoc
+
+:_content-type: PROCEDURE
+[id="eco-checking_status_of_node_maintenance_cr_tasks_{context}"]
+= Checking status of current NodeMaintenance CR tasks
+
+You can check the status of current `NodeMaintenance` CR tasks.
+
+.Prerequisites
+
+* Install the {product-title} CLI `oc`.
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+* Check the status of current node maintenance tasks, for example the `NodeMaintenance` CR or `nm` object, by running the following command:
++
+[source,terminal]
+----
+$ oc get nm -o yaml
+----
++
+.Example output
++
+[source,yaml]
+----
+apiVersion: v1
+items:
+- apiVersion: nodemaintenance.medik8s.io/v1beta1
+  kind: NodeMaintenance
+  metadata:
+...
+  spec:
+    nodeName: node-1.example.com
+    reason: Node maintenance
+  status:
+    evictionPods: 3   <1>
+    lastError: "Last failure message" <2>
+    phase: Succeeded
+    totalpods: 5 <3>
+...
+----
+<1> The number of pods scheduled for eviction.
+<2> The latest eviction error, if any.
+<3> The total number of pods before the node entered maintenance mode.

--- a/modules/eco-maintaining-bare-metal-nodes.adoc
+++ b/modules/eco-maintaining-bare-metal-nodes.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// nodes/nodes/eco-node-maintenance-operator.adoc
+
+:_content-type: CONCEPT
+[id="eco-maintaining-bare-metal-nodes_{context}"]
+= Maintaining bare-metal nodes
+
+When you deploy {product-title} on bare-metal infrastructure, you must take additional considerations into account compared to deploying on cloud infrastructure. Unlike in cloud environments, where the cluster nodes are considered ephemeral, reprovisioning a bare-metal node requires significantly more time and effort for maintenance tasks.
+
+When a bare-metal node fails due to a kernel error or a NIC card hardware failure, workloads on the failed node need to be restarted on another node in the cluster while the problem node is repaired or replaced. Node maintenance mode allows cluster administrators to gracefully turn-off nodes, move workloads to other parts of the cluster, and ensure that workloads do not get interrupted. Detailed progress and node status details are provided during maintenance.
+

--- a/modules/eco-node-maintenance-operator-installation-cli.adoc
+++ b/modules/eco-node-maintenance-operator-installation-cli.adoc
@@ -1,0 +1,120 @@
+// Module included in the following assemblies:
+//
+// nodes/nodes/eco-node-maintenance-operator.adoc
+
+:_content-type: PROCEDURE
+[id="installing-maintenance-operator-using-cli_{context}"]
+= Installing the Node Maintenance Operator by using the CLI
+You can use the OpenShift CLI (`oc`) to install the Node Maintenance Operator.
+
+You can install the Node Maintenance Operator in your own namespace or in the `openshift-operators` namespace. 
+
+To install the Operator in your own namespace, follow the steps in the procedure. 
+
+To install the Operator in the `openshift-operators` namespace, skip to step 3 of the procedure because the steps to create a new `Namespace` custom resource (CR) and an `OperatorGroup` CR are not required.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a `Namespace` CR for the Node Maintenance Operator:
+.. Define the `Namespace` CR and save the YAML file, for example, `node-maintenance-namespace.yaml`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nmo-test
+----
+.. To create the `Namespace` CR, run the following command:
++
+[source,terminal]
+----
+$ oc create -f node-maintenance-namespace.yaml
+----
+
+. Create an `OperatorGroup` CR:
+.. Define the `OperatorGroup` CR and save the YAML file, for example, `node-maintenance-operator-group.yaml`:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: node-maintenance-operator
+  namespace: nmo-test
+----
+.. To create the `OperatorGroup` CR, run the following command:
++
+[source,terminal]
+----
+$ oc create -f node-maintenance-operator-group.yaml
+----
+
+. Create a `Subscription` CR:
+.. Define the `Subscription` CR and save the YAML file, for example, `node-maintenance-subscription.yaml`:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: node-maintenance-operator
+  namespace: nmo-test <1>
+spec:
+  channel: stable
+  InstallPlaneApproval: Automatic
+  name: node-maintenance-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  StartingCSV: node-maintenance-operator.v4.10.0
+----
++
+<1> Specify the `Namespace` where you want to install the Node Maintenance Operator. 
++
+[IMPORTANT]
+====
+To install the Node Maintenance Operator in the `openshift-operators` namespace, specify `openshift-operators` in the `Subscription` CR.
+====
+
+.. To create the `Subscription` CR, run the following command:
++
+[source,terminal]
+----
+$ oc create -f node-maintenance-subscription.yaml
+----
+
+.Verification
+
+. Verify that the installation succeeded by inspecting the CSV resource:
++
+[source,terminal]
+----
+$ oc get csv -n openshift-operators
+----
++
+.Example output
+
+[source,terminal]
+----
+NAME                               DISPLAY                     VERSION   REPLACES  PHASE
+node-maintenance-operator.v4.10    Node Maintenance Operator   4.10                Succeeded
+----
+. Verify that the Node Maintenance Operator is running:
++
+[source,terminal]
+----
+$ oc get deploy -n openshift-operators
+----
++
+.Example output
+
+[source,terminal]
+----
+NAME                                           READY   UP-TO-DATE   AVAILABLE   AGE
+node-maintenance-operator-controller-manager   1/1     1            1           10d
+----

--- a/modules/eco-node-maintenance-operator-installation-web-console.adoc
+++ b/modules/eco-node-maintenance-operator-installation-web-console.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// nodes/nodes/eco-node-maintenance-operator.adoc
+
+:_content-type: PROCEDURE
+[id="installing-node-maintenance-operator-using-web-console_{context}"]
+= Installing the Node Maintenance Operator by using the web console
+
+You can use the {product-title} web console to install the Node Maintenance Operator.
+
+.Prerequisites
+
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Operators* -> *OperatorHub*.
+. Search for the Node Maintenance Operator, then click *Install*.
+. Keep the default selection of *Installation mode* and *namespace* to ensure that the Operator will be installed to the `openshift-operators` namespace.
+. Click *Install*.
+
+.Verification
+
+To confirm that the installation is successful:
+
+. Navigate to the *Operators* -> *Installed Operators* page.
+. Check that the Operator is installed in the `openshift-operators` namespace and that its status is `Succeeded`.
+
+If the Operator is not installed successfully:
+
+. Navigate to the *Operators* -> *Installed Operators* page and inspect the `Status` column for any errors or failures.
+. Navigate to the *Workloads* -> *Pods* page and check the logs in any pods in the `openshift-operators` project that are reporting issues.

--- a/modules/eco-resuming-node-from-maintenance-mode-with-cr.adoc
+++ b/modules/eco-resuming-node-from-maintenance-mode-with-cr.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+//nodes/nodes/eco-node-maintenance-operator.adoc
+
+:_content-type: PROCEDURE
+[id="eco-resuming-node-from-maintenance-mode-with-cr_{context}"]
+= Resuming a node from maintenance mode with the NodeMaintenance CR
+
+You can resume a node from maintenance mode that was initiated with a `NodeMaintenance` CR by deleting the `NodeMaintenance` CR.
+
+.Prerequisites
+
+* Install the {product-title} CLI `oc`.
+* Log in to the cluster as a user with `cluster-admin` privileges.
+
+.Procedure
+
+* When your node maintenance task is complete, delete the active `NodeMaintenance` CR:
++
+[source,terminal]
+----
+$ oc delete -f nodemaintenance-cr.yaml
+----
++
+.Example output
++
+[source,terminal]
+----
+nodemaintenance.nodemaintenance.medik8s.io "maintenance-example" deleted
+----

--- a/modules/eco-resuming-node-maintenance-cli.adoc
+++ b/modules/eco-resuming-node-maintenance-cli.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+//nodes/nodes/eco-node-maintenance-operator.adoc
+
+:_content-type: PROCEDURE
+[id="eco-resuming-node-maintenance-cli_{context}"]
+= Resuming a node from maintenance mode in the CLI
+
+Resume a node from maintenance mode by making it schedulable again.
+
+.Procedure
+
+* Mark the node as schedulable. You can then resume scheduling new workloads on the node.
++
+[source,terminal]
+----
+$ oc adm uncordon <node1>
+----

--- a/modules/eco-setting-node-maintenance-cli.adoc
+++ b/modules/eco-setting-node-maintenance-cli.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+//nodes/nodes/eco-node-maintenance-operator.adoc
+
+:_content-type: PROCEDURE
+[id="eco-setting-node-maintenance-cli_{context}"]
+= Setting a node to maintenance mode in the CLI
+
+Set a node to maintenance mode by marking it as unschedulable and using the `oc adm drain` command to evict or delete pods from the node.
+
+.Procedure
+
+. Mark the node as unschedulable. The node status changes to `NotReady,SchedulingDisabled`.
++
+[source,terminal]
+----
+$ oc adm cordon <node1>
+----
+
+. Drain the node in preparation for maintenance.
++
+[source,terminal]
+----
+$  oc adm drain <node1> --delete-emptydir-data --ignore-daemonsets=true --force
+----
+
+* The `--delete-emptydir-data` flag removes any pods on the node that use `emptyDir` volumes. Data in these volumes is ephemeral and is safe to be deleted after termination.
+
+* The `--ignore-daemonsets=true` flag ensures that daemon sets are ignored and pod eviction can continue successfully.
+
+* The `--force` flag is required to delete pods that are not managed by a replica set or daemon set controller.

--- a/modules/eco-setting-node-to-maintenance-mode-with-cr.adoc
+++ b/modules/eco-setting-node-to-maintenance-mode-with-cr.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+//nodes/nodes/eco-node-maintenance-operator.adoc
+
+:_content-type: PROCEDURE
+[id="eco-setting-node-to-maintenance-mode-with-cr_{context}"]
+= Setting a node to maintenance mode with a NodeMaintenance CR
+
+You can put a node into maintenance mode with a `NodeMaintenance` custom resource (CR). When you apply a `NodeMaintenance` CR, all allowed pods are evicted and the node is rendered unschedulable. Evicted pods are queued to be moved to another node in the cluster.
+
+.Prerequisites
+
+* Install the {product-title} CLI `oc`.
+* Log in to the cluster as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create the following node maintenance CR, and save the file as `nodemaintenance-cr.yaml`:
++
+[source,yaml]
+----
+apiVersion: nodemaintenance.medik8s.io/v1beta1
+kind: NodeMaintenance
+metadata:
+  name: maintenance-example  <1>
+spec:
+  nodeName: node-1.example.com <2>
+  reason: "NIC replacement" <3>
+----
+<1> The name of the node maintenance CR
+<2> The name of the node to be put into maintenance mode
+<3> A plain text description of the reason for maintenance
++
+.  Apply the node maintenance CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f nodemaintenance-cr.yaml
+----
+
+. Check the progress of the maintenance task by running the following command, replacing `<node-name>` with the name of your node:
++
+[source,terminal]
+----
+$ oc describe node <node-name>
+----
++
+.Example output
++
+[source,terminal]
+----
+Events:
+  Type     Reason                     Age                   From     Message
+  ----     ------                     ----                  ----     -------
+  Normal   NodeNotSchedulable         61m                   kubelet  Node node-1.example.com status is now: NodeNotSchedulable
+----

--- a/nodes/nodes/eco-node-maintenance-operator.adoc
+++ b/nodes/nodes/eco-node-maintenance-operator.adoc
@@ -1,0 +1,54 @@
+:_content-type: ASSEMBLY
+[id="node-maintenance-operator"]
+= Using the Node Maintenance Operator to place nodes in maintenance mode
+include::_attributes/common-attributes.adoc[]
+include::_attributes/virt-document-attributes.adoc[]
+:context: node-maintenance-operator
+toc::[]
+
+You can use the Node Maintenance Operator to place nodes in maintenance mode. This is a standalone version of the Node Maintenance Operator that is independent of {VirtProductName} installation.
+
+[NOTE]
+====
+If you have installed {VirtProductName}, you must use the Node Maintenance Operator that is bundled with it. 
+====
+
+include::modules/eco-about-node-maintenance-standalone.adoc[leveloffset=+1]
+
+include::modules/eco-maintaining-bare-metal-nodes.adoc[leveloffset=+1]
+
+[id="installing-standalone-nmo"]
+== Installing the Node Maintenance Operator
+You can install the Node Maintenance Operator using the web console or the OpenShift CLI (`oc`).
+
+include::modules/eco-node-maintenance-operator-installation-web-console.adoc[leveloffset=+2]
+
+include::modules/eco-node-maintenance-operator-installation-cli.adoc[leveloffset=+2]
+
+The Node Maintenance Operator is supported in a restricted network environment. For more information, see xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+
+[id="setting-node-in-maintenance-mode"]
+== Setting a node to maintenance mode
+You can place a node into maintenance from the CLI or by using a `NodeMaintenance` CR.
+
+include::modules/eco-setting-node-maintenance-cli.adoc[leveloffset=+2]
+
+include::modules/eco-setting-node-to-maintenance-mode-with-cr.adoc[leveloffset=+2]
+
+You can check the status of current `NodeMaintenance` CR tasks.
+
+include::modules/eco-checking_status_of_node_maintenance_cr_tasks.adoc[leveloffset=+3]
+
+[id="resuming-node-from-maintenance-mode"]
+== Resuming a node from maintenance mode
+
+You can resume a node from maintenance mode from the CLI or by using a `NodeMaintenance` CR. Resuming a node brings it out of maintenance mode and makes it schedulable again.
+
+include::modules/eco-resuming-node-maintenance-cli.adoc[leveloffset=+2]
+
+include::modules/eco-resuming-node-from-maintenance-mode-with-cr.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources-node-maintenance-operator-installation"]
+== Additional resources
+* xref:../../support/gathering-cluster-data.adoc#gathering-cluster-data[Gathering data about your cluster]


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-43 Documentation for the standalone Node Maintenance Operator

Applies to OpenShift version : 4.10 +

Preview:
[Using the Node Maintenance Operator to place nodes in maintenance mode](https://deploy-preview-42107--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/eco-node-maintenance-operator.html)