### PR TITLE
ECOPORJECT-201: Documentation for the Poison Pill Operator for 4.10

### DIFF
--- a/modules/eco-poison-pill-operator-about.adoc
+++ b/modules/eco-poison-pill-operator-about.adoc
@@ -40,12 +40,42 @@ spec:
 ----
 
 <1> Specify the timeout duration for the surviving peer, after which the Operator can assume that an unhealthy node has been rebooted. The Operator automatically calculates the lower limit for this value. However, if different nodes have different watchdog timeouts, you must change this value to a higher value.
-<2> Specify the file path of the watchdog device in the nodes. If a watchdog device is unavailable, the `PoisonPillConfig` CR uses a software reboot.
+<2> Specify the file path of the watchdog device in the nodes. If you enter an incorrect path to the watchdog device, the Poison Pill Operator automatically detects the softdog device path.
++
+If a watchdog device is unavailable, the `PoisonPillConfig` CR uses a software reboot. 
 <3> Specify if you want to enable software reboot of the unhealthy nodes. By default, the value of `isSoftwareRebootEnabled` is set to `true`. To disable the software reboot, set the parameter value to `false`.
 <4> Specify the timeout duration to check connectivity with each API server. When this duration elapses, the Operator starts remediation.
 <5> Specify the frequency to check connectivity with each API server.
 <6> Specify a threshold value. After reaching this threshold, the node starts contacting its peers.
-<7> Specify the timeout duration to connect with the peer API server.
+<7> Specify the timeout duration for the peer to connect the API server.
 <8> Specify the timeout duration for establishing connection with the peer.
 <9> Specify the timeout duration to get a response from the peer.
 <10> Specify the frequency to update peer information, such as IP address.
+
+[id="understanding-poison-pill-remediation-template-config_{context}"]
+== Understanding the Poison Pill Remediation Template configuration
+
+The Poison Pill Operator also creates the `PoisonPillRemediationTemplate` CR with the name `poison-pill-default-template` in the Poison Pill Operator's namespace. This CR defines the remediation strategy for the nodes.
+
+The default remediation strategy is `NodeDeletion` that removes the `node` object.
+In {product-title} 4.10, the Poison Pill Operator introduces a new remediation strategy called `ResourceDeletion`. The `ResourceDeletion` remediation strategy removes the pods and associated volume attachments on the node rather than the `node` object. This strategy helps to recover workloads faster.
+
+The `PoisonPillRemediationTemplate` CR resembles the following YAML file:
+
+[source,yaml]
+----
+apiVersion: poison-pill.medik8s.io/v1alpha1
+kind: PoisonPillRemediationTemplate
+metadata:
+creationTimestamp: "2022-03-02T08:02:40Z"
+generation: 1
+name: poison-pill-default-template
+namespace: openshift-operators
+resourceVersion: "596469"
+uid: 5d29e437-c485-48fa-ba9e-0354649afd31
+spec:
+template:
+spec:
+remediationStrategy: NodeDeletion <1>
+----
+<1> Specifies the remediation strategy. The default remediation strategy is `NodeDeletion`.


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-451 Documentation for the Poison Pill Operator for 4.10

Applies to OpenShift version : 4.10 +

Preview:
[Understanding the Poison Pill Remediation Template configuration](https://deploy-preview-42794--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/eco-poison-pill-operator.html#understanding-poison-pill-remediation-template-config_poison-pill-operator-remediate-nodes)