### PR TITLE
CNV16405: Adding release note about critical alerts

### DIFF
--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -114,6 +114,8 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 
 * You can now link:https://access.redhat.com/articles/6409731[deploy {VirtProductName} on AWS bare metal nodes].
 
+* {VirtProductName} has xref:../virt/logging_events_monitoring/virt-virtualization-alerts.adoc#virt-virtualization-alerts[critical alerts] that inform you when a problem occurs that requires immediate attention. Now, each alert has a corresponding description of the problem, a reason for why the alert is occurring, a troubleshooting process to diagnose the source of the problem, and steps for resolving the alert.
+
 [id="virt-4-10-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
This PR addresses JIRA story [CNV-16405](https://issues.redhat.com/browse/CNV-16405).

The story is a release note about the tech preview for OpenShift Virtualization critical alerts.

CP: 4.10

Preview: Bullet starting with "OpenShift Virtualization has critical alerts..." in the "Technology Preview features" section of https://deploy-preview-42496--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-10-release-notes#virt-4-10-technology-preview