### PR TITLE
OSDOCS-3221: clarifying default statement per customer confusion

### DIFF
--- a/modules/nw-ingress-creating-a-route-via-an-ingress.adoc
+++ b/modules/nw-ingress-creating-a-route-via-an-ingress.adoc
@@ -32,7 +32,7 @@ spec:
       - backend:
           service:
             name: frontend
-            port: 
+            port:
               number: 443
         path: /
         pathType: Prefix
@@ -44,7 +44,7 @@ spec:
 +
 <1> The `route.openshift.io/termination` annotation can be used to configure the `spec.tls.termination` field of the `Route`
 as `Ingress` has no field for this. The accepted values are `edge`, `passthrough` and `reencrypt`. All
-other values are silently ignored. When unset, `edge` is used.
+other values are silently ignored. When the annotation value is unset, `edge` is the default route. The TLS certificate details must be defined in the template file to implement the default edge route.
 
 .. If you specify the `passthrough` value in the `route.openshift.io/termination` annotation, set `path` to `''` and `pathType` to `ImplementationSpecific` in the spec:
 +
@@ -60,7 +60,7 @@ other values are silently ignored. When unset, `edge` is used.
           backend:
             service:
               name: frontend
-              port: 
+              port:
                 number: 443
 ----
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3221

For 4.6+ 

Preview: https://deploy-preview-42221--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-ingress-creating-a-route-via-an-ingress_route-configuration

Clarifying a statement in the Ingress routing doc per a customer confusion, likely due to wording.

@quarterpin I think you're my unofficial QE for this, would you mind taking a look?