### PR TITLE
OSDOCS-2329: GCP Workload Identity

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -952,8 +952,10 @@ Topics:
     File: cco-mode-passthrough
   - Name: Using manual mode
     File: cco-mode-manual
-  - Name: Using manual mode with STS
+  - Name: Using manual mode with AWS Secure Token Service
     File: cco-mode-sts
+  - Name: Using manual mode with GCP Workload Identity
+    File: cco-mode-gcp-workload-identity
 ---
 Name: Networking
 Dir: networking

--- a/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
+++ b/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
@@ -26,7 +26,9 @@ Mint mode is the default and recommended best practice setting for the CCO to us
 
 * **xref:../../authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc#cco-mode-manual[Manual]**: In manual mode, a user manages cloud credentials instead of the CCO.
 
-** **xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-mode-sts[Manual with AWS STS]**: In manual mode, you can configure an AWS cluster to use Amazon Web Services Secure Token Service (AWS STS). With this configuration, the CCO uses temporary credentials for different components.
+** **xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-mode-sts[Manual with AWS Secure Token Service]**: In manual mode, you can configure an AWS cluster to use Amazon Web Services Secure Token Service (AWS STS). With this configuration, the CCO uses temporary credentials for different components.
+
+** **xref:../../authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc#cco-mode-gcp-workload-identity[Manual with GCP Workload Identity]**: In manual mode, you can configure a GCP cluster to use GCP Workload Identity. With this configuration, the CCO uses temporary credentials for different components.
 
 .CCO mode support matrix
 [cols="<.^2,^.^1,^.^1,^.^1"]

--- a/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
@@ -1,0 +1,129 @@
+:_content-type: ASSEMBLY
+[id="cco-mode-gcp-workload-identity"]
+= Using manual mode with GCP Workload Identity
+include::_attributes/common-attributes.adoc[]
+:context: cco-mode-gcp-workload-identity
+
+toc::[]
+
+Manual mode with GCP Workload Identity is supported for Google Cloud Platform (GCP).
+
+In manual mode with GCP Workload Identity, the individual {product-title} cluster components can impersonate IAM service accounts using short-term, limited-privilege credentials.
+
+Requests for new and refreshed credentials are automated by using an appropriately configured OpenID Connect (OIDC) identity provider, combined with IAM service accounts. {product-title} signs service account tokens that are trusted by GCP, and can be projected into a pod and used for authentication. Tokens are refreshed after one hour by default.
+
+////
+to-do: GCP diagram from https://github.com/openshift/cloud-credential-operator/blob/master/docs/gcp_workload_identity_flow.png?raw=true
+
+.Workload Identity authentication flow
+image::<new_filename_for_gcp_workload_id.svg[Detailed authentication flow between GCP and the cluster when using GCP Workload Identity]
+//to-do: improve alt-text
+////
+
+Using manual mode with GCP Workload Identity changes the content of the GCP credentials that are provided to individual {product-title} components.
+
+.GCP secret format
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: <target_namespace> <1>
+  name: <target_secret_name> <2>
+data:
+  service_account.json: <service_account> <3>
+----
+<1> The namespace for the component.
+<2> The name of the component secret.
+<3> The Base64 encoded service account.
+
+.Content of the Base64 encoded `service_account.json` file using long-lived credentials
+
+[source,json]
+----
+{
+   "type": "service_account", <1>
+   "project_id": "<project_id>",
+   "private_key_id": "<private_key_id>",
+   "private_key": "<private_key>", <2>
+   "client_email": "<client_email_address>",
+   "client_id": "<client_id>",
+   "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+   "token_uri": "https://oauth2.googleapis.com/token",
+   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/<client_email_address>"
+}
+----
+<1> The credential type is `service_account`.
+<2> The private RSA key that is used to authenticate to GCP. This key must be kept secure and is not rotated.
+
+.Content of the Base64 encoded `service_account.json` file using GCP Workload Identity
+
+[source,json]
+----
+{
+   "type": "external_account", <1>
+   "audience": "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/test-pool/providers/test-provider", <2>
+   "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+   "token_url": "https://sts.googleapis.com/v1/token",
+   "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/<client_email_address>:generateAccessToken", <3>
+   "credential_source": {
+      "file": "<path_to_token>", <4>
+      "format": {
+         "type": "text"
+      }
+   }
+}
+----
+<1> The credential type is `external_account`.
+<2> The target audience is the GCP Workload Identity provider.
+<3> The resource URL of the service account that can be impersonated with these credentials.
+<4> The path to the service account token inside the pod. By convention, this is `/var/run/secrets/openshift/serviceaccount/token` for {product-title} components.
+
+//Supertask: Installing an OCP cluster configured for manual mode with GCP Workload Identity
+[id="gcp-workload-identity-mode-installing"]
+== Installing an {product-title} cluster configured for manual mode with GCP Workload Identity
+
+To install a cluster that is configured to use the Cloud Credential Operator (CCO) in manual mode with GCP Workload Identity:
+
+. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc#cco-ccoctl-configuring_cco-mode-gcp-workload-identity[Configure the Cloud Credential Operator utility].
+. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc#cco-ccoctl-creating-at-once_cco-mode-gcp-workload-identity[Create the required GCP resources].
+. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc#sts-mode-installing-manual-run-installer_cco-mode-gcp-workload-identity[Run the {product-title} installer].
+. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc#sts-mode-installing-verifying_cco-mode-gcp-workload-identity[Verify that the cluster is using short-lived credentials].
+
+////
+// Remove until upgrade is supported.
+[NOTE]
+====
+Because the cluster is operating in manual mode when using GCP Workload Identity, it is not able to create new credentials for components with the permissions that they require. When upgrading to a different minor version of {product-title}, there are often new GCP permission requirements. Before upgrading a cluster that is using GCP Workload Identity, the cluster administrator must manually ensure that the GCP permissions are sufficient for existing components and available to any new components.
+====
+////
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
+
+//Task part 2: Creating the required GCP resources all at once
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+2]
+
+//Task part 3: Run the OCP installer
+include::modules/sts-mode-installing-manual-run-installer.adoc[leveloffset=+2]
+
+//Task part 4: Verify that the cluster is using short-lived credentials
+include::modules/sts-mode-installing-verifying.adoc[leveloffset=+2]
+
+////
+// No Upgrade in 4.10 but this should work exactly the same as AWS STS does.
+[id="gcp-workload-identity-mode-upgrading"]
+== Upgrading an {product-title} cluster configured for manual mode with GCP Workload Identity
+
+The release image for the version of {product-title} that you are upgrading to contains a version of the `ccoctl` binary and list of `CredentialsRequest` objects specific to that release.
+
+:context: sts-mode-upgrading
+
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
+
+include::modules/cco-ccoctl-upgrading.adoc[leveloffset=+2]
+
+include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+2]
+////

