### PR TITLE
BZ2030026: BMH status ready changed to available

### DIFF
--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -133,6 +133,6 @@ Where `<num>` is the worker node number.
 .Example output
 [source,terminal]
 ----
-NAME                    STATE   CONSUMER   ONLINE   ERROR
-openshift-worker-<num>  ready              true
+NAME                    STATE       CONSUMER   ONLINE   ERROR
+openshift-worker-<num>  available              true
 ----

--- a/modules/ipi-install-provisioning-the-bare-metal-node.adoc
+++ b/modules/ipi-install-provisioning-the-bare-metal-node.adoc
@@ -10,7 +10,7 @@ Provisioning the bare metal node requires executing the following procedure from
 
 .Procedure
 
-. Ensure the `STATE` is `ready` before provisioning the bare metal node.
+. Ensure the `STATE` is `available` before provisioning the bare metal node.
 +
 [source,bash]
 ----
@@ -21,8 +21,8 @@ Where `<num>` is the worker node number.
 +
 [source,bash]
 ----
-NAME                     STATE   CONSUMER     ONLINE   ERROR
-openshift-worker-<num>   ready                true
+NAME                     STATE      CONSUMER     ONLINE   ERROR
+openshift-worker-<num>   available               true
 ----
 
 . Get a count of the number of worker nodes.
@@ -74,7 +74,7 @@ Replace `<num>` with the new number of worker nodes. Replace `<machineset>` with
 $ oc -n openshift-machine-api get bmh openshift-worker-<num>
 ----
 +
-Where `<num>` is the worker node number. The STATE changes from `ready` to `provisioning`.
+Where `<num>` is the worker node number. The `STATE` changes from `available` to `provisioning`.
 +
 [source,bash]
 ----


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2030026

For release(s): 4.10

Preview: https://deploy-preview-42631--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-the-bare-metal-node_ipi-install-expanding

https://deploy-preview-42631--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#provisioning-the-bare-metal-node_ipi-install-expanding