### PR TITLE
RHDEVDOCS-3850 Add link to solution: How to use builds with Red Hat S…

### DIFF
--- a/cicd/builds/running-entitled-builds.adoc
+++ b/cicd/builds/running-entitled-builds.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Use the following sections to run entitled builds on {product-title}.
 
 include::modules/builds-create-imagestreamtag.adoc[leveloffset=+1]
@@ -21,6 +22,11 @@ include::modules/builds-strategy-docker-entitled-subman.adoc[leveloffset=+2]
 include::modules/builds-source-input-satellite-config.adoc[leveloffset=+2]
 
 include::modules/builds-strategy-docker-entitled-satellite.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/solutions/5847331[How to use builds with Red Hat Satellite subscriptions and which certificate to use]
 
 // Beginning of "Running entitled builds with SharedSecret objects" section
 


### PR DESCRIPTION
 Aligned team: Dev Tools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3850
- Direct link to doc preview: Scroll down to first "Additional resources" section below https://deploy-preview-43015--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/running-entitled-builds.html#running-builds-with-red-hat-satellite-subscriptions
- SME review: Not needed 
- QE review: Not needed
- Peer review: @Srivaralakshmi 