--- a/installing/installing_gcp/manually-creating-iam-gcp.adoc
+++ b/installing/installing_gcp/manually-creating-iam-gcp.adoc
@@ -13,7 +13,8 @@ include::modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc[level
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-rotate-remove-cloud-creds[Rotating or removing cloud provider credentials].
+* xref:../../authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc#cco-mode-gcp-workload-identity[Using manual mode with GCP Workload Identity]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-rotate-remove-cloud-creds[Rotating or removing cloud provider credentials]
 
 For a detailed description of all available CCO credential modes and their supported platforms, see xref:../../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator].
 

--- a/installing/installing_gcp/uninstalling-cluster-gcp.adoc
+++ b/installing/installing_gcp/uninstalling-cluster-gcp.adoc
@@ -9,3 +9,5 @@ toc::[]
 You can remove a cluster that you deployed to Google Cloud Platform (GCP).
 
 include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]
+
+include::modules/cco-ccoctl-deleting-sts-resources.adoc[leveloffset=+1]

--- a/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
+++ b/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
@@ -35,6 +35,13 @@ You can use the CCO utility (`ccoctl`) to configure the cluster to use the Amazo
 
 endif::aws[]
 
+ifdef::google-cloud-platform[]
+* *Use manual mode with GCP Workload Identity*:
++
+You can use the CCO utility (`ccoctl`) to configure the cluster to use manual mode with GCP Workload Identity. When the CCO utility is used to configure the cluster for GCP Workload Identity, it signs service account tokens that provide short-term, limited-privilege security credentials to components.
+
+endif::google-cloud-platform[]
+
 ifdef::aws,google-cloud-platform[]
 * *Manage cloud credentials manually*:
 +

--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+// * authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
 // * installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
 // * installing/installing_alibaba/manually-creating-alibaba-ram.adoc
 
@@ -13,14 +14,18 @@ endif::[]
 ifeval::["{context}" == "manually-creating-alibaba-ram"]
 :alibabacloud:
 endif::[]
+ifeval::["{context}" == "cco-mode-gcp-workload-identity"]
+:google-cloud-platform:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="cco-ccoctl-configuring_{context}"]
 = Configuring the Cloud Credential Operator utility
 
-To create and manage cloud credentials from outside of the cluster when the Cloud Credential Operator (CCO) is operating in 
+To create and manage cloud credentials from outside of the cluster when the Cloud Credential Operator (CCO) is operating in
 ifdef::aws-sts[manual mode with STS,]
 ifdef::ibm-cloud[manual mode,]
