### PR TITLE
OSDOCS-2678: Alibaba install with network customizations

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -129,6 +129,8 @@ Topics:
       File: installing-alibaba-default
     - Name: Installing a cluster on Alibaba Cloud with customizations
       File: installing-alibaba-customizations
+    - Name: Installing a cluster on Alibaba Cloud with network customizations
+      File: installing-alibaba-network-customizations
     - Name: Uninstalling a cluster on Alibaba Cloud
       File: uninstall-cluster-alibaba
 - Name: Installing on AWS

--- a/installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+++ b/installing/installing_alibaba/installing-alibaba-network-customizations.adoc
@@ -1,0 +1,80 @@
+:_content-type: ASSEMBLY
+[id="installing-alibaba-network-customizations"]
+= Installing a cluster on Alibaba Cloud with network customizations
+include::_attributes/common-attributes.adoc[]
+:context: installing-alibaba-network-customizations
+
+toc::[]
+
+In {product-title} {product-version}, you can install a cluster on Alibaba Cloud with customized network configuration options. By customizing your network configuration, your cluster can coexist with existing IP address allocations in your environment and integrate with existing MTU and
+VXLAN configurations.
+
+You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
+
+:FeatureName: Alibaba Cloud on {product-title}
+include::snippets/technology-preview.adoc[]
+
+[id="prerequisites_installing-alibaba-network-customizations"]
+== Prerequisites
+
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_alibaba/preparing-to-install-on-alibaba.html#installation-alibaba-dns_preparing-to-install-on-alibaba[registered your domain].
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud Resource Access Management (RAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_alibaba/manually-creating-alibaba-ram.adoc#manually-creating-alibaba-ram[manually create and maintain Resource Access Management (RAM) credentials].
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+//Networking-specific customization module
+include::modules/nw-network-config.adoc[leveloffset=+1]
+
+include::modules/installation-initializing.adoc[leveloffset=+2]
+
+include::modules/manually-creating-alibaba-manifests.adoc[leveloffset=+2]
+
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+2]
+
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
+include::modules/installation-alibaba-config-yaml.adoc[leveloffset=+2]
+
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+//Networking-specific customization module
+include::modules/nw-operator-cr.adoc[leveloffset=+1]
+
+//Networking-specific customization module
+include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
+
+//Networking-specific customization module
+include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
+
+include::modules/cluster-telemetry.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.
+* See xref:../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console
+* See xref:../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
+
+[id="next-steps_installing-alibaba-network-customizations"]
+== Next steps
+
+* xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validate an installation].
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
+* If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+//Given that manual mode is required to install on Alibaba Cloud, I do not believe this xref is necessary.
+//* If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials].

--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -2,6 +2,7 @@
 //
 // * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
 // * installing/installing_alibaba/manually-creating-alibaba-ram.adoc
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 
 :_content-type: PROCEDURE
 ifeval::["{context}" == "cco-mode-sts"]
@@ -42,7 +43,7 @@ You must have:
 
 * Extracted and prepared the `ccoctl` binary.
 ifdef::alibabacloud-default,alibabacloud-customizations[]
-* Created a RAM user with sufficient permission to create the {product-title} cluster. 
+* Created a RAM user with sufficient permission to create the {product-title} cluster.
 * Added the AccessKeyID (`access_key_id`) and AccessKeySecret (`access_key_secret`) of that RAM user into the link:https://www.alibabacloud.com/help/en/doc-detail/311667.htm#h2-sls-mfm-3p3[`~/.alibabacloud/credentials` file] on your local computer.
 endif::alibabacloud-default,alibabacloud-customizations[]
 

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // * cli_reference/openshift_cli/getting-started.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc

--- a/modules/cli-logging-in-kubeadmin.adoc
+++ b/modules/cli-logging-in-kubeadmin.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-default.adoc

--- a/modules/cluster-entitlements.adoc
+++ b/modules/cluster-entitlements.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc

--- a/modules/cluster-telemetry.adoc
+++ b/modules/cluster-telemetry.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc

--- a/modules/installation-alibaba-config-yaml.adoc
+++ b/modules/installation-alibaba-config-yaml.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // * installing/installing_alibaba/installing-alibaba-customizations.adoc
 
 :_content-type: REFERENCE

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/installing_alibaba//installing-alibaba-default.adoc
 // * installing/installing_aws/installing-alibaba-customizations.adoc
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // * installing/installing_aws/installing-aws-china.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
@@ -810,11 +811,11 @@ On clusters that use Kuryr, {rh-openstack} Octavia does not support availability
 |A list of strings, for example `["zone-1", "zone-2"]`.
 
 |`compute.platform.openstack.serverGroupPolicy`
