### PR TITLE
TELCODOCS-323: Updates PTP API reference

### DIFF
--- a/modules/cnf-fast-event-notifications-api-refererence.adoc
+++ b/modules/cnf-fast-event-notifications-api-refererence.adoc
@@ -7,11 +7,18 @@
 
 You can use the PTP fast event notifications REST API to subscribe an application to the PTP events that are generated for the parent node. PTP fast events notifications are available on each node where a PTP capable network interface is configured.
 
-You can subscribe DU applications to PTP event notifications by using the resource address `/cluster/node/<node_name>/ptp`, where `<node_name>` is the cluster node running the DU application.
+You can subscribe distributed unit (DU) applications to PTP event notifications by using the resource address `/cluster/node/<node_name>/ptp`, where `<node_name>` is the cluster node running the DU application.
 
-Status request are sent by making a REST API `PUT` call to `/subscriptions/status/<subscription_id>`. The API call returns events through the AMQP event bus to the subscribed address.
+The PTP Operator deploys the `linuxptp-daemon` container and the `cloud-event-proxy` sidecar container in a pod managed by the PTP Operator. The `cloud-event-proxy` container collects the PTP events and publishes the events using the `cloud-event-proxy` publisher API at [x-]`http://localhost:8089/api/cloudNotifications/v1/`.
 
-The PTP fast events notifications REST API is served at `http://localhost:8080/` by default. The following API endpoints are available:
+Deploy your DU application container that needs to subscribe to PTP events and a `cloud-event-proxy` sidecar container in a separate DU application pod. The DU application container uses the subscription API provided by the `cloud-event-proxy` container to subscribe to events at [x-]`http://localhost:8089/api/cloudNotifications/v1/`.
+
+[NOTE]
+====
+The PTP fast events notifications REST API is provided by `cloud-event-proxy`. To access the API, applications must be in the same pod as the `cloud-event-proxy` container.
+====
+
+The following API endpoints are available at [x-]`http://localhost:8089/api/cloudNotifications/v1/` on the DU application pod:
 
 * `/api/cloudNotifications/v1/publishers`
 - `POST`: Creates a new publisher
@@ -50,18 +57,9 @@ Creates a new publisher. If publisher creation is successful, or if it already e
 [source,json]
 ----
 {
-  "uriLocation": "http://localhost:8080/api/cloudNotifications/v1/publishers",
+  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/publishers",
   "resource": "/cluster/node/compute-1.example.com/ptp"
 }
-----
-
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location --request POST 'http://localhost:8080/api/cloudNotifications/v1/publishers' --header 'Content-Type: application/json' --insecure --data '{
-  "uriLocation": "http://localhost:8080/api/cloudNotifications/v1/publishers",
-  "resource": "/cluster/node/compute-1.example.com/ptp"
-}'
 ----
 
 === HTTP method
@@ -72,20 +70,14 @@ $ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- cur
 
 Returns a list of publishers. If publishers exist, a `200 OK` status code is returned along with the list of publishers.
 
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location http://localhost:8080/api/cloudNotifications/v1/publishers
-----
-
-.Example return
+.Example API response
 [source,json]
 ----
 [
  {
   "id": "56e8a064-dc4b-4428-8085-91c18ea07930",
-  "endpointUri": "http://localhost:8080/api/cloudNotifications/v1/dummy",
-  "uriLocation": "http://localhost:8080/api/cloudNotifications/v1/publishers/56e8a064-dc4b-4428-8085-91c18ea07930",
+  "endpointUri": "http://localhost:8089/api/cloudNotifications/v1/dummy",
+  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/publishers/56e8a064-dc4b-4428-8085-91c18ea07930",
   "resource": "/cluster/node/compute-1.example.com/ptp"
  }
 ]
@@ -109,19 +101,13 @@ Returns the publisher with ID `<publisher_id>`.
 | string
 |===
 
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location http://localhost:8080/api/cloudNotifications/v1/publishers/56e8a064-dc4b-4428-8085-91c18ea07930
-----
-
-.Example return
+.Example API response
 [source,json]
 ----
 {
  "id":"56e8a064-dc4b-4428-8085-91c18ea07930",
- "endpointUri":"http://localhost:8080/api/cloudNotifications/v1/dummy",
- "uriLocation":"http://localhost:8080/api/cloudNotifications/v1/publishers/56e8a064-dc4b-4428-8085-91c18ea07930",
+ "endpointUri":"http://localhost:8089/api/cloudNotifications/v1/dummy",
+ "uriLocation":"http://localhost:8089/api/cloudNotifications/v1/publishers/56e8a064-dc4b-4428-8085-91c18ea07930",
  "resource":"/cluster/node/compute-1.example.com/ptp"
 }
 ----
