### PR TITLE
RN-typo-fix: issued 2.28.22

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -735,9 +735,9 @@ When configuring the `docker/config.json` file to allow pods to pull images from
 Node-related metrics and alerts have been enhanced to give you an earlier indication of when the stability of a node is compromised.
 
 [id="ocp-4-9-poison-pill-operator"]
-==== Enhanced remediation with the Poison Pill Operator 
+==== Enhanced remediation with the Poison Pill Operator
 
-You can use the Poison Pill Operator regardless of the cluster installation type, such as Installer Provisioned Infrastructure (IPI) or User Provisioned Infrastructure (UPI). 
+You can use the Poison Pill Operator regardless of the cluster installation type, such as Installer Provisioned Infrastructure (IPI) or User Provisioned Infrastructure (UPI).
 The Operator now provides enhanced remediation with the use of watchdog devices. For more information, see xref:../nodes/nodes/eco-poison-pill-operator.adoc#about-watchdog-devices_poison-pill-operator-remediate-nodes[About watchdog devices].
 
 [id="ocp-4-9-node-health-check-operator"]
@@ -2567,7 +2567,7 @@ link:https://access.redhat.com/solutions/6762051[{product-title} 4.9.23 containe
 [id="ocp-4-9-23-bug-fixes"]
 ==== Bug fixes
 
-* Previously, installation failed when installing to a region that had local zone enabled. With this update, the installation program considers only availability zones and not local zones. Now, installation with local zones enabled will only installs to the availability zones in that region and not to any local zones. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2052307[BZ#*2052307*])
+* Previously, installation failed when installing to a region that had local zone enabled. With this update, the installation program considers only availability zones and not local zones. Now, installation with local zones enabled will only install to the availability zones in that region and not to any local zones. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2052307[BZ#*2052307*])
 
 [id="ocp-4-9-23-updating"]
 ==== Updating


### PR DESCRIPTION
4.9 RN

Fixes small typo

[Preview](https://deploy-preview-42824--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html)