### PR TITLE
BZ 2053972 Adding clarification about DHCP infinite lease and MCO

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -105,6 +105,8 @@ For the `baremetal` network, a network administrator must reserve a number of IP
 .Reserving IP addresses so they become static IP addresses
 ====
 Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To use static IP addresses in the {product-title} cluster, reserve the IP addresses with an infinite lease. During deployment, the installer will reconfigure the NICs from DHCP assigned addresses to static IP addresses. NICs with DHCP leases that are not infinite will remain configured to use DHCP.
+
+Setting IP addresses with an infinite lease is incompatible with network configuration deployed by using the Machine Config Operator.
 ====
 
 [IMPORTANT]

--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -14,6 +14,8 @@ ifeval::[{product-version}>4.6]
 .Reserving IP addresses so they become static IP addresses
 ====
 Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To use static IP addresses in the {product-title} cluster, *reserve the IP addresses in the DHCP server with an infinite lease*. After the installer provisions the node successfully, the dispatcher script will check the node's network configuration. If the dispatcher script finds that the network configuration contains a DHCP infinite lease, it will recreate the connection as a static IP connection using the IP address from the DHCP infinite lease. NICs without DHCP infinite leases will remain unmodified.
+
+Setting IP addresses with an infinite lease is incompatible with network configuration deployed by using the Machine Config Operator.
 ====
 endif::[]
 


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=2053972
Relevant for 4.9 and needs backported to 4.8 and 4.7

Preview link: [Preview link 1](https://deploy-preview-42181--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites#network-requirements-reserving-ip-addresses_ipi-install-prerequisites)

