### PR TITLE
[RHACS] Added info about adding new clusters to RHACS

### DIFF
--- a/installing/install-ocp-operator.adoc
+++ b/installing/install-ocp-operator.adoc
@@ -59,7 +59,7 @@ include::modules/portal-generate-init-bundle.adoc[leveloffset=+2]
 include::modules/roxctl-generate-init-bundle.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-==== Additional resources
+=== Additional resources
 * xref:../cli/getting-started-cli.adoc#installing-roxctl-cli[Installing the `roxctl` CLI]
 * xref:../cli/getting-started-cli.adoc#using-cli_cli-getting-started[Using the `roxctl` CLI]
 
@@ -70,3 +70,14 @@ include::modules/install-secured-cluster-operator.adoc[leveloffset=+1]
 include::modules/secured-cluster-configuration-options-operator.adoc[leveloffset=+1]
 
 include::modules/verify-acs-installation.adoc[leveloffset=+1]
+
+//Adding a new cluster to RHACS
+== Adding a new cluster to {product-title-short}
+To add more clusters to {product-title}, you must install the {product-title} Operator in every cluster that you want to add.
+
+The following steps represent the high-level flow for adding additional clusters to {product-title}:
+
+. xref:../installing/install-ocp-operator.adoc#install-acs-operator_install-ocp-operator[Install the {product-title} Operator] in your cluster.
+. Use an existing init bundle or xref:../installing/install-ocp-operator.adoc#generate-init-bundle-operator[generate a new init bundle].
+. xref:../installing/install-ocp-operator.adoc#create-resource-init-bundle_install-ocp-operator[Create resources in your cluster by using the init bundle].
+. xref:../installing/install-ocp-operator.adoc#install-secured-cluster-operator_install-ocp-operator[Install secured cluster services] on your cluster.


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSDOCS-2740

Applies to :
- `rhacs-docs-3.67`
- `rhacs-docs-3.68`
- `rhacs-docs-3.69`
- `rhacs-docs-3.70`

Preview: https://openshift-docs-git-adding-cluster-to-acs-gnelson.vercel.app/openshift-acs/master/installing/install-ocp-operator.html#adding-a-new-cluster-to-rhacs

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
