### PR TITLE
IBM Z install: Backport rhel 8.4 and adding attributes to enterprise-4.7

### DIFF
--- a/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -6,6 +6,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 In {product-title} version {product-version}, you can install a cluster on
 IBM Z or LinuxONE infrastructure that you provision.
 
@@ -33,7 +34,7 @@ xref:../../architecture/architecture-installation.adoc#architecture-installation
 processes.
 * If you use a firewall, you must
 xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* {op-system-base} Kernel Virtual Machine (KVM) system that is hosted on the logical partition (LPAR) and based on {op-system-base} 8.3 or higher
+* {op-system-base} Kernel Virtual Machine (KVM) system that is hosted on the logical partition (LPAR) and based on {op-system-base} 8.4 or later
 +
 [NOTE]
 ====
@@ -46,6 +47,7 @@ include::modules/installation-requirements-user-infra-ibm-z-kvm.adoc[leveloffset
 include::modules/csr-management.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
+[id="additional-resources_ibmz-requirements-kvm"]
 .Additional resources
 
 * xref:../../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended host practices for IBM Z & LinuxONE environments]
@@ -55,6 +57,7 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
+[id="additional-resources_ibmz-kvm-chrony-time-service"]
 .Additional resources
 
 * xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
@@ -98,6 +101,7 @@ include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_ibmz-kvm-remote-health-monitoring"]
 .Additional resources
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
@@ -105,10 +109,12 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 include::modules/installation-ibm-z-troubleshooting-and-debugging.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_ibmz-kvm-sosreport"]
 .Additional resources
 
 * See also link:https://access.redhat.com/solutions/4387261[How to generate SOSREPORT within OpenShift4 nodes without SSH].
 
+[id="next-steps_ibmz-kvm"]
 == Next steps
 
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -6,6 +6,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 In {product-title} version {product-version}, you can install a cluster on
 IBM Z and LinuxONE infrastructure that you provision in a restricted network.
 
@@ -29,16 +30,13 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 ====
 Ensure that installation steps are done from a machine with access to the installation media.
 ====
-* Provision
-xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
-using NFS for your cluster. To deploy a private image registry, your storage
-must provide `ReadWriteMany` access modes.
+* * You provisioned xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS] for your cluster. To deploy a private image registry, you must set up persistent storage with `ReadWriteMany` access.
 * Review details about the
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
 processes.
 * If you use a firewall, you must
 xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* Provision a {op-system-base} Kernel Virtual Machine (KVM) system that is hosted on the logical partition (LPAR) and based on {op-system-base} 8.3 or higher.
+*  You provisioned a {op-system-base} Kernel Virtual Machine (KVM) system that is hosted on the logical partition (LPAR) and based on {op-system-base} 8.4 or later.
 +
 [NOTE]
 ====
@@ -53,6 +51,7 @@ include::modules/csr-management.adoc[leveloffset=+2]
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_ibmz-kvm-restricted-recommended-host-practices"]
 .Additional resources
 
 * xref:../../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended host practices for IBM Z & LinuxONE environments]
@@ -108,6 +107,7 @@ include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_ibmz-kvm-restricted-remote-health-monitoring"]
 .Additional resources
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
@@ -115,7 +115,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 include::modules/installation-ibm-z-troubleshooting-and-debugging.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_ibmz-kvm-restricted"]
+[id="additional-resources_ibmz-kvm-restricted-sosreport"]
 .Additional resources
 
 * link:https://access.redhat.com/solutions/4387261[How to generate SOSREPORT within {product-title} version 4 nodes without SSH].

--- a/modules/installation-ibm-z-kvm-user-infra-machines-iso.adoc
+++ b/modules/installation-ibm-z-kvm-user-infra-machines-iso.adoc
@@ -10,7 +10,7 @@ Before you install a cluster on IBM Z infrastructure that you provision, you mus
 
 .Prerequisites
 
-* At least 1 LPAR running {op-system-base} 8.3 with KVM, referred to as {op-system-base} KVM host in this procedure.
+* At least one LPAR running {op-system-base} 8.4 with KVM, referred to as {op-system-base} KVM host in this procedure.
 * The KVM/QEMU hypervisor is installed on the {op-system-base} KVM host.
 * A domain name server (DNS) that can perform hostname and reverse lookup for the nodes.
 * A DHCP server that provides IP addresses.

--- a/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
+++ b/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
@@ -3,13 +3,15 @@
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
 
 
+
+:_content-type: CONCEPT
 [id="installation-requirements-user-infra_{context}"]
 = Machine requirements for a cluster with user-provisioned infrastructure
 
 For a cluster that contains user-provisioned infrastructure, you must deploy all
 of the required machines.
 
