### PR TITLE
Document IPI for vSphere w/ existing resource pool

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1335,6 +1335,10 @@ in vSphere.
 |Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the datacenter virtual machine folder.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
+|`platform.vsphere.resourcePool`
+|_Optional_. The absolute path of an existing resource pool where the installer creates the virtual machines. If you do not specify a value, resources are installed in the root of the cluster `/<datacenter_name>/host/<cluster_name>/Resources`.
+|String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
+
 |`platform.vsphere.network`
 |The network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -79,13 +79,14 @@ platform:
     datacenter: datacenter
     defaultDatastore: datastore
     folder: folder
-    diskType: thin <6>
+    resourcePool: resource_pool <6>
+    diskType: thin <7>
     network: VM_Network
-    cluster: vsphere_cluster_name <7>
+    cluster: vsphere_cluster_name <8>
     apiVIP: api_vip
     ingressVIP: ingress_vip
 ifdef::restricted[]
-    clusterOSImage: http://mirror.example.com/images/rhcos-47.83.202103221318-0-vmware.x86_64.ova <8>
+    clusterOSImage: http://mirror.example.com/images/rhcos-47.83.202103221318-0-vmware.x86_64.ova <9>
 endif::restricted[]
 ifndef::openshift-origin[]
 fips: false
@@ -94,15 +95,15 @@ ifndef::restricted[]
 pullSecret: '{"auths": ...}'
 endif::restricted[]
 ifdef::restricted[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <9>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <10>
 endif::restricted[]
 sshKey: 'ssh-ed25519 AAAA...'
 ifdef::restricted[]
-additionalTrustBundle: | <10>
+additionalTrustBundle: | <11>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <11>
+imageContentSources: <12>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -136,16 +137,17 @@ simultaneous multithreading.
 ====
 <4> Optional: Provide additional configuration for the machine pool parameters for the compute and control plane machines.
 <5> The cluster name that you specified in your DNS records.
-<6> The vSphere disk provisioning method.
-<7> The vSphere cluster to install the {product-title} cluster in. The installation program uses the root resource pool of the vSphere cluster as the default resource pool.
+<6> Optional: Provide an existing resource pool for machine creation. If you do not specify a value, the installation program uses the root resource pool of the vSphere cluster.
+<7> The vSphere disk provisioning method.
+<8> The vSphere cluster to install the {product-title} cluster in.
 ifdef::restricted[]
-<8> The location of the {op-system-first} image that is accessible from the bastion server.
-<9> For `<local_registry>`, specify the registry domain name, and optionally the
+<9> The location of the {op-system-first} image that is accessible from the bastion server.
+<10> For `<local_registry>`, specify the registry domain name, and optionally the
 port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
-<10> Provide the contents of the certificate file that you used for your mirror registry.
-<11> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<11> Provide the contents of the certificate file that you used for your mirror registry.
+<12> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::restricted[]
 
 ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -43,40 +43,41 @@ platform:
     datacenter: datacenter <10>
     defaultDatastore: datastore <11>
     folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>" <12>
-    diskType: thin <13>
+    resourcePool: "/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>" <13>
+    diskType: thin <14>
 ifndef::restricted[]
 ifndef::openshift-origin[]
-fips: false <14>
+fips: false <15>
 endif::openshift-origin[]
 ifndef::openshift-origin[]
+pullSecret: '{"auths": ...}' <16>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
 pullSecret: '{"auths": ...}' <15>
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-pullSecret: '{"auths": ...}' <14>
-endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-fips: false <14>
+fips: false <15>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <16>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
 pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <15>
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <14>
-endif::openshift-origin[]
 endif::restricted[]
 ifndef::openshift-origin[]
-sshKey: 'ssh-ed25519 AAAA...' <16>
+sshKey: 'ssh-ed25519 AAAA...' <17>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: 'ssh-ed25519 AAAA...' <15>
+sshKey: 'ssh-ed25519 AAAA...' <16>
 endif::openshift-origin[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-additionalTrustBundle: | <17>
+additionalTrustBundle: | <18>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <18>
+imageContentSources: <19>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -85,11 +86,11 @@ imageContentSources: <18>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-additionalTrustBundle: | <16>
+additionalTrustBundle: | <17>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <17>
+imageContentSources: <18>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -140,9 +141,10 @@ in vSphere.
 <10> The vSphere datacenter.
 <11> The default vSphere datastore to use.
 <12> Optional: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster, omit this parameter.
-<13> The vSphere disk provisioning method.
+<13> Optional: For installer-provisioned infrastructure, the absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`. If you do not specify a value, resources are installed in the root of the cluster `/example_datacenter/host/example_cluster/Resources`.
+<14> The vSphere disk provisioning method.
 ifndef::openshift-origin[]
-<14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<15> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
@@ -151,13 +153,13 @@ The use of FIPS Validated / Modules in Process cryptographic libraries is only s
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]
-<15> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
-<16> The public portion of the default SSH key for the `core` user in
+<16> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+<17> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<14> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
-<15> The public portion of the default SSH key for the `core` user in
+<15> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+<16> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 +
 [NOTE]
@@ -168,6 +170,19 @@ endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
+<16> For `<local_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example
+`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+specify the base64-encoded user name and password for your mirror registry.
+<17> The public portion of the default SSH key for the `core` user in
+{op-system-first}.
++
+[NOTE]
+====
+For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
+====
+endif::openshift-origin[]
+ifdef::openshift-origin[]
 <15> For `<local_registry>`, specify the registry domain name, and optionally the
 port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
@@ -180,31 +195,18 @@ specify the base64-encoded user name and password for your mirror registry.
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-<14> For `<local_registry>`, specify the registry domain name, and optionally the
-port, that your mirror registry uses to serve content. For example
-`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
-specify the base64-encoded user name and password for your mirror registry.
-<15> The public portion of the default SSH key for the `core` user in
-{op-system-first}.
-+
-[NOTE]
-====
-For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
-====
-endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-<17> Provide the contents of the certificate file that you used for your mirror
+<18> Provide the contents of the certificate file that you used for your mirror
 registry.
-<18> Provide the `imageContentSources` section from the output of the command to
+<19> Provide the `imageContentSources` section from the output of the command to
 mirror the repository.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<16> Provide the contents of the certificate file that you used for your mirror
+<17> Provide the contents of the certificate file that you used for your mirror
 registry.
-<17> Provide the `imageContentSources` section from the output of the command to
+<18> Provide the `imageContentSources` section from the output of the command to
 mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]

--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -57,7 +57,17 @@ An additional role is required if the installation program is to create a vSpher
 `StorageProfile.View`
 
 |vSphere vCenter Cluster
-|Always
+|If VMs will be created in the cluster root
+|
+[%hardbreaks]
+`Host.Config.Storage`
+`Resource.AssignVMToPool`
+`VApp.AssignResourcePool`
+`VApp.Import`
+`VirtualMachine.Config.AddNewDisk`
+
+|vSphere vCenter Resource Pool
+|If an existing resource pool is provided
 |
 [%hardbreaks]
 `Host.Config.Storage`
@@ -158,7 +168,7 @@ Additionally, the user requires some `ReadOnly` permissions, and some of the rol
 [cols="3a,3a,3a,3a",options="header"]
 |===
 |vSphere object
-|Folder type
+|When required
 |Propagate to children
 |Permissions required
 
@@ -176,8 +186,12 @@ Additionally, the user requires some `ReadOnly` permissions, and some of the rol
 |True
 |Listed required privileges
 
-|vSphere vCenter Cluster
-|Always
+.2+|vSphere vCenter Cluster
+|Existing resource pool
+|True
+|`ReadOnly` permission
+
+|VMs in cluster root
 |True
 |Listed required privileges
 
@@ -198,6 +212,11 @@ Additionally, the user requires some `ReadOnly` permissions, and some of the rol
 
 |vSphere vCenter Virtual Machine Folder
 |Existing folder
+|True
+|Listed required privileges
+
+|vSphere vCenter Resource Pool
+|Existing resource pool
 |True
 |Listed required privileges
 |===


### PR DESCRIPTION
Document required permissions and usage of IPI installation on vSphere with and existing resource pool. Note that this process allows a narrower scope of permissions in vSphere, which is very useful for users on shared vmware infrastructure.

fixes #43011