### PR TITLE
BZ2035903: Manually creating IAM instructions for tech preview CRs

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -43,7 +43,7 @@ endif::alibabacloud-default,alibabacloud-customizations[]
 
 [NOTE]
 ====
-By default, `ccoctl` creates objects in the directory in which the commands are run. To specify a directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this location.
+By default, `ccoctl` creates objects in the directory in which the commands are run. To create the objects in a different directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this directory.
 ====
 
 .Prerequisites
@@ -63,17 +63,26 @@ endif::alibabacloud-default,alibabacloud-customizations[]
 [source,terminal]
 ifdef::aws-sts[]
 ----
-$ oc adm release extract --credentials-requests --cloud=aws --to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
+$ oc adm release extract \
+--credentials-requests \
+--cloud=aws \
+--to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
 ----
 endif::aws-sts[]
 ifdef::google-cloud-platform[]
 ----
-$ oc adm release extract --credentials-requests --cloud=gcp --to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
+$ oc adm release extract \
+--credentials-requests \
+--cloud=gcp \
+--to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
 ----
 endif::google-cloud-platform[]
 ifdef::alibabacloud-default,alibabacloud-customizations[]
 ----
-$ oc adm release extract --credentials-requests --cloud=alibabacloud --to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
+$ oc adm release extract \
+--credentials-requests \
+--cloud=alibabacloud \
+--to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
 ----
 endif::alibabacloud-default,alibabacloud-customizations[]
 +
@@ -89,27 +98,48 @@ endif::aws-sts,google-cloud-platform[]
 ifdef::aws-sts[]
 [source,terminal]
 ----
-$ ccoctl aws create-all --name=<name> --region=<aws_region> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
+$ ccoctl aws create-all \
+--name=<name> \
+--region=<aws_region> \
+--credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
 ----
 +
 where:
 +
+--
 ** `<name>` is the name used to tag any cloud resources that are created for tracking.
 ** `<aws_region>` is the AWS region in which cloud resources will be created.
 ** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files for the component `CredentialsRequest` objects.
+--
++
+[NOTE]
+====
+If your cluster uses Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set, you must include the `--enable-tech-preview` parameter.
+====
 endif::aws-sts[]
 ifdef::google-cloud-platform[]
 [source,terminal]
 ----
-$ ccoctl gcp create-all --name=<name> --region=<gcp_region> --project=<gcp_project_id> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
+$ ccoctl gcp create-all \
+--name=<name> \
+--region=<gcp_region> \
+--project=<gcp_project_id> \
+--credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
 ----
 +
 where:
 +
+--
 ** `<name>` is the user-defined name for all created GCP resources used for tracking.
 ** `<gcp_region>` is the GCP region in which cloud resources will be created.
 ** `<gcp_project_id>` is the GCP project ID in which cloud resources will be created.
 ** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files of `CredentialsRequest` manifests to create GCP service accounts.
+--
++
+[NOTE]
+====
+If your cluster uses Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set, you must include the `--enable-tech-preview` parameter.
+====
 endif::google-cloud-platform[]
 
 ifdef::alibabacloud-default,alibabacloud-customizations[]
@@ -119,15 +149,26 @@ ifdef::alibabacloud-default,alibabacloud-customizations[]
 +
 [source,terminal]
 ----
-$ ccoctl alibabacloud create-ram-users --name <name> --region=<alibaba_region> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests --output-dir=<path_to_ccoctl_output_dir>
+$ ccoctl alibabacloud create-ram-users \
+--name <name> \
+--region=<alibaba_region> \
+--credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \
+--output-dir=<path_to_ccoctl_output_dir>
 ----
 +
 where:
 +
+--
 ** `<name>` is the name used to tag any cloud resources that are created for tracking.
 ** `<alibaba_region>` is the Alibaba Cloud region in which cloud resources will be created.
 ** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files for the component `CredentialsRequest` objects.
 ** `<path_to_ccoctl_output_dir>` is the directory where the generated component credentials secrets will be placed.
