### PR TITLE
[ENTERPRISE-4.9] Removed an instance of cloud.redhat.com

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -63,7 +63,7 @@ This section provides the necessary details that enable you to control egress tr
 
 |`sso.redhat.com`
 |443
-|The `https://cloud.redhat.com/openshift` site uses authentication from `sso.redhat.com`.
+|The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`.
 
 |`pull.q1w2.quay.rhcloud.com`
 |443

--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -18,7 +18,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 
 //Red Hat did not publicly release {product-title} 4.9.0 as the GA version and, instead, is releasing {product-title} 4.9.TBD as the GA version.
 
-{product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {cluster-manager-first} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
+{product-title} {product-version} clusters are available at https://console.redhat.com/openshift. The {cluster-manager-first} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
 {product-title} {product-version} is supported on {op-system-base-full} 7.9 and 8.4, as well as on {op-system-first} 4.9.
 


### PR DESCRIPTION
This PR fixes some out-of-date links that refer to cloud.redhat.com

PREVIEWS:

* ROSA getting started: https://deploy-preview-42983--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites
* 4.9 Release Notes: https://deploy-preview-42983--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-about-this-release