### PR TITLE
BZ-2059759: Removing three NICs from SR-IOV

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -391,7 +391,6 @@ Single node clusters support SR-IOV hardware and the SR-IOV Network Operator. Be
 {product-title} {product-version} adds support for additional Broadcom and Intel hardware.
 
 * Broadcom BCM57414 and BCM57508
-* Intel E810-CQDA2, E810-XXVDA2, and E810-XXVDA4
 
 For more information, see the xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[supported devices].
 


### PR DESCRIPTION
4.9 only.
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=2059759
Based on https://github.com/openshift/openshift-docs/pull/39606/files we need to remove the three NICs from the supported hardware section in the release notes. 
QE ack required: @wsun1 
Eng/PM/Product Experience: @sferich888 or @reestr 
Docs: @sjstout 
Preview Link: https://deploy-preview-42652--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-supported-hardware-sriov
