### PR TITLE
MULTIARCH-696: Release Notes -  Add IBM P/Z k8s NMState supported platforms

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -567,9 +567,9 @@ Intel 800-Series Columbiaville NICs are now fully supported for interfaces confi
 For more information, see xref:../networking/using-ptp.adoc#configuring-ptp-devices[Configuring PTP devices].
 
 [id="ocp-4-10-networking-k8s-nmstate-operator"]
-==== Kubernetes NMState Operator is GA for bare-metal installations
+==== Kubernetes NMState Operator is GA for bare-metal, IBM Power, IBM Z, and LinuxONE installations
 
-{product-title} now provides the Kubernetes NMState Operator for bare-metal installations. The Kubernetes NMState Operator is still a Technology Preview for all other platforms. See xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc[About the Kubernetes NMState Operator] for additional details.
+{product-title} now provides the Kubernetes NMState Operator for bare-metal, IBM Power, IBM Z, and LinuxONE installations. The Kubernetes NMState Operator is still a Technology Preview for all other platforms. See xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc[About the Kubernetes NMState Operator] for additional details.
 
 
 [id="ocp-4-10-hardware"]


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.10

Jira epic: https://issues.redhat.com/browse/MULTIARCH-696

Related PR: https://github.com/openshift/openshift-docs/pull/42647

Preview: 

QE review

- IBM Z: Holger Wolf
- IBM Power: Luvella McFadden