### PR TITLE
BZ2056590: Added note block about /dev/disk/by-path not supported for local storage

### DIFF
--- a/modules/persistent-storage-local-create-cr.adoc
+++ b/modules/persistent-storage-local-create-cr.adoc
@@ -56,7 +56,12 @@ spec:
 <4> The volume mode, either `Filesystem` or `Block`, that defines the type of local volumes.
 <5> The file system that is created when the local volume is mounted for the first time.
 <6> The path containing a list of local storage devices to choose from.
-<7> Replace this value with your actual local disks filepath to the `LocalVolume` resource, such as `/dev/disk/by-id/wwn`. PVs are created for these local disks when the provisioner is deployed successfully.
+<7> Replace this value with your actual local disks filepath to the `LocalVolume` resource `by-id`, such as `/dev/disk/by-id/wwn`. PVs are created for these local disks when the provisioner is deployed successfully.
++
+[NOTE]
+====
+The Local Storage Operator does not support the `LocalVolume` resource `by-path` or `by-partuuid`, such as `/dev/disk/by-path/wwn` or `/dev/disk/by-partuuid`.
+====
 +
 [NOTE]
 ====
@@ -92,7 +97,12 @@ spec:
 <3> The name of the storage class to use when creating persistent volume objects.
 <4> The volume mode, either `Filesystem` or `Block`, that defines the type of local volumes.
 <5> The path containing a list of local storage devices to choose from.
-<6> Replace this value with your actual local disks filepath to the `LocalVolume` resource, such as `dev/disk/by-id/wwn`. PVs are created for these local disks when the provisioner is deployed successfully.
+<6> Replace this value with your actual local disks filepath to the `LocalVolume` resource `by-id`, such as `dev/disk/by-id/wwn`. PVs are created for these local disks when the provisioner is deployed successfully.
++
+[NOTE]
+====
+The Local Storage Operator does not support the `LocalVolume` resource `by-path` or `by-partuuid`, such as `/dev/disk/by-path/wwn` or `/dev/disk/by-partuuid`.
+====
 
 . Create the local volume resource in your {product-title} cluster. Specify the file you just created:
 +


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2056590

OCP version: 4.6+

Direct Doc preview Link: https://deploy-preview-42445--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local.html#local-volume-cr_persistent-storage-local

@tdaleibm @chao007 PTAL and let me know your feedback.