### PR TITLE
[enterprise-4.10] Fixing OSD build errors

### DIFF
--- a/modules/upgrade-49-acknowledgement.adoc
+++ b/modules/upgrade-49-acknowledgement.adoc
@@ -8,7 +8,7 @@
 [id="upgrade-49-acknowledgement_{context}"]
 = Administrator acknowledgment when upgrading to OpenShift 4.9
 
-{product-title} 4.9 uses Kubernetes 1.22, which removed a xref:../release_notes/ocp-4-9-release-notes.adoc#ocp-4-9-removed-kube-1-22-apis[significant number of deprecated `v1beta1` APIs].
+{product-title} 4.9 uses Kubernetes 1.22, which removed a link:https://docs.openshift.com/container-platform/4.9/release_notes/ocp-4-9-release-notes.html#ocp-4-9-removed-kube-1-22-apis[significant number of deprecated `v1beta1` APIs].
 
 {product-title} 4.8.14 introduced a requirement that an administrator must provide a manual acknowledgment before the cluster can be upgraded from {product-title} 4.8 to 4.9. This is to help prevent issues after upgrading to {product-title} 4.9, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this is done, the administrator can provide the administrator acknowledgment.
 

--- a/networking/configuring-cluster-wide-proxy.adoc
+++ b/networking/configuring-cluster-wide-proxy.adoc
@@ -23,11 +23,11 @@ Cluster-wide proxy is a functionally-complete feature and suitable for productio
 ifdef::openshift-dedicated[]
 * You must have a Customer Cloud Subscription (CCS) cluster with a VPC that the proxy can access.
 
-For more information, see xref:../../osd_quickstart/osd-quickstart.adoc[Quick Start] for a basic cluster installation workflow.
+For more information, see xref:../osd_quickstart/osd-quickstart.adoc#osd-quickstart[Quick Start] for a basic cluster installation workflow.
 endif::[]
 
 ifdef::openshift-rosa[]
-For information about standard installation prerequisites, see xref:../../rosa_getting_started/rosa-aws-prereqs.adoc[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc[AWS prerequisites for ROSA with STS].
+For information about standard installation prerequisites, see xref:../rosa_getting_started/rosa-aws-prereqs.adoc#prerequisites[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prerequisites[AWS prerequisites for ROSA with STS].
 endif::[]
 
 include::modules/cluster-wide-proxy.adoc[leveloffset=+1]

--- a/upgrading/osd-upgrading-cluster-prepare.adoc
+++ b/upgrading/osd-upgrading-cluster-prepare.adoc
@@ -12,12 +12,12 @@ Upgrading your {product-title} clusters to OpenShift 4.9 requires you to evaluat
 
 Before you can upgrade your {product-title} clusters, you must update the required tools to the appropriate version.
 
-include::modules/upgrade-49-acknowledgement.adoc[leveloffset=+2]
+include::modules/upgrade-49-acknowledgement.adoc[leveloffset=+1]
 
 // Removed Kubernetes APIs
 
 // Removed Kubernetes APIs
-include::modules/osd-update-preparing-list.adoc[leveloffset=+2]
+include::modules/osd-update-preparing-list.adoc[leveloffset=+1]
 
 [id="osd-evaluating-cluster-removed-apis"]
 == Evaluating your cluster for removed APIs
@@ -25,7 +25,7 @@ include::modules/osd-update-preparing-list.adoc[leveloffset=+2]
 There are several methods to help administrators identify where APIs that will be removed are in use. However, {product-title} cannot identify all instances, especially workloads that are idle or external tools that are used. It is the responsibility of the administrator to properly evaluate all workloads and other integrations for instances of removed APIs.
 
 // Reviewing alerts to identify uses of removed APIs
-include::modules/osd-update-preparing-evaluate-alerts.adoc[leveloffset=+2]
+include::modules/osd-update-preparing-evaluate-alerts.adoc[leveloffset=+1]
 
 // Using APIRequestCount to identify uses of removed APIs
 include::modules/osd-update-preparing-evaluate-apirequestcount.adoc[leveloffset=+2]


### PR DESCRIPTION
This applies to `enterprise-4.10`.

This PR resolves build issues for OSD and ROSA and fixes some `asciibinder build` warnings.