### PR TITLE
SRVCOM-1661: release notes and build error fix

### DIFF
--- a/modules/serverless-rn-1-20-0.adoc
+++ b/modules/serverless-rn-1-20-0.adoc
@@ -19,6 +19,12 @@
 * The `kn func` CLI plug-in now uses `func` 0.20.
 
 * The Kafka broker is now available as a Technology Preview.
++
+[IMPORTANT]
+====
+The Kafka broker, which is currently in Technology Preview, is not supported on FIPS.
+====
+
 * The `kn event` plug-in is now available as a Technology Preview.
 
 [id="known-issues-1-20-0_{context}"]

--- a/modules/serverless-rn-1-21-0.adoc
+++ b/modules/serverless-rn-1-21-0.adoc
@@ -11,19 +11,49 @@
 [id="new-features-1-21-0_{context}"]
 == New features
 
-* {ServerlessProductName} now uses Knative Serving 0.27.
-* {ServerlessProductName} now uses Knative Eventing 0.27.
-* {ServerlessProductName} now uses Kourier 0.27.
-* {ServerlessProductName} now uses Knative `kn` CLI 0.27.
-* {ServerlessProductName} now uses Knative Kafka 0.27.
+* {ServerlessProductName} now uses Knative Serving 1.0
+* {ServerlessProductName} now uses Knative Eventing 1.0.
+* {ServerlessProductName} now uses Kourier 1.0.
+* {ServerlessProductName} now uses Knative `kn` CLI 1.0.
+* {ServerlessProductName} now uses Knative Kafka 1.0.
 * The `kn func` CLI plug-in now uses `func` 0.21.
-// check versions
-* The Knative open source project has begun to deprecate camel-cased configuration keys in favor of using kebab-cased keys consistently. As a result, the `defaultExternalScheme` key, previously mentioned in the {ServerlessProductName} 1.18.0 release notes, has been deprecated and replaced by the `default-external-scheme` key. Usage instructions for the key remain the same.
+* The Kafka sink is now available as a Technology Preview.
+
+* The Knative open source project has begun to deprecate camel-cased configuration keys in favor of using kebab-cased keys consistently. As a result, the `defaultExternalScheme` key, previously mentioned in the {ServerlessProductName} 1.18.0 release notes, is now deprecated and replaced by the `default-external-scheme` key. Usage instructions for the key remain the same.
 
 [id="fixed-issues-1-21-0_{context}"]
 == Fixed issues
-// add a version, e.g. 1-20-0
+
+* In {ServerlessProductName} 1.20.0, there was an event delivery issue affecting the use of `kn event send` to send events to a service. This issue is now fixed.
+
+* In {ServerlessProductName} 1.20.0 (`func` 0.20), TypeScript functions created with the `http` template failed to deploy on the cluster. This issue is now fixed.
+
+* In {ServerlessProductName} 1.20.0 (`func` 0.20), deploying a function using the `gcr.io` registry failed with an error. This issue is now fixed.
+
+* In {ServerlessProductName} 1.20.0 (`func` 0.20), creating a Springboot function project directory with the `kn func create` command and then running the `kn func build` command failed with an error message. This issue is now fixed.
+
+* In {ServerlessProductName} 1.19.0 (`func` 0.19), some runtimes were unable to build a function by using podman. This issue is now fixed.
 
 [id="known-issues-1-21-0_{context}"]
 == Known issues
-// add a version, e.g. 1-20-0
+
+* Currently, the domain mapping controller cannot process the URI of a broker, which contains a path that is currently not supported.
++
+This means that, if you want to use a `DomainMapping` custom resource (CR) to map a custom domain to a broker, you must configure the `DomainMapping` CR with the broker's ingress service, and append the exact path of the broker to the custom domain:
++
+.Example `DomainMapping` CR
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1alpha1
+kind: DomainMapping
+metadata:
+  name: <domain-name>
+  namespace: knative-eventing
+spec:
+  ref:
+    name: broker-ingress
+    kind: Service
+    apiVersion: v1
+----
++
+The URI for the broker is then `<domain-name>/<broker-namespace>/<broker-name>`.

