### PR TITLE
TELCODOCS 243: Release Notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -590,6 +590,17 @@ The following enhancements to MetalLB and the MetalLB Operator are included in t
 
 For more information, see xref:../networking/metallb/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator].
 
+[id="ocp-4-10-host-firmware-settings"]
+==== Support for modifying host firmware settings
+
+{product-title} supports the `HostFirmwareSettings` and `FirmwareSchema` resources. When deploying OpenShift Container Platform on bare metal hosts, there are times when you need to make changes to the host either before or after provisioning. This can include inspecting the host's firmware and BIOS details. There are two new resources that you can use with the Bare Metal Operator (BMO):
+
+* `HostFirmwareSettings`: You can use the `HostFirmwareSettings` resource to retrieve and manage the BIOS settings for a host. The resource contains the complete BIOS configuration returned from the baseboard management controller (BMC). Whereas, the firmware field in the `BareMetalHost` resource returns three vendor-independent fields, the `HostFirmwareSettings` resource typically comprises many BIOS settings of vendor-specific fields per host model.
+
+* `FirmwareSchema`: You can use the `FirmwareSchema` to identify the host's modifiable BIOS values and limits when making changes to host firmware settings.
+
+See xref:../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration] for additional details.
+
 [id="ocp-4-10-storage"]
 === Storage
 


### PR DESCRIPTION
Release notes for [TELCODOCS-243](https://issues.redhat.com/browse/TELCODOCS-243), for 4.10.

Fixes: [TELCODOCS-243](https://issues.redhat.com/browse/TELCODOCS-243)

Preview URL: https://deploy-preview-42695--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/bare-metal-configuration.html#post-install-bare-metal-configuration

Signed-off-by: John Wilkins <jowilkin@redhat.com>