### PR TITLE
[Do not merge] Testing OSD and ROSA Netlify builds for 4.9

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -299,3 +299,5 @@ While cluster maintenance and host configuration is performed by the Red Hat Sit
 - *Monitor clusters*: Learn to use the Web UI to access monitoring dashboards.
 - *Manage nodes*: Learn to manage nodes, including configuring machine pools and autoscaling.
 endif::[]
+
+// Test


### PR DESCRIPTION
**This is a test PR, do not merge.**

This applies to `enterprise-4.9` only. This PR tests if Netlify builds for OSD and ROSA are triggered for PRs based on `enterprise-4.9`. The test relates to the distro map update that is applied in https://github.com/openshift/openshift-docs/pull/42180.
