### PR TITLE
Fixed a malformed table

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -5,6 +5,7 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
+:op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
 :cluster-manager-first: Red Hat OpenShift Cluster Manager
 :cluster-manager: OpenShift Cluster Manager
 :cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager]

--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -33,8 +33,8 @@ This section provides the necessary details that enable you to control egress tr
 |Provides core container images.
 
 |`sso.redhat.com`
-|Required. The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com` to  download the pull secret and use Red Hat SaaS solutions to facilitate monitoring of your subscriptions, cluster inventory, chargeback reporting, and so on.
 |443, 80
+|Required. The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com` to download the pull secret and use Red Hat SaaS solutions to facilitate monitoring of your subscriptions, cluster inventory, chargeback reporting, and so on.
 
 |`quay-registry.s3.amazonaws.com`
 |443
@@ -57,12 +57,12 @@ This section provides the necessary details that enable you to control egress tr
 |Provides access to the odo CLI tool that helps developers build on OpenShift and Kubernetes.
 
 |`console.redhat.com`
-|Required. Allows interactions between the cluster and OpenShift Console Manager to enable functionality, such as scheduling upgrades.
 |443, 80
+|Required. Allows interactions between the cluster and OpenShift Console Manager to enable functionality, such as scheduling upgrades.
 
 |`sso.redhat.com`
 |443
-|The `https://cloud.redhat.com/openshift` site uses authentication from `sso.redhat.com`.
+|The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`.
 
 |`pull.q1w2.quay.rhcloud.com`
 |443


### PR DESCRIPTION
This PR fixes a malformed table in the firewall prerequisites for ROSA. I also removed some leftover merge conflict information.

PREVIEW: 

* https://deploy-preview-42993--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs#osd-aws-privatelink-firewall-prerequisites