### PR TITLE
BZ2055902:Missing permissions - vsphere gap analysis

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -109,6 +109,8 @@ An additional role is required if the installation program is to create a vSpher
 `VirtualMachine.Inventory.CreateFromExisting`
 `VirtualMachine.Inventory.Delete`
 `VirtualMachine.Provisioning.Clone`
+`VirtualMachine.Provisioning.MarkAsTemplate`
+`VirtualMachine.Provisioning.DeployTemplate`
 
 |vSphere vCenter Datacenter
 |If the installation program creates the virtual machine folder


### PR DESCRIPTION
Applies to 4.8+

**Bugzilla:** https://bugzilla.redhat.com/show_bug.cgi?id=2055902

**Link to table missing two permissions:** https://docs.openshift.com/container-platform/4.8/installing/installing_vsphere/installing-vsphere-installer-provisioned.html#installation-vsphere-infrastructure_installing-vsphere-installer-provisioned

QE acknowledgement required. Requesting from @jinyunma 

Preview: https://deploy-preview-42559--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned.html