### PR TITLE
Add heading back for control plane Operators overview

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -23,7 +23,7 @@ include::modules/arch-platform-operators.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../operators/operator-reference.adoc#platform-operators-ref[Platform Operators reference].
+* xref:../operators/operator-reference.adoc#platform-operators-ref[Platform Operators reference]
 endif::[]
 
 include::modules/arch-olm-operators.adoc[leveloffset=+2]

--- a/modules/operators-overview.adoc
+++ b/modules/operators-overview.adoc
@@ -9,7 +9,10 @@ ifeval::["{context}" == "operators-overview"]
 endif::[]
 
 :_content-type: CONCEPT
+ifndef::index[]
 [id="operators-overview_{context}"]
+= Operators in {product-title}
+endif::[]
 
 Operators are among the most important components of {product-title}. Operators are the preferred method of packaging, deploying, and managing services on the control plane. They can also provide advantages to applications that users run.
 

--- a/operators/index.adoc
+++ b/operators/index.adoc
@@ -12,7 +12,7 @@ With Operators, you can create applications to monitor the running services in t
 Operators are designed specifically for your applications. Operators implement and automate the common Day 1 operations such as installation and configuration as well as Day 2 operations such as autoscaling up and down and creating backups. All these activities are in a piece of software running inside your cluster.
 
 
-[id="overview-developer-tasks"]
+[id="operators-overview-developer-tasks"]
 == For developers
 
 As a developer, you can perform the following Operator tasks:
@@ -23,7 +23,7 @@ As a developer, you can perform the following Operator tasks:
 ** xref:../operators/user/olm-installing-operators-in-namespace.adoc#olm-installing-operators-in-namespace[Install and subscribe an Operator to your namespace].
 ** xref:../operators/user/olm-creating-apps-from-installed-operators.adoc#olm-creating-apps-from-installed-operators[Create an application from an installed Operator through the web console].
 
-[id="overview-administrator-tasks"]
+[id="operators-overview-administrator-tasks"]
 == For administrators
 
 As a cluster administrator, you can perform the following Operator tasks:
@@ -38,8 +38,9 @@ As a cluster administrator, you can perform the following Operator tasks:
 ** xref:../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configure proxy support]
 ** xref:../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Use Operator Lifecycle Manager on restricted networks]
 
-To know all about the Platform Operators that Red Hat provides, see xref:../operators/operator-reference.adoc#platform-operators-ref[Red Hat Operators]
+To know all about the platform Operators that Red Hat provides, see xref:../operators/operator-reference.adoc#platform-operators-ref[Platform Operators reference].
 
+[id="operators-overview-next-steps"]
 == Next steps
 
 To understand more about Operators, see xref:../operators/understanding/olm-what-operators-are.adoc#olm-what-operators-are[What are Operators?]


### PR DESCRIPTION
Preview: https://deploy-preview-42324--osdocs.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#operators-overview_control-plane

Follow-up on https://github.com/openshift/openshift-docs/pull/41681. Reviewed w/ Amrita.