### PR TITLE
Remove CNF-2772 ZTP PTP procedure that references AMQ

### DIFF
--- a/scalability_and_performance/ztp-deploying-disconnected.adoc
+++ b/scalability_and_performance/ztp-deploying-disconnected.adoc
@@ -104,21 +104,6 @@ include::modules/ztp-precision-time-protocol-operator.adoc[leveloffset=+2]
 
 * For more information about using PTP hardware in your cluster nodes, see xref:../networking/using-ptp.adoc#using-ptp[Using PTP hardware].
 
-include::modules/ztp-configuring-ptp-fast-events.adoc[leveloffset=+2]
-
-[NOTE]
-====
-When changes are pushed to a site configuration repository, GitOps ZTP applies the CRs sequentially according to the `ran.openshift.io/ztp-deploy-wave` annotation. When two or more policies have the same `ran.openshift.io/ztp-deploy-wave` annotation, an alphanumeric sort order is used. For more information, see xref:../scalability_and_performance/ztp-deploying-disconnected.adoc#ztp-applying-the-ran-policies-for-monitoring-cluster-activity_ztp-deploying-disconnected[Applying RAN policies].
-====
-
-.Additional resources
-
-* For a complete `PtpConfig` CR that configures `linuxptp` as an ordinary clock, see xref:../networking/using-ptp.adoc#cnf-configuring-cvl-nic-as-ptp-slave_using-ptp[Configuring linuxptp services as an ordinary clock for Intel Columbiaville NIC].
-
-* For further information about configuring PTP fast event notifications, see xref:../networking/using-ptp.adoc#cnf-configuring-the-ptp-fast-event-publisher_using-ptp[Configuring PTP fast events].
-
-//../scalability_and_performance/cnf-topology-aware-lifecycle-operator.adoc#talo-apply-policies_cnf-topology-aware-lifecycle-operator[Applying update policies to managed clusters with the Topology Aware Lifecycle Operator]
-
 include::modules/ztp-creating-ztp-custom-resources-for-multiple-managed-clusters.adoc[leveloffset=+1]
 
 include::modules/ztp-prerequisites-for-deploying-the-ztp-pipeline.adoc[leveloffset=+2]


### PR DESCRIPTION
Remove [CNF-2772](https://issues.redhat.com/browse/CNF-2772) ZTP PTP procedure that references AMQ until this BZ is resolved: https://bugzilla.redhat.com/show_bug.cgi?id=2054385

Merge to enterprise-4.10 only

This procedure was originally added as part of https://issues.redhat.com/browse/TELCODOCS-323 for OCP 4.10 release. 

Preview: https://deploy-preview-42549--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-precision-time-protocol-operator_ztp-deploying-disconnected