### PR TITLE
BZ2037544: Clarifies how to get nodeLabel and nodeName

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp.adoc
+++ b/modules/nw-ptp-configuring-linuxptp.adoc
@@ -50,8 +50,8 @@ spec:
 <9> Specify the `profile` object name defined in the `profile` section.
 <10> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority will be applied to that node.
 <11> Specify `match` rules with `nodeLabel` or `nodeName`.
-<12> Specify `nodeLabel` with the `key` of `node.Labels` from the node object.
-<13> Specify `nodeName` with `node.Name` from the node object.
+<12> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command.
+<13> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command.
 
 . Create the CR by running the following command:
 +


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2037544

Related PR against main: https://github.com/openshift/openshift-docs/pull/42634

For release(s): 4.8

Preview: https://deploy-preview-42635--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring-ptp#configuring-linuxptp_configuring-ptp