### PR TITLE
OSDOCS-3001: Added Day 2 information for proxies

### DIFF
--- a/modules/cluster-wide-proxy-updates.adoc
+++ b/modules/cluster-wide-proxy-updates.adoc
@@ -1,0 +1,97 @@
+// Module included in the following assemblies:
+//
+// * networking/configuring-cluster-wide-proxy.adoc
+
+//OSDOCS-3001 Configuration for cluster-wide-proxy Day 2
+:_content-type: PROCEDURE
+[id="cluster-wide-proxy-updates_{context}"]
+= Configuring or updating your cluster-wide proxy after installation
+
+ifdef::openshift-rosa[]
+As the cluster owner, you may wish to add a proxy to your created cluster after installation, or you may wish to make changes to your proxy that you configured during cluster installation. The `rosa` CLI provides some options for adding a proxy to your cluster or modifying an existing proxy on your cluster.
+endif::[]
+ifdef::openshift-dedicated[]
+As the cluster owner, you may wish to add a proxy to your created cluster after installation, or you may wish to make changes to your proxy that you configured during cluster installation. The `ocm` CLI provides some options for adding a proxy to your cluster or modifying an existing proxy on your cluster.
+endif::[]
+
+You may need to perform these actions if:
+
+* the cluster-wide proxy is configured after installation,
+* the proxy's network address needs to be updated, and/or
+* any of the proxy's certificate authorities have expired and the additional trust bundle needs to be replaced.
+
+[NOTE]
+====
+The cluster applies the configuration to the cluster’s control plane and worker nodes. This process results in each node in the cluster temporarily being placed into an unschedulable state and drained of its workloads while applying the configuration. Each node will be restarted as part of this process.
+====
+
+.Prerequsites
+ifdef::openshift-rosa[]
+* You have the `rosa` CLI installed and configured.
+endif::[]
+ifdef::openshift-dedicated[]
+* You have the `ocm` CLI installed and configured.
+endif::[]
+
+.Procedure
+* To edit a cluster, run the following command:
++
+ifdef::openshift-rosa[]
+[source,terminal]
+----
+$ rosa edit cluster \
+ --cluster $CLUSTER_NAME \
+ --additional-trust-bundle-file $CA_BUNDLE_FILE \
+ --http-proxy $HTTP_PROXY \
+ --https-proxy $HTTPS_PROXY
+----
+endif::[]
+ifdef::openshift-dedicated[]
+[source,terminal]
+----
+$ ocm edit cluster \
+ --cluster $CLUSTER_NAME \
+ --additional-trust-bundle-file $CA_BUNDLE_FILE \
+ --http-proxy $HTTP_PROXY \
+ --https-proxy $HTTPS_PROXY
+----
+endif::[]
++
+While the `additional-trust-bundle-file`, `http-proxy`, and `https-proxy` arguments are optional, if you set a `additional-trust-bundle-file` without either an `http-proxy` or `https-proxy` argument, then the additional trust bundle will still be used for verifying cluster system egress traffic.
+* You can verify that the proxy and certificate authority configuration updates have been successfully applied to your cluster by:
+** All of the MachineConfigPools are updated. Run the following command to see their status:
++
+[source,terminal]
+----
+$ oc get machineconfigpools
+----
++
+.Sample Output
+[source,terminal]
+----
+NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+master   rendered-master-d9a03f612a432095dcde6dcf44597d90   True      False      False      3              3                   3                     0                      31h
+worker   rendered-worker-f6827a4efe21e155c25c21b43c46f65e   True      False      False      6              6                   6                     0                      31h
+----
++
+** As the cluster owner, the following command displays the proxy status:
++
+[source,terminal]
+----
+$ oc get proxy cluster -o yaml
+----
++
+.Sample Output
+[source,terminal]
+----
+apiVersion: config.openshift.io/v1
+kind: Proxy
+spec:
+  httpProxy: http://proxy.host.domain:<port>
+  httpsProxy: https://proxy.host.domain:<port>
+  <...more...>
+status:
+  httpProxy: http://proxy.host.domain:<port>
+  httpsProxy: https://proxy.host.domain:<port>
+  <...more...>
+----

--- a/modules/cluster-wide-proxy.adoc
+++ b/modules/cluster-wide-proxy.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="cluster-wide-proxy-config_{context}"]
-= Configuring a cluster-wide proxy
+= Configuring a cluster-wide proxy during installation
 
 You can add a proxy during cluster installation. Prior to installation, however, you should verify that the proxy is accessible from the intended cluster virtual private cloud (VPC) and its private subnets.
 
@@ -16,7 +16,6 @@ ifdef::openshift-dedicated[]
 * You have the `ocm` CLI installed and configured.
 endif::[]
 
-//CANARY
 [WARNING]
 ====
 Only cluster system egress traffic is proxied, including calls to the AWS API. A system-wide proxy does not affect user workloads. It only affects system components.