+--
++
+[NOTE]
+====
+If your cluster uses Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set, you must include the `--enable-tech-preview` parameter.
+====
 +
 .Example output
 +

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -14,9 +14,9 @@ Otherwise, you can use the `ccoctl aws create-all` command to create the AWS res
 
 [NOTE]
 ====
-By default, `ccoctl` creates objects in the directory in which the commands are run. To specify a directory, use the `--output-dir` flag. This procedure uses `_<path_to_ccoctl_output_dir>_` to refer to this location.
+By default, `ccoctl` creates objects in the directory in which the commands are run. To create the objects in a different directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this directory.
 
-Some `ccoctl` commands make AWS API calls to create or modify AWS resources. To place JSON files on the local file system instead, use the `--dry-run` flag. These JSON files can be reviewed or modified and then applied with the AWS CLI tool using the `--cli-input-json` parameters.
+Some `ccoctl` commands make AWS API calls to create or modify AWS resources. You can use the `--dry-run` flag to avoid making API calls. Using this flag creates JSON files on the local file system instead. You can review and modify the JSON files and then apply them with the AWS CLI tool using the `--cli-input-json` parameters.
 ====
 
 .Prerequisites
@@ -34,89 +34,102 @@ $ ccoctl aws create-key-pair
 +
 .Example output:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
 2021/04/13 11:01:02 Generating RSA keypair
-2021/04/13 11:01:03 Writing private key to /__<path_to_ccoctl_output_dir>__/serviceaccount-signer.private
-2021/04/13 11:01:03 Writing public key to /__<path_to_ccoctl_output_dir>__/serviceaccount-signer.public
+2021/04/13 11:01:03 Writing private key to /<path_to_ccoctl_output_dir>/serviceaccount-signer.private
+2021/04/13 11:01:03 Writing public key to /<path_to_ccoctl_output_dir>/serviceaccount-signer.public
 2021/04/13 11:01:03 Copying signing key for use by installer
 ----
 +
 where `serviceaccount-signer.private` and `serviceaccount-signer.public` are the generated key files.
 +
-This command also creates a private key that the cluster requires during installation in `/_<path_to_ccoctl_output_dir>_/tls/bound-service-account-signing-key.key`.
+This command also creates a private key that the cluster requires during installation in `/<path_to_ccoctl_output_dir>/tls/bound-service-account-signing-key.key`.
 
 . Create an OpenID Connect identity provider and S3 bucket on AWS:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ ccoctl aws create-identity-provider --name=__<name>__ --region=__<aws_region>__ --public-key-file=__<path_to_ccoctl_output_dir>__/serviceaccount-signer.public
+$ ccoctl aws create-identity-provider \
+--name=<name> \
+--region=<aws_region> \
+--public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public
 ----
 +
 where:
 +
-** `_<name>_` is the name used to tag any cloud resources that are created for tracking.
-** `_<aws-region>_` is the AWS region in which cloud resources will be created.
-** `_<path_to_ccoctl_output_dir>_` is the path to the public key file that the `ccoctl aws create-key-pair` command generated.
+--
+** `<name>` is the name used to tag any cloud resources that are created for tracking.
+** `<aws-region>` is the AWS region in which cloud resources will be created.
+** `<path_to_ccoctl_output_dir>` is the path to the public key file that the `ccoctl aws create-key-pair` command generated.
+--
 +
 .Example output:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-2021/04/13 11:16:09 Bucket __<name>__-oidc created
-2021/04/13 11:16:10 OpenID Connect discovery document in the S3 bucket __<name>__-oidc at .well-known/openid-configuration updated
+2021/04/13 11:16:09 Bucket <name>-oidc created
+2021/04/13 11:16:10 OpenID Connect discovery document in the S3 bucket <name>-oidc at .well-known/openid-configuration updated
 2021/04/13 11:16:10 Reading public key
