### PR TITLE
SRVCOM-1701: General doc fixes and improvements to Operator docs

### DIFF
--- a/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operators/admin/olm-deleting-operators-from-a-cluster.adoc
+// * serverless/install/removing-openshift-serverless.adoc
 
 :_content-type: PROCEDURE
 [id="olm-deleting-operator-from-a-cluster-using-cli_{context}"]

--- a/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/admin/olm-deleting-operators-from-a-cluster.adoc
 // * backup_and_restore/application_backup_and_restore/installing/uninstalling-oadp.adoc
+// * serverless/install/removing-openshift-serverless.adoc
 
 :_content-type: PROCEDURE
 [id="olm-deleting-operators-from-a-cluster-using-web-console_{context}"]

--- a/modules/olm-refresh-subs.adoc
+++ b/modules/olm-refresh-subs.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * support/troubleshooting/troubleshooting-operator-issues.adoc
+// * serverless/install/removing-openshift-serverless.adoc
 
 :_content-type: PROCEDURE
 [id="olm-refresh-subs_{context}"]

--- a/modules/serverless-config-replicas-eventing.adoc
+++ b/modules/serverless-config-replicas-eventing.adoc
@@ -6,7 +6,7 @@
 [id="serverless-config-replicas-eventing_{context}"]
 = Configuring high availability replicas for Knative Eventing
 
-You can scale Knative Eventing components by modifying the `spec.high-availability.replicas` value in the KnativeEventing custom resource.
+You can scale Knative Eventing components by modifying the `spec.high-availability.replicas` value in the `KnativeEventing` custom resource (CR).
 
 .Prerequisites
 
@@ -25,7 +25,7 @@ You can scale Knative Eventing components by modifying the `spec.high-availabili
 +
 image::eventing-YAML-HA.png[Knative Eventing YAML]
 
-. Modify the number of replicas in the `KnativeEventing` CRD:
+. Modify the number of replicas in the `KnativeEventing` CR:
 +
 .Example YAML
 [source,yaml]
@@ -40,11 +40,6 @@ spec:
     replicas: 3 <1>
 ----
 <1> Sets the number of replicas to `3`.
-+
-[IMPORTANT]
-====
-Do not modify any YAML contained inside the `config` field. Some of the configuration values in this field are injected by the {ServerlessOperatorName}, and modifying them will cause your deployment to become unsupported.
-====
 +
 * The `replicas` value sets the replica count for all HA controllers.
 * The default `replicas` value is `2`.

--- a/modules/serverless-config-replicas-kafka.adoc
+++ b/modules/serverless-config-replicas-kafka.adoc
@@ -6,7 +6,7 @@
 [id="serverless-config-replicas-kafka_{context}"]
 = Configuring high availability replicas for Knative Kafka
 
-You can scale Knative Kafka components by modifying the `spec.high-availability.replicas` value in the KnativeKafka custom resource.
+You can scale Knative Kafka components by modifying the `spec.high-availability.replicas` value in the `KnativeKafka` custom resource (CR).
 
 .Prerequisites
 
@@ -25,7 +25,7 @@ You can scale Knative Kafka components by modifying the `spec.high-availability.
 +
 image::kafka-YAML-HA.png[Knative Kafka YAML]
 
-. Modify the number of replicas in the `KnativeKafka` CRD:
+. Modify the number of replicas in the `KnativeKafka` CR:
 +
 .Example YAML
 [source,yaml]
@@ -40,11 +40,6 @@ spec:
     replicas: 3 <1>
 ----
 <1> Sets the number of replicas to `3`.
-+
-[IMPORTANT]
-====
-Do not modify any YAML contained inside the `config` field. Some of the configuration values in this field are injected by the {ServerlessOperatorName}, and modifying them will cause your deployment to become unsupported.
-====
 +
 * The `replicas` value sets the replica count for all HA controllers.
 * The default `replicas` value is `2`.

--- a/modules/serverless-config-replicas-serving.adoc
+++ b/modules/serverless-config-replicas-serving.adoc
@@ -6,7 +6,7 @@
 [id="serverless-config-replicas-serving_{context}"]
 = Configuring high availability replicas for Knative Serving
 