+ifdef::google-cloud-platform[manual mode with GCP Workload Identity,]
 extract and prepare the CCO utility (`ccoctl`) binary.
 
 ifdef::alibabacloud[]
@@ -71,19 +76,10 @@ $ chmod 775 ccoctl
 
 * To verify that `ccoctl` is ready to use, display the help file:
 +
-ifndef::ibm-cloud[]
 [source,terminal]
 ----
 $ ccoctl --help
 ----
-endif::ibm-cloud[]
-ifdef::ibm-cloud[]
-[source,terminal]
-----
-$ ccoctl ibmcloud --help
-----
-endif::ibm-cloud[]
-ifndef::ibm-cloud[]
 +
 .Output of `ccoctl --help`:
 +
@@ -106,7 +102,6 @@ Flags:
 
 Use "ccoctl [command] --help" for more information about a command.
 ----
-endif::ibm-cloud[]
 
 ifeval::["{context}" == "cco-mode-sts"]
 :!aws-sts:
@@ -117,4 +112,6 @@ endif::[]
 ifeval::["{context}" == "manually-creating-alibaba-ram"]
 :!alibabacloud:
 endif::[]
-
+ifeval::["{context}" == "cco-mode-gcp-workload-identity"]
+:!google-cloud-platform:
+endif::[]

--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -1,12 +1,15 @@
 // Module included in the following assemblies:
 //
 // * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+// * authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
 // * installing/installing_alibaba/manually-creating-alibaba-ram.adoc
-// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 
-:_content-type: PROCEDURE
 ifeval::["{context}" == "cco-mode-sts"]
-:aws:
+:aws-sts:
+endif::[]
+ifeval::["{context}" == "cco-mode-gcp-workload-identity"]
+:google-cloud-platform:
 endif::[]
 ifeval::["{context}" == "installing-alibaba-default"]
 :alibabacloud-default:
@@ -15,8 +18,9 @@ ifeval::["{context}" == "installing-alibaba-customizations"]
 :alibabacloud-customizations:
 endif::[]
 
-ifdef::aws[]
+:_content-type: PROCEDURE
 [id="cco-ccoctl-creating-at-once_{context}"]
+ifdef::aws-sts[]
 = Creating AWS resources with a single command
 
 If you do not need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, and if the process the `ccoctl` tool uses to create AWS resources automatically meets the requirements of your organization, you can use the `ccoctl aws create-all` command to automate the creation of AWS resources.
@@ -24,7 +28,12 @@ If you do not need to review the JSON files that the `ccoctl` tool creates befor
 Otherwise, you can create the AWS resources individually.
 
 //to-do if possible: xref to modules/cco-ccoctl-creating-individually.adoc for `create the AWS resources individually`
-endif::aws[]
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+= Creating GCP resources with the Cloud Credential Operator utility
+
+You can use the `ccoctl gcp create-all` command to automate the creation of GCP resources.
+endif::google-cloud-platform[]
 ifdef::alibabacloud-default,alibabacloud-customizations[]
 [id="cco-ccoctl-creating-at-once_{context}"]
 = Creating credentials for {product-title} components with the ccoctl tool
@@ -51,12 +60,17 @@ endif::alibabacloud-default,alibabacloud-customizations[]
 
 . Extract the list of `CredentialsRequest` objects from the {product-title} release image:
 +
-[source,terminal,subs="+quotes"]
-ifdef::aws[]
+[source,terminal]
+ifdef::aws-sts[]
 ----
 $ oc adm release extract --credentials-requests --cloud=aws --to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
 ----
-endif::aws[]
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+----
+$ oc adm release extract --credentials-requests --cloud=gcp --to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
+----
+endif::google-cloud-platform[]
 ifdef::alibabacloud-default,alibabacloud-customizations[]
 ----
 $ oc adm release extract --credentials-requests --cloud=alibabacloud --to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
@@ -68,10 +82,12 @@ endif::alibabacloud-default,alibabacloud-customizations[]
 This command can take a few moments to run.
 ====
 
-ifdef::aws[]
+ifdef::aws-sts,google-cloud-platform[]
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 +
-[source,terminal,subs="+quotes"]
+endif::aws-sts,google-cloud-platform[]
+ifdef::aws-sts[]
+[source,terminal]
 ----
 $ ccoctl aws create-all --name=<name> --region=<aws_region> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
 ----
@@ -79,8 +95,39 @@ $ ccoctl aws create-all --name=<name> --region=<aws_region> --credentials-reques
 where:
 +
 ** `<name>` is the name used to tag any cloud resources that are created for tracking.
