### PR TITLE
Removing old conditionals from main that dont exist in version branches

### DIFF
--- a/modules/nw-dns-operator.adoc
+++ b/modules/nw-dns-operator.adoc
@@ -10,7 +10,6 @@ group. The Operator deploys CoreDNS using a daemon set, creates a service for
 the daemon set, and configures the kubelet to instruct pods to use the CoreDNS
 service IP address for name resolution.
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 .Procedure
 
 The DNS Operator is deployed during installation with a `Deployment` object.
@@ -44,4 +43,3 @@ dns       4.1.0-0.11  True        False         False      92m
 ----
 +
 `AVAILABLE`, `PROGRESSING` and `DEGRADED` provide information about the status of the operator. `AVAILABLE` is `True` when at least 1 pod from the CoreDNS daemon set reports an `Available` status condition.
-endif::[]

--- a/modules/nw-dns-view.adoc
+++ b/modules/nw-dns-view.adoc
@@ -37,7 +37,6 @@ qualified pod and service domain names.
 <2> The Cluster IP is the address pods query for name resolution. The IP is
 defined as the 10th address in the service CIDR range.
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 . To find the service CIDR of your cluster,
 use the `oc get` command:
 +
@@ -51,4 +50,3 @@ $ oc get networks.config/cluster -o jsonpath='{$.status.serviceNetwork}'
 ----
 [172.30.0.0/16]
 ----
-endif::[]

--- a/networking/dns-operator.adoc
+++ b/networking/dns-operator.adoc
@@ -20,11 +20,9 @@ include::modules/nw-dns-view.adoc[leveloffset=+1]
 
 include::modules/nw-dns-forward.adoc[leveloffset=+1]
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 include::modules/nw-dns-operator-status.adoc[leveloffset=+1]
 
 include::modules/nw-dns-operator-logs.adoc[leveloffset=+1]
-endif::[]
 
 include::modules/nw-dns-loglevel.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR is for main only! The removed lines here don't exist in the version branches.

This was from #20549, because the PR never got cherry picked to branches past 4.3. So, removing from main to avoid future merge conflicts