### PR TITLE
OSDOCS-3324: osa CLI 1.1.11 required for ROSA 4.10 installs

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-quickly.adoc
+++ b/modules/rosa-sts-creating-a-cluster-quickly.adoc
@@ -19,6 +19,11 @@ Additionally, you can use `auto` mode to immediately create the required AWS Ide
 * You installed and configured the latest AWS (`aws`), ROSA (`rosa`), and OpenShift (`oc`) CLIs on your workstation.
 * You logged in to your Red Hat account by using the `rosa` CLI.
 * You verified that the AWS Elastic Load Balancing (ELB) service role exists in your AWS account.
++
+[NOTE]
+====
+To successfully install ROSA 4.10 clusters, use ROSA CLI 1.1.11 or above.
+====
 
 .Procedure
 

--- a/modules/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -29,7 +29,12 @@ link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[AWS Share
 * You have available AWS service quotas.
 * You have enabled the ROSA service in the AWS Console.
 * You have installed and configured the latest AWS, ROSA, and `oc` CLIs on your installation host.
-* If you are using a customer-managed AWS Key Management Service (KMS) key for encryption, you have created a symmetric KMS key and you have the key ID and Amazon Resource Name (ARN). For more information about creating AWS KMS keys, see link:https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html[the AWS documenation].
+* If you are using a customer-managed AWS Key Management Service (KMS) key for encryption, you have created a symmetric KMS key and you have the key ID and Amazon Resource Name (ARN). For more information about creating AWS KMS keys, see link:https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html[the AWS documentation].
++
+[NOTE]
+====
+To successfully install ROSA 4.10 clusters, use ROSA CLI 1.1.11 or above.
+====
 
 .Procedure
 


### PR DESCRIPTION
This applies to main, enterprise-4.10 and enterprise-4.9.

This relates to https://issues.redhat.com/browse/OSDOCS-3324. The PR provides a notice that ROSA CLI 1.1.11 is required in order to successfully install ROSA 4.10 clusters.

