### PR TITLE
release notes network observability

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -223,6 +223,22 @@ The metric names that start with `ovn` are unique to the OVN-Kubernetes CNI netw
 
 The `ovnkube_master_resource_update_total` metric is removed for the 4.10 release.
 
+[id="ocp-4-10-networkobservability-switch"]
+==== Switching between YAML view and a web console form
+
+* Previously, changes were not retained when switching between *YAML view* and *Form view* on the web console. Additionally, after switching to *YAML view*, you could not return to *Form view*. With this update, you can now easily switch between *YAML view* and *Form view* on the web console without losing changes.
+
+[id="ocp-4-10-networkobservability-targeted-pods"]
+==== Listing pods targeted by network policies
+When using the network policy functionality in the {product-title} web console, the pods affected by a policy are listed. The list changes as the combined namespace and pod selectors in these policy sections are modified:
+
+* Peer definition
+* Rule definition
+* Ingress
+* Egress
+
+The list of impacted pods includes only those pods accessible by the user.
+
 [id="ocp-4-10-networking-must-gather-tcpdump"]
 ==== Enhancement to must-gather to simplify network tracing
 


### PR DESCRIPTION
Adding two Network Observability enhancement release notes.

Direct link: https://deploy-preview-42105--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-networking

Originally found at https://github.com/openshift/openshift-docs/pull/42105/files. I took this PR due to a commit issue we couldn't resolve. 