### PR TITLE
OSDOCS-3233: Rel Note for Azure minting removal

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1302,6 +1302,11 @@ In the table, features are marked with the following statuses:
 |DEP
 |DEP
 
+|Minting credentials for Microsoft Azure clusters
+|GA
+|GA
+|REM
+
 |Persistent storage using FlexVolume
 |
 |
@@ -1390,6 +1395,51 @@ With this release, you can no longer access third-party web user interfaces (UIs
 
 Instead, you can navigate to the *Observe* section of the {product-title} web console to access metrics, alerting, and metrics targets UIs for platform components.
 
+[id="ocp-4-10-removed-feature-azure-mint-mode"]
+==== Support for minting credentials for Microsoft Azure removed
+
+Support for using the Cloud Credential Operator (CCO) in mint mode on Microsoft Azure clusters has been removed. This change is due to the planned link:https://azure.microsoft.com/en-us/updates/update-your-apps-to-use-microsoft-graph-before-30-june-2022/[retirement of the Azure AD Graph API by Microsoft on 30 June 2022] and is being backported to all supported versions of {product-title} in z-stream updates.
+
+For previously installed Azure clusters that use mint mode, the CCO attempts to update existing secrets. If a secret contains the credentials of previously minted app registration service principals, it is updated with the contents of the secret in `kube-system/azure-credentials`. This behavior is similar to passthrough mode.
+
+[NOTE]
+====
+In addition to the `Contributor` role that is required by mint mode, the modified app registration service principals now require the `User Access Administrator` role that is used for passthrough mode.
+====
+
+While the Azure AD Graph API is still available, the CCO in upgraded versions of {product-title} attempts to clean up previously minted app registration service principals. Upgrading your cluster before the Azure AD Graph API is retired might avoid the need to clean up resources manually.
+
+If the cluster is upgraded to a version of {product-title} that no longer supports mint mode after the Azure AD Graph API is retired, the CCO sets an `OrphanedCloudResource` condition on the associated `CredentialsRequest` but does not treat the error as fatal. The condition includes a message similar to `unable to clean up App Registration / Service Principal: <app_registration_name>`. Cleanup after the Azure AD Graph API is retired requires manual intervention using the Azure CLI tool or the Azure web console to remove any remaining app registration service principals.
+
+To clean up resources manually, you must find and delete the affected resources.
+
+. Using the Azure CLI tool, filter the app registration service principals that use the `<app_registration_name>` from an `OrphanedCloudResource` condition message by running the following command:
++
+[source,terminal]
+----
+$ az ad app list --filter "displayname eq '<app_registration_name>'" --query '[].objectId'
+----
++
+.Example output
++
+[source,terminal]
+----
+[
+  "038c2538-7c40-49f5-abe5-f59c59c29244"
+]
+----
+
+. Delete the app registration service principal by running the following command:
++
+[source,terminal]
+----
+$ az ad app delete --id 038c2538-7c40-49f5-abe5-f59c59c29244
+----
+
+[NOTE]
+====
+After cleaning up resources manually, the `OrphanedCloudResource` condition persists because the CCO cannot verify that the resources were cleaned up.
+====
 
 [id="ocp-4-10-bug-fixes"]
 == Bug fixes
@@ -2269,6 +2319,8 @@ In the table below, features are marked with the following statuses:
 |-
 |-
 |GA
+
+|====
 
 [id="ocp-4-10-known-issues"]
 == Known issues


### PR DESCRIPTION
For [OSDOCS-3233](https://issues.redhat.com/browse/OSDOCS-3233) (rel note update for [OSDOCS-3132](https://issues.redhat.com/browse/OSDOCS-3132))

Preview:
- [Table](https://deploy-preview-42692--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-deprecated-removed-features)
- [Description](https://deploy-preview-42692--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-removed-feature-azure-mint-mode)