### PR TITLE
SRVKE-1086: Add Kafka sink TP docs

### DIFF
--- a/modules/serverless-create-kafka-channel-yaml.adoc
+++ b/modules/serverless-create-kafka-channel-yaml.adoc
@@ -7,14 +7,13 @@
 [id="serverless-create-kafka-channel-yaml_{context}"]
 = Creating a Kafka channel by using YAML
 
-You can create a Kafka channel by using YAML to create the `KafkaChannel` object.
+You can create a Knative Eventing channel that is backed by Kafka topics. To do this, you must create a `KafkaChannel` object. The following procedure explains how you can create a `KafkaChannel` object by using YAML files and the `oc` CLI.
 
 .Prerequisites
 
 * The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {product-title} cluster.
 * You have installed the `oc` CLI.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
-* You have installed the `oc` CLI.
 
 .Procedure
 

--- a/modules/serverless-install-kafka-odc.adoc
+++ b/modules/serverless-install-kafka-odc.adoc
@@ -28,6 +28,8 @@ spec:
             bootstrapServers: <bootstrap_servers> <5>
             numPartitions: <num_partitions> <6>
             replicationFactor: <replication_factor> <7>
+    sink:
+        enabled: true <8>
 ----
 <1> Enables developers to use the `KafkaChannel` channel type in the cluster.
 <2> A comma-separated list of bootstrap servers from your AMQ Streams cluster.
@@ -41,6 +43,7 @@ spec:
 ====
 The `replicationFactor` value must be less than or equal to the number of nodes of your Red Hat AMQ Streams cluster.
 ====
+<8> Enables developers to use a Kafka sink in the cluster.
 
 .Prerequisites
 
@@ -68,7 +71,7 @@ endif::[]
 +
 [IMPORTANT]
 ====
-To use the Kafka channel, source, or broker on your cluster, you must toggle the *enabled* switch for the options you want to use to *true*. These switches are set to *false* by default. Additionally, to use the Kafka channel or broker, you must specify the bootstrap servers.
+To use the Kafka channel, source, broker, or sink on your cluster, you must toggle the *enabled* switch for the options you want to use to *true*. These switches are set to *false* by default. Additionally, to use the Kafka channel, broker or sink, you must specify the bootstrap servers.
 ====
 .. Using the form is recommended for simpler configurations that do not require full control of *KnativeKafka* object creation.
 .. Editing the YAML is recommended for more complex configurations that require full control of *KnativeKafka* object creation. You can access the YAML by clicking the *Edit YAML* link in the top right of the *Create Knative Kafka* page.

--- a/modules/serverless-kafka-sink.adoc
+++ b/modules/serverless-kafka-sink.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * serverless/develop/serverless-kafka-developer.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-kafka-sink_{context}"]
+= Using a Kafka sink
+
+You can create an event sink called a Kafka sink, that sends events to a Kafka topic. To do this, you must create a `KafkaSink` object. The following procedure explains how you can create a `KafkaSink` object by using YAML files and the `oc` CLI.
+
+.Prerequisites
+
+* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource (CR) are installed on your cluster.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* You have access to a Red Hat AMQ Streams (Kafka) cluster that produces the Kafka messages you want to import.
+* You have installed the `oc` CLI.
+
+.Procedure
+
+. Create a `KafkaSink` object definition as a YAML file:
++
+.Kafka sink YAML
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1alpha1
+kind: KafkaSink
+metadata:
+  name: <sink-name>
+  namespace: <namespace>
+spec:
+  topic: <topic-name>
+  bootstrapServers:
+   - <bootstrap-server>
+----
+
+. To create the Kafka sink, apply the `KafkaSink` YAML file:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+. Configure an event source so that the sink is specified in its spec:
++
+.Example of a Kafka sink connected to an API server source
+[source,yaml]
+----
+apiVersion: sources.knative.dev/v1alpha2
+kind: ApiServerSource
+metadata:
+  name: <source-name> <1>
+  namespace: <namespace> <2>
+spec:
+  serviceAccountName: <service-account-name> <3>
+  mode: Resource
+  resources:
+  - apiVersion: v1
+    kind: Event
+  sink:
+    ref:
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: KafkaSink
+      name: <sink-name> <4>
+----
+<1> The name of the event source.
+<2> The namespace of the event source.
+<3> The service account for the event source.
+<4> The Kafka sink name.

--- a/serverless/admin_guide/serverless-kafka-admin.adoc
+++ b/serverless/admin_guide/serverless-kafka-admin.adoc
@@ -26,10 +26,8 @@ The `KnativeKafka` CR provides users with additional options, such as:
 
 * Kafka source
 * Kafka channel
-* Kafka broker
-
-:FeatureName: Kafka broker
-include::snippets/technology-preview.adoc[leveloffset=+1]
+* Kafka broker (Technology Preview)
+* Kafka sink (Technology Preview)
 
 include::modules/serverless-install-kafka-odc.adoc[leveloffset=+1]
 

--- a/serverless/develop/serverless-kafka-developer.adoc
+++ b/serverless/develop/serverless-kafka-developer.adoc
@@ -21,10 +21,8 @@ Knative Kafka provides additional options, such as:
 
 * Kafka source
 * Kafka channel
-* Kafka broker
-
-:FeatureName: Kafka broker
-include::snippets/technology-preview.adoc[leveloffset=+1]
+* Kafka broker (Technology Preview)
+* Kafka sink (Technology Preview)
 
 include::modules/serverless-kafka-event-delivery.adoc[leveloffset=+1]
 
@@ -60,6 +58,17 @@ include::modules/serverless-kafka-broker.adoc[leveloffset=+2]
 
 // Kafka channels
 include::modules/serverless-create-kafka-channel-yaml.adoc[leveloffset=+1]
+
+[id="serverless-kafka-developer-sink"]
+== Kafka sink
+
+:FeatureName: Kafka sink
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
+Kafka sinks are a type of xref:../../serverless/develop/serverless-event-sinks.adoc#serverless-event-sinks[event sink] that are available if a cluster administrator has enabled Kafka on your cluster. You can send events directly from an xref:../../serverless/discover/knative-event-sources.adoc#knative-event-sources[event source] to a Kafka topic by using a Kafka sink.
+
+// Kafka sink
+include::modules/serverless-kafka-sink.adoc[leveloffset=+2]
 
 [id="additional-resources_serverless-kafka-developer"]
 [role="_additional-resources"]


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVKE-1086 + https://issues.redhat.com/browse/SRVCOM-1661

Applies for OCP 4.6+
**NOTE:** Needs manual cherry pick to versions older than 4.9 due to conditional text for OSD docs.

Direct preview links:
- https://deploy-preview-42770--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-rn-1-21-0_serverless-release-notes
- https://deploy-preview-42770--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-kafka-admin.html
- https://deploy-preview-42770--osdocs.netlify.app/openshift-enterprise/latest/serverless/develop/serverless-kafka-developer.html
   - https://deploy-preview-42770--osdocs.netlify.app/openshift-enterprise/latest/serverless/develop/serverless-kafka-developer.html#serverless-kafka-developer-sink
