### PR TITLE
OSSMDOC-516: Draft of service mesh z-stream release notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -95,9 +95,9 @@ endif::[]
 :product-dedicated: Red Hat OpenShift Dedicated
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.1.1
+:SMProductVersion: 2.1.2
 :MaistraVersion: 2.1
 //Service Mesh v1
-:SMProductVersion1x: 1.1.17
+:SMProductVersion1x: 1.1.18
 //Windows containers
 :productwinc: Red Hat OpenShift support for Windows Containers

--- a/modules/ossm-rn-fixed-issues-1x.adoc
+++ b/modules/ossm-rn-fixed-issues-1x.adoc
@@ -21,6 +21,8 @@ The following issues been resolved in the current release:
 
 * link:https://issues.redhat.com/browse/MAISTRA-2371[MAISTRA-2371] Handle tombstones in listerInformer. The updated cache codebase was not handling tombstones when translating the events from the namespace caches to the aggregated cache, leading to a panic in the go routine.
 
+* link:https://issues.redhat.com/browse/OSSM-542[OSSM-542] Galley is not using the new certificate after rotation.
+
 * link:https://issues.jboss.org/browse/OSSM-99[OSSM-99] Workloads generated from direct Pod without labels may crash Kiali.
 
 * link:https://issues.jboss.org/browse/OSSM-93[OSSM-93] IstioConfigList can't filter by two or more names.

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -19,6 +19,9 @@ The following issues been resolved in the current release:
 [id="ossm-rn-fixed-issues-ossm_{context}"]
 == {SMProductShortName} fixed issues
 
+* https://issues.redhat.com/browse/OSSM-1074[OSSM-1074]
+Pod annotations defined in SMCP are not injected in the pods.
+
 * link:https://issues.redhat.com/browse/OSSM-797[OSSM-797] Kiali Operator pod generates `CreateContainerConfigError` while installing or updating the operator.
 
 * https://issues.redhat.com/browse/OSSM-722[OSSM-722]

--- a/modules/ossm-rn-new-features-1x.adoc
+++ b/modules/ossm-rn-new-features-1x.adoc
@@ -19,7 +19,11 @@ Module included in the following assemblies:
 * *Policy Enforcement* - Apply organizational policy to the interaction between services, ensure access policies are enforced and resources are fairly distributed among consumers. Policy changes are made by configuring the mesh, not by changing application code.
 * *Telemetry* - Gain understanding of the dependencies between services and the nature and flow of traffic between them, providing the ability to quickly identify issues.
 
-== Component versions included in {SMProductName} version {SMProductVersion}
+== New features {SMProductName} 1.1.18
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs).
+
+=== Component versions included in {SMProductName} version 1.1.18
 
 |===
 |Component |Version

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -19,7 +19,35 @@ Module included in the following assemblies:
 * *Policy Enforcement* - Apply organizational policy to the interaction between services, ensure access policies are enforced and resources are fairly distributed among consumers. Policy changes are made by configuring the mesh, not by changing application code.
 * *Telemetry* - Gain understanding of the dependencies between services and the nature and flow of traffic between them, providing the ability to quickly identify issues.
 
-== Component versions included in {SMProductName} version {SMProductVersion}
+== New features {SMProductName} 2.1.2
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
+
+=== Component versions included in {SMProductName} version {SMProductVersion}
+
+|===
+|Component |Version
+
+|Istio
+|1.9.9
+
+|Envoy Proxy
+|1.17.1
+
+|Jaeger
+|1.30.1
+
+|Kiali
+|1.36.8
+|===
+
+== New features {SMProductName} 2.1.1
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
+
+This release also adds the ability to disable the automatic creation of network policies.
+
+=== Component versions included in {ProductName} version 2.1.1
 
 |===
 |Component |Version
@@ -36,12 +64,6 @@ Module included in the following assemblies:
 |Kiali
 |1.36.7
 |===
-
-== New features {SMProductName} 2.1.1
-
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
-
-This release also adds the ability to disable the automatic creation of network policies.
 
 [id="ossm-config-disable-networkpolicy_{context}"]
 === Disabling network policies
@@ -81,9 +103,25 @@ spec:
 
 == New features and enhancements {SMProductName} 2.1
 
-This release of {SMProductName} adds support for Istio 1.9.8, Envoy Proxy 1.17.1, Jaeger 1.24.1, and Kiali 1.36.5 on {product-title} 4.6 EUS, 4.7, 4.8, and 4.9.
+This release of {SMProductName} adds support for Istio 1.9.8, Envoy Proxy 1.17.1, Jaeger 1.24.1, and Kiali 1.36.5 on {product-title} 4.6 EUS, 4.7, 4.8, 4.9, along with new features and enhancements.
 
-In addition, this release has the following new features and enhancements:
+=== Component versions included in {SMProductName} version 2.1
+
+|===
+|Component |Version
+
+|Istio
+|1.9.6
+
+|Envoy Proxy
+|1.17.1
+
+|Jaeger
+|1.24.1
+
+|Kiali
+|1.36.5
+|===
 
 === Service Mesh Federation
 
@@ -140,6 +178,28 @@ Kiali 1.36 includes the following features and enhancements:
 ** Unified view showing Envoy proxy and application logs interleaved
 * Namespace and cluster boxing to support federated service mesh views
 * New validations, wizards, and distributed tracing enhancements
+
+== New features {SMProductName} 2.0.9
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
+
+=== Component versions included in {SMProductName} version 2.0.9
+
+|===
+|Component |Version
+
+|Istio
+|1.6.14
+
+|Envoy Proxy
+|1.14.5
+
+|Jaeger
+|1.24.1
+
+|Kiali
+|1.24.11
+|===
 
 == New features {SMProductName} 2.0.8
 


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.6, 4.7, 4.8, 4.9, 4.10, 4.11
- Jira: https://issues.redhat.com/browse/OSSMDO-516
- Direct link to **2.1.2 and 2.0.9** doc preview: https://deploy-preview-42275--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html
- Direct link to **1.1.18** doc preview: https://deploy-preview-42275--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v1x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-1-1-18
- SME review: @longmuir
- QE review: @yxun, @tsze-redhat, @mattmahoneyrh 
- Peer review: @JStickler 
