### PR TITLE
Adds notes for 4.8.32 release

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -3088,3 +3088,19 @@ This update fixes the problem. The web console reads the `resource` property and
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-8-32"]
+=== RHBA-2022:0559 - {product-title} 4.8.32 bug fix update
+
+Issued: 2022-02-23
+
+{product-title} release 4.8.32 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0559[RHBA-2022:0559] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0558[RHBA-2022:0558] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6749841[{product-title} 4.8.32 container image list]
+
+[id="ocp-4-8-32-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for Wednesday 02/23 4.8.32 release.

- Applies to `enterprise-4.8` only
- [Preview link](https://deploy-preview-42149--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-32)