### PR TITLE
JIRA-OSDOCS3169: Added hyperlink to RWX KB article

### DIFF
--- a/modules/rosa-sdpolicy-storage.adoc
+++ b/modules/rosa-sdpolicy-storage.adoc
@@ -27,4 +27,4 @@ Each cloud provider has its own limits for how many PVs can be attached to a sin
 
 == Shared Storage (RWX)
 
-The AWS CSI Driver can be used to provide RWX support for {product-title}. A community Operator is provided to simplify setup.
+The AWS CSI Driver can be used to provide RWX support for {product-title}. A community Operator is provided to simplify setup. See link:https://access.redhat.com/articles/5025181[AWS EFS Setup for OpenShift Dedicated and Red Hat OpenShift Service on AWS] for details. 

--- a/modules/sdpolicy-storage.adoc
+++ b/modules/sdpolicy-storage.adoc
@@ -25,4 +25,4 @@ Each cloud provider has its own limits for how many PVs can be attached to a sin
 [id="shared-storage_{context}"]
 == Shared storage (RWX)
 
-The link:https://access.redhat.com/articles/5025181[AWS CSI Driver] can be used to provide RWX support for {product-title} on AWS. A community Operator is provided to simplify setup.
+The AWS CSI Driver can be used to provide RWX support for {product-title} on AWS. A community Operator is provided to simplify setup. See link:https://access.redhat.com/articles/5025181[AWS EFS Setup for OpenShift Dedicated and Red Hat OpenShift Service on AWS] for details. 


### PR DESCRIPTION
This PR is to address the JIRA issue: https://issues.redhat.com/browse/OSDOCS-3169

Topics updated: 

- https://deploy-preview-42766--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-service-definition#shared-storage-rwx
- https://deploy-preview-42766--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/osd-service-definition.html#shared-storage_osd-service-definition

The exact change is as follows:
- In the section 'Shared Storage (RWX)', added a hyperlink to RWX KB article.

Repo: Request cherrypick to enterprise-4.9 and enterprise-4.10