### PR TITLE
RHDEVDOCS-3813 - added steps to install the operator using CLI

### DIFF
--- a/cicd/gitops/installing-openshift-gitops.adoc
+++ b/cicd/gitops/installing-openshift-gitops.adoc
@@ -6,10 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Red Hat {gitops-title} uses Argo CD to manage specific cluster-scoped resources, including platform operators, optional Operator Lifecycle Manager (OLM) operators, and user management.
+[role="_abstract"]
+{gitops-title} uses Argo CD to manage specific cluster-scoped resources, including platform Operators, optional Operator Lifecycle Manager (OLM) Operators, and user management.
 
-This guide explains how to install the Red Hat {gitops-title} Operator to an {product-title} cluster and logging in to the Argo CD instance.
+This guide explains how to install the {gitops-title} Operator to an {product-title} cluster and log in to the Argo CD instance.
 
 include::modules/installing-gitops-operator-in-web-console.adoc[leveloffset=+1]
+
+include::modules/installing-gitops-operator-using-cli.adoc[leveloffset=+1]
 
 include::modules/logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account.adoc[leveloffset=+1]

--- a/modules/installing-gitops-operator-using-cli.adoc
+++ b/modules/installing-gitops-operator-using-cli.adoc
@@ -1,0 +1,60 @@
+// Module is included in the following assemblies:
+//
+// * installing-openshift-gitops
+
+:_content-type: PROCEDURE
+[id="installing-gitops-operator-using-cli_{context}"]
+= Installing OpenShift GitOps Operator using CLI
+
+[role="_abstract"]
+You can install {gitops-title} Operator from the OperatorHub using the CLI.
+
+.Procedure
+
+. Create a Subscription object YAML file to subscribe a namespace to the {gitops-title}, for example, `sub.yaml`:
++
+.Example Subscription
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-operators
+spec:
+  channel: stable <1>
+  installPlanApproval: Automatic
+  name: openshift-gitops-operator <2>
+  source: redhat-operators <3>
+  sourceNamespace: openshift-marketplace <4> 
+----
+<1> Specify the channel name from where you want to subscribe the Operator.
+<2> Specify the name of the Operator to subscribe to.
+<3> Specify the name of the CatalogSource that provides the Operator.
+<4> The namespace of the CatalogSource. Use `openshift-marketplace` for the default OperatorHub CatalogSources.
++
+. Apply the `Subscription` to the cluster:
++
+[source,terminal]
+----
+$ oc apply -f openshift-gitops-sub.yaml
+----
+. After the installation is complete, ensure that all the pods in the `openshift-gitops` namespace are running:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-gitops
+----
+.Example output
++
+[source,terminal]
+----
+NAME                                                      	READY   STATUS	RESTARTS   AGE
+cluster-b5798d6f9-zr576                                   	1/1 	Running   0      	65m
+kam-69866d7c48-8nsjv                                      	1/1 	Running   0      	65m
+openshift-gitops-application-controller-0                 	1/1 	Running   0      	53m
+openshift-gitops-applicationset-controller-6447b8dfdd-5ckgh 1/1 	Running   0      	65m
+openshift-gitops-redis-74bd8d7d96-49bjf                   	1/1 	Running   0      	65m
+openshift-gitops-repo-server-c999f75d5-l4rsg              	1/1 	Running   0      	65m
+openshift-gitops-server-5785f7668b-wj57t                  	1/1 	Running   0      	53m
+----

--- a/modules/logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account.adoc
+++ b/modules/logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account.adoc
@@ -6,6 +6,7 @@
 [id="logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account_{context}"]
 = Logging in to the Argo CD instance by using the Argo CD admin account
 
+[role="_abstract"]
 Red Hat OpenShift GitOps Operator automatically creates a ready-to-use Argo CD instance that is available in the `openshift-gitops` namespace.
 
 .Prerequisites
@@ -22,7 +23,7 @@ Red Hat OpenShift GitOps Operator automatically creates a ready-to-use Argo CD i
 .. Use the left navigation panel to navigate to the *Secrets* page.
 .. Select the *openshift-gitops-cluster* instance to display the password.
 .. Copy the password.
-
++
 [NOTE]
 ====
 To login with your {product-title} credentials, select the `LOG IN VIA OPENSHIFT` option in the Argo CD user interface.


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.9, 4.10
JIRA issue: https://issues.redhat.com/browse/RHDEVDOCS-3813
Preview pages: https://deploy-preview-42879--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/installing-openshift-gitops

SME+QE review: @jannfis
Peer-review: @Srivaralakshmi 