### PR TITLE
Bug 2061883: replace incomplete section reference with link

### DIFF
--- a/modules/persistent-storage-csi-tp-enable.adoc
+++ b/modules/persistent-storage-csi-tp-enable.adoc
@@ -24,7 +24,7 @@ To enable the {FeatureName} Container Storage Interface (CSI) driver operator, y
 
 .Procedure
 
-. Enable feature gates with the `TechPreviewNoUpgrade` feature set (see _Nodes_ -> _Enabling features using feature gates_).
+. Enable feature gates with the `TechPreviewNoUpgrade` feature set (see xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc[Enabling features using feature gates]).
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
The intention of this PR is change the reference to `Enabling features using feature gates` section to include a link to the section.  Alternatively, the change for this also could have been to change `(see Nodes → Working with clusters →Enabling features using feature gates).`