### PR TITLE
 BZ:added a note not to use a key for static provisioning

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
@@ -27,6 +27,11 @@ In future {product-title} versions, volumes provisioned using existing in-tree p
 After full migration, in-tree plug-ins will eventually be removed in future versions of {product-title}.
 ====
 
+[NOTE]
+====
+The vSphere CSI Driver supports dynamic and static provisioning. When using static provisioning in the PV specifications, do not use the key `storage.kubernetes.io/csiProvisionerIdentity` in `csi.volumeAttributes` because this key indicates dynamically provisioned PVs.
+====
+
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-vsphere-stor-policy.adoc[leveloffset=+1]


### PR DESCRIPTION
- Applies to 4.10 only. Merge to main and cherry pick to 4.10
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2036897)
- [Preview](https://deploy-preview-42344--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html)
- Created this PR and closed the one (https://github.com/openshift/openshift-docs/pull/41517) 
- @duanwei33 ptal