### PR TITLE
JIRA-OSDOCS3069: Corrected the IOPS for Infrastructure and Worker nodes

### DIFF
--- a/modules/ccs-aws-provisioned.adoc
+++ b/modules/ccs-aws-provisioned.adoc
@@ -38,12 +38,12 @@ Volume requirements for each EC2 instance:
 - Infrastructure volumes
 * Size: 300 GB
 * Type: gp2
-* Input/output operations per second: 100
+* Input/output operations per second: 900
 
 - Worker volumes
 * Size: 300 GB
 * Type: gp2
-* Input/output operations per second: 100
+* Input/output operations per second: 900
 
 [id="aws-policy-elastic-load-balancers_{context}"]
 == Elastic load balancers

--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -22,7 +22,7 @@ Instance types can vary for control plane and infrastructure nodes, depending on
 For further guidance on worker node counts, see the link to "Initial Planning Considerations" in the "Additional resources" section of this page.
 
 [id="rosa-ebs-storage_{context}"]
-== Elastic Block Storage storage
+== AWS Elastic Block Store (EBS) storage
 
 Amazon EBS block storage is used for both local node storage and persistent volume storage.
 
@@ -36,12 +36,12 @@ Volume requirements for each EC2 instance:
 - Infrastructure Volume
 * Size: 300GB
 * Type: gp2
-* Input/Output Operations Per Second: 100
+* Input/Output Operations Per Second: 900
 
 - Worker Volume
 * Size: 300GB
 * Type: gp2
-* Input/Output Operations Per Second: 100
+* Input/Output Operations Per Second: 900
 
 [id="rosa-elastic-load-balancers_{context}"]
 == Elastic load balancers


### PR DESCRIPTION
This PR is to address the JIRA issue: https://issues.redhat.com/browse/OSDOCS-3069

Topics updated: 
- https://deploy-preview-42757--osdocs.netlify.app/openshift-dedicated/latest/osd_planning/aws-ccs.html#aws-policy-ebs-storage_aws-ccs
- https://deploy-preview-42757--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-aws-prereqs.html#rosa-ebs-storage_rosa-sts-aws-prerequisites

The exact changes are as follows:
- Updated the IOPS for Infra and worker nodes to be 900 (instead of 100) in both Dedicated and ROSA topics. 
- While at it, updated the title in ROSA topic from 'Elastic Block Storage storage' to "AWS Elastic Block Store (EBS) storage" for correctness and consistency. 

Repo: Request cherrypick to enterprise-4.9 and enterprise-4.10