### PR TITLE
BZ1894063: Added important block on using pods deployment in SSC

### DIFF
--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -8,6 +8,11 @@
 
 Similar to the way that RBAC resources control user access, administrators can use _security context constraints_ (SCCs) to control permissions for pods. These permissions include actions that a pod can perform and what resources it can access. You can use SCCs to define a set of conditions that a pod must run with to be accepted into the system.
 
+[IMPORTANT]
+====
+There is a difference in permissions experienced by containers, when you create pods directly by `kubectl` or `oc`. The pod creation uses the `kubectl` or `oc` user, but the deployment falls back to the `ServiceAccount`.
+====
+
 Security context constraints allow an administrator to control:
 
 * Whether a pod can run privileged containers with the `allowPrivilegedContainer` flag.


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1894063

OCP version: 4.6+

Direct Doc Link Preview: https://deploy-preview-42138--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html#security-context-constraints-about_configuring-internal-oauth

@stlaz @cardil PTAL and let me know your feedback.

@wangke19 PTAL for QA review.