### PR TITLE
OSDOCS-2329: Rel Notes for GCP Workload Identity

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1111,6 +1111,13 @@ Previously, `oc` commands that used the registry configuration, for example `oc 
 
 Users also have the option to use the `REGISTRY_AUTH_FILE` environment variable, which serves as an alternative to the existing `--registry-config` CLI flag. The `REGISTRY_AUTH_FILE` environment variable is also compatible with `podman`.
 
+[id="ocp-4-10-auth-gcp-workload-identity"]
+==== Support for Google Cloud Platform Workload Identity
+
+You can now use the Cloud Credential Operator (CCO) utility `ccoctl` to configure the CCO to use the Google Cloud Platform Workload Identity. When the CCO is configured to use GCP Workload Identity, the in-cluster components can impersonate IAM service accounts using short-term, limited-privilege security credentials to components.
+
+//For more information, see xr/ef:../authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc#cco-mode-gcp-workload-identity[Using manual mode with GCP Workload Identity].
+
 [id="ocp-4-10-notable-technical-changes"]
 == Notable technical changes
 


### PR DESCRIPTION
Rel notes for [OSDOCS-2329](https://issues.redhat.com/browse/OSDOCS-2329)

Preview: https://deploy-preview-42685--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-auth-gcp-workload-identity