### PR TITLE
OSDOCS-2943 - Updating the HTPasswd IDP description in the SD docs

### DIFF
--- a/modules/config-htpasswd-idp.adoc
+++ b/modules/config-htpasswd-idp.adoc
@@ -1,6 +1,18 @@
 // Module included in the following assemblies:
 //
+// * rosa_getting_started/rosa-sts-config-identity-providers.adoc
+// * rosa_getting_started/rosa_getting_started_iam/rosa-config-identity-providers.adoc
 // * identity_providers/config-identity-providers.adoc
+
+ifeval::["{context}" == "config-identity-providers"]
+:osd-distro:
+endif::[]
+ifeval::["{context}" == "rosa-sts-config-identity-providers"]
+:rosa-distro:
+endif::[]
+ifeval::["{context}" == "rosa-config-identity-providers"]
+:rosa-distro:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="config-htpasswd-idp_{context}"]
@@ -8,18 +20,18 @@
 
 Configure an HTPasswd identity provider to create a single, static user with cluster administration privileges. You can log in to your cluster as the user to troubleshoot issues.
 
+[IMPORTANT]
+====
+The HTPasswd identity provider option is included only to enable the creation of a single, static administration user. HTPasswd is not supported as a general-use identity provider for {product-title}.
+====
+
 .Procedure
 
-. From {cluster-manager-url}, navigate to the *Clusters* page and select the cluster that you need to configure identity providers for.
+. From {cluster-manager-url}, navigate to the *Clusters* page and select your cluster.
 
-. Click the *Access control* tab.
+. Select *Access control* -> *Identity providers*.
 
 . Click *Add identity provider*.
-+
-[NOTE]
-====
-You can also click the *Add Oauth configuration* link in the warning message displayed after cluster creation to configure your identity providers.
-====
 
 . Select *HTPasswd* from the *Identity Provider* drop-down menu.
 
@@ -29,26 +41,40 @@ You can also click the *Add Oauth configuration* link in the warning message dis
 +
 [NOTE]
 ====
-The credentials defined in this step are not visible after you select *Confirm* in the following step. If you lose the credentials, you must recreate the identity provider and define the credentials again.
+The credentials defined in this step are not visible after you select *Add* in the following step. If you lose the credentials, you must recreate the identity provider and define the credentials again.
 ====
 
-. Select *Confirm* to create the HTPasswd identity provider and the user.
+. Select *Add* to create the HTPasswd identity provider and the single, static user.
 
 . Grant the static user permission to manage the cluster:
-.. Select *Add user* in the *Cluster administrative users* section of the *Access control* page.
-.. Enter the username that you defined in the preceding step into the *User ID* field.
-.. Select *Add user* to grant standard administration privileges to the user.
-+
-[NOTE]
-====
-The user is added to the `dedicated-admins` group.
-====
+.. Under *Access control* -> *Cluster Roles and Access*, select *Add user*.
+.. Enter the *User ID* of the static user that you created in the preceding step.
+ifdef::osd-distro[]
+.. Select a *Group.*
+** If you are installing {product-title} using the Customer Cloud Subscription (CCS) infrastructure type, choose either the `dedicated-admins` or `cluster-admins` group. Users in the `dedicated-admins` group have standard administrative privileges for {product-title}. Users in the `cluster-admins` group have full administrative access to the cluster.
+** If you are installing {product-title} using the Red Hat cloud account infrastructure type, the `dedicated-admins` group is automatically selected.
+endif::osd-distro[]
+ifdef::rosa-distro[]
+.. Select a *Group*. Users in the `dedicated-admins` group have standard administrative privileges for {product-title}. Users in the `cluster-admins` group have full administrative access to the cluster.
+endif::rosa-distro[]
+.. Select *Add user* to grant the administration privileges to the user.
 
 .Verification
 
-* The configured identity provider is now visible on the *Access control* tab of the *Clusters* page.
+* The configured HTPasswd identity provider is visible on the *Access control* -> *Identity providers* page.
 +
 [NOTE]
 ====
-After creating the identity provider, synchronization usually completes within two minutes. You can login to the cluster as the user after the HTPasswd identity provider becomes available.
+After creating the identity provider, synchronization usually completes within two minutes. You can log in to the cluster as the user after the HTPasswd identity provider becomes available.
 ====
