### PR TITLE
TELCODOCS-243: D/S Docs & RN: METAL-6 (MPHARDWARE-4/KNIDEPLOY-2108) BIOS Settings Configuration (set values)

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -548,7 +548,7 @@ For more information, see xref:../networking/hardware_networks/configuring-hardw
 
 The most common use case for the `networkConfig` configuration setting is to set static IP addresses on a host's network interface during installation or while expanding the cluster.
 
-For more information, see xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-host-network-interfaces-in-the-install-config.yaml-file_ipi-install-installation-workflow[Configuring host network interfaces in the install-config.yaml file].
+For more information, see xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#configuring-host-network-interfaces-in-the-install-config.yaml-file_ipi-install-installation-workflow[Configuring host network interfaces in the install-config.yaml file].
 
 [id="ocp-4-10-hardware"]
 === Hardware
@@ -567,6 +567,18 @@ The following enhancements to MetalLB and the MetalLB Operator are included in t
 * Support for speaker pod tolerations in the MetalLB custom resrouce definition is added.
 
 For more information, see xref:../networking/metallb/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator].
+
+
+[id="ocp-4-10-host-firmware-settings"]
+==== Support for modifying host firmware settings
+
+{product-title} supports the `HostFirmwareSettings` and `FirmwareSchema` resources. When deploying OpenShift Container Platform on bare metal hosts, there are times when you need to make changes to the host either before or after provisioning. This can include inspecting the host's firmware and BIOS details. There are two new resources that you can use with the Bare Metal Operator (BMO):
+
+* `HostFirmwareSettings`: You can use the `HostFirmwareSettings` resource to retrieve and manage the BIOS settings for a host. The resource contains the complete BIOS configuration returned from the baseboard management controller (BMC). Whereas, the firmware field in the `BareMetalHost` resource returns three vendor-independent fields, the `HostFirmwareSettings` resource typically comprises many BIOS settings of vendor-specific fields per host model.
+
+* `FirmwareSchema`: You can use the `FirmwareSchema` to identify the host's modifiable BIOS values and limits when making changes to host firmware settings.
+
+See xref:../post_installation_configuration/bare-metal-configuration.html[Bare metal configuration] for additional details.
 
 [id="ocp-4-10-storage"]
 === Storage


### PR DESCRIPTION
Adds release notes for [TELCODOCS-243](https://issues.redhat.com/browse/TELCODOCS-243). The included hyperlink isn't showing, but the resource is included in the preview for [TELCODOCS-243](https://issues.redhat.com/browse/TELCODOCS-243) at: https://deploy-preview-41947--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/bare-metal-configuration.html  I believe https://github.com/openshift/openshift-docs/pull/41947 needs to get cherry-picked to 4.10.

Fixes: [TELCODOCS-243](https://issues.redhat.com/browse/TELCODOCS-243)

See https://issues.redhat.com/browse/TELCODOCS-243 for additional details.

Preview URL: https://deploy-preview-42533--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-host-firmware-settings

For release(s): 4.10
Signed-off-by: John Wilkins <jowilkin@redhat.com>