-2021/04/13 11:16:10 JSON web key set (JWKS) in the S3 bucket __<name>__-oidc at keys.json updated
-2021/04/13 11:16:18 Identity Provider created with ARN: arn:aws:iam::__<aws_account_id>__:oidc-provider/__<name>__-oidc.s3.__<aws_region>__.amazonaws.com
+2021/04/13 11:16:10 JSON web key set (JWKS) in the S3 bucket <name>-oidc at keys.json updated
+2021/04/13 11:16:18 Identity Provider created with ARN: arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
 ----
 +
 where `02-openid-configuration` is a discovery document and `03-keys.json` is a JSON web key set file.
 +
-This command also creates a YAML configuration file in `/_<path_to_ccoctl_output_dir>_/manifests/cluster-authentication-02-config.yaml`. This file sets the issuer URL field for the service account tokens that the cluster generates, so that the AWS IAM identity provider trusts the tokens.
+This command also creates a YAML configuration file in `/<path_to_ccoctl_output_dir>/manifests/cluster-authentication-02-config.yaml`. This file sets the issuer URL field for the service account tokens that the cluster generates, so that the AWS IAM identity provider trusts the tokens.
 
 . Create IAM roles for each component in the cluster.
 
 .. Extract the list of `CredentialsRequest` objects from the {product-title} release image:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ oc adm release extract --credentials-requests --cloud=aws --to=__<path_to_directory_with_list_of_credentials_requests>__/credrequests quay.io/__<path_to>__/ocp-release:__<version>__
+$ oc adm release extract --credentials-requests \
+--cloud=aws \
+--to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
 ----
 
 .. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ ccoctl aws create-iam-roles --name=__<name>__ --region=__<aws_region>__ --credentials-requests-dir=__<path_to_directory_with_list_of_credentials_requests>__/credrequests --identity-provider-arn=arn:aws:iam::__<aws_account_id>__:oidc-provider/__<name>__-oidc.s3.__<aws_region>__.amazonaws.com
+$ ccoctl aws create-iam-roles \
+--name=<name> \
+--region=<aws_region> \
+--credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \
+--identity-provider-arn=arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
 ----
 +
 [NOTE]
 ====
 For AWS environments that use alternative IAM API endpoints, such as GovCloud, you must also specify your region with the `--region` parameter.
+
+If your cluster uses Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set, you must include the `--enable-tech-preview` parameter.
 ====
 +
 For each `CredentialsRequest` object, `ccoctl` creates an IAM role with a trust policy that is tied to the specified OIDC identity provider, and a permissions policy as defined in each `CredentialsRequest` object from the {product-title} release image.
 
 .Verification
 
-* To verify that the {product-title} secrets are created, list the files in the `_<path_to_ccoctl_output_dir>_/manifests` directory:
+* To verify that the {product-title} secrets are created, list the files in the `<path_to_ccoctl_output_dir>/manifests` directory:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ ll __<path_to_ccoctl_output_dir>__/manifests
+$ ll <path_to_ccoctl_output_dir>/manifests
 ----
 +
 .Example output:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
 total 24
--rw-------. 1 __<user>__ __<user>__ 161 Apr 13 11:42 cluster-authentication-02-config.yaml
--rw-------. 1 __<user>__ __<user>__ 379 Apr 13 11:59 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 353 Apr 13 11:59 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 355 Apr 13 11:59 openshift-image-registry-installer-cloud-credentials-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 339 Apr 13 11:59 openshift-ingress-operator-cloud-credentials-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 337 Apr 13 11:59 openshift-machine-api-aws-cloud-credentials-credentials.yaml
+-rw-------. 1 <user> <user> 161 Apr 13 11:42 cluster-authentication-02-config.yaml
+-rw-------. 1 <user> <user> 379 Apr 13 11:59 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
+-rw-------. 1 <user> <user> 353 Apr 13 11:59 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
+-rw-------. 1 <user> <user> 355 Apr 13 11:59 openshift-image-registry-installer-cloud-credentials-credentials.yaml
+-rw-------. 1 <user> <user> 339 Apr 13 11:59 openshift-ingress-operator-cloud-credentials-credentials.yaml
+-rw-------. 1 <user> <user> 337 Apr 13 11:59 openshift-machine-api-aws-cloud-credentials-credentials.yaml
 ----
 
 You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.