-** `<aws-region>` is the AWS region in which cloud resources will be created.
+** `<aws_region>` is the AWS region in which cloud resources will be created.
 ** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files for the component `CredentialsRequest` objects.
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+[source,terminal]
+----
+$ ccoctl gcp create-all --name=<name> --region=<gcp_region> --project=<gcp_project_id> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
+----
++
+where:
++
+** `<name>` is the user-defined name for all created GCP resources used for tracking.
+** `<gcp_region>` is the GCP region in which cloud resources will be created.
+** `<gcp_project_id>` is the GCP project ID in which cloud resources will be created.
+** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files of `CredentialsRequest` manifests to create GCP service accounts.
+endif::google-cloud-platform[]
+
+ifdef::alibabacloud-default,alibabacloud-customizations[]
+. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
+
+.. Run the following command to use the tool:
++
+[source,terminal]
+----
+$ ccoctl alibabacloud create-ram-users --name <name> --region=<alibaba_region> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests --output-dir=<path_to_ccoctl_output_dir>
+----
++
+where:
++
+** `<name>` is the name used to tag any cloud resources that are created for tracking.
+** `<alibaba_region>` is the Alibaba Cloud region in which cloud resources will be created.
+** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files for the component `CredentialsRequest` objects.
+** `<path_to_ccoctl_output_dir>` is the directory where the generated component credentials secrets will be placed.
 +
 .Example output
 +
@@ -92,42 +139,25 @@ where:
 2022/02/11 16:18:28 Policy user1-alicloud-openshift-machine-api-alibabacloud-credentials-policy-policy has attached on user user1-alicloud-openshift-machine-api-alibabacloud-credentials
 2022/02/11 16:18:29 Created access keys for RAM User: user1-alicloud-openshift-machine-api-alibabacloud-credentials
 2022/02/11 16:18:29 Saved credentials configuration to: user1-alicloud/manifests/openshift-machine-api-alibabacloud-credentials-credentials.yaml
- ...
+...
 ----
-
-endif::aws[]
-ifdef::alibabacloud-default,alibabacloud-customizations[]
-. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
-
-.. Run the following command to use the tool:
-+
-[source,terminal,subs="+quotes"]
-----
-$ ccoctl alibabacloud create-ram-users --name <name> --region=<alibaba-region> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests --output-dir=<path_to_ccoctl_output_dir>
-----
-+
-where:
-+
-** `<name>` is the name used to tag any cloud resources that are created for tracking.
-** `<alibaba-region>` is the Alibaba Cloud region in which cloud resources will be created.
-** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files for the component `CredentialsRequest` objects.
-** `<path_to_ccoctl_output_dir>` is the directory where the generated component credentials secrets will be placed.
 +
 [NOTE]
 ====
 A RAM user can have up to two AccessKeys at the same time. If you run `ccoctl alibabacloud create-ram-users` more than twice, the previous generated manifests secret becomes stale and you must reapply the newly generated secrets.
 ====
-+
+// Above output was in AWS area but I believe belongs here.
+
 .. Verify that the {product-title} secrets are created:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
 $ ls <path_to_ccoctl_output_dir>/manifests
 ----
 +
 .Example output:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
 openshift-cluster-csi-drivers-alibaba-disk-credentials-credentials.yaml
 openshift-image-registry-installer-cloud-credentials-credentials.yaml
@@ -150,19 +180,21 @@ where:
 `<path_to_installation>dir>`:: Specifies the directory in which the installation program creates files.
 endif::alibabacloud-default,alibabacloud-customizations[]
 
-ifdef::aws[]
+ifdef::aws-sts,google-cloud-platform[]
 .Verification
 
 * To verify that the {product-title} secrets are created, list the files in the `<path_to_ccoctl_output_dir>/manifests` directory:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
 $ ls <path_to_ccoctl_output_dir>/manifests
 ----
+endif::aws-sts,google-cloud-platform[]
+ifdef::aws-sts[]
 +
 .Example output:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
 cluster-authentication-02-config.yaml
 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
@@ -171,12 +203,19 @@ openshift-image-registry-installer-cloud-credentials-credentials.yaml
 openshift-ingress-operator-cloud-credentials-credentials.yaml
 openshift-machine-api-aws-cloud-credentials-credentials.yaml
 ----
+//Would love a GCP version of the above output.
 
 You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.
-endif::aws[]
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+You can verify that the IAM service accounts are created by querying GCP. For more information, refer to GCP documentation on listing IAM service accounts.
+endif::google-cloud-platform[]
 
 ifeval::["{context}" == "cco-mode-sts"]
