### PR TITLE
OADP-298 Fixed indentation in yaml example.

### DIFF
--- a/modules/oadp-installing-dpa.adoc
+++ b/modules/oadp-installing-dpa.adoc
@@ -106,7 +106,7 @@ spec:
       enable: true <.>
   backupLocations:
     - velero:
-        configuration:
+        config:
           resourceGroup: <azure_resource_group> <.>
           storageAccount: <azure_storage_account_id> <.>
           subscriptionId: <azure_subscription_id> <.>
@@ -116,15 +116,15 @@ spec:
           name: {credentials}  <.>
         provider: {provider}
         default: true
-      objectStorage:
-        bucket: <bucket_name> <.>
-        prefix: <prefix> <.>
+        objectStorage:
+          bucket: <bucket_name> <.>
+          prefix: <prefix> <.>
   snapshotLocations: <.>
     - velero:
         config:
           resourceGroup: <azure_resource_group>
           subscriptionId: <azure_subscription_id>
-          incremental: true
+          incremental: "true"
         name: default
         provider: {provider}
 ----

--- a/modules/oadp-secrets-for-different-credentials.adoc
+++ b/modules/oadp-secrets-for-different-credentials.adoc
@@ -113,7 +113,7 @@ spec:
 ...
   backupLocations:
     - velero:
-        configuration:
+        config:
           resourceGroup: <azure_resource_group>
           storageAccount: <azure_storage_account_id>
           subscriptionId: <azure_subscription_id>
@@ -123,15 +123,15 @@ spec:
           name: <custom_secret> <1>
         provider: azure
         default: true
-      objectStorage:
-        bucket: <bucket_name>
-        prefix: <prefix>
+        objectStorage:
+          bucket: <bucket_name>
+          prefix: <prefix>
   snapshotLocations:
     - velero:
         config:
           resourceGroup: <azure_resource_group>
           subscriptionId: <azure_subscription_id>
-          incremental: true
+          incremental: "true"
         name: default
         provider: {provider}
 ----


### PR DESCRIPTION
This fixes: https://issues.redhat.com/browse/OADP-298

This applies to:
enterprise-4.9
enterprise-4.10
enterprise-4.11 (main)

Preview:
https://deploy-preview-42628--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.html