### PR TITLE
TELCODOCS-279: D/S Docs & RN: METAL-5 (MPHARDWARE-7) Metal Platform Implementation: Low Latency Event Mechanism for RAN Workloads (Fast Path)

### DIFF
--- a/modules/nw-rfhe-creating_bmc_event_sub.adoc
+++ b/modules/nw-rfhe-creating_bmc_event_sub.adoc
@@ -1,0 +1,100 @@
+// Module included in the following assemblies:
+//
+// * networking/using-rfhe.adoc
+:_content-type: PROCEDURE
+[id="nw-rfhe-creating_bmc_event_sub_{context}"]
+= Subscribing to Redfish hardware events
+You can configure applications that are running on bare-metal cluster nodes to subscribe to Redfish hardware events that the baseboard management controller (BMC) generates. Example Redfish events include an increase in device temperature, or removal of a device. Applications subscribe to Redfish hardware events using a REST API.
+Subscribe to Redfish hardware events for the node using a BMCEventSubscription custom resource (CR).
+[IMPORTANT]
+====
+You can only create a `BMCEventSubscription` CR for physical hardware that supports Redfish and has a vendor interface set to `redfish` or `idrac-redfish`.
+====
+[NOTE]
+====
+Use the `BMCEventSubscription` CR to subscribe to pre-defined Redfish events. The Redfish standard does not provide an option to create specific alerts and thresholds. For example, to receive an alert event when an enclosure's temperature exceeds 40° Celsius, you need to manually configure the event according to the vendor's recommendations.
+====
+.Prerequisites
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* Get the user name and password for the BMC.
+* Deploy a bare-metal node with Redfish hardware in your cluster, and enable Redfish events on the BMC.
+[NOTE]
+====
+Enabling Redfish events on specific hardware is outside the scope of this information. For more information about enabling Redfish events for your specific hardware, consult the BMC manufacturer documentation.
+====
+.Procedure
+. Confirm the node hardware has the Redfish `EventService` enabled using the following `curl` command:
++
+[source,terminal]
+----
+curl https://<bmc_ip_address>/redfish/v1/EventService --insecure -H 'Content-Type: application/json' -u "<user_name>:<password>"
+----
++
+where:
++
+--
+bmc_ip_address:: is the IP address of the BMC controller
+--
++
+.Example output
+[source,terminal]
+----
+{
+   "@odata.context": "/redfish/v1/$metadata#EventService.EventService",
+   "@odata.id": "/redfish/v1/EventService",
+   "@odata.type": "#EventService.v1_0_2.EventService",
+   "Actions": {
+      "#EventService.SubmitTestEvent": {
+         "EventType@Redfish.AllowableValues": ["StatusChange", "ResourceUpdated", "ResourceAdded", "ResourceRemoved", "Alert"],
+         "target": "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent"
+      }
+   },
+   "DeliveryRetryAttempts": 3,
+   "DeliveryRetryIntervalSeconds": 30,
+   "Description": "Event Service represents the properties for the service",
+   "EventTypesForSubscription": ["StatusChange", "ResourceUpdated", "ResourceAdded", "ResourceRemoved", "Alert"],
+   "EventTypesForSubscription@odata.count": 5,
+   "Id": "EventService",
+   "Name": "Event Service",
+   "ServiceEnabled": true,
+   "Status": {
+      "Health": "OK",
+      "HealthRollup": "OK",
+      "State": "Enabled"
+   },
+   "Subscriptions": {
+      "@odata.id": "/redfish/v1/EventService/Subscriptions"
+   }
+}
+----
+. Create a `BMCEventSubscription` resource to subscribe to the Redfish events:
+.. Save the following YAML in the `bmc_sub.yaml` file:
++
+[source,yaml]
+----
+apiVersion: metal3.io/v1alpha1
+kind: BMCEventSubscription
+metadata:
+  name: sub-01
+  namespace: openshift-machine-api
+spec:
+   hostName: <hostname> <1>
+   destination: <proxy_service_url> <2>
+   context: ''
+----
+<1> Specifies the name or UUID of the worker node where the Redfish events are generated.
+<2> Specifies the baremetal hardware event proxy service, for example, `https://hw-event-proxy-cloud-native-events.apps.compute-1.example.com/webhook`.
++
+.. Create the `BMCEventSubscription` CR:
++
+[source,terminal]
+----
+$ oc create -f bmc_sub.yaml
+----
+. To delete the BMC event subscription, run the following command:
++
+[source,terminal]
+----
+$ oc delete -f bmc_sub.yaml
+----


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/TELCODOCS-279

For: Version 4.10

Doc Preview: https://deploy-preview-42700--osdocs.netlify.app/openshift-enterprise/latest/networking/using-rfhe.html#nw-rfhe-creating_bmc_event_sub_using-rfhe

Signed-off-by: Katie Tothill ktothill@redhat.com