### PR TITLE
CNV13715: VM Snapshots Corrections for 4.9 - based on enterprise-4.9

### DIFF
--- a/modules/virt-creating-vm-snapshot-cli.adoc
+++ b/modules/virt-creating-vm-snapshot-cli.adoc
@@ -64,11 +64,13 @@ $ kubectl wait my-vm my-vmsnapshot --for condition=Ready
 +
 [NOTE]
 ====
-Online snapshots have a default time deadline of five (`5`) minutes. If the snapshot does not complete successfully in five minutes, the status is set to `failed`. Afterwards, the file system will be thawed and the VM unfrozen but the status remains `failed` until you delete the failed snapshot image.
+Online snapshots have a default time deadline of five minutes (`5m`). If the snapshot does not complete successfully in five minutes, the status is set to `failed`. Afterwards, the file system will be thawed and the VM unfrozen but the status remains `failed` until you delete the failed snapshot image.
 
-To change the default time deadline, add the `FailureDeadline` attribute to the VM snapshot spec with the time (in minutes) that you want to specify before the snapshot operation times out.
+To change the default time deadline, add the `FailureDeadline` attribute to the VM snapshot spec with the time designated in minutes (`m`) or in seconds (`s`) that you want to specify before the snapshot operation times out.
 
 To set no deadline, you can specify `0`, though this is generally not recommended, as it can result in an unresponsive VM.
+
+If you do not specify a unit of time such as `m` or `s`, the default is seconds (`s`).
 ====
 
 .Verification

--- a/virt/virtual_machines/virtual_disks/virt-managing-vm-snapshots.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-managing-vm-snapshots.adoc
@@ -11,6 +11,8 @@ You can create and delete virtual machine (VM) snapshots for VMs, whether the VM
 * Red Hat OpenShift Container Storage
 * Any other storage provider with the Container Storage Interface (CSI) driver that supports the Kubernetes Volume Snapshot API
 
+Online snapshots have a default time deadline of five minutes (`5m`) that can be changed, if needed.
+
 [IMPORTANT]
 ====
 Online snapshots are not supported for virtual machines that have hot-plugged virtual disks.


### PR DESCRIPTION
For 4.9 

Jira: https://issues.redhat.com/browse/CNV-13715

Replaces closed PR: https://github.com/openshift/openshift-docs/pull/41546

Direct doc link preview: https://deploy-preview-42338--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-managing-vm-snapshots.html

@adellape - Fixed quotes in this version (based on enterprise-4.9). It should be ready for merge and pick to 4.9. Thanks.

Bob