### PR TITLE
adds a batch of RHCOS bug fixes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1105,6 +1105,12 @@ You cannot upgrade {op-system-base} 7 compute machines to {op-system-base} 8. Yo
 [id="ocp-4-10-rhcos-bug-fixes"]
 ==== {op-system-first}
 
+* Previously, when the {op-system} live ISO added a UEFI boot entry for itself, it assumed the existing UEFI boot entry IDs were consecutive, thereby causing the live ISO to crash in the UEFI firmware when booting on systems with non-consecutive boot entry IDS. With this fix, the {op-system} live ISO no longer adds a UEFI boot entry for itself and the ISO boots successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2006690[*BZ#2006690*])
+
+* To help you determine whether a user-provided image was already booted, information has been added on the terminal console describing when the machine was provisioned via Ignition and whether a user Ignition config was provided. This allows you to verify that Ignition ran when you expected it to. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2016004[*BZ#2016004*])
+
+* Previously, when reusing an existing statically keyed LUKS volume during provisioning, the encryption key was not correctly written to disk and Ignition would fail with a "missing persisted keyfile" error. With this fix, Ignition now correctly writes keys for reused LUKS volumes so that existing statically keyed LUKS volumes can be reused during provisioning. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2043296[*BZ#2043296*])
+
 [discrete]
 [id="ocp-4-10-routing-bug-fixes"]
 ==== Routing


### PR DESCRIPTION
Adds a batch of RHCOS bug fixes to release notes.

- Applies to `enterprise-4.10` only.
- [Preview link](https://github.com/opayne1/openshift-docs/pull/new/RN-batch)