### PR TITLE
Adding a new openshift-dpu distro

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -187,6 +187,16 @@ openshift-webscale:
     enterprise-4.8:
       name: '4.8'
       dir: container-platform-ocp/4.8
+openshift-dpu:
+  name: OpenShift Container Platform
+  author: OpenShift Documentation Project <openshift-docs@redhat.com>
+  site: commercial
+  site_name: Documentation
+  site_url: https://docs.openshift.com/
+  branches:
+    enterprise-4.10:
+      name: '4.10'
+      dir: container-platform-dpu/4.10
 openshift-acs:
   name: Red Hat Advanced Cluster Security for Kubernetes
   author: OpenShift documentation team <openshift-docs@redhat.com>

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -10,6 +10,7 @@
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <%= (distro_key == "openshift-webscale") ? '<meta name="robots" content="noindex,nofollow">' : '' %>
+  <%= (distro_key == "openshift-dpu") ? '<meta name="robots" content="noindex,nofollow">' : '' %>
   <%= ((["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5"].include?(version)) && distro_key == "openshift-enterprise") ? '<meta name="googlebot" content="noindex">' : '' %>
   <title><%= [topic_title, subgroup_title].compact.join(' - ') %> | <%= group_title %> | <%= distro %> <%= version %></title>
   <link href="https://assets.openshift.net/content/subdomain.css" rel="stylesheet" type="text/css">
@@ -59,6 +60,14 @@
     <button id="hc-open-btn" class="open-btn-sm" onclick="openNav()" aria-label="Open"><span class="fa fa-bars" /></button>
     <ol class="breadcrumb hide-for-print">
       <% if (version == "4.10" || distro_key == "openshift-webscale") %>
+      <span>
+        <div class="alert alert-danger" role="alert" id="support-alert">
+          <strong>This documentation is work in progress and might not be complete or fully tested.</strong> The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html" class="link-primary" style="color: #545454 !important;">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.
+        </div>
+      </span>
+      <% end %>
+
+      <% if (version == "4.10" || distro_key == "openshift-dpu") %>
       <span>
         <div class="alert alert-danger" role="alert" id="support-alert">
           <strong>This documentation is work in progress and might not be complete or fully tested.</strong> The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html" class="link-primary" style="color: #545454 !important;">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2054,7 +2054,7 @@ Topics:
 ---
 Name: Scalability and performance
 Dir: scalability_and_performance
-Distros: openshift-origin,openshift-enterprise,openshift-webscale
+Distros: openshift-origin,openshift-enterprise,openshift-webscale,openshift-dpu
 Topics:
 - Name: Recommended installation practices
   File: recommended-install-practices


### PR DESCRIPTION
This change adds an update which creates an `openshift-dpu` distro to allow early access to dev preview features with password protection.