### PR TITLE
Sync accurate details in doc.

### DIFF
--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -13,7 +13,7 @@ This limitation can affect you when you add a service of type `LoadBalancer`, `N
 
 [NOTE]
 ====
-Openshift Installer provisioned infrastructure (IPI) installation on Azure cloud, the installer create Loadbalancer service with `ExternalTrafficPolicy` pointing to local, however the load is still distributed to the available backends until the fix is available, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[BZ#1903408].
+Openshift Installer provisioned infrastructure (IPI) installation on Azure cloud, the installer create Loadbalancer service with `ExternalTrafficPolicy` pointing to local, however the load is still distributed to the available backends until the fix is available, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1903408[BZ#1903408].
 ====
 
 // The foll limitation is also recorded in the installation section.

--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -11,6 +11,11 @@ The OVN-Kubernetes Container Network Interface (CNI) cluster network provider ha
 The default value, `cluster`, is supported for both parameters.
 This limitation can affect you when you add a service of type `LoadBalancer`, `NodePort`, or add a service with an external IP.
 
+[NOTE]
+====
+Openshift Installer provisioned infrastructure(IPI) on Azure cloud, installer create Loadbalancer service with `ExternalTrafficPolicy` pointing to local, however the load is still distributed to the available backends until the fix is available, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[BZ#1903408].
+====
+
 // The foll limitation is also recorded in the installation section.
 * For clusters configured for dual-stack networking, both IPv4 and IPv6 traffic must use the same network interface as the default gateway.
 If this requirement is not met, pods on the host in the `ovnkube-node` daemon set enter the `CrashLoopBackOff` state.

--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -13,7 +13,7 @@ This limitation can affect you when you add a service of type `LoadBalancer`, `N
 
 [NOTE]
 ====
-Openshift Installer provisioned infrastructure(IPI) on Azure cloud, installer create Loadbalancer service with `ExternalTrafficPolicy` pointing to local, however the load is still distributed to the available backends until the fix is available, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[BZ#1903408].
+Openshift Installer provisioned infrastructure (IPI) installation on Azure cloud, the installer create Loadbalancer service with `ExternalTrafficPolicy` pointing to local, however the load is still distributed to the available backends until the fix is available, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[BZ#1903408].
 ====
 
 // The foll limitation is also recorded in the installation section.

--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -13,7 +13,7 @@ This limitation can affect you when you add a service of type `LoadBalancer`, `N
 
 [NOTE]
 ====
-Openshift Installer provisioned infrastructure (IPI) installation on Azure cloud, for the ingress service, the installer create Loadbalancer service with `ExternalTrafficPolicy` pointing to local, however the load is still distributed to the available backends until the fix is available, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1903408[BZ#1903408].
+For openshift deployments in cloud platforms except IBM cloud and Power VS, the ingress operator create Loadbalancer type service for the ingress with `ExternalTrafficPolicy` pointing to local, however the load is still distributed to the available backends until the fix is available, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1903408[BZ#1903408].
 ====
 
 // The foll limitation is also recorded in the installation section.

--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -13,7 +13,7 @@ This limitation can affect you when you add a service of type `LoadBalancer`, `N
 
 [NOTE]
 ====
-Openshift Installer provisioned infrastructure (IPI) installation on Azure cloud, the installer create Loadbalancer service with `ExternalTrafficPolicy` pointing to local, however the load is still distributed to the available backends until the fix is available, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1903408[BZ#1903408].
+Openshift Installer provisioned infrastructure (IPI) installation on Azure cloud, for the ingress service, the installer create Loadbalancer service with `ExternalTrafficPolicy` pointing to local, however the load is still distributed to the available backends until the fix is available, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1903408[BZ#1903408].
 ====
 
 // The foll limitation is also recorded in the installation section.


### PR DESCRIPTION

The clusters are by default set up with ETP=local, but as the patch for local is yet not exist, we still balance the traffic even with ETP set to local.
Post the patch release (4.10), we will support local.

spec:
clusterIP: 172.30.64.132
externalTrafficPolicy: Local
healthCheckNodePort: 32424