### PR TITLE
Rm version for opm in 4.10+

### DIFF
--- a/modules/olm-creating-fb-catalog-image.adoc
+++ b/modules/olm-creating-fb-catalog-image.adoc
@@ -17,7 +17,7 @@ You can create a catalog image that uses the plain text _file-based catalog_ for
 
 .Prerequisites
 
-* `opm` version 1.18.0+
+* `opm`
 * `podman` version 1.9.3+
 * A bundle image built and pushed to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 

--- a/modules/olm-creating-index-image.adoc
+++ b/modules/olm-creating-index-image.adoc
@@ -10,7 +10,7 @@ You can create an index image based on the SQLite database format by using the `
 
 .Prerequisites
 
-* `opm` version 1.18.0+
+* `opm`
 * `podman` version 1.9.3+
 * A bundle image built and pushed to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 

--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -73,10 +73,3 @@ C:\> move opm.exe <directory>
 ----
 $ opm version
 ----
-+
-.Example output
-[source,terminal]
-----
-Version: version.Version{OpmVersion:"v1.18.0", GitCommit:"32eb2591437e394bdc58a58371c5cd1e6fe5e63f", BuildDate:"2021-09-21T10:41:00Z", GoOs:"linux", GoArch:"amd64"}
-
-----

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -41,7 +41,7 @@ ifeval::["{context}" != "olm-managing-custom-catalogs"]
 endif::[]
 * `podman` version 1.9.3+
 * link:https://github.com/fullstorydev/grpcurl[`grpcurl`] (third-party command-line tool)
-* `opm` version 1.18.0+
+* `opm`
 * Access to a registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 

--- a/modules/olm-updating-index-image.adoc
+++ b/modules/olm-updating-index-image.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 .Prerequisites
 
-* `opm` version 1.18.0+
+* `opm`
 * `podman` version 1.9.3+
 * An index image built and pushed to a registry.
 * An existing catalog source referencing the index image.


### PR DESCRIPTION
In 4.10+, `opm version` no longer provides a useful version number, just an upstream commit ID. The 4.10 docs for installing `opm` instruct downloading the latest version from the 4.10 dir on the mirror site anyway, so for now just remove the version specificity here. Can follow up with Eng/QE about potentially getting a better output from `opm` in a later release.