### PR TITLE
BZ2060714: monitoring: Fix example writeRelabelConfig field name in remoteWrite …

### DIFF
--- a/modules/monitoring-configuring-remote-write.adoc
+++ b/modules/monitoring-configuring-remote-write.adoc
@@ -170,7 +170,7 @@ data:
       remoteWrite:
       - url: "https://remote-write.endpoint"
         writeRelabelConfigs:
-        - source_labels: [__name__]
+        - sourceLabels: [__name__]
           regex: 'my_metric'
           action: keep
 


### PR DESCRIPTION
…documentation

The field is called `sourceLabels` not `source_labels`.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>