### PR TITLE
[enterprise-4.8] Backporting pruning wording improvements

### DIFF
--- a/modules/pruning-builds.adoc
+++ b/modules/pruning-builds.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/pruning-objects.adoc
 
+:_content-type: PROCEDURE
 [id="pruning-builds_{context}"]
 = Pruning builds
 
@@ -12,7 +13,7 @@ To prune builds that are no longer required by the system due to age and status,
 $ oc adm prune builds [<options>]
 ----
 
-.Prune builds CLI configuration options
+.`oc adm prune builds` flags
 [cols="4,8",options="header"]
 |===
 
@@ -25,25 +26,27 @@ $ oc adm prune builds [<options>]
 |Prune all builds whose build configuration no longer exists, status is complete, failed, error, or canceled.
 
 .^|`--keep-complete=<N>`
-|Per build configuration, keep the last `N` builds whose status is complete (default `5`).
+|Per build configuration, keep the last `N` builds whose status is complete. The default is `5`.
 
 .^|`--keep-failed=<N>`
-|Per build configuration, keep the last `N` builds whose status is failed, error, or canceled (default `1`).
+|Per build configuration, keep the last `N` builds whose status is failed, error, or canceled. The default is `1`.
 
 .^|`--keep-younger-than=<duration>`
-|Do not prune any object that is younger than `<duration>` relative to the current time (default `60m`).
+|Do not prune any object that is younger than `<duration>` relative to the current time. The default is `60m`.
 |===
 
-To see what a pruning operation would delete:
+.Procedure
 
+. To see what a pruning operation would delete, run the following command:
++
 [source,terminal]
 ----
 $ oc adm prune builds --orphans --keep-complete=5 --keep-failed=1 \
     --keep-younger-than=60m
 ----
 
-To actually perform the prune operation:
-
+. To actually perform the prune operation, add the `--confirm` flag:
++
 [source,terminal]
 ----
 $ oc adm prune builds --orphans --keep-complete=5 --keep-failed=1 \

--- a/modules/pruning-deployments.adoc
+++ b/modules/pruning-deployments.adoc
@@ -2,18 +2,21 @@
 //
 // * applications/pruning-objects.adoc
 
+:_content-type: PROCEDURE
 [id="pruning-deployments_{context}"]
-= Pruning DeploymentConfig objects
+= Pruning deployment resources
 
-To prune `DeploymentConfig` objects that are no longer required by the system due to age and status, administrators can run the following command:
+You can prune resources associated with deployments that are no longer required by the system, due to age and status.
+
+The following command prunes replication controllers associated with `DeploymentConfig` objects:
 
 [source,terminal]
 ----
 $ oc adm prune deployments [<options>]
 ----
 
-.Prune deployments CLI configuration options
-[cols="4,8",options="header"]
+.`oc adm prune deployments` flags
+[cols="4,8a",options="header"]
 |===
 
 |Option |Description
@@ -21,29 +24,31 @@ $ oc adm prune deployments [<options>]
 .^|`--confirm`
 |Indicate that pruning should occur, instead of performing a dry-run.
 
-.^|`--orphans`
-|Prune all deployments that no longer have a `DeploymentConfig` object, has status of `Complete` or `Failed`, and has a replica count of zero.
-
 .^|`--keep-complete=<N>`
-|Per the `DeploymentConfig` object, keep the last `N` deployments that have a status of `Complete` and replica count of zero. (default `5`)
+|Per the `DeploymentConfig` object, keep the last `N` replication controllers that have a status of `Complete` and replica count of zero. The default is `5`.
 
 .^|`--keep-failed=<N>`
-|Per the `DeploymentConfig` object, keep the last `N` deployments that have a status of `Failed` and replica count of zero. (default `1`)
+|Per the `DeploymentConfig` object, keep the last `N` replication controllers that have a status of `Failed` and replica count of zero. The default is `1`.
 
 .^|`--keep-younger-than=<duration>`
-|Do not prune any object that is younger than `<duration>` relative to the current time. (default `60m`) Valid units of measurement include nanoseconds (`ns`), microseconds (`us`), milliseconds (`ms`), seconds (`s`), minutes (`m`), and hours (`h`).
+|Do not prune any replication controller that is younger than `<duration>` relative to the current time. Valid units of measurement include nanoseconds (`ns`), microseconds (`us`), milliseconds (`ms`), seconds (`s`), minutes (`m`), and hours (`h`). The default is `60m`.
+
+.^|`--orphans`
+|Prune all replication controllers that no longer have a `DeploymentConfig` object, has status of `Complete` or `Failed`, and has a replica count of zero.
 |===
 
-To see what a pruning operation would delete:
+.Procedure
 
+. To see what a pruning operation would delete, run the following command:
++
 [source,terminal]
 ----
 $ oc adm prune deployments --orphans --keep-complete=5 --keep-failed=1 \
     --keep-younger-than=60m
 ----
 
-To actually perform the prune operation:
-
+. To actually perform the prune operation, add the `--confirm` flag:
++
 [source,terminal]
 ----
 $ oc adm prune deployments --orphans --keep-complete=5 --keep-failed=1 \

--- a/modules/pruning-groups.adoc
+++ b/modules/pruning-groups.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/pruning-objects.adoc
 
+:_content-type: PROCEDURE
 [id="pruning-groups_{context}"]
 = Pruning groups
 
@@ -14,7 +15,7 @@ $ oc adm prune groups \
     --sync-config=path/to/sync/config [<options>]
 ----
 
-.Prune groups CLI configuration options
+.`oc adm prune groups` flags
 [cols="4,8",options="header"]
 |===
 
@@ -33,15 +34,17 @@ $ oc adm prune groups \
 |Path to the synchronization configuration file.
 |===
 
-To see the groups that the prune command deletes:
+.Procedure
 
+. To see the groups that the prune command deletes, run the following command:
++
 [source,terminal]
 ----
 $ oc adm prune groups --sync-config=ldap-sync-config.yaml
 ----
 
-To perform the prune operation:
-
+. To perform the prune operation, add the `--confirm` flag:
++
 [source,terminal]
 ----
 $ oc adm prune groups --sync-config=ldap-sync-config.yaml --confirm


### PR DESCRIPTION
Backporting the wording improvements made in #41941 to 4.8. (Excludes the additions of the 4.10-specific --replica-sets flag).