### PR TITLE
Update to reflect Ali Cloud TP status in 4.10

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -10,9 +10,9 @@
 
 [NOTE]
 ====
-This Operator is only fully supported for Alibaba Cloud, Microsoft Azure Stack Hub, and IBM Cloud.
+This Operator is only fully supported for Microsoft Azure Stack Hub and IBM Cloud.
 
-It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, {rh-openstack-first}, and VMware vSphere.
+It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, {rh-openstack-first}, and VMware vSphere.
 ====
 
 The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).


### PR DESCRIPTION
Follows up on #41887

Preview: https://deploy-preview-42759--osdocs.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-cloud-controller-manager-operator_platform-operators-ref