### PR TITLE
CNV-14192: Automatic workload updates

### DIFF
--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -61,6 +61,7 @@ The SVVP Certification applies to:
 === Installation
 
 //CNV-14192 Update launchers using live-migration - default/opt out
+* {VirtProductName} workloads, such as `virt-launcher` pods, now automatically update if they support live migration. You can xref:../virt/upgrading-virt.adoc#configuring-workload-updates_upgrading-virt[configure workload update strategies] or opt out of future automatic updates by editing the `HyperConverged` custom resource.
 
 //CNV-14910 HyperConverged Operator technical debt
 


### PR DESCRIPTION
- [CNV-14192](https://issues.redhat.com/browse/CNV-14192) (from 4.9) is the closest Jira. 
- Context: I had to replace this note with a TP one in 4.9, so I am bringing it back for 4.10 now that it is GA. I am using most of the text from the previous RN, which was SME/QE/peer reviewed before the 4.9 release: https://github.com/openshift/openshift-docs/pull/37283 I am not including the workaround section because that does not pertain to 4.10.
- No cherrypick
- Preview build link: https://deploy-preview-42527--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-10-release-notes#virt-4-10-installation-new