### PR TITLE
OSDOCS-3307: Update 4.8 EOL date for OSD/ROSA

### DIFF
--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -9,7 +9,7 @@
 |===
 |Version    |General availability   |End of life
 |4.9        |Oct 18, 2021           |Jul 18, 2022
-|4.8        |Jul 27, 2021           |Apr 27, 2022
+|4.8        |Jul 27, 2021           |May 27, 2022
 
 ifeval::["{product-title}" == "OpenShift Dedicated"]
 |4.7        |Feb 24, 2021           |Dec 17, 2021 footnote:[4.7 minor version follows previous Y-1 life cycle]


### PR DESCRIPTION
This applies to main, enterprise-4.10 and enterprise-4.9.

This relates to https://issues.redhat.com/browse/OSDOCS-3307. This PR changes 4.8 EOL date to May 27, 2022 per @wgordon17. 

[OSD Preview](https://deploy-preview-42626--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/osd-life-cycle.html#rosa-life-cycle-dates_osd-life-cycle) 

[ROSA Preview](https://deploy-preview-42626--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-life-cycle.html#rosa-life-cycle-dates_rosa-life-cycle) 
