### PR TITLE
SRVCOM-1451: Add serving, security, support, additional admin docs for OSD

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -207,105 +207,133 @@ Topics:
 - Name: Update life cycle
   File: osd-life-cycle
 # serverless commented out til 1.21.0 release
-#---
-#Name: Serverless
-#Dir: serverless
-#Distros: openshift-dedicated
-#Topics:
-#- Name: Release notes
-#  File: serverless-release-notes
-#- Name: Discover
-#  Dir: discover
-#  Topics:
-#  - Name: About OpenShift Serverless
-#    File: about-serverless
-#  - Name: About OpenShift Serverless Functions
-#    File: serverless-functions-about
-#  - Name: Event sources
-#    File: knative-event-sources
-#  - Name: Channels and subscriptions
-#    File: serverless-channels
-#- Name: Install
-#  Dir: install
-#  Topics:
-#  - Name: Installing the OpenShift Serverless Operator
-#    File: install-serverless-operator
-#  - Name: Installing Knative Serving
-#    File: installing-knative-serving
-#  - Name: Installing Knative Eventing
-#    File: installing-knative-eventing
-#  - Name: Removing OpenShift Serverless
-#    File: removing-openshift-serverless
-#- Name: Develop
-#  Dir: develop
-#  Topics:
-#  - Name: Event sinks
-#    File: serverless-event-sinks
-#  - Name: Event delivery
-#    File: serverless-event-delivery
-#  - Name: Creating an API server source
-#    File: serverless-apiserversource
-#  - Name: Creating a ping source
-#    File: serverless-pingsource
-#  - File: serverless-custom-event-sources
-#    Name: Custom event sources
-#  - Name: Creating channels
-#    File: serverless-creating-channels
-#  - Name: Creating subscriptions
-#    File: serverless-subs
-# Brokers
-#  - Name: Brokers
-#    File: serverless-using-brokers
-# Triggers
-#  - Name: Triggers
-#    File: serverless-triggers
-#  - Name: Knative Kafka
-#    File: serverless-kafka-developer
-# Admin guide
-#- Name: Administer
-#  Dir: admin_guide
-#  Topics:
-#  - Name: Configuring Knative Eventing defaults
-#    File: serverless-configuring-eventing-defaults
-#  - Name: Knative Kafka
-#    File: serverless-kafka-admin
-#  - Name: High availability on OpenShift Serverless
-#    File: serverless-ha
-# Functions
-#- Name: Functions
-#  Dir: functions
-#  Topics:
-#  - Name: Setting up OpenShift Serverless Functions
-#    File: serverless-functions-setup
-#  - Name: Getting started with functions
-#    File: serverless-functions-getting-started
-#  - Name: Developing Node.js functions
-#    File: serverless-developing-nodejs-functions
-#  - Name: Developing TypeScript functions
-#    File: serverless-developing-typescript-functions
-#  - Name: Developing Golang functions
-#    File: serverless-developing-go-functions
-#  - Name: Developing Python functions
-#    File: serverless-developing-python-functions
-#  - Name: Developing Quarkus functions
-#    File: serverless-developing-quarkus-functions
-#  - Name: Using functions with Knative Eventing
-#    File: serverless-functions-eventing
-#  - Name: Function project configuration in func.yaml
-#    File: serverless-functions-yaml
-#  - Name: Accessing secrets and config maps from functions
-#    File: serverless-functions-accessing-secrets-configmaps
-#  - Name: Adding annotations to functions
-#    File: serverless-functions-annotations
-#  - Name: Functions development reference guide
-#    File: serverless-functions-reference-guide
-#- Name: CLI tools
-#  Dir: cli_tools
-#  Topics:
-#  - Name: Installing the Knative CLI
-#    File: installing-kn
-#  - Name: Knative CLI advanced configuration
-#    File: advanced-kn-config
+# ---
+# Name: Serverless
+# Dir: serverless
+# Distros: openshift-dedicated
+# Topics:
+# - Name: Release notes
+#   File: serverless-release-notes
+# - Name: Discover
+#   Dir: discover
+#   Topics:
+#   - Name: About OpenShift Serverless
+#     File: about-serverless
+#   - Name: About OpenShift Serverless Functions
+#     File: serverless-functions-about
+#   - Name: Event sources
+#     File: knative-event-sources
+#   - Name: Channels and subscriptions
+#     File: serverless-channels
+# - Name: Install
+#   Dir: install
+#   Topics:
+#   - Name: Installing the OpenShift Serverless Operator
+#     File: install-serverless-operator
+#   - Name: Installing Knative Serving
+#     File: installing-knative-serving
+#   - Name: Installing Knative Eventing
+#     File: installing-knative-eventing
+#   - Name: Removing OpenShift Serverless
+#     File: removing-openshift-serverless
+# - Name: Develop
+#   Dir: develop
+#   Topics:
+#   - Name: Serverless applications
+#     File: serverless-applications
+#   - Name: Autoscaling
+#     File: serverless-autoscaling-developer
+#   - Name: Traffic management
+#     File: serverless-traffic-management
+#   - Name: Routing
+#     File: serverless-configuring-routes
+#   - Name: Event sinks
+#     File: serverless-event-sinks
+#   - Name: Event delivery
+#     File: serverless-event-delivery
+#   - Name: Creating an API server source
+#     File: serverless-apiserversource
+#   - Name: Creating a ping source
+#     File: serverless-pingsource
+#   - File: serverless-custom-event-sources
+#     Name: Custom event sources
+#   - Name: Creating channels
+#     File: serverless-creating-channels
+#   - Name: Creating subscriptions
+#     File: serverless-subs
+#   - Name: Brokers
+#     File: serverless-using-brokers
+#   - Name: Triggers
+#     File: serverless-triggers
+#   - Name: Knative Kafka
+#     File: serverless-kafka-developer
+# # Admin guide
+# - Name: Administer
+#   Dir: admin_guide
+#   Topics:
+#   - Name: Configuring OpenShift Serverless
+#     File: serverless-configuration
+#   - Name: Configuring Knative Eventing defaults
+#     File: serverless-configuring-eventing-defaults
+#   - Name: Knative Kafka
+#     File: serverless-kafka-admin
+#   - Name: Creating Knative Eventing components in the Administrator perspective
+#     File: serverless-cluster-admin-eventing
+#   - Name: Creating Knative Serving components in the Administrator perspective
+#     File: serverless-cluster-admin-serving
+#   - Name: Configuring the Knative Serving custom resource
+#     File: knative-serving-CR-config
+#   - Name: Autoscaling
+#     File: serverless-admin-autoscaling
+#   - Name: High availability on OpenShift Serverless
+#     File: serverless-ha
+# - Name: Support
+#   File: serverless-support
+# - Name: Security
+#   Dir: security
+#   Topics:
+#   - Name: Configuring JSON Web Token authentication for Knative services
+#     File: serverless-ossm-with-kourier-jwt
+#   - Name: Configuring a custom domain for a Knative service
+#     File: serverless-custom-domains
+#   - Name: Using a custom TLS certificate for domain mapping
+#     File: serverless-custom-tls-cert-domain-mapping
+#   - Name: Security configuration for Knative Kafka
+#     File: serverless-kafka-security
+# - Name: Functions
+#   Dir: functions
+#   Topics:
+#   - Name: Setting up OpenShift Serverless Functions
+#     File: serverless-functions-setup
+#   - Name: Getting started with functions
+#     File: serverless-functions-getting-started
+#   - Name: Developing Node.js functions
+#     File: serverless-developing-nodejs-functions
+#   - Name: Developing TypeScript functions
+#     File: serverless-developing-typescript-functions
+#   - Name: Developing Golang functions
+#     File: serverless-developing-go-functions
+#   - Name: Developing Python functions
+#     File: serverless-developing-python-functions
+#   - Name: Developing Quarkus functions
+#     File: serverless-developing-quarkus-functions
+#   - Name: Using functions with Knative Eventing
+#     File: serverless-functions-eventing
+#   - Name: Function project configuration in func.yaml
+#     File: serverless-functions-yaml
+#   - Name: Accessing secrets and config maps from functions
+#     File: serverless-functions-accessing-secrets-configmaps
+#   - Name: Adding annotations to functions
+#     File: serverless-functions-annotations
+#   - Name: Functions development reference guide
+#     File: serverless-functions-reference-guide
+# - Name: CLI tools
+#   Dir: cli_tools
+#   Topics:
+#   - Name: Installing the Knative CLI
+#     File: installing-kn
+#   - Name: Knative CLI advanced configuration
+#     File: advanced-kn-config
 ---
 Name: Support
 Dir: support

