### PR TITLE
Bumps the version from 4.10 to 4.10.3 in the RNs

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -13,9 +13,9 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 [id="ocp-4-10-about-this-release"]
 == About this release
 
-{product-title} *(link:https://access.redhat.com/errata/RHSA-2022:0056[RHSA-2022:0056])* 4.10 is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md[Kubernetes 1.23] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2022:0056[RHSA-2022:0056]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md[Kubernetes 1.23] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
-//Red Hat did not publicly release {product-title} 4.10.0 as the GA version and, instead, is releasing {product-title} 4.10.TBD as the GA version.
+Red Hat did not publicly release {product-title} 4.10.0 as the GA version and, instead, is releasing {product-title} 4.10.3 as the GA version.
 
 {product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {console-redhat-com} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
@@ -183,7 +183,7 @@ Mirroring images for a disconnected installation using the oc-mirror plug-in].
 [id="ocp-4-10-installing-cluster-on-openstack-ovs-dpdk"]
 // ==== Installing a cluster on {rh-openstack} that uses OVS-DPDK (Technology Preview)
 
-// You can now install a cluster on {rh-openstack-first} for which compute machines run on Open vSwitch with the Data Plane Development Kit (OVS-DPDK) networks. Workloads that run on these machines can benefit from the performance and latency improvements of OVS-DPDK. 
+// You can now install a cluster on {rh-openstack-first} for which compute machines run on Open vSwitch with the Data Plane Development Kit (OVS-DPDK) networks. Workloads that run on these machines can benefit from the performance and latency improvements of OVS-DPDK.
 
 // // TODO: Link
 
@@ -946,7 +946,7 @@ In {product-title} 4.10, the Poison Pill Operator introduces a new remediation s
 [id="ocp-4-10-control-plane-migration"]
 ==== Control plane node migration on {rh-openstack}
 
-You can now migrate control plane nodes from one {rh-openstack} host to another without encountering a service disruption. 
+You can now migrate control plane nodes from one {rh-openstack} host to another without encountering a service disruption.
 
 // TODO: Link
 
@@ -2417,7 +2417,7 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 
-// |Installing a cluster on {rh-openstack} that uses OVS-DPDK 
+// |Installing a cluster on {rh-openstack} that uses OVS-DPDK
 // |-
 // |-
 // |TP
@@ -2464,6 +2464,10 @@ This script removes unauthenticated subjects from the following cluster role bin
 
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
+
+* When upgrading to {product-title} 4.10, the Cluster Version Operator blocks the upgrade for approximately five minutes while failing precondition checks. The error text, which says `It may not be safe to apply this update`, might be misleading. This error occurs when one or multiple precondition checks fail. In some situations, these precondition checks might only fail for a short period of time, for example, during an etcd backup. In these situations, the Cluster Version Operator and corresponding Operators will, by design, automatically resolve the failing precondition checks and the CVO successfully starts the upgrade.
++
+Users should check the status and conditions of their Cluster Operators. If the `It may not be safe to apply this update` error is displayed by the Cluster Version Operator, these statuses and conditions will provide more information about the severity of the message. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1999777[*BZ#1999777*], link:https://bugzilla.redhat.com/show_bug.cgi?id=2061444[*BZ#2061444*], link:https://bugzilla.redhat.com/show_bug.cgi?id=2006611[*BZ#2006611*].
 
 * The assignment of egress IP addresses to control plane nodes with the egress IP feature is not supported on a cluster provisioned on Amazon Web Services (AWS). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039656[*BZ#2039656*])
 
@@ -2543,13 +2547,13 @@ For any {product-title} release, always review the instructions on xref:../updat
 ====
 
 //Update with relevant advisory information
-[id="ocp-4-10-0-ga"]
-=== RHSA-2022:0056 - {product-title} 4.10.0 image release, bug fix, and security update advisory
+[id="ocp-4-10-3-ga"]
+=== RHSA-2022:0056 - {product-title} 4.10.3 image release, bug fix, and security update advisory
 
-Issued: 2022-03-09
+Issued: 2022-03-10
 
-{product-title} release 4.10.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:0056[RHSA-2022:0056] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0055[RHSA-2022:0055] advisory.
+{product-title} release 4.10.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:0056[RHSA-2022:0056] advisory. A secondary set of bug fixes can be found in the link:https://access.redhat.com/errata/RHEA-2022:0748[RHEA-2022:0748] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0055[RHSA-2022:0055] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
-link:https://access.redhat.com/solutions/6765671[{product-title} 4.10.0 container image list]
+link:https://access.redhat.com/solutions/6765671[{product-title} 4.10.3 container image list]


### PR DESCRIPTION
Preview: https://deploy-preview-42978--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-asynchronous-errata-updates

Adds one known issue and bumps some versions. 