### PR TITLE
Adding missing call out reference

### DIFF
--- a/modules/ipi-install-configuring-raid-for-worker-node.adoc
+++ b/modules/ipi-install-configuring-raid-for-worker-node.adoc
@@ -33,7 +33,7 @@ Because servers with BMC type `irmc` do not support software RAID, the following
 spec:
   raid:
     hardwareRAIDVolumes:
-    - level: "0"
+    - level: "0" <1>
       name: "sda"
       numberOfPhysicalDisks: 1
       rotational: true


### PR DESCRIPTION
At the moment, this applies to `main` only, because the 4.10 cherry pick for https://github.com/openshift/openshift-docs/pull/37664 has not yet been merged. I have added a note in that PR in relation to this.

This PR adds a missing call out reference to resolve an `asciibinder build` warning.