### PR TITLE
Fixing OSD and ROSA build errors

### DIFF
--- a/modules/upgrade-49-acknowledgement.adoc
+++ b/modules/upgrade-49-acknowledgement.adoc
@@ -8,7 +8,7 @@
 [id="upgrade-49-acknowledgement_{context}"]
 = Administrator acknowledgment when upgrading to OpenShift 4.9
 
-{product-title} 4.9 uses Kubernetes 1.22, which removed a xref:../release_notes/ocp-4-9-release-notes.adoc#ocp-4-9-removed-kube-1-22-apis[significant number of deprecated `v1beta1` APIs].
+{product-title} 4.9 uses Kubernetes 1.22, which removed a significant number of deprecated `v1beta1` APIs.
 
 {product-title} 4.8.14 introduced a requirement that an administrator must provide a manual acknowledgment before the cluster can be upgraded from {product-title} 4.8 to 4.9. This is to help prevent issues after upgrading to {product-title} 4.9, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this is done, the administrator can provide the administrator acknowledgment.
 

--- a/upgrading/osd-upgrading-cluster-prepare.adoc
+++ b/upgrading/osd-upgrading-cluster-prepare.adoc
@@ -12,12 +12,12 @@ Upgrading your {product-title} clusters to OpenShift 4.9 requires you to evaluat
 
 Before you can upgrade your {product-title} clusters, you must update the required tools to the appropriate version.
 
-include::modules/upgrade-49-acknowledgement.adoc[leveloffset=+2]
+include::modules/upgrade-49-acknowledgement.adoc[leveloffset=+1]
 
 // Removed Kubernetes APIs
 
 // Removed Kubernetes APIs
-include::modules/osd-update-preparing-list.adoc[leveloffset=+2]
+include::modules/osd-update-preparing-list.adoc[leveloffset=+1]
 
 [id="osd-evaluating-cluster-removed-apis"]
 == Evaluating your cluster for removed APIs


### PR DESCRIPTION
This applies to `enterprise-4.9` only.

The PR resolves build errors that were introduced in https://github.com/openshift/openshift-docs/pull/42171.

The preview is [here](http://people.redhat.com/pneedle/osd-upgrading-cluster-prepare.html).