### PR TITLE
OSDOCS-3340: Changing the title of the update chapters

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -498,9 +498,9 @@ Topics:
   File: understanding-upgrade-channels-release
 - Name: Preparing to perform an EUS-to-EUS update
   File: preparing-eus-eus-upgrade
-- Name: Updating a cluster within a minor version using the web console
+- Name: Updating a cluster using the web console
   File: updating-cluster-within-minor
-- Name: Updating a cluster within a minor version using the CLI
+- Name: Updating a cluster using the CLI
   File: updating-cluster-cli
 - Name: Performing update using canary rollout strategy
   File: update-using-custom-machine-config-pools

--- a/installing/installing_aws/manually-creating-iam.adoc
+++ b/installing/installing_aws/manually-creating-iam.adoc
@@ -27,8 +27,8 @@ include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional references
-* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster within a minor version using the web console]
-* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster within a minor version using the CLI]
+* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster using the web console]
+* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster using the CLI]
 
 include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/manually-creating-iam-azure.adoc
+++ b/installing/installing_azure/manually-creating-iam-azure.adoc
@@ -18,8 +18,8 @@ include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional references
-* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster within a minor version using the web console]
-* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster within a minor version using the CLI]
+* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster using the web console]
+* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster using the CLI]
 
 include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
 

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc
@@ -39,8 +39,8 @@ include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_installing-azure-stack-hub-default-cco"]
 .Additional resources
-* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster within a minor version using the web console]
-* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster within a minor version using the CLI]
+* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster using the web console]
+* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster using the CLI]
 
 include::modules/azure-stack-hub-internal-ca.adoc[leveloffset=+1]
 

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
@@ -38,8 +38,8 @@ include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_installing-azure-stack-hub-network-customizations-cco"]
 .Additional resources
-* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster within a minor version using the web console]
-* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster within a minor version using the CLI]
+* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster using the web console]
+* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster using the CLI]
 
 include::modules/azure-stack-hub-internal-ca.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/manually-creating-iam-gcp.adoc
+++ b/installing/installing_gcp/manually-creating-iam-gcp.adoc
@@ -21,8 +21,8 @@ include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional references
-* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster within a minor version using the web console]
-* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster within a minor version using the CLI]
+* xref:../../updating/updating-cluster-within-minor.adoc#manually-maintained-credentials-upgrade_updating-cluster-within-minor[Updating a cluster using the web console]
+* xref:../../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Updating a cluster using the CLI]
 
 include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
 

--- a/updating/update-using-custom-machine-config-pools.adoc
+++ b/updating/update-using-custom-machine-config-pools.adoc
@@ -60,8 +60,8 @@ include::modules/update-using-custom-machine-config-pools-pause.adoc[leveloffset
 
 When the MCPs enter ready state, you can perform the cluster update. See one of the following update methods, as appropriate for your cluster:
 
-* xref:../updating/updating-cluster-within-minor.adoc#update-upgrading-web_updating-cluster-within-minor[Updating a cluster within a minor version using the web console]
-* xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster within a minor version using the CLI]
+* xref:../updating/updating-cluster-within-minor.adoc#update-upgrading-web_updating-cluster-within-minor[Updating a cluster using the web console]
+* xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster using the CLI]
 
 After the update is complete, you can start to unpause the MCPs one-by-one.
 

--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="updating-cluster-cli"]
-= Updating a cluster within a minor version using the CLI
+= Updating a cluster using the CLI
 include::_attributes/common-attributes.adoc[]
 :context: updating-cluster-cli
 

--- a/updating/updating-cluster-within-minor.adoc
+++ b/updating/updating-cluster-within-minor.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="updating-cluster-within-minor"]
-= Updating a cluster within a minor version using the web console
+= Updating a cluster using the web console
 include::_attributes/common-attributes.adoc[]
 :context: updating-cluster-within-minor
 
@@ -10,7 +10,7 @@ You can update, or upgrade, an {product-title} cluster by using the web console.
 
 [NOTE]
 ====
-Use the web console or `oc adm upgrade channel _<channel>_` to change the update channel. You can follow the steps in xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] to complete the update after you change to a {product-version} channel.
+Use the web console or `oc adm upgrade channel _<channel>_` to change the update channel. You can follow the steps in xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] to complete the update after you change to a {product-version} channel.
 ====
 
 == Prerequisites


### PR DESCRIPTION
Applies to 4.6+
JIRA: https://issues.redhat.com/browse/OSDOCS-3340
QE ack not needed.
SME ack needed.
Preview Links:

- [Updating a cluster using the web console](https://deploy-preview-43007--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-within-minor.html)
- [Updating a cluster using the CLI](https://deploy-preview-43007--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-cli.html)