### PR TITLE
BZ2043222:ZTP installation with SecureBoot enabled may fail 

### DIFF
--- a/modules/ztp-creating-the-siteconfig-custom-resources.adoc
+++ b/modules/ztp-creating-the-siteconfig-custom-resources.adoc
@@ -48,6 +48,7 @@ spec:
         bmcAddress: "idrac-virtualmedia+https://[2620:52::10e7:f602:70ff:fee4:f4e2]/redfish/v1/Systems/System.Embedded.1"
         bmcCredentialsName:
           name: "test-sno-bmh-secret"
+        bmcDisableCertificateVerification: true <1>
         bootMACAddress: "0C:42:A1:8A:74:EC"
         bootMode: "UEFI"
         rootDeviceHints:
@@ -83,6 +84,7 @@ spec:
                 next-hop-address: 2620:52:0:10e7::fc
                 table-id: 254
 ----
+<1> If you are using `UEFI SecureBoot`, add this line to prevent failures due to invalid or local certificates.
 
 . Save the files and push them to the zero touch provisioning (ZTP) Git repository accessible from the hub cluster and defined as a source repository of the ArgoCD application.
 


### PR DESCRIPTION
OCP version 4.10 CP to 4.9

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2043222

Preview: https://deploy-preview-42782--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-creating-the-siteconfig-custom-resources_ztp-deploying-disconnected

QE: @juphoff /lgtm

