### PR TITLE
Put serverless OSD docs live

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -206,167 +206,166 @@ Topics:
   File: policy-understand-availability
 - Name: Update life cycle
   File: osd-life-cycle
-# serverless commented out til 1.21.0 release
-# ---
-# Name: Serverless
-# Dir: serverless
-# Distros: openshift-dedicated
-# Topics:
-# - Name: Release notes
-#   File: serverless-release-notes
-# - Name: Discover
-#   Dir: discover
-#   Topics:
-#   - Name: About OpenShift Serverless
-#     File: about-serverless
-#   - Name: About OpenShift Serverless Functions
-#     File: serverless-functions-about
-#   - Name: Event sources
-#     File: knative-event-sources
-#   - Name: Channels and subscriptions
-#     File: serverless-channels
-# - Name: Install
-#   Dir: install
-#   Topics:
-#   - Name: Installing the OpenShift Serverless Operator
-#     File: install-serverless-operator
-#   - Name: Installing Knative Serving
-#     File: installing-knative-serving
-#   - Name: Installing Knative Eventing
-#     File: installing-knative-eventing
-#   - Name: Removing OpenShift Serverless
-#     File: removing-openshift-serverless
-# - Name: Develop
-#   Dir: develop
-#   Topics:
-#   - Name: Serverless applications
-#     File: serverless-applications
-#   - Name: Autoscaling
-#     File: serverless-autoscaling-developer
-#   - Name: Traffic management
-#     File: serverless-traffic-management
-#   - Name: Routing
-#     File: serverless-configuring-routes
-#   - Name: Event sinks
-#     File: serverless-event-sinks
-#   - Name: Event delivery
-#     File: serverless-event-delivery
-#   - Name: Listing event sources and event source types
-#     File: serverless-listing-event-sources
-#   - Name: Creating an API server source
-#     File: serverless-apiserversource
-#   - Name: Creating a ping source
-#     File: serverless-pingsource
-#   - File: serverless-custom-event-sources
-#     Name: Custom event sources
-#   - Name: Creating channels
-#     File: serverless-creating-channels
-#   - Name: Creating subscriptions
-#     File: serverless-subs
-#   - Name: Brokers
-#     File: serverless-using-brokers
-#   - Name: Triggers
-#     File: serverless-triggers
-#   - Name: Knative Kafka
-#     File: serverless-kafka-developer
-# - Name: Administer
-#   Dir: admin_guide
-#   Topics:
-#   - Name: Configuring OpenShift Serverless
-#     File: serverless-configuration
-#   - Name: Configuring Knative Eventing defaults
-#     File: serverless-configuring-eventing-defaults
-#   - Name: Knative Kafka
-#     File: serverless-kafka-admin
-#   - Name: Creating Knative Eventing components in the Administrator perspective
-#     File: serverless-cluster-admin-eventing
-#   - Name: Creating Knative Serving components in the Administrator perspective
-#     File: serverless-cluster-admin-serving
-#   - Name: Configuring the Knative Serving custom resource
-#     File: knative-serving-CR-config
-#   - Name: Autoscaling
-#     File: serverless-admin-autoscaling
-#   - Name: Integrating Service Mesh with OpenShift Serverless
-#     File: serverless-ossm-setup
-#   - Name: Monitoring serverless components
-#     File: serverless-admin-monitoring
-#   - Name: Metrics
-#     File: serverless-admin-metrics
-#   - Name: High availability on OpenShift Serverless
-#     File: serverless-ha
-# - Name: Monitor
-#   Dir: monitor
-#   Topics:
-#   - Name: Cluster logging with OpenShift Serverless
-#     File: cluster-logging-serverless
-#   - Name: Tracing requests using Jaeger
-#     File: serverless-tracing
-#   - Name: Metrics
-#     File: serverless-serving-metrics
-#   - Name: Monitoring Knative services
-#     File: serverless-service-monitoring
-#   - Name: Autoscaling dashboard
-#     File: serverless-autoscaling-dashboard
-# - Name: Support
-#   File: serverless-support
-# - Name: Security
-#   Dir: security
-#   Topics:
-#   - Name: Configuring JSON Web Token authentication for Knative services
-#     File: serverless-ossm-with-kourier-jwt
-#   - Name: Configuring a custom domain for a Knative service
-#     File: serverless-custom-domains
-#   - Name: Using a custom TLS certificate for domain mapping
-#     File: serverless-custom-tls-cert-domain-mapping
-#   - Name: Security configuration for Knative Kafka
-#     File: serverless-kafka-security
-# - Name: Functions
-#   Dir: functions
-#   Topics:
-#   - Name: Setting up OpenShift Serverless Functions
-#     File: serverless-functions-setup
-#   - Name: Getting started with functions
-#     File: serverless-functions-getting-started
-#   - Name: Developing Node.js functions
-#     File: serverless-developing-nodejs-functions
-#   - Name: Developing TypeScript functions
-#     File: serverless-developing-typescript-functions
-#   - Name: Developing Golang functions
-#     File: serverless-developing-go-functions
-#   - Name: Developing Python functions
-#     File: serverless-developing-python-functions
-#   - Name: Developing Quarkus functions
-#     File: serverless-developing-quarkus-functions
-#   - Name: Using functions with Knative Eventing
-#     File: serverless-functions-eventing
-#   - Name: Function project configuration in func.yaml
-#     File: serverless-functions-yaml
-#   - Name: Accessing secrets and config maps from functions
-#     File: serverless-functions-accessing-secrets-configmaps
-#   - Name: Adding annotations to functions
-#     File: serverless-functions-annotations
-#   - Name: Functions development reference guide
-#     File: serverless-functions-reference-guide
-# - Name: CLI tools
-#   Dir: cli_tools
-#   Topics:
-#   - Name: Installing the Knative CLI
-#     File: installing-kn
-#   - Name: Knative CLI advanced configuration
-#     File: advanced-kn-config
-# - Name: Reference
-#   Dir: reference
-#   Topics:
-#   - Name: Knative CLI flags
-#     File: kn-flags-reference
-#   - Name: Knative Serving CLI commands
-#     File: kn-serving-ref
-#   - Name: Knative Eventing CLI commands
-#     File: kn-eventing-ref
-#   - Name: Functions commands
-#     File: kn-func-ref
-#   - Name: kn event
-#     File: kn-event-ref
+---
+Name: Serverless
+Dir: serverless
+Distros: openshift-dedicated
+Topics:
+- Name: Release notes
+  File: serverless-release-notes
+- Name: Discover
+  Dir: discover
+  Topics:
+  - Name: About OpenShift Serverless
+    File: about-serverless
+  - Name: About OpenShift Serverless Functions
+    File: serverless-functions-about
+  - Name: Event sources
+    File: knative-event-sources
+  - Name: Channels and subscriptions
+    File: serverless-channels
+- Name: Install
+  Dir: install
+  Topics:
+  - Name: Installing the OpenShift Serverless Operator
+    File: install-serverless-operator
+  - Name: Installing Knative Serving
+    File: installing-knative-serving
+  - Name: Installing Knative Eventing
+    File: installing-knative-eventing
+  - Name: Removing OpenShift Serverless
+    File: removing-openshift-serverless
+- Name: Develop
+  Dir: develop
+  Topics:
+  - Name: Serverless applications
+    File: serverless-applications
+  - Name: Autoscaling
+    File: serverless-autoscaling-developer
+  - Name: Traffic management
+    File: serverless-traffic-management
+  - Name: Routing
+    File: serverless-configuring-routes
+  - Name: Event sinks
+    File: serverless-event-sinks
+  - Name: Event delivery
+    File: serverless-event-delivery
+  - Name: Listing event sources and event source types
+    File: serverless-listing-event-sources
+  - Name: Creating an API server source
+    File: serverless-apiserversource
+  - Name: Creating a ping source
+    File: serverless-pingsource
+  - File: serverless-custom-event-sources
+    Name: Custom event sources
+  - Name: Creating channels
+    File: serverless-creating-channels
+  - Name: Creating subscriptions
+    File: serverless-subs
+  - Name: Brokers
+    File: serverless-using-brokers
+  - Name: Triggers
+    File: serverless-triggers
+  - Name: Knative Kafka
+    File: serverless-kafka-developer
+- Name: Administer
+  Dir: admin_guide
+  Topics:
+  - Name: Configuring OpenShift Serverless
+    File: serverless-configuration
+  - Name: Configuring Knative Eventing defaults
+    File: serverless-configuring-eventing-defaults
+  - Name: Knative Kafka
+    File: serverless-kafka-admin
+  - Name: Creating Knative Eventing components in the Administrator perspective
+    File: serverless-cluster-admin-eventing
+  - Name: Creating Knative Serving components in the Administrator perspective
+    File: serverless-cluster-admin-serving
+  - Name: Configuring the Knative Serving custom resource
+    File: knative-serving-CR-config
+  - Name: Autoscaling
+    File: serverless-admin-autoscaling
+  - Name: Integrating Service Mesh with OpenShift Serverless
+    File: serverless-ossm-setup
+  - Name: Monitoring serverless components
+    File: serverless-admin-monitoring
+  - Name: Metrics
+    File: serverless-admin-metrics
+  - Name: High availability on OpenShift Serverless
+    File: serverless-ha
+- Name: Monitor
+  Dir: monitor
+  Topics:
+  - Name: Cluster logging with OpenShift Serverless
+    File: cluster-logging-serverless
+  - Name: Tracing requests using Jaeger
+    File: serverless-tracing
+  - Name: Metrics
+    File: serverless-serving-metrics
+  - Name: Monitoring Knative services
+    File: serverless-service-monitoring
+  - Name: Autoscaling dashboard
+    File: serverless-autoscaling-dashboard
+- Name: Support
+  File: serverless-support
+- Name: Security
+  Dir: security
+  Topics:
+  - Name: Configuring JSON Web Token authentication for Knative services
+    File: serverless-ossm-with-kourier-jwt
+  - Name: Configuring a custom domain for a Knative service
+    File: serverless-custom-domains
+  - Name: Using a custom TLS certificate for domain mapping
+    File: serverless-custom-tls-cert-domain-mapping
+  - Name: Security configuration for Knative Kafka
+    File: serverless-kafka-security
+- Name: Functions
+  Dir: functions
+  Topics:
+  - Name: Setting up OpenShift Serverless Functions
+    File: serverless-functions-setup
+  - Name: Getting started with functions
+    File: serverless-functions-getting-started
+  - Name: Developing Node.js functions
+    File: serverless-developing-nodejs-functions
+  - Name: Developing TypeScript functions
+    File: serverless-developing-typescript-functions
+  - Name: Developing Golang functions
+    File: serverless-developing-go-functions
+  - Name: Developing Python functions
+    File: serverless-developing-python-functions
+  - Name: Developing Quarkus functions
+    File: serverless-developing-quarkus-functions
+  - Name: Using functions with Knative Eventing
+    File: serverless-functions-eventing
+  - Name: Function project configuration in func.yaml
+    File: serverless-functions-yaml
+  - Name: Accessing secrets and config maps from functions
+    File: serverless-functions-accessing-secrets-configmaps
+  - Name: Adding annotations to functions
+    File: serverless-functions-annotations
+  - Name: Functions development reference guide
+    File: serverless-functions-reference-guide
+- Name: CLI tools
+  Dir: cli_tools
+  Topics:
+  - Name: Installing the Knative CLI
+    File: installing-kn
+  - Name: Knative CLI advanced configuration
+    File: advanced-kn-config
+- Name: Reference
+  Dir: reference
+  Topics:
+  - Name: Knative CLI flags
+    File: kn-flags-reference
+  - Name: Knative Serving CLI commands
+    File: kn-serving-ref
+  - Name: Knative Eventing CLI commands
+    File: kn-eventing-ref
+  - Name: Functions commands
+    File: kn-func-ref
+  - Name: kn event
+    File: kn-event-ref
 ---
 Name: Support
 Dir: support

