### PR TITLE
BZ2054753: Removes incorrect prerequisite from Installing the OpenShift sandboxed containers Operator using the web console section

### DIFF
--- a/modules/sandboxed-containers-installing-operator-web-console.adoc
+++ b/modules/sandboxed-containers-installing-operator-web-console.adoc
@@ -12,7 +12,6 @@ You can install the {sandboxed-containers-operator} from the {product-title} web
 
 * You have {product-title} {product-version} installed.
 * You have access to the cluster as a user with the `cluster-admin` role.
-* You have installed the {sandboxed-containers-operator}.
 
 .Procedure
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2054753

For release(s): 4.9, 4.10

Preview: https://deploy-preview-42715--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads#sandboxed-containers-installing-operator-web-console_deploying-sandboxed-containers