### PR TITLE
JIRA-OSDOCS3037: Developed content for persistent storage using AWS EBS

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -203,6 +203,8 @@ Topics:
   Dir: persistent_storage
   Distros: openshift-rosa
   Topics:
+    - Name: Persistent storage using AWS Elastic Block Store (EBS)
+      File: rosa-persistent-storage-aws-ebs
     - Name: Persistent storage using AWS EFS
       File: osd-persistent-storage-aws
 ---

--- a/modules/rosa-howto-create-persistent-storage-aws-ebs.adoc
+++ b/modules/rosa-howto-create-persistent-storage-aws-ebs.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/rosa-persistent-storage-aws-ebs.adoc
+
+:_content-type: PROCEDURE
+[id="rosa-howto-create-persistent-volume-claim-aws-ebs_{context}"]
+= Creating a persistent volume claim
+
+toc::[]
+
+.Prerequisites
+Storage must exist in the underlying infrastructure before it can be mounted as a volume in the ROSA cluster.
+
+.Procedure
+. In the OpenShift Cluster console, click *Storage → Persistent Volume Claims*.
+. In the persistent volume claims overview, click *Create Persistent Volume Claim*.
+. Define the desired options on the page that appears.
+  .. Select the previously created storage class from the drop-down menu.
+  .. Enter a unique name for the storage claim.
+  .. Select the access mode. This selection determines the read and write access for the storage claim.
+  .. Define the size of the storage claim.
+. Click *Create* to create the persistent volume claim and generate a persistent volume.

--- a/storage/persistent_storage/rosa-persistent-storage-aws-ebs.adoc
+++ b/storage/persistent_storage/rosa-persistent-storage-aws-ebs.adoc
@@ -1,0 +1,49 @@
+:_content-type: ASSEMBLY
+[id="rosa-persistent-storage-aws-ebs"]
+= Persistent storage using AWS Elastic Block Store (EBS)
+include::modules/attributes-openshift-dedicated.adoc[]
+:context: rosa-persistent-storage-aws-ebs
+
+toc::[]
+
+{product-title} (ROSA) clusters are prebuilt with two storage classes that use AWS Elastic Block Store (EBS) volumes. These storage classes are ready to use and some familiarity with Kubernetes and AWS is assumed.
+
+Following are the two prebuilt storage classes:
+[options="header"]
+
+|===
+
+| Name | Provisioner
+
+| gp2 | kubernetes.io/aws-ebs
+
+| gp2-csi | ebs.csi.aws.com
+
+|===
+The gp2 storage class is set as default; however, you can select either one as the default storage class.
+
+The Kubernetes persistent volume framework enables administrators to provision a cluster with persistent storage and gives users a way to request those resources without having any knowledge of the underlying infrastructure. You can dynamically provision AWS EBS volumes. Persistent volumes are not bound to a single project or namespace; therefore, the volumes can be shared across ROSA clusters. Persistent volume claims are specific to a project or namespace and can be requested by users.
+
+[IMPORTANT]
+====
+* ROSA defaults to using an in-tree, or non-Container Storage Interface (CSI), plug-in to provision AWS EBS storage. In future ROSA versions, volumes provisioned using existing in-tree plug-ins are planned for migration to their equivalent CSI driver. After full migration, the in-tree plug-ins are planned to be removed from the future versions of ROSA.
+* High-availability of storage in the infrastructure is left to the underlying storage provider.
+====
+
+[id="format-persistent-storage-aws-ebs"]
+== Format of persistent volumes
+Before a ROSA cluster mounts the volume and passes it to a container, the cluster checks that the volume contains a file system as specified by the *fsType* parameter in the persistent volume definition. If the device is not formatted with a file system, all data from the device is erased and the device is automatically formatted with the given file system.
+This verification enables you to use unformatted AWS volumes as persistent volumes, as the ROSA cluster formats the AWS volumes before the first use.
+
+[id="capacity-persistent-storage-aws-ebs"]
+== Capacity of EBS volumes on a node
+By default, a ROSA cluster supports a maximum of 39 EBS volumes attached to one node. This limit is consistent with the link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html#linux-specific-volume-limits[AWS volume limits]. The volume limit depends on the instance type.
+
+[IMPORTANT]
+====
+You must use either in-tree or CSI volumes and their respective storage classes, but never both volume types at the same time. The maximum attached EBS volume number is counted separately for in-tree and CSI volumes, so you could have up to 39 EBS volumes of each type.
+====
+
+For information about accessing additional storage options, such as volume snapshots, that are not possible with in-tree volume plug-ins, see link:https://docs.openshift.com/container-platform/4.9/storage/container_storage_interface/persistent-storage-csi-ebs.html#persistent-storage-csi-ebs[Elastic Block Store CSI Driver Operator].
+
+include::modules/rosa-howto-create-persistent-storage-aws-ebs.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR is to address JIRA issue: https://issues.redhat.com/browse/OSDOCS-3037

Topic updated: https://deploy-preview-42174--osdocs.netlify.app/openshift-rosa/latest/storage/persistent_storage/rosa-persistent-storage-aws-ebs.html

The exact changes are as follows:

- Developed a new topic 'Persistent storage using AWS Elastic Block Store (EBS)'
- Updated the topic map topic_map_rosa.yml to include the newly-created topic. 

Repo: Request cherrypick to enterprise-4.9 and enterprise-4.10