-:!aws:
+:!aws-sts:
+endif::[]
+ifeval::["{context}" == "cco-mode-gcp-workload-identity"]
+:!google-cloud-platform:
 endif::[]
 ifeval::["{context}" == "installing-alibaba-default"]
 :!alibabacloud-default:

--- a/modules/cco-ccoctl-deleting-sts-resources.adoc
+++ b/modules/cco-ccoctl-deleting-sts-resources.adoc
@@ -1,52 +1,102 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_aws/uninstalling-cluster-aws.adoc
+// * installing/installing_gcp/uninstalling-cluster-gcp.adoc
+
+ifeval::["{context}" == "uninstall-cluster-aws"]
+:aws-sts:
+endif::[]
+ifeval::["{context}" == "uninstalling-cluster-gcp"]
+:google-cloud-platform:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="cco-ccoctl-deleting-sts-resources_{context}"]
+ifdef::aws-sts[]
 = Deleting AWS resources with the Cloud Credential Operator utility
 
 To clean up resources after uninstalling an {product-title} cluster with the Cloud Credential Operator (CCO) in manual mode with STS, you can use the CCO utility (`ccoctl`) to remove the AWS resources that `ccoctl` created during installation.
+endif::aws-sts[]
+
+ifdef::google-cloud-platform[]
+= Deleting GCP resources with the Cloud Credential Operator utility
+
+To clean up resources after uninstalling an {product-title} cluster with the Cloud Credential Operator (CCO) in manual mode with GCP Workload Identity, you can use the CCO utility (`ccoctl`) to remove the GCP resources that `ccoctl` created during installation.
+endif::google-cloud-platform[]
 
 .Prerequisites
 
 * Extract and prepare the `ccoctl` binary.
+ifdef::aws-sts[]
 * Install an {product-title} cluster with the CCO in manual mode with STS.
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+* Install an {product-title} cluster with the CCO in manual mode with GCP Workload Identity.
+endif::google-cloud-platform[]
 
 .Procedure
 
+ifdef::aws-sts[]
 * Delete the AWS resources that `ccoctl` created:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ ccoctl aws delete --name=__<name>__ --region=__<aws_region>__
+$ ccoctl aws delete --name=<name> --region=<aws_region>
 ----
 +
 where:
 +
-** `_<name>_` matches the name used to originally create and tag the cloud resources.
-** `_<aws-region>_` is the AWS region in which cloud resources will be deleted.
+** `<name>` matches the name used to originally create and tag the cloud resources.
+** `<aws_region>` is the AWS region in which cloud resources will be deleted.
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+* Delete the GCP resources that `ccoctl` created:
++
+[source,terminal]
+----
+$ ccoctl gcp delete --name=<name> --project=<gcp_project_id>
+----
++
+where:
++
+** `<name>` matches the name used to originally create and tag the cloud resources.
+** `<gcp_project_id>` is the GCP project ID in which cloud resources will be deleted.
+endif::google-cloud-platform[]
 +
 .Example output:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-2021/04/08 17:50:41 Identity Provider object .well-known/openid-configuration deleted from the bucket __<name>__-oidc
