### PR TITLE
Document for SBO 1.0.1 Release notes

### DIFF
--- a/applications/connecting_applications_to_services/sbo-release-notes.adoc
+++ b/applications/connecting_applications_to_services/sbo-release-notes.adoc
@@ -1,7 +1,7 @@
 //OpenShift Service Binding Release Notes
 :_content-type: ASSEMBLY
 [id="servicebinding-release-notes"]
-= {servicebinding-title} release notes
+= Release notes for {servicebinding-title} 
 :context: servicebinding-release-notes
 include::modules/common-attributes.adoc[]
 include::modules/servicebinding-document-attributes.adoc[]
@@ -24,7 +24,9 @@ With {servicebinding-title}, you can:
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
 
 // Modules included, most to least recent
+include::modules/sbo-release-notes-1-0-1.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-0.adoc[leveloffset=+1]
+
 
 == Additional resources
 * xref:../../applications/connecting_applications_to_services/understanding-service-binding-operator.adoc#understanding-service-binding-operator[Understanding Service Binding Operator].

--- a/modules/sbo-release-notes-1-0-1.adoc
+++ b/modules/sbo-release-notes-1-0-1.adoc
@@ -1,0 +1,87 @@
+[id="sbo-release-notes-1-0-1_{context}"]
+= Release notes for {servicebinding-title} 1.0.1
+
+{servicebinding-title} is now available on {product-title} 4.7, 4.8 and 4.9.
+
+{servicebinding-title} 1.0.1 supports OpenShift Container Platform 4.9 and later running on:
+
+* IBM Power Systems
+* IBM Z and LinuxONE
+
+The custom resource definition (CRD) of the {servicebinding-title} 1.0.1 supports the following APIs:
+
+* *Service Binding* with the `binding.operators.coreos.com` API group.
+* *Service Binding (Spec API Tech Preview)* with the `servicebinding.io` API group.
++
+[IMPORTANT]
+====
+*Service Binding (Spec API Tech Preview)* with the `servicebinding.io` API group is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/.
+====
+
+[id="support-matrix-1-0-1_{context}"]
+== Support matrix
+
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use.
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+In the table below, features are marked with the following statuses:
+
+- *TP*: _Technology Preview_
+
+- *GA*: _General Availability_
+
+Note the following scope of support on the Red Hat Customer Portal for these features:
+
+.Support matrix
+[cols="1,1",options="header"]
+|===
+| Feature | {servicebinding-title} 1.0.1
+| `binding.operators.coreos.com` API group
+| GA
+| `servicebinding.io` API group
+| TP
+|===
+
+
+[id="fixed-issues-1-0-1_{context}"]
+== Fixed issues
+* Before this update, binding the data values from a `Cluster` custom resource (CR) of the `postgresql.k8s.enterpriesedb.io/v1` API collected the `host` binding value from the `.metadata.name` field of the CR. The collected binding value is an incorrect hostname and the correct hostname is available at the `.status.writeService` field. With this update, the annotations that the {servicebinding-title} uses to expose the binding data values from the backing service CR are now modified to collect the `host` binding value from the `.status.writeService` field. The {servicebinding-title} uses these modified annotations to project the correct hostname in the `host` and `provider` bindings. link:https://issues.redhat.com/browse/APPSVC-1040[APPSVC-1040]
+* Before this update, when you would bind a `PostgresCluster` CR of the `postgres-operator.crunchydata.com/v1beta1` API, the binding data values did not include the values for the database certificates. As a result, the application failed to connect to the database. With this update, modifications to the annotations that the {servicebinding-title} uses to expose the binding data from the backing service CR now include the database certificates. The {servicebinding-title} uses these modified annotations to project the correct `ca.crt`, `tls.crt`, and `tls.key` certificate files. link:https://issues.redhat.com/browse/APPSVC-1045[APPSVC-1045]
+* Before this update, when you would bind a `PerconaXtraDBCluster` custom resource (CR) of the `pxc.percona.com` API, the binding data values did not include the `port` and `database` values. These binding values along with the others already projected are necessary for an application to successfully connect to the database service. With this update, the annotations that the {servicebinding-title} uses to expose the binding data values from the backing service CR are now modified to project the additional `port` and `database` binding values. The {servicebinding-title} uses these modified annotations to project the complete set of binding values that the application can use to successfully connect to the database service. link:https://issues.redhat.com/browse/APPSVC-1073[APPSVC-1073]
+
+
+[id="known-issues-1-0-1_{context}"]
+== Known issues
+* Currently, when you install the {servicebinding-title} in the single namespace installation mode, the absence of an appropriate namespace-scoped role-based access control (RBAC) rule prevents the successful binding of an application to a few known Operator-backed services that the {servicebinding-title} can automatically detect and bind to. In addition, the following error message is generated:
++
+.Example error message
+----
+`postgresclusters.postgres-operator.crunchydata.com "hippo" is forbidden:
+        User "system:serviceaccount:my-petclinic:service-binding-operator" cannot
+        get resource "postgresclusters" in API group "postgres-operator.crunchydata.com"
+        in the namespace "my-petclinic"`
+----
++
+Workaround 1: Install the {servicebinding-title} in the `all namespaces` installation mode. As a result, the appropriate cluster-scoped RBAC rule now exists and the binding succeeds.
++
+Workaround 2: If you cannot install the {servicebinding-title} in the `all namespaces` installation mode, install the following role binding into the namespace where the {servicebinding-title} is installed: 
++
+.Example: Role binding for Crunchy Postgres Operator
+[source,yaml]
+----
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: service-binding-crunchy-postgres-viewer
+subjects:
+  - kind: ServiceAccount
+    name: service-binding-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: service-binding-crunchy-postgres-viewer-role
+----
+link:https://issues.redhat.com/browse/APPSVC-1062[APPSVC-1062]


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: enterprise-`4.9`, enterprise-`4.10`
- **JIRA issues**: [RHDEVDOCS-3572](https://issues.redhat.com/browse/RHDEVDOCS-3572)
- **Preview pages**: [Release notes for Service Binding Operator](https://deploy-preview-42134--osdocs.netlify.app/openshift-enterprise/latest/applications/connecting_applications_to_services/sbo-release-notes.html)
- **SME Review**: Approved by @baijum, @dperaza4dustbit 
- **QE review**:  Approved by @pmacik 
- **Peer-review**: Approved by @jc-berger 