### PR TITLE
bug 2043153: custom-scheduler: deploy system:volume-scheduler crb

### DIFF
--- a/modules/nodes-custom-scheduler-deploying.adoc
+++ b/modules/nodes-custom-scheduler-deploying.adoc
@@ -45,6 +45,19 @@ roleRef:
   name: system:kube-scheduler
   apiGroup: rbac.authorization.k8s.io
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: custom-scheduler-as-volume-scheduler
+subjects:
+- kind: ServiceAccount
+  name: custom-scheduler
+  namespace: kube-system <1>
+roleRef:
+  kind: ClusterRole
+  name: system:volume-scheduler
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
To address:
```
E0120 10:02:59.316882       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1.StorageClass: unknown (get storageclasses.storage.k8s.io)
```

The missing CRB was fixed in upstream through https://github.com/kubernetes/website/pull/20691.