### PR TITLE
OSDOCS-2855: Adding xref to IBM Cloud IPI release note

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -114,7 +114,7 @@ The following Operators are supported for {product-title} on ARM:
 
 {product-title} 4.10 introduces support for installing a cluster on IBM Cloud using installer-provisioned infrastructure.
 
-//For more information, see ../installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc#preparing-to-install-on-ibm-cloud[Preparing to install on IBM Cloud].
+For more information, see xref:../installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc#preparing-to-install-on-ibm-cloud[Preparing to install on IBM Cloud].
 
 [id="ocp-4-10-installation-and-upgrade-vsphere-provisioning"]
 ==== Thin provisioning support for VMware vSphere cluster installation


### PR DESCRIPTION
CP to 4.10

This is a continuation of https://github.com/openshift/openshift-docs/pull/42293. Updated the IBM Cloud IPI release note to include a link to Preparing to install on IBM Cloud.

Preview
[Installing a cluster on IBM Cloud using installer-provisioned infrastructure](https://deploy-preview-42510--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-ibm-cloud-installation)

QE ack is not required