### PR TITLE
OSS-Docs-32: Removed instances of OCM

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -23,7 +23,10 @@ endif::[]
 :kebab: image:kebab.png[title="Options menu"]
 :rh-openstack-first: Red Hat OpenStack Platform (RHOSP)
 :rh-openstack: RHOSP
-:cloud-redhat-com: Red Hat OpenShift Cluster Manager
+:cluster-manager-first: Red Hat OpenShift Cluster Manager
+:cluster-manager: OpenShift Cluster Manager
+:cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager]
+:cluster-manager-url-pull: link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager]
 :rh-storage-first: Red Hat OpenShift Container Storage
 :rh-storage: OpenShift Container Storage
 :rh-virtualization-first: Red Hat Virtualization (RHV)

--- a/_attributes/distr-tracing-document-attributes.adoc
+++ b/_attributes/distr-tracing-document-attributes.adoc
@@ -10,7 +10,7 @@
 //
 :product-title: OpenShift Container Platform
 :product-dedicated: Red Hat OpenShift Dedicated
-:console-redhat-com: Red Hat OpenShift Cluster Manager
+:cluster-manager-first: Red Hat OpenShift Cluster Manager
 
 :ProductName: Red Hat OpenShift Service Mesh
 
@@ -28,7 +28,7 @@
 
 :product-build:
 :DownloadURL: registry.redhat.io
-:cloud-redhat-com: Red Hat OpenShift Cluster Manager
+:cluster-manager-first: Red Hat OpenShift Cluster Manager
 :kebab: image:kebab.png[title="Options menu"]
 //
 // Documentation publishing attributes used in the master-docinfo.xml file

--- a/_attributes/jaeger-document-attributes.adoc
+++ b/_attributes/jaeger-document-attributes.adoc
@@ -15,7 +15,7 @@
 :ProductVersion: 1.24.0
 :product-build:
 :DownloadURL: registry.redhat.io
-:cloud-redhat-com: Red Hat OpenShift Cluster Manager
+:cluster-manager-first: Red Hat OpenShift Cluster Manager
 :kebab: image:kebab.png[title="Options menu"]
 //
 // Documentation publishing attributes used in the master-docinfo.xml file

--- a/_attributes/ossm-document-attributes-1x.adoc
+++ b/_attributes/ossm-document-attributes-1x.adoc
@@ -16,7 +16,7 @@
 :MaistraVersion: 1.1
 :product-build:
 :DownloadURL: registry.redhat.io
-:cloud-redhat-com: Red Hat OpenShift Cluster Manager
+:cluster-manager-first: Red Hat OpenShift Cluster Manager
 :kebab: image:kebab.png[title="Options menu"]
 //
 // Documentation publishing attributes used in the master-docinfo.xml file

--- a/_attributes/ossm-document-attributes.adoc
+++ b/_attributes/ossm-document-attributes.adoc
@@ -6,7 +6,7 @@
 :toc-title:
 :experimental:
 :DownloadURL: registry.redhat.io
-:console-redhat-com: Red Hat OpenShift Cluster Manager
+:cluster-manager-first: Red Hat OpenShift Cluster Manager
 :kebab: image:kebab.png[title="Options menu"]
 
 // Service Mesh product content attributes, that is, substitution variables in the files.

--- a/cloud_infrastructure_access/dedicated-aws-access.adoc
+++ b/cloud_infrastructure_access/dedicated-aws-access.adoc
@@ -63,7 +63,7 @@ It is not recommended to set a permissions boundary.
 . Gather the IAM user's Amazon Resource Name (ARN). The ARN will have the following format: `arn:aws:iam::000111222333:user/username`.
 
 [id=dedicated-aws-ocm-iam-role]
-=== Granting the IAM role from the OpenShift Cluster Manager
+=== Granting the IAM role from {cluster-manager-first}
 
 .Procedure
 

--- a/cloud_infrastructure_access/dedicated-aws-private-cluster.adoc
+++ b/cloud_infrastructure_access/dedicated-aws-private-cluster.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 An {product-title} cluster can be made private so that internal applications can be hosted inside a corporate network. In addition, private clusters can be configured to have only internal API endpoints for increased security.
 
-{product-title} administrators can choose between public and private cluster configuration from within the *OpenShift Cluster Manager* (OCM). Privacy settings can be configured during cluster creation or after a cluster is established.
+{product-title} administrators can choose between public and private cluster configuration from within *{cluster-manager}*. Privacy settings can be configured during cluster creation or after a cluster is established.
 
 include::modules/dedicated-enable-private-cluster-new.adoc[leveloffset=+1]
 

--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -457,6 +457,7 @@ If it makes more sense in context to refer to the major version of the product i
 Other common attribute values are defined in the `_attributes/common-attributes.adoc` file. Where possible, generalize references to those values by using the common attributes. For example, use `{console-redhat-com}` to refer to Red Hat OpenShift Cluster Manager.
 ====
 
+//CANARY
 [id="conditional-content"]
 == Conditional content
 

