### PR TITLE
Release note for swap memory feature

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -566,7 +566,12 @@ For more information on configuration drift, see xref:../post_installation_confi
 [id="ocp-4-10-node-cgroups-v2"]
 ==== Linux control groups version 2 (Developer Preview)
 
-You can now enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control groups version 2] (cgroups v2) on specific nodes in your cluster. The {product-title} process for enabling cgroups v2 disables all cgroups version 1 controllers and hierarchies. The {product-title} cgroups version 2 feature is in Developer Preview and is not supported by Red Hat at this time.
+You can now enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control groups version 2] (cgroups v2) on specific nodes in your cluster. The {product-title} process for enabling cgroups v2 disables all cgroups version 1 controllers and hierarchies. The {product-title} cgroups version 2 feature is in Developer Preview and is not supported by Red Hat at this time. For more information, see xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-cgroups-2_nodes-nodes-working[Enabling Linux control groups version 2 (cgroups v2)].
+
+[id="ocp-4-10-node-swap-memory"]
+==== Support for swap memory use on nodes (Technology preview)
+
+You can enable swap memory use for {product-title} workloads on a per-node basis. For more information, see xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-swap-memory_nodes-nodes-working[Enabling swap memory use on nodes].
 
 [id="ocp-4-10-logging"]
 === Red Hat OpenShift Logging


### PR DESCRIPTION
Release note for https://github.com/openshift/openshift-docs/pull/41755

Added release note for Node Swap feature. Added link to the existing _Linux control groups version 2_ release note while I was in there.