### PR TITLE
Adding snippets symlink in modules directory

### DIFF
--- a/modules/snippets
+++ b/modules/snippets
@@ -1,0 +1,1 @@
+../snippets


### PR DESCRIPTION
This applies to `main` and `enterprise-4.10`. The symlink is already in place for the earlier enterprise 4.6+ branches.

This pull request adds a symlink to the top-level `symlinks` directory in the `modules` directory. A number of `include` statements have been added in modules to snippet files. This is causing `asciibinder build` errors such as the following:

`asciidoctor: ERROR: modules/odc-importing-codebase-from-git-to-create-application.adoc: line 58: include file not found: <directories>/openshift-docs/modules/snippets/routing-odc.adoc`

Even though the syntax of the `include` statements in the modules is correct (for example `include::snippets/routing-odc.adoc`), the snippet files are being searched for in `modules/snippets/` instead of in `snippets/`. This is presumably because the `include` statements are within modules.

https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#writing-text-snippets indicates the snippets let you reuse content in assemblies and modules.

I locally tested the symlink that this PR adds and it resolves the build issues. The snippets are subsequently shown in the preview build. At the moment, the snippets that are listed in the errors are not included in the live build.