--- a/installing/validating-an-installation.adoc
+++ b/installing/validating-an-installation.adoc
@@ -39,7 +39,7 @@ include::modules/querying-the-status-of-cluster-nodes-using-the-cli.adoc[levelof
 //Reviewing the cluster status from the OpenShift Container Platform web console
 include::modules/reviewing-cluster-status-from-the-openshift-web-console.adoc[leveloffset=+1]
 
-//Reviewing the cluster status from the OpenShift Cluster Manager
+//Reviewing the cluster status from {cluster-manager}
 include::modules/reviewing-cluster-status-from-the-openshift-cluster-manager.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/cluster-entitlements.adoc
+++ b/modules/cluster-entitlements.adoc
@@ -117,7 +117,7 @@ your cluster.
 
 You must have Internet access to:
 
-* Access the link:https://console.redhat.com/openshift[{cloud-redhat-com}] page to download the installation program and perform subscription management. If the cluster has Internet access and you do not disable Telemetry, that service automatically entitles your cluster.
+* Access {cluster-manager-url} to download the installation program and perform subscription management. If the cluster has internet access and you do not disable Telemetry, that service automatically entitles your cluster.
 * Access link:http://quay.io[Quay.io] to obtain the packages that are required to install your cluster.
 * Obtain the packages that are required to perform cluster updates.
 ifdef::openshift-enterprise,openshift-webscale[]

--- a/modules/cluster-logging-deploy-cli.adoc
+++ b/modules/cluster-logging-deploy-cli.adoc
@@ -21,7 +21,7 @@ If you use a local volume for persistent storage, do not use a raw block volume,
 Elasticsearch is a memory-intensive application. By default, {product-title} installs three Elasticsearch nodes with memory requests and limits of 16 GB. This initial set of three {product-title} nodes might not have enough memory to run Elasticsearch within your cluster. If you experience memory issues that are related to Elasticsearch, add more Elasticsearch nodes to your cluster rather than increasing the memory on existing nodes.
 
 ifdef::openshift-origin[]
-* Ensure that you have downloaded the link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in _Obtaining the installation program_ in the installation documentation for your platform.
+* Ensure that you have downloaded the {cluster-manager-url-pull} as shown in _Obtaining the installation program_ in the installation documentation for your platform.
 +
 If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in *Configuring {product-title} to use Red Hat Operators*.
 endif::[]

--- a/modules/cluster-logging-deploy-console.adoc
+++ b/modules/cluster-logging-deploy-console.adoc
@@ -26,7 +26,7 @@ If you use a local volume for persistent storage, do not use a raw block volume,
 Elasticsearch is a memory-intensive application. By default, {product-title} installs three Elasticsearch nodes with memory requests and limits of 16 GB. This initial set of three {product-title} nodes might not have enough memory to run Elasticsearch within your cluster. If you experience memory issues that are related to Elasticsearch, add more Elasticsearch nodes to your cluster rather than increasing the memory on existing nodes.
 
 ifdef::openshift-origin[]
-* Ensure that you have downloaded the link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in _Obtaining the installation program_ in the installation documentation for your platform.
+* Ensure that you have downloaded the {cluster-manager-url-pull} as shown in _Obtaining the installation program_ in the installation documentation for your platform.
 +
 If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
 endif::[]

--- a/modules/cluster-telemetry.adoc
+++ b/modules/cluster-telemetry.adoc
@@ -61,8 +61,8 @@
 ifndef::openshift-origin[]
 = Telemetry access for {product-title}
 
-In {product-title} {product-version}, the Telemetry service, which runs by default to provide metrics about cluster health and the success of updates, requires Internet access. If your cluster is connected to the Internet, Telemetry runs automatically, and your cluster is registered to the link:https://console.redhat.com/openshift[{cloud-redhat-com} (OCM)].
+In {product-title} {product-version}, the Telemetry service, which runs by default to provide metrics about cluster health and the success of updates, requires internet access. If your cluster is connected to the internet, Telemetry runs automatically, and your cluster is registered to {cluster-manager-url}.
 
-After you confirm that your {cloud-redhat-com} inventory is correct, either maintained automatically by Telemetry or manually by using OCM, link:https://access.redhat.com/documentation/en-us/subscription_central/2020-04/html/getting_started_with_subscription_watch/con-how-to-select-datacollection-tool_assembly-requirements-and-your-responsibilities-ctxt#red_hat_openshift[use subscription watch] to track your {product-title} subscriptions at the account or multi-cluster level.
+After you confirm that your {cluster-manager-url} inventory is correct, either maintained automatically by Telemetry or manually by using {cluster-manager}, link:https://access.redhat.com/documentation/en-us/subscription_central/2020-04/html/getting_started_with_subscription_watch/con-how-to-select-datacollection-tool_assembly-requirements-and-your-responsibilities-ctxt#red_hat_openshift[use subscription watch] to track your {product-title} subscriptions at the account or multi-cluster level.
 
 endif::openshift-origin[]

--- a/modules/dedicated-accessing-your-cluster.adoc
+++ b/modules/dedicated-accessing-your-cluster.adoc
@@ -9,7 +9,6 @@ Use the following steps to access your {product-title} cluster.
 
 .Procedure
 
-. From link:https://console.redhat.com/openshift[console.redhat.com/openshift], click
- on the cluster you want to access.
+. From {cluster-manager-url}, click on the cluster you want to access.
 
  . Click *Launch Console*.

--- a/modules/dedicated-cluster-admin-enable.adoc
+++ b/modules/dedicated-cluster-admin-enable.adoc
@@ -8,8 +8,8 @@
 The cluster-admin role must be enabled at the cluster level before it can be assigned to a user.
 
 .Prerequisites
-. Open a technical support case with Red Hat to request that `cluster-admin` be enabled for your cluster. 
+. Open a technical support case with Red Hat to request that `cluster-admin` be enabled for your cluster.
 
 .Procedure
-. In the OpenShift Cluster Manager, select the cluster you want to assign cluster-admin privileges.
+. In {cluster-manager}, select the cluster you want to assign cluster-admin privileges.
 . Under the *Actions* dropdown menu, select *Allow cluster-admin access*.

--- a/modules/dedicated-cluster-admin-grant.adoc
+++ b/modules/dedicated-cluster-admin-grant.adoc
@@ -11,7 +11,7 @@ After enabling cluster-admin rights on your cluster, you can assign the role to 
 * Cluster access with cluster owner permissions
 
 .Procedure
-. In the OpenShift Cluster Manager, select the cluster you want to assign cluster-admin privileges.
+. In {cluster-manager}, select the cluster you want to assign cluster-admin privileges.
 . Under the *Access Control* tab, locate the *Cluster Administrative Users* section. Click *Add user*.
 . After determining an appropriate User ID, select *cluster-admin* from the *Group* selection, then click *Add user*.
 +

--- a/modules/dedicated-creating-your-cluster.adoc
+++ b/modules/dedicated-creating-your-cluster.adoc
@@ -9,7 +9,7 @@ Use the following steps to create your {product-title} cluster.
 
 .Procedure
 
-. Log in to link:https://console.redhat.com/openshift[console.redhat.com/openshift].
+. Log in to {cluster-manager-url}.
 
 . Select *Create Cluster* -> *Red Hat OpenShift Dedicated*.
 

--- a/modules/dedicated-enable-private-cluster-existing.adoc
+++ b/modules/dedicated-enable-private-cluster-existing.adoc
@@ -5,7 +5,7 @@
 [id="dedicated-enable-private-cluster-existing"]
 = Enabling private cluster on an existing cluster
 
-You can enable private clusters after a cluster has been created: 
+You can enable private clusters after a cluster has been created:
 
 .Prerequisites
 
@@ -13,7 +13,7 @@ You can enable private clusters after a cluster has been created:
 
 .Procedure
 
-. Access your cluster in the OpenShift Cluster Manager.
+. Access your cluster in {cluster-manager}.
 . Navigate to the *Networking* tab.
 . Select *Make API private* under *Master API endpoint* and click *Change settings*.
 +

--- a/modules/dedicated-enable-private-cluster-new.adoc
+++ b/modules/dedicated-enable-private-cluster-new.adoc
@@ -13,7 +13,7 @@ You can enable private cluster settings when creating a new cluster:
 
 .Procedure
 
-. In the OpenShift Cluster Manager, click *Create cluster* and select *{product-title}*.
+. In {cluster-manager-first}, click *Create cluster* and select *{product-title}*.
 . Configure your cluster details, then select *Advanced* in the Networking section.
 . Determine your CIDR requirements for your network and input the required fields.
 +

--- a/modules/dedicated-enable-public-cluster.adoc
+++ b/modules/dedicated-enable-public-cluster.adoc
@@ -5,11 +5,11 @@
 [id="dedicated-enable-public-cluster"]
 = Enabling public cluster on a private cluster
 
-You can set a private cluster to public facing: 
+You can set a private cluster to public facing:
 
 .Procedure
 
-. Access your cluster in the OpenShift Cluster Manager.
+. Access your cluster in {cluster-manager-first}.
 . Navigate to the *Networking* tab.
 . Deselect *Make API private* under *Master API endpoint* and click *Change settings*.
 +

--- a/modules/dedicated-managing-dedicated-administrators.adoc
+++ b/modules/dedicated-managing-dedicated-administrators.adoc
@@ -5,9 +5,7 @@
 [id="dedicated-managing-dedicated-administrators_{context}"]
 =  Managing {product-title} administrators
 
-Administrator roles are managed using a `dedicated-admins` group on the cluster.
-Existing members of this group can edit membership via the
-link:https://console.redhat.com/openshift[{cloud-redhat-com}] site.
+Administrator roles are managed using a `dedicated-admins` group on the cluster. Existing members of this group can edit membership via {cluster-manager-url}.
 
 [id="dedicated-administrators-adding-user_{context}"]
 == Adding a user

--- a/modules/dedicated-scaling-your-cluster.adoc
+++ b/modules/dedicated-scaling-your-cluster.adoc
@@ -7,12 +7,10 @@
 
 To scale your {product-title} cluster:
 
-. From link:https://console.redhat.com/openshift[console.redhat.com/openshift], click
- on the cluster you want to resize.
+. From {cluster-manager-url}, click on the cluster you want to resize.
 
 . Click *Actions*, then *Scale Cluster*.
 
 . Select how many compute nodes are required, then click *Apply*.
 
-Scaling occurs automatically. In the *Overview* tab under the *Details*
-heading,the *Status* indicator shows that your cluster is *Ready* for use.
+Scaling occurs automatically. In the *Overview* tab under the *Details* heading,the *Status* indicator shows that your cluster is *Ready* for use.

--- a/modules/displaying-potential-issues-with-your-cluster.adoc
+++ b/modules/displaying-potential-issues-with-your-cluster.adoc
@@ -6,15 +6,15 @@
 [id="displaying-potential-issues-with-your-cluster_{context}"]
 = Displaying potential issues with your cluster
 
-This section describes how to display the Insights report in the {cloud-redhat-com}.
+This section describes how to display the Insights report in {cluster-manager-url}.
 
 Note that Insights repeatedly analyzes your cluster and shows the latest results. These results can change, for example, if you fix an issue or a new issue has been detected.
 
 .Prerequisites
 
-* Your cluster is registered in the {cloud-redhat-com}.
+* Your cluster is registered in {cluster-manager-url}.
 * Remote health reporting is enabled, which is the default.
-* You are logged in to the link:https://console.redhat.com/openshift[{cloud-redhat-com}].
+* You are logged in to {cluster-manager-url}.
 
 .Procedure
 

--- a/modules/generating-icsp-object-scoped-to-a-registry.adoc
+++ b/modules/generating-icsp-object-scoped-to-a-registry.adoc
@@ -30,7 +30,7 @@ where:
 --
 <local_registry>:: is the local registry you have configured for your disconnected cluster, for example, `local.registry:5000`.
 <pull_spec>:: is the pull specification as configured in your disconnected registry, for example, `redhat/redhat-operator-index:v{product-version}`
-<pull_secret_file>:: is the `registry.redhat.io` pull secret in `.json` file format downloaded from the link:https://cloud.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site.
+<pull_secret_file>:: is the `registry.redhat.io` pull secret in `.json` file format. You can download the {cluster-manager-url-pull}.
 --
 +
 The `oc adm catalog mirror` command creates a `/redhat-operator-index-manifests` directory and generates `imageContentSourcePolicy.yaml`, `catalogSource.yaml`, and `mapping.txt` files.

--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -10,9 +10,9 @@ You can update the global pull secret for your cluster by either replacing the c
 
 [IMPORTANT]
 ====
-To transfer your cluster to another owner, you must first initiate the transfer in link:https://console.redhat.com/openshift/[Red Hat OpenShift Cluster Manager], and then update the pull secret on the cluster. Updating a cluster's pull secret without initiating the transfer in OpenShift Cluster Manager causes the cluster to stop reporting Telemetry metrics in OpenShift Cluster Manager. 
+To transfer your cluster to another owner, you must first initiate the transfer in {cluster-manager-url}, and then update the pull secret on the cluster. Updating a cluster's pull secret without initiating the transfer in {cluster-manager} causes the cluster to stop reporting Telemetry metrics in {cluster-manager}.
 
-For more information link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2021/html/managing_clusters/assembly-managing-clusters#transferring-cluster-ownership_assembly-managing-clusters[about transferring cluster ownership], see "Transferring cluster ownership" in the Red Hat OpenShift Cluster Manager documentation. 
+For more information link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2021/html/managing_clusters/assembly-managing-clusters#transferring-cluster-ownership_assembly-managing-clusters[about transferring cluster ownership], see "Transferring cluster ownership" in the {cluster-manager-first} documentation.
 ====
 
 [WARNING]
@@ -48,7 +48,7 @@ $ oc registry login --registry="<registry>" \ <1>
 --auth-basic="<username>:<password>" \ <2>
 --to=<pull_secret_location> <3>
 ----
-<1> Provide the new registry.
+<1> Provide the new registry. You can include multiple repositories within the same registry, for example: `--registry="<registry/my-namespace/my-repository>"`.
 <2> Provide the credentials of the new registry.
 <3> Provide the path to the pull secret file.
 +

--- a/modules/insights-operator-about.adoc
+++ b/modules/insights-operator-about.adoc
@@ -8,12 +8,12 @@
 
 The Insights Operator periodically gathers configuration and component failure status and, by default, reports that data every two hours to Red Hat. This information enables Red Hat to assess configuration and deeper failure data than is reported through Telemetry.
 
-Users of {product-title} can display the report of each cluster in {cloud-redhat-com}. If any issues have been identified, Insights provides further details and, if available, steps on how to solve a problem.
+Users of {product-title} can display the report of each cluster in {cluster-manager-url}. If any issues have been identified, Insights provides further details and, if available, steps on how to solve a problem.
 
 The Insights Operator does not collect identifying information, such as user names, passwords, or certificates. See link:https://console.redhat.com/security/insights[Red Hat Insights Data & Application Security] for information about Red Hat Insights data collection and controls.
 
 Red Hat uses all connected cluster information to:
 
-* Proactively identify potential cluster issues and provide a solution and preventive actions in {cloud-redhat-com}
+* Proactively identify potential cluster issues and provide a solution and preventive actions in {cluster-manager-url}
 * Improve {product-title} by providing aggregated and critical information to product and support teams
 * Make {product-title} more intuitive

--- a/modules/installation-adding-registry-pull-secret.adoc
+++ b/modules/installation-adding-registry-pull-secret.adoc
@@ -47,8 +47,7 @@ endif::restricted[]
 Complete the following steps on the installation host:
 
 ifndef::openshift-origin[]
-. Download your `registry.redhat.io` pull secret from the
-link:https://console.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site and save it to a `.json` file.
+. Download your `registry.redhat.io` {cluster-manager-url-pull} and save it to a `.json` file.
 endif::[]
 
 . Generate the base64-encoded user name and password or token for your mirror
@@ -97,7 +96,6 @@ The contents of the file resemble the following example:
   }
 }
 ----