@@ -48,5 +47,5 @@ endif::[]
 +
 <1> The `http-proxy`, `https-proxy`, and `additional-trust-bundle-file` arguments are all optional.
 <2> If you use the `additional-trust-bundle-file` option without an `http(s)-proxy` argument, the passed additional trust bundle is set on the cluster, but it is not configured to be used with the proxy.
-<3> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The `additionalTrustBundle` field is required unless the proxy's identity certificate is signed by an authority from the {op-system} trust bundle. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
+<3> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The `additionalTrustBundle` parameter is required unless the proxy's identity certificate is signed by an authority from the {op-system} trust bundle. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
 <4> The `http-proxy` and `https-proxy` arguments must point to a valid URL.

--- a/networking/configuring-cluster-wide-proxy.adoc
+++ b/networking/configuring-cluster-wide-proxy.adoc
@@ -11,6 +11,12 @@ toc::[]
 
 You can configure a cluster-wide proxy during cluster installation.
 
+//OSDOCS-2830 Customer Responsibilities
+If you use a cluster-wide proxy, you are responsible for the following:
+
+* Maintaining the availability of the proxy to the cluster.
+* Understanding that if the proxy becomes unavailable, then it may impact the health and supportability of the cluster.
+
 [IMPORTANT]
 ====
 Cluster-wide proxy is a functionally-complete feature and suitable for production workloads. There are additional considerations that need to be added to documentation, and until then, this feature is considered a Technology Preview.
@@ -22,13 +28,46 @@ Cluster-wide proxy is a functionally-complete feature and suitable for productio
 * You are the cluster owner.
 * Your account has sufficient privileges.
 * You have added the `ec2.<region>.amazonaws.com`, `elasticloadbalancing.<region>.amazonaws.com`, and `s3.<region>.amazonaws.com` endpoints to your VPC endpoint. These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works on the container level, not the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not sufficient.
+ifdef::openshift-rosa[]
+For information about standard installation prerequisites, see xref:../rosa_getting_started/rosa-aws-prereqs.adoc#prerequisites[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prerequisites[AWS prerequisites for ROSA with STS].
+endif::[]
 ifdef::openshift-dedicated[]
 * You must have a Customer Cloud Subscription (CCS) cluster with a VPC that the proxy can access.
 
 For more information, see xref:../osd_quickstart/osd-quickstart.adoc#osd-getting-started[Getting started with {product-title}] for a basic cluster installation workflow.
 endif::[]
-ifdef::openshift-rosa[]
-For information about standard installation prerequisites, see xref:../rosa_getting_started/rosa-aws-prereqs.adoc#prerequisites[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prerequisites[AWS prerequisites for ROSA with STS].
-endif::[]
+
+//OSDOCS-3290 Transparent Proxy Update
+[IMPORTANT]
+====
+The use of a proxy server to perform TLS re-encryption is currently not supported if the server is acting as a transparent forward proxy where it is not configured on-cluster via the `--http-proxy` or `--https-proxy` arguments.
+
+A transparent forward proxy intercepts the cluster’s traffic, but it is not actually configured on the cluster itself.
+====
 
 include::modules/cluster-wide-proxy.adoc[leveloffset=+1]
+include::modules/cluster-wide-proxy-updates.adoc[leveloffset=+1]
+
+//OSDOCS-2630 Proxy Configuration Expectations
+ifdef::openshift-rosa[]
+[NOTE]
+====
+You should not attempt to change the proxy or additional trust bundle configuration on the cluster itself. These changes should always be done via the `rosa` command-line tools. Any changes that are made directly to the cluster will be reverted automatically.
+====
+endif::[]
+ifdef::openshift-dedicated[]
+[NOTE]
+====
+You should not attempt to change the proxy or additional trust bundle configuration on the cluster itself. These changes should always be done via the `ocm` command-line tools. Any changes that are made directly to the cluster will be reverted automatically.
+====
+endif::[]
+
+//OSDOCS-2830 Customer Responsibilities
+[id="trust_bundle_responsibilities_cluster-wide-proxy-configuration"]
+=== Responsibilites for additional trust bundles
+
+If you supplied an additional trust bundle file, you are responsible for the following:
+
+* Ensuring that the contents of the additional trust bundle are valid,
+* Ensuring that the certificates, including intermediary certificates, contained in the additional trust bundle have not expired, and
+* Tracking the expiry and performing any necessary renewals for certificates contained in the additional trust bundle, and subsequently updating the cluster’s configuration with the updated additional trust bundle.


### PR DESCRIPTION
This PR details the upgrading and deleting configuration process with a cluster-wide proxy.

JIRA: https://issues.redhat.com/browse/OSDOCS-3001

PREVIEWS: 

**ROSA** https://deploy-preview-42320--osdocs.netlify.app/openshift-rosa/latest/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-config_cluster-wide-proxy-configuration

**OSD** https://deploy-preview-42320--osdocs.netlify.app/openshift-dedicated/latest/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-updates_cluster-wide-proxy-configuration