### PR TITLE
[ENTERPRISE-4.10] Removed instances of cloud.redhat.com

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -62,7 +62,7 @@ This section provides the necessary details that enable you to control egress tr
 
 |`sso.redhat.com`
 |443
-|The `https://cloud.redhat.com/openshift` site uses authentication from `sso.redhat.com`.
+|The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`.
 
 |`pull.q1w2.quay.rhcloud.com`
 |443

--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -17,7 +17,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 
 //Red Hat did not publicly release {product-title} 4.10.0 as the GA version and, instead, is releasing {product-title} 4.10.TBD as the GA version.
 
-{product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {console-redhat-com} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
+{product-title} {product-version} clusters are available at https://console.redhat.com/openshift. The {console-redhat-com} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
 // Double check OP system versions
 {product-title} {product-version} is supported on {op-system-base-full} 8.4 and 8.5, as well as on {op-system-first} 4.10.
@@ -183,7 +183,7 @@ Mirroring images for a disconnected installation using the oc-mirror plug-in].
 [id="ocp-4-10-installing-cluster-on-openstack-ovs-dpdk"]
 // ==== Installing a cluster on {rh-openstack} that uses OVS-DPDK (Technology Preview)
 
-// You can now install a cluster on {rh-openstack-first} for which compute machines run on Open vSwitch with the Data Plane Development Kit (OVS-DPDK) networks. Workloads that run on these machines can benefit from the performance and latency improvements of OVS-DPDK. 
+// You can now install a cluster on {rh-openstack-first} for which compute machines run on Open vSwitch with the Data Plane Development Kit (OVS-DPDK) networks. Workloads that run on these machines can benefit from the performance and latency improvements of OVS-DPDK.
 
 // // TODO: Link
 
@@ -946,7 +946,7 @@ In {product-title} 4.10, the Poison Pill Operator introduces a new remediation s
 [id="ocp-4-10-control-plane-migration"]
 ==== Control plane node migration on {rh-openstack}
 
-You can now migrate control plane nodes from one {rh-openstack} host to another without encountering a service disruption. 
+You can now migrate control plane nodes from one {rh-openstack} host to another without encountering a service disruption.
 
 // TODO: Link
 
@@ -2417,7 +2417,7 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 
-// |Installing a cluster on {rh-openstack} that uses OVS-DPDK 
+// |Installing a cluster on {rh-openstack} that uses OVS-DPDK
 // |-
 // |-
 // |TP


### PR DESCRIPTION
This PR fixes some out-of-date links that refer to cloud.redhat.com

PREVIEWS:
* ROSA getting started: https://deploy-preview-42979--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites
* 4.10 Release Notes: https://deploy-preview-42979--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-about-this-release
