### PR TITLE
GH#42560: Removed incorrect example output code block

### DIFF
--- a/modules/virt-creating-interface-on-nodes.adoc
+++ b/modules/virt-creating-interface-on-nodes.adoc
@@ -62,18 +62,6 @@ spec:
 +
 [source,terminal]
 ----
-$ oc apply -f br1-eth1_policy.yaml <1>
+$ oc apply -f br1-eth1-policy.yaml <1>
 ----
 <1> File name of the node network configuration policy manifest.
-+
-.Example output
-[source,terminal]
-----
-NAME                     STATUS
-node01.br1-eth1-policy   Pending
-node02.br1-eth1-policy   Progressing
-node03.br1-eth1-policy   Available
-node04.br1-eth1-policy   Progressing
-node05.br1-eth1-policy   Progressing
-node06.br1-eth1-policy   Pending
-----


### PR DESCRIPTION
Fixes #42560 

Deleted the `Example output` code block in the `Creating an interface on nodes` module as it is not the output of the `oc apply` command. 

Preview: https://deploy-preview-42674--osdocs.netlify.app/openshift-enterprise/latest/virt/node_network/virt-updating-node-network-config.html#virt-creating-interface-on-nodes_virt-updating-node-network-config