### PR TITLE
Rename OLM features section back to 'Operator lifecycle'

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -749,7 +749,7 @@ For more information, see xref:../storage/understanding-persistent-storage.adoc#
 === Registry
 
 [id="ocp-4-10-olm"]
-=== Operator Lifecycle Manager
+=== Operator lifecycle
 
 [id="ocp-4-10-copied-csvs"]
 ==== Disabling copied CSVs to support large clusters


### PR DESCRIPTION
This got changed recently during some BZ additions, setting back to match previous OCP release notes.