### PR TITLE
SRVKE-528: Add broker config docs

### DIFF
--- a/modules/serverless-admin-broker-default.adoc
+++ b/modules/serverless-admin-broker-default.adoc
@@ -1,0 +1,110 @@
+// Module included in the following assemblies:
+//
+//  * serverless/admin_guide/serverless-configuring-eventing-defaults.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-broker-default_{context}"]
+= Configuring the default broker implementation
+
+You can configure the default broker class for your cluster as well as for individual namespaces on the cluster. To do this, you must configure the `defaultBrokerClass` spec in the `KnativeEventing` custom resource (CR), as well as adding configuration for the `config-br-defaults` config map.
+
+Currently, the available broker class options for {ServerlessProductName} are:
+
+* The `MTChannelBasedBroker` class, which uses the default Knative multi-tenant, channel-based broker.
++
+The `config-br-default-channel` config map defines the channel implementation for channel based brokers. This config map is created by default on the cluster when Knative Eventing is installed. This config map must be specified in the `KnativeEventing` CR if you want to set the multi-tenant, channel-based broker as the default broker for a namespace or cluster.
+
+* The `Kafka` broker class, which uses the Knative Kafka broker (currently Technology Preview).
++
+The `kafka-broker-config` config map defines the configuration for Kafka brokers, and is created on the cluster when Knative Kafka is installed. This config map must be specified in the `KnativeEventing` CR if you want to set the Kafka broker as the default broker for a namespace or cluster.
+
+If no broker class is specified, the cluster uses the `MTChannelBasedBroker` class by default.
+
+.Prerequisites
+
+ifdef::openshift-enterprise[]
+* You have cluster administrator permissions on {product-title}.
+endif::[]
+
+ifdef::openshift-dedicated[]
+* You have cluster or dedicated administrator permissions on {product-title}.
+endif::[]
+
+* You have installed the {ServerlessOperatorName} and Knative Eventing on your cluster.
+
+* Optional: If you want to use the Kafka broker, you must install Knative Kafka on your cluster.
+
+.Procedure
+
+* Modify the `KnativeEventing` CR to add the `defaultBrokerClass` spec and `config-br-defaults` config map details:
++
+.Example `KnativeEventing` CR
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  defaultBrokerClass: <default-broker-class> <1>
+  config:
+    config-br-defaults: <2>
+      default-br-config: |
+        clusterDefault: <3>
+          apiVersion: v1
+          kind: ConfigMap
+          name: config-br-default-channel
+        namespaceDefaults: <4>
+          namespace1:
+            apiVersion: v1
+            kind: ConfigMap
+            name: kafka-broker-config
+            namespace: knative-eventing
+...
+----
+<1> The default broker class for the cluster. This can be either `MTChannelBasedBroker` or `Kafka`. If no broker class is specified, the cluster uses the `MTChannelBasedBroker` class by default.
+<2> Configuration for the `config-br-defaults` config map.
+<3> The cluster-wide default broker class configuration. In this example, the default cluster-wide broker class is `MTChannelBasedBroker` because the `config-br-default-channel` config map is specified.
+<4> The namespace-scoped default broker class configuration. In this example, the default broker implementation for the `knative-eventing` namespace is `Kafka`, because the `kafka-broker-config` config map is specified.
+
+[IMPORTANT]
+====
+Configuring a namespace-specific default overrides any cluster-wide settings.
+====
+
+.Example `config-br-default-channel` config map
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-br-default-channel <1>
+  namespace: knative-eventing <2>
+data:
+  channelTemplateSpec: |
+    apiVersion: messaging.knative.dev/v1
+    kind: InMemoryChannel <3>
+----
+<1> The name of the config map.
+<2> The namespace where the config map exists.
+<3> The broker backing channel implementation type.
+
+.Example `kafka-broker-config` config map
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-broker-config <1>
+  namespace: knative-eventing <2>
+data:
+  default.topic.partitions: "10" <3>
+  default.topic.replication.factor: "1" <4>
+  bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092" <5>
+----
+<1> The name of the config map.
+<2> The namespace where the config map exists.
+<3> Number of topic partitions.
+<4> Replication factor of topic messages.
+<5> A comma separated list of bootstrap servers. These can exist in or outside of the cluster.

--- a/modules/serverless-create-broker-kn.adoc
+++ b/modules/serverless-create-broker-kn.adoc
@@ -14,12 +14,24 @@
 
 .Procedure
 
-* Create the `default` broker:
+* Create a broker:
 +
 [source,terminal]
 ----
-$ kn broker create default
+$ kn broker create <broker-name>
 ----
++
+You can optionally use the `--class` flag if you want to specify the class of the broker:
++
+[source,terminal]
+----
+$ kn broker create <broker-name> --class <broker-class>
+----
++
+Currently the supported classes for brokers are:
+
+** The default, multi-tenant, channel-based broker. This is specified by using the `MTChannelBasedBroker` class.
+** The Kafka broker (Technology Preview), which is specified by using the `Kafka` class.
 
 .Verification
 

--- a/serverless/admin_guide/serverless-configuring-eventing-defaults.adoc
+++ b/serverless/admin_guide/serverless-configuring-eventing-defaults.adoc
@@ -15,5 +15,5 @@ ifdef::openshift-dedicated[]
 If you have cluster or dedicated administrator permissions, you can set default options for Knative Eventing components, either for the whole cluster or for a specific namespace.
 endif::[]
 
-
 include::modules/serverless-channel-default.adoc[leveloffset=+1]
+include::modules/serverless-admin-broker-default.adoc[leveloffset=+1]


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVKE-528

Applies for OCP 4.6+

Direct preview link(s):
- OCP: https://deploy-preview-42899--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-configuring-eventing-defaults.html#serverless-broker-default_serverless-configuring-eventing-defaults
- OCP: https://deploy-preview-42899--osdocs.netlify.app/openshift-enterprise/latest/serverless/develop/serverless-using-brokers.html#serverless-create-broker-kn_serverless-using-brokers
- OSD: https://deploy-preview-42899--osdocs.netlify.app/openshift-dedicated/latest/serverless/admin_guide/serverless-configuring-eventing-defaults.html#serverless-broker-default_serverless-configuring-eventing-defaults
- OSD: https://deploy-preview-42899--osdocs.netlify.app/openshift-dedicated/latest/serverless/develop/serverless-using-brokers.html#serverless-create-broker-kn_serverless-using-brokers