### PR TITLE
BZ2056452: Table description changed to reflect that 4789 is for VXLAN while 6081 is for Geneve.

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -211,10 +211,10 @@ the Cluster Version Operator on port `9099`.
 
 .3+|UDP
 |`4789`
-|VXLAN and Geneve
+|VXLAN
 
 |`6081`
-|VXLAN and Geneve
+|Geneve
 
 |`9000`-`9999`
 |Host level services, including the node exporter on ports `9100`-`9101`.


### PR DESCRIPTION
Bugzilla
https://bugzilla.redhat.com/show_bug.cgi?id=2056452

Preview
https://deploy-preview-42633--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html#installation-network-connectivity-user-infra_installing-restricted-networks-bare-metal

Versions:
Applies to OpenShift version : 4.10+