### PR TITLE
OSDOCS-3177: ROSA Private Link Firewall Prerequisites are wrong

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -4,274 +4,198 @@
 
 :_content-type: PROCEDURE
 [id="osd-aws-privatelink-firewall-prerequisites"]
-= AWS PrivateLink firewall prerequisites
+= Firewall prerequisites
 
-If you are using a firewall and want to create your cluster using AWS PrivateLink, you must configure your firewall to grant access to the sites that {product-title} requires.
+[IMPORTANT]
+====
+Only ROSA clusters deployed with PrivateLink may use a firewall to control egress traffic.
+====
+
+This section provides the necessary details that enable you to control egress traffic from your {product-title} cluster. If you are using a firewall to control egress traffic, you must configure your firewall to grant access to the domain and port combinations below. {product-title} requires this access to provide a fully managed OpenShift service.
 
 .Procedure
 
 . Allowlist the following URLs that are used to install and download packages and tools:
 +
-[cols="3,4,1",options="header"]
+[cols="6,1,6",options="header"]
 |===
-|URL | Function | Port
+|Domain | Port | Function
 |`registry.redhat.io`
-|Required. Provides core components such as dev tools and operator based add-ons, and Red Hat provided container images including middleware and Universal Base Image.
-|443, 80
+|443
+|Provides core container images.
 
 |`quay.io`
-|Required. Used by the cluster to download the platform container images.
-|443, 80
+|443
+|Provides core container images.
 
-|`.quay.io`
-|Required. Used by the cluster to download the platform container images.
-|443, 80
-
-|`sso.redhat.com`
-|Required. The `https://cloud.redhat.com/openshift` site uses authentication from `sso.redhat.com` to  download the pull secret and use Red Hat SaaS solutions to facilitate monitoring of your subscriptions, cluster inventory, chargeback reporting, and so on.
-|443, 80
-
-|`pull.q1w2.quay.rhcloud.com`
-|Recommended. Provides a fallback registry used by the cluster when quay.io is not available.
-|443, 80
-
-|`.q1w2.quay.rhcloud.com`
-|Recommended. Enables a CNAME to resolve to a regionalised endpoint.
-|443, 80
-
-|`openshift.org`
-|Required. Provides Red Hat Enterprise Linux CoreOS (RHCOS) images.
-|443, 80
-
-|`console.redhat.com`
-|Required. Allows interactions between the cluster and OpenShift Console Manager (OCM) to enable functionality, such as scheduling upgrades.
-|443, 80
+|`*.quay.io`
+|443
+|Provides core container images.
 
 |`quayio-production-s3.s3.amazonaws.com`
-|Required. Used to access Quay image content in AWS.
-|443, 80
+|443
+|Provides core container images.
+
+|`quay-registry.s3.amazonaws.com`
+|443
+|Provides core container images.
+
+|`cm-quay-production-s3.s3.amazonaws.com`
+|443
+|Provides core container images.
+
+|`cart-rhcos-ci.s3.amazonaws.com`
+|443
+|Provides {op-system-first} images.
+
+|`openshift.org`
+|443
+|Provides {op-system-first} images.
+
+|`registry.access.redhat.com`
+|443
+|Provides access to the odo CLI tool that helps developers build on OpenShift and Kubernetes.
+
+|`sso.redhat.com`
+|443
+|The `https://cloud.redhat.com/openshift` site uses authentication from `sso.redhat.com`.
+
+|`pull.q1w2.quay.rhcloud.com`
+|443
+|Provides core container images as a fallback when quay.io is not available.
+
+|`.q1w2.quay.rhcloud.com`
+|443
+|Provides core container images as a fallback when quay.io is not available.
 |===
 +
 When you add a site such as `quay.io` to your allowlist, do not add a wildcard entry such as `*.quay.io` to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a host name such as `cdn01.quay.io`.
 +
 CDN host names, such as `cdn01.quay.io`, are covered when you add a wildcard entry, such as `.quay.io`, in your allowlist.
-+
-Allowlist any site that provides resources for a language or framework that your builds require. 
 
-. Managed clusters require telemetry to be enabled to allow Red Hat to react more quickly to problems, to better support our customers, and to better understand how product upgrades impact clusters.
-See link:https://docs.openshift.com/container-platform/4.6/support/remote_health_monitoring/about-remote-health-monitoring.html[About remote health monitoring] for more information about how remote health monitoring data is used by Red Hat.
+. Allowlist the following telemetry URLs:
 +
-[cols="3,4,1",options="header"]
+[cols="6,1,6",options="header"]
 |===