--- a/modules/serverless-creating-broker-labeling.adoc
+++ b/modules/serverless-creating-broker-labeling.adoc
@@ -19,6 +19,10 @@ Brokers created using this method are not removed if you remove the label. You m
 * You have installed the `oc` CLI.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
+ifdef::openshift-dedicated[]
+* You have cluster or dedicated administrator permissions.
+endif::[]
+
 .Procedure
 
 * Label a namespace with `eventing.knative.dev/injection=enabled`:

--- a/modules/serverless-list-source-types-kn.adoc
+++ b/modules/serverless-list-source-types-kn.adoc
@@ -15,6 +15,7 @@ You can list event source types that can be created and used on your cluster by 
 
 .Procedure
 
+ifdef::openshift-enterprise[]
 . List the available event source types in the terminal:
 +
 [source,terminal]
@@ -37,3 +38,23 @@ SinkBinding       sinkbindings.sources.knative.dev                Binding for co
 ----
 $ kn source list-types -o yaml
 ----
+endif::[]
+// optional step not allowed yet for OSD due to upstream CLI issue #1385
+
+ifdef::openshift-dedicated[]
+* List the available event source types in the terminal:
++
+[source,terminal]
+----
+$ kn source list-types
+----
++
+.Example output
+[source,terminal]
+----
+TYPE              NAME                                            DESCRIPTION
+ApiServerSource   apiserversources.sources.knative.dev            Watch and send Kubernetes API events to a sink
+PingSource        pingsources.sources.knative.dev                 Periodically send ping events to a sink
+SinkBinding       sinkbindings.sources.knative.dev                Binding for connecting a PodSpecable to a sink
+----
+endif::[]


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/SRVCOM-1451

Applies for OCP 4.9+

Too many files to list all for direct preview, includes entire serverless section in OSD.
https://deploy-preview-42520--osdocs.netlify.app/openshift-dedicated/latest/serverless/serverless-release-notes.html
All files except those listed as specific changes below have already been reviewed extensively by QE, peer reviewers, and don't need another review.

Specific changes in this PR:
- uncomment sections from topicmap
- add condition to source list kn docs for OSD: https://deploy-preview-42520--osdocs.netlify.app/openshift-dedicated/latest/serverless/develop/serverless-listing-event-sources.html#serverless-list-source-types-kn_serverless-listing-event-sources
- updated injection broker docs for OSD only: https://deploy-preview-42520--osdocs.netlify.app/openshift-dedicated/latest/serverless/develop/serverless-using-brokers.html#serverless-creating-broker-labeling_serverless-using-brokers