### PR TITLE
SRVKS-852: Add additional knative serving admin config docs

### DIFF
--- a/modules/serverless-kourier-gateway-service-type.adoc
+++ b/modules/serverless-kourier-gateway-service-type.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies
+//
+// * serverless/admin_guide/knative-serving-CR-config.adoc
+
+:_content-type: REFERENCE
+[id="serverless-kourier-gateway-service-type_{context}"]
+= Setting the Kourier Gateway service type
+
+The default service type by which the Kourier Gateway is exposed is `ClusterIP`, and is determined by the `service-type` ingress spec in the `KnativeServing` custom resource (CR):
+
+.Default spec
+[source,yaml]
+----
+...
+spec:
+  ingress:
+    kourier:
+      service-type: ClusterIP
+...
+----
+
+You can override the default service type to use a load balancer service type instead by modifying the `service-type` spec:
+
+.LoadBalancer override spec
+[source,yaml]
+----
+...
+spec:
+  ingress:
+    kourier:
+      service-type: LoadBalancer
+...
+----

--- a/modules/serverless-rn-1-21-0.adoc
+++ b/modules/serverless-rn-1-21-0.adoc
@@ -18,6 +18,7 @@
 * {ServerlessProductName} now uses Knative Kafka 0.27.
 * The `kn func` CLI plug-in now uses `func` 0.21.
 // check versions
+* The Knative open source project has begun to deprecate camel-cased configuration keys in favor of using kebab-cased keys consistently. As a result, the `defaultExternalScheme` key, previously mentioned in the {ServerlessProductName} 1.18.0 release notes, has been deprecated and replaced by the `default-external-scheme` key. Usage instructions for the key remain the same.
 
 [id="fixed-issues-1-21-0_{context}"]
 == Fixed issues

--- a/modules/serverless-url-scheme-external-routes.adoc
+++ b/modules/serverless-url-scheme-external-routes.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies
+//
+// * serverless/admin_guide/knative-serving-CR-config.adoc
+
+:_content-type: REFERENCE
+[id="serverless-url-scheme-external-routes_{context}"]
+= Setting the URL scheme for external routes
+
+The URL scheme of external routes defaults to HTTPS for enhanced security. This scheme is determined by the `default-external-scheme` key in the `KnativeServing` custom resource (CR) spec:
+
+.Default spec
+[source,yaml]
+----
+...
+spec:
+  config:
+    network:
+      default-external-scheme: "https"
+...
+----
+
+You can override the default spec to use HTTP by modifying the `default-external-scheme` key:
+
+.HTTP override spec
+[source,yaml]
+----
+...
+spec:
+  config:
+    network:
+      default-external-scheme: "http"
+...
+----

--- a/serverless/admin_guide/knative-serving-CR-config.adoc
+++ b/serverless/admin_guide/knative-serving-CR-config.adoc
@@ -18,9 +18,12 @@ endif::[]
 // config options
 include::modules/knative-serving-CR-system-deployments.adoc[leveloffset=+1]
 include::modules/serverless-config-emptydir.adoc[leveloffset=+1]
-
 // global https redirect
 include::modules/serverless-https-redirect-global.adoc[leveloffset=+1]
+// URL scheme for external routes
+include::modules/serverless-url-scheme-external-routes.adoc[leveloffset=+1]
+// Kourier Gateway service type
+include::modules/serverless-kourier-gateway-service-type.adoc[leveloffset=+1]
 
 ifdef::openshift-enterprise[]
 [id="additional-resources_knative-serving-CR-config"]

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -32,8 +32,8 @@ endif::[]
 
 // Release notes included, most to least recent
 // OCP + OSD
-include::modules/serverless-rn-1-20-0.adoc[leveloffset=+1]
 // include::modules/serverless-rn-1-21-0.adoc[leveloffset=+1]
+include::modules/serverless-rn-1-20-0.adoc[leveloffset=+1]
 
 // OCP only
 ifdef::openshift-enterprise[]


### PR DESCRIPTION
Jiras: 
- https://issues.redhat.com/browse/SRVKS-852
- https://issues.redhat.com/browse/SRVKS-826
- https://issues.redhat.com/browse/SRVCOM-1661

Applies for OCP 4.6+
**NOTE:** PR will require manual cherry pick for versions older than 4.9, due to conditional text for OSD that was added in 4.9 and 4.10.

Direct preview(s):
- https://deploy-preview-42764--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/knative-serving-cr-config#serverless-url-scheme-external-routes_knative-serving-CR-config
- https://deploy-preview-42764--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/knative-serving-cr-config#serverless-kourier-gateway-service-type_knative-serving-CR-config
- https://deploy-preview-42764--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-rn-1-21-0_serverless-release-notes (won't be published yet, only showing for this preview, then will comment out for merging)