### PR TITLE
OSDOCS-2173: Removed Intel E810 NICs, support delayed by bug

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -37,21 +37,6 @@
 |8086
 |158b
 
-|Intel
-|E810-CQDA2
-|8088
-|1592
-
-|Intel
-|E810-XXVDA2
-|8088
-|159b
-
-|Intel
-|E810-XXVDA4
-|8088
-|1593
-
 |Mellanox
 |MT27700 Family [ConnectX&#8209;4]
 |15b3


### PR DESCRIPTION
RE https://issues.redhat.com/browse/OSDOCS-2173

Applies to `main` and `enterprise-4.10`

Support for the Intel E810 is delayed because of a bug. 

We'll return this to the docs after the fix has made it into the kernel we're using in OCP.

Preview:https://deploy-preview-42554--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov

Reviews:
SME: @zshi-redhat 
QE: @zhaozhanqi 