### PR TITLE
Added notes for release 4.8.33

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -3043,7 +3043,7 @@ To upgrade an existing {product-title} 4.8 cluster to this latest release, see x
 
 Issued: 2022-02-15
 
-{product-title} release 4.8.31 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0484[RHBA-2022:0484] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0483[RHSA-2022:0483] advisory.
+{product-title} release 4.8.31, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0484[RHBA-2022:0484] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0483[RHSA-2022:0483] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -3101,6 +3101,22 @@ Space precluded documenting all of the container images for this release in the 
 link:https://access.redhat.com/solutions/6749841[{product-title} 4.8.32 container image list]
 
 [id="ocp-4-8-32-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-8-33"]
+=== RHBA-2022:0651 - {product-title} 4.8.33 bug fix update
+
+Issued: 2022-03-01
+
+{product-title} release 4.8.33 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0651[RHBA-2022:0651] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0650[RHBA-2022:0650] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6764661[{product-title} 4.8.33 container image list]
+
+[id="ocp-4-8-33-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
These are the notes for release 4.8.33.

Applies only to `enteprise-4.8`

Preview: https://deploy-preview-42485--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-33