-You can scale Knative Serving components by modifying the `spec.high-availability.replicas` value in the KnativeServing custom resource.
+You can scale Knative Serving components by modifying the `spec.high-availability.replicas` value in the `KnativeServing` custom resource (CR).
 
 .Prerequisites
 
@@ -25,7 +25,7 @@ You can scale Knative Serving components by modifying the `spec.high-availabilit
 +
 image::serving-YAML-HA.png[Knative Serving YAML]
 
-. Modify the number of replicas in the `KnativeServing` CRD:
+. Modify the number of replicas in the `KnativeServing` CR:
 +
 .Example YAML
 [source,yaml]
@@ -40,11 +40,6 @@ spec:
     replicas: 3 <1>
 ----
 <1> Sets the number of replicas to `3`.
-+
-[IMPORTANT]
-====
-Do not modify any YAML contained inside the `config` field. Some of the configuration values in this field are injected by the {ServerlessOperatorName}, and modifying them will cause your deployment to become unsupported.
-====
 +
 * The `replicas` value sets the replica count for all HA controllers.
 * The default `replicas` value is `2`.

--- a/serverless/install/install-serverless-operator.adoc
+++ b/serverless/install/install-serverless-operator.adoc
@@ -18,11 +18,6 @@ Read the following information about supported configurations and prerequisites 
 
 * {ServerlessProductName} currently cannot be used in a multi-tenant configuration on a single cluster.
 
-[IMPORTANT]
-====
-Before upgrading to the latest Serverless release, you must remove the community Knative Eventing Operator if you have previously installed it. Having the Knative Eventing Operator installed prevents you from being able to install the latest version of Knative Eventing using the {ServerlessOperatorName}.
-====
-
 include::modules/serverless-cluster-sizing-req.adoc[leveloffset=+2]
 
 [id="install-serverless-operator-scaling-with-machinesets"]

--- a/serverless/install/installing-knative-eventing.adoc
+++ b/serverless/install/installing-knative-eventing.adoc
@@ -13,3 +13,8 @@ This guide provides information about installing Knative Eventing using the defa
 
 include::modules/serverless-install-eventing-web-console.adoc[leveloffset=+1]
 include::modules/serverless-install-eventing-yaml.adoc[leveloffset=+1]
+
+[id="next-steps_installing-knative-eventing"]
+== Next steps
+
+* If you want to use Knative services you can xref:../../serverless/install/installing-knative-serving.adoc#installing-knative-serving[install Knative Serving].

--- a/serverless/install/removing-openshift-serverless.adoc
+++ b/serverless/install/removing-openshift-serverless.adoc
@@ -22,7 +22,16 @@ include::modules/serverless-uninstalling-knative-eventing.adoc[leveloffset=+1]
 [id="removing-openshift-serverless-removing-the-operator"]
 == Removing the {ServerlessOperatorName}
 
-You can remove the {ServerlessOperatorName} from the host cluster by following the documentation on xref:../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster].
+You can remove the {ServerlessOperatorName} from the host cluster by using the web console or the `oc` CLI.
+
+[NOTE]
+====
+Before you can remove the {ServerlessOperatorName}, you must remove Knative Serving and Knative Eventing.
+====
+
+include::modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc[leveloffset=+2]
+include::modules/olm-deleting-operators-from-a-cluster-using-cli.adoc[leveloffset=+2]
+include::modules/olm-refresh-subs.adoc[leveloffset=+2]
 
 // deleting serverless CRDs
 include::modules/serverless-deleting-crds.adoc[leveloffset=+1]


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVCOM-1701

Applies for OCP 4.6+

Direct previews:
- https://deploy-preview-42270--osdocs.netlify.app/openshift-enterprise/latest/serverless/install/install-serverless-operator.html#install-serverless-operator-before-you-begin
- https://deploy-preview-42270--osdocs.netlify.app/openshift-enterprise/latest/serverless/install/installing-knative-eventing.html#next-steps_installing-knative-eventing
- https://deploy-preview-42270--osdocs.netlify.app/openshift-enterprise/latest/serverless/install/removing-openshift-serverless.html#removing-openshift-serverless-removing-the-operator
- https://deploy-preview-42270--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-ha.html

Changes:
- Remove obsolete notes
- Fix minor formatting errors
- Directly include operator removal modules in serverless docs
- Add next steps to eventing install to make the same as serving (linking between both sections)