### PR TITLE
OSDOCS-2900: Update AWS AMIs

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -79,6 +79,12 @@ ifndef::openshift-origin[]
 |`us-east-2`
 |`ami-09e637fc5885c13cc`
 
+|`us-gov-east-1`
+|`ami-0c3b11bcccf6ec63c`
+
+|`us-gov-west-1`
+|`ami-084d95ff443d8bf99`
+
 |`us-west-1`
 |`ami-0fa0f6fce7e63dd26`
 


### PR DESCRIPTION
CP to 4.10

This PR address [OSDOCS-2900](https://issues.redhat.com/browse/OSDOCS-2900).

RedHat now provides RHCOS AWS AMIs for the `us-gov-east-1` and `us-gov-west-1` regions. Updated x86_64 RHCOS AMIs table with these regions.

Preview
[RHCOS AMIs for the AWS infrastructure](https://deploy-preview-42489--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-aws-user-infra-rhcos-ami_installing-aws-user-infra)