### PR TITLE
[BZ2057291] Enhance the section

### DIFF
--- a/modules/registry-accessing-directly.adoc
+++ b/modules/registry-accessing-directly.adoc
@@ -101,7 +101,7 @@ endif::[]
 +
 [source,terminal]
 ----
-$ podman pull name.io/image
+sh-4.2# podman pull name.io/image
 ----
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
@@ -111,7 +111,7 @@ correctly place and later access the image in the registry:
 +
 [source,terminal]
 ----
-$ podman tag name.io/image image-registry.openshift-image-registry.svc:5000/openshift/image
+sh-4.2# podman tag name.io/image image-registry.openshift-image-registry.svc:5000/openshift/image
 ----
 endif::[]
 +
@@ -128,6 +128,6 @@ to push the image.
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 [source,terminal]
 ----
-$ podman push image-registry.openshift-image-registry.svc:5000/openshift/image
+sh-4.2# podman push image-registry.openshift-image-registry.svc:5000/openshift/image
 ----
 endif::[]

--- a/modules/registry-checking-the-status-of-registry-pods.adoc
+++ b/modules/registry-checking-the-status-of-registry-pods.adoc
@@ -11,7 +11,6 @@ As a cluster administrator, you can list the image registry pods running in the 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/registry/accessing-the-registry.adoc
+++ b/registry/accessing-the-registry.adoc
@@ -14,7 +14,7 @@ endif::[]
 You can access the registry directly to invoke `podman` commands. This allows
 you to push images to or pull them from the integrated registry directly using
 operations like `podman push` or `podman pull`. To do so, you must be logged in
-to the registry using the `oc login` command. The operations you can perform
+to the registry using the `podman login` command. The operations you can perform
 depend on your user permissions, as described in the following sections.
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]


### PR DESCRIPTION
1. Corrected the `oc login` command https://deploy-preview-42712--osdocs.netlify.app/openshift-enterprise/latest/registry/accessing-the-registry.html
2. Removed the redundant prerequisite from the list https://deploy-preview-42712--osdocs.netlify.app/openshift-enterprise/latest/registry/accessing-the-registry.html#checking-the-status-of-registry-pods_accessing-the-registry
3. Corrected the shell command prompt symbol. https://deploy-preview-42712--osdocs.netlify.app/openshift-enterprise/latest/registry/accessing-the-registry.html#registry-accessing-directly_accessing-the-registry

OCP version: 4.6+
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2057291)

QE contact  @xiuwang LGTMed