### PR TITLE
GH#41632: correcting network policy example callout

### DIFF
--- a/modules/nw-networkpolicy-object.adoc
+++ b/modules/nw-networkpolicy-object.adoc
@@ -30,9 +30,8 @@ spec:
     - protocol: TCP
       port: 27017
 ----
-<1> The `name` of the NetworkPolicy object.
-<2> A selector describing the pods the policy applies to. The policy object can
-only select pods in the project that the NetworkPolicy object is defined.
-<3> A selector matching the pods that the policy object allows ingress traffic
-from. The selector will match pods in any project.
-<4> A list of one or more destination ports to accept traffic on.
+<1> The name of the NetworkPolicy object.
+<2> A selector that describes the pods to which the policy applies. The policy object can
+only select pods in the project that defines the NetworkPolicy object.
+<3> A selector that matches the pods from which the policy object allows ingress traffic. The selector matches pods in the same namespace as the NetworkPolicy.
+<4> A list of one or more destination ports on which to accept traffic.


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/41632

Based on the [Kubernetes](https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors) documentation for `podSelector` we had an incorrect definition in an example code callout. As the reporter of the issue states, we get the definition correct elsewhere.

Looks like this example callout goes back to 4.6. 

Preview: https://deploy-preview-42781--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/creating-network-policy.html#nw-networkpolicy-object_creating-network-policy

@anuragthehatter I see that you've previously QE'd this docs file before. Would you mind taking a look and verifying that the definition change in the callout is appropriate?