### PR TITLE
RHDEVDOCS-3355: Document the sizing requirements for GitOps Operator and the default instance

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1628,13 +1628,14 @@ Topics:
     File: configuring-argo-cd-rbac
   - Name: Running Control Plane Workloads on Infra nodes
     File: run-gitops-control-plane-workload-on-infra-nodes
+  - Name: Sizing requirements for GitOps Operator
+    File: about-sizing-requirements-gitops
 - Name: Jenkins
   Dir: jenkins
   Distros: openshift-enterprise
   Topics:
   - Name: Migrating from Jenkins to OpenShift Pipelines
     File: migrating-from-jenkins-to-openshift-pipelines
-
 ---
 Name: Images
 Dir: openshift_images

--- a/cicd/gitops/about-sizing-requirements-gitops.adoc
+++ b/cicd/gitops/about-sizing-requirements-gitops.adoc
@@ -1,0 +1,12 @@
+:_content-type: ASSEMBLY
+[id="about-sizing-requirements-gitops"]
+= Sizing requirements for GitOps Operator
+include::_attributes/common-attributes.adoc[]
+:context: about-sizing-requirements-gitops
+
+toc::[]
+
+[role="_abstract"]
+The sizing requirements page displays the sizing requirements for installing {gitops-title} on {product-title}. It also provides the sizing details for the default ArgoCD instance that is instantiated by the GitOps Operator.
+
+include::modules/sizing-requirements-for-gitops.adoc[leveloffset=+1]

--- a/modules/sizing-requirements-for-gitops.adoc
+++ b/modules/sizing-requirements-for-gitops.adoc
@@ -1,0 +1,31 @@
+// Module is included in the following assemblies:
+//
+// * openshift-docs/cicd/gitops/about-sizing-requirements-gitops.adoc
+
+:_content-type: CONCEPT
+[id="sizing-requirements-for-gitops_{context}"]
+= Sizing requirements for GitOps
+
+[role="_abstract"]
+{gitops-title} is a declarative way to implement continuous deployment for cloud-native applications. Through GitOps, you can define and configure the CPU and memory requirements of your application.
+
+Every time you install the {gitops-title} Operator, the resources on the namespace are installed within the defined limits. If the default installation does not set any limits or requests, the Operator fails within the namespace with quotas. Without enough resources, the cluster cannot schedule ArgoCD related pods. The following table details the resource requests and limits for the default workloads:
+
+[cols="2,2,2,2,2",options="header"]
+|===
+|Workload |CPU requests |CPU limits |Memory requests |Memory limits
+|argocd-application-controller |1 |2 |1024M |2048M
+|applicationset-controller |1 |2 |512M |1024M
+|argocd-server |0.125 |0.5 |128M |256M
+|argocd-repo-server |0.5 |1 |256M |1024M
+|argocd-redis |0.25 |0.5 |128M |256M
+|argocd-dex |0.25 |0.5 |128M |256M
+|HAProxy |0.25 |0.5 |128M |256M
+|===
+
+Optionally, you can also use the ArgoCD custom resource with the `oc` command to see the specifics and modify them:
+
+[source,terminal]
+----
+oc edit argocd <name of argo cd> -n namespace
+----


### PR DESCRIPTION
- JIRA ID: [RHDEVDOCS-3355](https://issues.redhat.com/browse/RHDEVDOCS-3355)
- Aligned team: GitOps
- SME review: 
- Peer Review:  
- Docs Preview: https://deploy-preview-42876--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/about-sizing-requirements-gitops
