### PR TITLE
OSDOCS-2935 & OSDOCS-2858: 4.10 RN OSDK v1.16.0 and k8s 1.22

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -689,6 +689,23 @@ To manage the cloud controller manager and cloud node manager deployments and li
 
 For more information, see the xref:../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_platform-operators-ref[Cluster Cloud Controller Manager Operator] entry in the _Platform Operators reference_.
 
+[discrete]
+[id="ocp-4-10-operator-sdk-v-1-16-0"]
+==== Operator SDK v1.16.0
+
+{product-title} 4.10 supports Operator SDK v1.16.0. See xref:../cli_reference/osdk/cli-osdk-install.adoc#cli-osdk-install[Installing the Operator SDK CLI] to install or update to this latest version.
+
+[NOTE]
+====
+Operator SDK v1.16.0 supports Kubernetes 1.22.
+====
+
+Many deprecated `v1beta1` APIs were removed in Kubernetes 1.22, including `sigs.k8s.io/controller-runtime v0.10.0` and `controller-gen v0.7`. This is a breaking change if you need to scaffold `v1beta1` APIs for custom resource definitions (CRDs) or webhooks to publish your project into older cluster versions.
+
+For more information about changes introduced in Kubernetes 1.22, see link:https://docs.openshift.com/container-platform/4.9/release_notes/ocp-4-9-release-notes.html#ocp-4-9-osdk-k8s-api-bundle-validate[Validating bundle manifests for APIs removed from Kubernetes 1.22] and link:https://docs.openshift.com/container-platform/4.9/release_notes/ocp-4-9-release-notes.html#ocp-4-9-removed-kube-1-22-apis[Beta APIs removed from Kubernetes 1.22].
+
+If you have any Operator projects that were previously created or maintained with Operator SDK v1.10.1, see xref:../operators/operator_sdk/osdk-upgrading-projects.adoc#osdk-upgrading-projects[Upgrading projects for newer Operator SDK versions] to ensure your projects are upgraded to maintain compatibility with Operator SDK v1.16.0.
+
 [id="ocp-4-10-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
- OCP 4.10
- [OSDOCS-2935](https://issues.redhat.com/browse/OSDOCS-2935)
- [OSDOCS-2858](https://issues.redhat.com/browse/OSDOCS-2858)
- [Link to docs preview](https://deploy-preview-42332--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-notable-technical-changes)

This PR adds the version update to the OpenShift 4.10 Release notes as
a notable technical change. The note mentions OSDK v1.16.0's support
for Kubernetes 1.22 and the deprecated APIs removed in k8s 1.22.

See #41710 for QE and SME acks