### PR TITLE
BZ 2060478: Indicates that DHCP leases on the baremetal network must be infinite …

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -7,7 +7,7 @@
 
 Installer-provisioned installation of {product-title} involves several network requirements. First, installer-provisioned installation involves an optional non-routable `provisioning` network for provisioning the operating system on each bare metal node. Second, installer-provisioned installation involves a routable `baremetal` network.
 
-.Configuring NICs
+== Configuring NICs
 
 {product-title} deploys with two networks:
 
@@ -21,7 +21,7 @@ Installer-provisioned installation of {product-title} involves several network r
 Each NIC should be on a separate VLAN corresponding to the appropriate network.
 ====
 
-.Configuring the DNS server
+== Configuring the DNS server
 
 Clients access the {product-title} cluster nodes over the `baremetal` network.
 A network administrator must configure a subdomain or subzone where the canonical name extension is the cluster name.
@@ -36,46 +36,26 @@ For example:
 test-cluster.example.com
 ----
 
-ifeval::[{product-version}>4.7]
-{product-title} 4.8 and later releases include functionality that uses cluster membership information to generate A/AAAA records. This resolves the node names to their IP addresses. Once the nodes are registered with the API, the cluster can disperse node information without using CoreDNS-mDNS. This eliminates the network traffic associated with multicast DNS.
-endif::[]
+{product-title} includes functionality that uses cluster membership information to generate A/AAAA records. This resolves the node names to their IP addresses. Once the nodes are registered with the API, the cluster can disperse node information without using CoreDNS-mDNS. This eliminates the network traffic associated with multicast DNS.
 
-ifdef::upstream[]
-For assistance in configuring the DNS server, check xref:ipi-install-upstream-appendix[Appendix] section for:
-
-- xref:creating-dns-records-on-a-dns-server-option1_{context}[Creating DNS Records with Bind (Option 1)]
-- xref:creating-dns-records-using-dnsmasq-option2_{context}[Creating DNS Records with dnsmasq (Option 2)]
-
-endif::[]
-
-.Dynamic Host Configuration Protocol (DHCP) requirements
+== Dynamic Host Configuration Protocol (DHCP) requirements
 
 By default, installer-provisioned installation deploys `ironic-dnsmasq` with DHCP enabled for the `provisioning` network. No other DHCP servers should be running on the `provisioning` network when the `provisioningNetwork` configuration setting is set to `managed`, which is the default value. If you have a DHCP server running on the `provisioning` network, you must set the `provisioningNetwork` configuration setting to `unmanaged` in the `install-config.yaml` file.
 
 Network administrators must reserve IP addresses for each node in the {product-title} cluster for the `baremetal` network on an external DHCP server.
 
-.Reserving IP addresses for nodes with the DHCP server
+== Reserving IP addresses for nodes with the DHCP server
 
-For the `baremetal` network, a network administrator must reserve a number of IP addresses, including:
+For the `baremetal` network, a network administrator must reserve a number of IP addresses to ensure that they do not change after deployment, including:
 
-ifeval::[{product-version} > 4.5]
-. Two virtual IP addresses.
-endif::[]
-ifeval::[{product-version} <= 4.5]
-. Three virtual IP addresses
-endif::[]
-+
-- One IP address for the API endpoint
-- One IP address for the wildcard ingress endpoint
-ifeval::[{product-version} <= 4.5]
-- One IP address for the name server
-endif::[]
+. Two virtual IP addresses:
+- One IP address for the API endpoint.
+- One IP address for the wildcard ingress endpoint.
 
 . One IP address for the provisioner node.
 . One IP address for each control plane (master) node.
-. One IP address for each worker node, if applicable.
+. One IP address for each worker node.
 
-ifeval::[{product-version} > 4.6]
 [IMPORTANT]
 .Reserving IP addresses so they become static IP addresses
 ====
@@ -87,7 +67,12 @@ Some administrators prefer to use static IP addresses so that each node's IP add
 ====
 Your DHCP server must provide a DHCP expiration time of 4294967295 seconds to properly set an infinite lease as specified by link:https://datatracker.ietf.org/doc/html/rfc2131[rfc2131]. If a lesser value is returned for the DHCP infinite lease time, the node reports an error and a permanent IP is not set for the node. In RHEL 8, `dhcpd` does not provide infinite leases. If you want to use the provisioner node to serve dynamic IP addresses with infinite lease times, use `dnsmasq` rather than `dhcpd`.
 ====