--- a/modules/serverless-creating-broker-admin-web-console.adoc
+++ b/modules/serverless-creating-broker-admin-web-console.adoc
@@ -6,12 +6,25 @@
 [id="serverless-creating-broker-admin-web-console_{context}"]
 = Creating a broker by using the Administrator perspective
 
-If you have cluster administrator permissions, you can create a broker by using the Administrator perspective in the web console.
+ifdef::openshift-enterprise[]
+If you have cluster administrator permissions, you can create a broker by using the *Administrator* perspective in the web console.
+endif::[]
+
+ifdef::openshift-dedicated[]
+If you have cluster or dedicated administrator permissions, you can create a broker by using the *Administrator* perspective in the web console.
+endif::[]
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Eventing are installed on your {product-title} cluster.
+
+ifdef::openshift-enterprise[]
 * You have cluster administrator permissions for {product-title}.
+endif::[]
+
+ifdef::openshift-dedicated[]
+* You have cluster or dedicated administrator permissions for {product-title}.
+endif::[]
 
 .Procedure
 

--- a/modules/serverless-creating-channel-admin-web-console.adoc
+++ b/modules/serverless-creating-channel-admin-web-console.adoc
@@ -6,12 +6,25 @@
 [id="serverless-creating-channel-admin-web-console_{context}"]
 = Creating a channel by using the Administrator perspective
 
