### PR TITLE
Fixed xref extension from html to adoc

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -119,7 +119,7 @@ The following Operators are supported for {product-title} on ARM:
 [id="ocp-4-10-installation-and-upgrade-vsphere-provisioning"]
 ==== Thin provisioning support for VMware vSphere cluster installation
 
-{product-title} {product-version} introduces support for thin provisioned disks when you install a cluster using installer-provisioned infrastructure. You can provision disks as `thin`, `thick`, or `eagerZeroedThick`. For more information about disk provisioning modes in VMware vSphere, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-configuration-parameters_installing-vsphere-installer-provisioned-customizations[Installation configuration parameters].
+{product-title} {product-version} introduces support for thin provisioned disks when you install a cluster using installer-provisioned infrastructure. You can provision disks as `thin`, `thick`, or `eagerZeroedThick`. For more information about disk provisioning modes in VMware vSphere, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installation-configuration-parameters_installing-vsphere-installer-provisioned-customizations[Installation configuration parameters].
 
 [id="ocp-4-10-installation-and-upgrade-aws-ami"]
 ==== Installing a cluster into an Amazon Web Services GovCloud region


### PR DESCRIPTION
This is a fix to [this Release Notes PR](https://github.com/openshift/openshift-docs/pull/40703) to fix an xref with ".html" instead of ".adoc". There is no Jira as it's just fixing an extension.

[Doc preview here](https://deploy-preview-42522--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-installation-and-upgrade-vsphere-provisioning)