### PR TITLE
OSDOCS-2841: Updating CCO support table and links for IBM Cloud

### DIFF
--- a/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
+++ b/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
@@ -49,6 +49,11 @@ Mint mode is the default and recommended best practice setting for the CCO to us
 |X
 |X
 
+|IBM Cloud
+|
+|
+|X
+
 |{rh-openstack-first}
 |
 |X

--- a/authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc
@@ -6,13 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Manual mode is supported for Amazon Web Services (AWS), Microsoft Azure, and Google Cloud Platform (GCP).
+Manual mode is supported for Amazon Web Services (AWS), Microsoft Azure, IBM Cloud, and Google Cloud Platform (GCP).
 
 In manual mode, a user manages cloud credentials instead of the Cloud Credential Operator (CCO). To use this mode, you must examine the `CredentialsRequest` CRs in the release image for the version of {product-title} that you are running or installing, create corresponding credentials in the underlying cloud provider, and create Kubernetes Secrets in the correct namespaces to satisfy all `CredentialsRequest` CRs for the cluster's cloud provider.
 
 Using manual mode allows each cluster component to have only the permissions it requires, without storing an administrator-level credential in the cluster. This mode also does not require connectivity to the AWS public IAM endpoint. However, you must manually reconcile permissions with new release images for every upgrade.
 
-For information about configuring your cloud provider to use manual mode, see _Manually creating IAM_ for xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[AWS], xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[Azure], or xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[GCP].
+For information about configuring your cloud provider to use manual mode, see _Manually creating IAM_ for xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[AWS], xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[Azure], xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[IBM Cloud], or xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[GCP].
 
 [id="manual-mode-sts-blurb"]
 == Manual mode with AWS STS
@@ -28,4 +28,5 @@ include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
 * xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[Manually creating IAM for AWS]
 * xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[Manually creating IAM for Azure]
 * xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[Manually creating IAM for GCP]
+* xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud]
 * xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-mode-sts[Using manual mode with AWS STS]


### PR DESCRIPTION
For [OSDOCS-2841](https://issues.redhat.com/browse/OSDOCS-2841), which documents [CCO-100](https://issues.redhat.com/browse/CCO-100)

Notes:
The bulk of the content was covered by Install, this updates the support table and adds some relevant links to the manual mode content.

Previews:
- [Support table](https://deploy-preview-42519--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.html#about-cloud-credential-operator-modes)
- [Manual mode](https://deploy-preview-42519--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-manual.html#cco-mode-manual)