### PR TITLE
TELCODOCS-365: Using pod-level bonding -- TERMINOLOGY FIX

### DIFF
--- a/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
+++ b/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
@@ -80,7 +80,7 @@ apiVersion: v1
         image: quay.io/openshift/origin-network-interface-bond-cni:4.9.0
         command: ["/bin/bash", "-c", "sleep INF"]
 ----
-<1> Note the network annotation: it contains two SR-IOV network attachments, and one bond network attachment. The bond attachment uses the two SR-IOV interfaces as bond slaves.
+<1> Note the network annotation: it contains two SR-IOV network attachments, and one bond network attachment. The bond attachment uses the two SR-IOV interfaces as bonded port interfaces.
 
 You can inspect the pod interfaces with the following command:
 [source,yaml]


### PR DESCRIPTION
This PR includes a terminology fix for https://github.com/openshift/openshift-docs/pull/39555.

@evgenLevin @mmirecki Can you take a quick look?