-If you have cluster administrator permissions, you can create a channel by using the Administrator perspective in the web console.
+ifdef::openshift-enterprise[]
+If you have cluster administrator permissions, you can create a channel by using the *Administrator* perspective in the web console.
+endif::[]
+
+ifdef::openshift-dedicated[]
+If you have cluster or dedicated administrator permissions, you can create a channel by using the *Administrator* perspective in the web console.
+endif::[]
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Eventing are installed on your {product-title} cluster.
+
+ifdef::openshift-enterprise[]
 * You have cluster administrator permissions for {product-title}.
+endif::[]
+
+ifdef::openshift-dedicated[]
+* You have cluster or dedicated administrator permissions for {product-title}.
+endif::[]
 
 .Procedure
 

--- a/modules/serverless-creating-event-source-admin-web-console.adoc
+++ b/modules/serverless-creating-event-source-admin-web-console.adoc
@@ -6,12 +6,25 @@
 [id="serverless-creating-event-source-admin-web-console_{context}"]
 = Creating an event source by using the Administrator perspective
 
-If you have cluster administrator permissions, you can create an event source by using the Administrator perspective in the web console.
+ifdef::openshift-enterprise[]
+If you have cluster administrator permissions, you can create an event source by using the *Administrator* perspective in the web console.
+endif::[]
+
+ifdef::openshift-dedicated[]
+If you have cluster or dedicated administrator permissions, you can create an event source by using the *Administrator* perspective in the web console.
+endif::[]
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Eventing are installed on your {product-title} cluster.
+
+ifdef::openshift-enterprise[]
 * You have cluster administrator permissions for {product-title}.
+endif::[]
+
+ifdef::openshift-dedicated[]
+* You have cluster or dedicated administrator permissions for {product-title}.
+endif::[]
 
 .Procedure
 

--- a/modules/serverless-creating-subscription-admin-web-console.adoc
+++ b/modules/serverless-creating-subscription-admin-web-console.adoc
@@ -6,12 +6,26 @@
 [id="serverless-creating-subscription-admin-web-console_{context}"]
 = Creating a subscription by using the Administrator perspective
 
-If you have cluster administrator permissions and have created a channel, you can create a subscription to connect your broker to a subscriber by using the Administrator perspective in the web console.
+ifdef::openshift-enterprise[]
+If you have cluster administrator permissions and have created a channel, you can create a subscription to connect your broker to a subscriber by using the *Administrator* perspective in the web console.
+endif::[]
+
+ifdef::openshift-dedicated[]
+If you have cluster or dedicated administrator permissions and have created a channel, you can create a subscription to connect your broker to a subscriber by using the *Administrator* perspective in the web console.
+endif::[]
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Eventing are installed on your {product-title} cluster.
+
+ifdef::openshift-enterprise[]
 * You have cluster administrator permissions for {product-title}.