-endif::[]
 
 ifndef::openshift-origin[]
 . Edit the new

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -37,9 +37,7 @@ ifdef::ibm-power[]
 = Sample `install-config.yaml` file for IBM Power Systems
 endif::ibm-power[]
 
-You can customize the `install-config.yaml` file to specify more details about
-your {product-title} cluster's platform or modify the values of the required
-parameters.
+You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
 
 [source,yaml]
 ----
@@ -215,16 +213,10 @@ The use of FIPS Validated / Modules in Process cryptographic libraries is only s
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]
-<12> The pull secret that you obtained from the link:https://console.redhat.com/openshift[{cloud-redhat-com}] site.
-This pull secret allows you to authenticate with the services that are
-provided by the included authorities, including Quay.io, which serves the
-container images for {product-title} components.
+<12> The {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<11> The pull secret that you obtained from the link:https://console.redhat.com/openshift[{cloud-redhat-com}] site.
-This pull secret allows you to authenticate with the services that are
-provided by the included authorities, including Quay.io, which serves the
-container images for {product-title} components.
+<11> The {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
 endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
@@ -235,10 +227,7 @@ port, that your mirror registry uses to serve content. For example
 specify the base64-encoded user name and password for your mirror registry.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<11> For `<local_registry>`, specify the registry domain name, and optionally the
-port, that your mirror registry uses to serve content. For example,
-`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
-specify the base64-encoded user name and password for your mirror registry.
+<11> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
 endif::openshift-origin[]
 endif::restricted[]
 ifndef::openshift-origin[]
@@ -257,24 +246,20 @@ For production {product-title} clusters on which you want to perform installatio
 ifdef::restricted[]
 ifndef::ibm-z[]
 ifndef::openshift-origin[]
-<14> Provide the contents of the certificate file that you used for your mirror
-registry.
+<14> Provide the contents of the certificate file that you used for your mirror registry.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<13> Provide the contents of the certificate file that you used for your mirror
-registry.
+<13> Provide the contents of the certificate file that you used for your mirror registry.
 endif::openshift-origin[]
 endif::ibm-z[]
 ifdef::ibm-z[]
 <14> Add the `additionalTrustBundle` parameter and value. The value must be the contents of the certificate file that you used for your mirror registry, which can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.
 endif::ibm-z[]
 ifndef::openshift-origin[]
-<15> Provide the `imageContentSources` section from the output of the command to
-mirror the repository.
+<15> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<14> Provide the `imageContentSources` section from the output of the command to
-mirror the repository.
+<14> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -197,7 +197,7 @@ endif::osp[]
 
 ifndef::openshift-origin[]
 |`pullSecret`
-|Get a pull secret from link:https://console.redhat.com/openshift/install/pull-secret[] to authenticate downloading container images for {product-title} components from services such as Quay.io.
+|Get a {cluster-manager-url-pull} to authenticate downloading container images for {product-title} components from services such as Quay.io.
 |
 [source,json]
 ----

--- a/modules/installation-generate-aws-user-infra-install-config.adoc
+++ b/modules/installation-generate-aws-user-infra-install-config.adoc
@@ -62,8 +62,7 @@ The AWS access key ID and secret access key are stored in `~/.aws/credentials` i
 ... Select the AWS region to deploy the cluster to.
 ... Select the base domain for the Route 53 service that you configured for your cluster.
 ... Enter a descriptive name for your cluster.
-... Paste the pull secret that you obtained from the
-link:https://console.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site.
+... Paste the {cluster-manager-url-pull}.
 ifdef::openshift-origin[]
 This field is optional.
 endif::[]

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -332,11 +332,10 @@ ocpadmin@internal
 ... For `Ingress virtual IP`, enter the static IP address you reserved for the wildcard apps domain.
 ... For `Base Domain`, enter the base domain of the {product-title} cluster. If this cluster is exposed to the outside world, this must be a valid domain recognized by DNS infrastructure. For example, enter: `virtlab.example.com`
 ... For `Cluster Name`, enter the name of the cluster. For example, `my-cluster`. Use cluster name from the externally registered/resolvable DNS entries you created for the {product-title} REST API and apps domain names. The installation program also gives this name to the cluster in the {rh-virtualization} environment.
-... For `Pull Secret`, copy the pull secret from the `pull-secret.txt` file you downloaded earlier and paste it here. You can also get a copy of the same pull secret from the link:https://console.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site.
+... For `Pull Secret`, copy the pull secret from the `pull-secret.txt` file you downloaded earlier and paste it here. You can also get a copy of the same {cluster-manager-url-pull}.
 endif::rhv[]
 ifndef::rhv[]
-... Paste the pull secret that you obtained from the
-link:https://console.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site.
+... Paste the {cluster-manager-url-pull}.
 ifdef::openshift-origin[]
 This field is optional.
 endif::[]

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -299,13 +299,11 @@ than 6 characters, only the first 6 characters will be used in the infrastructur
 ID that is generated from the cluster name.
 endif::gcp[]
 ifndef::openshift-origin[]
-.. Paste the pull secret that you obtained from the
-link:https://cloud.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site.
+.. Paste the {cluster-manager-url-pull}.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-.. Paste the pull secret that you obtained from the
-link:https://cloud.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site.
-* If you do not have a pull secret from the {cloud-redhat-com} site, you can paste the pull secret another private registry.
+.. Paste the {cluster-manager-url-pull}.
+* If you do not have a {cluster-manager-url-pull}, you can paste the pull secret another private registry.
 * If you do not need the cluster to pull images from a private registry, you can paste `{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}` as the pull secret.
 endif::openshift-origin[]
 endif::rhv[]
@@ -356,7 +354,7 @@ endif::openshift-origin[]
 .. For `Ingress virtual IP`, enter the static IP address you reserved for the wildcard apps domain.
 .. For `Base Domain`, enter the base domain of the {product-title} cluster. If this cluster is exposed to the outside world, this must be a valid domain recognized by DNS infrastructure. For example, enter: `virtlab.example.com`
 .. For `Cluster Name`, enter the name of the cluster. For example, `my-cluster`. Use cluster name from the externally registered/resolvable DNS entries you created for the {product-title} REST API and apps domain names. The installation program also gives this name to the cluster in the {rh-virtualization} environment.
-.. For `Pull Secret`, copy the pull secret from the `pull-secret.txt` file you downloaded earlier and paste it here. You can also get a copy of the same pull secret from the link:https://cloud.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site.
+.. For `Pull Secret`, copy the pull secret from the `pull-secret.txt` file you downloaded earlier and paste it here. You can also get a copy of the same {cluster-manager-url-pull}.
 endif::rhv[]
 --
 endif::no-config[]

--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -15,8 +15,7 @@ Mirror the {product-title} image repository to your registry to use during clust
 * You configured a mirror registry to use in your restricted network and
 can access the certificate and credentials that you configured.
 ifndef::openshift-origin[]
-* You downloaded the pull secret from the
-link:https://console.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site and modified it to include authentication to your mirror repository.
+* You downloaded the {cluster-manager-url-pull} and modified it to include authentication to your mirror repository.
 endif::[]
 ifdef::openshift-origin[]
 * You have created a pull secret for your mirror repository.

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -63,8 +63,8 @@ ifndef::ibm-z,ibm-z-kvm[* You have a computer that runs Linux or macOS, with 500
 .Procedure
 
 ifndef::openshift-origin[]
-. Access the link:https://console.redhat.com/openshift/install[Infrastructure Provider]
-page on the {cloud-redhat-com} site. If you have a Red Hat account, log in with your credentials. If you do not, create an account.
+. Access the link:https://console.redhat.com/openshift/install[Infrastructure Provider] page on the {cluster-manager} site. If you have a Red Hat account, log in with your credentials. If you do not, create an account.
+ifndef::ash[]
 . Select your infrastructure provider.
 . Navigate to the page for your installation type, download the installation program for your operating system, and place the file in the directory where you will store the installation configuration files.
 endif::[]
@@ -80,10 +80,7 @@ The installation program creates several files on the computer that you use to i
 +
 [IMPORTANT]
 ====
-Deleting the files created by the installation program does not remove your
-cluster, even if the cluster failed during installation. To remove your cluster, complete the
-{product-title} uninstallation procedures for your specific cloud
-provider.
+Deleting the files created by the installation program does not remove your cluster, even if the cluster failed during installation. To remove your cluster, complete the {product-title} uninstallation procedures for your specific cloud provider.
 ====
 
 . Extract the installation program. For example, on a computer that uses a Linux
@@ -94,15 +91,12 @@ operating system, run the following command:
 $ tar xvf openshift-install-linux.tar.gz
 ----
 
-. From the
-link:https://console.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site, download your installation pull secret as a `.txt` file. This pull secret allows you to authenticate with the services that
-are provided by the included authorities, including Quay.io, which serves the
-container images for {product-title} components.
+. Download your installation {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
 ifdef::openshift-origin[]
 +
-Using a pull secret from the {cloud-redhat-com} site is not required. You can use a pull secret for another private registry. Or, if you do not need the cluster to pull images from a private registry, you can use `{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}` as the pull secret when prompted during the installation.
+Using a {cluster-manager-url-pull} is not required. You can use a pull secret for another private registry. Or, if you do not need the cluster to pull images from a private registry, you can use `{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}` as the pull secret when prompted during the installation.
 +
-If you do not use the pull secret from the {cloud-redhat-com} site:
+If you do not use the {cluster-manager-url-pull}:
 +
 * Red Hat Operators are not available.
 * The Telemetry and Insights operators do not send data to Red Hat.

--- a/modules/installation-rhv-creating-install-config-file.adoc
+++ b/modules/installation-rhv-creating-install-config-file.adoc
@@ -51,4 +51,4 @@ For `Internal API virtual IP` and `Ingress virtual IP`, supply the IP addresses 
 
 Together, the values you enter for the `oVirt cluster` and `Base Domain` prompts form the FQDN portion of URLs for the REST API and any applications you create, such as `\https://api.ocp4.example.org:6443/` and `\https://console-openshift-console.apps.ocp4.example.org`.
 
-To get your pull secret, visit https://console.redhat.com/openshift/install/pull-secret.
+You can get the {cluster-manager-url-pull}.

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -149,18 +149,12 @@ The use of FIPS Validated / Modules in Process cryptographic libraries is only s
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]
-<14> The pull secret that you obtained from the
-link:https://console.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site. This pull secret allows you to authenticate with the services that are
-provided by the included authorities, including Quay.io, which serves the
-container images for {product-title} components.
+<14> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
 <15> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<13> The pull secret that you obtained from the
-link:https://console.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site. This pull secret allows you to authenticate with the services that are
-provided by the included authorities, including Quay.io, which serves the
-container images for {product-title} components.
+<13> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
 <14> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 +

--- a/modules/migration-configuring-mcg.adoc
+++ b/modules/migration-configuring-mcg.adoc
@@ -12,9 +12,7 @@
 You can configure the Multicloud Object Gateway (MCG) as a replication repository for the {mtc-full} ({mtc-short}). MCG is a component of OpenShift Container Storage.
 
 ifdef::openshift-origin[]
-.Prerequisites
-
-* Ensure that you have downloaded the link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in _Obtaining the installation program_ in the installation documentation for your platform.
+* Ensure that you have downloaded the {cluster-manager-url-pull} as shown in _Obtaining the installation program_ in the installation documentation for your platform.
 +
 If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
 endif::[]

--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -12,14 +12,14 @@ You can activate the following feature set by using the `FeatureGate` CR:
 
 * `IPv6DualStackNoUpgrade`. This feature gate enables the dual-stack networking mode in your cluster. Dual-stack networking supports the use of IPv4 and IPv6 simultaneously. Enabling this feature set is _not supported_, cannot be undone, and prevents updates. This feature set is not recommended on production clusters.
 
-//// 
+////
 Do not document per Derek Carr: https://github.com/openshift/api/pull/370#issuecomment-510632939
 |`CustomNoUpgrade` ^[2]^
-|Allows the enabling or disabling of any feature. Turning on this feature set on is not supported, cannot be undone, and prevents upgrades. 
+|Allows the enabling or disabling of any feature. Turning on this feature set on is not supported, cannot be undone, and prevents upgrades.
 
 [.small]
 --
-1. 
+1.
 2. If you use the `CustomNoUpgrade` feature set to disable a feature that appears in the web console, you might see that feature, but
 no objects are listed. For example, if you disable builds, you can see the *Builds* tab in the web console, but there are no builds present. If you attempt to use commands associated with a disabled feature, such as `oc start-build`, {product-title} displays an error.
 

--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -13,7 +13,7 @@ The descheduler is not available by default. To enable the descheduler, you must
 * Cluster administrator privileges.
 * Access to the {product-title} web console.
 ifdef::openshift-origin[]
-* Ensure that you have downloaded the link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in _Obtaining the installation program_ in the installation documentation for your platform.
+* Ensure that you have downloaded the {cluster-manager-url-pull} as shown in _Obtaining the installation program_ in the installation documentation for your platform.
 +
 If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
 endif::[]

--- a/modules/nodes-pods-vertical-autoscaler-install.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-install.adoc
@@ -11,7 +11,7 @@ You can use the {product-title} web console to install the Vertical Pod Autoscal
 ifdef::openshift-origin[]
 .Prerequisites
 
-* Ensure that you have downloaded the link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in _Obtaining the installation program_ in the installation documentation for your platform.
+* Ensure that you have downloaded the {cluster-manager-url-pull} as shown in _Obtaining the installation program_ in the installation documentation for your platform.
 +
 If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
 endif::[]
@@ -32,7 +32,7 @@ is automatically created if it does not exist.
 
 .. Navigate to *Workloads* -> *Pods*.
 
-.. Select the `openshift-vertical-pod-autoscaler` project from the drop-down menu and verify that there are four pods running. 
+.. Select the `openshift-vertical-pod-autoscaler` project from the drop-down menu and verify that there are four pods running.
 
 .. Navigate to *Workloads* -> *Deployments* to verify that there are four deployments running.
 
@@ -69,4 +69,3 @@ replicaset.apps/vpa-admission-plugin-default-67644fc87f       1         1       
 replicaset.apps/vpa-recommender-default-7c54764b59            1         1         1       2m56s
 replicaset.apps/vpa-updater-default-7f6cc87858                1         1         1       2m56s
 ----
-

--- a/modules/olm-installing-operators-from-operatorhub-configure.adoc
+++ b/modules/olm-installing-operators-from-operatorhub-configure.adoc
@@ -12,11 +12,11 @@
 [id="olm-installing-operators-from-operatorhub-configure_{context}"]
 = Configuring {product-title} to use Red Hat Operators
 
-In {product-title}, Red Hat Operators are not available by default. You can access and install these Operators if you have a pull secret from the Red Hat OpenShift Cluster Manager site by editing the `OperatorHub` custom resource (CR). 
+In {product-title}, Red Hat Operators are not available by default. You can access and install these Operators if you have a pull secret from {cluster-manager-first} by editing the `OperatorHub` custom resource (CR).
 
 .Prerequisites
 
-* Ensure that you have downloaded the link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in the installation procedure.
+* Ensure that you have downloaded the {cluster-manager-url-pull} as shown in the installation procedure.
 
 .Procedure
 
@@ -50,7 +50,7 @@ spec:
   - disabled: false
     name: community-operators
 ----
-<1> Add the `name: redhat-operators` and `disabled: false` parameters. 
+<1> Add the `name: redhat-operators` and `disabled: false` parameters.
 
 .. Using the web console:
 
@@ -81,7 +81,7 @@ spec:
   - disabled: false
     name: community-operators
 ----
-<1> Add the `name: redhat-operators` and `disabled: false` parameters. 
+<1> Add the `name: redhat-operators` and `disabled: false` parameters.
 
 ... Click *Save*.
 

--- a/modules/reviewing-cluster-status-from-the-openshift-cluster-manager.adoc
+++ b/modules/reviewing-cluster-status-from-the-openshift-cluster-manager.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="reviewing-cluster-status-from-the-openshift-cluster-manager_{context}"]
-= Reviewing the cluster status from the {cloud-redhat-com}
+= Reviewing the cluster status from {cluster-manager-first}
 
