### PR TITLE
Update incorrect oc commands + API endpoint in Using PTP section

### DIFF
--- a/modules/cnf-fast-event-notifications-api-refererence.adoc
+++ b/modules/cnf-fast-event-notifications-api-refererence.adoc
@@ -3,132 +3,30 @@
 // * networking/using-ptp.adoc
 
 [id="cnf-fast-event-notifications-api-refererence_{context}"]
-= PTP fast event notifications REST API reference
+= Subscribing DU applications to PTP events REST API reference
 
-You can use the PTP fast event notifications REST API to subscribe an application to the PTP events that are generated for the parent node. PTP fast events notifications are available on each node where a PTP capable network interface is configured.
+Use the PTP event notifications REST API to subscribe a distributed unit (DU) application to the PTP events that are generated on the parent node.
 
-You can subscribe DU applications to PTP event notifications by using the resource address `/cluster/node/<node_name>/ptp`, where `<node_name>` is the cluster node running the DU application.
+Subscribe applications to PTP events by using the resource address `/cluster/node/<node_name>/ptp`, where `<node_name>` is the cluster node running the DU application.
 
-Status request are sent by making a REST API `PUT` call to `/subscriptions/status/<subscription_id>`. The API call returns events through the AMQP event bus to the subscribed address.
+Deploy your `cloud-event-consumer` DU application container and `cloud-event-proxy` sidecar container in a separate DU application pod. The `cloud-event-consumer` DU application subscribes to the `cloud-event-proxy` container in the application pod.
 
-The PTP fast events notifications REST API is served at `http://localhost:8080/` by default. The following API endpoints are available:
+Use the following API endpoints to subscribe the `cloud-event-consumer` DU application to PTP events posted by the `cloud-event-proxy` container at [x-]`http://localhost:8089/api/cloudNotifications/v1/` in the DU application pod:
 
-* `/api/cloudNotifications/v1/publishers`
-- `POST`: Creates a new publisher
-- `GET`: Retrieves a list of publishers
-* `/api/cloudNotifications/v1/publishers/<publisher_id>`
-- `GET`: Creates a new status ping request for the specified publisher id
 * `/api/cloudNotifications/v1/subscriptions`
 - `POST`: Creates a new subscription
 - `GET`: Retrieves a list of subscriptions
 * `/api/cloudNotifications/v1/subscriptions/<subscription_id>`
-- `GET`: Creates a new status ping request for the specified subscription id
+- `GET`: Returns details for the specified subscription ID
 * `api/cloudNotifications/v1/subscriptions/status/<subscription_id>`
-- `PUT`: Creates a new status ping request for the specified subscription id
+- `PUT`: Creates a new status ping request for the specified subscription ID
 * `/api/cloudNotifications/v1/health`
 - `GET`: Returns the health status of `cloudNotifications` API
 