+endif::[]
+
+ifdef::openshift-dedicated[]
+* You have cluster or dedicated administrator permissions for {product-title}.
+endif::[]
+
 * You have created a channel.
 * You have created a Knative service to use as a subscriber.
 

--- a/modules/serverless-creating-trigger-admin-web-console.adoc
+++ b/modules/serverless-creating-trigger-admin-web-console.adoc
@@ -6,12 +6,26 @@
 [id="serverless-creating-trigger-admin-web-console_{context}"]
 = Creating a trigger by using the Administrator perspective
 
-If you have cluster administrator permissions and have created a broker, you can create a trigger to connect your broker to a subscriber by using the Administrator perspective in the web console.
+ifdef::openshift-enterprise[]
+If you have cluster administrator permissions and have created a broker, you can create a trigger to connect your broker to a subscriber by using the *Administrator* perspective in the web console.
+endif::[]
+
+ifdef::openshift-dedicated[]
+If you have cluster or dedicated administrator permissions and have created a broker, you can create a trigger to connect your broker to a subscriber by using the *Administrator* perspective in the web console.
+endif::[]
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Eventing are installed on your {product-title} cluster.
+
+ifdef::openshift-enterprise[]
 * You have cluster administrator permissions for {product-title}.
+endif::[]
+
+ifdef::openshift-dedicated[]
+* You have cluster or dedicated administrator permissions for {product-title}.
+endif::[]
+
 * You have created a broker.
 * You have created a Knative service to use as a subscriber.
 

--- a/modules/serverless-domain-mapping-odc-admin.adoc
+++ b/modules/serverless-domain-mapping-odc-admin.adoc
@@ -6,7 +6,13 @@
 [id="serverless-domain-mapping-odc-admin_{context}"]
 = Mapping a custom domain to a service by using the Administrator perspective
 
+ifdef::openshift-enterprise[]
 If you have cluster administrator permissions, you can create a `DomainMapping` custom resource (CR) by using the *Administrator* perspective in the {product-title} web console.
+endif::[]
+
+ifdef::openshift-dedicated[]
+If you have cluster or dedicated administrator permissions, you can create a `DomainMapping` custom resource (CR) by using the *Administrator* perspective in the {product-title} web console.
+endif::[]
 
 .Prerequisites
 

--- a/modules/serverless-enable-scale-to-zero.adoc
+++ b/modules/serverless-enable-scale-to-zero.adoc
@@ -6,12 +6,26 @@
 [id="serverless-enable-scale-to-zero_{context}"]
 = Enabling scale-to-zero
 
+ifdef::openshift-enterprise[]
 Cluster administrators can enable or disable scale-to-zero globally for the cluster.
+endif::[]
+
+ifdef::openshift-dedicated[]
+Cluster or dedicated administrators can enable or disable scale-to-zero globally for the cluster.
+endif::[]
 
 .Prerequisites
 
 * You have installed {ServerlessOperatorName} and Knative Serving on your cluster.
+
+ifdef::openshift-enterprise[]
 * You have cluster administrator permissions.
+endif::[]
+
+ifdef::openshift-dedicated[]
+* You have cluster or dedicated administrator permissions.
+endif::[]
+
 * You are using the default Knative Pod Autoscaler. The scale to zero feature is not available if you are using the Kubernetes Horizontal Pod Autoscaler.
 
 .Procedure

--- a/modules/serverless-ossm-enable-sidecar-injection-with-kourier.adoc
+++ b/modules/serverless-ossm-enable-sidecar-injection-with-kourier.adoc
@@ -12,7 +12,9 @@ You can add the `sidecar.istio.io/inject="true"` annotation to a Knative service
 ====
 Adding sidecar injection to pods in system namespaces, such as `knative-serving` and `knative-serving-ingress`, is not supported when Kourier is enabled.
 
+ifdef::openshift-enterprise[]
 If you require sidecar injection for pods in these namespaces, see the {ServerlessProductName} documentation on _Integrating {ProductShortName} with {ServerlessProductName} natively_.
+endif::[]
 ====
 
 .Prerequisites

--- a/modules/serverless-scale-to-zero-grace-period.adoc
+++ b/modules/serverless-scale-to-zero-grace-period.adoc
@@ -11,7 +11,15 @@ This setting specifies an upper bound time limit that Knative waits for scale-fr
 .Prerequisites
 
 * You have installed {ServerlessOperatorName} and Knative Serving on your cluster.
