### PR TITLE
[BZ1989394]:Remove endpointPublishingStrategy

### DIFF
--- a/modules/nw-configure-ingress-access-logging.adoc
+++ b/modules/nw-configure-ingress-access-logging.adoc
@@ -31,15 +31,12 @@ metadata:
   namespace: openshift-ingress-operator
 spec:
   replicas: 2
-  endpointPublishingStrategy:
-    type: NodePortService <1>
   logging:
     access:
       destination:
         type: Container
 ----
-<1> `NodePortService` is not required to configure Ingress access logging to a sidecar. Ingress logging is compatible with any `endpointPublishingStrategy`.
-+
+
 * When you configure the Ingress Controller to log to a sidecar, the operator creates a container named `logs` inside the Ingress Controller Pod:
 +
 [source,terminal]
@@ -66,8 +63,6 @@ metadata:
   namespace: openshift-ingress-operator
 spec:
   replicas: 2
-  endpointPublishingStrategy:
-    type: NodePortService
   logging:
     access:
       destination:
@@ -95,8 +90,6 @@ metadata:
   namespace: openshift-ingress-operator
 spec:
   replicas: 2
-  endpointPublishingStrategy:
-    type: NodePortService
   logging:
     access:
       destination:
@@ -120,8 +113,6 @@ metadata:
   namespace: openshift-ingress-operator
 spec:
   replicas: 2
-  endpointPublishingStrategy:
-    type: NodePortService
   logging:
     access: null
 ----


### PR DESCRIPTION
Removes the unnecessary `endpointPublishingStrategy` instances
OCP version: 4.7+
[Preview](https://deploy-preview-42795--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-configure-ingress-access-logging_configuring-ingress)
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1989394)
QE contact @qiliRedHat LGTMed