### PR TITLE
CNV-14946: reversing about-virt placeholder

### DIFF
--- a/virt/about-virt.adoc
+++ b/virt/about-virt.adoc
@@ -6,6 +6,13 @@ include::_attributes/virt-document-attributes.adoc[]
 
 toc::[]
 
-Documentation for {VirtProductName} will be available for {product-title} {product-version} in the near future.
+Learn about {VirtProductName}'s capabilities and support scope.
 
-In the meantime, the link:https://docs.openshift.com/container-platform/4.9/virt/about-virt.html[{VirtProductName} 4.9 documentation] is available as part of the {product-title} 4.9 documentation.
+include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
+
+// This line is attached to the above `virt-what-you-can-do-with-virt` module.
+// It is included here in the assembly because of the xref ban.
+
+You can use {VirtProductName} with the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes], xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShift SDN], or one of the other certified default Container Network Interface (CNI) network providers listed in link:https://access.redhat.com/articles/5436171[Certified OpenShift CNI Plug-ins].
+
+include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]


### PR DESCRIPTION
[CNV-14946](https://issues.redhat.com/browse/CNV-14946)

reverting about-virt assembly to its previous state (to be merged after CNV-4.10 GA)

preview: https://deploy-preview-42596--osdocs.netlify.app/openshift-enterprise/latest/virt/about-virt.html