### PR TITLE
Adds batch of bug fixes for Console storage plug-in

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -967,6 +967,12 @@ You cannot upgrade {op-system-base} 7 compute machines to {op-system-base} 8. Yo
 [id="ocp-4-10-console-storage-bug-fixes"]
 ==== Console Storage Plug-in
 
+* Previously, a loading prompt was not present while the persistent volumes (PVs) were being provisioned and the capacity was `0` TiB which created a confusing scenario. With this update, a loader is added for the loading state which provides details to the user if the PVs are still being provisioned or capacity is to be determined. It will also inform the user of any errors in the process. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1928285[*BZ#1928285*])
+
+* Previously, the grammar was not correct in certain places and there were instances where translators were unable to interpret the context. This had a negative impact on readability. With this update, the grammar in various places is corrected, the storage classes for translators is itemized, and the overall readability is improved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1961391[*BZ#1961391*])
+
+* Previously, when pressing a pool inside the block pools page, the final `Ready` phase persisted after deletion. Consequently, the pool was in the `Ready` state even after deletion. This update redirects users to the *Pools* page and refreshes the pools after detention. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1981396[*BZ#1981396*])
+
 [discrete]
 [id="ocp-4-10-image-registry-bug-fixes"]
 ==== Image Registry


### PR DESCRIPTION
Adds a batch of bug fixes to console storage plug-in.

- Applies to `enterprise-4.10` only
- [Preview link](https://deploy-preview-42372--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-bug-fixes)