### PR TITLE
Adds notes for 4.9.23 release

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2546,3 +2546,24 @@ link:https://access.redhat.com/solutions/6750371[{product-title} 4.9.22 containe
 ==== Updating
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-9-23"]
+=== RHSA-2022:0655 - {product-title} 4.9.23 bug fix and security update
+
+Issued: 2022-02-28
+
+{product-title} release 4.9.23, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:0655[RHSA-2022:0655] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0654[RHBA-2022:0654] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6762051[{product-title} 4.9.23 container image list]
+
+[id="ocp-4-9-23-bug-fixes"]
+==== Bug fixes
+
+* Previously, installation failed when installing to a region that had local zone enabled. With this update, the installation program considers only availability zones and not local zones. Now, installation with local zones enabled will only installs to the availability zones in that region and not to any local zones. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2052307[BZ#*2052307*])
+
+[id="ocp-4-9-23-updating"]
+==== Updating
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.9.23 release today.

- Applies to `enterprise-4.9` only
- [Preview link]( https://github.com/opayne1/openshift-docs/pull/new/RNs-4.9.23)