### PR TITLE
Add explicit `ref: "master"` to various sample builds

### DIFF
--- a/modules/builds-chaining-builds.adoc
+++ b/modules/builds-chaining-builds.adoc
@@ -35,6 +35,7 @@ spec:
   source:
     git:
       uri: https://github.com/openshift/openshift-jee-sample.git
+      ref: "master"
   strategy:
     sourceStrategy:
       from:

--- a/modules/builds-define-build-inputs.adoc
+++ b/modules/builds-define-build-inputs.adoc
@@ -55,6 +55,7 @@ The following example of a source definition includes multiple input types and a
 source:
   git:
     uri: https://github.com/openshift/ruby-hello-world.git <1>
+    ref: "master"
   images:
   - from:
       kind: ImageStreamTag

--- a/modules/builds-image-source.adoc
+++ b/modules/builds-image-source.adoc
@@ -16,6 +16,7 @@ Image inputs are specified in the `source` definition of the `BuildConfig`:
 source:
   git:
     uri: https://github.com/openshift/ruby-hello-world.git
+    ref: "master"
   images: <1>
   - from: <2>
       kind: ImageStreamTag

--- a/modules/builds-using-proxy-git-cloning.adoc
+++ b/modules/builds-using-proxy-git-cloning.adoc
@@ -17,6 +17,7 @@ Your source URI must use the HTTP or HTTPS protocol for this to work.
 source:
   git:
     uri: "https://github.com/openshift/ruby-hello-world"
+    ref: "master"
     httpProxy: http://proxy.example.com
     httpsProxy: https://proxy.example.com
     noProxy: somedomain.com, otherdomain.com


### PR DESCRIPTION
As I understand it, `master` is the implicit default on the API
side.  But there's been an effort to use `main` or other names,
xref https://sfconservancy.org/news/2020/jun/23/gitbranchname/

The client will clone the default branch, but this can cause
problems around things like webhooks because the build API object
is still watching for the implicit `master`.

Make this explicit, in the hopes that people know to change it
to `main` when they need to.