### PR TITLE
Update oc-compliance installation method

### DIFF
--- a/modules/oc-compliance-installing.adoc
+++ b/modules/oc-compliance-installing.adoc
@@ -12,7 +12,7 @@
 +
 [source,terminal]
 ----
-$ podman run --rm --entrypoint /bin/cat registry.redhat.io/compliance/oc-compliance-rhel8 /usr/bin/oc-compliance > ~/.local/bin/oc-compliance
+$ podman run --rm -v ~/.local/bin:/mnt/out:Z registry.redhat.io/compliance/oc-compliance-rhel8 /bin/cp /usr/bin/oc-compliance /mnt/out/
 ----
 +
 .Example output


### PR DESCRIPTION
The oc-compliance plugin is a handy tool for interacting with compliance
scans and results, but it doesn't come installed with the OpenShift
client. Instead, users have to install it separately.

The documented method for installing this plugin requires you to pull a
container image and copy the `oc-compliance` binary from the image. The
documented method hangs redirecting the binary output to a local file on
the host.

This commit updates the command to work around that issue by using the
cp command instead of redirecting output.

Related-Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2049926