### PR TITLE
CNV-14946: placing redirects to prevent CNV from releasing with OCP

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -237,7 +237,7 @@ AddType text/vtt                            vtt
     # NOTE THAT THESE ARE A 302 REDIRECT, not a 301. Replace with 301 at CNV GA
     # send all cnv/ to virt/about-virt.html.
     # send all virt/ to virt/about-virt.html excluding about-virt.html otherwise there is an infinite loop
-    # RewriteRule container-platform/4\.9/virt/(?!about-virt\.html) /container-platform/4.9/virt/about-virt.html [NE,R=302]
+    RewriteRule container-platform/4\.10/virt/(?!about-virt\.html)(.+)$ /container-platform/4.10/virt/about-virt.html [NE,R=302]
     # RewriteRule container-platform/4\.5/cnv/?(.*)$ /container-platform/4.5/virt/about-virt.html [NE,R=301]
 
     # Serverless Redirects


### PR DESCRIPTION
[CNV-14946](https://issues.redhat.com/browse/CNV-14946)

- CNV GA has been pushed back to March 16
- Added rule to redirect all `/virt/*` content to the `about-virt.adoc` assembly to support asynchronous release from OCP
- To be reversed when CNV 4.10 GAs (after merging placeholder reversal)
- No CP