### PR TITLE
CNV-16638: RN VMIO no longer supported

### DIFF
--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -84,9 +84,9 @@ The SVVP Certification applies to:
 [id="virt-4-10-web-new"]
 === Web console
 
-// NOTE: no deprecated features in 4.10; commenting out these sections to retain for future use
-//[id="virt-4-10-deprecated-removed"]
-//== Deprecated and removed features
+
+[id="virt-4-10-deprecated-removed"]
+== Deprecated and removed features
 
 //[id="virt-4-10-deprecated"]
 //=== Deprecated features
@@ -95,10 +95,12 @@ The SVVP Certification applies to:
 
 // NOTE: when uncommenting deprecated features list, change the header level below to ===
 
-//[id="virt-4-10-removed"]
-//=== Removed features
+[id="virt-4-10-removed"]
+=== Removed features
 
-//Removed features are not supported in the current release.
+Removed features are not supported in the current release.
+
+* The VM Import Operator has been removed from {VirtProductName} with this release. It is replaced by the link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.2[Migration Toolkit for Virtualization].
 
 // NOTE: no notable technical changes in 4.9, commenting out to retain
 //[id="virt-4-10-changes"]


### PR DESCRIPTION
[CNV-16638](https://issues.redhat.com/browse/CNV-16638)

The VM Import Operator is no longer supported. Added RN in the "Deprecated and removed features" section

Preview: https://deploy-preview-42537--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-10-release-notes#virt-4-10-removed