-|Server group policy to apply to the group that will contain the compute machines in the pool. You cannot change server group policies or affiliations after creation. Supported options include `anti-affinity`, `soft-affinity`, and `soft-anti-affinity`. The default value is `soft-anti-affinity`. 
+|Server group policy to apply to the group that will contain the compute machines in the pool. You cannot change server group policies or affiliations after creation. Supported options include `anti-affinity`, `soft-affinity`, and `soft-anti-affinity`. The default value is `soft-anti-affinity`.
 
 An `affinity` policy prevents migrations and therefore affects {rh-openstack} upgrades. The `affinity` policy is not supported.
 
-If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is required during instance migration. 
+If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is required during instance migration.
 |A server group policy to apply to the machine pool. For example, `soft-affinity`.
 
 |`controlPlane.platform.openstack.additionalNetworkIDs`
@@ -836,11 +837,11 @@ On clusters that use Kuryr, {rh-openstack} Octavia does not support availability
 |A list of strings, for example `["zone-1", "zone-2"]`.
 
 |`controlPlane.platform.openstack.serverGroupPolicy`
-|Server group policy to apply to the group that will contain the control plane machines in the pool. You cannot change server group policies or affiliations after creation. Supported options include `anti-affinity`, `soft-affinity`, and `soft-anti-affinity`. The default value is `soft-anti-affinity`. 
+|Server group policy to apply to the group that will contain the control plane machines in the pool. You cannot change server group policies or affiliations after creation. Supported options include `anti-affinity`, `soft-affinity`, and `soft-anti-affinity`. The default value is `soft-anti-affinity`.
 
 An `affinity` policy prevents migrations, and therefore affects {rh-openstack} upgrades. The `affinity` policy is not supported.
 
-If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is required during instance migration. 
+If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is required during instance migration.
 |A server group policy to apply to the machine pool. For example, `soft-affinity`.
 
 |`platform.openstack.clusterOSImage`
@@ -1436,7 +1437,7 @@ Additional Alibaba Cloud configuration parameters are described in the following
 
 |`platform.alibabacloud.defaultMachinePlatform.imageID`
 |For compute machines, the image ID that should be used to create ECS instance. If set, the image ID should belong to the same region as the cluster
-|String. 
+|String.
 
 |`platform.alibabacloud.defaultMachinePlatform.instanceType`
 |For compute machines, the configuration used when installing on Alibaba Cloud.

--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // * installing/installing_aws/installing_aws-customizations.adoc
 // * installing/installing_aws/installing_aws-network-customizations.adoc
 // * installing/installing_aws/installing_aws-private.adoc

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/installing_aws/installing-alibaba-default.adoc
 // * installing/installing_aws/installing-alibaba-customizations.adoc
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc
@@ -412,7 +413,7 @@ ifdef::alibabacloud-default,alibabacloud-custom[]
 ----
 apiVersion: v1
 baseDomain: cluster1.example.com
-credentialsMode: Manual <1> 
+credentialsMode: Manual <1>
 compute:
 - architecture: amd64
   hyperthreading: Enabled

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // * installing/installing_alibaba/installing-alibaba-customizations.adoc
 // * installing/installing_alibaba/installing-alibaba-default.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-default.adoc

--- a/modules/logging-in-by-using-the-web-console.adoc
+++ b/modules/logging-in-by-using-the-web-console.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // *installing/installing_aws/installing-aws-china.adoc.
 // * installing/installing_aws/installing-aws-secret-region.adoc
 // *installing/validating-an-installation.adoc

--- a/modules/manually-creating-alibaba-manifests.adoc
+++ b/modules/manually-creating-alibaba-manifests.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_alibaba/installing-alibaba-default.adoc
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 
 :_content-type: PROCEDURE
 [id="manually-creating-alibaba-manifests_{context}"]

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-aws-china.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc


### PR DESCRIPTION
Adds an assembly to the Alibaba installation guide about installing with network customizations.

https://issues.redhat.com/browse/OSDOCS-2678

The main Alibaba install guide: https://github.com/openshift/openshift-docs/pull/41083

Applies only to `main` and `enterprise-4.10`

Preview: https://deploy-preview-42836--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-network-customizations.html

CC @mburke5678 