### PR TITLE
Updating the TechPreviewNoUpdate list in 4.6

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -8,26 +8,9 @@
 
 You can use the `FeatureGate` custom resource (CR) to enable specific feature sets in your cluster. A feature set is a collection of {product-title} features that are not enabled by default.
 
-For example, the `TechPreviewNoUpgrade` feature set allows you to enable a subset of the current Technology Preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters.
+You can activate the following feature set by using the `FeatureGate` CR:
 
-You can activate any of the following feature sets by using the `FeatureGate` CR:
-
-[options="header"]
-|===
-| Feature Set| Description
-
-|`IPv6DualStackNoUpgrade`
-|Enables the dual-stack networking mode in your cluster. Dual-stack networking supports the use of IPv4 and IPv6 simultaneously. Enabling this feature set is _not supported_, cannot be undone, and prevents upgrades. This feature set is not recommended on production clusters.
-
-|`TechPreviewNoUpgrade`
-a|Enables Technology Preview features that are not part of the default features. Enabling this feature set cannot be undone and prevents upgrades. This feature set is not recommended on production clusters. 
-
-The following Technology Preview features are enabled by this feature set:
-
-* link:https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#certificate-rotation[RotateKubeletServerCertificate]. Enables the rotation of the server TLS certificate on the kubelet.
-* link:https://kubernetes.io/docs/concepts/policy/pid-limiting/#pod-pid-limits[Pod PID limits (SupportPodPidsLimit)]. Enables limiting process IDs (PIDs) in pods.
-
-|===
+* `IPv6DualStackNoUpgrade`. This feature gate enables the dual-stack networking mode in your cluster. Dual-stack networking supports the use of IPv4 and IPv6 simultaneously. Enabling this feature set is _not supported_, cannot be undone, and prevents updates. This feature set is not recommended on production clusters.
 
 //// 
 Do not document per Derek Carr: https://github.com/openshift/api/pull/370#issuecomment-510632939

--- a/modules/nodes-cluster-enabling-features-cli.adoc
+++ b/modules/nodes-cluster-enabling-features-cli.adoc
@@ -31,17 +31,15 @@ kind: FeatureGate
 metadata:
   name: cluster <1>
 spec:
-  featureSet: TechPreviewNoUpgrade <2>
+  featureSet: IPv6DualStackNoUpgrade <2>
 ----
 +
 --
 <1> The name of the `FeatureGate` CR must be `cluster`.
-<2> Add the feature sets that you want to enable in a comma-separated list:
-* `IPv6DualStackNoUpgrade` enables the dual-stack networking mode.
-* `TechPreviewNoUpgrade` enables specific Technology Preview features.
+<2> Add the `IPv6DualStackNoUpgrade` feature set to enable the dual-stack networking mode.
 --
 +
 [NOTE]
 ====
-Enabling the `TechPreviewNoUpgrade` or `IPv6DualStackNoUpgrade` feature sets cannot be undone and prevents upgrades. These feature sets are not recommended on production clusters.
+Enabling the `IPv6DualStackNoUpgrade` feature set cannot be undone and prevents updates. This feature set is not recommended on production clusters. 
 ====

--- a/modules/nodes-cluster-enabling-features-console.adoc
+++ b/modules/nodes-cluster-enabling-features-console.adoc
@@ -32,17 +32,15 @@ metadata:
 ....
 
 spec:
-  featureSet: TechPreviewNoUpgrade <2>
+  featureSet: IPv6DualStackNoUpgrade <2>
 ----
 +
 --
 <1> The name of the `FeatureGate` CR must be `cluster`.
-<2> Add the feature sets that you want to enable in a comma-separated list:
-* `IPv6DualStackNoUpgrade` enables the dual-stack networking mode.
-* `TechPreviewNoUpgrade` enables specific Technology Preview features.
+<2> Add the `IPv6DualStackNoUpgrade` feature set to enable the dual-stack networking mode.
 --
 +
 [NOTE]
 ====
-Enabling the `TechPreviewNoUpgrade` or `IPv6DualStackNoUpgrade` feature sets cannot be undone and prevents upgrades. These feature sets are not recommended on production clusters. 
+Enabling the `IPv6DualStackNoUpgrade` feature set cannot be undone and prevents updates. This feature set is not recommended on production clusters. 
 ====


### PR DESCRIPTION
Updated the list to match: https://github.com/openshift/api/blob/release-4.7/config/v1/types_feature.go#L108

Preview: [Understanding feature gates](https://deploy-preview-42125--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html)