### PR TITLE
Round of 4.10 rel notes cleanup

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Red Hat {product-title} provides developers and IT organizations with a hybrid cloud application platform for deploying both new and existing applications on secure, scalable resources with minimal configuration and management overhead. {product-title} supports a wide selection of programming languages and frameworks, such as Java, JavaScript, Python, Ruby, and PHP.
 
-Built on {op-system-base-full} and Kubernetes, {product-title} provides a more secure and scalable multi-tenant operating system for today's enterprise-class applications, while delivering integrated application runtimes and libraries. {product-title} enables organizations to meet security, privacy, compliance, and governance requirements.
+Built on {op-system-base-full} and Kubernetes, {product-title} provides a more secure and scalable multitenant operating system for today's enterprise-class applications, while delivering integrated application runtimes and libraries. {product-title} enables organizations to meet security, privacy, compliance, and governance requirements.
 
 [id="ocp-4-10-about-this-release"]
 == About this release
@@ -79,7 +79,7 @@ This includes the ability to customize the installation to fetch Ignition config
 [id="ocp-4-10-AWS-default-components"]
 ==== New default component types for AWS installations
 
-The {product-title} 4.10 installer uses new default component types for installations on AWS. The installer uses the following components by default:
+The {product-title} 4.10 installer uses new default component types for installations on AWS. The installation program uses the following components by default:
 
 * AWS EC2 M6i instances for both control plane and compute nodes, where available
 * AWS EBS gp3 storage
@@ -119,7 +119,7 @@ For more information, see xref:../installing/installing_ibm_cloud_public/prepari
 [id="ocp-4-10-installation-and-upgrade-vsphere-provisioning"]
 ==== Thin provisioning support for VMware vSphere cluster installation
 
-{product-title} {product-version} introduces support for thin provisioned disks when you install a cluster using installer-provisioned infrastructure. You can provision disks as `thin`, `thick`, or `eagerZeroedThick`. For more information about disk provisioning modes in VMware vSphere, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installation-configuration-parameters_installing-vsphere-installer-provisioned-customizations[Installation configuration parameters].
+{product-title} {product-version} introduces support for thin-provisioned disks when you install a cluster using installer-provisioned infrastructure. You can provision disks as `thin`, `thick`, or `eagerZeroedThick`. For more information about disk provisioning modes in VMware vSphere, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installation-configuration-parameters_installing-vsphere-installer-provisioned-customizations[Installation configuration parameters].
 
 [id="ocp-4-10-installation-and-upgrade-aws-ami"]
 ==== Installing a cluster into an Amazon Web Services GovCloud region
@@ -131,7 +131,7 @@ For more information, see xref:../installing/installing_aws/installing-aws-gover
 [id="ocp-4-10-installation-and-upgrade-tagrole"]
 ==== Using a custom AWS IAM role for instance profiles
 
-Beginning with {product-title} {product-version}, if you configure a cluster with an existing IAM role, the installer no longer adds the `shared` tag to the role when deploying the cluster. This enhancement improves the installation process for organizations that want to use a custom IAM role, but whose security policies prevent the use of the `shared` tag.
+Beginning with {product-title} {product-version}, if you configure a cluster with an existing IAM role, the installation program no longer adds the `shared` tag to the role when deploying the cluster. This enhancement improves the installation process for organizations that want to use a custom IAM role, but whose security policies prevent the use of the `shared` tag.
 
 [id="ocp-4-10-installation-vsphere-csi"]
 ==== CSI driver installation on vSphere clusters
@@ -185,11 +185,11 @@ Starting with {product-title} {product-version}, the ability to create OpenShift
 * Adding perspectives and updating navigation items
 * Adding tabs and actions to resource pages
 
-For more information on the dynamic plug-in, see xref:../web_console/dynamic-plug-ins.adoc#dynamic-plug-ins_dynamic-plug-ins[Adding a dynamic plug-in to the {product-title} web console].
+For more information about the dynamic plug-in, see xref:../web_console/dynamic-plug-ins.adoc#dynamic-plug-ins_dynamic-plug-ins[Adding a dynamic plug-in to the {product-title} web console].
 
 [id="ocp-4-10-multicluster-console-technology-preview"]
-==== Multi-cluster console (Technology Preview)
-Starting with {product-title} 4.10, the multi-cluster console is now available as a Technology Preview feature. By enabling this feature, you can connect to remote clusters' API servers from a single {product-title} console.
+==== Multicluster console (Technology Preview)
+Starting with {product-title} 4.10, the multicluster console is now available as a Technology Preview feature. By enabling this feature, you can connect to remote clusters' API servers from a single {product-title} console.
 
 [id="pod-debug-mode-web-console"]
 ==== Running a pod in debug mode
@@ -206,7 +206,7 @@ With this update, you can customize workload notifications on the *User Preferen
 
 [id="improved-quota-visibility-web-console"]
 ==== Improved quota visibility
