### PR TITLE
[BZ2035855]: Change the default value

### DIFF
--- a/using_images/other_images/jenkins_slaves.adoc
+++ b/using_images/other_images/jenkins_slaves.adoc
@@ -112,7 +112,7 @@ For memory efficiency, by default the Jenkins agent images dynamically
 use a 32-bit JVM if running in a container with a memory limit under 2GiB.
 
 * `JAVA_MAX_HEAP_PARAM` +
-`CONTAINER_HEAP_PERCENT` (default: `0.5`, i.e. 50%) +
+`CONTAINER_HEAP_PERCENT` (default: `0.1`, i.e. 10%) +
 `JNLP_MAX_HEAP_UPPER_BOUND_MB` +
 +
 These values control the maximum heap size of the Jenkins agent JVM. If


### PR DESCRIPTION
This PR changes the default value of a variable `CONTAINER_HEAP_PERCENT` from 0.5 to 0.1
OCP version: 3.11
[Preview](https://deploy-preview-42708--osdocs.netlify.app/openshift-enterprise/latest/using_images/other_images/jenkins_slaves.html#configuration-and-customization)
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2035855)
QE contact @jitendar-singh 