### PR TITLE
[BZ2060706]: Remove the note

### DIFF
--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -386,12 +386,14 @@ Use the `openshift-install` command from the bastion hosted in the VMC environme
 ====
 endif::vmc[]
 +
+ifndef::vsphere[]
 [NOTE]
 ====
 If the cloud provider account that you configured on your host does not have sufficient
 permissions to deploy the cluster, the installation process stops, and the
 missing permissions are displayed.
 ====
+endif::vsphere[]
 +
 When the cluster deployment completes, directions for accessing your cluster,
 including a link to its web console and credentials for the `kubeadmin` user,


### PR DESCRIPTION
Removes the note from ipi-on-vsphere documents until epic [CORS-1917](https://issues.redhat.com/browse/CORS-1917) is done.
OCP version: 4.6+
[Preview](https://deploy-preview-42874--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned.html#installation-launching-installer_installing-vsphere-installer-provisioned)
QE contact: @jinyunma LGTMed
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2060706)