### PR TITLE
OSDOCS-2647: Adding xref to RHOCS AMI for AWS GovCloud release note

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -125,7 +125,8 @@ The following Operators are supported for {product-title} on ARM:
 ==== Installing a cluster into an Amazon Web Services GovCloud region
 
 {op-system-first} Amazon Machine Images (AMIs) are now available for AWS GovCloud regions. The availability of these AMIs improves the installation process because you are no longer required to upload a custom RHCOS AMI to deploy a cluster.
-//For more information on installing to a AWS GovCloud region, <insert link to topic after it merges>
+
+For more information, see xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[Installing a cluster on AWS into a government region].
 
 [id="ocp-4-10-installation-and-upgrade-tagrole"]
 ==== Using a custom AWS IAM role for instance profiles


### PR DESCRIPTION
CP to 4.10

This is a continuation of https://github.com/openshift/openshift-docs/pull/40352. Updated the AWS GovCloud region release note to include a link to the installation assembly.

Preview
[Installing a cluster into an Amazon Web Services GovCloud region](https://deploy-preview-42486--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-installation-and-upgrade-aws-ami)

QE ack is not required.