### PR TITLE
OSDOCS-3336: CIT: 4.10 Replace hard d.o.c links with CP links

### DIFF
--- a/operators/operator_sdk/osdk-upgrading-projects.adoc
+++ b/operators/operator_sdk/osdk-upgrading-projects.adoc
@@ -21,8 +21,8 @@ include::modules/osdk-updating-v1101-to-v1160.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../../operators/operator_sdk/osdk-pkgman-to-bundle.adoc#osdk-pkgman-to-bundle[Migrating package manifest projects to bundle format]
-* link:https://docs.openshift.com/container-platform/4.9/operators/operator_sdk/osdk-upgrading-projects.html#osdk-upgrading-v180-to-v1101_osdk-upgrading-projects[Upgrading projects for Operator SDK v1.10.1]
-* link:https://docs.openshift.com/container-platform/4.8/operators/operator_sdk/osdk-upgrading-projects.html#osdk-upgrading-v130-to-v180_osdk-upgrading-projects[Upgrading projects for Operator SDK v1.8.0]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/operators/developing-operators#osdk-upgrading-v180-to-v1101_osdk-upgrading-projects[Upgrading projects for Operator SDK v1.10.1]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/html/operators/developing-operators#osdk-upgrading-v130-to-v180_osdk-upgrading-projects[Upgrading projects for Operator SDK v1.8.0]
 //Consider updating this during the 4.10 to 4.11 version scrub.
 
 :!osdk_ver:


### PR DESCRIPTION
- enterprise-4.10
- [OSDOCS-3336](https://issues.redhat.com/browse/OSDOCS-3336)
- Link to docs preview

In the Operator SDK upgrading projects procedure, we need to link to
the previous upgrading procedure in 4.8 and 4.9. Since we cannot
`xref` across branches, this PR replaces hard-coded docs.openshift.com
links with links to the customer portal.

Follow on PR for enterprise-4.9: #42976