### PR TITLE
BZ:2053972 MCO degraded upon deployment of cluster with bond and DHCP and infinite lease

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -105,6 +105,8 @@ For the `baremetal` network, a network administrator must reserve a number of IP
 .Reserving IP addresses so they become static IP addresses
 ====
 Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To configure static IP addresses with NMState, see "(Optional) Configuring host network interfaces in the `install-config.yaml` file" in the "Setting up the environment for an OpenShift installation" section.
+
+Using NMState is the preferred way to configure a static IP address. If you do not use NMState you can still serve a dynamic IP address with an infinite lease, however you need to be aware that this setting is incompatible with network configuration deployed by using the Machine Config Operator. 
 ====
 
 [IMPORTANT]


### PR DESCRIPTION
Addresses bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=2053972

Preview link: https://deploy-preview-42152--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-reserving-ip-addresses_ipi-install-prerequisites

Change relevant for 4.10 and going forward. 

Based on latest dialog with @cybertron in 4.10 there is a better soln for static IP address and this PR is not needed for 4.10 