-2021/04/08 17:50:42 Identity Provider object keys.json deleted from the bucket __<name>__-oidc
-2021/04/08 17:50:43 Identity Provider bucket __<name>__-oidc deleted
-2021/04/08 17:51:05 Policy __<name>__-openshift-cloud-credential-operator-cloud-credential-o associated with IAM Role __<name>__-openshift-cloud-credential-operator-cloud-credential-o deleted
-2021/04/08 17:51:05 IAM Role __<name>__-openshift-cloud-credential-operator-cloud-credential-o deleted
-2021/04/08 17:51:07 Policy __<name>__-openshift-cluster-csi-drivers-ebs-cloud-credentials associated with IAM Role __<name>__-openshift-cluster-csi-drivers-ebs-cloud-credentials deleted
-2021/04/08 17:51:07 IAM Role __<name>__-openshift-cluster-csi-drivers-ebs-cloud-credentials deleted
-2021/04/08 17:51:08 Policy __<name>__-openshift-image-registry-installer-cloud-credentials associated with IAM Role __<name>__-openshift-image-registry-installer-cloud-credentials deleted
-2021/04/08 17:51:08 IAM Role __<name>__-openshift-image-registry-installer-cloud-credentials deleted
-2021/04/08 17:51:09 Policy __<name>__-openshift-ingress-operator-cloud-credentials associated with IAM Role __<name>__-openshift-ingress-operator-cloud-credentials deleted
-2021/04/08 17:51:10 IAM Role __<name>__-openshift-ingress-operator-cloud-credentials deleted
-2021/04/08 17:51:11 Policy __<name>__-openshift-machine-api-aws-cloud-credentials associated with IAM Role __<name>__-openshift-machine-api-aws-cloud-credentials deleted
-2021/04/08 17:51:11 IAM Role __<name>__-openshift-machine-api-aws-cloud-credentials deleted
-2021/04/08 17:51:39 Identity Provider with ARN arn:aws:iam::__<aws_account_id>__:oidc-provider/__<name>__-oidc.s3.__<aws_region>__.amazonaws.com deleted
+2021/04/08 17:50:41 Identity Provider object .well-known/openid-configuration deleted from the bucket <name>-oidc
+2021/04/08 17:50:42 Identity Provider object keys.json deleted from the bucket <name>-oidc
+2021/04/08 17:50:43 Identity Provider bucket <name>-oidc deleted
+2021/04/08 17:51:05 Policy <name>-openshift-cloud-credential-operator-cloud-credential-o associated with IAM Role <name>-openshift-cloud-credential-operator-cloud-credential-o deleted
+2021/04/08 17:51:05 IAM Role <name>-openshift-cloud-credential-operator-cloud-credential-o deleted
+2021/04/08 17:51:07 Policy <name>-openshift-cluster-csi-drivers-ebs-cloud-credentials associated with IAM Role <name>-openshift-cluster-csi-drivers-ebs-cloud-credentials deleted
+2021/04/08 17:51:07 IAM Role <name>-openshift-cluster-csi-drivers-ebs-cloud-credentials deleted
+2021/04/08 17:51:08 Policy <name>-openshift-image-registry-installer-cloud-credentials associated with IAM Role <name>-openshift-image-registry-installer-cloud-credentials deleted
+2021/04/08 17:51:08 IAM Role <name>-openshift-image-registry-installer-cloud-credentials deleted
+2021/04/08 17:51:09 Policy <name>-openshift-ingress-operator-cloud-credentials associated with IAM Role <name>-openshift-ingress-operator-cloud-credentials deleted
+2021/04/08 17:51:10 IAM Role <name>-openshift-ingress-operator-cloud-credentials deleted
+2021/04/08 17:51:11 Policy <name>-openshift-machine-api-aws-cloud-credentials associated with IAM Role <name>-openshift-machine-api-aws-cloud-credentials deleted
+2021/04/08 17:51:11 IAM Role <name>-openshift-machine-api-aws-cloud-credentials deleted
+2021/04/08 17:51:39 Identity Provider with ARN arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com deleted
 ----
+//Would love a GCP version of the above output.
 
 .Verification
 
-You can verify that the resources are deleted by querying AWS. For more information, refer to AWS documentation.
+ifdef::aws-sts[]
+* To verify that the resources are deleted, query AWS. For more information, refer to AWS documentation.
+endif::aws-sts[]
+
+ifdef::google-cloud-platform[]
+* To verify that the resources are deleted, query GCP. For more information, refer to GCP documentation.
+endif::google-cloud-platform[]
+
+ifeval::["{context}" == "uninstall-cluster-aws"]
+:!aws-sts:
+endif::[]
+ifeval::["{context}" == "uninstalling-cluster-gcp"]
+:!google-cloud-platform:
+endif::[]

--- a/modules/cco-ccoctl-upgrading.adoc
+++ b/modules/cco-ccoctl-upgrading.adoc
@@ -2,18 +2,40 @@
 //
 // * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
 
+ifeval::["{context}" == "cco-mode-sts"]
+:aws-sts:
+endif::[]
+ifeval::["{context}" == "cco-mode-gcp-workload-identity"]
+:google-cloud-platform:
+endif::[]
+
 :_content-type: PROCEDURE
 [id="cco-ccoctl-upgrading_{context}"]
+ifdef::aws-sts[]
 = Updating AWS resources with the Cloud Credential Operator utility
 
 The process for upgrading an {product-title} cluster configured for manual mode with AWS Secure Token Service (STS) is similar to installing on a cluster for which you create the AWS resources individually.
+endif::aws-sts[]
+
+ifdef::google-cloud-platform[]
+= Updating GCP resources with the Cloud Credential Operator utility
+
+The process for upgrading an {product-title} cluster configured for manual mode with GCP Workload Identity is similar to installing on a cluster for which you create the GCP resources individually.
+endif::google-cloud-platform[]
 
 [NOTE]
 ====
-By default, `ccoctl` creates objects in the directory in which the commands are run. To specify a directory, use the `--output-dir` flag. This procedure uses `_<path_to_ccoctl_output_dir>_` to refer to this location.
+By default, `ccoctl` creates objects in the directory in which the commands are run. To specify a directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this location.
 