+
+ifdef::openshift-enterprise[]
 * You have cluster administrator permissions.
+endif::[]
+
+ifdef::openshift-dedicated[]
+* You have cluster or dedicated administrator permissions.
+endif::[]
+
 * You are using the default Knative Pod Autoscaler. The scale to zero feature is not available if you are using the Kubernetes Horizontal Pod Autoscaler.
 
 .Procedure

--- a/serverless/admin_guide/knative-serving-CR-config.adoc
+++ b/serverless/admin_guide/knative-serving-CR-config.adoc
@@ -7,7 +7,13 @@ include::modules/serverless-document-attributes.adoc[]
 
 toc::[]
 
+ifdef::openshift-enterprise[]
 This guide describes how cluster administrators can manage settings for developer-created custom resources (CRs) that are created from the Knative Serving CR.
+endif::[]
+
+ifdef::openshift-dedicated[]
+This guide describes how cluster or dedicated administrators can manage settings for developer-created custom resources (CRs) that are created from the Knative Serving CR.
+endif::[]
 
 // config options
 include::modules/knative-serving-CR-system-deployments.adoc[leveloffset=+1]
@@ -16,8 +22,10 @@ include::modules/serverless-config-emptydir.adoc[leveloffset=+1]
 // global https redirect
 include::modules/serverless-https-redirect-global.adoc[leveloffset=+1]
 
+ifdef::openshift-enterprise[]
 [id="additional-resources_knative-serving-CR-config"]
 [role="_additional-resources"]
 == Additional resources
 
 * See xref:../../operators/understanding/crds/crd-managing-resources-from-crds.adoc[Managing resources from custom resource definitions].
+endif::[]

--- a/serverless/admin_guide/serverless-admin-autoscaling.adoc
+++ b/serverless/admin_guide/serverless-admin-autoscaling.adoc
@@ -7,7 +7,13 @@ include::modules/serverless-document-attributes.adoc[]
 
 toc::[]
 
+ifdef::openshift-enterprise[]
 As a cluster administrator, you can set global and per-namespace default configurations for autoscaling features by modifying the `KnativeServing` custom resource (CR). This propagates changes to the relevant config maps.
+endif::[]
+
+ifdef::openshift-dedicated[]
+As a cluster or dedicated administrator, you can set global and per-namespace default configurations for autoscaling features by modifying the `KnativeServing` custom resource (CR). This propagates changes to the relevant config maps.
+endif::[]
 
 include::modules/serverless-enable-scale-to-zero.adoc[leveloffset=+1]
 include::modules/serverless-scale-to-zero-grace-period.adoc[leveloffset=+1]

--- a/serverless/admin_guide/serverless-cluster-admin-serving.adoc
+++ b/serverless/admin_guide/serverless-cluster-admin-serving.adoc
@@ -7,7 +7,13 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+ifdef::openshift-enterprise[]
 If you have cluster administrator permissions on an {product-title} cluster, you can create Knative Serving components with {ServerlessProductName} in the *Administrator* perspective of the web console or by using the `kn` and `oc` CLIs.
+endif::[]
+
+ifdef::openshift-dedicated[]
+If you have cluster or dedicated administrator permissions on an {product-title} cluster, you can create Knative Serving components with {ServerlessProductName} in the *Administrator* perspective of the web console or by using the `kn` and `oc` CLIs.
+endif::[]
 
 // Create services as an admin
 include::modules/creating-serverless-apps-admin-console.adoc[leveloffset=+1]

--- a/serverless/develop/serverless-applications.adoc
+++ b/serverless/develop/serverless-applications.adoc
@@ -37,7 +37,15 @@ spec:
 
 You can create a serverless application by using one of the following methods:
 
+ifdef::openshift-enterprise[]
 * Create a Knative service from the {product-title} web console. See the documentation about xref:../../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating applications using the Developer perspective].
+endif::[]
+
+ifdef::openshift-dedicated[]
+* Create a Knative service from the {product-title} web console.
+endif::[]
+// TODO: remove conditional once Applications docs are available in OSD
+
 * Create a Knative service using the `kn` CLI.
 * Create and apply a YAML file.
 
