### PR TITLE
BZ1836311: Change the position of the callout

### DIFF
--- a/modules/graceful-shutdown.adoc
+++ b/modules/graceful-shutdown.adoc
@@ -42,8 +42,9 @@ $ oc -n openshift-kube-apiserver-operator get secret kube-apiserver-to-kubelet-s
 +
 [source,terminal]
 ----
-$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1 <1>; done
+$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1 ; done <1>
 ----
+<1> `-h 1` indicates how long, in minutes, this process lasts before the control-plane nodes are shut down. For large-scale clusters with 10 nodes or more, set to 10 minutes or longer to make sure all the compute nodes have time to shut down first.
 +
 .Example output
 ----
@@ -56,7 +57,6 @@ Starting pod/ip-10-0-150-116us-east-2computeinternal-debug ...
 To use host binaries, run `chroot /host`
 Shutdown scheduled for Mon 2021-09-13 09:36:29 UTC, use 'shutdown -c' to cancel.
 ----
-<1> Indicates how long, in minutes, this process lasts before the control-plane nodes are shut down. For large-scale clusters with 10 nodes or more, set to 10 minutes or longer to make sure all the compute nodes have time to shut down first.
 +
 Shutting down the nodes using one of these methods allows pods to terminate gracefully, which reduces the chance for data corruption.
 +


### PR DESCRIPTION
`Asciibinder build` command currently is giving warning due to placing of a callout. This PR eliminates that warning
`asciidoctor: WARNING: modules/graceful-shutdown.adoc: line 59: no callout found for <1>`
https://bugzilla.redhat.com/show_bug.cgi?id=1836311
OCP version: 4.6+
QE @sunilcio 
[Preview](https://deploy-preview-42254--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-shutdown#graceful-shutdown_graceful-shutdown-cluster)