-|URL | Function | Port
-
-|`https://cloud.redhat.com`
-|Required. Used by the cluster for the `insights operator` that integrates with the SaaS Red Hat Insights.
-|443, 80
+|Domain | Port | Function
 
 |`cert-api.access.redhat.com`
-|Required. Used by telemetry.
-|443, 80
+|443
+|Required for telemetry.
 
 |`api.access.redhat.com`
-|Required. Used by telemetry.
-|443, 80
+|443
+|Required for telemetry.
 
 |`infogw.api.openshift.com`
-|Required. Used by telemetry.
-|443, 80
-|===
+|443
+|Required for telemetry.
 
-. For Amazon Web Services (AWS), you must grant access to the URLs that provide the AWS API and DNS services:
-* You can grant access by allowing the `.amazonaws.com` wildcard:
-+
-[cols="3,4,1",options="header"]
+|`console.redhat.com`
+|443
+|Required for telemetry and Red Hat Insights.
+
+|`observatorium.api.openshift.comm`
+|443
+|Required for managed OpenShift-specific telemetry.
 |===
-|URL | Function | Requirement
++
+Managed clusters require enabling telemetry to allow Red Hat to react more quickly to problems, better support the customers, and better understand how product upgrades impact clusters.
+See link:https://docs.openshift.com/container-platform/4.9/support/remote_health_monitoring/about-remote-health-monitoring.html[About remote health monitoring] for more information about how remote health monitoring data is used by Red Hat.
+
+. Allowlist the following Amazon Web Services (AWS) API URls:
++
+[cols="6,1,6",options="header"]
+|===
+|Domain | Port | Function
 
 |`.amazonaws.com`
-|Required. Used to access AWS services and resources.
-|443, 80
-
-|`oso-rhc4tp-docker-registry.s3-us-west-2.amazonaws.com`
-|Required. Used to access AWS services and resources when using strict security requirements. Review the AWS Service Endpoints in the AWS documentation to determine the exact endpoints to allow for the regions that you use.
-|443, 80
+|443
+|Required to access AWS services and resources.
 |===
 +
-* Alternatively, you can grant access by allowing the following regional AWS service endpoints:
+Alternatively, if you wish to not use a wildcard for Amazon Web Services (AWS) APIs, you must allowlist the following URLs:
 +
-[cols="3,4,1",options="header"]
+[cols="6,1,6",options="header"]
 |===
-|URL | Function | Port
-|`ec2.<aws_region>.amazonaws.com`
-|Required. Used for regional access to Amazon EC2 services. EC2 instances are required to deploy the control plane and data plane functions of ROSA. Replace `<aws_region>` with an AWS region code, for example `us-east-1`.
-|443, 80
-
-|`elasticloadbalancing.<aws_region>.amazonaws.com`
-|Required. Used to access Amazon Elastic Load Balancers (ELBs) for API and application load balancing.
-|443, 80
-
-|`<cluster_id>-<shard>.<aws_region>.amazonaws.com`
-|Required. Used for access to the registry.
-|443, 80
-|===
-+
-The cluster ID and shard information is generated at installation time. Use `rosa describe cluster --cluster=<cluster_name>` to get the `<cluster_id>`, `<shard>`, and `<aws_region>` values.
-+
-You can grant access to `.<aws_region>.amazonaws.com` when you create a cluster and later refine the firewall configuration by specifying the cluster ID and shard.
-+
-Review the link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS Service Endpoints] in the AWS documentation to determine the exact endpoints to allow for the regions that you use.
-
-. Allowlist the following URLs:
-+
-[cols="3,4,1",options="header"]
-|===
-|URL | Function | Port
-
-|`mirror.openshift.com`
-|Used to access mirrored installation content and images. This site is also a source of release image signatures, although the Cluster Version Operator needs only a single functioning source. Required if you do not allow `storage.googleapis.com/openshift-release`.
-|443, 80
-
-|`storage.googleapis.com/openshift-release`
-|Recommended. Alternative site to mirror.openshift.com/. Used to download platform release signatures that are used by the cluster to know what images to pull from quay.io.
-|443, 80
-
-|`.apps.<cluster_name>.<base_domain>`
-|Required. Used to access the default cluster routes unless you set an ingress wildcard during installation.
-|443, 80
-
-|`quayio-production-s3.s3.amazonaws.com`
-|Required. Used to access Quay image content in AWS.
-|443, 80
-
-|`api.openshift.com`
-|Required. Used to check if updates are available for the cluster.
-|443, 80
-
-|`art-rhcos-ci.s3.amazonaws.com`
-|Required. Specifies the {op-system-first} images to download.
-|443, 80
-
-|`cloud.redhat.com/openshift`
-|Required. Used for cluster tokens.
-|443, 80
-
-|`registry.access.redhat.com`
-|Required. Used to access the `odo` CLI tool that helps developers build on OpenShift and Kubernetes.
-|443, 80
-
-|`quayio-production-s3.s3.amazonaws.com`
-|Required. Used to install and manage clusters in an AWS environment.
-|443, 80
-
-|`cm-quay-production-s3.s3.amazonaws.com`
-|Required. Used to install and manage clusters in an AWS environment.
-|443, 80
-
+|Domain | Port | Function
 |`ec2.amazonaws.com`
