### PR TITLE
Remove the note

### DIFF
--- a/modules/graceful-shutdown.adoc
+++ b/modules/graceful-shutdown.adoc
@@ -59,15 +59,13 @@ Shutdown scheduled for Mon 2021-09-13 09:36:29 UTC, use 'shutdown -c' to cancel.
 ----
 +
 Shutting down the nodes using one of these methods allows pods to terminate gracefully, which reduces the chance for data corruption.
+
+. Optional: Adjust the shut down time to be longer for large-scale clusters:
 +
-[NOTE]
-====
-Adjust the shut down time to be longer for large-scale clusters:
 [source,terminal]
 ----
 $ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 10; done
 ----
-====
 +
 [NOTE]
 ====


### PR DESCRIPTION
Adding an optional step to avoid two back-to-back notes.
OCP version: 4.6+
QE ack is not required
[Preview](https://deploy-preview-42334--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-shutdown.html#graceful-shutdown_graceful-shutdown-cluster)
No bug assigned 