### PR TITLE
Typo Fix for "offset"

### DIFF
--- a/networking/dns-operator.adoc
+++ b/networking/dns-operator.adoc
@@ -26,4 +26,4 @@ include::modules/nw-dns-operator-logs.adoc[leveloffset=+1]
 
 include::modules/nw-dns-loglevel.adoc[leveloffset=+1]
 
-include::modules/nw-dns-operatorloglevel.adoc[levelofset=+1]
+include::modules/nw-dns-operatorloglevel.adoc[leveloffset=+1]


### PR DESCRIPTION
Doc had "ofset" instead of "offset"
No BZ
