### PR TITLE
Add a note about volume snapshot on AliCloud

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-alicloud-disk.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-alicloud-disk.adoc
@@ -20,6 +20,11 @@ To create CSI-provisioned PVs that mount to AliCloud Disk storage assets, {produ
 
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 
+[id="persistent-storage-csi-alicloud-volume-snapshot-limitations"]
+== Volume snapshot limitation
+
+Alibaba Alicloud can take snapshot of a Disk only when the Disk is attached to a node. Attempt to take a snapshot of a PVC that is not attached to any node will results in error `rpc error: code = InvalidArgument desc = CreateSnapshot:: target disk: d-0xid8nzf2kqhzevjr9c1 must be attached`. {product-title} will retry taking the snapshot periodically, until the PVC is used by a Pod and corresponding AliCloud Disk is attached to a node and the snapshot is taken.
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]


### PR DESCRIPTION
Alibaba does not support taking a snapshot of un-attached volume, it fails with an error. Add a note to warn users about this.