-Some `ccoctl` commands make AWS API calls to create or modify AWS resources. To place JSON files on the local file system instead, use the `--dry-run` flag. These JSON files can be reviewed or modified and then applied with the AWS CLI tool using the `--cli-input-json` parameters.
+ifdef::aws-sts[]
+Some `ccoctl` commands make AWS API calls to create or modify AWS resources.
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+Some `ccoctl` commands make GCP API calls to create or modify GCP resources.
+endif::google-cloud-platform[]
+To place JSON files on the local file system instead, use the `--dry-run` flag. These JSON files can be reviewed or modified and then applied with the AWS CLI tool using the `--cli-input-json` parameters.
 ====
+
 
 .Prerequisites
 
@@ -27,7 +49,7 @@ Some `ccoctl` commands make AWS API calls to create or modify AWS resources. To 
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc adm release extract --credentials-requests --cloud=aws --to=__<path_to_directory_with_list_of_credentials_requests>__/credrequests quay.io/__<path_to>__/ocp-release:__<version>__
+$ oc adm release extract --credentials-requests --cloud=aws --to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
 ----
 
 . For each `CredentialsRequest` CR in the release image, ensure that a namespace that matches the text in the `spec.secretRef.namespace` field exists in the cluster. This field is where the generated secrets that hold the credentials configuration are stored.
@@ -62,21 +84,21 @@ spec:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc create namespace __<component_namespace>__
+$ oc create namespace <component_namespace>
 ----
 
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ ccoctl aws create-iam-roles --name __<name>__ --region=__<aws_region>__ --credentials-requests-dir=__<path_to_directory_with_list_of_credentials_requests>__/credrequests --identity-provider-arn arn:aws:iam::__<aws_account_id>__:oidc-provider/__<name>__-oidc.s3.__<aws_region>__.amazonaws.com
+$ ccoctl aws create-iam-roles --name <name> --region=<aws_region> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests --identity-provider-arn arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
 ----
 +
 where:
 +
-** _<name>_ is the name used to tag any cloud resources that are created for tracking. For upgrades, use the same value that was used for the initial installation.
-** _<aws_account_id>_ is the AWS account ID.
-** _<aws_region>_ is the AWS region in which cloud resources will be created.
+** `<name>` is the name used to tag any cloud resources that are created for tracking. For upgrades, use the same value that was used for the initial installation.
+** `<aws_account_id>` is the AWS account ID.
+** `<aws_region>` is the AWS region in which cloud resources will be created.
 +
 [NOTE]
 ====
@@ -89,7 +111,7 @@ For each `CredentialsRequest` object, `ccoctl` creates an IAM role with a trust 
 +
 [source,terminal,subs="+quotes"]
 ----
-$ ls __<path_to_ccoctl_output_dir>__/manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
+$ ls <path_to_ccoctl_output_dir>/manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
 ----
 
 .Verification

--- a/modules/sts-mode-installing-manual-run-installer.adoc
+++ b/modules/sts-mode-installing-manual-run-installer.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+// * authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
 
 :_content-type: PROCEDURE
 [id="sts-mode-installing-manual-run-installer_{context}"]
@@ -32,7 +33,6 @@ credentialsMode: Manual <1>
 compute:
 - architecture: amd64
   hyperthreading: Enabled
-...
 ----
 <1> This line is added to set the `credentialsMode` parameter to `Manual`.
 
@@ -47,14 +47,14 @@ $ openshift-install create manifests
 +
 [source,terminal,subs="+quotes"]
 ----
