### PR TITLE
OSDOCS-3247: This PR fixes the missing prereqs from the OSD/ROSA proxy info

### DIFF
--- a/networking/configuring-cluster-wide-proxy.adoc
+++ b/networking/configuring-cluster-wide-proxy.adoc
@@ -1,3 +1,4 @@
+:_content-type: ASSEMBLY
 include::modules/common-attributes.adoc[]
 ifdef::openshift-dedicated[]
 include::modules/attributes-openshift-dedicated.adoc[]
@@ -20,12 +21,12 @@ Cluster-wide proxy is a functionally-complete feature and suitable for productio
 
 * You are the cluster owner.
 * Your account has sufficient privileges.
+* You have added the `ec2.<region>.amazonaws.com`, `elasticloadbalancing.<region>.amazonaws.com`, and `s3.<region>.amazonaws.com` endpoints to your VPC endpoint. These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works on the container level, not the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not sufficient.
 ifdef::openshift-dedicated[]
 * You must have a Customer Cloud Subscription (CCS) cluster with a VPC that the proxy can access.
 
 For more information, see xref:../osd_quickstart/osd-quickstart.adoc#osd-quickstart[Quick Start] for a basic cluster installation workflow.
 endif::[]
-
 ifdef::openshift-rosa[]
 For information about standard installation prerequisites, see xref:../rosa_getting_started/rosa-aws-prereqs.adoc#prerequisites[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prerequisites[AWS prerequisites for ROSA with STS].
 endif::[]


### PR DESCRIPTION
This PR fixes the missing prereq from #41726 

JIRA: https://issues.redhat.com/browse/OSDOCS-3247

PREVIEWS: 

**OSD** https://deploy-preview-42268--osdocs.netlify.app/openshift-dedicated/latest/networking/configuring-cluster-wide-proxy.html
**ROSA** https://deploy-preview-42268--osdocs.netlify.app/openshift-rosa/latest/networking/configuring-cluster-wide-proxy