### PR TITLE
RHDEVDOCS-3763 - Added argo cd properties

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1583,6 +1583,8 @@ Topics:
     File: configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations
   - Name: Deploying a Spring Boot application with Argo CD
     File: deploying-a-spring-boot-application-with-argo-cd
+  - Name: Argo CD custom resource properties
+    File: argo-cd-custom-resource-properties  
   - Name: Monitoring application health status
     File: health-information-for-resources-deployment
   - Name: Configuring SSO for Argo CD using Dex

--- a/cicd/gitops/argo-cd-custom-resource-properties.adoc
+++ b/cicd/gitops/argo-cd-custom-resource-properties.adoc
@@ -1,0 +1,13 @@
+:_content-type: ASSEMBLY
+[id="argo-cd-custom-resource-properties"]
+= Argo CD Operator
+include::_attributes/common-attributes.adoc[]
+:context: argo-cd-custom-resource-properties
+
+toc::[]
+
+[role="_abstract"]
+The `ArgoCD` custom resource is a Kubernetes Custom Resource (CRD) that describes the desired state for a given Argo CD cluster that allows you to configure the components which make up an Argo CD cluster.
+
+include::modules/argo-cd-command-line.adoc[leveloffset=+1]
+include::modules/gitops-argo-cd-properties.adoc[leveloffset=+1]

--- a/modules/argo-cd-command-line.adoc
+++ b/modules/argo-cd-command-line.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * argo-cd-custom-resource-properties.adoc
+
+:_content-type: PROCEDURE
+[id="command-line-tool_{context}"]
+= Argo CD CLI tool
+
+[role="_abstract"]
+The Argo CD CLI tool is a tool used to configure Argo CD through the command line. {gitops-title} does not support this binary. Use the OpenShift Console to configure the Argo CD.
+

--- a/modules/gitops-argo-cd-properties.adoc
+++ b/modules/gitops-argo-cd-properties.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * argo-cd-custom-resource-properties.adoc
+
+:_content-type: PROCEDURE
+[id="argo-cd-properties_{context}"]
+= Argo CD custom resource properties
+
+[role="_abstract"]
+The ArgoCD Custom Resource consists of the following properties:
+
+|===
+|**Name** |**Default** |**Description**
+|`ApplicationInstanceLabelKey` |`mycompany.com/appname`|The `metadata.label` key name where Argo CD injects the app name as a tracking label.
+|`ApplicationSet` |__<Object>__|`ApplicationSet` controller configuration options.
+|`ConfigManagementPlugins`    |__<empty>__|Add a configuration management plugin.
+|`Controller`    |__<Object>__|Argo CD Application Controller options.
+|`Dex`    |__<Object>__|Dex configuration options.
+|`Disable Admin`    |`false` |Disable the admin user.
+|`GATrackingID`    |__<empty>__|Use a Google Analytics tracking ID.
+|`GAAnonymizeusers`    |`false` |Enable hashed usernames sent to google analytics.
+|`Grafana`    |__<Object>__|Grafana configurable options.
+|`HA`    |__<Object>__|High availablity options.
+|`HelpChatURL`    |`https://mycorp.slack.com/argo-cd` |URL for getting chat help (this will typically be your Slack channel for support).
+|`HelpChatText`    |`Chat now!`|The text appears in a text box for getting chat help.
+|`Image`    |`argoproj/argocd` |The container image for all Argo CD components. This overrides the `ARGOCD_IMAGE` environment variable.
+|`Import`    |__<Object>__|Import configuration options.
+|`Ingress`    |__<Object>__|Ingress configuration options.
+|`InitialRepositories`    |__<empty>__|Initial Git repositories to configure Argo CD to use upon creation of the cluster.
+|`RepositoryCredentials`    |__<Object>__|Git repository credential templates to configure Argo CD to use upon creation of the cluster.
+|`InitialSSHKnownHosts`    |__<default_Argo_CD_Known_Hosts>__|Initial SSH Known Hosts for Argo CD to use upon creation of the cluster.
+|`KustomizeBuildOptions`    |__<empty>__|The build options and parameters to use with `kustomize build`.
+|`OIDCConfig` |__<empty>__|The OIDC configuration as an alternative to Dex.
+|`NodePlacement` |__<empty>__|Add the `nodeSelector` and the `tolerations`.
+|`Prometheus` |__<Object>__|Prometheus configuration options.
+|`RBAC` |__<Object>__|RBAC configuration options.
+|`Redis` |__<Object>__|Redis configuration options.
+|`ResourceCustomizations` |__<empty>__|Customize resource behavior.
+|`ResourceExclusions` |__<Object>__|Completely ignore entire classes of resource group.
+|`ResourceInclusions` |__<Object>__|The configuration to configure which resource group/kinds are applied.
+|`Server` |__<Object>__|Argo CD Server configuration options.
+|`SSO` |__<Object>__|Single sign-on options.
+|`StatusBadgeEnabled` |`true` |Enable application status badge.
+|`TLS` |__<Object>__|TLS configuration options.
+|`UserAnonyousEnabled` |`true` |Enable anonymous user access.
+|`Version` |`v2.2.2` |The tag to use with the container image for all Argo CD components.
+|===
+
+
+


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.9, 4.10, 4.11
JIRA issue: https://issues.redhat.com/browse/RHDEVDOCS-3763

Preview pages: https://deploy-preview-42877--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/argo-cd-custom-resource-properties.html

SME+QE review:
Peer-review: