### PR TITLE
BZ-1699472: adds note recommedning OverlayFS and fixes hyperlink

### DIFF
--- a/scaling_performance/optimizing_storage.adoc
+++ b/scaling_performance/optimizing_storage.adoc
@@ -222,7 +222,7 @@ storage technology), such as DeviceMapper and OverlayFS. Each has advantages
 and disadvantages.
 
 For more information about OverlayFS, including supportability and usage caveats, see the
-link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/?version=7[Red Hat Enterprise Linux (RHEL) 7 Release Notes] for your version.
+link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.5_release_notes/technology_previews_file_systems[Red Hat Enterprise Linux (RHEL) 7 Release Notes] for your version.
 
 .Graph driver comparisons
 |===
@@ -454,6 +454,11 @@ significant overlap in image content.
 
 Page cache sharing is not possible with DeviceMapper because thin-provisioned
 devices are allocated on a per-container basis.
+
+[NOTE]
+====
+OverlayFS is the default Docker storage driver for Red Hat Enterprise Linux (RHEL) 7.5 and is supported in 7.3 and later. Set OverlayFS to the default Docker storage configuration on RHEL to improve performance. See the link:https://access.redhat.com/solutions/2908851[instructions] for configuring OverlayFS for use with the Docker container runtime.
+====
 
 [[comparing-overlay-graph-drivers]]
 === Comparing the Overlay and Overlay2 graph drivers


### PR DESCRIPTION
3.11

BZ [issue](https://bugzilla.redhat.com/show_bug.cgi?id=1699472)

[Preview](https://deploy-preview-42562--osdocs.netlify.app/openshift-enterprise/latest/scaling_performance/optimizing_storage.html)

Adds a note per the BZ request to clarify that OverlayFS is preferred to DeviceMapper. Changed a link to point more directly to discussion of OverlayFS in the RN.