### PR TITLE
Update BM IBM Cloud label in TOC

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -265,7 +265,7 @@ Topics:
     File: ipi-install-expanding-the-cluster
   - Name: Troubleshooting
     File: ipi-install-troubleshooting
-- Name: Deploying installer-provisioned clusters on IBM Cloud
+- Name: Installing bare metal clusters on IBM Cloud
   Dir: installing_ibm_cloud
   Distros: openshift-origin,openshift-enterprise
   Topics:


### PR DESCRIPTION
CP to 4.10

There is no associated Jira/BZ. This is a continuation of https://github.com/openshift/openshift-docs/pull/39716.

This request came from PM to clarify the TOC labels for the bare metal and IPI installations on IBM Cloud. PM approval of the change is in the previous PR. QE ack is not required.

Updated the TOC label from `Deploying installer-provisioned clusters on IBM Cloud` to `nstalling bare metal clusters on IBM Cloud`

Preview
[Installing bare metal clusters on IBM Cloud](https://deploy-preview-42578--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/install-ibm-cloud-prerequisites.html)