-One or more KVM host machines based on {op-system-base} 8.3 or later. Each {op-system-base} KVM host machine must have libvirt installed and running. The virtual machines are provisioned under each {op-system-base} KVM host machine.
+One or more KVM host machines based on {op-system-base} 8.4 or later. Each {op-system-base} KVM host machine must have libvirt installed and running. The virtual machines are provisioned under each {op-system-base} KVM host machine.
 
 
 [id="machine-requirements_{context}"]
@@ -69,7 +71,7 @@ You can install {product-title} version {product-version} on the following IBM h
 [discrete]
 === Hardware requirements
 
-* The equivalent of 6 IFLs, which are SMT2 enabled, for each cluster.
+* The equivalent of six IFLs, which are SMT2 enabled, for each cluster.
 * At least one network connection to both connect to the `LoadBalancer` service and to serve data for traffic outside the cluster.
 
 [NOTE]
@@ -84,13 +86,13 @@ Since the overall performance of the cluster can be impacted, the LPARs that are
 
 [discrete]
 === Operating system requirements
-* One LPAR running {op-system-base} 8.3 or later with KVM, which is managed via libvirt
+* One LPAR running {op-system-base} 8.4 or later with KVM, which is managed by libvirt
 
 On your {op-system-base} KVM host, set up:
 
-* 3 guest virtual machines for {product-title} control plane machines
-* 2 guest virtual machines for {product-title} compute machines
-* 1 guest virtual machine for the temporary {product-title} bootstrap machine
+* Three guest virtual machines for {product-title} control plane machines
+* Two guest virtual machines for {product-title} compute machines
+* One guest virtual machine for the temporary {product-title} bootstrap machine
 
 [id="minimum-resource-requirements_{context}"]
 == Minimum resource requirements
@@ -140,19 +142,19 @@ Each cluster virtual machine must meet the following minimum requirements:
 [discrete]
 === Hardware requirements
 
-* 3 LPARS that each have the equivalent of 6 IFLs, which are SMT2 enabled, for each cluster.
+* Three LPARS that each have the equivalent of six IFLs, which are SMT2 enabled, for each cluster.
 * Two network connections to connect to both connect to the `LoadBalancer` service and to serve data for traffic outside the cluster.
 
 [discrete]
 === Operating system requirements
 
-* For high availability, 2 or 3 LPARs running {op-system-base} 8.3 or later with KVM, which are managed via libvirt.
+* For high availability, two or three LPARs running {op-system-base} 8.4 or later with KVM, which are managed by libvirt.
 
 On your {op-system-base} KVM host, set up:
 
-* 3 guest virtual machines for {product-title} control plane machines, distributed across the {op-system-base} KVM host machines.
-* At least 6 guest virtual machines for {product-title} compute machines, distributed across the {op-system-base} KVM host machines.
-* 1 guest virtual machine for the temporary {product-title} bootstrap machine.
+* Three guest virtual machines for {product-title} control plane machines, distributed across the {op-system-base} KVM host machines.
+* At least six guest virtual machines for {product-title} compute machines, distributed across the {op-system-base} KVM host machines.
+* One guest virtual machine for the temporary {product-title} bootstrap machine.
 * To ensure the availability of integral components in an overcommitted environment, increase the priority of the control plane by using `cpu_shares`. Do the same for infrastructure nodes, if they exist. See link:https://www.ibm.com/docs/en/linux-on-systems?topic=domain-schedinfo[schedinfo] in IBM Documentation.
 
 [id="preferred-resource-requirements_{context}"]


### PR DESCRIPTION
This PR backports the RHEL 8.3 to 8.4 updates made in this PR to enterprise-4.7: 
https://github.com/openshift/openshift-docs/pull/41848
See: https://access.redhat.com/support/policy/updates/errata

Related PRs: 
- 4.8: https://github.com/openshift/openshift-docs/pull/42345
- 4.9: https://github.com/openshift/openshift-docs/pull/42350
- 4.10: https://github.com/openshift/openshift-docs/pull/41848

Also adding attributes for Jupiter. 

Preview: 
- [Installing a cluster with RHEL KVM on IBM Z and LinuxONE](https://deploy-preview-42347--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html)
- [Installing a cluster with RHEL KVM on IBM Z and LinuxONE in a restricted network](https://deploy-preview-42347--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.html)

QE review: Holger Wolf