### PR TITLE
Updates to the Technology Preview Table in RNs

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2056,10 +2056,20 @@ In the table below, features are marked with the following statuses:
 |TP
 |TP
 
+|CSI AliCloud Disk Driver Operator
+|-
+|-
+|GA
+
 |CSI Azure Disk Driver Operator
 |TP
 |TP
 |GA
+
+|CSI Azure File Driver Operator
+|-
+|-
+|TP
 
 |CSI Azure Stack Hub Driver Operator
 |-
@@ -2067,6 +2077,16 @@ In the table below, features are marked with the following statuses:
 |GA
 
 |CSI GCP PD Driver Operator
+|GA
+|GA
+|GA
+
+|CSI IBM VPC Block Driver Operator
+|-
+|-
+|GA
+
+|CSI OpenStack Cinder Driver Operator
 |GA
 |GA
 |GA
@@ -2082,9 +2102,9 @@ In the table below, features are marked with the following statuses:
 |GA
 
 |CSI automatic migration
-|GA
-|GA
-|GA
+|TP
+|TP
+|TP
 
 |CSI inline ephemeral volumes
 |TP
@@ -2095,11 +2115,6 @@ In the table below, features are marked with the following statuses:
 |TP
 |TP
 |GA
-
-|Shared Resource CSI Driver
-|-
-|-
-|TP
 
 |Shared Resource CSI Driver
 |-


### PR DESCRIPTION
Edits to the Technology Preview table in the release notes. 

- Applies to `enterprise-4.10` only
- [Preview link](https://deploy-preview-42927--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-technology-preview)