-With this update, non-admin users are now able to view their usage of the `AppliedClusterResourceQuota` on the *Project Overview*, *ResourceQuotas*, and *API Explorer* pages in order to determine the cluster-scoped quota available for use. Additionally, `AppliedClusterResourceQuota` details can now be found on the *Search* page.
+With this update, non-admin users are now able to view their usage of the `AppliedClusterResourceQuota` on the *Project Overview*, *ResourceQuotas*, and *API Explorer* pages to determine the cluster-scoped quota available for use. Additionally, `AppliedClusterResourceQuota` details can now be found on the *Search* page.
 
 [id="ocp-cluster-support-level"]
 ==== Cluster support level
@@ -377,7 +377,7 @@ The following restrictions impact {product-title} on IBM Power:
 
 Information regarding new features, enhancements, and bug fixes for security and compliance components can be found in the xref:../security/compliance_operator/compliance-operator-release-notes.adoc[Compliance Operator] and xref:../security/file_integrity_operator/file-integrity-operator-release-notes.adoc[File Integrity Operator] release notes.
 
-For more information on security and compliance, see xref:../security/index.adoc[{product-title} security and compliance].
+For more information about security and compliance, see xref:../security/index.adoc[{product-title} security and compliance].
 
 [id="ocp-4-10-networking"]
 === Networking
@@ -586,9 +586,9 @@ The following enhancements to MetalLB and the MetalLB Operator are included in t
 * Support for Bidirectional Forwarding Detection (BFD) in combination with BGP is added.
 * Support for IPv6 and dual-stack networking is added.
 * Support for specifying a node selector on the `speaker` pods is added. You can now control which nodes are used for advertising load balancer service IP addresses. This enhancement applies to layer 2 mode and BGP mode.
-* Validating web hooks are added to ensure that addresss pool and BGP peer custom resources are valid.
+* Validating web hooks are added to ensure that address pool and BGP peer custom resources are valid.
 * The `v1alpha1` API version for the `AddressPool` and `MetalLB` custom resource definitions that were introduced in the 4.9 release are deprecated. Both custom resources are updated to the `v1beta1` API version.
-* Support for speaker pod tolerations in the MetalLB custom resrouce definition is added.
+* Support for speaker pod tolerations in the MetalLB custom resource definition is added.
 
 For more information, see xref:../networking/metallb/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator].
 
@@ -658,7 +658,7 @@ For more details, see xref:../operators/operator_sdk/osdk-monitoring-prometheus.
 [id="ocp-4-10-builds"]
 === Builds
 
-* With this update, you can use CSI volumes in OpenShift Builds, which is a Technology Preview feature. This feature relies on the newly introduced Shared Resource CSI Driver and the Insights Operator to import {op-system-base} Simple Content Access (SCA) certificates. For example, by using this feature, you can run entitled builds with `SharedSecret` objects and install entitled RPM packages during builds instead of copying your {op-system-base} subscription credentials and certificates into the builds' namespaces. (link:https://issues.redhat.com/browse/BUILD-274[BUILD-274])
+* With this update, you can use CSI volumes in OpenShift Builds, which is a Technology Preview feature. This feature relies on the newly introduced Shared Resource CSI Driver and the Insights Operator to import {op-system-base} Simple Content Access (SCA) certificates. For example, by using this feature, you can run entitled builds with `SharedSecret` objects and install entitled RPM packages during builds rather than copying your {op-system-base} subscription credentials and certificates into the builds' namespaces. (link:https://issues.redhat.com/browse/BUILD-274[BUILD-274])
 +
 [IMPORTANT]
 ====
@@ -682,7 +682,7 @@ With this enhancement, the Machine Config Daemon (MCD) now checks nodes for conf
 
 Configuration drift occurs when the on-disk state of a node differs from what is configured in the machine config. The Machine Config Operator (MCO) uses the MCD to check nodes for configuration drift and, if detected, sets that node and machine config pool (MCP) to `degraded`.
 
-For more information on configuration drift, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-drift-detection_post-install-machine-configuration-tasks[Understanding configuration drift detection].
+For more information about configuration drift, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-drift-detection_post-install-machine-configuration-tasks[Understanding configuration drift detection].
 
 [id="ocp-4-10-nodes"]
 === Nodes
@@ -733,7 +733,6 @@ A Node Tuning Operator (NTO) metric is now added to Telemetry. Follow the proced
 
 The Node Feature Discovery (NFD) Topology Updater is a daemon responsible for examining allocated resources on a worker node. It accounts for resources that are available to be allocated to new pod on a per-zone basis, where a zone can be a Non-Uniform Memory Access (NUMA) node. See xref:../hardware_enablement/psap-node-feature-discovery-operator.adoc#using-the-nfd-topology-updater_node-feature-discovery-operator[Using the NFD Topology Updater] for more information.
 
-
 [id="ocp-4-10-hyperthreading-aware-CPU-manager-policy"]
 ==== Hyperthreading-aware CPU manager policy (Technology Preview)
 Hyperthreading-aware CPU manager policy in {product-title} is now available without the need for extra tuning. The cluster administrator can enable this feature if required. Hyperthreads are abstracted by the hardware as logical processors. Hyperthreading allows a single physical processor to execute two heavyweight threads (processes) at the same time, dynamically sharing processor resources.
