### PR TITLE
Correcting the Tech Preview status for Node Health Check Operator 

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -889,7 +889,7 @@ You can enable swap memory use for {product-title} workloads on a per-node basis
 The Node Maintenance Operator (NMO) cordons off nodes from the rest of the cluster and drains all the pods from the nodes. By placing nodes under maintenance, you can investigate problems with a machine, or perform operations on the underlying machine, that might result in a node failure. This is a standalone version of NMO. If you installed OpenShift Virtualization, then you must use the NMO that is bundled with it.
 
 [id="ocp-4-10-node-health-check-operator"]
-==== Node Health Check Operator enhancements
+==== Node Health Check Operator enhancements (Technology Preview)
 
 The Node Health Check Operator provides these new enhancements:
 
@@ -2274,7 +2274,7 @@ In the table below, features are marked with the following statuses:
 |Node Health Check Operator
 |-
 |TP
-|GA
+|TP
 
 |Network bound disk encryption (Requires Clevis, Tang)
 |-


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-344 This PR corrects the Tech Preview status for Node Health Check Operator in the Technology Preview tracker for OpenShift 4.10

It seems that the changes were implemented based on @opayne1 's [comment](https://github.com/openshift/openshift-docs/pull/42765/files#r819026121). However, that status is incorrect. 

Applies to OpenShift 4.10 (enterprise 4.10)

Preview: 
https://deploy-preview-42880--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-technology-preview