### PR TITLE
update URLs and command for downloading installer Ansible playbooks

### DIFF
--- a/modules/installation-rhv-downloading-ansible-playbooks.adoc
+++ b/modules/installation-rhv-downloading-ansible-playbooks.adoc
@@ -12,7 +12,6 @@ Download the Ansible playbooks for installing {product-title} version {product-v
 
 * On your installation machine, run the following commands:
 +
-ifdef::openshift-origin[]
 [source,terminal,subs=attributes+]
 ----
 $ mkdir playbooks
@@ -25,35 +24,22 @@ $ cd playbooks
 +
 [source,terminal,subs=attributes+]
 ----
-$ curl -s -L -X GET https://api.github.com/repos/openshift/installer/contents/upi/ovirt?ref=release-<version>  |
-grep 'download_url.*\.yml' |
-awk '{ print $2 }' | sed -r 's/("|",)//g' |
-xargs -n 1 curl -O
+$  xargs -n 1 curl -O <<< '
+        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/bootstrap.yml
+        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/common-auth.yml
+        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/create-templates-and-vms.yml
+        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/inventory.yml
+        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/<release-version>s.yml
+        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/retire-bootstrap.yml
+        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/retire-<release-version>s.yml
+        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/retire-workers.yml
+        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/workers.yml'
+
 ----
 +
 where:
 +
-<version>:: Specifies the minor release version, such as `release-4.8`. See the branch drop-down list in the link:https://github.com/openshift/installer/tree/master/upi/ovirt[`openshift/installer` repository] for the available minor versions. 
-endif::openshift-origin[]
-ifndef::openshift-origin[]
-[source,terminal,subs=attributes+]
-----
-$ mkdir playbooks
-----
-+
-[source,terminal,subs=attributes+]
-----
-$ cd playbooks
-----
-+
-[source,terminal,subs=attributes+]
-----
-$ curl -s -L -X GET https://api.github.com/repos/openshift/installer/contents/upi/ovirt?ref=release-{product-version} |
-grep 'download_url.*\.yml' |
-awk '{ print $2 }' | sed -r 's/("|",)//g' |
-xargs -n 1 curl -O
-----
-endif::openshift-origin[]
+<release-version>:: Specifies the minor release version, such as `release-4.11`. See the branch drop-down list in the link:https://github.com/openshift/installer/tree/master/upi/ovirt[`openshift/installer` repository] for the available minor versions.
 
 .Next steps
 


### PR DESCRIPTION
Target - enterprise-4.11
https://issues.redhat.com/browse/OCPRHV-417
update GitHub resource URL and  command for downloading installer Ansible playbooks

Preview: https://deploy-preview-43020--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-user-infra.html#installation-rhv-downloading-ansible-playbooks_installing-rhv-user-infra

