### PR TITLE
BZ2056457: Adds olm.constraint dependencies

### DIFF
--- a/modules/olm-bundle-format-dependencies-file.adoc
+++ b/modules/olm-bundle-format-dependencies-file.adoc
@@ -8,10 +8,11 @@
 
 The dependencies of an Operator are listed in a `dependencies.yaml` file in the `metadata/` folder of a bundle. This file is optional and currently only used to specify explicit Operator-version dependencies.
 
-The dependency list contains a `type` field for each item to specify what kind of dependency this is. There are two supported types of Operator dependencies:
+The dependency list contains a `type` field for each item to specify what kind of dependency this is. There are three supported types of Operator dependencies:
 
 * `olm.package`: This type indicates a dependency for a specific Operator version. The dependency information must include the package name and the version of the package in semver format. For example, you can specify an exact version such as `0.5.2` or a range of versions such as `>0.5.1`.
 * `olm.gvk`: With a `gvk` type, the author can specify a dependency with group/version/kind (GVK) information, similar to existing CRD and API-based usage in a CSV. This is a path to enable Operator authors to consolidate all dependencies, API or explicit versions, to be in the same place.
+* `olm.constraint`: It declares a dependency constraint of a particular type, differentiating non-constraint and constraint properties. Its `value` field is an object containing a `failureMessage` field holding a string-representation of the constraint message that will be surfaced to the users if the constraint is not satisfiable at runtime.
 
 In the following example, dependencies are specified for a Prometheus Operator and etcd CRDs:
 


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2056457

OCP version: **Applicable only to 4.10**

Direct Doc Preview Link: https://deploy-preview-42199--osdocs.netlify.app/openshift-enterprise/latest/operators/understanding/olm-packaging-format.html#olm-bundle-format-dependencies_olm-packaging-format

https://deploy-preview-42199--osdocs.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-dependency-resolution.html#olm-bundle-format-dependencies_olm-understanding-dependency-resolution

@Xia-Zhao-rh PTAL and let me know your feedback.