### PR TITLE
BZ2057386:Updated openshift-ansible for ose-efs-provisioner

### DIFF
--- a/install_config/provisioners.adoc
+++ b/install_config/provisioners.adoc
@@ -82,7 +82,7 @@ ifdef::openshift-origin[]
 `openshift/origin-efs-provisioner:v1.0.0`, set version  as `v1.0.0`.
 endif::[]
 ifdef::openshift-enterprise[]
-`openshift3/efs-provisioner:v3.6`, set version as `v3.6`.
+`openshift3/ose-efs-provisioner:v3.11`, set version as `v3.11`.
 endif::[]
 
 |`openshift_provisioners_project`
@@ -163,7 +163,7 @@ configure a corresponding xref:../install_config/persistent_storage/dynamically_
 === Deploying the AWS EFS Provisioner
 The following command sets the directory in the EFS volume to
 `/data/persistentvolumes`. This directory must exist in the file system and must
-be mountable and writeable by the provisioner pod. Change to the playbook 
+be mountable and writeable by the provisioner pod. Change to the playbook
 directory and run the following playbook:
 
 ----


### PR DESCRIPTION
This fix is related to https://bugzilla.redhat.com/show_bug.cgi?id=1636993.
EFS provisioner image name `efs-provisioner` is updated to `ose-efs-provisioner`.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2057386

OCP version: **applicable only to 3.11**

Direct Doc Preview: https://deploy-preview-42251--osdocs.netlify.app/openshift-enterprise/latest/install_config/provisioners#provisioners-ansible-variables

@jsafrane @chao007 PTAL and let me know your feedback.