### PR TITLE
OSDOCS-3137: Removed a version flag.

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-quickly.adoc
+++ b/modules/rosa-sts-creating-a-cluster-quickly.adoc
@@ -29,8 +29,6 @@ Additionally, you can use `auto` mode to immediately create the required AWS Ide
 $ rosa create account-roles --mode auto
 ----
 +
-You can optionally specify an OpenShift minor release, for example `4.8`, by using the `--version` option. The latest stable version is assumed if the option is not included. The account-wide roles and policies are specific to an OpenShift minor release version and are backward compatible.
-+
 [NOTE]
 ====
 When using `auto` mode, you can optionally specify the `-y` argument to bypass the interactive prompts and automatically confirm operations.

--- a/modules/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -42,8 +42,6 @@ $ rosa create account-roles --mode manual <1>
 ----
 <1> `manual` mode generates the `aws` CLI commands and JSON files needed to create the account-wide roles and policies. After review, you must run the commands manually to create the resources.
 +
-You can optionally specify an OpenShift minor release, for example `4.8`, by using the `--version` option. The latest stable version is assumed if the option is not included. The account-wide roles and policies are specific to an OpenShift minor release version and are backward compatible.
-+
 .. After review, run the `aws` commands manually to create the roles and policies. Alternatively, you can run the preceding command using `--mode auto` to run the `aws` commands immediately.
 
 . (Optional) If you are using your own AWS KMS key to encrypt the control plane data volumes and the persistent volumes (PVs) for your applications, add the ARN for the account-wide installer role to your KMS key policy.


### PR DESCRIPTION
This PR removes guidance on installing a specified version with the deprecated `--version` flag.

JIRA: https://issues.redhat.com/browse/OSDOCS-3137

PREVIEW:
**ROSA** https://deploy-preview-42701--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations_rosa-sts-creating-a-cluster-with-customizations