### PR TITLE
[ENTERPRISE-4.7] Removed an instance of cloud.redhat.com

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -18,7 +18,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 
 //Red Hat did not publicly release {product-title} 4.7.0 as the GA version and, instead, is releasing {product-title} 4.7.z as the GA version.
 
-{product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {cluster-manager-first} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
+{product-title} {product-version} clusters are available at https://console.redhat.com/openshift. The {cluster-manager-first} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
 {product-title} {product-version} is supported on {op-system-base-full} 7.9 or later, as well as {op-system-first} 4.7.
 


### PR DESCRIPTION
This PR fixes some out-of-date links that refer to cloud.redhat.com

PREVIEWS:

4.7 Release Notes: https://deploy-preview-42985--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-about-this-release