### PR TITLE
BZ2029731: add unique VM name requirement for vSphere UPI

### DIFF
--- a/modules/installation-machine-requirements.adoc
+++ b/modules/installation-machine-requirements.adoc
@@ -52,6 +52,7 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :ibm-power:
 endif::[]
 
+:_content-type: REFERENCE
 [id="installation-machine-requirements_{context}"]
 = Required machines for cluster installation
 
@@ -98,7 +99,7 @@ ifndef::ibm-z,ibm-power[]
 The bootstrap and control plane machines must use {op-system-first} as the operating system. However, the compute machines can choose between {op-system-first}, {op-system-base-full} 8.4, or {op-system-base} 8.5.
 endif::ibm-z,ibm-power[]
 ifdef::ibm-z,ibm-power[]
-The bootstrap, control plane, and compute machines must use {op-system-first} as the operating system. 
+The bootstrap, control plane, and compute machines must use {op-system-first} as the operating system.
 endif::ibm-z,ibm-power[]
 
 ifndef::openshift-origin[]
@@ -109,7 +110,7 @@ See link:https://access.redhat.com/articles/rhel-limits[Red Hat Enterprise Linux
 ifdef::vsphere[]
 [IMPORTANT]
 ====
-All virtual machines must reside in the same datastore and in the same folder as the installer.
+All virtual machines must reside in the same datastore and in the same folder as the installer. Ensure that all virtual machine names across a vSphere installation are unique.
 ====
 endif::vsphere[]
 

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -133,6 +133,11 @@ It is recommended that you update the hardware version of the VM template to ver
 . After the template deploys, deploy a VM for a machine in the cluster.
 .. Right-click the template name and click *Clone* -> *Clone to Virtual Machine*.
 .. On the *Select a name and folder* tab, specify a name for the VM. You might include the machine type in the name, such as `control-plane-0` or `compute-1`.
++
+[NOTE]
+====
+Ensure that all virtual machine names across a vSphere installation are unique.
+====
 .. On the *Select a name and folder* tab, select the name of the folder that you created for the cluster.
 .. On the *Select a compute resource* tab, select the name of a host in your datacenter.
 +

--- a/modules/machine-vsphere-machines.adoc
+++ b/modules/machine-vsphere-machines.adoc
@@ -24,6 +24,11 @@ You can add more compute machines to a user-provisioned {product-title} cluster 
 . After the template deploys, deploy a VM for a machine in the cluster.
 .. Right-click the template's name and click *Clone* -> *Clone to Virtual Machine*.
 .. On the *Select a name and folder* tab, specify a name for the VM. You might include the machine type in the name, such as `compute-1`.
++
+[NOTE]
+====
+Ensure that all virtual machine names across a vSphere installation are unique.
+====
 .. On the *Select a name and folder* tab, select the name of the folder that you created for the cluster.
 .. On the *Select a compute resource* tab, select the name of a host in your datacenter.
 .. Optional: On the *Select storage* tab, customize the storage options.


### PR DESCRIPTION
For BZ2029731 (related to [OCPCLOUD-1295](https://issues.redhat.com/browse/OCPCLOUD-1295))

Adds requirement for VM names on a vSphere install to be unique

Previews:
- [Required machines for cluster installation](https://deploy-preview-42780--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-machine-requirements_installing-vsphere)
- [Installing RHCOS and starting the OpenShift Container Platform bootstrap process](https://deploy-preview-42780--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-machines_installing-vsphere) (step 9b)
- [Adding more compute machines to a cluster in vSphere](https://deploy-preview-42780--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#machine-vsphere-machines_installing-vsphere) (step 1b)