### PR TITLE
[enterprise-4.10] Correcting ShiftStack TP status in RNs

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -181,11 +181,11 @@ For more information, see xref:../installing/disconnected_install/installing-mir
 Mirroring images for a disconnected installation using the oc-mirror plug-in].
 
 [id="ocp-4-10-installing-cluster-on-openstack-ovs-dpdk"]
-// ==== Installing a cluster on {rh-openstack} that uses OVS-DPDK (Technology Preview)
+==== Installing a cluster on {rh-openstack} that uses OVS-DPDK
 
-// You can now install a cluster on {rh-openstack-first} for which compute machines run on Open vSwitch with the Data Plane Development Kit (OVS-DPDK) networks. Workloads that run on these machines can benefit from the performance and latency improvements of OVS-DPDK.
+You can now install a cluster on {rh-openstack-first} for which compute machines run on Open vSwitch with the Data Plane Development Kit (OVS-DPDK) networks. Workloads that run on these machines can benefit from the performance and latency improvements of OVS-DPDK. 
 
-// // TODO: Link
+For more infromation, see xref:../installing/installing_openstack/installing-openstack-installer-ovs-dpdk.adoc#installing-openstack-installer-ovs-dpdk[Installing a cluster on {rh-openstack} that supports DPDK-connected compute machines].
 
 [id="ocp-4-10-installing-cluster-on-openstack-compute-machine-affinity"]
 ==== Setting compute machine affinity during installation on {rh-openstack}
@@ -610,7 +610,7 @@ Cluster administrators can now configure the Ingress Controller endpoint publish
 For more information, see xref:../networking/nw-ingress-controller-endpoint-publishing-strategies.adoc#nw-ingress-controller-endpoint-publishing-strategies_nw-ingress-controller-endpoint-publishing-strategies[Ingress Controller endpoint publishing strategy].
 
 [id="ocp-4-10-ovs-hardware-offloading-openstack"]
-==== OVS hardware offloading for clusters on {rh-openstack}
+==== OVS hardware offloading for clusters on {rh-openstack} (Technology Preview)
 For clusters that run on Red Hat OpenStack Platform (RHOSP), you can enable Open vSwitch (OVS) hardware offloading.
 
 For more information, see xref:../post_installation_configuration/network-configuration.adoc#nw-osp-enabling-ovs-offload_post-install-network-configuration[Enabling OVS hardware offloading].
@@ -2417,10 +2417,10 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 
-// |Installing a cluster on {rh-openstack} that uses OVS-DPDK
-// |-
-// |-
-// |TP
+|OVS hardware offloading for clusters on {rh-openstack} 
+|-
+|-
+|TP
 |====
 
 [id="ocp-4-10-known-issues"]


### PR DESCRIPTION
This PR is the sibling of #42980. It corrects what is and isn't TP for ShiftStack in 4.10, as well as uncomments a post-freeze addition.

Preview: https://deploy-preview-42982--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-technology-preview