### PR TITLE
Add :release: 4.6 varible per slack convo

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -3,6 +3,7 @@
 = Setting up the environment for an OpenShift installation
 include::_attributes/common-attributes.adoc[]
 :context: ipi-install-installation-workflow
+:release: 4.6
 
 toc::[]
 


### PR DESCRIPTION
The asciibinder build process was crashing for any feature branch based on `enterprise-4.6`. @gabriel-rh [determined the cause was a missing versioning variable in one file](https://coreos.slack.com/archives/C85JYPHL3/p1646679097812979?thread_ts=1645654852.716739&cid=C85JYPHL3). This PR adds the needed variable. 