### PR TITLE
BZ-2008919: Fixing device list

### DIFF
--- a/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
+++ b/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
@@ -93,7 +93,7 @@ spec:
     - interfaceName: “eth0”
     - interfaceName: “eth1”
     - vendorID: “0x1af4”
-    deviceID: “0x1000”
+    - deviceID: “0x1000”
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
 ----
@@ -154,8 +154,8 @@ spec:
     userLevelNetworking: true
     devices:
     - interfaceName: “eth0”
-      vendorID: “0x1af4”
-      deviceID: “0x1000”
+    - vendorID: “0x1af4”
+    - deviceID: “0x1000”
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
 ----


### PR DESCRIPTION
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=2008919
Applies to 4.8+
QE required @xltian 
Preview Link: https://deploy-preview-42623--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#adjusting-nic-queues-with-the-performance-profile_cnf-master