-$ cp /__<path_to_ccoctl_output_dir>__/manifests/* ./manifests/
+$ cp /<path_to_ccoctl_output_dir>/manifests/* ./manifests/
 ----
 
 . Copy the private key that the `ccoctl` generated in the `tls` directory to the installation directory:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ cp -a /__<path_to_ccoctl_output_dir>__/tls .
+$ cp -a /<path_to_ccoctl_output_dir>/tls .
 ----
 
 . Run the {product-title} installer:

--- a/modules/sts-mode-installing-verifying.adoc
+++ b/modules/sts-mode-installing-verifying.adoc
@@ -1,6 +1,14 @@
 // Module included in the following assemblies:
 //
 // * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+// * authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
+
+ifeval::["{context}" == "cco-mode-sts"]
+:aws-sts:
+endif::[]
+ifeval::["{context}" == "cco-mode-gcp-workload-identity"]
+:google-cloud-platform:
+endif::[]
 
 [id="sts-mode-installing-verifying_{context}"]
 = Verifying the installation
@@ -9,32 +17,92 @@
 
 . Verify that the cluster does not have `root` credentials:
 +
+ifdef::aws-sts[]
 [source,terminal]
 ----
 $ oc get secrets -n kube-system aws-creds
 ----
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+[source,terminal]
+----
+$ oc get secrets -n kube-system gcp-credentials
+----
+endif::google-cloud-platform[]
 +
 The output should look similar to:
 +
+ifdef::aws-sts[]
 [source,terminal]
 ----
 Error from server (NotFound): secrets "aws-creds" not found
 ----
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+[source,terminal]
+----
+Error from server (NotFound): secrets "gcp-credentials" not found
+----
+endif::google-cloud-platform[]
 
-. Verify that the components are assuming the IAM roles that are specified in the secret manifests, instead of using credentials that are created by the CCO:
+. Verify that the components are assuming the
+ifdef::aws-sts[]
+IAM roles
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+service accounts
+endif::google-cloud-platform[]
+that are specified in the secret manifests, instead of using credentials that are created by the CCO:
 +
 .Example command with the Image Registry Operator
+ifdef::aws-sts[]
 [source,terminal]
 ----
 $ oc get secrets -n openshift-image-registry installer-cloud-credentials -o json | jq -r .data.credentials | base64 --decode
 ----
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+[source,terminal]
+----
+$ oc get secrets -n openshift-image-registry installer-cloud-credentials -o json | jq -r '.data."service_account.json"' | base64 -d
+----
+endif::google-cloud-platform[]
 +
 The output should show the role and web identity token that are used by the component and look similar to:
 +
 .Example output with the Image Registry Operator
+ifdef::aws-sts[]
 [source,terminal]
 ----
 [default]
 role_arn = arn:aws:iam::123456789:role/openshift-image-registry-installer-cloud-credentials
 web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 ----
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+[source,json]
+----
+{
+   "type": "external_account", <1>
+   "audience": "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+   "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+   "token_url": "https://sts.googleapis.com/v1/token",
+   "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/<client-email-address>:generateAccessToken", <2>
+   "credential_source": {
+      "file": "/var/run/secrets/openshift/serviceaccount/token",
+      "format": {
+         "type": "text"
+      }
+   }
+}
+----
+<1> The credential type is `external_account`.
+<2> The resource URL of the service account used by the Image Registry Operator.
+endif::google-cloud-platform[]
+
+ifeval::["{context}" == "cco-mode-sts"]
+:!aws-sts:
+endif::[]
+ifeval::["{context}" == "cco-mode-gcp-workload-identity"]
+:!google-cloud-platform:
+endif::[]


### PR DESCRIPTION
For [OSDOCS-2329](https://issues.redhat.com/browse/OSDOCS-2329), which documents [CCO-114](https://issues.redhat.com/browse/CCO-114)

Notes:
- Repurposed AWS STS content (same flow). Long-term, this needs to be broken up and distributed to install and upgrade books, but that is not in scope of this release.
- Does not include deep-dive conceptual workings. Since this content needs to be broken up and placed into install and upgrade books, I am not 100% sure where that info should go in the future. Plan to break STS and Workload Identity content up before 4.11 and find an appropriate home for the conceptual info at that time.
- Comparing vs [dev-provided steps](https://github.com/openshift/cloud-credential-operator/blob/master/docs/gcp_workload_identity.md#steps-to-install-an-openshift-cluster-with-workload-identity):
  - Moved step 7 up under step 2, which is closer to how the STS steps flow.
  - In the STS procedure we don't have step 3, and in fact I don't see `oc adm release extract --command=openshift-install` anywhere in our entire repo. Is this something that we have historically just assumed? Do we need to add it here specifically?

Change log:
- 2022.02.28: Initial draft
- 2022.03.07: Some Alibaba output was accidentally appended to an AWS command. Noticed while rebasing, and [added a fix](https://deploy-preview-42544--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-default.html#cco-ccoctl-creating-at-once_installing-alibaba-default) to this PR. 
- 2022.03.10: Addressed SME comments (round 1)

Previews:
- [Using manual mode with GCP Workload Identity](https://deploy-preview-42544--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.html)
- New bullet for Workload Identity in [Alternatives to storing administrator-level secrets in the kube-system project](https://deploy-preview-42544--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/manually-creating-iam-gcp.html#alternatives-to-storing-admin-secrets-in-kube-system_manually-creating-iam-gcp) and link in additional resources to new section
- [New bullet under manual mode](https://deploy-preview-42544--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.html#about-cloud-credential-operator-modes)
- New section in [Uninstalling a cluster on GCP](https://deploy-preview-42544--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/uninstalling-cluster-gcp.html#cco-ccoctl-deleting-sts-resources_uninstall-cluster-gcp)
- [Fixed Alibaba output (step 2a)](https://deploy-preview-42544--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-default.html#cco-ccoctl-creating-at-once_installing-alibaba-default)