### PR TITLE
Operator SDK Release notes: object pruning and disconnected bundles

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -796,6 +796,18 @@ Operator authors can now use the Ansible-based Operator support in the Operator 
 
 For more details, see xref:../operators/operator_sdk/osdk-monitoring-prometheus.adoc#osdk-monitoring-prometheus[Exposing custom metrics for Ansible-based Operators].
 
+==== Object pruning for Go-based Operators
+
+The `operator-lib` pruning utility lets Go-based Operators clean up objects, such as jobs or pods, that can stay in the cluster and use resources. The utility includes common pruning strategies for Go-based Operators. Operator authors can also use the utility to create custom hooks and strategies.
+
+For more information about the pruning utility, see xref:../operators/operator_sdk/osdk-pruning-utility.adoc#osdk-pruning-utility_osdk-pruning-utility[Object pruning utility for Go-based Operators].
+
+==== Digest-based bundle for disconnected environments
+
+With this enhancement, Operator SDK can now package an Operator project into a bundle that works in a disconnected environment with Operator Lifecycle Manager (OLM). Operator authors can run the `make bundle` command and set `USE_IMAGE_DIGESTS` to `true` to automatically update your Operator image reference to a digest rather than a tag. To use the command, you must use environment variables to replace hard-coded related image references.
+
+For more information about developing Operators for disconnected environments, see xref:../operators/operator_sdk/osdk-generating-csvs.adoc#olm-enabling-operator-for-restricted-network_osdk-generating-csvs[Enabling your Operator for restricted network environments].
+
 [id="ocp-4-10-builds"]
 === Builds
 


### PR DESCRIPTION
- enterprise-4.10
- [OSDOCS-2932](https://issues.redhat.com/browse/OSDOCS-2932) and [OSDOCS-2934](https://issues.redhat.com/browse/OSDOCS-2934)
- [Preview link](https://deploy-preview-42540--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#object-pruning-for-go-based-operators)
