### PR TITLE
Adds 3.11.634 release notes

### DIFF
--- a/install/disconnected_install.adoc
+++ b/install/disconnected_install.adoc
@@ -3,9 +3,9 @@
 {product-author}
 {product-version}
 :major-tag: v3.11
-:latest-tag: v3.11.521
-:latest-int-tag: v3.11.521
-:latest-registry-console-tag: v3.11.521
+:latest-tag: v3.11.634
+:latest-int-tag: v3.11.634
+:latest-registry-console-tag: v3.11.634
 :data-uri:
 :icons:
 :experimental:

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -3,10 +3,10 @@
 {product-author}
 {product-version}
 ifdef::openshift-enterprise[]
-:latest-tag: v3.11.521
+:latest-tag: v3.11.634
 endif::[]
 ifdef::openshift-origin[]
-:latest-tag: v3.11.521
+:latest-tag: v3.11.634
 endif::[]
 :data-uri:
 :icons:

--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -5575,3 +5575,104 @@ openshift3/ose-template-service-broker:v3.11.570-1.g6e33ff0
 ==== Upgrading
 
 To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.
+
+[[ocp-3-11-634]]
+=== RHSA-2022:0555 - {product-title} 3.11.634 bug fix and security update
+
+Issued: 2022-02-24
+
+{product-title} release 3.11.634, which includes security updates, is now available. The list of packages and bug fixes included in the update are documented in the link:https://access.redhat.com/errata/RHSA-2022:0555[RHSA-2022:0555] advisory. The container images included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0556[RHBA-2022:0556] advisory.
+
+[[ocp-3-11-634-bug-fix]]
+==== Bug fix
+* Previously, insecure EFS provisioner image name efs-provisioner was used in the ansible installer. This update changes the EFS provisioner image name to ose-efs-provisioner. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1636993[*BZ#1636993*])
+
+[[ocp-3-11-634-images]]
+==== Images
+
+This release updates the Red Hat Container Registry (`registry.redhat.io`) with the following images:
+
+----
+openshift3/ose-ansible:v3.11.634-1.g86bbe6f
+openshift3/ose-cluster-autoscaler:v3.11.634-1.g99b2acf
+openshift3/ose-descheduler:v3.11.634-1.gd435537
+openshift3/ose-metrics-server:v3.11.634-1.gf8bf728
+openshift3/ose-node-problem-detector:v3.11.634-1.gc8f26da
+openshift3/automation-broker-apb:v3.11.634-1
+openshift3/ose-cluster-monitoring-operator:v3.11.634-1.ga9fd527
+openshift3/ose-configmap-reloader:v3.11.634-1.gbb85bd3
+openshift3/csi-attacher:v3.11.634-1
+openshift3/csi-driver-registrar:v3.11.634-1
+openshift3/csi-livenessprobe:v3.11.634-1
+openshift3/csi-provisioner:v3.11.634-1
+openshift3/ose-efs-provisioner:v3.11.634-1.g04aa20d
+openshift3/oauth-proxy:v3.11.634-1.gedebe84
+openshift3/prometheus-alertmanager:v3.11.634-1.g13de638
+openshift3/prometheus-node-exporter:v3.11.634-1.g609cd20
+openshift3/prometheus:v3.11.634-1.g99aae51
+openshift3/grafana:v3.11.634-1.g2ea5517
+openshift3/image-inspector:v3.11.634-1
+openshift3/jenkins-agent-maven-35-rhel7:v3.11.634-1.g77b0225
+openshift3/jenkins-agent-maven-36-rhel7:v3.11.634-1.g77b0225
+openshift3/jenkins-agent-nodejs-10-rhel7:v3.11.634-1.g77b0225
+openshift3/jenkins-agent-nodejs-12-rhel7:v3.11.634-1.g77b0225
+openshift3/jenkins-slave-base-rhel7:v3.11.634-1.g77b0225
+openshift3/ose-kube-rbac-proxy:v3.11.634-1.g31106c3
+openshift3/ose-kube-state-metrics:v3.11.634-1.gb7c6d38
+openshift3/kuryr-cni:v3.11.634-1.g0c4bf66
+openshift3/ose-logging-curator5:v3.11.634-1.ge84e80c
+openshift3/ose-logging-elasticsearch5:v3.11.634-1.ge84e80c
+openshift3/ose-logging-eventrouter:v3.11.634-1
+openshift3/logging-fluentd:v3.11.634-1.ge84e80c
+openshift3/ose-logging-kibana5:v3.11.634-1.ge84e80c
+openshift3/metrics-cassandra:v3.11.634-1
+openshift3/metrics-hawkular-metrics:v3.11.634-1
+openshift3/metrics-hawkular-openshift-agent:v3.11.634-1
+openshift3/metrics-heapster:v3.11.634-1
+openshift3/metrics-schema-installer:v3.11.634-1
+openshift3/apb-base:v3.11.634-1.g79409e5
+openshift3/apb-tools:v3.11.634-1
+openshift3/ose-ansible-service-broker:v3.11.634-1
+openshift3/ose-docker-builder:v3.11.634-1.g9b5be6d
+openshift3/ose-cli:v3.11.634-1.g9b5be6d
+openshift3/ose-cluster-capacity:v3.11.634-1.g22be164
+openshift3/ose-console:v3.11.634-1.g34f65c8
+openshift3/ose:v3.11.634-1.g9b5be6d
+openshift3/ose-deployer:v3.11.634-1.g9b5be6d
+openshift3/ose-egress-dns-proxy:v3.11.634-1.g9b5be6d
+openshift3/ose-egress-router:v3.11.634-1.g9b5be6d
+openshift3/ose-haproxy-router:v3.11.634-1.g9b5be6d
+openshift3/ose-hyperkube:v3.11.634-1.g9b5be6d
+openshift3/ose-hypershift:v3.11.634-1.g9b5be6d
+openshift3/ose-keepalived-ipfailover:v3.11.634-1.g9b5be6d
+openshift3/mariadb-apb:v3.11.634-1
+openshift3/mediawiki-apb:v3.11.634-1
+openshift3/mediawiki:v3.11.634-1
+openshift3/mysql-apb:v3.11.634-1
+openshift3/node:v3.11.634-1.g9b5be6d
+openshift3/ose-pod:v3.11.634-1.g9b5be6d
+openshift3/postgresql-apb:v3.11.634-1
+openshift3/ose-recycler:v3.11.634-1.g9b5be6d
+openshift3/ose-docker-registry:v3.11.634-1.g3571208
+openshift3/ose-service-catalog:v3.11.634-1.g2e6be86
+openshift3/ose-tests:v3.11.634-1.g9b5be6d
+openshift3/jenkins-2-rhel7:v3.11.634-1.g77b0225
+openshift3/local-storage-provisioner:v3.11.634-1
+openshift3/manila-provisioner:v3.11.634-1
+openshift3/ose-operator-lifecycle-manager:v3.11.634-1.g1054881
+openshift3/ose-web-console:v3.11.634-1.g737ee87
+openshift3/ose-egress-http-proxy:v3.11.634-1.g9b5be6d
+openshift3/kuryr-controller:v3.11.634-1.g0c4bf66
+openshift3/ose-ovn-kubernetes:v3.11.634-1.g21370b4
+openshift3/ose-prometheus-config-reloader:v3.11.634-1.gd4bae2d
+openshift3/ose-prometheus-operator:v3.11.634-1.gd4bae2d
+openshift3/registry-console:v3.11.634-1
+openshift3/snapshot-controller:v3.11.634-1
+openshift3/snapshot-provisioner:v3.11.634-1
+openshift3/ose-template-service-broker:v3.11.634-1.g9b5be6d
+----
+
+[[ocp-3-11-634-updating]]
+==== Updating
+
+To update an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.

--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -2,9 +2,9 @@
 = Performing automated in-place cluster upgrades
 {product-author}
 {product-version}
-:latest-tag: v3.11.521
-:latest-short-tag: v3.11
-:latest-int-tag: v3.11.521
+:latest-tag: v3.11.634
+:latest-short-tag: v3.11.634
+:latest-int-tag: v3.11.634
 ifdef::openshift-enterprise[]
 :pb-prefix: /usr/share/ansible/openshift-ansible/
 endif::[]


### PR DESCRIPTION
No BZ.

To be merged on 02-24. I will send a reminder.

OCP version: **applicable only to 3.11**

Direct Doc Preview Link: https://deploy-preview-42277--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp_3_11_release_notes.html#ocp-3-11-634