@@ -765,7 +764,6 @@ For more information, see xref:../support/remote_health_monitoring/insights-oper
 ==== Insights Operator data collection enhancements
 
 To reduce the amount of data sent to Red Hat, Insights Operator only gathers information when certain conditions are met. For example, Insights Operator only gathers the Alertmanager logs when Alertmanager fails to send alert notifications.
-
 
 In {product-title} 4.10, the Insights Operator collects the following additional information:
 
@@ -1060,7 +1058,7 @@ With this update, the image change trigger controller continuously checks the co
 
 * Before this update, version 1.0.48 of the OpenShift Jenkins Sync Plugin introduced a `NullPointerException` error when Jenkins notified the plug-in of new jobs that were not associated with an OpenShift Jenkins Pipeline Build Strategy Build Config. Ultimately, this error was benign because there was no `BuildConfig` object to associate with the incoming Jenkins Job. Core Jenkins ignored the exception in our plug-in and moved on to the next listener. However, a long stack trace showed up in the Jenkins log that distracted users. With this update, the plug-in resolves the issue by making the proper checks to avoid this error and the subsequent stack trace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2030692[BZ#2030692])
 
-* Before this update, performance improvements in version 1.0.48 of the OpenShift Sync Jenkins plug-in incorrectly specified the labels accepted for `ConfigMap` and `ImageStream` objects intended to map into the Jenkins Kubernetes plug-in pod templates. As a result, the plug-in no longer imported pod templates from `ConfigMap` and `ImageStream` objects with a `jenkins-agent` label.
+* Before this update, performance improvements in version 1.0.48 of the OpenShift Sync Jenkins plugin incorrectly specified the labels accepted for `ConfigMap` and `ImageStream` objects intended to map into the Jenkins Kubernetes plugin pod templates. As a result, the plug-in no longer imported pod templates from `ConfigMap` and `ImageStream` objects with a `jenkins-agent` label.
 +
 This update corrects the accepted label specification so that the plug-in imports pod templates from `ConfigMap` and `ImageStream` objects that have the `jenkins-agent` label. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2034839[2034839])
 
