### PR TITLE
MULTIARCH-696 - NMState Operator - Add IBM P/Z to supported platforms

### DIFF
--- a/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -10,7 +10,7 @@ The Kubernetes NMState Operator provides a Kubernetes API for performing state-d
 
 [IMPORTANT]
 ====
-Red Hat supports the Kubernetes NMState Operator in production environments on bare metal platform installations only. For other platforms, the Kubernetes NMState Operator is a Technology Preview. See the following Technology Preview statement for support limitations when using Kubernetes NMState on platforms other than bare metal.
+Red Hat supports the Kubernetes NMState Operator in production environments on bare-metal, IBM Power, IBM Z, and LinuxONE installations only. For other platforms, the Kubernetes NMState Operator is a Technology Preview. See the following Technology Preview statement for support limitations when using Kubernetes NMState on platforms other than bare metal, IBM Power, IBM Z, and LinuxONE.
 ====
 
 include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
OCP version:   enterprise-4.10 and later

Jira epic: https://issues.redhat.com/browse/MULTIARCH-696
See discussion: https://github.com/openshift/openshift-docs/pull/42539#discussion_r816994534
Related PR for RNs: https://github.com/openshift/openshift-docs/pull/42666

Preview: [About the Kubernetes NMSTATE Operator](https://deploy-preview-42647--osdocs.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html)

QE review

-  IBM Z: Holger Wolf
-  IBM Power: Manoj Kumar
