### PR TITLE
Adds the fifth batch of RN bug doc text

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -715,6 +715,23 @@ You cannot upgrade {op-system-base} 7 compute machines to {op-system-base} 8. Yo
 [id="ocp-4-10-image-registry-bug-fixes"]
 ==== Image Registry
 
+* Previously, the registry internally resolved `\docker.io` references into `\registry-1.docker.io` and used it to store credentials. As a result, credentials for `\docker.io` images could not be located. With this update, the `\registry-1.docker.io` hostname has been changed back to `\docker.io` when searching for credentials. As a result, the registry can correctly find credentials for `\docker.io images`. (https://bugzilla.redhat.com/show_bug.cgi?id=2024859[*BZ#2024859*])
+
+* Previously, the image pruner job did not retry upon failure. As a result, a single failure could degrade the Image Registry Operator until the next time it ran. With this fix, the temporary problems with the pruner do not degrade the Image Registry Operator. (https://bugzilla.redhat.com/show_bug.cgi?id=2051692[*BZ#2051692*])
+
+* Previously, the Image Registry Operator was modifying objects from the informer. As a result, these objects could be concurrently modified by the informer and cause race conditions. With this fix, controllers and informers have different copies of the object and do not have race conditions. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2028030[*BZ#2028030*])
+
+* Previously, `TestAWSFinalizerDeleteS3Bucket` would fail because of an issue with the location of the configuration object in the Image Registry Operator. This update ensures that the configuration object is stored in the correct location. As a result, the Image Registry Operator no longer panics when running `TestAWSFinalizerDeleteS3Bucket`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2048443[*BZ#2048443*])
+
+
+[discrete]
+[id="ocp-4-10-image-streams-bug-fixes"]
+==== Image Streams
+
+* Previously, the image policy admission plug-in did not recognize deployment configurations, notably that stateful sets could be updated. As a result, image stream references stayed unresolved in deployment configurations when the `resolve-names` annotation was used. Now, the plug-in is updated so that it resolves annotations in deployment configurations and stateful sets. As a result, image stream tags get resolved in created and edited deployment configurations. (https://bugzilla.redhat.com/show_bug.cgi?id=2000216[*BZ#2000216*])
+
+* Previously, when global pull secrets were updated, existing API server pod pull secrets were not updated. Now, the mount point for the pull secret is changed from the `/var/lib/kubelet/config.json` file to the `/var/lib/kubelet` directory. As a result, the updated pull secret now appears in existing API server pods. (https://bugzilla.redhat.com/show_bug.cgi?id=1984592[*BZ#1984592*])
+
 [discrete]
 [id="ocp-4-10-installer-bug-fixes"]
 ==== Installer


### PR DESCRIPTION
RN batch 5.

No QE needed.

Preview: https://deploy-preview-42169--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-bug-fixes

Can be merged upon approval. 