@@ -59,8 +67,11 @@ include::modules/kn-service-describe.adoc[leveloffset=+1]
 include::modules/verifying-serverless-app-deployment.adoc[leveloffset=+1]
 include::modules/interacting-serverless-apps-http2-gRPC.adoc[leveloffset=+1]
 
+// OCP only
+ifdef::openshift-enterprise[]
 // Using Knative services w/ restrictive NetworkPolicies
 include::modules/serverless-services-network-policies.adoc[leveloffset=+1]
+endif::[]
 
 [role="_additional-resources"]
 .Additional resources

--- a/serverless/develop/serverless-autoscaling-developer.adoc
+++ b/serverless/develop/serverless-autoscaling-developer.adoc
@@ -9,7 +9,15 @@ toc::[]
 
 Knative Serving provides automatic scaling, or _autoscaling_, for applications to match incoming demand. For example, if an application is receiving no traffic, and scale-to-zero is enabled, Knative Serving scales the application down to zero replicas. If scale-to-zero is disabled, the application is scaled down to the minimum number of replicas configured for applications on the cluster. Replicas can also be scaled up to meet demand if traffic to the application increases.
 
-Autoscaling settings for Knative services can be global settings that are configured by cluster administrators, or per-revision settings that are configured for individual services. You can modify per-revision settings for your services by using the {product-title} web console, by modifying the YAML file for your service, or by using the `kn` CLI.
+ifdef::openshift-enterprise[]
+Autoscaling settings for Knative services can be global settings that are configured by cluster administrators, or per-revision settings that are configured for individual services.
+endif::[]
+
+ifdef::openshift-dedicated[]
+Autoscaling settings for Knative services can be global settings that are configured by cluster or dedicated administrators, or per-revision settings that are configured for individual services.
+endif::[]
+
+You can modify per-revision settings for your services by using the {product-title} web console, by modifying the YAML file for your service, or by using the `kn` CLI.
 
 [NOTE]
 ====
@@ -45,4 +53,10 @@ include::modules/serverless-target-utilization.adoc[leveloffset=+2]
 [role="_additional-resources"]
 == Additional resources
 
+ifdef::openshift-enterprise[]
 * Scale-to-zero can be enabled or disabled for the cluster by cluster administrators. For more information, see xref:../../serverless/admin_guide/serverless-admin-autoscaling.adoc#serverless-enable-scale-to-zero_serverless-admin-autoscaling[Enabling scale-to-zero].
+endif::[]
+
+ifdef::openshift-dedicated[]
+* Scale-to-zero can be enabled or disabled for the cluster by cluster or dedicated administrators. For more information, see xref:../../serverless/admin_guide/serverless-admin-autoscaling.adoc#serverless-enable-scale-to-zero_serverless-admin-autoscaling[Enabling scale-to-zero].
+endif::[]

--- a/serverless/develop/serverless-configuring-routes.adoc
+++ b/serverless/develop/serverless-configuring-routes.adoc
@@ -17,8 +17,10 @@ include::modules/serverless-customize-labels-annotations-routes.adoc[leveloffset
 include::modules/serverless-openshift-routes.adoc[leveloffset=+1]
 include::modules/knative-service-cluster-local.adoc[leveloffset=+1]
 
+ifdef::openshift-enterprise[]
 [id="additional-resources_serverless-configuring-routes"]
 [role="_additional-resources"]
 == Additional resources
 
 * For more information about supported {product-title} route annotations, see xref:../..//networking/routes/route-configuration.adoc#nw-route-specific-annotations_route-configuration[Route-specific annotations].
+endif::[]


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVCOM-1451

Applies for OCP 4.9, 4.10+

Direct preview links:
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/develop/serverless-applications.html
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/develop/serverless-autoscaling-developer.html
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/develop/serverless-traffic-management.html
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/develop/serverless-configuring-routes.html
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/admin_guide/serverless-cluster-admin-eventing.html
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/admin_guide/serverless-cluster-admin-serving.html
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/admin_guide/knative-serving-cr-config
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/admin_guide/serverless-admin-autoscaling.html
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/serverless-support.html
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/security/serverless-ossm-with-kourier-jwt.html
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/security/serverless-custom-domains.html
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/security/serverless-custom-tls-cert-domain-mapping.html
- https://deploy-preview-42307--osdocs.netlify.app/openshift-dedicated/latest/serverless/security/serverless-kafka-security.html