### PR TITLE
Replacing docs.openshift.com links to old RNs with portal links

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1176,7 +1176,7 @@ X.509 certificates must have a properly set the Subject Alternative Name field.
 If you update your cluster without this, you risk breaking your cluster or rendering it inaccessible.
 
 In older versions of {product-title}, X.509 certificates worked without a Subject Alternative Name, so long as the Common Name field was set.
-link:https://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html#ocp-4-6-tls-common-name[This behavior was removed in {product-title} 4.6].
+link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/release_notes/ocp-4-6-release-notes#ocp-4-6-tls-common-name[This behavior was removed in {product-title} 4.6].
 
 In some cases, certificates without a Subject Alternative Name continued to work in {product-title} 4.6, 4.7, 4.8, and 4.9.
 Because it uses Kubernetes 1.23, {product-title} 4.10 does not allow this under any circumstances.
@@ -1208,7 +1208,7 @@ Operator SDK v1.16.0 supports Kubernetes 1.22.
 
 Many deprecated `v1beta1` APIs were removed in Kubernetes 1.22, including `sigs.k8s.io/controller-runtime v0.10.0` and `controller-gen v0.7`. This is a breaking change if you need to scaffold `v1beta1` APIs for custom resource definitions (CRDs) or webhooks to publish your project into older cluster versions.
 
-For more information about changes introduced in Kubernetes 1.22, see link:https://docs.openshift.com/container-platform/4.9/release_notes/ocp-4-9-release-notes.html#ocp-4-9-osdk-k8s-api-bundle-validate[Validating bundle manifests for APIs removed from Kubernetes 1.22] and link:https://docs.openshift.com/container-platform/4.9/release_notes/ocp-4-9-release-notes.html#ocp-4-9-removed-kube-1-22-apis[Beta APIs removed from Kubernetes 1.22].
+For more information about changes introduced in Kubernetes 1.22, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/release_notes/ocp-4-9-release-notes#ocp-4-9-osdk-k8s-api-bundle-validate[Validating bundle manifests for APIs removed from Kubernetes 1.22] and link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/release_notes/ocp-4-9-release-notes#ocp-4-9-removed-kube-1-22-apis[Beta APIs removed from Kubernetes 1.22] in the {product-title} 4.9 release notes.
 
 If you have any Operator projects that were previously created or maintained with Operator SDK v1.10.1, see xref:../operators/operator_sdk/osdk-upgrading-projects.adoc#osdk-upgrading-projects[Upgrading projects for newer Operator SDK versions] to ensure your projects are upgraded to maintain compatibility with Operator SDK v1.16.0.
 


### PR DESCRIPTION
Replaced hard coded docs.openshift.com links with portal links. Would be best to avoid switching users from one platform to the other, but if we have to go a certain way, it would be better for docs.openshift.com users to be redirected to portal docs, as opposed to the other way around)

Previews:

* https://deploy-preview-42931--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-TLS-subject-alternative-names-required
* https://deploy-preview-42931--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-operator-sdk-v-1-16-0