### PR TITLE
OCM Removal Fixes: Callout Numbering Issue

### DIFF
--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -151,13 +151,13 @@ The use of FIPS Validated / Modules in Process cryptographic libraries is only s
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]
-<14> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
-<15> The public portion of the default SSH key for the `core` user in
+<15> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+<16> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<13> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
-<14> The public portion of the default SSH key for the `core` user in
+<14> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+<15> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 +
 [NOTE]


### PR DESCRIPTION
This PR is to fix some of the build warnings generated in the OCM Removal PR #41055

The area that is correct is as follows:

`ifndef::openshift-origin[]`
`<14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.`
`+`
`[IMPORTANT]`
`====`
`The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.`
`====`
`endif::openshift-origin[]`
`ifndef::restricted[]`
`ifndef::openshift-origin[]`
`<15> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.`
`<16> The public portion of the default SSH key for the `core` user in {op-system-first}.`
`endif::openshift-origin[]`
`ifdef::openshift-origin[]`
`<14> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.`
`<15> The public portion of the default SSH key for the `core` user in {op-system-first}.`
`+`
`[NOTE]`
`====`
`For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.`
`====`
`endif::openshift-origin[]`
`endif::restricted[]`
`ifdef::restricted[]`
`ifndef::openshift-origin[]`
`<15> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.`
`<16> The public portion of the default SSH key for the `core` user in {op-system-first}.`
`+`
`[NOTE]`
`====`
`For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.`
`====`
`endif::openshift-origin[]`
`ifdef::openshift-origin[]`
`<14> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.`
`<15> The public portion of the default SSH key for the `core` user in {op-system-first}.`
`+`
`[NOTE]`
`====`
`For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.`
`====`
`endif::openshift-origin[]`
`endif::restricted[]`
`ifdef::restricted[]`
`ifndef::openshift-origin[]`
`<17> Provide the contents of the certificate file that you used for your mirror registry.`
`<18> Provide the `imageContentSources` section from the output of the command to mirror the repository.`
`endif::openshift-origin[]`
`ifdef::openshift-origin[]`
`<16> Provide the contents of the certificate file that you used for your mirror registry.`
`<17> Provide the `imageContentSources` section from the output of the command to mirror the repository.`
`endif::openshift-origin[]`
`endif::restricted[]`

PREVIEWS:

* **Restricted/non-Origin** https://deploy-preview-42885--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere.html#installation-vsphere-config-yaml_installing-restricted-networks-vsphere

> 14. Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
>
> [IMPORTANT]
> The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
> 
> 15. For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
> 16. The public portion of the default SSH key for the `core` user in {op-system-first}.`
> 
> [NOTE]
> For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.`
> 
> 17. Provide the contents of the certificate file that you used for your mirror registry.
> 18. Provide the `imageContentSources` section from the output of the command to mirror the repository.

* **Non-Restricted/non-Origin** https://deploy-preview-42885--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-user-infra.html#installation-vsphere-config-yaml_installing-vmc-user-infra

> 14. Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
>
> [IMPORTANT]
> The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
>
> 15. The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.`
> 16. The public portion of the default SSH key for the `core` user in {op-system-first}.

* **Restricted/Origin** https://people.redhat.com/eponvell/030722/OCMPR_Fixes/installing/installing_vsphere/installing-restricted-networks-vsphere.html#installation-vsphere-config-yaml_installing-restricted-networks-vsphere

> 14. For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
> 15. The public portion of the default SSH key for the `core` user in {op-system-first}.
> 
> [NOTE]
> 
> For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
>
> 16. Provide the contents of the certificate file that you used for your mirror registry.
> 17. Provide the `imageContentSources` section from the output of the command to mirror the repository.

*  **Non-Restricted/Origin** https://people.redhat.com/eponvell/030722/OCMPR_Fixes/installing/installing_vmc/installing-vmc-user-infra.html#installation-vsphere-config-yaml_installing-vmc-user-infra

> 14. You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
> 15. The public portion of the default SSH key for the `core` user in {op-system-first}.
> 
> [NOTE]
> 
> For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
> 