@@ -1072,7 +1070,7 @@ This update corrects the accepted label specification so that the plug-in import
 
 * Previously, on clusters that run on {rh-openstack-first}, floating IP addresses were not reported for machine objects. As a result, certificate signing requests (CSRs) that the kubelet created were not accepted, preventing nodes from joining the cluster. All IP addresses are now reported for machine objects. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2022627[*BZ#2022627*])
 
-* Previously, the check to ensure that the AWS machine was not updated before requeueing was removed. Consequently, problems arose when the AWS machine's virtual machine had been removed, but its object was still available. In the event that this happened, the AWS machine would requeue in an infinite loop and could not be deleted or updated. This update restores the check that was used to ensure that the AWS machine was not updated before requeueing. As a result, machines no longer requeue if they have been updated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2007802[*BZ#2007802*])
+* Previously, the check to ensure that the AWS machine was not updated before requeueing was removed. Consequently, problems arose when the AWS machine's virtual machine had been removed, but its object was still available. If this happens, the AWS machine would requeue in an infinite loop and could not be deleted or updated. This update restores the check that was used to ensure that the AWS machine was not updated before requeueing. As a result, machines no longer requeue if they have been updated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2007802[*BZ#2007802*])
 
 * Previously, modifying a selector changed the list of machines that a machine set observed. As a result, leaks could occur because the machine set lost track of machines it had already created. This update ensures that the selector is immutable once created. As a result, machine sets now lists the correct machines. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2005052[*BZ#2005052*])
 
@@ -1084,9 +1082,9 @@ This update corrects the accepted label specification so that the plug-in import
 
 * Previously, egress IPs on vSphere were picked up by the vSphere cloud provider within the kubelet. These were unexpected by the certificate signing requests (CSR) approver. Consequently, nodes with egress IPs would not have their CSR renewals approved. This update allows the CSR approver to account for egress IPs. As a result, nodes with egress IPs on vSphere SDN clusters now continue to function and have valid CSR renewals. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1860774[*BZ#1860774*])
 
-* Previously, worker nodes failed to launch, and the installer failed to generate URL images due to the broken path defaulting for the disk image and incompatible changes in the Google Cloud Platform (GCP) SDK. As a result, the machine controller was unable to create machines. This fix repairs the URL images by changing the base path in the GCP SDK. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2009111[*BZ#2009111*])
+* Previously, worker nodes failed to start, and the installation program failed to generate URL images due to the broken path defaulting for the disk image and incompatible changes in the Google Cloud Platform (GCP) SDK. As a result, the machine controller was unable to create machines. This fix repairs the URL images by changing the base path in the GCP SDK. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2009111[*BZ#2009111*])
 
-* Previously, the machine would freeze during the deletion process due to a lag in the vCenter's `powerOff` task. VMware showed the machine to be powered off, but {product-title} reported it to be powered on, which resulted in the machine freezing during the deletion process. This update improves the `powerOff` task handling on vSphere to be checked before the destroy task is created, which prevents the machine from freezing during the deletion process. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2011668[*BZ#2011668*])
+* Previously, the machine would freeze during the deletion process due to a lag in the vCenter's `powerOff` task. VMware showed the machine to be powered off, but {product-title} reported it to be powered on, which resulted in the machine freezing during the deletion process. This update improves the `powerOff` task handling on vSphere to be checked before the task to delete from the database is created, which prevents the machine from freezing during the deletion process. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2011668[*BZ#2011668*])
 
 * After installing or updating {product-title}, the value of the metrics showed one pending CSR after the last CSR was reconciled. This resulted in the metrics reporting one pending CSR when there should be no pending CSRs. This fix ensures the pending CSR count is always valid post-approval by updating the metrics at the end of each reconcile loop. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2013528[*BZ#2013528*])
 
@@ -1121,7 +1119,7 @@ This update corrects the accepted label specification so that the plug-in import
 [id="ocp-4-10-cluster-version-operator-bug-fixes"]
 ==== Cluster Version Operator
 
-* Previously, a pod might fail to launch due to an invalid mount request that was not a part of the manifest. With this update, the Cluster Version Operator (CVO) removes any volumes and volume mounts from in-cluster resources that are not included in the manifest. This allows pods to launch successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2002834[*BZ#2002834*])
+* Previously, a pod might fail to start due to an invalid mount request that was not a part of the manifest. With this update, the Cluster Version Operator (CVO) removes any volumes and volume mounts from in-cluster resources that are not included in the manifest. This allows pods to start successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2002834[*BZ#2002834*])
 
 * Previously, when monitoring certificates were rotated, the Cluster Version Operator (CVO) would log errors and monitoring would be unable to query metrics until the CVO pod was manually restarted. With this update, the CVO monitors the certificate files and automatically recreates the metrics connection whenever the certificate files change. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2027342[*BZ#2027342*])
 
@@ -1181,43 +1179,43 @@ This update corrects the accepted label specification so that the plug-in import
 
 Previously, pre-flight checks did not account for {rh-openstack-first} resource utilization. As a result, those checks failed with an incorrect error message when utilization, rather than quota, impeded installation. Pre-flight checks now process both {rh-openstack} quota and utilization. The checks fail with correct error messages if the quota is sufficient but resources are not. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2001317[*BZ#2001317*])
 
-* Previously, when installing a Microsoft Azure cluster with a special size, the installer would check if the total number of virtual CPUs (vCPU) met the minimum resource requirement to deploy the cluster. Consequently, this could cause an install error. This update changes the check the installer makes from the total number of vCPUs to the number of vCPUs available. As a result, a concise error message is given that lets the Operator know that the virtual machine size does not meet the minimum resource requirements. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2025788[*BZ#2025788*])
+* Previously, when installing a Microsoft Azure cluster with a special size, the installation program would check if the total number of virtual CPUs (vCPU) met the minimum resource requirement to deploy the cluster. Consequently, this could cause an install error. This update changes the check the installation program makes from the total number of vCPUs to the number of vCPUs available. As a result, a concise error message is given that lets the Operator know that the virtual machine size does not meet the minimum resource requirements. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2025788[*BZ#2025788*])
 
 * Previously, RAM validation for {rh-openstack-first} checked for values using a wrong unit, and as a result the validation accepted flavors that did not meet minimum RAM requirements. With this fix, RAM validation now rejects flavors with insufficient RAM. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2009699[*BZ#2009699*])
 
 * Previously, {product-title} master nodes were missing Ingress security group rules when they were schedulable and deployed on {rh-openstack}. As a result, {product-title} deployments on {rh-openstack} failed for compact clusters with no dedicated workers. This fix adds Ingress security group rules on {rh-openstack-first} when masters are schedulable. Now, you can deploy compact three-node clusters on {rh-openstack}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1955544[*BZ#1955544*])
 
-* Previously, if you specified an invalid AWS region, the installation program continued to try and validate availability zones. This caused the installer to become unresponsive for 60 minutes before timing out. The installer now verifies the AWS region and service endpoints before availability zones, which reduces the amount of time the installer takes to report the error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2019977[*BZ#2019977*])
+* Previously, if you specified an invalid AWS region, the installation program continued to try and validate availability zones. This caused the installation program to become unresponsive for 60 minutes before timing out. The installation program now verifies the AWS region and service endpoints before availability zones, which reduces the amount of time the installer takes to report the error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2019977[*BZ#2019977*])
 
-* Previously, you could not install a cluster to VMware vSphere if the vCenter host name began with a number. The installer has been updated and no longer treats this type of host name as invalid. Now, a cluster deploys successfully when the vCenter host name begins with a number.
+* Previously, you could not install a cluster to VMware vSphere if the vCenter host name began with a number. The installation program has been updated and no longer treats this type of host name as invalid. Now, a cluster deploys successfully when the vCenter host name begins with a number.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2021607[*BZ#2021607*])
 
-* Previously, if you specified a custom disk instance type when deploying a cluster on Microsoft Azure, the cluster might not deploy. This occurred because the installer incorrectly determined that the minimum resource requirements had been met. The installer has been updated, and now reports an error when the number of vcpus available for the instance type in the selected region does not meet the minimum resource requirements. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2025788[*BZ#2025788*])
+* Previously, if you specified a custom disk instance type when deploying a cluster on Microsoft Azure, the cluster might not deploy. This occurred because the installation program incorrectly determined that the minimum resource requirements had been met. The installation program has been updated, and now reports an error when the number of vcpus available for the instance type in the selected region does not meet the minimum resource requirements. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2025788[*BZ#2025788*])
 
-* Previously, if you defined custom IAM roles when deploying an AWS cluster, you might have to manually remove bootstrap instance profiles after uninstalling the cluster. Intermittently, the installer did not remove bootstrap instance profiles. The installer has been updated, and all machine instance profiles are removed when the cluster is uninstalled.
+* Previously, if you defined custom IAM roles when deploying an AWS cluster, you might have to manually remove bootstrap instance profiles after uninstalling the cluster. Intermittently, the installer did not remove bootstrap instance profiles. The installation program has been updated, and all machine instance profiles are removed when the cluster is uninstalled.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2028695[*BZ#2028695*])
 
-* Previously, the default provisioningIP value was different when the host bits were set in the provisioning network CIDR. This resulted in a different value for the provisioningIP than expected. This difference caused a conflict with the other IP addresses on the provisioning network. This fix adds a validation to ensure that the ProvisioningNetworkCIDR does not have host bits set. As a result, if the ProvisioningNetworkCIDR has the host bits set, the installer will stop and report the validation error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2006291[*BZ#2006291*])
+* Previously, the default provisioningIP value was different when the host bits were set in the provisioning network CIDR. This resulted in a different value for the provisioningIP than expected. This difference caused a conflict with the other IP addresses on the provisioning network. This fix adds a validation to ensure that the ProvisioningNetworkCIDR does not have host bits set. As a result, if the ProvisioningNetworkCIDR has the host bits set, the installation program will stop and report the validation error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2006291[*BZ#2006291*])
 
 * Previously, the BMC driver IPMI was not supported for a secure UEFI boot. This resulted in an unsuccessful boot. This fix adds a validation check to ensure that `UEFISecureBoot` mode is not used with bare-metal drivers. As a result, a secure UEFI boot is successful. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2011893[*BZ#2011893*])
 
-* With this update, the 4.8 UPI template is updated from version 3.1.0 to 3.2.0 in order to match the Ignition version. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1949672[*BZ#1949672*])
+* With this update, the 4.8 UPI template is updated from version 3.1.0 to 3.2.0 to match the Ignition version. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1949672[*BZ#1949672*])
 
-* Previously, when asked to mirror the contents of the base registry, the {product-title} installer would exit with a validation error, citing incorrect `install-config` file values for `imageContentSources`. With this update, the installer now allows `imageContentSources` values to specify base registry names and the installer no longer exits when specifying a base registry name. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1960378[*BZ#1960378*])
+* Previously, when asked to mirror the contents of the base registry, the {product-title} installation program would exit with a validation error, citing incorrect `install-config` file values for `imageContentSources`. With this update, the installation program now allows `imageContentSources` values to specify base registry names and the installation program no longer exits when specifying a base registry name. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1960378[*BZ#1960378*])
 
 * Previously, the UPI ARM templates were attaching an SSH key to the virtual machine (VM) instances created. As a result, the creation of the VMs fails when the SSH key provided by the user is the `ed25519` type. With this update, the creation of the VMs succeeds regardless of the type of the SSH key provided by the user. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1968364[*BZ#1968364*])
 
 * After successfully creating a `aws_vpc_dhcp_options_association` resource, AWS might still report that the resource does not exist. Consequently, the AWS Terraform provider fails the installation. With this update, you can retry the query of the `aws_vpc_dhcp_options_association` resource for a period of time after creation until AWS reports that the resource exists. As a result, installations succeed despite AWS reporting that the `aws_vpc_dhcp_options_association` resource does not exist. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2032521[*BZ#2032521*])
 
-* Previously, when installing {product-title} on AWS with local zones enabled, the installer could create some resources on a local zone instead of an availability zone. This caused the installer to fail because load balancers cannot run on local zones. With this fix, the installer ignores local zones and only considers availability zones when installing cluster components. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1997059[*BZ#1997059*])
+* Previously, when installing {product-title} on AWS with local zones enabled, the installation program could create some resources on a local zone rather than an availability zone. This caused the installation program to fail because load balancers cannot run on local zones. With this fix, the installation program ignores local zones and only considers availability zones when installing cluster components. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1997059[*BZ#1997059*])
 
 * Previously, terraform could attempt to upload the bootstrap ignition configuration file to Azure before it had finished creating the configuration file. If the upload started before the local file was created, the installation would fail. With this fix, terraform uploads the ignition configuration file directly to Azure rather than creating a local copy first. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2004313[*BZ#2004313*])
 
-* Previously, a race condition could occur if the `cluster-bootstrap` and Cluster Version Operator components attempted to write a manifest for the same resource to the Kubernetes API at the same time. This could result in the `Authentication` resource being overwritten by a default copy, which removed any customizations made to that resource. With this fix, the Cluster Version Operator has been blocked from overwriting the manifests that come from the installer. This prevents any user-specified customizations to the `Authentication` resource from being overwritten. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2008119[*BZ#2008119*])
+* Previously, a race condition could occur if the `cluster-bootstrap` and Cluster Version Operator components attempted to write a manifest for the same resource to the Kubernetes API at the same time. This could result in the `Authentication` resource being overwritten by a default copy, which removed any customizations made to that resource. With this fix, the Cluster Version Operator has been blocked from overwriting the manifests that come from the installation program. This prevents any user-specified customizations to the `Authentication` resource from being overwritten. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2008119[*BZ#2008119*])
 
-* Previously, when installing {product-title} on AWS, the installer created the bootstrap machine using the `m5.large` instance type. This caused the installation to fail in regions where that instance type is not available. With this fix, the bootstrap machine uses the same instance type as the control plane machines. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2016955[*BZ#2016955*])
+* Previously, when installing {product-title} on AWS, the installation program created the bootstrap machine using the `m5.large` instance type. This caused the installation to fail in regions where that instance type is not available. With this fix, the bootstrap machine uses the same instance type as the control plane machines. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2016955[*BZ#2016955*])
 
-* Previously, when installing {product-title} on AWS, the installer did not recognize EC2 G and VT instances and defaulted them to X instances. This caused incorrect instance quotas to be applied to these instances. With this fix, the installer recognizes EC2 G and VT instances and applies the correct instance quotas. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2017874[*BZ#2017874*])
+* Previously, when installing {product-title} on AWS, the installation program did not recognize EC2 G and VT instances and defaulted them to X instances. This caused incorrect instance quotas to be applied to these instances. With this fix, the installation program recognizes EC2 G and VT instances and applies the correct instance quotas. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2017874[*BZ#2017874*])
 
 [discrete]
 [id="ocp-4-10-kube-api-server-bug-fixes"]
@@ -1299,13 +1297,13 @@ Previously, pre-flight checks did not account for {rh-openstack-first} resource 
 
 * Previously, `oc debug` assumed that it was always targeting Linux-based containers by trying to run a Bash shell, and if Bash was not present in the container, it attempted to debug as a Windows container. The `oc debug` command now uses pod selectors to determine the operating system of the containers and now works properly on both Linux and Windows-based containers. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1990014[*BZ#1990014*])
 
-* Previously, the `--dry-run` flag was not working properly for several `oc set` subcommands, so `--dry-run=server` was performing updates to resources instead of performing a dry run. The `--dry-run` flags are now working properly to perform dry runs on the `oc set` subcommands. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2035393[*BZ#2035393*])
+* Previously, the `--dry-run` flag was not working properly for several `oc set` subcommands, so `--dry-run=server` was performing updates to resources rather than performing a dry run. The `--dry-run` flags are now working properly to perform dry runs on the `oc set` subcommands. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2035393[*BZ#2035393*])
 
 [discrete]
 [id="ocp-4-10-container-bug-fixes"]
 ==== OpenShift containers
 
-* Previously, a container using SELinux could not read `/var/log/containers` log files due to a missing policy. This update makes all log files in `/var/log` accessible including those accessed via symlink. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2005997[*BZ#2005997*])
+* Previously, a container using SELinux could not read `/var/log/containers` log files due to a missing policy. This update makes all log files in `/var/log` accessible including those accessed through symlink. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2005997[*BZ#2005997*])
 
 [discrete]
 [id="ocp-4-10-openshift-controller-manage-bug-fixes"]
@@ -1347,9 +1345,9 @@ Previously, pre-flight checks did not account for {rh-openstack-first} resource 
 [id="ocp-4-10-rhcos-bug-fixes"]
 ==== {op-system-first}
 
-* Previously, when the {op-system} live ISO added a UEFI boot entry for itself, it assumed the existing UEFI boot entry IDs were consecutive, thereby causing the live ISO to crash in the UEFI firmware when booting on systems with non-consecutive boot entry IDS. With this fix, the {op-system} live ISO no longer adds a UEFI boot entry for itself and the ISO boots successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2006690[*BZ#2006690*])
+* Previously, when the {op-system} live ISO added a UEFI boot entry for itself, it assumed the existing UEFI boot entry IDs were consecutive, thereby causing the live ISO to fail in the UEFI firmware when booting on systems with non-consecutive boot entry IDS. With this fix, the {op-system} live ISO no longer adds a UEFI boot entry for itself and the ISO boots successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2006690[*BZ#2006690*])
 
-* To help you determine whether a user-provided image was already booted, information has been added on the terminal console describing when the machine was provisioned via Ignition and whether a user Ignition config was provided. This allows you to verify that Ignition ran when you expected it to. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2016004[*BZ#2016004*])
+* To help you determine whether a user-provided image was already booted, information has been added on the terminal console describing when the machine was provisioned through Ignition and whether a user Ignition configuration was provided. This allows you to verify that Ignition ran when you expected it to. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2016004[*BZ#2016004*])
 
 * Previously, when reusing an existing statically keyed LUKS volume during provisioning, the encryption key was not correctly written to disk and Ignition would fail with a "missing persisted keyfile" error. With this fix, Ignition now correctly writes keys for reused LUKS volumes so that existing statically keyed LUKS volumes can be reused during provisioning. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2043296[*BZ#2043296*])
 
@@ -1357,7 +1355,7 @@ Previously, pre-flight checks did not account for {rh-openstack-first} resource 
 
 * Previously, `initramfs` files were missing udev rules for by-id symlinks of attached SCSI devices. Because of this, Ignition configuration files that referenced these symlinks would result in a failed boot of the installed system. With this update, the `63-scsi-sg3_symlink.rules` for SCSI rules are added in dracut. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1990506[*BZ#1990506*])
 
-* Previously, on bare-metal machines, a race condition occurred between `system-rfkill.service` and `ostree-remount.service`. Consequently, the `ostree-remount` service failed and the node OS froze during the boot process. With this update, the `/sysroot/` directory is now read-only. As a result, the issue no longer occurs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1992618[*BZ#1992618*])
+* Previously, on bare-metal machines, a race condition occurred between `system-rfkill.service` and `ostree-remount.service`. Consequently, the `ostree-remount` service failed and the node operating system froze during the boot process. With this update, the `/sysroot/` directory is now read-only. As a result, the issue no longer occurs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1992618[*BZ#1992618*])
 
 * Previously, {op-system-first} live ISO boots added a UEFI boot entry, prompting a reboot on systems with a TPM. With this update, the {op-system} live ISO no longer adds a UEFI boot entry so the ISO does not initiate a reboot after first boot. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2004449[*BZ#2004449*])
 
@@ -1369,7 +1367,7 @@ Previously, pre-flight checks did not account for {rh-openstack-first} resource 
 
 * Previously, a route created where the combined name and namespace for the DNS segment was greater than 63 characters long would be rejected. This expected behavior could cause problems integrating with upgraded versions of {product-title}. Now, an annotation allows non-conformant DNS hostnames. With `AllowNonDNSCompliantHostAnnotation` set to `true`, the non-conformant DNS hostname, or one longer than 63 characters, is allowed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1964112[*BZ#1964112*])
 
-* Prevoiusly, the Cluster Ingress Operator would not create wildcard DNS records for Ingress Controllers when the cluster's `ControlPlaneTopology` was set to `External`. In Hypershift clusters where the `ControlPlaneTopology` was set to `External` and the Platform was AWS, the Cluster Ingress Operator never became available. This updates limits the disabling of DNS updates when the `ControlPlaneTopology` is `External` and the platform is IBM Cloud. As a result, wildcard DNS entries are created for Hypershift clusters running on AWS. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2011972[*BZ#2011972*])
+* Previously, the Cluster Ingress Operator would not create wildcard DNS records for Ingress Controllers when the cluster's `ControlPlaneTopology` was set to `External`. In Hypershift clusters where the `ControlPlaneTopology` was set to `External` and the Platform was AWS, the Cluster Ingress Operator never became available. This updates limits the disabling of DNS updates when the `ControlPlaneTopology` is `External` and the platform is IBM Cloud. As a result, wildcard DNS entries are created for Hypershift clusters running on AWS. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2011972[*BZ#2011972*])
 
 * Previously, the cluster ingress router was blocked from working because the Ingress Operator failed to configure a wildcard DNS record for the cluster ingress router on Azure Stack Hub IPI. With this fix, the Ingress Operator now uses the configured ARM endpoint to configure DNS on Azure Stack Hub IPI. As a result, the cluster ingress router now works properly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2032566[*BZ#2032566*])
 
@@ -1385,7 +1383,7 @@ Previously, pre-flight checks did not account for {rh-openstack-first} resource 
 
 * Before this update, various allowed and blocked registry configuration options in the cluster image configuration might prevent the Cluster Samples Operator from creating image streams. As a result, the samples operator might mark itself as degraded, which impacted the general {product-title} install and upgrade status.
 +
-In various circumstances, the management state of the Cluster Samples Operator can transition to `Removed`. With this update, these circumstances now include when the image controller configuration parameters prevent the creation of image streams by using either the default image registry or the image registry specified by the `samplesRegistry` setting. The Operator status now also indicates that the cluster image configuration is preventing the creation of the sample image streams. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2002368[BZ#2002368])
+In various circumstances, the management state of the Cluster Samples Operator can make the transition to `Removed`. With this update, these circumstances now include when the image controller configuration parameters prevent the creation of image streams by using either the default image registry or the image registry specified by the `samplesRegistry` setting. The Operator status now also indicates that the cluster image configuration is preventing the creation of the sample image streams. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2002368[BZ#2002368])
 
 
 [discrete]
@@ -1394,7 +1392,7 @@ In various circumstances, the management state of the Cluster Samples Operator c
 
 * Previously, the Local Storage Operator (LSO) took a long time to delete orphaned persistent volumes (PVs) due to the accumulation of a 10-second delay. With this update, the LSO does not use the 10-second delay, PVs are deleted promptly, and local disks are made available for new persistent volume claims sooner. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2001605[*BZ#2001605*])
 
-* Previously, Manila error handling would degrade the Manila Operator, and the cluster. Errors are now treated as non-fatal so that the Manila Operator is disabled, instead of degrading the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2001620[*BZ#2001620*])
+* Previously, Manila error handling would degrade the Manila Operator, and the cluster. Errors are now treated as non-fatal so that the Manila Operator is disabled, rather than degrading the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2001620[*BZ#2001620*])
 
 * In slower cloud environments, such as when using Cinder, the cluster might become degraded. Now, {product-title} accommodates slower environments so that the cluster does not become degraded. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2027685[*BZ#2027685*])
 
@@ -1412,11 +1410,11 @@ In various circumstances, the management state of the Cluster Samples Operator c
 
 * Before this update, the web terminal icon was available in the web console's banner head only if you installed the Web Terminal Operator in the `openShift-operators` namespace. With this update, the terminal icon is available regardless of the namespace where you install the Web Terminal Operator. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2006329[2006329])
 
-* Before this update, the service binding connector did not appear in topology if you used a `resource` property instead of a `kind` property to define a `ServiceBinding` custom resource (CR). This update resolves the issue by reading the CR's `resource` property to display the connector on the topology. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2013545[BZ#2013545])
+* Before this update, the service binding connector did not appear in topology if you used a `resource` property rather than a `kind` property to define a `ServiceBinding` custom resource (CR). This update resolves the issue by reading the CR's `resource` property to display the connector on the topology. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2013545[BZ#2013545])
 
 * Before this update, the name input fields used a complex and recursive regular expression to validate user inputs. This regular expression made name detection very slow and often caused errors. This update resolves the issue by optimizing the regular expression and avoiding recursive matching. Now, name detection is fast and does not cause errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2014497[BZ#2014497])
 
-* Before this update, feature flag gating was missing from some extensions contributed by the knative plugin. Although this issue did not affect what was displayed, these extensions ran unnecessarily, even if the serverless operator was not installed. This update resolves the issue by adding feature flag gating to the extensions where it was missing. Now, the extensions do not run unnecessarily. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2016438[BZ#2016438])
+* Before this update, feature flag gating was missing from some extensions contributed by the knative plug-in. Although this issue did not affect what was displayed, these extensions ran unnecessarily, even if the serverless operator was not installed. This update resolves the issue by adding feature flag gating to the extensions where it was missing. Now, the extensions do not run unnecessarily. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2016438[BZ#2016438])
 
 * Before this update, if you repeatedly clicked links to get details for resources such as custom resource definitions or pods and the application encountered multiple code reference errors, it crashed and displayed a `t is not a function` error. This update resolves the issue. When an error occurs, the application resolves a code reference and stores the resolution state so that it can correctly handle additional errors. The application no longer crashes when code reference errors occur. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2017130[BZ#2017130])
 
@@ -1700,7 +1698,7 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 
-|Multi-cluster console
+|Multicluster console
 |-
 |-
 |TP
@@ -1762,7 +1760,7 @@ This script removes unauthenticated subjects from the following cluster role bin
 
 * This release contains a known issue with Jenkins. If you customize the hostname and certificate of the OpenShift OAuth route, Jenkins no longer trusts the OAuth server endpoint. As a result, users cannot log in to the Jenkins console if they rely on the OpenShift OAuth integration to manage identity and access.
 +
-Workaround: See the Red Hat Knowledgebase solution, link:https://access.redhat.com/solutions/6470721[Deploy Jenkins on OpenShift with Custom OAuth Server URL]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1991448[*BZ#1991448*])
+Workaround: See the Red Hat Knowledge base solution, link:https://access.redhat.com/solutions/6470721[Deploy Jenkins on OpenShift with Custom OAuth Server URL]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1991448[*BZ#1991448*])
 
 * This release contains a known issue with Jenkins. The `xmlstarlet` command line toolkit, which is required to validate or query XML files, is missing from this {op-system-base}-based image. This issue impacts deployments that do not use OpenShift OAuth for authentication. Although OpenShift OAuth is enabled by default, users can disable it.
 +
@@ -1784,7 +1782,7 @@ Workaround: Use OpenShift OAuth for authentication. (link:https://bugzilla.redha
 
 Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
 
-Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified via email whenever new errata relevant to their registered systems are released.
+Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified through email whenever new errata relevant to their registered systems are released.
 
 [NOTE]
 ====


### PR DESCRIPTION
Cleaning up 4.10 release notes/last minute edits.

- applies to `enterprise-4.10` only
- [Preview link](https://deploy-preview-42646--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html)