### PR TITLE
RHDEVDOCS-3438 - OCP 4.10 Monitoring Release Notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -775,6 +775,157 @@ In {product-title} 4.7, _Cluster Logging_ became _Red Hat OpenShift Logging_. Fo
 [id="ocp-4-10-monitoring"]
 === Monitoring
 
+The monitoring stack for this release includes the following new and modified features.
+
+[id="ocp-4-10-monitoring-stack-components-and-dependencies"]
+==== Monitoring stack components and dependencies
+
+Updates to versions of monitoring stack components and dependencies include the following:
+
+* Alertmanager to 0.23.0
+* Grafana to 8.3.4
+* kube-state-metrics to 2.3.0
+* node-exporter to 1.3.1
+* prom-label-proxy to 0.4.0
+* Prometheus to 2.32.1
+* Prometheus adapter to 0.9.1
+* Prometheus operator to 0.53.1
+* Thanos to 0.23.1
+
+[id="ocp-4-10-monitoring-new-metrics-targets-page-in-web-console"]
+==== New page for metrics targets in the {product-title} web console
+
+A new *Metrics Targets* page in the {product-title} web console shows targets for default {product-title} projects and for user-defined projects. You can use this page to view, search, and filter the endpoints that are currently targeted for scraping, which helps you to identify and troubleshoot problems.
+
+[id="ocp-4-10-monitoring-components-use-tls-authentication-for-metrics"]
+==== Monitoring components updated to use TLS authentication for metrics collection
+
+With this release, all monitoring components are now configured to use mutual TLS authentication, rather than Bearer Token static authentication for metrics collection. TLS authentication is more resilient to Kubernetes API outages and decreases the load on the Kubernetes API.
+
+[id="ocp-4-10-monitoring-updated-cmo-to-use-global-tls-profile"]
+==== Cluster Monitoring Operator updated to use the global TLS security profile
+
+With this release, the Cluster Monitoring Operator components now honor the global {product-title} `tlsSecurityProfile` settings. 
+The following components and services now use the TLS security profile:
+
+* Alertmanager pods (ports 9092 and 9097)
+* kube-state-metrics pod (ports 8443 and 9443)
+* openshift-state-metrics pod (ports 8443 and 9443)
+* node-exporter pods (port 9100)
+* Grafana pod (port 3002)
+* prometheus-adapter pods (port 6443)
+* prometheus-k8s pods (ports 9092 and 10902)
+* Thanos query pods (ports 9092, 9093 and 9094)
+* Prometheus Operator (ports 8080 and 8443)
+* telemeter-client pod (port 8443)
+
+If you have enabled user-defined monitoring, the following pods now use the profile:
+
+* prometheus-user-workload pods (ports 9091 and 10902)
+* prometheus-operator pod (ports 8080 and 8443)
+
+[id="ocp-4-10-monitoring-changes-to-alerting-rules"]
+==== Changes to alerting rules
+
+* *New*
+** Added a `namespace` label to all Thanos alerting rules.
+** Added the `openshift_io_alert_source="platform"` label to all platform alerts. 
+
+
+* *Changed*
+** Renamed `AggregatedAPIDown` to `KubeAggregatedAPIDown`.
+** Renamed `AggregatedAPIErrors` to `KubeAggregatedAPIErrors`.
+** Removed the `HighlyAvailableWorkloadIncorrectlySpread` alert.
+** Improved the description of the `KubeMemoryOvercommit` alert.
+** Improved `NodeFilesystemSpaceFillingUp` alerts to make it consistent with the Kubernetes garbage collection thresholds.
+** Excluded `ReadOnlyMany` volumes from the `KubePersistentVolumeFillingUp` alerts.
+** Extended `PrometheusOperator` alerts to include the Prometheus operator running in the `openshift-user-workload-monitoring` namespace.
+** Replaced the `ThanosSidecarPrometheusDown` and `ThanosSidecarUnhealthy` alerts by `ThanosSidecarNoConnectionToStartedPrometheus`.
+** Changed the severity of `KubeletTooManyPods` from `warning` to `info`.
+** Enabled exclusion of specific persistent volumes from `KubePersistentVolumeFillingUp` alerts by adding the `alerts.k8s.io/KubePersistentVolumeFillingUp: disabled` label to a persistent volume resource.
+
+
+[NOTE]
+=====
+Red Hat does not guarantee backward compatibility for recording rules or alerting rules.
+=====
+
+[id="ocp-4-10-monitoring-changes-to-metrics"]
+==== Changes to metrics
+
+* Pod-centric cAdvisor metrics available at the slice level have been dropped.
+* The following metrics are now exposed:
+** `kube_poddisruptionbudget_labels`
+** `kube_persistentvolumeclaim_labels`
+** `kube_persistentvolume_labels`
+* Metrics with the name `kube_*annotation` have been removed from `kube-state-metrics`.
+
+[NOTE]
+=====
+Red Hat does not guarantee backward compatibility for metrics.
+=====
+
+[id="ocp-4-10-monitoring-added-hard-anti-affinity-rules-and-pod-distruption-budgets"]
+==== Added hard anti-affinity rules and pod disruption budgets for certain components
+
+With this release, hard anti-affinity rules and pod disruption budgets have been enabled for the following monitoring components to reduce downtime during patch upgrades:
+
+* Alertmanager
++
+[NOTE]
+=====
+As part of this change, the number of Alertmanager replicas has been reduced from three to two. However, the persistent volume claim (PVC) for the removed third replica is not automatically removed as part of the upgrade process. If you have configured persistent storage for Alertmanager, you can remove this PVC manually from the Cluster Monitoring Operator. See the "Known Issues" section for more information.
+=====
++
+* Prometheus adapter
+* Prometheus
+* Thanos Querier
+
+If you have enabled user-defined monitoring, the following components also use these rules and budgets:
+
+* Prometheus
+* Thanos Ruler
+
+[id="ocp-4-10-monitoring-alert-routing-user-defined-project-tech-preview"]
+==== Alert routing for user-defined projects (Technology preview)
+
+This release introduces a Technology Preview feature in which an administrator can enable alert routing for user-defined projects monitoring. Users can then add and configure alert routing for their user-defined projects.
+
+
+[id="ocp-4-10-monitoring-alertmanager"]
+==== Alertmanager
+
+Access to the third-party Alertmanager web user interface from the {product-title} route has been removed.
+
+[id="ocp-4-10-monitoring-prometheus"]
+==== Prometheus
+
+* {product-title} cluster administrators can now configure query logging for Prometheus.
+* Access to the third-party Prometheus web user interface is deprecated and will be removed in a future {product-title} release.
+
+[id="ocp-4.10-monitoring-prometheus-adapter"]
+==== Prometheus adapter
+
+* The Prometheus adapter now uses the Thanos Querier API instead of the Prometheus API.
+* {product-title} cluster administrators can now configure audit logs for the Prometheus adapter.
+
+[id="ocp-4-10-monitoring-thanos-querier"]
+==== Thanos Querier
+
+* Access to the third-party Thanos Querier web user interface from the {product-title} route has been removed.
+* The `/api/v1/labels`, `/api/v1/label/*/values`, and `/api/v1/series` endpoints on the Thanos Querier tenancy port are now exposed.
+* {product-title} cluster administrators can now configure query logging.
+
+[id="ocp-4-10-monitoring-thanos-ruler"]
+
+* If user workload monitoring is enabled, access to the third-party Thanos Ruler web user interface from the {product-title} route has been removed.
+
+
+[id="ocp-4-10-monitoring-grafana"]
+==== Grafana
+
+Access to the third-party Grafana web user interface is deprecated and will be removed in a future {product-title} release.
+
 [id="ocp-4-10-scalability-and-performance"]
 === Scalability and performance
 
