### PR TITLE
CNV-13679: RN SR-IOV live migration feature gate enabled by default

### DIFF
--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -72,6 +72,7 @@ The SVVP Certification applies to:
 //CNV-13660 Inherit static IP from a NIC attached to the bridge
 
 //CNV-13679 SR-IOV live-migration without privilege escalation
+* xref:../virt/live_migration/virt-live-migration.adoc#virt-live-migration[Live migration] is now supported by default for virtual machines that are attached to an SR-IOV network interface.
 
 //CNV-13680 Primary and secondary networks over a shared NIC on OVN clusters
 


### PR DESCRIPTION
[CNV-13679](https://issues.redhat.com/browse/CNV-13679)

RN to document that live migration is now supported by default for VMs connected to SR-IOV network interfaces

Preview: https://deploy-preview-42300--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-10-release-notes#virt-4-10-networking-new