### PR TITLE
CNV-15707: RN for CentOS templates - Notable Tech Feature and Removed Feature

### DIFF
--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -77,6 +77,7 @@ The SVVP Certification applies to:
 
 //CNV-13680 Primary and secondary networks over a shared NIC on OVN clusters
 
+//CNV-15779 Network alerts when Kubemacpool detects duplicated MAC addresses
 
 [id="virt-4-10-storage-new"]
 === Storage
@@ -85,8 +86,8 @@ The SVVP Certification applies to:
 === Web console
 
 // NOTE: no deprecated features in 4.10; commenting out these sections to retain for future use
-//[id="virt-4-10-deprecated-removed"]
-//== Deprecated and removed features
+[id="virt-4-10-deprecated-removed"]
+== Deprecated and removed features
 
 //[id="virt-4-10-deprecated"]
 //=== Deprecated features
@@ -95,14 +96,22 @@ The SVVP Certification applies to:
 
 // NOTE: when uncommenting deprecated features list, change the header level below to ===
 
-//[id="virt-4-10-removed"]
-//=== Removed features
+[id="virt-4-10-removed"]
+=== Removed features
 
 //Removed features are not supported in the current release.
 
-// NOTE: no notable technical changes in 4.9, commenting out to retain
+//CNV-15707 Replacing template for CentOS Linux 8, because CentOS Linux 8 reached End Of Life (EOL) (Removed features)
+
+* The template for CentOS Linux 8 is no longer supported because support for CentOS Linux 8 is no longer supported as of December 31st, 2021. The template for CentOS Linux 8 has been replaced by templates for CentOS Stream 8 and CentOS Stream 9.
+
 //[id="virt-4-10-changes"]
-//== Notable technical changes
+== Notable technical changes
+
+//CNV-15707 Replacing template for CentOS Linux 8, because CentOS Linux 8 reached End Of Life (EOL) (Notable technical change)
+
+* The templates for CentOS Stream 8 and CentOS Stream 9 replace the CentOS Linux 8 template, which is no longer supported as of December 31st, 2021. The
+templates for CentOS Stream 8 and CentOS Stream 9 are currently unsupported by {VirtProductName}.
 
 [id="virt-4-10-technology-preview"]
 == Technology Preview features
@@ -120,19 +129,17 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 [id="virt-4-10-bug-fixes"]
 == Bug fixes
 
+* If you hot-plug a virtual disk and then force delete the `virt-launcher` pod, you no longer lose data. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2007397[*BZ#2007397*])
+
+* If you initiate a cloning operation before the clone source becomes available, the cloning operation now completes successfully without using a workaround. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1855182[*BZ#1855182*])
+
 [id="virt-4-10-known-issues"]
 == Known issues
 
 //Known issues at time of 4.9 release
-//BZ-2007397
-* If you hot-plug a virtual disk and then force delete the `virt-launcher` pod, you might lose data. This is due to a race condition that can cause the VM disk's contents to be wiped from the persistent volume. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2007397[*BZ#2007397*])
 
 // Review this for permanent doc home in 4.10
 * Editing a virtual machine fails if the VM references a deleted template that was provided by {VirtProductName} before version 4.8. In {VirtProductName} 4.8 and later, deleted {VirtProductName}-provided templates are automatically recreated by the {VirtProductName} Operator.
-
-* If a cloning operation is initiated before the source is available to be cloned, the operation stalls indefinitely. This is because the clone authorization expires before the cloning operation starts. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1855182[*BZ#1855182*])
-+
-** As a workaround, delete the `DataVolume` object that is requesting the clone. When the source is available, recreate the `DataVolume` object that you deleted so that the cloning operation can complete successfully.
 
 * If your {product-title} cluster uses OVN-Kubernetes as the default Container Network Interface (CNI) provider, you cannot attach a Linux bridge or bonding to the default interface of a host because of a change in the host network topology of OVN-Kubernetes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1885605[*BZ#1885605*])
 
@@ -202,7 +209,15 @@ metadata:
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1977037[*BZ#1977037*])
 
-//Known issues discovered after 4.9 release
+//Known issues for 4.10 release
+* `openshift-monitoring` sends a `PodDisruptionBudgetAtLimit` alert every 60 minutes. This alert affects virtual machines with the `LiveMigrate` eviction strategy when an application that is protected by a Pod Disruption Budget (PDB) does not allow disruptions for migratable virtual machine images. To workaround this issue, silence the alert by setting OCP Monitoring Results.
+// More information is needed as to how to set OCP Monitoring Results. Contact Stu Gott re: BZ2026733. BZ reporter has not responded to queries.
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2026733[*BZ#2026733*])
 
-* If a single node contains more than 50 images, pod scheduling might be imbalanced across nodes. This is because the list of images on a node is shortened to 50 by default.
-** As a workaround, you can disable the image limit by xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing[editing the `KubeletConfig` object] and setting the value of `nodeStatusMaxImages` to `-1`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1984442[*BZ#1984442*])
+* If you configure the `HyperConverged` custom resource (CR) to enable mediated devices before drivers are installed, then configuration setting changes to the CR will not be saved. This issue can be triggered by updates. For example, if `virt-handler` is updated before `daemonset`, which installs NVIDIA drivers, then nodes are not able to provide virtual machine GPUs.
+** As a workaround:
+. Remove `mediatedDevicesConfiguration` and `permittedHostDevices` from the `HyperConverged` CR.
+. Update both `mediatedDevicesConfiguration` and `permittedHostDevices` stanzas with the desired configuration.
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2046298[*BZ#2046298*])


### PR DESCRIPTION
For 4.10 Only

Notable technical changes

* The templates for CentOS Stream 8 and CentOS Stream 9 replace the CentOS Linux 8 template, which is no longer supported as of December 31st, 2021. The
templates for CentOS Stream 8 and CentOS Stream 9 are currently unsupported by {VirtProductName}.



JIRA: https://issues.redhat.com/browse/CNV-15707

Tagging @dominikholler for Code Review
Will tag a QE resource shortly.

Direct doc preview link:https://deploy-preview-42538--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-10-release-notes.html
