### PR TITLE
[TELCODOCS-323] - Fix oc logs error + rename example endpoint

### DIFF
--- a/modules/cnf-configuring-cvl-nic-as-oc.adoc
+++ b/modules/cnf-configuring-cvl-nic-as-oc.adoc
@@ -189,7 +189,7 @@ ptp-operator-657bbb64c8-2f8sj   1/1     Running   0          43m   10.129.0.61  
 +
 [source,terminal]
 ----
-$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp
+$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp -c linuxptp-daemon-container
 ----
 +
 .Example output

--- a/modules/cnf-fast-event-notifications-api-refererence.adoc
+++ b/modules/cnf-fast-event-notifications-api-refererence.adoc
@@ -3,28 +3,16 @@
 // * networking/using-ptp.adoc
 
 [id="cnf-fast-event-notifications-api-refererence_{context}"]
-= PTP fast event notifications REST API reference
+= Subscribing DU applications to PTP events REST API reference
 
-You can use the PTP fast event notifications REST API to subscribe an application to the PTP events that are generated for the parent node. PTP fast events notifications are available on each node where a PTP capable network interface is configured.
+Use the PTP event notifications REST API to subscribe a distributed unit (DU) application to the PTP events that are generated on the parent node.
 
-You can subscribe distributed unit (DU) applications to PTP event notifications by using the resource address `/cluster/node/<node_name>/ptp`, where `<node_name>` is the cluster node running the DU application.
+Subscribe applications to PTP events by using the resource address `/cluster/node/<node_name>/ptp`, where `<node_name>` is the cluster node running the DU application.
 
-The PTP Operator deploys the `linuxptp-daemon` container and the `cloud-event-proxy` sidecar container in a pod managed by the PTP Operator. The `cloud-event-proxy` container collects the PTP events and publishes the events using the `cloud-event-proxy` publisher API at [x-]`http://localhost:8089/api/cloudNotifications/v1/`.
+Deploy your `cloud-event-consumer` DU application container and `cloud-event-proxy` sidecar container in a separate DU application pod. The `cloud-event-consumer` DU application subscribes to the `cloud-event-proxy` container in the application pod.
 
-Deploy your DU application container that needs to subscribe to PTP events and a `cloud-event-proxy` sidecar container in a separate DU application pod. The DU application container uses the subscription API provided by the `cloud-event-proxy` container to subscribe to events at [x-]`http://localhost:8089/api/cloudNotifications/v1/`.
+Use the following API endpoints to subscribe the `cloud-event-consumer` DU application to PTP events posted by the `cloud-event-proxy` container at [x-]`http://localhost:8089/api/cloudNotifications/v1/` in the DU application pod:
 
-[NOTE]
-====
-The PTP fast events notifications REST API is provided by `cloud-event-proxy`. To access the API, applications must be in the same pod as the `cloud-event-proxy` container.
-====
-
-The following API endpoints are available at [x-]`http://localhost:8089/api/cloudNotifications/v1/` on the DU application pod:
-
-* `/api/cloudNotifications/v1/publishers`
-- `POST`: Creates a new publisher
-- `GET`: Retrieves a list of publishers
-* `/api/cloudNotifications/v1/publishers/<publisher_id>`
-- `GET`: Creates a new status ping request for the specified publisher id
 * `/api/cloudNotifications/v1/subscriptions`
 - `POST`: Creates a new subscription
 - `GET`: Retrieves a list of subscriptions
