### PR TITLE
fixing attribute path in a newish file

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-alibaba.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-alibaba.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 [id="creating-machineset-alibaba"]
 = Creating a machine set on Alibaba Cloud
-include::modules/common-attributes.adoc[]
+include::_attributes/common-attributes.adoc[]
 :context: creating-machineset-alibaba
 
 toc::[]


### PR DESCRIPTION
This was fixed for 4.10 in #42704, but that was against `enterprise-4.10` and the fix needs to go into `main` also