### PR TITLE
BZ2037544: Clarifies how to get nodeLabel and nodeName

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -171,8 +171,8 @@ spec:
 <14> Specify the `profile` object name defined in the `profile` section.
 <15> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
 <16> Specify `match` rules with `nodeLabel` or `nodeName`.
-<17> Specify `nodeLabel` with the `key` of `node.Labels` from the node object.
-<18> Specify `nodeName` with `node.Name` from the node object.
+<17> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command.
+<18> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command.
 
 . Create the CR by running the following command:
 +

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -164,8 +164,8 @@ spec:
 <12> Specify the `profile` object name defined in the `profile` section.
 <13> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
 <14> Specify `match` rules with `nodeLabel` or `nodeName`.
-<15> Specify `nodeLabel` with the `key` of `node.Labels` from the node object.
-<16> Specify `nodeName` with `node.Name` from the node object.
+<15> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command.
+<16> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command.
 
 . Create the `PtpConfig` CR by running the following command:
 +


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2037544

For releases: 4.9 and 4.10

Preview: https://deploy-preview-42634--osdocs.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#configuring-linuxptp-services-as-ordinary-clock_using-ptp

https://deploy-preview-42634--osdocs.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#configuring-linuxptp-services-as-boundary-clock_using-ptp