### PR TITLE
[enterprise-4.9] Adding OSD and ROSA to distro map

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -9,3 +9,26 @@ openshift-enterprise:
     enterprise-4.1:
       name: '4.1'
       dir: container-platform/4.1
+openshift-dedicated:
+  name: OpenShift Dedicated
+  author: OpenShift Documentation Project <openshift-docs@redhat.com>
+  site: commercial
+  site_name: Documentation
+  site_url: https://docs.openshift.com/
+  branches:
+    enterprise-3.11:
+      name: '3'
+      dir: dedicated/3
+    enterprise-4.9:
+      name: ''
+      dir: dedicated/
+openshift-rosa:
+  name: Red Hat OpenShift Service on AWS
+  author: OpenShift Documentation Project <openshift-docs@redhat.com>
+  site: commercial
+  site_name: Documentation
+  site_url: https://docs.openshift.com/
+  branches:
+    enterprise-4.9:
+      name: ''
+      dir: rosa/


### PR DESCRIPTION
This applies to `enterprise-4.9` only.

The PR adds the OSD and ROSA stanzas to the distro map for 4.9, to enable preview builds for those collections in cherry pick PRs that are based on `enterprise-4.9`.