### PR TITLE
[BZ2002435]: Change the Ansible version

### DIFF
--- a/modules/osdk-common-prereqs.adoc
+++ b/modules/osdk-common-prereqs.adoc
@@ -26,7 +26,7 @@ ifdef::golang[]
 - link:https://www.mercurial-scm.org/downloads[Mercurial] v3.9+
 endif::[]
 ifdef::ansible[]
-- link:https://docs.ansible.com/ansible/latest/index.html[Ansible] v2.9.0+
+- link:https://docs.ansible.com/ansible/2.9/index.html[Ansible] v2.9.0
 - link:https://ansible-runner.readthedocs.io/en/latest/install.html[Ansible Runner] v2.0.2+
 - link:https://github.com/ansible/ansible-runner-http[Ansible Runner HTTP Event Emitter plug-in] v1.0.0+
 - link:https://pypi.org/project/openshift/[OpenShift Python client] v0.11.2+


### PR DESCRIPTION
Changed the Ansible version and the link.

OCP version: 4.7+
QE contact @emmajiafan 
[Preview](https://deploy-preview-42644--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-quickstart.html)
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2002435)