### PR TITLE
Removing TP boilerplate for Hot Plug Disks in 4.10

### DIFF
--- a/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc
@@ -4,9 +4,6 @@
 include::modules/virt-document-attributes.adoc[]
 :context: virt-hot-plugging-virtual-disks
 
-:FeatureName: Hot-plugging virtual disks
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 toc::[]
 
 Hot-plug and hot-unplug virtual disks when you want to add or remove them without stopping your virtual machine or virtual machine instance. This capability is helpful when you need to add storage to a running virtual machine without incurring down-time.


### PR DESCRIPTION
For 4.10 only.

This PR only removes the Tech Preview boilerplate INCLUDE from this assembly, as Hot Plug Disks are no longer in Tech preview in 4.10.

There is no JIRA story associated with this task.

Direct doc preview link: https://deploy-preview-42521--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.html