-endif::[]
+
+[IMPORTANT]
+.Do not change IP addresses manually after deployment
+====
+Do not change a worker node's IP address manually after deployment. To change the IP address of a worker node after deployment, you must mark the worker node unschedulable, evacuate the pods, delete the node, and recreate it with the new IP address. See "Working with nodes" for additional details. To change the IP address of a control plane node after deployment, contact support.
+====
 
 The following table provides an exemplary embodiment of fully qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The hostnames of the control plane and worker nodes are exemplary, so you can use any host naming convention you prefer.
 
@@ -96,9 +81,6 @@ The following table provides an exemplary embodiment of fully qualified domain n
 | Usage | Host Name | IP
 | API | api.<cluster_name>.<domain> | <ip>
 | Ingress LB (apps) |  *.apps.<cluster_name>.<domain>  | <ip>
-ifeval::[{product-version} <= 4.5]
-| Nameserver | ns1.<cluster_name>.<domain> | <ip>
-endif::[]
 | Provisioner node | provisioner.<cluster_name>.<domain> | <ip>
 | Master-0 | openshift-master-0.<cluster_name>.<domain> | <ip>
 | Master-1 | openshift-master-1.<cluster_name>.<domain> | <ip>
@@ -108,14 +90,7 @@ endif::[]
 | Worker-n | openshift-worker-n.<cluster_name>.<domain> | <ip>
 |=====
 
-ifdef::upstream[]
-For assistance in configuring the DHCP server, check xref:ipi-install-upstream-appendix[Appendix] section for:
-
-- xref:creating-dhcp-reservations-option1_{context}[Creating DHCP reservations with dhcpd (Option 1)]
-- xref:creating-dhcp-reservations-using-dnsmasq-option2_{context}[Creating DHCP reservations with dnsmasq (Option 2)]
-endif::[]
-
-.Network Time Protocol (NTP)
+== Network Time Protocol (NTP)
 
 Each {product-title} node in the cluster must have access to an NTP server. {product-title} nodes use NTP to synchronize their clocks. For example, cluster nodes use SSL certificates that require validation, which might fail if the date and time between the nodes are not in sync.
 
@@ -126,25 +101,7 @@ Define a consistent clock date and time format in each cluster node's BIOS setti
 
 You may reconfigure the control plane nodes to act as NTP servers on disconnected clusters, and reconfigure worker nodes to retrieve time from the control plane nodes.
 
-ifeval::[{product-version} == 4.6]
-.Additional requirements with no provisioning network
-
-All installer-provisioned installations require a `baremetal` network. The `baremetal` network is a routable network used for external network access to the outside world. In addition to the IP address supplied to the {product-title} cluster node, installations without a `provisioning` network require the following:
-
-- Setting an available IP address from the `baremetal` network to the `bootstrapProvisioningIP` configuration setting within the `install-config.yaml` configuration file.
-
-- Setting an available IP address from the `baremetal` network to the `provisioningHostIP` configuration setting within the `install-config.yaml` configuration file.
-
-- Deploying the {product-title} cluster using RedFish Virtual Media/iDRAC Virtual Media.
-
-[NOTE]
-====
-Configuring additional IP addresses for `bootstrapProvisioningIP` and `provisioningHostIP` is not required when using a `provisioning` network.
-====
-endif::[]
-
-ifeval::[{product-version} > 4.6]
-.State-driven network configuration requirements (Technology Preview)
+== State-driven network configuration requirements (Technology Preview)
 
 {product-title} supports additional post-installation state-driven network configuration on the secondary network interfaces of cluster nodes using `kubernetes-nmstate`. For example, system administrators might configure a secondary network interface on cluster nodes after installation for a storage network.
 
@@ -154,8 +111,7 @@ Configuration must occur before scheduling pods.
 ====
 
 State-driven network configuration requires installing `kubernetes-nmstate`, and also requires Network Manager running on the cluster nodes. See *OpenShift Virtualization > Kubernetes NMState (Tech Preview)* for additional details.
-endif::[]
 
-.Port access for the out-of-band management IP address
+== Port access for the out-of-band management IP address
 
 The out-of-band management IP address is on a separate network from the node. To ensure that the out-of-band management can communicate with the `baremetal` node during installation, the out-of-band management IP address address must be granted access to the TCP 6180 port.


### PR DESCRIPTION
This PR addresses BZ 20604787 for the 4.7 release. It indicates that DHCP leases on the baremetal network must be infinite to set them as static IP address. It also admonishes the user not to change a static IP address manually after installation, directing them instead to make the node unschedulable, evacuate the node, delete it, and recreate it with the new IP address. 

I have also removed extraneous conditional tags to improve maintainability.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2060478

For release: 4.7

Preview URL: https://deploy-preview-42932--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites#reserving-ip-addresses-for-nodes-with-the-dhcp-server

Signed-off-by: John Wilkins <jowilkin@redhat.com>