--- a/modules/cco-ccoctl-upgrading.adoc
+++ b/modules/cco-ccoctl-upgrading.adoc
@@ -1,8 +1,9 @@
 // Module included in the following assemblies:
 //
 // * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+// NOTE: This module is included in the cco-mode-sts.adoc assembly, but is included past the secondary/temporary context established for the upgrade steps (sts-mode-upgrading). Thus the context evaluation for AWS is set to the temporary context rather than cco-mode-sts.
 
-ifeval::["{context}" == "cco-mode-sts"]
+ifeval::["{context}" == "sts-mode-upgrading"]
 :aws-sts:
 endif::[]
 ifeval::["{context}" == "cco-mode-gcp-workload-identity"]
@@ -15,27 +16,26 @@ ifdef::aws-sts[]
 = Updating AWS resources with the Cloud Credential Operator utility
 
 The process for upgrading an {product-title} cluster configured for manual mode with AWS Secure Token Service (STS) is similar to installing on a cluster for which you create the AWS resources individually.
-endif::aws-sts[]
 
+[NOTE]
+====
+By default, `ccoctl` creates objects in the directory in which the commands are run. To create the objects in a different directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this directory.
+
+Some `ccoctl` commands make AWS API calls to create or modify AWS resources. You can use the `--dry-run` flag to avoid making API calls. Using this flag creates JSON files on the local file system instead. You can review and modify the JSON files and then apply them with the AWS CLI tool using the `--cli-input-json` parameters.
+====
+endif::aws-sts[]
 ifdef::google-cloud-platform[]
 = Updating GCP resources with the Cloud Credential Operator utility
 
 The process for upgrading an {product-title} cluster configured for manual mode with GCP Workload Identity is similar to installing on a cluster for which you create the GCP resources individually.
-endif::google-cloud-platform[]
 
 [NOTE]
 ====
-By default, `ccoctl` creates objects in the directory in which the commands are run. To specify a directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this location.
+By default, `ccoctl` creates objects in the directory in which the commands are run. To create the objects in a different directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this directory.
 
-ifdef::aws-sts[]
-Some `ccoctl` commands make AWS API calls to create or modify AWS resources.
-endif::aws-sts[]
-ifdef::google-cloud-platform[]
-Some `ccoctl` commands make GCP API calls to create or modify GCP resources.
-endif::google-cloud-platform[]
-To place JSON files on the local file system instead, use the `--dry-run` flag. These JSON files can be reviewed or modified and then applied with the AWS CLI tool using the `--cli-input-json` parameters.
+Some `ccoctl` commands make GCP API calls to create or modify GCP resources. You can use the `--dry-run` flag to avoid making API calls. Using this flag creates bash scripts with Google Cloud CLI commands on the local file system instead. You can review and modify the bash scripts and then run them to create the required GCP resources.
 ====
-
+endif::google-cloud-platform[]
 
 .Prerequisites
 
@@ -47,9 +47,11 @@ To place JSON files on the local file system instead, use the `--dry-run` flag. 
 
 . Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ oc adm release extract --credentials-requests --cloud=aws --to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
+$ oc adm release extract --credentials-requests \
+--cloud=aws \
+--to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
 ----
 
 . For each `CredentialsRequest` CR in the release image, ensure that a namespace that matches the text in the `spec.secretRef.namespace` field exists in the cluster. This field is where the generated secrets that hold the credentials configuration are stored.
@@ -91,25 +93,33 @@ $ oc create namespace <component_namespace>
 +
 [source,terminal,subs="+quotes"]
 ----
