### PR TITLE
TELCODOCS-362: D/S Documentation & RN: SDN-2215/MPNETWORK-4:Track Kubernetes NMstate to be GA for the bare metal platform

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -568,6 +568,12 @@ Intel 800-Series Columbiaville NICs are now fully supported for interfaces confi
 
 For more information, see xref:../networking/using-ptp.adoc#configuring-ptp-devices[Configuring PTP devices].
 
+[id="ocp-4-10-networking-k8s-nmstate-operator"]
+==== Kubernetes NMState Operator is GA for bare-metal installations
+
+{product-title} now provides the Kubernetes NMState Operator for bare-metal installations. The Kubernetes NMState Operator is still a Technology Preview for all other platforms. See xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc[About the Kubernetes NMState Operator] for additional details.
+
+
 [id="ocp-4-10-hardware"]
 === Hardware
 


### PR DESCRIPTION
Adds release notes for [TELCODOCS-362](https://issues.redhat.com/browse/TELCODOCS-362).

Fixes: [TELCODOCS-362](https://issues.redhat.com/browse/TELCODOCS-362)

See https://issues.redhat.com/browse/TELCODOCS-362 for additional details.

Preview URL: https://deploy-preview-42539--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-networking-k8s-nmstate-operator

For release(s): 4.10
Signed-off-by: John Wilkins <jowilkin@redhat.com>
