### PR TITLE
[enterprise-4.6] BZ2056590: Added note block about /dev/disk/by-path not supported for local storage

### DIFF
--- a/modules/persistent-storage-local-create-cr.adoc
+++ b/modules/persistent-storage-local-create-cr.adoc
@@ -62,7 +62,12 @@ local volumes.
 <4> The file system that is created when the local volume is mounted for the
 first time.
 <5> The path containing a list of local storage devices to choose from.
-<6> Replace this value with your actual local disks filepath to the LocalVolume resource, such as `/dev/xvdg`. PVs are created for these local disks when the provisioner is deployed successfully.
+<6> Replace this value with your actual local disks filepath to the `LocalVolume` resource `by-id`, such as `/dev/disk/by-id/wwn`. PVs are created for these local disks when the provisioner is deployed successfully.
++
+[NOTE]
+====
+The Local Storage Operator does not support the `LocalVolume` resource `by-path` or `by-partuuid`, such as `/dev/disk/by-path/wwn` or `/dev/disk/by-partuuid`.
+====
 +
 [NOTE]
 ====
@@ -101,7 +106,12 @@ on all available nodes.
 <3> The volume mode, either `Filesystem` or `Block`, defining the type of the
 local volumes.
 <4> The path containing a list of local storage devices to choose from.
-<5> Replace this value with your actual local disks filepath to the LocalVolume resource, such as `/dev/xvdg`. PVs are created for these local disks when the provisioner is deployed successfully.
+<5> Replace this value with your actual local disks filepath to the `LocalVolume` resource `by-id`, such as `dev/disk/by-id/wwn`. PVs are created for these local disks when the provisioner is deployed successfully.
++
+[NOTE]
+====
+The Local Storage Operator does not support the `LocalVolume` resource `by-path` or `by-partuuid`, such as `/dev/disk/by-path/wwn` or `/dev/disk/by-partuuid`.
+====
 
 . Create the local volume resource in your {product-title} cluster, specifying
 the file you just created:


### PR DESCRIPTION
Cherry Picked from c0f284ae50f8d53c3957d2bd60238c1394b7ad2e xref: https://github.com/openshift/openshift-docs/pull/42445. 

Direct Doc Preview Link: https://deploy-preview-42886--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local#local-volume-cr_persistent-storage-local