### PR TITLE
Added notes for release 4.6.55

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3460,3 +3460,30 @@ link:https://access.redhat.com/solutions/6663261[{product-title} 4.6.54 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-6-55"]
+=== RHBA-2022:0566 - {product-title} 4.6.55 bug fix and security update
+
+Issued: 2022-02-23
+
+{product-title} release 4.6.55, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0566[RHBA-2022:0566] advisory. There are no RPM packages for this release. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0565[RHSA-2022:0565] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6751271[{product-title} 4.6.55 container image list]
+
+[id="ocp-4-6-55-features"]
+==== Features
+
+[id="ocp-4-6-55-features-ip-reconciler"]
+===== IP reconciliation for Whereabouts CNI IPAM plug-in
+
+A new enhancement to the Whereabouts CNI IPAM plug-in adds an IP reconciliation job, `ip-reconciler`, which runs as a Kubernetes cronjob.
+Previously, if a `CNI DEL` request did not finish for a pod, the pod's IP addresses remained allocated even though they were not used.
+Now these IP addresses are periodically collected and made available to be reallocated.
+(https://bugzilla.redhat.com/show_bug.cgi?id=2028968[*BZ#2028968*])
+
+[id="ocp-4-6-55-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
These are the release notes for OCP 4.6.55.

Applies only to `enterprise-4.6`

Preview: https://deploy-preview-42179--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes#ocp-4-6-55