### PR TITLE
BZ2049266 Added note on configuring MTU during installation

### DIFF
--- a/installing/installing_aws/installing-aws-government-region.adoc
+++ b/installing/installing_aws/installing-aws-government-region.adoc
@@ -41,6 +41,7 @@ include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]

--- a/modules/installation-aws-about-government-region.adoc
+++ b/modules/installation-aws-about-government-region.adoc
@@ -42,6 +42,14 @@ ifdef::aws-secret[]
 The following AWS Top Secret Region partition is supported:
 
 * `us-iso-east-1`
+
+[NOTE]
+====
+The maximum supported MTU in an AWS Top Secret Region is not the same as
+AWS commercial. For more information about configuring MTU during installation,
+see the _Cluster Network Operator configuration object_ section in _Installing
+a cluster on AWS with network customizations_
+====
 endif::aws-secret[]
 
 ifeval::["{context}" == "installing-aws-government-region"]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -223,6 +223,7 @@ endif::bare,ibm-power,ibm-z,ash[]
 After installation, you cannot modify these parameters in the `install-config.yaml` file.
 ====
 
+
 [id="installation-configuration-parameters-required_{context}"]
 == Required configuration parameters
 


### PR DESCRIPTION
CP to 4.10 and 4.11


Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2049266#c4

Direct link to doc preview: https://deploy-preview-42239--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-secret-region.html#installation-aws-about-gov-secret-region_installing-aws-secret-region

Ready for QA: @yunjiang29 

This replaces PR: https://github.com/openshift/openshift-docs/pull/42230

**Note:** This change also applies to 4.7- 4.8: https://github.com/openshift/openshift-docs/pull/44066, and 4.9: https://github.com/openshift/openshift-docs/pull/44279