### PR TITLE
BZ2054660: Ingress controller sharding is not supported in AWS

### DIFF
--- a/modules/nw-ingress-sharding.adoc
+++ b/modules/nw-ingress-sharding.adoc
@@ -15,3 +15,8 @@ As the primary mechanism for traffic to enter the cluster, the demands on the In
 * Expose different routes on different addresses so that internal and external users can see different routes, for example.
 
 Ingress Controller can use either route labels or namespace labels as a sharding method.
+
+[NOTE]
+====
+Ingress controller sharding is not supported in AWS by Red Hat.
+====


### PR DESCRIPTION
OCP version: 4.6+
[Preview ](https://deploy-preview-42336--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-sharding_configuring-ingress)
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2054660)
QE contact @lihongan 