### PR TITLE
GH42366: Wrong command flag in Verifying node health section

### DIFF
--- a/modules/reviewing-node-status-usage-and-configuration.adoc
+++ b/modules/reviewing-node-status-usage-and-configuration.adoc
@@ -15,23 +15,23 @@ Review cluster node health status, resource consumption statistics, and node log
 
 .Procedure
 
-. List the name, status, and role for all nodes in the cluster:
+* List the name, status, and role for all nodes in the cluster:
 +
 [source,terminal]
 ----
 $ oc get nodes
 ----
 
-. Summarize CPU and memory usage for each node within the cluster:
+* Summarize CPU and memory usage for each node within the cluster:
 +
 [source,terminal]
 ----
 $ oc adm top nodes
 ----
 
-. Summarize CPU and memory usage for a specific node:
+* Summarize CPU and memory usage for a specific node:
 +
 [source,terminal]
 ----
-$ oc adm top node -l my-node
+$ oc adm top node my-node
 ----


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/42366

Preview: [Reviewing node status, resource usage, and configuration](https://deploy-preview-42778--osdocs.netlify.app/openshift-enterprise/latest/support/troubleshooting/verifying-node-health.html#reviewing-node-status-use-and-configuration_verifying-node-health)