### PR TITLE
Conflict Cleanup: Removed leftover text from conflict cleanup

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -52,15 +52,13 @@ This section provides the necessary details that enable you to control egress tr
 |443
 |Provides {op-system-first} images.
 
-<<<<<<< HEAD
 |`registry.access.redhat.com`
 |443
 |Provides access to the odo CLI tool that helps developers build on OpenShift and Kubernetes.
-=======
+
 |`console.redhat.com`
 |Required. Allows interactions between the cluster and OpenShift Console Manager to enable functionality, such as scheduling upgrades.
 |443, 80
->>>>>>> 762abb159a... OSS-Docs-32: Removed instances of OCM
 
 |`sso.redhat.com`
 |443


### PR DESCRIPTION
This PR cleans up some leftover text from the OCM removal PR #41055

Preview:

https://deploy-preview-42915--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs#osd-aws-privatelink-firewall-prerequisites