### PR TITLE
OSDOCS-2210: OSDK-1713 scorecard storage RN and known issue

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -765,6 +765,14 @@ Operator authors can now use the Ansible-based Operator support in the Operator 
 
 For more details, see xref:../operators/operator_sdk/osdk-monitoring-prometheus.adoc#osdk-monitoring-prometheus[Exposing custom metrics for Ansible-based Operators].
 
+[id="ocp-4-10-osdk-scorecard-storage"]
+==== Storing scorecard test results
+
+Operator authors can now enable local storage for scorecard test results either by using the `scorecard` CLI or by modifying a configuration file. For more information, see
+xref:../operators/operator_sdk/osdk-scorecard.adoc#osdk-scorecard-store-output_osdk-scorecard[Scorecard output storage]
+
+Currently, there is a known issue with the scorecard storage utility. See the "Known Issues" section for more information.
+
 [id="ocp-4-10-builds"]
 === Builds
 
@@ -2305,6 +2313,8 @@ Workaround: Use OpenShift OAuth for authentication. (link:https://bugzilla.redha
 * In the default ZTP Argo CD configuration, cluster names cannot begin with `ztp`. Using names starting with `ztp` for clusters deployed with Zero Touch Provisioning (ZTP) results in provisioning not completing. As a workaround, ensure that either cluster names do not start with `ztp`, or adjust the Argo CD policy application namespace to a pattern that excludes the names of your clusters but still matches your policy namespace. For example, if your cluster names start with `ztp`, change the pattern in the Argo CD policy app configuration to something different, like `ztp-`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049154[*BZ#2049154*])
 
 * Previously, the `oc adm must-gather` tool did not collect performance specific data when more than one `--image` argument was supplied. Files, including node and performance related files, were missing when the operation finished. The issue affects {product-title} versions between 4.7 and 4.10. This issue can be resolved by executing the `oc adm must-gather` operation twice, once for each image. As a result, all expected files can be collected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2018159[*BZ#2018159*])
+
+* This release contains a known issue with the Operator SDK scorecard storage utility. Currently, running the `operator-sdk scorecard` command with the `--test-output` flag returns an empty directory. There is no known workaround at this time. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2017669[*BZ#2017669*])
 
 [id="ocp-4-10-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
- `enterprise-4.10`
- [OSDOCS-2210](https://issues.redhat.com/browse/OSDOCS-2210)

Preview links:
- [Release note](https://deploy-preview-42843--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-osdk-scorecard-storage)
- [Known issues](https://deploy-preview-42843--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-known-issues): at the bottom on the list, right above asynchronous updates