### PR TITLE
Adds 4th batch of RN bug doc text

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -341,6 +341,11 @@ For more information, see xref:../networking/metallb/about-metallb.adoc#about-me
 [id="ocp-4-10-storage"]
 === Storage
 
+[id="ocp-4-10-console-storage-plugin-enhancement"]
+==== Console Storage Plug-in enhancement
+
+* A new feature has been added to the Console Storage Plug-in that adds Aria labels throughout the installation flow for screen readers. This provides better accessibility for users that use screen readers to access the console.
+
 [id="ocp-4-10-registry"]
 === Registry
 
@@ -730,6 +735,16 @@ You cannot upgrade {op-system-base} 7 compute machines to {op-system-base} 8. Yo
 * Previously, systemd units were cleaned up only when completely removed. As a result, systemd units could not be unmasked by using a machine config because the masks were not being removed unless the systemd unit was completely removed. With this fix, when you configure a systemd unit as `mask: true` in a machine config, any existing masks are removed. As a result, systemd units can be unmasked.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1966445[*BZ#1966445*])
 
 [discrete]
+[id="ocp-4-10-management-console-bug-fixes"]
+==== Management Console
+
+* Previously, the *OperatorHub* category and card links did not include valid `href` attributes. Consequently, the *OperatorHub* cateogry and card links could not be opened in a new tab. This update adds valid `href` attributes to the *OperatorHub* category and card links. As a result, the *OperatorHub* and its card links can be opened in new tabs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2013127[*BZ#2013127*])
+
+* Previously, on the *Operand Details* page, a special case was created where the conditions table for the `status.conditions` property always rendered before all other tables. Consequently, the `status.conditions` table did not follow the ordering rules of descriptors, which caused unexpected behavior when users tried to change the order of the tables. This update removes the special case for `status.conditions` and only defaults to rendering it first if no descriptor is defined for that property. As a result, the table for `status.condition` is rendered according to descriptor ordering rules when a descriptor is defined on that property. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2014488[*BZ#2014488*])
+
+* Previously, the *Resource Details* page metrics tab was exceeding the cluster-scoped Thanos endpoint. Consequently, users without authorization for this endpoint would receive a `401` response for all queries. With this update, the Thanos tenancy endpoints are updated, and redundant namespace query arguments are removed. As a result, users with the correct role-based access control (RBAC) permissions can now see data in the metrics tab of the *Resource Details* page. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2015806[*BZ#2015806*])
+
+[discrete]
 [id="ocp-4-10-networking-bug-fixes"]
 ==== Networking
 
@@ -1085,6 +1100,9 @@ This script removes unauthenticated subjects from the following cluster role bin
 * The assignment of egress IP addresses to control plane nodes with the egress IP feature is not supported on a cluster provisioned on Amazon Web Services (AWS). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039656[*BZ#2039656*])
 
 * Previously, there was a race condition between {rh-openstack-first} credentials secret creation and `kube-controller-manager` startup. As a result, {rh-openstack-first} cloud provider would not be configured with {rh-openstack} credentials and would break support when creating Octavia load balancers for `LoadBalancer` services. To work around this, you must restart the `kube-controller-manager` pods by deleting the pods manually from the manifests. When you use the workaround, the `kube-controller-manager` pods restart and {rh-openstack} credentials are properly configured. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2004542[*BZ#2004542*])
+
+* The ability to delete operands from the web console using the `delete all operands` option is currently disabled. It will be re-enabled in a future version of {product-title}. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2012120[BZ#2012120] and link:https://bugzilla.redhat.com/show_bug.cgi?id=2012971[BZ#2012971].
+
 
 
 [id="ocp-4-10-asynchronous-errata-updates"]


### PR DESCRIPTION
No BZ

Preview:

Storage Plug-in: https://deploy-preview-42162--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-storage

Bug fix: https://deploy-preview-42162--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-bug-fixes


Fourth batch of doc text for RNs.

Thanks! 