### PR TITLE
BZ-1969741: Including module for for image registry access

### DIFF
--- a/modules/images-configuration-cas.adoc
+++ b/modules/images-configuration-cas.adoc
@@ -3,6 +3,7 @@
 // * registry/configuring-registry-operator.adoc
 // * openshift_images/image-configuration.adoc
 // * post_installation_configuration/preparing-for-users.adoc
+// * updating/updating-restricted-network-cluster.adoc
 
 :_content-type: PROCEDURE
 [id="images-configuration-cas_{context}"]

--- a/updating/updating-restricted-network-cluster.adoc
+++ b/updating/updating-restricted-network-cluster.adoc
@@ -145,6 +145,8 @@ You can create an OpenShift Update Service application by using the {product-tit
 
 include::modules/update-service-create-service-web-console.adoc[leveloffset=+3]
 
+include::modules/images-configuration-cas.adoc[leveloffset=+3]
+
 include::modules/update-service-create-service-cli.adoc[leveloffset=+3]
 
 [NOTE]


### PR DESCRIPTION
Applies to 4.7+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1969741
QE ack required. 
Preview Link:
[Configuring additional trust stores for image registry access](https://deploy-preview-42966--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster#images-configuration-cas_updating-restricted-network-cluster)