### PR TITLE
Tiny typo fix in OCP on ARM release notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -69,7 +69,7 @@ The following features are supported for {product-title} on ARM:
 * RHEL 8 Application Streams
 * OVNKube
 * OpenShift Logging
-* Elastic Book Store (EBS) for AWS
+* Elastic Block Store (EBS) for AWS
 * AWS Certificate Manager (ACM)
 * AWS .NET applications
 * NFS storage on bare metal


### PR DESCRIPTION
Description: The OCP on ARM release notes are already merged in this PR (https://github.com/openshift/openshift-docs/pull/41301), but there was a small typo mistake that was missed and this update fixes it. 

No QE required

Preview: https://deploy-preview-42158--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-installation-and-upgrade