### PR TITLE
Telcodocs 338 Configuring hub cluster to scale up to 2000 cluster

### DIFF
--- a/modules/ztp-creating-ztp-config-hub-for-scaling-to-2000.adoc
+++ b/modules/ztp-creating-ztp-config-hub-for-scaling-to-2000.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/ztp-deploying-disconnected.adoc
+
+:_content-type: PROCEDURE
+[id="ztp-configuring-hub-clusters-for-scaling-to-2000_{context}"]
+= Configuring the hub clusters for scaling to 2000 cluster deployments
+
+The following procedure tells you how to configure a hub cluster at scale to deploy and manage up to 2000 managed single node hub clusters configured as distributed units (DUs).
+
+.Prerequisites
+
+
+== Reducing policies in an existing configuration
+
+.Procedure 

--- a/modules/ztp-scaling-hub-cluster-to-2000.adoc
+++ b/modules/ztp-scaling-hub-cluster-to-2000.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/ztp-deploying-disconnected.adoc
+
+:_content-type: CONCEPT
+[id="ztp-scaling-to-2000-cluster-deployments_{context}"]
+= Scaling to 2000 cluster deployments
+
+Scalability limitiations come from the ability of the ArgoCD application to manage the generated CRs and of ACM to managed the clusters.
+In 4.10 improvements have been made to help address scalability concerns for example: 
+
+* When you upgrade to 4.10, or if you are installing 4.10 ZTP solution for the first time, applying the “deployment” directory configures the ArgoCD application to scale.
+* The 4.10 reference PolicyGenTemplates combine multiple configuration CRs into relatively few policies. The reduced number of policies improves scaling of the hub cluster.
+* The 4.10 ZTP solution uses a improved internal structure for generating the installation and configuration CRs which improves scalability. When you follow the installation/upgrade instructions these improvements are automatically pulled in and no additional action is needed.
+
+The recommended ZTP structure defines several categories of configuration, denoted common, group, and site-specific. The common and group categories define once a set of configuration which applies to multiple clusters. This results in relatively fewer configuration CRs which need to be managed by the hub cluster which in turn improves scalability.
+The recommendation is to put CRs into common or group rather than site-specific when the config applies to multiple clusters.
+
+The DU configuration is governed by the following RAN policies: 
+
+**Common** 
+A set of policies that apply to all 2000 nodes containing at least five policies.
+
+**Group**
+ A set of policies that apply to a subset of the 2000 nodes. There should be at least two groups containing at least seven policies per group.
+
+**Sites**
+A set of policies that apply to only one node. There should be 2000 sets of these policies, each containing at least six policies.
+
+
+

--- a/scalability_and_performance/ztp-deploying-disconnected.adoc
+++ b/scalability_and_performance/ztp-deploying-disconnected.adoc
@@ -104,6 +104,10 @@ include::modules/ztp-precision-time-protocol-operator.adoc[leveloffset=+2]
 
 include::modules/ztp-creating-ztp-custom-resources-for-multiple-managed-clusters.adoc[leveloffset=+1]
 
+include::modules/ztp-scaling-hub-cluster-to-2000.adoc[leveloffset=+2]
+
+include::modules/ztp-creating-ztp-config-hub-for-scaling-to-2000.adoc[leveloffset=+3]
+
 include::modules/ztp-prerequisites-for-deploying-the-ztp-pipeline.adoc[leveloffset=+2]
 
 include::modules/ztp-installing-the-gitops-ztp-pipeline.adoc[leveloffset=+2]


### PR DESCRIPTION
Addressing https://issues.redhat.com/browse/TELCODOCS-338

Preview: [Scaling to 2000 clusters](https://deploy-preview-42424--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-scaling-to-2000-cluster-deployments_ztp-deploying-disconnected)