--- a/serverless/develop/serverless-kafka-developer.adoc
+++ b/serverless/develop/serverless-kafka-developer.adoc
@@ -9,10 +9,13 @@ toc::[]
 
 Knative Kafka functionality is available in an {ServerlessProductName} installation xref:../../serverless/admin_guide/serverless-kafka-admin.adoc#serverless-install-kafka-odc_serverless-kafka-admin[if a cluster administrator has installed the `KnativeKafka` custom resource].
 
+// OCP
+ifdef::openshift-enterprise[]
 [NOTE]
 ====
 Knative Kafka is not currently supported for IBM Z and IBM Power.
 ====
+endif::[]
 
 Knative Kafka provides additional options, such as:
 
@@ -43,10 +46,15 @@ include::modules/serverless-kafka-source-yaml.adoc[leveloffset=+2]
 [id="serverless-kafka-developer-broker"]
 == Kafka broker
 
+If a cluster administrator has configured your {ServerlessProductName} deployment to use Kafka broker as the default broker type, xref:../../serverless/develop/serverless-using-brokers.adoc#serverless-using-brokers-creating-brokers[creating a broker by using the default settings] creates a Kafka-based `Broker` object. If your {ServerlessProductName} deployment is not configured to use Kafka broker as the default broker type, you can still use the following procedure to create a Kafka-based broker.
+
 :FeatureName: Kafka broker
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-If a cluster administrator has configured your {ServerlessProductName} deployment to use Kafka broker as the default broker type, xref:../../serverless/develop/serverless-using-brokers.adoc#serverless-using-brokers-creating-brokers[creating a broker by using the default settings] creates a Kafka-based `Broker` object. If your {ServerlessProductName} deployment is not configured to use Kafka broker as the default broker type, you can still use the following procedure to create a Kafka-based broker.
+[IMPORTANT]
+====
+The Kafka broker, which is currently in Technology Preview, is not supported on FIPS.
+====
 
 include::modules/serverless-kafka-broker.adoc[leveloffset=+2]
 

--- a/serverless/install/install-serverless-operator.adoc
+++ b/serverless/install/install-serverless-operator.adoc
@@ -18,9 +18,13 @@ Read the following information about supported configurations and prerequisites 
 * {ServerlessProductName} is supported for installation in a restricted network environment.
 
 * {ServerlessProductName} currently cannot be used in a multi-tenant configuration on a single cluster.
-endif::[]
 
 include::modules/serverless-cluster-sizing-req.adoc[leveloffset=+2]
+endif::[]
+
+ifdef::openshift-dedicated[]
+include::modules/serverless-cluster-sizing-req.adoc[leveloffset=+1]
+endif::[]
 
 ifdef::openshift-enterprise[]
 [id="install-serverless-operator-scaling-with-machinesets"]

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -24,7 +24,7 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD
-// include::modules/serverless-rn-1-21-0.adoc[leveloffset=+1]
+include::modules/serverless-rn-1-21-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-20-0.adoc[leveloffset=+1]
 
 // OCP only


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVCOM-1661 (add release notes)
Also fixes issue reported by @bergerhoffer 

Applies for OCP 4.6+ (requires manual CP for versions older than 4.9)

Direct preview links:
OCP
- https://deploy-preview-43021--osdocs.netlify.app/openshift-enterprise/latest/serverless/install/install-serverless-operator.html
- https://deploy-preview-43021--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-rn-1-21-0_serverless-release-notes
- https://deploy-preview-43021--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-rn-1-20-0_serverless-release-notes (updated to add FIPS note)
- https://deploy-preview-43021--osdocs.netlify.app/openshift-enterprise/latest/serverless/develop/serverless-kafka-developer.html#serverless-kafka-developer-broker (updated to add FIPS note)

OSD
- https://deploy-preview-43021--osdocs.netlify.app/openshift-dedicated/latest/serverless/install/install-serverless-operator.html
- https://deploy-preview-43021--osdocs.netlify.app/openshift-dedicated/latest/serverless/serverless-release-notes.html#serverless-rn-1-21-0_serverless-release-notes
- https://deploy-preview-43021--osdocs.netlify.app/openshift-dedicated/latest/serverless/serverless-release-notes.html#serverless-rn-1-20-0_serverless-release-notes (updated to add FIPS note)
- https://deploy-preview-43021--osdocs.netlify.app/openshift-dedicated/latest/serverless/develop/serverless-kafka-developer.html#serverless-kafka-developer-broker (updated to add FIPS note)