### PR TITLE
GH#40734: adding passthrough route as tlsinspectdelay option to docs

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -191,7 +191,7 @@ supports up to `64` threads. If this field is empty, the Ingress Controller uses
 
 * `clientFinTimeout` specifies how long a connection is held open while waiting for the client response to the server closing the connection. If unset, the default timeout is `1s`.
 
-* `tlsInspectDelay` specifies how long the router can hold data to find a matching route. Setting this value too short can cause the router to fall back to the default certificate for edge-terminated or reencrypted routes, even when using a better matched certificate. If unset, the default inspect delay is `5s`.
+* `tlsInspectDelay` specifies how long the router can hold data to find a matching route. Setting this value too short can cause the router to fall back to the default certificate for edge-terminated, reencrypted, or passthrough routes, even when using a better matched certificate. If unset, the default inspect delay is `5s`.
 
 * `tunnelTimeout` specifies how long a tunnel connection, including websockets, remains open while the tunnel is idle. If unset, the default timeout is `1h`.
 


### PR DESCRIPTION
Fix for GH issue https://github.com/openshift/openshift-docs/issues/40734

Preview: https://deploy-preview-42568--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress

SME request in [Slack discussion](https://coreos.slack.com/archives/CCH60A77E/p1642541682036000?thread_ts=1642539370.035300&cid=CCH60A77E) thread.

@lihongan @quarterpin  can you QE this docs update please? 

Applies to 4.9+