### PR TITLE
[OCP 4.10] up rev ACM docs version in ZTP docs

### DIFF
--- a/modules/ztp-acm-installing-disconnected-rhacm.adoc
+++ b/modules/ztp-acm-installing-disconnected-rhacm.adoc
@@ -23,4 +23,4 @@ See link:https://docs.openshift.com/container-platform/4.9/operators/admin/olm-r
 
 .Procedure
 
-* Install {rh-rhacm} on the hub cluster in the disconnected environment. See link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html/install/installing#install-on-disconnected-networks[Installing {rh-rhacm} in a disconnected environment].
+* Install {rh-rhacm} on the hub cluster in the disconnected environment. See link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.4/html/install/installing#install-on-disconnected-networks[Installing {rh-rhacm} in disconnected networks].


### PR DESCRIPTION
Updating the linked version of ACM docs from 2.3 to 2.4. Merge to main, enterprise-4.10

Preview: https://deploy-preview-42443--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#installing-disconnected-rhacm_ztp-deploying-disconnected