### PR TITLE
RHDEVDOCS-2802 Jenkins shared library in Tekton + RHDEVDOCS-2875 Basic common use cases

### DIFF
--- a/cicd/jenkins-tekton/migrating-from-jenkins-to-tekton.adoc
+++ b/cicd/jenkins-tekton/migrating-from-jenkins-to-tekton.adoc
@@ -18,3 +18,11 @@ include::modules/jt-migrating-from-jenkins-plugins-to-tekton-hub-tasks.adoc[leve
 include::modules/jt-extending-tekton-capabilities-using-custom-tasks-and-scripts.adoc[leveloffset=+1]
 
 include::modules/jt-comparison-of-jenkins-tekton-execution-models.adoc[leveloffset=+1]
+
+include::modules/jt-examples-of-common-use-cases.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources"]
+== Additional resources
+
+* xref:../../authentication/using-rbac.adoc#using-rbac[Role-based Access Control]

--- a/modules/jt-examples-of-common-use-cases.adoc
+++ b/modules/jt-examples-of-common-use-cases.adoc
@@ -1,0 +1,164 @@
+:_content-type: CONCEPT
+// Module included in the following assembly:
+//
+// jenkins-tekton/migrating-from-jenkins-to-tekton.adoc
+
+[id="jt-examples-of-common-use-cases_{context}"]
+= Examples of common use cases
+
+Both Jenkins and Tekton offer capabilities for common CI/CD use cases, such as: 
+
+* Compiling, building, and deploying images using maven
+* Extending the core capabilities by using plugins
+* Reusing shareable libraries and custom scripts
+
+== Running a maven pipeline in Jenkins and Tekton
+
+You can use maven in both Jenkins and Tekton workflows for compiling, building, and deploying images. To map your existing Jenkins workflow to Tekton, consider the following examples:
+
+.Example: Compile and build an image and deploy it to OpenShift using maven in Jenkins
+[source,groovy]
+----
+#!/usr/bin/groovy
+node('maven') {
+    stage 'Checkout'
+    checkout scm
+ 
+    stage 'Build'
+    sh 'cd helloworld && mvn clean'
+    sh 'cd helloworld && mvn compile'
+ 
+    stage 'Run Unit Tests'
+    sh 'cd helloworld && mvn test'
+ 
+    stage 'Package'
+    sh 'cd helloworld && mvn package'
+ 
+    stage 'Archive artifact'
+    sh 'mkdir -p artifacts/deployments && cp helloworld/target/*.war artifacts/deployments'
+    archive 'helloworld/target/*.war'
+ 
+    stage 'Create Image'
+    sh 'oc login https://kubernetes.default -u admin -p admin --insecure-skip-tls-verify=true'
+    sh 'oc new-project helloworldproject'
+    sh 'oc project helloworldproject'
+    sh 'oc process -f helloworld/jboss-eap70-binary-build.json | oc create -f -'
+    sh 'oc start-build eap-helloworld-app --from-dir=artifacts/'
+ 
+    stage 'Deploy'
+    sh 'oc new-app helloworld/jboss-eap70-deploy.json' }
+
+----
+
+.Example: Compile and build an image and deploy it to OpenShift using maven in Tekton.
+[source,yaml]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: maven-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+    - name: maven-settings
+    - name: kubeconfig-dir
+      optional: true
+  params:
+    - name: repo-url
+    - name: revision
+    - name: context-path
+  tasks:
+    - name: fetch-repo
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: "$(params.repo-url)"
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+        - name: revision
+          value: $(params.revision)
+    - name: mvn-build
+      taskRef:
+        name: maven
+      runAfter:
+        - fetch-repo
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: maven-settings
+          workspace: maven-settings
+      params:
+        - name: CONTEXT_DIR
+          value: "$(params.context-path)"
+        - name: GOALS
+          value: ["-DskipTests", "clean", "compile"]
+    - name: mvn-tests
+      taskRef:
+        name: maven
+      runAfter:
+        - mvn-build
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: maven-settings
+          workspace: maven-settings
+      params:
+        - name: CONTEXT_DIR
+          value: "$(params.context-path)"
+        - name: GOALS
+          value: ["test"]
+    - name: mvn-package
+      taskRef:
+        name: maven
+      runAfter:
+        - mvn-tests
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: maven-settings
+          workspace: maven-settings
+      params:
+        - name: CONTEXT_DIR
+          value: "$(params.context-path)"
+        - name: GOALS
+          value: ["package"]
+    - name: create-image-and-deploy
+      taskRef:
+        name: openshift-client
+      runAfter:
+        - mvn-package
+      workspaces:
+        - name: manifest-dir
+          workspace: shared-workspace
+        - name: kubeconfig-dir
+          workspace: kubeconfig-dir
+      params:
+        - name: SCRIPT
+          value: |
+            cd "$(params.context-path)"
+            mkdir -p ./artifacts/deployments && cp ./target/*.war ./artifacts/deployments
+            oc new-project helloworldproject
+            oc project helloworldproject
+            oc process -f jboss-eap70-binary-build.json | oc create -f -
+            oc start-build eap-helloworld-app --from-dir=artifacts/
+            oc new-app jboss-eap70-deploy.json
+
+----
+
+== Extending the core capabilities of Jenkins and Tekton by using plugins
+Jenkins has the advantage of a large ecosystem of numerous plugins developed over the years by its extensive user base. You can search and browse the plugins in the link:https://plugins.jenkins.io/[Jenkins Plugin Index]. 
+
+Tekton also has many tasks developed and contributed by the community and enterprise users. A publicly available catalog of reusable Tekton tasks are available in the link:https://hub.tekton.dev/[Tekton Hub].
+
+In addition, Tekton incorporates many of the plugins of the Jenkins ecosystem within its core capabilities. For example, authorization is a critical function in both Jenkins and Tekton. While Jenkins ensures authorization using the link:https://plugins.jenkins.io/role-strategy/[Role-based Authorization Strategy] plugin, Tekton uses OpenShift's built-in Role-based Access Control system.
+
+== Sharing reusable code in Jenkins and Tekton
+Jenkins link:https://www.jenkins.io/doc/book/pipeline/shared-libraries/[shared libraries] provide reusable code for parts of Jenkins pipelines. The libraries are shared between link:https://www.jenkins.io/doc/book/pipeline/jenkinsfile/[Jenkinsfiles] to create highly modular pipelines without code repetition.
+
+Although there is no direct equivalent of Jenkins shared libraries in Tekton, you can achieve similar workflows by using tasks from the link:https://hub.tekton.dev/[Tekton Hub], in combination with custom tasks and scripts.


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`
- **JIRA issues**: 
  - [RHDEVDOCS-2802 Dealing with Jenkins shared library in Tekton](https://issues.redhat.com/browse/RHDEVDOCS-2802)
  - [RHDEVDOCS-2875 Document basic common use cases](https://issues.redhat.com/browse/RHDEVDOCS-2875)
- **Preview pages**: [Examples of common use cases](https://deploy-preview-42629--osdocs.netlify.app/openshift-enterprise/latest/cicd/jenkins-tekton/migrating-from-jenkins-to-tekton#jt-examples-of-common-use-cases_migrating-from-jenkins-to-tekton)
- **SME review**: @rupalibehera      
- **Peer-review**: @jc-berger   