-== api/cloudNotifications/v1/publishers
-
-=== HTTP method
-
-`POST api/cloudNotifications/v1/publishers`
-
-==== Description
-
-Creates a new publisher. If publisher creation is successful, or if it already exists, a `201 Created` status code is returned.
-
-.Query parameters
-|===
-| Parameter | Type
-
-| publisher
-| data
-|===
-
-.Example payload
-[source,json]
-----
-{
-  "id": "56e8a064-dc4b-4428-8085-91c18ea07930",
-  "endpointUri": "http://localhost:8080/api/cloudNotifications/v1/dummy",
-  "uriLocation": "http://localhost:8080/api/cloudNotifications/v1/publishers/56e8a064-dc4b-4428-8085-91c18ea07930",
-  "resource": "/cluster/node/compute-1.example.com/ptp"
- }
-----
-
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location --request POST 'http://localhost:8080/api/cloudNotifications/v1/publishers' --header 'Content-Type: application/json' --insecure --data ' {
-  "id": "56e8a064-dc4b-4428-8085-91c18ea07930",
-  "endpointUri": "http://localhost:8080/api/cloudNotifications/v1/dummy",
-  "uriLocation": "http://localhost:8080/api/cloudNotifications/v1/publishers/56e8a064-dc4b-4428-8085-91c18ea07930",
-  "resource": "/cluster/node/compute-1.example.com/ptp"
- }'
-----
-
-=== HTTP method
-
-`GET api/cloudNotifications/v1/publishers`
-
-==== Description
-
-Returns a list of publishers. If publishers exist, a `200 OK` status code is returned along with the list of publishers.
-
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location http://localhost:8080/api/cloudNotifications/v1/publishers
-----
-
-.Example return
-[source,json]
-----
-[
- {
-  "id": "56e8a064-dc4b-4428-8085-91c18ea07930",
-  "endpointUri": "http://localhost:8080/api/cloudNotifications/v1/dummy",
-  "uriLocation": "http://localhost:8080/api/cloudNotifications/v1/publishers/56e8a064-dc4b-4428-8085-91c18ea07930",
-  "resource": "/cluster/node/compute-1.example.com/ptp"
- }
-]
-----
-
-== api/cloudNotifications/v1/publishers/<publisher_id>
-
-=== HTTP method
-
-`GET api/cloudNotifications/v1/publishers/<publisher_id>`
-
-==== Description
-
-Returns the publisher with id `<publisher_id>`.
-
-.Query parameters
-|===
-| Parameter | Type
-
-| `<publisher_id>`
-| string
-|===
-
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location http://localhost:8080/api/cloudNotifications/v1/publishers/56e8a064-dc4b-4428-8085-91c18ea07930
-----
-
-.Example return
-[source,json]
-----
-{
- "id":"56e8a064-dc4b-4428-8085-91c18ea07930",
- "endpointUri":"http://localhost:8080/api/cloudNotifications/v1/dummy",
- "uriLocation":"http://localhost:8080/api/cloudNotifications/v1/publishers/56e8a064-dc4b-4428-8085-91c18ea07930",
- "resource":"/cluster/node/compute-1.example.com/ptp"
-}
-----
+[NOTE]
+====
+`9089` is the default port for the `cloud-event-consumer` container deployed in the application pod. You can configure a different port for your DU application as required.
+====
 
 == api/cloudNotifications/v1/subscriptions
 
@@ -140,20 +38,14 @@ $ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- cur
 
 Returns a list of subscriptions. If subscriptions exist, a `200 OK` status code is returned along with the list of subscriptions.
 
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location http://localhost:8080/api/cloudNotifications/v1/subscriptions
-----
-
-.Example return
+.Example API response
 [source,json]
 ----
 [
  {
   "id": "75b1ad8f-c807-4c23-acf5-56f4b7ee3826",
-  "endpointUri": "http://localhost:8080/api/cloudNotifications/v1/dummy",
-  "uriLocation": "http://localhost:8080/api/cloudNotifications/v1/subscriptions/75b1ad8f-c807-4c23-acf5-56f4b7ee3826",
+  "endpointUri": "http://localhost:9089/event",
+  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/subscriptions/75b1ad8f-c807-4c23-acf5-56f4b7ee3826",
   "resource": "/cluster/node/compute-1.example.com/ptp"
  }
 ]
@@ -179,22 +71,9 @@ Creates a new subscription. If a subscription is successfully created, or if it 
 [source,json]
 ----
 {
-  "id": "56e8a064-dc4b-4428-8085-91c18ea07930",
-  "endpointUri": "http://localhost:8080/api/cloudNotifications/v1/dummy",
-  "uriLocation": "http://localhost:8080/api/cloudNotifications/v1/subscriptions/56e8a064-dc4b-4428-8085-91c18ea07930",
+  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/subscriptions",
   "resource": "/cluster/node/compute-1.example.com/ptp"
- }
-----
-
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location --request POST 'http://localhost:8080/api/cloudNotifications/v1/subscriptions' --header 'Content-Type: application/json' --insecure --data ' {
-"id": "56e8a064-dc4b-4428-8085-91c18ea07930",
-"endpointUri": "http://localhost:8080/api/cloudNotifications/v1/dummy",
-"uriLocation": "http://localhost:8080/api/cloudNotifications/v1/subscriptions/75b1ad8f-dc4b-4428-8085-91c18ea07930",
-"resource": "/cluster/node/compute-1.example.com/ptp"
-}'
+}
 ----
 
 == api/cloudNotifications/v1/subscriptions/<subscription_id>
