### PR TITLE
Removed ash condition on Optional config parameters

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -459,7 +459,6 @@ Set the `networking.machineNetwork` to match the CIDR that the preferred NIC res
 
 |====
 
-ifndef::ash[]
 [id="installation-configuration-parameters-optional_{context}"]
 == Optional configuration parameters
 
@@ -629,7 +628,6 @@ For production {product-title} clusters on which you want to perform installatio
 a|For example, `sshKey: ssh-ed25519 AAAA..`.
 
 |====
-endif::ash[]
 
 ifdef::aws[]
 [id="installation-configuration-parameters-optional-aws_{context}"]


### PR DESCRIPTION
CP to 4.10

Removed a condition that was preventing "Installation configuration parameters" > "Optional configuration parameters" from publishing in in Azure Stack Hub content. Content is now appearing correctly.

Preview
[Optional configuration parameters](https://deploy-preview-42977--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.html#installation-configuration-parameters-optional_installing-azure-stack-hub-default)
