### PR TITLE
Fixing two build errors

### DIFF
--- a/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
+++ b/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
@@ -28,10 +28,10 @@ metadata:
 spec:
   machineConfigSelector:
     matchExpressions:
-      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,mcp-offloading <1>]}
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,mcp-offloading]} <1>
   nodeSelector:
     matchLabels:
-      node-role.kubernetes.io/mcp-offloading <2>: ""
+      node-role.kubernetes.io/mcp-offloading: "" <2>
 ----
 <1> The name of your machine config pool for hardware offloading.
 <2> This node role label is used to add nodes to the machine config pool.


### PR DESCRIPTION
Fixing these two build errors:

```
asciidoctor: WARNING: modules/nw-sriov-hwol-configuring-machine-config-pool.adoc: line 37: no callout found for <2>
asciidoctor: ERROR: k8s-nmstate-about-the-k8s-nmstate-operator.adoc: line 16: include file not found: /home/ahoffer/git/review-openshift-docs/openshift-docs/modules/technology-preview.adoc
```

Previews:

* https://deploy-preview-42516--osdocs.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html
* https://deploy-preview-42516--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-hardware-offloading.html#configuring-machine-config-pool_configuring-hardware-offloading