@@ -136,20 +122,14 @@ $ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- cur
 
 Returns a list of subscriptions. If subscriptions exist, a `200 OK` status code is returned along with the list of subscriptions.
 
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location http://localhost:8080/api/cloudNotifications/v1/subscriptions
-----
-
-.Example return
+.Example API response
 [source,json]
 ----
 [
  {
   "id": "75b1ad8f-c807-4c23-acf5-56f4b7ee3826",
-  "endpointUri": "http://localhost:8080/api/cloudNotifications/v1/dummy",
-  "uriLocation": "http://localhost:8080/api/cloudNotifications/v1/subscriptions/75b1ad8f-c807-4c23-acf5-56f4b7ee3826",
+  "endpointUri": "http://localhost:8089/api/cloudNotifications/v1/dummy",
+  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/subscriptions/75b1ad8f-c807-4c23-acf5-56f4b7ee3826",
   "resource": "/cluster/node/compute-1.example.com/ptp"
  }
 ]
@@ -175,18 +155,9 @@ Creates a new subscription. If a subscription is successfully created, or if it 
 [source,json]
 ----
 {
-  "uriLocation": "http://localhost:8080/api/cloudNotifications/v1/subscriptions",
+  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/subscriptions",
   "resource": "/cluster/node/compute-1.example.com/ptp"
 }
-----
-
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location --request POST 'http://localhost:8080/api/cloudNotifications/v1/subscriptions' --header 'Content-Type: application/json' --insecure --data '{
-  "uriLocation": "http://localhost:8080/api/cloudNotifications/v1/subscriptions",
-  "resource": "/cluster/node/compute-1.example.com/ptp"
-}'
 ----
 
 == api/cloudNotifications/v1/subscriptions/<subscription_id>
@@ -207,19 +178,13 @@ Returns details for the subscription with ID `<subscription_id>`
 | string
 |===
 
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location http://localhost:8080/api/cloudNotifications/v1/subscriptions/48210fb3-45be-4ce0-aa9b-41a0e58730ab
-----
-
-.Example return
+.Example API response
 [source,terminal]
 ----
 {
   "id":"48210fb3-45be-4ce0-aa9b-41a0e58730ab",
-  "endpointUri":"http://localhost:8080/api/cloudNotifications/v1/dummy",
-  "uriLocation":"http://localhost:8080/api/cloudNotifications/v1/subscriptions/48210fb3-45be-4ce0-aa9b-41a0e58730ab",
+  "endpointUri":"http://localhost:8089/api/cloudNotifications/v1/dummy",
+  "uriLocation":"http://localhost:8089/api/cloudNotifications/v1/subscriptions/48210fb3-45be-4ce0-aa9b-41a0e58730ab",
   "resource":"/cluster/node/compute-1.example.com/ptp"
 }
 ----
@@ -242,12 +207,6 @@ Creates a new status ping request for subscription with ID `<subscription_id>`. 
 | string
 |===
 
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location --request PUT http://localhost:8080/api/cloudNotifications/v1/subscriptions/status/48210fb3-45be-4ce0-aa9b-41a0e58730ab
-----
-
 .Example output
 [source,json]
 ----
@@ -264,13 +223,7 @@ $ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- cur
 
 Returns the health status for the `cloudNotifications` REST API.
 
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location http://localhost:8080/api/cloudNotifications/v1/health
-----
-
-.Example return
+.Example API response
 [source,terminal]
 ----
 OK


### PR DESCRIPTION
Part of the doc work for https://issues.redhat.com/browse/TELCODOCS-323

This change removes example `oc exec` commands in the PTP Events API reference that are misleading to users.

Merge to main, enterprise-4.9, enterprise-4.10.

Preview: https://deploy-preview-42881--osdocs.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#cnf-fast-event-notifications-api-refererence_using-ptp