### PR TITLE
Fix typo in feature gates 4.8

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -10,8 +10,10 @@ You can use the `FeatureGate` custom resource (CR) to enable specific feature se
 
 You can activate any of the following feature sets by using the `FeatureGate` CR:
 
-* `TechPreviewNoUpgrade`. This featrue set a subset of the current Technology Preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents upgrades. This feature set is not recommended on production clusters. The following Technology Preview features are enabled by this feature set:
-
+* `TechPreviewNoUpgrade`. This feature set is a subset of the current Technology Preview features. This feature set allows you to enable these tech preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents upgrades. This feature set is not recommended on production clusters. 
++
+The following Technology Preview features are enabled by this feature set:
++
 ** Azure Disk CSI Driver Operator. Enables the provisioning of persistent volumes (PVs) by using the Container Storage Interface (CSI) driver for Microsoft Azure Disk Storage.
 ** VMware vSphere CSI Driver Operator. Enables the provisioning of persistent volumes (PVs) by using the Container Storage Interface (CSI) VMware vSphere driver for Virtual Machine Disk (VMDK) volumes.
 ** CSI automatic migration. Enables the automatic migration of supported in-tree volume plug-ins to their equivalent Container Storage Interface (CSI) drivers. Available as a Technology Preview for:


### PR DESCRIPTION
Noticed a typo.

Preview: [Understanding feature gates](https://deploy-preview-42612--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)