### PR TITLE
BZ2037717: Adds clarification about complianceType value

### DIFF
--- a/modules/ztp-the-policygentemplate.adoc
+++ b/modules/ztp-the-policygentemplate.adoc
@@ -71,7 +71,7 @@ spec:
                     include:
                         - '*'
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: musthave <1>
                       objectDefinition:
                         apiVersion: ptp.openshift.io/v1
                         kind: PtpConfig
@@ -100,3 +100,4 @@ spec:
                                     domainNumber 24
                                     .....
 ----
+<1> Displays the value of the `complianceType` field. The default value is `musthave` which indicates that an object must exist with the same `name` as specified in `object-templates`. To find the exact matches to roles and objects, set the value to `mustonlyhave`. For more information about the accepted values, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.4/html-single/governance/index#configuration-policy-yaml-table[Configuration policy YAML table].


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2037717

For release(s): 4.10

Preview: https://deploy-preview-42655--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-the-policygentemplate_ztp-deploying-disconnected