### PR TITLE
BZ2054711: clarification on OVN limitation

### DIFF
--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -8,7 +8,7 @@
 The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has the following limitations:
 
 * OVN-Kubernetes does not support setting the external traffic policy or internal traffic policy for a Kubernetes service to `local`.
-The default value, `cluster`, is supported for both parameters.
+For the `ExternalTrafficPolicy` parameter, the default value is `local`. However the load is still distributed to the available backends until the fix is available, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[BZ#1903408]. The value, `cluster`, is supported for both the parameters.
 This limitation can affect you when you add a service of type `LoadBalancer`, `NodePort`, or add a service with an external IP.
 
 // The foll limitation is also recorded in the installation section.
@@ -24,4 +24,3 @@ F1006 16:09:50.985939   60651 ovnkube.go:130] multiple gateway interfaces detect
 ----
 +
 The only resolution is to reconfigure the host networking so that both IP families use the same network interface for the default gateway.
-


### PR DESCRIPTION
- Applies to 4.9 and below versions, cherrypick to 4.8,4.7 and 4.6
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2054711)  
- [Preview](url)
- @zhaozhanqi ptal

Note : replicated from https://github.com/openshift/openshift-docs/pull/41906 