### PR TITLE
Added missing Alibaba entries to supported installation matrix

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -163,7 +163,7 @@ endif::openshift-origin[]
 |
 
 |Network customization
-|
+|xref:../installing/installing_alibaba/installing-alibaba-network-customizations.adoc#installing-alibaba-network-customizations[X]
 |xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[X]
 |xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[X]
 |xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[X]
@@ -268,14 +268,15 @@ endif::openshift-origin[]
 .User-provisioned infrastructure options
 |===
 ifndef::openshift-origin[]
-||AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
+||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-||AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |oVirt |Bare metal |vSphere |VMC |IBM Cloud |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
+||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |oVirt |Bare metal |vSphere |VMC |IBM Cloud |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
 endif::openshift-origin[]
 
 
 |Custom
+|
 |xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[X]
 |xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[X]
 |xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installing-azure-stack-hub-user-infra[X]
@@ -300,6 +301,7 @@ endif::openshift-origin[]
 |
 |
 |
+|
 |xref:../installing/installing_openstack/installing-openstack-user-kuryr.adoc#installing-openstack-user-kuryr[X]
 |
 |
@@ -314,6 +316,7 @@ endif::openshift-origin[]
 |
 
 |Restricted network
+|
 |xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[X]
 |
 |
@@ -332,6 +335,7 @@ endif::openshift-origin[]
 |
 
 |Shared VPC hosted outside of cluster project
+|
 |
 |
 |


### PR DESCRIPTION
CP to 4.10

A few Alibaba entries where missing from "Supported installation methods for different platforms" Updated the following:

- IPI table: Added support for installing an Alibaba cluster with network customizations.
- UPI table: Added a column for Alibaba. A UPI installation is not yet supported. Left the column blank.

Preview
[Supported installation methods for different platforms](https://deploy-preview-42953--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#supported-installation-methods-for-different-platforms)