### PR TITLE
Adding developer preview snippet

### DIFF
--- a/snippets/developer-preview.adoc
+++ b/snippets/developer-preview.adoc
@@ -1,0 +1,11 @@
+// DO NOT USE THIS SNIPPET. DEVELOPER PREVIEW FEATURES ARE NOT DOCUMENTED IN CORE OPENSHIFT DOCS.
+
+// When including this file, ensure that {FeatureName} is set immediately before the include. Otherwise it will result in an incorrect replacement.
+
+[IMPORTANT]
+====
+[subs="attributes+"]
+{FeatureName} is a Developer Preview feature only. Developer Preview features are not supported by Red Hat in any way and are not functionally complete or production-ready. Do not use Developer Preview features for production or business-critical workloads. Developer Preview features provide early access to upcoming product features in advance of their possible inclusion in a Red Hat product offering, enabling customers to test functionality and provide feedback during the development process. These features might not have any documentation, are subject to change or removal at any time, and testing is limited. Red Hat might provide ways to submit feedback on Developer Preview features without an associated SLA.
+====
+// Undefine {FeatureName} attribute, so that any mistakes are easily spotted
+:!FeatureName:


### PR DESCRIPTION
Telco docs team often require a Dev Preview note when delivering content, usually behind a password protected website for early access to Dev Preview feature documentation, or via privately shared early release zips. This PR provides a reusable snippet to promote consistency and reuse in Dev Preview messaging.

The intent of this PR is for the snippet to be used in early release or password protected doc deliverables. It is not intended to be used in production docs.

Example preview using the snippet: http://file.emea.redhat.com/aireilly/dev-preview-snippet/scalability_and_performance/cnf-talm-for-cluster-upgrades.html

Merge to main, CP to enterprise-4.10, enterprise-4.11, enterprise-4.12.