### PR TITLE
Adding redirects in the Updating book

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -160,6 +160,8 @@ AddType text/vtt                            vtt
     # Redirects for the Updating book
     RewriteRule ^container-platform/(4\.6|4\.7|4\.8|4\.9)/updating/updating-cluster-between-minor.html /container-platform/$1/updating/updating-cluster-within-minor.html [NE,R=302]
     RewriteRule ^container-platform/(4\.6|4\.7|4\.8|4\.9)/updating/updating-cluster.html /container-platform/$1/updating/updating-cluster-within-minor.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.8|4\.9)/updating/installing-update-service.html /container-platform/$1/updating/updating-restricted-network-cluster.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.8|4\.9)/updating/understanding-the-update-service.html /container-platform/$1/updating/updating-restricted-network-cluster.html [NE,R=302]
 
     # CNV scenarios based redirect
     RewriteRule ^container-platform/4\.8/virt/learn_more_about_ov.html /container-platform/4.8/virt/virt-learn-more-about-openshift-virtualization.html [NE,R=301]


### PR DESCRIPTION
This applies to `main` only.

The PR adds temporary (302) redirect rules for two pages in the Updating book for OCP 4.8 to 4.9 that have been relocated. The content relocation occurred in https://github.com/openshift/openshift-docs/pull/41224.