### PR TITLE
Updates for openshift-dpu distro

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -59,15 +59,7 @@
   <div class="container">
     <button id="hc-open-btn" class="open-btn-sm" onclick="openNav()" aria-label="Open"><span class="fa fa-bars" /></button>
     <ol class="breadcrumb hide-for-print">
-      <% if (version == "4.10" || distro_key == "openshift-webscale") %>
-      <span>
-        <div class="alert alert-danger" role="alert" id="support-alert">
-          <strong>This documentation is work in progress and might not be complete or fully tested.</strong> The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html" class="link-primary" style="color: #545454 !important;">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.
-        </div>
-      </span>
-      <% end %>
-
-      <% if (version == "4.10" || distro_key == "openshift-dpu") %>
+      <% if (version == "4.10" || distro_key == "openshift-webscale" || distro_key == "openshift-dpu") %>
       <span>
         <div class="alert alert-danger" role="alert" id="support-alert">
           <strong>This documentation is work in progress and might not be complete or fully tested.</strong> The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html" class="link-primary" style="color: #545454 !important;">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -24,7 +24,7 @@
 ---
 Name: About
 Dir: welcome
-Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-online
+Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-online,openshift-dpu
 Topics:
 - Name: Welcome
   File: index

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -20,6 +20,12 @@ To navigate the {product-title} (ROSA) documentation, use the left navigation ba
 For documentation that is not ROSA-specific, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
 endif::[]
 
+ifdef::openshift-dpu[]
+To navigate the {product-title} data processing units (DPU) documentation, use the left navigation bar.
+
+For documentation that is not DPU-specific, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
+endif::[]
+
 ifdef::openshift-dedicated[]
 To navigate the {product-title} documentation, use the left navigation bar.
 


### PR DESCRIPTION
There is an error in the page logic that causes this note to be displayed twice: 

![image](https://user-images.githubusercontent.com/74046732/157204408-90950eb7-e88b-414e-b58f-c2f666b78729.png)

This PR fixes the problem.