### PR TITLE
[ENTERPRISE-4.6] Removed instances of cloud.redhat.com

### DIFF
--- a/modules/installation-overview.adoc
+++ b/modules/installation-overview.adoc
@@ -100,7 +100,7 @@ When you install an {product-title} cluster, you download the
 installation program from
 ifndef::openshift-origin[]
 the appropriate
-link:https://cloud.redhat.com/openshift/install[Infrastructure Provider]
+link:https://console.redhat.com/openshift/create[Infrastructure Provider]
 page on the {cluster-manager-first} site. This site manages:
 
 * REST API for accounts

--- a/pipelines/installing-pipelines.adoc
+++ b/pipelines/installing-pipelines.adoc
@@ -23,7 +23,7 @@ The {pipelines-title} Operator is supported for installation in a restricted net
 * You have installed xref:../cli_reference/tkn_cli/installing-tkn.adoc#installing-tkn[OpenShift Pipelines (`tkn`) CLI] on your local system.
 
 ifdef::openshift-origin[]
-* Ensure that you have downloaded the link:https://cloud.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in the xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-obtaining-installer_installing-gcp-customizations[Obtaining the installation program] to install this Operator.
+* Ensure that you have downloaded the link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager] as shown in the xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-obtaining-installer_installing-gcp-customizations[Obtaining the installation program] to install this Operator.
 +
 If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in xref:../post_installation_configuration/preparing-for-users.adoc#olm-installing-operators-from-operatorhub-configure_post-install-preparing-for-users[Configuring {product-title} to use Red Hat Operators].
 endif::[]

--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -17,7 +17,7 @@ Red Hat {product-title} (link:https://access.redhat.com/errata/RHBA-2020:4196[RH
 
 Red Hat did not publicly release {product-title} 4.6.0 as the GA version and, instead, is releasing {product-title} 4.6.1 as the GA version.
 
-{product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {cluster-manager-first} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
+{product-title} {product-version} clusters are available at https://console.redhat.com/openshift. The {cluster-manager-first} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
 {product-title} {product-version} is supported on Red Hat Enterprise Linux 7.9 or later, as well as {op-system-first} 4.6.
 


### PR DESCRIPTION
This PR fixes some out-of-date links that refer to cloud.redhat.com

PREVIEWS:

* 4.6 Release Notes: https://deploy-preview-42988--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-about-this-release