+* The single, administrative user is visible on the *Access control* -> *Cluster Roles and Access* page. The administration group membership of the user is also displayed.
+
+ifeval::["{context}" == "config-identity-providers"]
+:!osd-distro:
+endif::[]
+ifeval::["{context}" == "rosa-sts-config-identity-providers"]
+:!rosa-distro:
+endif::[]
+ifeval::["{context}" == "rosa-config-identity-providers"]
+:!rosa-distro:
+endif::[]

--- a/modules/config-idp.adoc
+++ b/modules/config-idp.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * assemblies/osd-quickstart.adoc
+// * osd_quickstart/osd-quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="config-idp_{context}"]
@@ -9,6 +9,11 @@
 After you have installed {product-title}, you must configure your cluster to use an identity provider. You can then add members to your identity provider to grant them access to your cluster.
 
 You can configure different identity provider types for your {product-title} cluster. Supported types include GitHub, GitHub Enterprise, GitLab, Google, LDAP, OpenID Connect, and HTPasswd identity providers.
+
+[IMPORTANT]
+====
+The HTPasswd identity provider option is included only to enable the creation of a single, static administration user. HTPasswd is not supported as a general-use identity provider for {product-title}.
+====
 
 The following procedure configures a GitHub identity provider as an example.
 

--- a/modules/rosa-getting-started-configure-an-idp.adoc
+++ b/modules/rosa-getting-started-configure-an-idp.adoc
@@ -6,7 +6,12 @@
 [id="rosa-getting-started-configure-an-idp_{context}"]
 = Configuring an identity provider
 
-You can configure different identity provider types for your {product-title} (ROSA) cluster. Supported types include GitHub, GitHub Enterprise, GitLab, Google, LDAP, OpenID Connect and HTPassword identity providers.
+You can configure different identity provider types for your {product-title} (ROSA) cluster. Supported types include GitHub, GitHub Enterprise, GitLab, Google, LDAP, OpenID Connect and HTPasswd identity providers.
+
+[IMPORTANT]
+====
+The HTPasswd identity provider option is included only to enable the creation of a single, static administration user. HTPasswd is not supported as a general-use identity provider for {product-title}.
+====
 
 The following procedure configures a GitHub identity provider as an example.
 

--- a/modules/understanding-idp.adoc
+++ b/modules/understanding-idp.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
+// * rosa_getting_started/rosa-sts-config-identity-providers.adoc
+// * rosa_getting_started/rosa_getting_started_iam/rosa-config-identity-providers.adoc
 // * identity_providers/config-identity-providers.adoc
-// * rosa_getting_started/rosa-config-identity-providers.adoc
-// * rosa_getting_started_sts/rosa-sts-config-identity-providers.adoc
 
 :_content-type: CONCEPT
 [id="understanding-idp_{context}"]
@@ -22,22 +22,27 @@ You can configure the following types of identity providers:
 |Description
 
 |GitHub or GitHub Enterprise
-|Configure a `github` identity provider to validate usernames and passwords against GitHub or GitHub Enterprise's OAuth authentication server.
+|Configure a GitHub identity provider to validate usernames and passwords against GitHub or GitHub Enterprise's OAuth authentication server.
 
 |GitLab
-|Configure a `gitlab` identity provider to use link:https://gitlab.com/[GitLab.com] or any other GitLab instance as an identity provider.
+|Configure a GitLab identity provider to use link:https://gitlab.com/[GitLab.com] or any other GitLab instance as an identity provider.
 
 |Google
-|Configure a `google` identity provider using link:https://developers.google.com/identity/protocols/OpenIDConnect[Google's OpenID Connect integration].
+|Configure a Google identity provider using link:https://developers.google.com/identity/protocols/OpenIDConnect[Google's OpenID Connect integration].
 
 |LDAP
-|Configure the `ldap` identity provider to validate usernames and passwords against an LDAPv3 server, using simple bind authentication.
+|Configure an LDAP identity provider to validate usernames and passwords against an LDAPv3 server, using simple bind authentication.
 
 |OpenID Connect
-|Configure an `oidc` identity provider to integrate with an OpenID Connect identity provider using an link:http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth[Authorization Code Flow].
+|Configure an OpenID Connect (OIDC) identity provider to integrate with an OIDC identity provider using an link:http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth[Authorization Code Flow].
 
 |HTPasswd
-|Configure an `htpasswd` identity provider for a single, static administration user. You can log in to the cluster as the user to troubleshoot issues.
+|Configure an HTPasswd identity provider for a single, static administration user. You can log in to the cluster as the user to troubleshoot issues.
+
+[IMPORTANT]
+====
+The HTPasswd identity provider option is included only to enable the creation of a single, static administration user. HTPasswd is not supported as a general-use identity provider for {product-title}. For the steps to configure the single user, see _Configuring an HTPasswd identity provider_.
+====
 
 |===
 

