### PR TITLE
BZ2054801: Changed agentLabelSelector instances to agentLabels

### DIFF
--- a/modules/ztp-configuring-a-static-ip.adoc
+++ b/modules/ztp-configuring-a-static-ip.adoc
@@ -79,12 +79,12 @@ spec:
     name: <cluster_name>
     namespace: <cluster_name>
   sshAuthorizedKey: <public_key>
-  agentLabelSelector:
-    matchLabels:
-      cluster-name: <cluster_name>
+  agentLabels: <1>
+    location: "<label-name>"
   pullSecretRef:
     name: assisted-deployment-pull-secret
   nmStateConfigLabelSelector:
     matchLabels:
       sno-cluster-<cluster-name>: <cluster_name> # Match this label
 ----
+<1> Sets a label to match. The labels apply when the agents boot.

--- a/modules/ztp-creating-siteconfig-custom-resources.adoc
+++ b/modules/ztp-creating-siteconfig-custom-resources.adoc
@@ -245,13 +245,13 @@ spec:
     name: <cluster_name>
     namespace: <cluster_name>
   sshAuthorizedKey: <public_key> <1>
-  agentLabelSelector:
-    matchLabels:
-      cluster-name: <cluster_name>
+  agentLabels: <2>
+    location: "<label-name>"
   pullSecretRef:
     name: assisted-deployment-pull-secret
 ----
 <1> Entered as plain text. You can use the public key to SSH into the target bare-metal host when it boots from the ISO.
+<2> Sets a label to match. The labels apply when the agents boot.
 
 . Create the `BareMetalHost` custom resource:
 +


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2054801

Creating custom resources to install a single managed cluster: https://deploy-preview-42342--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-creating-siteconfig-custom-resources_ztp-deploying-disconnected

Configuring static IP addresses for managed clusters: https://deploy-preview-42342--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-configuring-a-static-ip_ztp-deploying-disconnected

For release(s): 4.9, 4.10