### PR TITLE
OSDOCS-3032: Removed a customer support line

### DIFF
--- a/modules/understanding-admin-roles.adoc
+++ b/modules/understanding-admin-roles.adoc
@@ -16,6 +16,6 @@ As an administrator of an {product-title} cluster, your account has additional p
 
 [NOTE]
 ====
-While your account does have these increased permissions, the actual cluster maintenance and host configuration is still performed by the OpenShift Operations Team. If you would like to request a change to your cluster that you cannot perform using the administrator CLI, open a support case on the link:https://access.redhat.com/support/[Red Hat Customer Portal].
+While your account does have these increased permissions, the actual cluster maintenance and host configuration is still performed by the OpenShift Operations Team.
 ====
 // TODO: this is the only reference to the "OpenShift Operations Team". Should this be that SRE team?


### PR DESCRIPTION
This PR removes a reference to contact customer support.

JIRA: https://issues.redhat.com/browse/OSDOCS-3032

PREVIEW: 

**OSD** https://deploy-preview-42699--osdocs.netlify.app/openshift-dedicated/latest/administering_a_cluster/osd-admin-roles#the-dedicated-admin-role