### PR TITLE
[TELCODOCS-323] Put back ZTP 4.10 PTP procedure

### DIFF
--- a/scalability_and_performance/ztp-deploying-disconnected.adoc
+++ b/scalability_and_performance/ztp-deploying-disconnected.adoc
@@ -104,6 +104,19 @@ include::modules/ztp-precision-time-protocol-operator.adoc[leveloffset=+2]
 
 * For more information about using PTP hardware in your cluster nodes, see xref:../networking/using-ptp.adoc#using-ptp[Using PTP hardware].
 
+include::modules/ztp-configuring-ptp-fast-events.adoc[leveloffset=+2]
+
+[NOTE]
+====
+When changes are pushed to a site configuration repository, GitOps ZTP applies the CRs sequentially according to the `ran.openshift.io/ztp-deploy-wave` annotation. When two or more policies have the same `ran.openshift.io/ztp-deploy-wave` annotation, an alphanumeric sort order is used. For more information, see xref:../scalability_and_performance/ztp-deploying-disconnected.adoc#ztp-applying-the-ran-policies-for-monitoring-cluster-activity_ztp-deploying-disconnected[Applying RAN policies].
+====
+
+.Additional resources
+
+* For a complete `PtpConfig` CR that configures `linuxptp` as an ordinary clock, see xref:../networking/using-ptp.adoc#cnf-configuring-cvl-nic-as-ptp-slave_using-ptp[Configuring linuxptp services as an ordinary clock for Intel Columbiaville NIC].
+
+* For further information about configuring PTP fast event notifications, see xref:../networking/using-ptp.adoc#cnf-configuring-the-ptp-fast-event-publisher_using-ptp[Configuring PTP fast events].
+
 include::modules/ztp-creating-ztp-custom-resources-for-multiple-managed-clusters.adoc[leveloffset=+1]
 
 include::modules/ztp-prerequisites-for-deploying-the-ztp-pipeline.adoc[leveloffset=+2]


### PR DESCRIPTION
Documents the ZTP > PTP procedure that was not delivered on time for 4.10 as part of https://issues.redhat.com/browse/TELCODOCS-323

Merge when https://bugzilla.redhat.com/show_bug.cgi?id=2054385  is closed.