### PR TITLE
OSDOCS-2231: RN for hardware offloading

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -499,6 +499,14 @@ You can now set the maximum length of the syslog message in the Ingress Controll
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration parameters].
 
+[id="ocp-4-10-ovs-hardware-offloading"]
+==== Open vSwitch hardware offloading support for SR-IOV
+
+You can now configure Open vSwitch hardware offloading to increase data processing performance on compatible bare metal nodes.
+Hardware offloading is a method for processing data that removes data processing tasks from the CPU and transfers them to the dedicated data processing unit of a network interface controller.
+Benefits of this feature include faster data processing, reduced CPU workloads, and lower computing costs.
+
+For more information, see xref:../networking/hardware_networks/configuring-hardware-offloading.adoc#about-hardware-offloading_hardware-offloading[Configuring hardware offloading].
 
 [id="ocp-4-10-networking-ipi-nmstate"]
 ==== Configuring host network interfaces with NMState on installer-provisioned clusters


### PR DESCRIPTION
Release note for hardware offloading
See also https://github.com/openshift/openshift-docs/pull/41762

**NOTE**: The build will continue to break until the feature docs are merged and the cross reference in the RN can resolve.

Applies only to `enterprise-4.10`

Preview: https://deploy-preview-42128--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-hardware-offloading