### PR TITLE
BZ2056623: Deploy templates to default namespace

### DIFF
--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -114,6 +114,12 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 [id="virt-4-10-known-issues"]
 == Known issues
 
+//Known issues at time of 4.10 release
+//BZ-2054650
+* The web console does not display virtual machine templates that are deployed to a custom namespace. Only templates deployed to the default namespace will display in the web console. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054650[*BZ#2056623*])
++
+** As a workaround, avoid deploying templates to a custom namespace.
+
 //Known issues at time of 4.9 release
 //BZ-2007397
 * If you hot-plug a virtual disk and then force delete the `virt-launcher` pod, you might lose data. This is due to a race condition that can cause the VM disk's contents to be wiped from the persistent volume. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2007397[*BZ#2007397*])


### PR DESCRIPTION
This PR is associated with:
https://bugzilla.redhat.com/show_bug.cgi?id=2056623
https://issues.redhat.com/browse/CNV-16535

It applies to the CNV 4.10 release.