### PR TITLE
Adds release notes 4.7.44

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -3104,3 +3104,24 @@ A new enhancement to the Whereabouts CNI plug-in adds an IP reconciliation job, 
 ==== Updating
 
 To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-7-44"]
+=== RHBA-2022:0647 - {product-title} 4.7.44 bug fix update
+
+Issued: 2022-03-02
+
+{product-title} release 4.7.44 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0647[RHBA-2022:0647] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0646[RHBA-2022:0646] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6772591[{product-title} 4.7.44 container image list]
+
+[id="ocp-4-7-44-bug-fixes"]
+==== Bug fixes
+* Previously, a `reclaimPolicy` value was missing in the `standard-csi` storage class. Consequently, OpenStack Cinder CSI Driver Operator continuously printed `StorageClassUpdated` events in the logs. With this update, a default value for `reclaimPolicy` in the `standard-csi` storage class is set. As a result, OpenStack Cinder CSI Driver Operator does not spam the logs with `StorageClassUpdated` events. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049879[*BZ#2049879*])
+
+
+[id="ocp-4-7-44-updating"]
+==== Updating
+
+To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

To be merged when the erratas are shipped live. I will send a reminder.

OCP version: **Applicable only to 4.7**

Direct Doc Preview Link: https://deploy-preview-42630--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-44
