### PR TITLE
CNV16551: Adding 4.10 release note for tech preview of OADP integration for backup/restore

### DIFF
--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -117,6 +117,8 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 
 * {VirtProductName} has xref:../virt/logging_events_monitoring/virt-virtualization-alerts.adoc#virt-virtualization-alerts[critical alerts] that inform you when a problem occurs that requires immediate attention. Now, each alert has a corresponding description of the problem, a reason for why the alert is occurring, a troubleshooting process to diagnose the source of the problem, and steps for resolving the alert.
 
+* A cluster administrator can now back up namespaces that contain VMs by using the xref:../virt/backup_restore/virt-backup-restore-overview.adoc#virt-backup-restore-overview[OpenShift API for Data Protection] with the `kubevirt` plug-in.
+
 [id="virt-4-10-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
This PR is for a 4.10 release note story [CNV-16551](https://issues.redhat.com/browse/CNV-16551) about the Tech Preview for the backup and restore functions of OADP integration.

Preview: Bullet starting with "A cluster administrator can now" in https://deploy-preview-42557--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-10-release-notes#virt-4-10-technology-preview