--- a/rosa_getting_started/rosa-sts-config-identity-providers.adoc
+++ b/rosa_getting_started/rosa-sts-config-identity-providers.adoc
@@ -16,6 +16,7 @@ include::modules/config-gitlab-idp.adoc[leveloffset=+1]
 include::modules/config-google-idp.adoc[leveloffset=+1]
 include::modules/config-ldap-idp.adoc[leveloffset=+1]
 include::modules/config-openid-idp.adoc[leveloffset=+1]
+include::modules/config-htpasswd-idp.adoc[leveloffset=+1]
 
 [id="additional-resources-cluster-access-sts"]
 [role="_additional-resources"]

--- a/rosa_getting_started/rosa_getting_started_iam/rosa-config-identity-providers.adoc
+++ b/rosa_getting_started/rosa_getting_started_iam/rosa-config-identity-providers.adoc
@@ -16,6 +16,7 @@ include::modules/config-gitlab-idp.adoc[leveloffset=+1]
 include::modules/config-google-idp.adoc[leveloffset=+1]
 include::modules/config-ldap-idp.adoc[leveloffset=+1]
 include::modules/config-openid-idp.adoc[leveloffset=+1]
+include::modules/config-htpasswd-idp.adoc[leveloffset=+1]
 
 [id="additional-resources-idps"]
 [role="_additional-resources"]


### PR DESCRIPTION
**This PR is a work in progress. Do not merge.**

This applies to `main`, `enterprise-4.11` and `enterprise-4.10`.

This relates to https://issues.redhat.com/browse/OSDOCS-2943. The pull request updates the description of the HTPasswd identity provider in various OSD and ROSA sections. The updates clarify that the IDP is provided only to enable the creation of a single, static administration user. The PR also adds the procedure section for adding the HTPasswd IDP and creating the static user in the ROSA docs. At present that section is only available in the OSD docs. The feature is in OpenShift Cluster Manager for both OSD and ROSA.

The previews are available as follows:

#### OSD:

 - **Getting started** -> **Getting started with OpenShift Dedicated** -> [**Configuring an identity provider**](https://deploy-preview-42822--osdocs.netlify.app/openshift-dedicated/latest/osd_quickstart/osd-quickstart.html#config-idp_osd-getting-started)
 - **Configuring identity providers** -> **Configuring your identity providers** -> [**Supported identity providers**](https://deploy-preview-42822--osdocs.netlify.app/openshift-dedicated/latest/identity_providers/config-identity-providers.html#understanding-idp-supported_config-identity-providers)
 - **Configuring identity providers** -> **Configuring your identity providers** -> [**Configuring an HTPasswd identity provider**](https://deploy-preview-42822--osdocs.netlify.app/openshift-dedicated/latest/identity_providers/config-identity-providers.html#config-htpasswd-idp_config-identity-providers)

#### ROSA:

- **Getting started** -> **Getting started with ROSA** -> [**Configuring an identity provider**](https://deploy-preview-42822--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-getting-started.html#rosa-getting-started-configure-an-idp_rosa-getting-started)
- **Getting started** -> **Configuring identity providers using Red Hat OpenShift Cluster Manager** -> [**Supported identity providers**](https://deploy-preview-42822--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-sts-config-identity-providers.html#understanding-idp-supported_rosa-sts-config-identity-providers)
- **Getting started** -> **Configuring identity providers using Red Hat OpenShift Cluster Manager** -> [**Configuring an HTPasswd identity provider**](https://deploy-preview-42822--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-sts-config-identity-providers.html#config-htpasswd-idp_rosa-sts-config-identity-providers)
- **Getting started** -> **Deploying ROSA without AWS STS** -> **Configuring identity providers using Red Hat OpenShift Cluster Manager** -> [**Supported identity providers**](https://deploy-preview-42822--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa_getting_started_iam/rosa-config-identity-providers.html#understanding-idp-supported_rosa-config-identity-providers)
- **Getting started** -> **Deploying ROSA without AWS STS** -> **Configuring identity providers using Red Hat OpenShift Cluster Manager** -> [**Configuring an HTPasswd identity provider**](https://deploy-preview-42822--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa_getting_started_iam/rosa-config-identity-providers.html#config-htpasswd-idp_rosa-config-identity-providers)