-You can review detailed information about the status of your cluster in the {cloud-redhat-com}.
+You can review detailed information about the status of your cluster in the {cluster-manager}.
 
 .Prerequisites
 
@@ -14,11 +14,11 @@ You can review detailed information about the status of your cluster in the {clo
 
 .Procedure
 
-. In the *Administrator* perspective, navigate to *Home* -> *Overview* -> *Details* -> *OpenShift Cluster Manager* to open the *Overview* page for the cluster in the {cloud-redhat-com}.
+. In the *Administrator* perspective, navigate to *Home* -> *Overview* -> *Details* -> *{cluster-manager}* to open the *Overview* page for the cluster in {cluster-manager-url}.
 +
 [NOTE]
 ====
-Alternatively, you can navigate to the link:https://console.redhat.com/openshift/[{cloud-redhat-com}] directly and select your cluster ID from the list of available clusters.
+Alternatively, you can navigate to {cluster-manager-url} directly and select your cluster ID from the list of available clusters.
 ====
 
 . In the *Overview* page, review the following information about your cluster:

--- a/modules/support.adoc
+++ b/modules/support.adoc
@@ -14,7 +14,7 @@ If you experience difficulty with a procedure described in this documentation, o
 // TODO: xref
 * Access other product documentation.
 
-To identify issues with your cluster, you can use Insights in {cloud-redhat-com}. Insights provides details about issues and, if available, information on how to solve a problem.
+To identify issues with your cluster, you can use Insights in {cluster-manager-url}. Insights provides details about issues and, if available, information on how to solve a problem.
 
 // TODO: verify that these settings apply for Service Mesh and OpenShift virtualization, etc.
 If you have a suggestion for improving this documentation or have found an

--- a/modules/telemetry-consequences-of-disabling-telemetry.adoc
+++ b/modules/telemetry-consequences-of-disabling-telemetry.adoc
@@ -5,7 +5,7 @@
 [id="telemetry-consequences-of-disabling-telemetry_{context}"]
 = Consequences of disabling remote health reporting
 
-In {product-title}, customers can opt out of reporting usage information. However, connected clusters allow Red Hat to react more quickly to problems and better support our customers, as well as better understand how product upgrades impact clusters. Connected clusters also help to simplify the subscription and entitlement process and enable the {cloud-redhat-com} service to provide an overview of your clusters and their subscription status.
+In {product-title}, customers can opt out of reporting usage information. However, connected clusters allow Red Hat to react more quickly to problems and better support our customers, as well as better understand how product upgrades impact clusters. Connected clusters also help to simplify the subscription and entitlement process and enable the {console-redhat-com} service to provide an overview of your clusters and their subscription status.
 
 Red Hat strongly recommends leaving health and usage reporting enabled for pre-production and test clusters even if it is necessary to opt out for production clusters. This allows Red Hat to be a participant in qualifying {product-title} in your environments and react more rapidly to product issues.
 
@@ -13,7 +13,7 @@ Some of the consequences of opting out of having a connected cluster are:
 
 * Red Hat will not be able to monitor the success of product upgrades or the health of your clusters without a support case being opened.
 * Red Hat will not be able to use configuration data to better triage customer support cases and identify which configurations our customers find important.
-* The {cloud-redhat-com} will not show data about your clusters including health and usage information.
+* The {console-redhat-com} will not show data about your clusters including health and usage information.
 ifndef::openshift-origin[]
 * Your subscription entitlement information must be manually entered via console.redhat.com without the benefit of automatic usage reporting.
 endif::[]

--- a/modules/update-service-mirror-release.adoc
+++ b/modules/update-service-mirror-release.adoc
@@ -15,8 +15,7 @@ To avoid excessive memory usage by the OpenShift Update Service application, it 
 //TODO: Add xref to preceding step when allowed.
 * You configured a mirror registry to use in your restricted network and can access the certificate and credentials that you configured.
 ifndef::openshift-origin[]
-* You downloaded the pull secret from the
-link:https://console.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site and modified it to include authentication to your mirror repository.
+* You downloaded the {cluster-manaager-url-pull} and modified it to include authentication to your mirror repository.
 endif::[]
 ifdef::openshift-origin[]
 * You have created a pull secret for your mirror repository.

--- a/openshift_images/managing_images/using-image-pull-secrets.adoc
+++ b/openshift_images/managing_images/using-image-pull-secrets.adoc
@@ -10,7 +10,7 @@ If you are using the {product-title} internal registry and are pulling from imag
 
 However, for other scenarios, such as referencing images across {product-title} projects or from secured registries, then additional configuration steps are required.
 
-You can obtain the image pull secret, `pullSecret`, from the link:https://console.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site.
+You can obtain the image {cluster-manager-url-pull}. This pull secret is called `pullSecret`.
 
 You use this pull secret to authenticate with the services that are provided by the included authorities, link:https://quay.io/[Quay.io] and link:https://registry.redhat.io[registry.redhat.io], which serve the container images for {product-title} components.
 

--- a/operators/admin/olm-adding-operators-to-cluster.adoc
+++ b/operators/admin/olm-adding-operators-to-cluster.adoc
@@ -15,7 +15,7 @@ ifdef::openshift-origin[]
 [id="olm-adding-operators-to-a-cluster-prereqs"]
 == Prerequisites
 
-* Ensure that you have downloaded the link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in _Obtaining the installation program_ in the installation documentation for your platform.
+* Ensure that you have downloaded the {cluster-manager-url-pull} as shown in _Obtaining the installation program_ in the installation documentation for your platform.
 +
 If you have the pull secret, add the `redhat-operators` catalog to the `OperatorHub` custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
 endif::[]

--- a/operators/user/olm-installing-operators-in-namespace.adoc
+++ b/operators/user/olm-installing-operators-in-namespace.adoc
@@ -14,7 +14,7 @@ If a cluster administrator has delegated Operator installation permissions to yo
 * A cluster administrator must add certain permissions to your {product-title} user account to allow self-service Operator installation to a namespace. See xref:../../operators/admin/olm-creating-policy.adoc#olm-creating-policy[Allowing non-cluster administrators to install Operators] for details.
 
 ifdef::openshift-origin[]
-* Ensure that you have downloaded the link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in _Obtaining the installation program_ in the installation documentation for your platform.
+* Ensure that you have downloaded the {cluster-manager-url-pull} as shown in _Obtaining the installation program_ in the installation documentation for your platform.
 +
 If you have the pull secret, add the `redhat-operators` catalog to the `OperatorHub` custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
 endif::[]

--- a/support/index.adoc
+++ b/support/index.adoc
@@ -26,7 +26,7 @@ xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#abo
 * *Insight Operator*: By default, {product-title} installs and enables the Insight Operator, which reports configuration and component failure status every two hours. The Insight Operator helps to:
 
 ** Identify potential cluster issues proactively.
-** Provide a solution and preventive action in Red Hat OpenShift Cluster Manager.
+** Provide a solution and preventive action in {cluster-manager-first}.
 
 You can xref:../support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc#showing-data-collected-by-remote-health-monitoring[Review telemetry information].
 

--- a/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
+++ b/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
@@ -6,6 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Insights repeatedly analyzes the data Insights Operator sends. Users of {product-title} can display the report on the *Insights* tab of each cluster in {cloud-redhat-com}.
+Insights repeatedly analyzes the data Insights Operator sends. Users of {product-title} can display the report on the *Insights* tab of each cluster in {cluster-manager-url}.
 
 include::modules/displaying-potential-issues-with-your-cluster.adoc[leveloffset=+1]

--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -252,7 +252,7 @@ The following table is a summary of the feature availability in {oke} and
 | Log Forwarding (with fluentd) | Included | Included | Red Hat OpenShift Logging Operator (for log forwarding with fluentd)
 | Telemeter and Insights Connected Experience | Included | Included | N/A
 s| Feature s| {oke} s| {product-title} s| Operator name
-| OpenShift Cloud Manager(OCM) SaaS Service | Included | Included | N/A
+| OpenShift Cloud Manager SaaS Service | Included | Included | N/A
 | OVS and OVN SDN | Included | Included | N/A
 | HAProxy Ingress Controller | Included | Included | N/A
 | {rh-openstack-first} Kuryr Integration | Included | Included | N/A


### PR DESCRIPTION
This is the manual cherry-pick for `enterprise-4.6` of #41055