### PR TITLE
CNV-13807: RN Linked to KBase article for list of supported guest os

### DIFF
--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -21,17 +21,8 @@ include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]
 
 [id="virt-guest-os"]
 === Supported guest operating systems
-{VirtProductName} guests can use the following operating systems:
-
-* Red Hat Enterprise Linux 6, 7, and 8.
-* Red Hat Enterprise Linux 9 Alpha (Technology Preview).
-* Microsoft Windows Server 2012 R2, 2016, and 2019.
-* Microsoft Windows 10.
-
-Other operating system templates shipped with {VirtProductName} are not supported.
-
-//CNV-8167  Supported guest operating systems
-//CNV-13793 Supported guest OS
+//CNV-13807 Supported guest operating systems
+To view the supported guest operating systems for {VirtProductName}, refer to link:https://access.redhat.com/articles/973163#ocpvirt[Certified Guest Operating Systems in Red Hat OpenStack Platform, Red Hat Virtualization and OpenShift Virtualization].
 
 [id="virt-4-10-inclusive-language"]
 == Making open source more inclusive


### PR DESCRIPTION
[CNV-13807](https://issues.redhat.com/browse/CNV-13807)

Removed the existing text from the "Supported guest operating systems" section and added a link to the KBase article.

Preview: https://deploy-preview-42574--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-10-release-notes.html#virt-guest-os