### PR TITLE
BZ-1934849:Add missing Operators to Operators Reference

### DIFF
--- a/modules/cluster-csi-snapshot-controller-operator.adoc
+++ b/modules/cluster-csi-snapshot-controller-operator.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * operators/operator-reference.adoc
+
+[id="cluster-csi-snapshot-controller-operator_{context}"]
+= Cluster CSI Snapshot Controller Operator
+
+[discrete]
+== Purpose
+
+The Cluster CSI Snapshot Controller Operator installs and maintains the CSI Snapshot Controller. The CSI Snapshot Controller is responsible for watching the `VolumeSnapshot` CRD objects and manages the creation and deletion lifecycle of volume snapshots.
+
+[discrete]
+== Project
+
+link:https://github.com/openshift/cluster-csi-snapshot-controller-operator[cluster-csi-snapshot-controller-operator]

--- a/modules/cluster-kube-storage-version-migrator-operator.adoc
+++ b/modules/cluster-kube-storage-version-migrator-operator.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * operators/operator-reference.adoc
+
+[id="cluster-kube-storage-version-migrator-operator_{context}"]
+= Kubernetes Storage Version Migrator Operator
+
+[discrete]
+== Purpose
+
+The Kubernetes Storage Version Migrator Operator detects changes of the default storage version, creates migration requests for resource types when the storage version changes, and processes migration requests.
+
+[discrete]
+== Project
+
+link:https://github.com/openshift/cluster-kube-storage-version-migrator-operator[cluster-kube-storage-version-migrator-operator]

--- a/modules/openshift-service-ca-operator.adoc
+++ b/modules/openshift-service-ca-operator.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * operators/operator-reference.adoc
+
+[id="openshift-service-ca-operator_{context}"]
+= OpenShift Service CA Operator
+
+[discrete]
+== Purpose
+
+The OpenShift Service CA Operator mints and manages serving certificates for Kubernetes services.
+
+[discrete]
+== Project
+
+link:https://github.com/openshift/service-ca-operator[openshift-service-ca-operator]

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -29,6 +29,7 @@ include::modules/cluster-authentication-operator.adoc[leveloffset=+1]
 include::modules/cluster-autoscaler-operator.adoc[leveloffset=+1]
 include::modules/cluster-cloud-controller-manager-operator.adoc[leveloffset=+1]
 include::modules/cluster-config-operator.adoc[leveloffset=+1]
+include::modules/cluster-csi-snapshot-controller-operator.adoc[leveloffset=+1]
 include::modules/cluster-image-registry-operator.adoc[leveloffset=+1]
 include::modules/cluster-machine-approver-operator.adoc[leveloffset=+1]
 include::modules/cluster-monitoring-operator.adoc[leveloffset=+1]
@@ -50,6 +51,7 @@ include::modules/insights-operator.adoc[leveloffset=+1]
 include::modules/kube-apiserver-operator.adoc[leveloffset=+1]
 include::modules/kube-controller-manager-operator.adoc[leveloffset=+1]
 include::modules/cluster-kube-scheduler-operator.adoc[leveloffset=+1]
+include::modules/cluster-kube-storage-version-migrator-operator.adoc[leveloffset=+1]
 include::modules/machine-api-operator.adoc[leveloffset=+1]
 include::modules/machine-config-operator.adoc[leveloffset=+1]
 include::modules/operator-marketplace.adoc[leveloffset=+1]
@@ -77,6 +79,7 @@ include::modules/olm-arch-catalog-registry.adoc[leveloffset=+2]
 
 * For more information, see the sections on xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[understanding Operator Lifecycle Manager (OLM)].
 
+include::modules/openshift-service-ca-operator.adoc[leveloffset=+1]
 include::modules/vsphere-problem-detector-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Applies to 4.7+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1934849
QE ack required.
Preview Links: 

- [Cluster CSI Snapshot Controller Operator](https://deploy-preview-42962--osdocs.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-csi-snapshot-controller-operator_platform-operators-ref)
- [Kubernetes Storage Version Migrator Operator](https://deploy-preview-42962--osdocs.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-kube-storage-version-migrator-operator_platform-operators-ref)
- [OpenShift Service CA Operator](https://deploy-preview-42962--osdocs.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#openshift-service-ca-operator_platform-operators-ref)