### PR TITLE
Remove #TODO note from output.

### DIFF
--- a/distr_tracing/distr_tracing_arch/distr-tracing-architecture.adoc
+++ b/distr_tracing/distr_tracing_arch/distr-tracing-architecture.adoc
@@ -24,6 +24,3 @@ include::modules/distr-tracing-product-overview.adoc[leveloffset=+1]
 include::modules/distr-tracing-features.adoc[leveloffset=+1]
 
 include::modules/distr-tracing-architecture.adoc[leveloffset=+1]
-
-#TODO
-#WRITE more detailed component docs


### PR DESCRIPTION
Someone must have done a scripted replace because I do not use hash marks to comment out notes to myself.  