### PR TITLE
OCP on Arm release notes - updated

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -94,9 +94,7 @@ The following features are supported for {product-title} on ARM:
 * OpenShift Cluster Monitoring
 * RHEL 8 Application Streams
 * OVNKube
-* OpenShift Logging
 * Elastic Block Store (EBS) for AWS
-* AWS Certificate Manager (ACM)
 * AWS .NET applications
 * NFS storage on bare metal
 


### PR DESCRIPTION
Description: The OCP on ARM release notes are already merged in this PR (https://github.com/openshift/openshift-docs/pull/41301), but development wanted to remove two of the features since the delivery dates don't alight with the regular 4.10 GA.

No QE required.

Preview: https://deploy-preview-42668--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-installation-and-upgrade