### PR TITLE
Github-39273: fixes typo of RHACM

### DIFF
--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -181,8 +181,7 @@ for this support.
 the kubevirt.io open source project.
 
 === Advanced cluster management
-{oke} is compatible with your additional purchase of Red Hat Advanced Cluster
-Manager for Kubernetes. An {oke} subscription does not offer a cluster-wide log
+{oke} is compatible with your additional purchase of {rh-rhacm-first} for Kubernetes. An {oke} subscription does not offer a cluster-wide log
 aggregation solution or support Elasticsearch, Fluentd, or Kibana based logging solutions.
 Similarly, the chargeback features found in {product-title} or the console.redhat.com
 Cost Management SaaS service are not supported with {oke}. Red Hat Service Mesh


### PR DESCRIPTION
4.6+

Github issue #39273

[Preview](https://deploy-preview-42386--osdocs.netlify.app/openshift-enterprise/latest/welcome/oke_about.html) directly under "Advanced Cluster Management"

Fixes typo in the product name "Red Hat Advanced Cluster Management (RHACM)" 

I'll need labels and to have this merged, please.