### PR TITLE
BZ-1981746: Adding procedure for authentication of local registry in OSUS docs

### DIFF
--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -2,9 +2,14 @@
 // * openshift_images/managing_images/using-image-pull-secrets.adoc
 // * post_installation_configuration/cluster-tasks.adoc
 // * support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc
+// * updating/updating-restricted-network-cluster.adoc
 //
 // Not included, but linked to from:
 // * operators/admin/olm-managing-custom-catalogs.adoc
+
+ifeval::["{context}" == "using-image-pull-secrets"]
+:image-pull-secrets:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="images-update-global-pull-secret_{context}"]
@@ -12,12 +17,18 @@
 
 You can update the global pull secret for your cluster by either replacing the current pull secret or appending a new pull secret.
 
+ifndef::image-pull-secrets[]
+The procedure is required when users use a separate registry to store images than the registry used during installation.
+endif::image-pull-secrets[]
+
+ifdef::image-pull-secrets[]
 [IMPORTANT]
 ====
 To transfer your cluster to another owner, you must first initiate the transfer in {cluster-manager-url}, and then update the pull secret on the cluster. Updating a cluster's pull secret without initiating the transfer in {cluster-manager} causes the cluster to stop reporting Telemetry metrics in {cluster-manager}.
 
 For more information link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2021/html/managing_clusters/assembly-managing-clusters#transferring-cluster-ownership_assembly-managing-clusters[about transferring cluster ownership], see "Transferring cluster ownership" in the {cluster-manager-first} documentation.
 ====
+endif::image-pull-secrets[]
 
 [WARNING]
 ====
@@ -68,3 +79,8 @@ This update is rolled out to all nodes, which can take some time depending on th
 As of {product-title} 4.7.4, changes to the global pull secret no longer trigger a node drain or reboot.
 ====
 //Also referred to as the cluster-wide pull secret.
+
+
+ifeval::["{context}" == "using-image-pull-secrets"]
+:!image-pull-secrets:
+endif::[]

--- a/updating/updating-restricted-network-cluster.adoc
+++ b/updating/updating-restricted-network-cluster.adoc
@@ -120,6 +120,8 @@ data:
 <1> The OpenShift Update Service Operator requires the config map key name updateservice-registry in the registry CA cert.
 <2>  If the registry has the port, such as `registry-with-port.example.com:5000`, `:` should be replaced with `..`.
 
+include::modules/images-update-global-pull-secret.adoc[leveloffset=+2]
+
 [id="update-service-install"]
 === Installing the OpenShift Update Service Operator
 


### PR DESCRIPTION
Applies to 4.6+
Manual CP: 4.6: https://github.com/openshift/openshift-docs/pull/43438  4.7: https://github.com/openshift/openshift-docs/pull/43439
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1981746
QE and SME ack required.
Preview Link: [Updating the global cluster pull secret](https://deploy-preview-43009--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster#images-update-global-pull-secret_updating-restricted-network-cluster)