### PR TITLE
RHDEVDOCS-3846 Fix blurry right navigation pane in Pipelines docs

### DIFF
--- a/cicd/jenkins-tekton/migrating-from-jenkins-to-tekton.adoc
+++ b/cicd/jenkins-tekton/migrating-from-jenkins-to-tekton.adoc
@@ -1,13 +1,11 @@
 :_content-type: ASSEMBLY
 //Jenkins-Tekton-Migration
-include::_attributes/common-attributes.adoc[]
 [id="migrating-from-jenkins-to-tekton_{context}"]
 = Migrating from Jenkins to Tekton
+include::_attributes/common-attributes.adoc[]
 :context: migrating-from-jenkins-to-tekton
-//include::_attributes/common-attributes.adoc[]
 
 toc::[]
-
 
 Jenkins and Tekton are extensively used to automate the process of building, testing, and deploying applications and projects. However, Tekton is a cloud-native CI/CD solution that works seamlessly with Kubernetes and {product-title}. This document helps you migrate your Jenkins CI/CD workflows to Tekton.
 

--- a/cicd/pipelines/reducing-pipelines-resource-consumption.adoc
+++ b/cicd/pipelines/reducing-pipelines-resource-consumption.adoc
@@ -6,7 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-
 If you use clusters in multi-tenant environments you must control the consumption of CPU, memory, and storage resources for each project and Kubernetes object. This helps prevent any one application from consuming too many resources and affecting other applications.
 
 To define the final resource limits that are set on the resulting pods, {pipelines-title} use resource quota limits and limit ranges of the project in which they are executed.

--- a/cicd/pipelines/securing-webhooks-with-event-listeners.adoc
+++ b/cicd/pipelines/securing-webhooks-with-event-listeners.adoc
@@ -2,7 +2,6 @@
 [id="securing-webhooks-with-event-listeners"]
 = Securing webhooks with event listeners
 include::_attributes/common-attributes.adoc[]
-
 :context: securing-webhooks-with-event-listeners
 
 toc::[]

--- a/cicd/pipelines/setting-compute-resource-quota-for-openshift-pipelines.adoc
+++ b/cicd/pipelines/setting-compute-resource-quota-for-openshift-pipelines.adoc
@@ -6,7 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-
 A `ResourceQuota` object in {pipelines-title} controls the total resource consumption per namespace. You can use it to limit the quantity of objects created in a namespace, based on the type of the object. In addition, you can specify a compute resource quota to restrict the total amount of compute resources consumed in a namespace.
 
 However, you might want to limit the amount of compute resources consumed by pods resulting from a pipeline run, rather than setting quotas for the entire namespace. Currently, {pipelines-title} does not enable you to directly specify the compute resource quota for a pipeline.

--- a/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.adoc
+++ b/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.adoc
@@ -2,7 +2,6 @@
 [id='working-with-pipelines-using-the-developer-perspective']
 = Working with {pipelines-title} using the Developer perspective
 include::_attributes/common-attributes.adoc[]
-
 :context: working-with-pipelines-using-the-developer-perspective
 
 toc::[]

--- a/modules/jt-comparison-of-jenkins-and-tekton-concepts.adoc
+++ b/modules/jt-comparison-of-jenkins-and-tekton-concepts.adoc
@@ -5,9 +5,6 @@
 [id="jt-comparison-of-jenkins-and-tekton-concepts_{context}"]
 = Comparison of Jenkins and Tekton concepts
 
-toc::[]
-
-
 This section summarizes the basic terms used in Jenkins and Tekton, and compares the equivalent terms.
 
 == Jenkins terminology

--- a/modules/jt-extending-tekton-capabilities-using-custom-tasks-and-scripts.adoc
+++ b/modules/jt-extending-tekton-capabilities-using-custom-tasks-and-scripts.adoc
@@ -5,9 +5,6 @@
 [id="jt-extending-tekton-capabilities-using-custom-tasks-and-scripts_{context}"]
 = Extending Tekton capabilities using custom tasks and scripts
 
-toc::[]
-
-
 In Tekton, if you do not find the right task in Tekton Hub, or need greater control over tasks, you can create custom tasks and scripts to extend Tekton's capabilities.
 
 .Example: Custom task for running the `maven test` command

--- a/modules/jt-migrating-a-sample-pipeline-from-jenkins-to-tekton.adoc
+++ b/modules/jt-migrating-a-sample-pipeline-from-jenkins-to-tekton.adoc
@@ -5,9 +5,6 @@
 [id="jt-migrating-a-sample-pipeline-from-jenkins-to-tekton_{context}"]
 = Migrating a sample pipeline from Jenkins to Tekton
 
-toc::[]
-
-
 This section provides equivalent examples of pipelines in Jenkins and Tekton and helps you to migrate your build, test, and deploy pipelines from Jenkins to Tekton.
 
 == Jenkins pipeline

--- a/modules/jt-migrating-from-jenkins-plugins-to-tekton-hub-tasks.adoc
+++ b/modules/jt-migrating-from-jenkins-plugins-to-tekton-hub-tasks.adoc
@@ -5,10 +5,7 @@
 [id="jt-migrating-from-jenkins-plugins-to-tekton-hub-tasks_{context}"]
 = Migrating from Jenkins plugins to Tekton Hub tasks
 
-toc::[]
-
-
-You can exend the capability of Jenkins by using link:https://plugins.jenkinsci.org[plugins]. To achieve similar extensibility in Tekton, use any of the available tasks from link:https://hub.tekton.dev[Tekton Hub].
+You can extend the capability of Jenkins by using link:https://plugins.jenkinsci.org[plugins]. To achieve similar extensibility in Tekton, use any of the available tasks from link:https://hub.tekton.dev[Tekton Hub].
 
 As an example, consider the link:https://hub.tekton.dev/tekton/task/git-clone[git-clone] task available in the Tekton Hub, that corresponds to the link:https://plugins.jenkins.io/git/[git plugin] for Jenkins.
 

--- a/modules/op-running-pipeline-and-task-run-pods-with-privileged-security-context.adoc
+++ b/modules/op-running-pipeline-and-task-run-pods-with-privileged-security-context.adoc
@@ -3,7 +3,6 @@
 = Running pipeline run and task run pods with privileged security context
 :context: op-running-pipeline-and-task-run-pods-with-privileged-security-context
 
-toc::[]
 
 .Procedure
 

--- a/modules/op-using-custom-pipeline-template-for-git-import.adoc
+++ b/modules/op-using-custom-pipeline-template-for-git-import.adoc
@@ -8,8 +8,6 @@
 
 :context: using-custom-pipeline-template-for-git-import
 
-toc::[]
-
 As a cluster administrator, to create and deploy an application from a Git repository, you can use custom pipeline templates that override the default pipeline templates provided by {pipelines-title} 1.5 and later.
 
 [NOTE]


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.8`, `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`
- **JIRA issues**: [RHDEVDOCS-3846 Fix blurry right nav pane in Pipelines docs](https://issues.redhat.com/browse/RHDEVDOCS-3846)
- **Preview pages**: 
  - [Migrating from Jenkins to Tekton](https://deploy-preview-42950--osdocs.netlify.app/openshift-enterprise/latest/cicd/jenkins-tekton/migrating-from-jenkins-to-tekton.html)
  - [Working with Pipelines using the Developer perspective](https://deploy-preview-42950--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.html)
  - [Using pods in a privileged security context](https://deploy-preview-42950--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/using-pods-in-a-privileged-security-context.html)
- **SME review**: N/A    
- **Peer-review**: @Preeticp  