### PR TITLE
TELCODOCS-261: Removed Redfish entry as feature won't be in base release

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -389,20 +389,6 @@ When you create a service that uses multiple IP address families, you must expli
 
 For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2045576[BZ#2045576].
 
-[id="ocp-4-10-redfish-events"]
-==== Low-latency Redfish hardware event delivery (Technology Preview)
-
-{product-title} now provides a hardware event proxy that enables applications running on bare-metal clusters to respond quickly to Redfish hardware events, such as hardware changes and failures.
-
-The hardware event proxy supports a publish-subscribe service that allows relevant applications to consume hardware events detected by Redfish. The proxy must be running on hardware that supports Redfish v1.8 and higher. An Operator manages the lifecycle of the `hw-event-proxy` container.
-
-You can use a REST API to develop applications to consume and respond to events such as breaches of temperature thresholds, fan failure, disk loss, power outages, and memory failure. Reliable end-to-end messaging without persistent stores is based on the Advanced Message Queuing Protocol (AMQP). The latency of the messaging service is in the 10 millisecond range.
-
-[NOTE]
-====
-This feature is supported for single node OpenShift clusters only.
-====
-
 [id="ocp-4-10-networking-ovn-gateway-config"]
 ==== OVN-Kubernetes support for gateway configuration
 


### PR DESCRIPTION
This is dependent on JIRA https://issues.redhat.com/browse/CNF-1985. Latest intelligence is that the feature won't make vase release. 