### PR TITLE
OSDOCS-3315: urgent change: ROSA upgrade prep CLI version

### DIFF
--- a/modules/rosa-upgrading-preparing-4-8-to-4-9.adoc
+++ b/modules/rosa-upgrading-preparing-4-8-to-4-9.adoc
@@ -11,7 +11,7 @@ You must meet the following requirements before upgrading a {product-title} (ROS
 .Prerequisites
 
 * You have installed the latest AWS CLI on your installation host.
-* You have installed link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa[version 1.1.9 or later of the ROSA CLI] on your installation host.
+* You have installed 1.1.10 or later of the ROSA CLI on your installation host.
 * You have installed version 4.9 or later of the OpenShift CLI (`oc`) on your workstation(s) as needed.
 * You have the permissions required to update the AWS account-wide roles and policies.
 * You have access to the cluster as a user with the `cluster-admin` role.


### PR DESCRIPTION
This applies to main, enterprise-4.10 and enterprise-4.9.

This relates to https://issues.redhat.com/browse/OSDOCS-3315. In the page https://docs.openshift.com/rosa/upgrading/rosa-upgrading-cluster-prepare.html, under prerequisites, the minimum installed ROSA CLI, this PR changes 1.1.9 to 1.1.10 because a critical bug is fixed in the new version.

[Preview](https://deploy-preview-42783--osdocs.netlify.app/openshift-rosa/latest/upgrading/rosa-upgrading-cluster-prepare)