### PR TITLE
[enterprise-4.10] OSDOCS-2950: Adding support default IPI cluster installation to Azure…

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -187,6 +187,8 @@ Topics:
     File: installing-azure-stack-hub-account
   - Name: Installing a cluster on Azure Stack Hub with an installer-provisioned infrastructure
     File: installing-azure-stack-hub-default
+  - Name: Installing a cluster on Azure Stack Hub with network customizations
+    File: installing-azure-stack-hub-network-customizations
   - Name: Installing a cluster on Azure Stack Hub using ARM templates
     File: installing-azure-stack-hub-user-infra
   - Name: Uninstalling a cluster on Azure Stack Hub

--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -164,7 +164,7 @@ endif::openshift-origin[]
 |xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[X]
 |xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[X]
 |xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[X]
-|
+|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc#installing-azure-stack-hub-network-customizations[X]
 |xref:../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[X]
 |xref:../installing/installing_openstack/installing-openstack-installer-kuryr.adoc#installing-openstack-installer-kuryr[X]
 |

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
@@ -1,0 +1,88 @@
+[id="installing-azure-stack-hub-network-customizations"]
+= Installing a cluster on Azure Stack Hub with network customizations
+include::_attributes/common-attributes.adoc[]
+:context: installing-azure-stack-hub-network-customizations
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a cluster with a customized network configuration on infrastructure that the installation program provisions on Azure Stack Hub. By customizing your network configuration, your cluster can coexist with existing IP address allocations in your environment and integrate with existing MTU and VXLAN configurations.
+
+[NOTE]
+====
+While you can select `azure` when using the installation program to deploy a cluster using installer-provisioned infrastructure, this option is only supported for the Azure Public Cloud.
+====
+
+[id="prerequisites_installing-azure-stack-hub-network-customizations"]
+== Prerequisites
+
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_azure_stack_hub/installing-azure-stack-hub-account.adoc#installing-azure-stack-hub-account[configured an Azure Stack Hub account] to host the cluster.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* You verified that you have approximately 16 GB of local disk space. Installing the cluster requires that you download the {op-system} virtual hard disk (VHD) cluster image and upload it to your Azure Stack Hub environment so that it is accessible during deployment. Decompressing the VHD files requires this amount of local disk space.
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-azure-user-infra-uploading-rhcos.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/installation-initializing-manual.adoc[leveloffset=+1]
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+include::modules/installation-azure-stack-hub-config-yaml.adoc[leveloffset=+2]
+
+include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_installing-azure-stack-hub-network-customizations-cco"]
+.Additional resources
+* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster within a minor version using the web console]
+* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster within a minor version using the CLI]
+
+include::modules/azure-stack-hub-internal-ca.adoc[leveloffset=+1]
+
+//include::modules/installation-launching-installer.adoc[leveloffset=+1]
+//Leaving this stubbed in case future might remove the requirement to manually configure the install configuration file.
+
+// Network Operator specific configuration
+include::modules/nw-network-config.adoc[leveloffset=+1]
+include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
+include::modules/nw-operator-cr.adoc[leveloffset=+1]
+include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
+
+////
+[NOTE]
+====
+For more information on using Linux and Windows nodes in the same cluster, see xref ../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+====
+////
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_installing-azure-stack-hub-network-customizations-console"]
+.Additional resources
+* xref:../../web_console/web-console.adoc#web-console[Accessing the web console].
+
+include::modules/cluster-telemetry.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_installing-azure-stack-hub-network-customizations-telemetry"]
+.Additional resources
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+
+[id="next-steps_installing-azure-stack-hub-network-customizations"]
+== Next steps
+
+* xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
+* If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials].

--- a/modules/cluster-entitlements.adoc
+++ b/modules/cluster-entitlements.adoc
@@ -68,6 +68,7 @@
 // * installing/installing_vmc/installing-vmc.adoc
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+// * installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
 // * architecture/architecture.adoc
 
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]

--- a/modules/configuring-hybrid-ovnkubernetes.adoc
+++ b/modules/configuring-hybrid-ovnkubernetes.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_azure/installing-azure-network-customizations.adoc
+// * installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
 // * networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
 
 :_content-type: PROCEDURE

--- a/modules/installation-azure-stack-hub-config-yaml.adoc
+++ b/modules/installation-azure-stack-hub-config-yaml.adoc
@@ -9,6 +9,9 @@ endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
 :ash-default:
 endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
