### PR TITLE
BZ2050796: Removes RHEL versions in Prerequisites section in OSC deploy guide

### DIFF
--- a/modules/sandboxed-containers-preparing-openshift-cluster.adoc
+++ b/modules/sandboxed-containers-preparing-openshift-cluster.adoc
@@ -12,7 +12,7 @@ Before you install {sandboxed-containers-first}, ensure that your {product-title
 +
 [IMPORTANT]
 ====
-* {sandboxed-containers-first} only supports {op-system} worker nodes. RHEL 7 or RHEL  8 nodes are not supported.
+* {sandboxed-containers-first} only supports {op-system} worker nodes. {op-system-base} nodes are not supported.
 * Nested virtualization is not supported.
 ====
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2050796

Main PR: https://github.com/openshift/openshift-docs/pull/42714

For release(s): 4.9

Preview: https://deploy-preview-42714--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads#sandboxed-containers-prerequisites_deploying-sandboxed-containers