### PR TITLE
Hide winc content for OCP rel 4.10 so its OCP 4.10 operator compatible

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1871,38 +1871,38 @@ Topics:
   - Name: Using remote worker node at the network edge
     File: nodes-edge-remote-workers
 ---
-Name: Windows Container Support for OpenShift
-Dir: windows_containers
-Distros: openshift-origin,openshift-enterprise
-Topics:
-- Name: Windows Container Support for Openshift overview
-  File: index
-- Name: Windows Container Support for OpenShift release notes
-  File: windows-containers-release-notes-4-x
-- Name: Understanding Windows container workloads
-  File: understanding-windows-container-workloads
-- Name: Enabling Windows container workloads
-  File: enabling-windows-container-workloads
-- Name: Creating Windows MachineSet objects
-  Dir: creating_windows_machinesets
-  Topics:
-  - Name: Creating a Windows MachineSet object on AWS
-    File: creating-windows-machineset-aws
-  - Name: Creating a Windows MachineSet object on Azure
-    File: creating-windows-machineset-azure
-  - Name: Creating a Windows MachineSet object on vSphere
-    File: creating-windows-machineset-vsphere
-- Name: Scheduling Windows container workloads
-  File: scheduling-windows-workloads
-- Name: Windows node upgrades
-  File: windows-node-upgrades
-- Name: Using Bring-Your-Own-Host Windows instances as nodes
-  File: byoh-windows-instance
-- Name: Removing Windows nodes
-  File: removing-windows-nodes
-- Name: Disabling Windows container workloads
-  File: disabling-windows-container-workloads
----
+#Name: Windows Container Support for OpenShift
+#Dir: windows_containers
+#Distros: openshift-origin,openshift-enterprise
+#Topics:
+#- Name: Windows Container Support for Openshift overview
+#  File: index
+#- Name: Windows Container Support for OpenShift release notes
+#  File: windows-containers-release-notes-4-x
+#- Name: Understanding Windows container workloads
+#  File: understanding-windows-container-workloads
+#- Name: Enabling Windows container workloads
+#  File: enabling-windows-container-workloads
+#- Name: Creating Windows MachineSet objects
+#  Dir: creating_windows_machinesets
+#  Topics:
+#  - Name: Creating a Windows MachineSet object on AWS
+#    File: creating-windows-machineset-aws
+#  - Name: Creating a Windows MachineSet object on Azure
+#    File: creating-windows-machineset-azure
+#  - Name: Creating a Windows MachineSet object on vSphere
+#    File: creating-windows-machineset-vsphere
+#- Name: Scheduling Windows container workloads
+#  File: scheduling-windows-workloads
+#- Name: Windows node upgrades
+#  File: windows-node-upgrades
+#- Name: Using Bring-Your-Own-Host Windows instances as nodes
+#  File: byoh-windows-instance
+#- Name: Removing Windows nodes
+#  File: removing-windows-nodes
+#- Name: Disabling Windows container workloads
+#  File: disabling-windows-container-workloads
+
 Name: Sandboxed Containers Support for OpenShift
 Dir: sandboxed_containers
 Distros: openshift-enterprise


### PR DESCRIPTION
The Windows Containers content should be hidden for the initial release of OCP 4.10, since the 4.10-compatible WMCO rel 5.0.0 is scheduled around 28th Mar.
[Preview](https://deploy-preview-42143--osdocs.netlify.app/openshift-enterprise/latest/welcome/index.html)

@mburke5678 ptal