### PR TITLE
JIRA-OSDOCS3185: Removed sentence about creating cluster from AWS console

### DIFF
--- a/modules/rosa-understanding.adoc
+++ b/modules/rosa-understanding.adoc
@@ -12,8 +12,6 @@
 
 This service is licensed directly from your AWS account. ROSA pricing is consumption based and is billed directly to your AWS account.
 
-You can quickly deploy OpenShift clusters directly from the AWS console and integrate with other AWS services.
-
 [id="rosa-cluster-consoles_{context}"]
 == Cluster creation consoles
 


### PR DESCRIPTION
This PR is to address the JIRA issue: https://issues.redhat.com/browse/OSDOCS-3185

Topic updated: https://deploy-preview-42754--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-understanding#rosa-about_rosa-understanding

The exact change is as follows:
- On the introduction page, in section 'About Red Hat OpenShift Service on AWS', removed the sentence "You can quickly deploy OpenShift clusters directly from the AWS console and integrate with other AWS services." as users cannot deploy a ROSA cluster from the AWS Console.

Repo: Request cherrypick to enterprise-4.9 and enterprise-4.10