### PR TITLE
Fixing link issues

### DIFF
--- a/modules/update-common-terms.adoc
+++ b/modules/update-common-terms.adoc
@@ -11,16 +11,10 @@ Control plane:: The _control plane_, which is composed of control plane machines
 Cluster Version Operator:: The _Cluster Version Operator_ (CVO) starts the update process for the cluster. It checks with OSUS based on the current cluster version and retrieves the graph which contains available or possible update paths.
 
 Machine Config Operator:: The _Machine Config Operator_ (MCO) is a cluster-level Operator that manages the operating system and machine configurations. Through the MCO, platform administrators can configure and update systemd, CRI-O and Kubelet, the kernel, NetworkManager, and other system features on the worker nodes.
-+
-For more information, see link:https://docs.openshift.com/container-platform/latest/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks[Machine config overview].
 
 OpenShift Update Service:: The _OpenShift Update Service_ (OSUS) provides over-the-air updates to {product-title}, including to {op-system-first}. It provides a graph, or diagram, that contains the vertices of component Operators and the edges that connect them.
-+
-For more information, see link:https://docs.openshift.com/container-platform/latest/updating/understanding-the-update-service.html#update-service-overview_understanding-the-update-service[About the OpenShift Update Service].
 
 Channels:: _Channels_ declare an update strategy tied to minor versions of {product-title}. The OSUS uses this configured strategy to recommend update edges consistent with that strategy.
-+
-For more information, see link:https://docs.openshift.com/container-platform/latest/updating/understanding-upgrade-channels-release.html[Understanding update channels and releases].
 
 Recommended update edge:: A _recommended update edge_ is a recommended update between {product-title} releases.  Whether a given update is recommended can depend on the cluster's configured channel, current version, known bugs, and other information. OSUS communicates the recommended edges to the CVO, which runs in every cluster.
 

--- a/updating/understanding-openshift-updates.adoc
+++ b/updating/understanding-openshift-updates.adoc
@@ -13,3 +13,10 @@ The graph is based on recommended, tested update paths from a specific version. 
 After the CVO receives the update image from the registry, the CVO then applies the changes.
 
 include::modules/update-common-terms.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-overview-post-install-machine-configuration-tasks[Machine config overview]
+* xref:../updating/updating-restricted-network-cluster.adoc#update-service-overview_updating-restricted-network-cluster[About the OpenShift Update Service]
+* xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Update channels and releases]


### PR DESCRIPTION
Applies 4.8+ 
Fixing link issues that were introduced by https://github.com/openshift/openshift-docs/pull/41224
QE not required.
Preview: [Additional resources](https://deploy-preview-42491--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-openshift-updates.html) section.