### PR TITLE
CNV15581, CNV13210: Bootsource autoupdate features

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3134,6 +3134,8 @@ Topics:
       File: virt-configuring-mediated-devices
     - Name: Configuring a watchdog device
       File: virt-configuring-a-watchdog
+    - Name: Automatic importing and updating of pre-defined boot sources
+      File: virt-automatic-bootsource-updates
     - Name: Enabling descheduler evictions on virtual machines
       File: virt-enabling-descheduler-evictions
 # Importing virtual machines

--- a/modules/virt-autoupdate-custom-bootsource.adoc
+++ b/modules/virt-autoupdate-custom-bootsource.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assembly:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-automatic-bootsource-updates.adoc
+//
+
+:_content-type: PROCEDURE
+[id="virt-autoupdate-custom-bootsource_{context}"]
+= Enabling automatic updates on custom boot sources
+
+{VirtProductName} automatically updates pre-defined boot sources by default, but does not automatically update custom boot sources. You must manually enable automatic imports and updates on any custom boot sources by editing the `HyperConverged` custom resource (CR).
+
+.Procedure
+
+. Use the following command to open the `HyperConverged` CR for editing:
++
+[source,terminal]
+----
+$ oc edit -n openshift-cnv HyperConverged
+----
+
+. Edit the `HyperConverged` CR, specifying the appropriate template and boot source in the `dataImportCronTemplates` section. For example:
++
+.Example in CentOS 7
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  dataImportCronTemplates:
+  - metadata:
+      name: centos7-image-cron
+      annotations:
+        cdi.kubevirt.io/storage.bind.immediate.requested: "true" <1>
+    spec:
+      schedule: "0 */12 * * *" <2>
+      template:
+        spec:
+          source:
+            registry: <3>
+              url: docker://quay.io/containerdisks/centos:7-2009
+          storage:
+            resources:
+              requests:
+                storage: 10Gi
+      managedDataSource: centos7 <4>
+      retentionPolicy: "None" <5>
+----
+<1> This annotation is required for storage classes with `volumeBindingMode` set to `WaitForFirstConsumer`.
+<2> Schedule for the job specified in cron format.
+<3> Use to create a data volume from a registry source. Use the default `pod` `pullMethod` and not `node` `pullMethod`, which is based on the `node` docker cache. The `node` docker cache is useful when a registry image is available via `Container.Image`, but the CDI importer is not authorized to access it.
+<4> For the custom image to be detected as an available boot source, the name of the image's `managedDataSource` must match the name of the template's `DataSource`, which is found under `spec.dataVolumeTemplates.spec.sourceRef.name` in the VM template YAML file.
+<5> Use `All` to retain data volumes and data sources when the cron job is deleted. Use `None` to delete data volumes and data sources when the cron job is deleted.

--- a/modules/virt-disable-bootsource-update.adoc
+++ b/modules/virt-disable-bootsource-update.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assembly:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-automatic-bootsource-updates.adoc
+//
+
+:_content-type: PROCEDURE
+[id="virt-disabling-bootsource-update_{context}"]
+= Disabling automatic boot source updates
+
+You can reduce the number of logs on disconnected environments or reduce resource usage by disabling the automatic imports and updates of pre-defined boot sources. Set the `spec.featureGates.enableCommonBootImageImport` field in the `HyperConverged` custom resource (CR) to `false`.
+
+[NOTE]
+====
+Custom boot sources are not affected by this setting.
+====
+
+.Procedure
+
+* Use the following command to disable automatic updates:
++
+[source,terminal]
+----
+$ oc patch hco kubevirt-hyperconverged -n openshift-cnv --type json -p '[{"op": "replace", "path": "/spec/featureGates/enableCommonBootImageImport", "value": false}]'
+----

--- a/modules/virt-enabling-bootsource-update.adoc
+++ b/modules/virt-enabling-bootsource-update.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assembly:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-automatic-bootsource-updates.adoc
+//
+
+:_content-type: PROCEDURE
+[id="virt-enabling-bootsource-update_{context}"]
+= Enabling automatic boot source updates
+
+If you have pre-defined boot sources from {VirtProductName} 4.9, then you must manually opt them in to the automatic boot source updates. All pre-defined boot sources from {VirtProductName} 4.10 and later are automatically updated by default.
+
+.Procedure
+
+* Use the following command to apply the `dataImportCron` label to the data source:
++
+[source,terminal]
+----
+$ oc label --overwrite DataSource rhel8 -n openshift-virtualization-os-images cdi.kubevirt.io/dataImportCron=true
+----

--- a/modules/virt-reenabling-bootsource-update.adoc
+++ b/modules/virt-reenabling-bootsource-update.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assembly:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-automatic-bootsource-updates.adoc
+//
+
+:_content-type: PROCEDURE
+[id="virt-reenabling-bootsource-update_{context}"]
+= Re-enabling automatic boot source updates
+
+If you have previously disabled automatic boot source updates, you must manually re-enable the feature. Set the `spec.featureGates.enableCommonBootImageImport` field in the `HyperConverged` custom resource (CR) to `true`.
+
+.Procedure
+
+* Use the following command to re-enable automatic updates:
++
+[source,terminal]
+----
+$ oc patch hco kubevirt-hyperconverged -n openshift-cnv --type json -p '[{"op": "replace", "path": "/spec/featureGates/enableCommonBootImageImport", "value": true}]'
+----

--- a/virt/virtual_machines/advanced_vm_management/virt-automatic-bootsource-updates.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-automatic-bootsource-updates.adoc
@@ -1,0 +1,17 @@
+:_content-type: ASSEMBLY
+[id="virt-automatic-bootsource-updates"]
+= Automatic importing and updating of pre-defined boot sources
+include::_attributes/virt-document-attributes.adoc[]
+:context: virt-automatic-bootsource-updates
+
+toc::[]
+
+As of version 4.10, {VirtProductName} automatically imports and updates pre-defined boot sources, unless you manually opt-out. If you upgrade to version {VirtProductName} 4.10 from version 4.9 or earlier and have pre-defined boot sources from the earlier version, you must manually opt-in to automatic imports and updates for those pre-defined boot sources.
+
+include::modules/virt-enabling-bootsource-update.adoc[leveloffset=+1]
+
+include::modules/virt-disable-bootsource-update.adoc[leveloffset=+1]
+
+include::modules/virt-reenabling-bootsource-update.adoc[leveloffset=+1]
+
+include::modules/virt-autoupdate-custom-bootsource.adoc[leveloffset=+1]


### PR DESCRIPTION
Re: [CNV-15581](https://issues.redhat.com/browse/CNV-15581) and [CNV-13210](https://issues.redhat.com/browse/CNV-13210)
For 4.10 and later
preview: https://deploy-preview-42176--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-automatic-bootsource-updates.html