### PR TITLE
[enterprise-4.10] Fix TP status for two ShiftStack features

### DIFF
--- a/installing/installing_openstack/installing-openstack-installer-ovs-dpdk.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-ovs-dpdk.adoc
@@ -6,11 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Installing a cluster on {rh-openstack} that supports DPDK-connected compute machines
-
-include::snippets/technology-preview.adoc[]
-
-If your {rh-openstack-first} deployment has Open vSwitch with the Data Plane Development Kit (OVS-DPDK) enabled, you can install an {product-title} cluster on it. Clusters that run on such {rh-openstack} deployments use OVS-DPDK features by providing access to link:https://doc.dpdk.org/guides/prog_guide/poll_mode_drv.html[poll mode drivers].
+If your {rh-openstack-first} deployment has Open vSwitch with the Data Plane Development Kit (OVS-DPDK) enabled, you can install an {product-title} cluster on it. Clusters that run on such {rh-openstack} deployments use OVS-DPDK features by providing access to link:https://doc.dpdk.org/guides/prog_guide/poll_mode_drv.html[poll mode drivers]. 
 
 == Prerequisites
 

--- a/modules/nw-osp-enabling-ovs-offload.adoc
+++ b/modules/nw-osp-enabling-ovs-offload.adoc
@@ -6,6 +6,10 @@
 [id="nw-osp-enabling-ovs-offload_{context}"]
 = Enabling OVS hardware offloading
 
+:FeatureName: OVS hardware offloading
+
+include::snippets/technology-preview.adoc[]
+
 For clusters that run on {rh-openstack-first}, you can enable link:https://www.openvswitch.org/[Open vSwitch (OVS)] hardware offloading. 
 
 OVS is a multi-layer virtual switch that enables large-scale, multi-server network virtualization. 


### PR DESCRIPTION
Manual CP to 4.10 of #42980

Previews:
- https://deploy-preview-42998--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-ovs-dpdk.html
- https://deploy-preview-42998--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/network-configuration.html#nw-osp-enabling-ovs-offload_post-install-network-configuration