### PR TITLE
[BZ2056331]: Required permissions to delete base cluster resources 

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -7,6 +7,11 @@
 [id="installation-aws-permissions_{context}"]
 = Required AWS permissions for the IAM user
 
+[NOTE]
+====
+Your IAM user must have the permission `tag:GetResources` in the region `us-east-1` to delete the base cluster resources. As part of the AWS API requirement, the {product-title} installation program performs various actions in this region.
+====
+
 When you attach the `AdministratorAccess` policy to the IAM user that you create in Amazon Web Services (AWS),
 you grant that user all of the required permissions. To deploy all components of an {product-title}
 cluster, the IAM user requires the following permissions:

--- a/modules/installation-aws-regions.adoc
+++ b/modules/installation-aws-regions.adoc
@@ -7,6 +7,11 @@
 
 You can deploy an {product-title} cluster to the following regions.
 
+[NOTE]
+====
+Your IAM user must have the permission `tag:GetResources` in the region `us-east-1` to delete the base cluster resources. As part of the AWS API requirement, the {product-title} installation program performs various actions in this region.
+====
+
 [id="installation-aws-public_{context}"]
 == AWS public regions
 


### PR DESCRIPTION
Adds the note about required permissions to delete base cluster resources
OCP version: 4.6+
[Preview](https://deploy-preview-42545--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-permissions_installing-aws-account)
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2056331)
QE contact  @yunjiang29 LGTMed