@@ -1066,6 +1217,16 @@ Support for empty files using the `--registry-config` and `--to` flags in `oc re
 
 * In {product-title} 4.10, the non-sidecar `maven` and `nodejs` pod templates for Jenkins are deprecated. These pod templates are planned for removal in a future release. Bug fixes and support are provided through the end of that future life cycle, after which no new feature enhancements are made. Instead, with this update, you can run Jenkins agents as sidecar containers. (link:https://issues.redhat.com/browse/JKNS-257[JKNS-257])
 
+[id="ocp-4-10-third-party-monitoring-components-uis-deprecation"]
+==== Third-party monitoring components user interface deprecation
+
+For the following monitoring stack components, access to third-party web user interfaces (UIs) is deprecated and is planned to be removed in a future {product-title} release:
+
+* Grafana
+* Prometheus
+
+As an alternative, users can navigate to the *Observe* section of the {product-title} web console to access dashboards and other UIs for platform components.
+
 [id="ocp-4-10-removed-features"]
 === Removed features
 
@@ -1093,6 +1254,18 @@ Support for configuring a scheduler policy has been removed with this release. U
 Support for running {op-system-base-full} 7 compute machines in {product-title} has been removed. If you prefer using {op-system-base} compute machines, they must run on {op-system-base} 8.
 
 You cannot upgrade {op-system-base} 7 compute machines to {op-system-base} 8. You must deploy new {op-system-base} 8 hosts, and the old {op-system-base} 7 hosts must be removed.
+
+[id="ocp-4-10-third-party-monitoring-component-uis-removal"]
+==== Third-party monitoring component user interface access removed
+
+With this release, you can no longer access third-party web user interfaces (UIs) for the following monitoring stack components:
+
+* Alertmanager
+* Thanos Querier
+* Thanos Ruler (if user workload monitoring is enabled)
+
+Instead, you can navigate to the *Observe* section of the {product-title} web console to access metrics, alerting, and metrics targets UIs for platform components.
+
 
 [id="ocp-4-10-bug-fixes"]
 == Bug fixes
@@ -1341,6 +1514,55 @@ This update corrects the accepted label specification so that the plug-in import
 * Previously, in the {console-redhat-com} for {rh-openstack-first}, the control plane was not translated into simplified Chinese. As a result, naming differed from {product-title} documentation. This update fixes the translation issue in the {console-redhat-com}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1982063[*BZ#1982063*])
 
 * Previously, filtering of virtual tables in the {console-redhat-com} was broken. Consequently, all of the available `nodes` would not appear following a search. This update includes new virtual table logic that fixes the filtering issue in the {console-redhat-com}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1990255[*BZ#1990255*])
+
+[discrete]
+[id="ocp-4-10-monitoring-bug-fixes"]
+==== Monitoring
+
+* Previously, during {product-title} upgrades, the Prometheus service could become unavailable because either two Prometheus pods were located on the same node or the two nodes running the pods rebooted during the same interval. 
+This situation was possible because the Prometheus pods had soft anti-affinity rules regarding node placement and no `PodDisruptionBudget` resources provisioned. 
+Consequently, metrics were not collected and rules were not evaluated over a period of time.
++
+To fix this issue, the Cluster Monitoring Operator (CMO) now configures hard anti-affinity rules to ensure that the two Prometheus pods are scheduled on different nodes.
+The CMO also provisions `PodDisruptionBudget` resources to ensure that at least one Prometheus pod is always running.
+As a result, during upgrades, the nodes now reboot in sequence to ensure that at least one Prometheus pod is always running. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1933847[*BZ#1933847*])
+
+* Previously, the Thanos Ruler service would become unavailable when the node that contains the two Thanos Ruler pods experienced an outage. 
+This situation occurred because the Thanos Ruler pods had only soft anti-affinity rules regarding node placement. 
+Consequently, user-defined rules would not be evaluated until the node came back online.
++
+With this release, the Cluster Monitoring Operator (CMO) now configures hard anti-affinity rules to ensure that the two Thanos Ruler pods are scheduled on different nodes. 
+As a result, a single-node outage no longer creates a gap in user-defined rule evaluation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1955490[*BZ#1955490*])
+
+* Previously, the Prometheus service would become unavailable when the two Prometheus pods were located on the same node and that node experienced an outage.
+This situation occurred because the Prometheus pods had only soft anti-affinity rules regarding node placement.
+Consequently, metrics would not be collected, and rules would not be evaluated until the node came back online.
++
+With this release, the Cluster Monitoring Operator configures hard anti-affinity rules to ensure that the two Prometheus pods are scheduled on different nodes.
+As a result, Prometheus pods are now scheduled on different nodes, and a single node outage no longer creates a gap in monitoring.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1949262[*BZ#1949262*])
+
+* Previously, during {product-title} patch upgrades, the Alertmanager service might become unavailable because either the three Alertmanager pods were located on the same node or the nodes running the Alertmanager pods happened to reboot at the same time. 
+This situation was possible because the Alertmanager pods had soft anti-affinity rules regarding node placement and no `PodDisruptionBudget` provisioned. 
+This release enables hard anti-affinity rules and `PodDisruptionBudget` resources to ensure no downtime during patch upgrades for the Alertmanager and other monitoring components. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1955489[*BZ#1955489*])
+
+* Previously, a false positive `NodeFilesystemSpaceFillingUp` alert was triggered when the file system space was occupied by many Docker images. 
+For this release, the threshold to fire the `NodeFilesystemSpaceFillingUp` warning alert is now reduced to 20% space available, instead of 40%, which stops the false positive alert from firing. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1987263[*BZ#1987263*])
+
+* Previously, alerts for the Prometheus Operator component did not apply to the Prometheus Operator that runs the `openshift-user-workload-monitoring` namespace when user-defined monitoring is enabled.
+Consequently, no alerts fired when the Prometheus Operator that manages the `openshift-user-workload-monitoring` namespace encountered issues.
++
+With this release, alerts have been modified to monitor both the `openshift-monitoring` and `openshift-user-workload-monitoring` namespaces.
+As a result, cluster administrators receive alert notifications when the Prometheus Operator that manages user-defined monitoring encounters issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2001566[*BZ#2001566*])
+
+* Previously, if the number of DaemonSet pods for the `node-exporter` agent was not equal to the number of nodes in the cluster, the Cluster Monitoring Operator (CMO) would report a condition of `degraded`. This issue would occur when one of the nodes was not in the `ready` condition.
++
+This release now verifies that the number of DaemonSet pods for the `node-exporter` agent is not less than the number of ready nodes in the cluster. This process ensures that a `node-exporter` pod is running on every active node.
+As a result, the CMO will not report a degraded condition if one of the nodes is not in a ready state. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2004051[*BZ#2004051*])
+
+* This release fixes an issue in which some pods in the monitoring stack would start before TLS certificate-related resources were present, which resulted in failures and restarts. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2016352[*BZ#2016352*])
+
+* Previously, if reporting metrics failed due to reaching the configured sample limit, the metrics target would still appear with a status of `Up` in the web console UI even though the metrics were missing. With this release, Prometheus bypasses the sample limit setting for reporting metrics, and the metrics now appear regardless of the sample limit setting. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2034192[*BZ#2034192*])
+
 
 [discrete]
 [id="ocp-4-10-networking-bug-fixes"]
@@ -1822,6 +2044,11 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 
+|Alert routing for user-defined projects monitoring
+|-
+|-
+|TP
+
 |Disconnected mirroring with the oc-mirror CLI plug-in
 |-
 |-
@@ -1905,6 +2132,12 @@ Workaround: Use OpenShift OAuth for authentication. (link:https://bugzilla.redha
 * Currently, while running high-volume pipeline logs, the auto-scroll functionality does not work and logs are stuck showing older messages. This issue happens because running high-volume pipeline logs generates a large number of calls to the `scrollIntoView` method. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2014161[BZ#2014161])
 
 * Curently, when you use the *Import from Git* form to import a private git repository, the correct import type and a builder image are not identified. This issue happens because the secret to fetch the private repository details is not decoded. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2053501[BZ#2053501])
+
+* During an upgrade of the monitoring stack, Prometheus and Alertmanager might become briefly unavailable. No workaround for this issue is necessary because the components will be available after a short time has passed. No user intervention is required. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2030539[*BZ#203059*])
+
+* For this release, monitoring stack components have been updated to use TLS authentication for metrics collection. However, sometimes Prometheus tries to keep HTTP connections to metrics targets open using expired TLS credentials even after new ones have been provided. Authentication errors then occur, and some metrics targets become unavailable. When this issue occurs, a `TargetDown` alert will fire. To work around this issue, restart the pods that are reported as down. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033575[*BZ#2033575*])
+
+* For this release, the number of Alertmanager replicas in the monitoring stack was reduced from three to two. However, the persistent volume claim (PVC) for the removed third replica is not automatically removed as part of the upgrade process. After the upgrade, an administrator can remove this PVC manually from the Cluster Monitoring Operator. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2040131[*BZ#2040131*])
 
 [id="ocp-4-10-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
- Aligned team: DevTools
- For branches: 4.10 only
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3438
- Direct link to doc preview: https://deploy-preview-42606--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-monitoring
- SME review: @jan--f @simonpasquier 
- QE review: @juzhao 
- Peer review: @rolfedh
- <All reviews complete. Please merge now>


