### PR TITLE
[enterprise-4.10] Removing recursive snippets symlink

### DIFF
--- a/snippets/snippets
+++ b/snippets/snippets
@@ -1,1 +1,0 @@
-../snippets/


### PR DESCRIPTION
This applies to `enterprise-4.10` only.

The PR unlinks a recursive `snippets/snippets` symlink. Before the fix in this PR, the symlink is currently as follows:

```
$ ls -ald snippets/snippets
lrwxrwxrwx. 1 pneedle pneedle 12 Feb 23 13:42 snippets/snippets -> ../snippets/

$ ls snippets/snippets
routing-odc.adoc  scaling-odc.adoc  serverless-domain-mapping-odc.adoc  serverless-service-account-apiserversource.adoc  snippets  technology-preview.adoc
```

This results in recursive symbolically linked `snippets` directories in the top-level `snippets` directory. Each recursive symlink directory links to its own parent directory. For example:

```
$ ls -ald snippets/snippets/snippets
lrwxrwxrwx. 1 pneedle pneedle 12 Feb 23 13:36 snippets/snippets/snippets -> ../snippets/
```