### PR TITLE
OSDOCS-3245: Reworded a proxy warning

### DIFF
--- a/modules/cluster-wide-proxy.adoc
+++ b/modules/cluster-wide-proxy.adoc
@@ -16,6 +16,12 @@ ifdef::openshift-dedicated[]
 * You have the `ocm` CLI installed and configured.
 endif::[]
 
+//CANARY
+[WARNING]
+====
+Only cluster system egress traffic is proxied, including calls to the AWS API. A system-wide proxy does not affect user workloads. It only affects system components.
+====
+
 .Procedure
 * To create a cluster with a proxy, run the following command:
 +


### PR DESCRIPTION
This PR fixes the wording in a warning about cluster-wide proxies. Fixes #41300

JIRA: https://issues.redhat.com/browse/OSDOCS-3245

PREVIEW: 

**ROSA** https://deploy-preview-42734--osdocs.netlify.app/openshift-rosa/latest/networking/configuring-cluster-wide-proxy.html
**OSD** https://deploy-preview-42734--osdocs.netlify.app/openshift-dedicated/latest/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-config_cluster-wide-proxy-configuration