+:ash-network:
+endif::[]
 
 [id="installation-azure-stack-hub-config-yaml_{context}"]
 = Sample customized install-config.yaml file for Azure Stack Hub
@@ -102,7 +105,7 @@ For production {product-title} clusters on which you want to perform installatio
 ====
 endif::ash[]
 
-ifdef::ash-default[]
+ifdef::ash-default,ash-network[]
 [source,yaml]
 ----
 apiVersion: v1
@@ -192,11 +195,14 @@ ifdef::openshift-origin[]
 <12> If the Azure Stack Hub environment is using an internal Certificate Authority (CA), adding the CA certificate is required.
 endif::openshift-origin[]
 
-endif::ash-default[]
+endif::ash-default,ash-network[]
 
 ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 :!ash:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
 :!ash-default:
+endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
+:!ash-network:
 endif::[]

--- a/modules/installation-azure-user-infra-uploading-rhcos.adoc
+++ b/modules/installation-azure-user-infra-uploading-rhcos.adoc
@@ -13,6 +13,9 @@ endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
 :ash-ipi:
 endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
+:ash-ipi:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="installation-azure-user-infra-uploading-rhcos_{context}"]
@@ -169,5 +172,8 @@ ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 :!ash:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
+:!ash-ipi:
+endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
 :!ash-ipi:
 endif::[]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -45,6 +45,7 @@
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
 // * installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc
+// * installing/installing_azure_stack_hub/installing-azure-stack-hub-customizations.adoc
 
 ifeval::["{context}" == "installing-aws-customizations"]
 :aws:
@@ -192,7 +193,10 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :ibm-power:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
-:ash-default:
+:ash:
+endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
+:ash:
 endif::[]
 
 :_content-type: CONCEPT
@@ -269,6 +273,7 @@ endif::[]
 
 |====
 
+ifndef::ash-default[]
 [id="installation-configuration-parameters-network_{context}"]
 == Network configuration parameters
 
@@ -448,7 +453,9 @@ Set the `networking.machineNetwork` to match the CIDR that the preferred NIC res
 ====
 
 |====
+endif::ash-default[]
 
+ifndef::ash-default[]
 [id="installation-configuration-parameters-optional_{context}"]
 == Optional configuration parameters
 
