### PR TITLE
BZ-2055147: correcting output of oc get bmh

### DIFF
--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -134,6 +134,6 @@ Where `<num>` is the worker node number.
 .Example output
 [source,terminal]
 ----
-NAME                 STATUS   PROVISIONING STATUS   CONSUMER   BMC                 HARDWARE PROFILE   ONLINE   ERROR
-openshift-worker-<num>   OK       ready                            ipmi://<out-of-band-ip>   unknown            true
+NAME                    STATE   CONSUMER   ONLINE   ERROR
+openshift-worker-<num>  ready              true
 ----

--- a/modules/ipi-install-provisioning-the-bare-metal-node.adoc
+++ b/modules/ipi-install-provisioning-the-bare-metal-node.adoc
@@ -10,7 +10,7 @@ Provisioning the bare metal node requires executing the following procedure from
 
 .Procedure
 
-. Ensure the `PROVISIONING STATUS` is `ready` before provisioning the bare metal node.
+. Ensure the `STATE` is `ready` before provisioning the bare metal node.
 +
 [source,bash]
 ----
@@ -21,8 +21,8 @@ Where `<num>` is the worker node number.
 +
 [source,bash]
 ----
-NAME                 STATUS   PROVISIONING STATUS   CONSUMER   BMC                 HARDWARE PROFILE   ONLINE   ERROR
-openshift-worker-<num>   OK       ready                            ipmi://<out-of-band-ip>   unknown            true
+NAME                     STATE   CONSUMER     ONLINE   ERROR
+openshift-worker-<num>   ready                true
 ----
 
 . Get a count of the number of worker nodes.
@@ -74,20 +74,20 @@ Replace `<num>` with the new number of worker nodes. Replace `<machineset>` with
 $ oc -n openshift-machine-api get bmh openshift-worker-<num>
 ----
 +
-Where `<num>` is the worker node number. The status changes from `ready` to `provisioning`.
+Where `<num>` is the worker node number. The STATE changes from `ready` to `provisioning`.
 +
 [source,bash]
 ----
-NAME                 STATUS   PROVISIONING STATUS   CONSUMER                  BMC                 HARDWARE PROFILE   ONLINE   ERROR
-openshift-worker-<num>   OK       provisioning          openshift-worker-<num>-65tjz   ipmi://<out-of-band-ip>   unknown            true
+NAME                    STATE             CONSUMER                          ONLINE   ERROR
+openshift-worker-<num>  provisioning      openshift-worker-<num>-65tjz      true
 ----
 +
-The `provisioning` status remains until the {product-title} cluster provisions the node. This can take 30 minutes or more. After the node is provisioned, the status will change to `provisioned`.
+The `provisioning` status remains until the {product-title} cluster provisions the node. This can take 30 minutes or more. After the node is provisioned, the state will change to `provisioned`.
 +
 [source,bash]
 ----
-NAME                 STATUS   PROVISIONING STATUS   CONSUMER                  BMC                 HARDWARE PROFILE   ONLINE   ERROR
-openshift-worker-<num>   OK       provisioned           openshift-worker-<num>-65tjz   ipmi://<out-of-band-ip>   unknown            true
+NAME                    STATE             CONSUMER                          ONLINE   ERROR
+openshift-worker-<num>  provisioning      openshift-worker-<num>-65tjz      true
 ----
 
 . After provisioning completes, ensure the bare metal node is ready.


### PR DESCRIPTION
Addresses BZ https://bugzilla.redhat.com/show_bug.cgi?id=2055147

Preview: [Preview link](https://deploy-preview-42550--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html)

Relevant for 4.10 and needs merged back to 4.9