### PR TITLE
[enterprise-4.9] Fixing OSD build errors

### DIFF
--- a/networking/configuring-cluster-wide-proxy.adoc
+++ b/networking/configuring-cluster-wide-proxy.adoc
@@ -23,11 +23,11 @@ Cluster-wide proxy is a functionally-complete feature and suitable for productio
 ifdef::openshift-dedicated[]
 * You must have a Customer Cloud Subscription (CCS) cluster with a VPC that the proxy can access.
 
-For more information, see xref:../../osd_quickstart/osd-quickstart.adoc[Quick Start] for a basic cluster installation workflow.
+For more information, see xref:../osd_quickstart/osd-quickstart.adoc#osd-quickstart[Quick Start] for a basic cluster installation workflow.
 endif::[]
 
 ifdef::openshift-rosa[]
-For information about standard installation prerequisites, see xref:../../rosa_getting_started/rosa-aws-prereqs.adoc[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc[AWS prerequisites for ROSA with STS].
+For information about standard installation prerequisites, see xref:../rosa_getting_started/rosa-aws-prereqs.adoc#prerequisites[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prerequisites[AWS prerequisites for ROSA with STS].
 endif::[]
 
 include::modules/cluster-wide-proxy.adoc[leveloffset=+1]


### PR DESCRIPTION
This applies to `enterprise-4.9`.

This PR resolves build issues for OSD and ROSA and fixes some `asciibinder build` warnings.