### PR TITLE
[Do not merge][main] Travis test - adding a broken ROSA xref

### DIFF
--- a/rosa_getting_started/rosa-getting-started.adoc
+++ b/rosa_getting_started/rosa-getting-started.adoc
@@ -65,3 +65,5 @@ include::modules/rosa-getting-started-deleting-a-cluster.adoc[leveloffset=+1]
 * For information about setting up accounts and ROSA clusters without using AWS STS, see xref:../rosa_getting_started/rosa-getting-started-workflow.adoc#rosa-understanding-the-deployment-workflow[Understanding the ROSA deployment workflow]
 
 * For documentation on upgrading your cluster, see xref:../upgrading/rosa-upgrading.adoc#rosa-upgrading[Upgrading ROSA clusters]
+
+* Broken cross-reference test xref:../absent_directory/absent_file.adoc#absent-id[broken cross-reference].


### PR DESCRIPTION
**Do not merge, this is a test PR.**

This applies to `main` only.

This is a test PR to test the new Travis updates that were implemented in https://github.com/openshift/openshift-docs/pull/40741. This PR adds a broken cross-reference in the ROSA documentation.