@@ -205,7 +84,7 @@ $ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- cur
 
 ==== Description
 
-Returns details for the subscription with id `<subscription_id>`
+Returns details for the subscription with ID `<subscription_id>`
 
 .Query parameters
 |===
@@ -215,16 +94,15 @@ Returns details for the subscription with id `<subscription_id>`
 | string
 |===
 
-.Example oc exec curl command
-[source,terminal]
+.Example API response
+[source,json]
 ----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location http://localhost:8080/api/cloudNotifications/v1/subscriptions/48210fb3-45be-4ce0-aa9b-41a0e58730ab
-----
-
-.Example return
-[source,terminal]
-----
-{"id":"48210fb3-45be-4ce0-aa9b-41a0e58730ab","endpointUri":"http://localhost:8080/api/cloudNotifications/v1/dummy","uriLocation":"http://localhost:8080/api/cloudNotifications/v1/subscriptions/48210fb3-45be-4ce0-aa9b-41a0e58730ab","resource":"/cluster/node/compute-1.example.com/ptp"}
+{
+  "id":"48210fb3-45be-4ce0-aa9b-41a0e58730ab",
+  "endpointUri": "http://localhost:9089/event",
+  "uriLocation":"http://localhost:8089/api/cloudNotifications/v1/subscriptions/48210fb3-45be-4ce0-aa9b-41a0e58730ab",
+  "resource":"/cluster/node/compute-1.example.com/ptp"
+}
 ----
 
 == api/cloudNotifications/v1/subscriptions/status/<subscription_id>
@@ -235,7 +113,7 @@ $ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- cur
 
 ==== Description
 
-Creates a new status ping request for subscription with id `<subscription_id>`. If a subscription is present, the status request is successful and a `202 Accepted` status code is returned.
+Creates a new status ping request for subscription with ID `<subscription_id>`. If a subscription is present, the status request is successful and a `202 Accepted` status code is returned.
 
 .Query parameters
 |===
@@ -245,13 +123,7 @@ Creates a new status ping request for subscription with id `<subscription_id>`. 
 | string
 |===
 
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location --request PUT http://localhost:8080/api/cloudNotifications/v1/subscriptions/status/48210fb3-45be-4ce0-aa9b-41a0e58730ab
-----
-
-.Example output
+.Example API response
 [source,json]
 ----
 {"status":"ping sent"}
@@ -267,13 +139,7 @@ $ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- cur
 
 Returns the health status for the `cloudNotifications` REST API.
 
-.Example oc exec curl command
-[source,terminal]
-----
-$ oc exec -it linuxptp-daemon-5j265 -n openshift-ptp -c cloud-event-proxy -- curl --location http://localhost:8080/api/cloudNotifications/v1/health
-----
-
-.Example return
+.Example API response
 [source,terminal]
 ----
 OK

--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -196,7 +196,7 @@ ptp-operator-657bbb64c8-2f8sj   1/1     Running   0          43m   10.129.0.61  
 +
 [source,terminal]
 ----
-$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp
+$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp -c linuxptp-daemon-container
 ----
 +
 .Example output

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -89,7 +89,7 @@ ptp-operator-657bbb64c8-2f8sj   1/1     Running   0          43m   10.129.0.61  
 +
 [source,terminal]
 ----
-$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp
+$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp -c linuxptp-daemon-container
 ----
 +
 .Example output


### PR DESCRIPTION
enterprise-4.9 PR that removes example oc exec commands in the PTP Events API reference that are misleading to users.

This PR also fixes an incorrect `oc logs` command.

Merge to enterprise-4.9

Preview: https://deploy-preview-42937--osdocs.netlify.app/openshift-enterprise/latest/networking/using-ptp#cnf-fast-event-notifications-api-refererence_using-ptp