@@ -35,82 +23,10 @@ The following API endpoints are available at [x-]`http://localhost:8089/api/clou
 * `/api/cloudNotifications/v1/health`
 - `GET`: Returns the health status of `cloudNotifications` API
 
-== api/cloudNotifications/v1/publishers
-
-=== HTTP method
-
-`POST api/cloudNotifications/v1/publishers`
-
-==== Description
-
-Creates a new publisher. If publisher creation is successful, or if it already exists, a `201 Created` status code is returned.
-
-.Query parameters
-|===
-| Parameter | Type
-
-| publisher
-| data
-|===
-
-.Example payload
-[source,json]
-----
-{
-  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/publishers",
-  "resource": "/cluster/node/compute-1.example.com/ptp"
-}
-----
-
-=== HTTP method
-
-`GET api/cloudNotifications/v1/publishers`
-
-==== Description
-
-Returns a list of publishers. If publishers exist, a `200 OK` status code is returned along with the list of publishers.
-
-.Example API response
-[source,json]
-----
-[
- {
-  "id": "56e8a064-dc4b-4428-8085-91c18ea07930",
-  "endpointUri": "http://localhost:8089/api/cloudNotifications/v1/dummy",
-  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/publishers/56e8a064-dc4b-4428-8085-91c18ea07930",
-  "resource": "/cluster/node/compute-1.example.com/ptp"
- }
-]
-----
-
-== api/cloudNotifications/v1/publishers/<publisher_id>
-
-=== HTTP method
-
-`GET api/cloudNotifications/v1/publishers/<publisher_id>`
-
-==== Description
-
-Returns the publisher with ID `<publisher_id>`.
-
-.Query parameters
-|===
-| Parameter | Type
-
-| `<publisher_id>`
-| string
-|===
-
-.Example API response
-[source,json]
-----
-{
- "id":"56e8a064-dc4b-4428-8085-91c18ea07930",
- "endpointUri":"http://localhost:8089/api/cloudNotifications/v1/dummy",
- "uriLocation":"http://localhost:8089/api/cloudNotifications/v1/publishers/56e8a064-dc4b-4428-8085-91c18ea07930",
- "resource":"/cluster/node/compute-1.example.com/ptp"
-}
-----
+[NOTE]
+====
+`9089` is the default port for the `cloud-event-consumer` container deployed in the application pod. You can configure a different port for your DU application as required.
+====
 
 == api/cloudNotifications/v1/subscriptions
 
@@ -128,7 +44,7 @@ Returns a list of subscriptions. If subscriptions exist, a `200 OK` status code 
 [
  {
   "id": "75b1ad8f-c807-4c23-acf5-56f4b7ee3826",
-  "endpointUri": "http://localhost:8089/api/cloudNotifications/v1/dummy",
+  "endpointUri": "http://localhost:9089/event",
   "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/subscriptions/75b1ad8f-c807-4c23-acf5-56f4b7ee3826",
   "resource": "/cluster/node/compute-1.example.com/ptp"
  }
@@ -179,11 +95,11 @@ Returns details for the subscription with ID `<subscription_id>`
 |===
 
 .Example API response
-[source,terminal]
+[source,json]
 ----
 {
   "id":"48210fb3-45be-4ce0-aa9b-41a0e58730ab",
-  "endpointUri":"http://localhost:8089/api/cloudNotifications/v1/dummy",
+  "endpointUri": "http://localhost:9089/event",
   "uriLocation":"http://localhost:8089/api/cloudNotifications/v1/subscriptions/48210fb3-45be-4ce0-aa9b-41a0e58730ab",
   "resource":"/cluster/node/compute-1.example.com/ptp"
 }
@@ -207,7 +123,7 @@ Creates a new status ping request for subscription with ID `<subscription_id>`. 
 | string
 |===
 
-.Example output
+.Example API response
 [source,json]
 ----
 {"status":"ping sent"}

--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -205,7 +205,7 @@ ptp-operator-657bbb64c8-2f8sj   1/1     Running   0          43m   10.129.0.61  
 +
 [source,terminal]
 ----
-$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp
+$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp -c linuxptp-daemon-container
 ----
 +
 .Example output

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -198,7 +198,7 @@ ptp-operator-657bbb64c8-2f8sj   1/1     Running   0          43m   10.129.0.61  
 +
 [source,terminal]
 ----
-$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp
+$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp -c linuxptp-daemon-container
 ----
 +
 .Example output


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-323

This PR fixes a number of instances of an `oc log` command that are incorrect +  clarifies API details.

Merge to main, enterprise-4.10, enterprise-4.11

Preview: https://deploy-preview-42949--osdocs.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#cnf-fast-event-notifications-api-refererence_using-ptp