-|Required. Used to install and manage clusters in an AWS environment.
-|443, 80
+|443
+|Used to install and manage clusters in an AWS environment.
 
 |`events.amazonaws.com`
-|Required. Used to install and manage clusters in an AWS environment.
-|443, 80
+|443
+|Used to install and manage clusters in an AWS environment.
 
 |`iam.amazonaws.com`
-|Required. Used to install and manage clusters in an AWS environment.
-|443, 80
+|443
+|Used to install and manage clusters in an AWS environment.
 
 |`route53.amazonaws.com`
-|Required. Used to install and manage clusters in an AWS environment.
-|443, 80
+|443
+|Used to install and manage clusters in an AWS environment.
 
 |`sts.amazonaws.com`
-|Required. Used to install and manage clusters in an AWS environment.
-|443, 80
+|443
+|Used to install and manage clusters in an AWS environment.
+
+|`tagging.us-east-1.amazonaws.com`
+|443
+|Used to install and manage clusters in an AWS environment. This endpoint is always us-east-1, regardless of the region the cluster is deployed in.
 
 |`ec2.<aws_region>.amazonaws.com`
-|Required. Region dependent. Must be added per cluster and per region.
-|443, 80
-
-|`CLUSTER-NAME-k5bxz-image-registry-<aws_region>-lsiflffxtmfyikx.s3.dualstack.us-east-1.amazonaws.com`
-|Required. Region dependent. Must be added per cluster and per region.
-|443, 80
+|443
+|Used to install and manage clusters in an AWS environment.
 
 |`elasticloadbalancing.<aws_region>.amazonaws.com`
-|Required. Region dependent. Must be added per cluster and per region.
-|443, 80
-|===
-+
-Region is created during installation. To find the region, run:
-+
-[source,terminal]
-----
- $ rosa describe cluster --cluster=<cluster_name>
-----
-+
-To retrieve the endpoint, run:
-+
-[source,terminal]
-----
-$ oc -n openshift-image-registry get pod -l docker-registry=default -o json | jq '.items[].spec.containers[].env[] | select(.name=="REGISTRY_STORAGE_S3_BUCKET")'
-----
-
-. Operators require route access to perform health checks. Specifically, the authentication and web console Operators connect to two routes to verify that the routes work. If you are the cluster administrator and do not want to allow *.apps.<cluster_name>.<base_domain>, then you must allow these routes:
-+
-[cols="3,4,1",options="header"]
-|===
-|URL | Function | Port
-
-|`oauth-openshift.apps.<cluster_name>.<shard>.<base_domain>`
-|Required.
 |443
-
-|`console-openshift-console.apps.<cluster_name>.<shard>.<base_domain>`, or the host name that is specified in the `spec.route.hostname` field of the `consoles.operator/cluster` object if the field is not empty
-|Required.
-|443
-
-|`canary-openshift-ingress-canary.apps.<cluster_name>.<shard>.s1.devshift.org`
-|Required.
-|443
+|Used to install and manage clusters in an AWS environment.
 |===
 
-. If you use a default Red Hat Network Time Protocol (NTP) server, allowlist the following URLs:
+. Allowlist the following OpenShift URLs:
 +
-* 1.rhel.pool.ntp.org
-* 2.rhel.pool.ntp.org
-* 3.rhel.pool.ntp.org
-+
-[NOTE]
-====
-If you do not use a default Red Hat NTP server, verify the NTP server for your platform and allowlist it in your firewall.
-====
-
-. Allowlist the following OpenShift Dedicated URLs:
-+
-[cols="4,3,1",options="header"]
+[cols="6,1,6",options="header"]
 |===
-|URL | Function | Port
+|Domain | Port | Function
 
-|`api.pagerduty.com` and `events.pagerduty.com`
-|Required. This alerting service is used by the in-cluster alertmanager to send alerts notifying Red Hat SRE of an event to take action on.
+|`mirror.openshift.com`
 |443
+|Used to access mirrored installation content and images. This site is also a source of release image signatures, although the Cluster Version Operator (CVO) needs only a single functioning source.
 