-$ ccoctl aws create-iam-roles --name <name> --region=<aws_region> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests --identity-provider-arn arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
+$ ccoctl aws create-iam-roles \
+--name <name> \
+--region=<aws_region> \
+--credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \
+--identity-provider-arn arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
 ----
 +
 where:
 +
+--
 ** `<name>` is the name used to tag any cloud resources that are created for tracking. For upgrades, use the same value that was used for the initial installation.
 ** `<aws_account_id>` is the AWS account ID.
 ** `<aws_region>` is the AWS region in which cloud resources will be created.
+--
 +
 [NOTE]
 ====
 For AWS environments that use alternative IAM API endpoints, such as GovCloud, you must also specify your region with the `--region` parameter.
+
+If your cluster uses Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set, you must include the `--enable-tech-preview` parameter.
 ====
 +
 For each `CredentialsRequest` object, `ccoctl` creates an IAM role with a trust policy that is tied to the specified OIDC identity provider, and a permissions policy as defined in each `CredentialsRequest` object from the {product-title} release image.
 
 . Apply the secrets to your cluster:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
 $ ls <path_to_ccoctl_output_dir>/manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
 ----
@@ -117,3 +127,10 @@ $ ls <path_to_ccoctl_output_dir>/manifests/*-credentials.yaml | xargs -I{} oc ap
 .Verification
 
 You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.
+
+ifeval::["{context}" == "sts-mode-upgrading"]
+:!aws-sts:
+endif::[]
+ifeval::["{context}" == "cco-mode-gcp-workload-identity"]
+:!google-cloud-platform:
+endif::[]

--- a/modules/installation-uninstall-clouds.adoc
+++ b/modules/installation-uninstall-clouds.adoc
@@ -118,6 +118,13 @@ $ ccoctl ibmcloud delete-service-id \
     --credentials-requests-dir <path_to_credential_requests_directory> \
     --name <cluster_name>
 ----
++
+--
+[NOTE]
+====
+If your cluster uses Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set, you must include the `--enable-tech-preview` parameter.
+====
+--
 endif::ibm-cloud[]
 // The above CCO credential removal for IBM Cloud is only necessary for manual mode. Future releases that support other credential methods will not require this step.
 

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -396,9 +396,18 @@ spec:
     - role: Contributor
 ----
 
-.. Remove the YAML file for any `CredentialRequest` object that is in Technology Preview or they cause the installation to fail. As of {product-version}, the only credential request in Technology Preview is for the `capi-operator`. To remove this request:
-To remove this request:
-... To list the credential request, run the following command:
+.. Create YAML files for secrets in the `openshift-install` manifests directory that you generated previously. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object. The format for the secret data varies for each cloud provider.
++
+[IMPORTANT]
+====
+The release image includes `CredentialsRequest` objects for Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set. You can identify these objects by their use of the `release.openshift.io/feature-gate: TechPreviewNoUpgrade` annotation.
+
+* If you are not using any of these features, do not create secrets for these objects. Creating secrets for Technology Preview features that you are not using can cause the installation to fail.
+
+* If you are using any of these features, you must create secrets for the corresponding objects.
+====
+
+*** To find `CredentialsRequest` objects with the `TechPreviewNoUpgrade` annotation, run the following command:
 +
 [source,terminal]
 ----
@@ -410,16 +419,9 @@ $ grep "release.openshift.io/feature-gate" *
 ----
 0000_30_capi-operator_00_credentials-request.yaml:  release.openshift.io/feature-gate: TechPreviewNoUpgrade
 ----
-... To remove the credential request, run the following command:
-+
-[source,terminal]
-----
-$ rm 0000_30_capi-operator_00_credentials-request.yaml
-----
+// Right now, only the CAPI Operator is an issue, but it might make sense to update `0000_30_capi-operator_00_credentials-request.yaml` to `<tech_preview_credentials_request>.yaml` for the future.
 
-.. Create YAML files for secrets in the `openshift-install` manifests directory that you generated previously. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object. The format for the secret data varies for each cloud provider.
-
-.. Create a `cco-configmap.yaml` file in the manifests directory with the Cloud Config Operator (CCO) disabled:
+.. Create a `cco-configmap.yaml` file in the manifests directory with the Cloud Credential Operator (CCO) disabled:
 +
 .Sample `ConfigMap` object
 [source,yaml]

--- a/modules/manually-create-iam-ibm-cloud.adoc
+++ b/modules/manually-create-iam-ibm-cloud.adoc
@@ -100,7 +100,7 @@ This command creates a YAML file for each `CredentialsRequest` object.
 $ ccoctl ibmcloud create-service-id \
     --credentials-requests-dir <path_to_store_credential_request_templates> \ <1>
     --name <cluster_name> \ <2>
-    --output-dir <installation_directory>
+    --output-dir <installation_directory> \
     --resource-group-name <resource_group_name> <3>
 ----
 <1> The directory where the credential requests are stored.
@@ -110,6 +110,8 @@ $ ccoctl ibmcloud create-service-id \
 --
 [NOTE]
 ====
+If your cluster uses Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set, you must include the `--enable-tech-preview` parameter.
+
 If an incorrect resource group name is provided, the installation fails during the bootstrap phase. To find the correct resource group name, run the following command:
 
 [source,terminal]

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -198,10 +198,18 @@ spec:
 ----
 endif::google-cloud-platform[]
 
-ifdef::cco-manual-mode[]
+. Create YAML files for secrets in the `openshift-install` manifests directory that you generated previously. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object. The format for the secret data varies for each cloud provider.
++
+[IMPORTANT]
+====
+The release image includes `CredentialsRequest` objects for Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set. You can identify these objects by their use of the `release.openshift.io/feature-gate: TechPreviewNoUpgrade` annotation.
 
-. Remove the YAML file for any `CredentialRequest` object that is in Technology Preview or they cause the installation to fail. As of {product-version}, the only credential request in Technology Preview is for the `capi-operator`. To remove this request:
-.. To list the credential request, run the following command:
+* If you are not using any of these features, do not create secrets for these objects. Creating secrets for Technology Preview features that you are not using can cause the installation to fail.
+
+* If you are using any of these features, you must create secrets for the corresponding objects.
+====
+
+** To find `CredentialsRequest` objects with the `TechPreviewNoUpgrade` annotation, run the following command:
 +
 [source,terminal]
 ----
@@ -213,15 +221,7 @@ $ grep "release.openshift.io/feature-gate" *
 ----
 0000_30_capi-operator_00_credentials-request.yaml:  release.openshift.io/feature-gate: TechPreviewNoUpgrade
 ----
-.. To remove the credential request, run the following command:
-+
-[source,terminal]
-----
-$ rm 0000_30_capi-operator_00_credentials-request.yaml
-----
-endif::cco-manual-mode[]
-
-. Create YAML files for secrets in the `openshift-install` manifests directory that you generated previously. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object. The format for the secret data varies for each cloud provider.
+// Right now, only the CAPI Operator is an issue, but it might make sense to update `0000_30_capi-operator_00_credentials-request.yaml` to `<tech_preview_credentials_request>.yaml` for the future.
 
 ifdef::cco-multi-mode[]
 . From the directory that contains the installation program, proceed with your cluster creation:

--- a/modules/manually-maintained-credentials-upgrade.adoc
+++ b/modules/manually-maintained-credentials-upgrade.adoc
@@ -98,6 +98,13 @@ $ ccoctl ibmcloud delete-service-id \
 ----
 <1> The directory where the credential requests are stored.
 <2> The name of the {product-title} cluster.
++
+--
+[NOTE]
+====
+If your cluster uses Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set, you must include the `--enable-tech-preview` parameter.
+====
+--
 endif::ibm-cloud[]
 
 ifeval::["{context}" == "configuring-iam-ibm-cloud"]

--- a/modules/refreshing-service-ids-ibm-cloud.adoc
+++ b/modules/refreshing-service-ids-ibm-cloud.adoc
@@ -27,3 +27,10 @@ $ ccoctl ibmcloud refresh-keys \
 <1> The `kubeconfig` file associated with the cluster. For example, `<installation_directory>/auth/kubeconfig`.
 <2> The directory where the credential requests are stored.
 <3> The name of the {product-title} cluster.
++
+--
+[NOTE]
+====
+If your cluster uses Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set, you must include the `--enable-tech-preview` parameter.
+====
+--


### PR DESCRIPTION
For [BZ2035903](https://bugzilla.redhat.com/show_bug.cgi?id=2035903). Also relates to phase-1 approach for [BZ2065161](https://bugzilla.redhat.com/show_bug.cgi?id=2065161).

Created a docs ticket ([OSDOCS-3332](https://issues.redhat.com/browse/OSDOCS-3332)) to track this work since the BZ is not a docs bug

Notes:
- This issue had already been covered for ASH [with a different approach](https://docs.openshift.com/container-platform/4.10/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.html#manually-create-iam_installing-azure-stack-hub-default) (deleting the CAPI `CredentialsRequest` CR rather than instructing users to ignore it when creating secrets). I have replaced that content with instructions to ignore the CR, but would like confirmation that this approach for AWS/global Azure/GCP will also work for ASH.
- From what I understand, this would be a problem for any CR with the tech preview annotation. I have left the example as CAPI for now, but I think long term it makes sense to make it more generic so that it applies to any problematic CRs.

Previews:
- [Manually create IAM (AWS)](https://deploy-preview-42921--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/manually-creating-iam.html#manually-create-iam_manually-creating-iam-aws) step 6
- [Manually create IAM (global Azure)](https://deploy-preview-42921--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/manually-creating-iam-azure.html#manually-create-iam_manually-creating-iam-azure) step 6
- [Manually manage cloud credentials (ASH IPI)](https://deploy-preview-42921--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.html#manually-create-iam_installing-azure-stack-hub-default) step 4
- [Creating the Kubernetes manifest and Ignition config files (ASH UPI)](https://deploy-preview-42921--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.html#installation-user-infra-generate-k8s-manifest-ignition_installing-azure-stack-hub-user-infra) step 8c
- [Manually create IAM (GCP)](https://deploy-preview-42921--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/manually-creating-iam-gcp.html#manually-create-iam_manually-creating-iam-gcp) step 6

Places I added the `--enable-tech-preview` flag:
- [Creating AWS resources with a single command](https://deploy-preview-42921--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-at-once_cco-mode-sts) (step 2)
- [Creating AWS resources individually](https://deploy-preview-42921--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-individually_cco-mode-sts) (x3: steps 1, 2, and 3b)
- ~~[Deleting AWS resources with the Cloud Credential Operator utility](https://deploy-preview-42921--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/uninstalling-cluster-aws.html#cco-ccoctl-deleting-sts-resources_uninstall-cluster-aws) (same in GCP version of this topic)~~ Removed change per feedback
- [Updating AWS resources with the Cloud Credential Operator utility](https://deploy-preview-42921--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-upgrading_sts-mode-upgrading) (step 4)
- [Removing a cluster that uses installer-provisioned infrastructure](https://deploy-preview-42921--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/uninstalling-cluster-ibm-cloud.html#installation-uninstall-clouds_uninstalling-cluster-ibm-cloud) (step 4)
- [Manually creating IAM for IBM Cloud](https://deploy-preview-42921--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.html#manually-create-iam-ibm-cloud_installing-ibm-cloud-customizations) (step 5)
- [Upgrading clusters with manually maintained credentials (IBM)](https://github.com/openshift/openshift-docs/pull/42921/files#diff-f52694df735b4be63528116a2adc548b861064502477d3b7c5315799f422e180) This content is not yet included in the actual build but it planned for a later release. Just want to make sure it is also right.
- [Rotating API keys for IBM Cloud](https://deploy-preview-42921--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#refreshing-service-ids-ibm-cloud_post-install-cluster-tasks)