@@ -623,6 +630,7 @@ sshKey:
   <key3>
 ```
 |====
+endif::ash-default[]
 
 ifdef::aws[]
 [id="installation-configuration-parameters-optional-aws_{context}"]
@@ -1520,5 +1528,8 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :!ibm-power:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
-:!ash-default:
+:!ash:
+endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
+:!ash:
 endif::[]

--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -18,6 +18,7 @@
 // * installing/installing_vsphere/installing-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
+// * installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
 
 ifeval::["{context}" == "installing-azure-government-region"]
 :azure-gov:
@@ -55,14 +56,17 @@ endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
 :ash-default:
 endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
+:ash-network:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="installation-initializing-manual_{context}"]
 = Manually creating the installation configuration file
 
-ifndef::aws-china,aws-gov,aws-secret,azure-gov,ash,aws-private,azure-private,gcp-private,ash-default[]
+ifndef::aws-china,aws-gov,aws-secret,azure-gov,ash,aws-private,azure-private,gcp-private,ash-default,ash-network[]
 For user-provisioned installations of {product-title}, you manually generate your installation configuration file.
-endif::aws-china,aws-gov,aws-secret,azure-gov,ash,aws-private,azure-private,gcp-private,ash-default[]
+endif::aws-china,aws-gov,aws-secret,azure-gov,ash,aws-private,azure-private,gcp-private,ash-default,ash-network[]
 ifdef::aws-china,aws-gov,aws-secret[]
 Installing the cluster requires that you manually generate the installation configuration file.
 //Made this update as part of feedback in PR3961. tl;dr Simply state you have to create the config file, instead of creating a number of conditions to explain why.
@@ -74,9 +78,9 @@ endif::azure-gov[]
 ifdef::aws-private,azure-private,gcp-private[]
 For installations of a private {product-title} cluster that are only accessible from an internal network and are not visible to the internet, you must manually generate your installation configuration file.
 endif::aws-private,azure-private,gcp-private[]
-ifdef::ash-default[]
+ifdef::ash-default,ash-network[]
 When installing {product-title} on Microsoft Azure Stack Hub, you must manually create your installation configuration file.
-endif::ash-default[]
+endif::ash-default,ash-network[]
 
 .Prerequisites
 
@@ -128,12 +132,12 @@ mirror the repository.
 endif::restricted[]
 +
 
-ifndef::aws-china,aws-gov,aws-secret,azure-gov,ash,ash-default[]
+ifndef::aws-china,aws-gov,aws-secret,azure-gov,ash,ash-default,ash-network[]
 [NOTE]
 ====
 For some platform types, you can alternatively run `./openshift-install create install-config --dir <installation_directory>` to generate an `install-config.yaml` file. You can provide details about your cluster configuration at the prompts.
 ====
-endif::aws-china,aws-gov,aws-secret,azure-gov,ash,ash-default[]
+endif::aws-china,aws-gov,aws-secret,azure-gov,ash,ash-default,ash-network[]
 ifdef::ash[]
 +
 Make the following modifications for Azure Stack Hub:
@@ -169,7 +173,7 @@ platform:
 <4> Specify the name of your Azure Stack Hub region.
 endif::ash[]
 
-ifdef::ash-default[]
+ifdef::ash-default,ash-network[]
 +
 Make the following modifications:
 
@@ -180,7 +184,7 @@ Make the following modifications:
 .. Optional: Update one or more of the default configuration parameters to customize the installation.
 +
 For more information about the parameters, see "Installation configuration parameters".
-endif::ash-default[]
+endif::ash-default,ash-network[]
 
 . Back up the `install-config.yaml` file so that you can use it to install
 multiple clusters.
@@ -226,4 +230,7 @@ ifeval::["{context}" == "installing-gcp-private"]
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
 :!ash-default:
+endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
+:!ash-network:
 endif::[]

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -106,6 +106,10 @@ ifeval::["{context}" == "installing-azure-stack-hub-default"]
 :custom-config:
 :ash:
 endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
+:custom-config:
+:ash:
+endif::[]
 ifeval::["{context}" == "installing-openstack-installer-custom"]
 :osp:
 :custom-config:
@@ -513,6 +517,10 @@ ifeval::["{context}" == "installing-azure-vnet"]
 :!azure:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
+:!custom-config:
+:!ash:
+endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
 :!custom-config:
 :!ash:
 endif::[]

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -56,6 +56,9 @@ endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 :ash:
 endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
+:ash:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="installation-obtaining-installer_{context}"]
@@ -132,5 +135,8 @@ ifeval::["{context}" == "installing-azure-stack-hub-default"]
 :!ash:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
+:!ash:
+endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
 :!ash:
 endif::[]

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -21,6 +21,10 @@ ifeval::["{context}" == "installing-azure-stack-hub-default"]
 :ash:
 :cco-manual-mode:
 endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
+:ash:
+:cco-manual-mode:
+endif::[]
 
 
 :_content-type: PROCEDURE
@@ -246,6 +250,10 @@ ifeval::["{context}" == "manually-creating-iam-gcp"]
 :!cco-multi-mode:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
+:!ash:
+:!cco-manual-mode:
+endif::[]
+ifeval::["{context}" == "installing-azure-stack-hub-network-customizations"]
 :!ash:
 :!cco-manual-mode:
 endif::[]

--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -9,6 +9,7 @@
 // * installing/installing_gcp/installing-gcp-network-customizations.adoc
 // * installing/installing_vmc/installing-vmc-network-customizations.adoc
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+// * installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
 
 ifeval::["{context}" == "installing-bare-metal-network-customizations"]
 :ignition-config:

--- a/modules/nw-network-config.adoc
+++ b/modules/nw-network-config.adoc
@@ -11,6 +11,7 @@
 // * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
 // * installing/installing_gcp/installing-gcp-network-customizations.adoc
+// * installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
 
 [id="nw-network-config_{context}"]
 = Network configuration phases

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -18,6 +18,13 @@
 // * networking/network_policy/logging-network-policy.adoc
 // * post_installation_configuration/network-configuration.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_z/installing-ibm-z.adoc
+// * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+// * installing/installing_ibm_power/installing-ibm-power.adoc
+// * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+// * installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
 
 // Installation assemblies need different details than the CNO operator does
 ifeval::["{context}" == "cluster-network-operator"]


### PR DESCRIPTION
… Stack Hub

Looks like `../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads` is not available yet on 4.10.

Refs https://github.com/openshift/openshift-docs/pull/42670.