-|`api.deadmanssnitch.com` and `nosnch.in`
-|Required. Alerting service used by OpenShift Dedicated to send periodic pings that indicate whether the cluster is available and running.
+|`storage.googleapis.com/openshift-release` (Recommended)
 |443
+|Alternative site to mirror.openshift.com/. Used to download platform release signatures that are used by the cluster to know what images to pull from quay.io.
 
-|`sftp.access.redhat.com`
-|Recommended. The FTP server used by `must-gather-operator` to upload diagnostic logs to help troubleshoot issues with the cluster.
+|`api.openshift.com`
 |443
+|Used to check if updates are available for the cluster.
+|===
+
+. Allowlist the following site reliability engineering (SRE) and management URLs:
++
+[cols="6,1,6",options="header"]
+|===
+|Domain | Port | Function
+
+|`api.pagerduty.com`
+|443
+|This alerting service is used by the in-cluster alertmanager to send alerts notifying Red Hat SRE of an event to take action on.
+
+|`events.pagerduty.com`
+|443
+|This alerting service is used by the in-cluster alertmanager to send alerts notifying Red Hat SRE of an event to take action on.
+
+|`api.deadmanssnitch.com`
+|443
+|Alerting service used by OpenShift Dedicated to send periodic pings that indicate whether the cluster is available and running.
+
+|`nosnch.in`
+|443
+|Alerting service used by OpenShift Dedicated to send periodic pings that indicate whether the cluster is available and running.
 
 |`*.osdsecuritylogs.splunkcloud.com`
-|Required. Used by the `splunk-forwarder-operator` as a log forwarding endpoint to be used by Red Hat SRE for log-based alerting.
-|443 and 9997
-
-|`http-inputs-osdsecuritylogs.splunkcloud.com`
-|Required. Used by the `splunk-forwarder-operator` as a log forwarding endpoint to be used by Red Hat SRE for log-based alerting.
-|443
-
-|`inputs1.osdsecuritylogs.splunkcloud.com`
+OR
+`inputs1.osdsecuritylogs.splunkcloud.com`
 `inputs2.osdsecuritylogs.splunkcloud.com`
 `inputs4.osdsecuritylogs.splunkcloud.com`
 `inputs5.osdsecuritylogs.splunkcloud.com`
@@ -285,13 +209,26 @@ If you do not use a default Red Hat NTP server, verify the NTP server for your p
 `inputs13.osdsecuritylogs.splunkcloud.com`
 `inputs14.osdsecuritylogs.splunkcloud.com`
 `inputs15.osdsecuritylogs.splunkcloud.com`
-|Required. Used by the `splunk-forwarder-operator` as a log forwarding endpoint to be used by Red Hat SRE for log-based alerting.
 |9997
+|Used by the `splunk-forwarder-operator` as a logging forwarding endpoint to be used by Red Hat SRE for log-based alerting.
 
-|`observatorium.api.openshift.com`
-|Required. Used for Managed OpenShift-specific telemetry.
+|`http-inputs-osdsecuritylogs.splunkcloud.com`
 |443
+|Required. Used by the `splunk-forwarder-operator` as a logging forwarding endpoint to be used by Red Hat SRE for log-based alerting.
+
+|`sftp.access.redhat.com` (Recommended)
+|22
+|The SFTP server used by `must-gather-operator` to upload diagnostic logs to help troubleshoot issues with the cluster.
 |===
+
+. If you did not allow a wildcard for Amazon Web Services (AWS) APIs, you will need to also allow the S3 bucket used for the internal OpenShift registry. To retrieve that endpoint, run the following command once the cluster has successfully been provisioned:
 +
+[source,terminal]
+----
+$ oc -n openshift-image-registry get pod -l docker-registry=default -o json | jq '.items[].spec.containers[].env[] | select(.name=="REGISTRY_STORAGE_S3_BUCKET")'
+----
++
+The S3 endpoint should be in the following format: '<cluster-name>-<random-string>-image-registry-<cluster-region>-<random-string>.s3.dualstack.<cluster-region>.amazonaws.com'.
+
 . Allowlist any site that provides resources for a language or framework that your builds require.
 . Allowlist any outbound URLs that depend on the languages and frameworks used in OpenShift. See link:https://access.redhat.com/solutions/2998411[OpenShift Outbound URLs to Allow] for a list of recommended URLs to be allowed on the firewall or proxy.


### PR DESCRIPTION
This applies to `main`, `enterprise-4.10` and `enterprise-4.9`.

This relates to https://issues.redhat.com/browse/OSDOCS-3177. This PR adds a missing new dependency on tagging.us-east-1.amazonaws.com:443 and other port specifications.

[Preview](https://deploy-preview-42173--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites)