### PR TITLE
Fixing some xrefs to try to fix 4.10 build issues

### DIFF
--- a/networking/configuring-a-custom-pki.adoc
+++ b/networking/configuring-a-custom-pki.adoc
@@ -14,7 +14,7 @@ its privately signed CA certificates are recognized across the cluster.
 You can leverage the Proxy API to add cluster-wide trusted CA certificates. You
 must do this either during installation or at runtime.
 
-* During _installation_, xref:installation-configure-proxy_{context}[configure the cluster-wide proxy]. You must define your
+* During _installation_, xref:../networking/configuring-a-custom-pki.adoc#installation-configure-proxy_{context}[configure the cluster-wide proxy]. You must define your
 privately signed CA certificates in the `install-config.yaml` file's
 `additionalTrustBundle` setting.
 +
@@ -24,8 +24,7 @@ Operator then creates a `trusted-ca-bundle` ConfigMap that merges these CA
 certificates with the {op-system-first} trust bundle; this ConfigMap is
 referenced in the Proxy object's `trustedCA` field.
 
-* At _runtime_, xref:nw-proxy-configure-object_{context}[modify the default Proxy object to include your privately signed
-CA certificates] (part of cluster's proxy enablement workflow). This involves
+* At _runtime_, xref:../networking/configuring-a-custom-pki.adoc#nw-proxy-configure-object_{context}[modify the default Proxy object to include your privately signed CA certificates] (part of cluster's proxy enablement workflow). This involves
 creating a ConfigMap that contains the privately signed CA certificates that
 should be trusted by the cluster, and then modifying the proxy resource with the
 `trustedCA` referencing the privately signed certificates' ConfigMap.

--- a/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc
@@ -53,9 +53,7 @@ include::modules/nw-ingress-sharding-namespace-labels.adoc[leveloffset=+1]
 == Additional resources
 
 * The Ingress Operator manages wildcard DNS. For more information, see
-xref:../../networking/ingress-operator.adoc#configuring-ingress[Ingress Operator
-in {product-title}],
-xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[Installing
-a cluster on bare metal], and
+xref:../../networking/ingress-operator.adoc#configuring-ingress[Ingress Operator in {product-title}],
+xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[Installing a cluster on bare metal], and
 xref:../../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[Installing a cluster on vSphere].
 endif::[]

--- a/networking/hardware_networks/configuring-hardware-offloading.adoc
+++ b/networking/hardware_networks/configuring-hardware-offloading.adoc
@@ -20,9 +20,9 @@ include::modules/nw-sriov-hwol-supported-devices.adoc[leveloffset=+1]
 == Prerequisites
 
 * Your cluster has at least one bare metal machine with a network interface controller that is supported for hardware offloading.
-* You xref:./installing-sriov-operator.html#installing-sr-iov-operator_installing-sriov-operator[installed the SR-IOV Network Operator].
-* Your cluster uses the xref:../ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes CNI].
-* In your xref:../cluster-network-operator.adoc#gatewayConfig-object_cluster-network-operator[OVN-Kubernetes CNI configuration], the `gatewayConfig.routingViaHost` field is set to `false`.
+* You xref:../../networking/hardware_networks/installing-sriov-operator.adoc#installing-sr-iov-operator_installing-sriov-operator[installed the SR-IOV Network Operator].
+* Your cluster uses the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes CNI].
+* In your xref:../../networking/cluster-network-operator.adoc#gatewayConfig-object_cluster-network-operator[OVN-Kubernetes CNI configuration], the `gatewayConfig.routingViaHost` field is set to `false`.
 
 //Configure a machine config pool for hardware offloading
 include::modules/nw-sriov-hwol-configuring-machine-config-pool.adoc[leveloffset=+1]

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -16,8 +16,8 @@ include::modules/virt-creating-interface-on-nodes.adoc[leveloffset=+1]
 [discrete]
 [role="_additional-resources"]
 == Additional resources
-* xref:virt-example-nmstate-multiple-interfaces_{context}[Example for creating multiple interfaces in the same policy]
-* xref:virt-example-nmstate-IP-management_{context}[Examples of different IP management methods in policies]
+* xref:../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-example-nmstate-multiple-interfaces_{context}[Example for creating multiple interfaces in the same policy]
+* xref:../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-example-nmstate-IP-management_{context}[Examples of different IP management methods in policies]
 
 include::modules/virt-confirming-policy-updates-on-nodes.adoc[leveloffset=+1]
 

--- a/networking/network_policy/creating-network-policy.adoc
+++ b/networking/network_policy/creating-network-policy.adoc
@@ -15,4 +15,4 @@ include::modules/nw-networkpolicy-object.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* xref:../../web_console/web-console.adoc[Accessing the web console]
+* xref:../../web_console/web-console.adoc#web-console[Accessing the web console]


### PR DESCRIPTION
Trying to fix 4.10, but will pick these fixes back as far as possible.

Preview:
* https://deploy-preview-42997--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring-a-custom-pki.html
* https://deploy-preview-42997--osdocs.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html
* https://deploy-preview-42997--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html#additional-resources
* https://deploy-preview-42997--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-hardware-offloading.html
* https://deploy-preview-42997--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/creating-network-policy.html