### PR TITLE
BZ1891361: Added note block about vSphere volume is not deleted after  the cluster is destroyed

### DIFF
--- a/installing/installing_vsphere/uninstalling-cluster-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/uninstalling-cluster-vsphere-installer-provisioned.adoc
@@ -8,4 +8,9 @@ toc::[]
 
 You can remove a cluster that you deployed in your VMware vSphere instance by using installer-provisioned infrastructure.
 
+[NOTE]
+====
+When you run the `openshift-install destroy cluster` command to uninstall {product-title}, vSphere volumes are not automatically deleted. The cluster administrator must manually find the vSphere volumes and delete them.
+====
+
 include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1891361

OCP version: 4.6+

Direct Doc Preview Link: https://deploy-preview-42447--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/uninstalling-cluster-vsphere-installer-provisioned.html

@gnufied @jsafrane @duanwei33 PTAL at the PR and let me whether the NOTE block is placed at the right location.