### PR TITLE
OSDOCS-3342: Network Requirements

### DIFF
--- a/modules/cluster-wide-proxy-preqs.adoc
+++ b/modules/cluster-wide-proxy-preqs.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * networking/configuring-cluster-wide-proxy.adoc
+
+:_content-type: PROCEDURE
+[id="cluster-wide-proxy-prereqs_{context}"]
+= Prerequisites for configuring a cluster-wide proxy
+
+To configure a cluster-wide proxy, you must meet the following requirements. These requirements are valid for both fresh installation and post installation proxy configuration.
+
+[id="cluster-wide-proxy-general-prereqs_{context}"]
+== General requirements
+
+* You are the cluster owner.
+* Your account has sufficient privileges.
+* You have added the `ec2.<region>.amazonaws.com`, `elasticloadbalancing.<region>.amazonaws.com`, and `s3.<region>.amazonaws.com` endpoints to your virtual private cloud (VPC) endpoint. These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works on the container level, not the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not sufficient.
+ifdef::openshift-rosa[]
+* You have the `rosa` CLI installed and configured.
+endif::[]
+ifdef::openshift-dedicated[]
+* You must have a Customer Cloud Subscription (CCS) cluster with a VPC that the proxy can access.
+* You have the `ocm` CLI installed and configured.
+endif::[]
+
+[id="cluster-wide-proxy-network-prereqs_{context}"]
+== Network requirements
+
+* If your proxy re-encyrpts egress traffic, you must create exclusions to the domain and port combinations. The following table offers guidance into these exceptions.
+** Allowlist the following OpenShift URLs for re-encryption.
++
+[cols="6,1,6",options="header"]
+|===
+|Address | Protocol/Port | Function
+|`observatorium-mst.api.openshift.com`
+|https/443
+|Required. Used for Managed OpenShift-specific telemetry.
+
+|`sso.redhat.com`
+|https/443
+|The https://cloud.redhat.com/openshift site uses authentication from sso.redhat.com to download the cluster pull secret and use Red Hat SaaS solutions to facilitate monitoring of your subscriptions, cluster inventory, and chargeback reporting.
+|===
++
+** Allowlist the following site reliability engineering (SRE) and management URLs for re-encryption.
++
+[cols="6,1,6",options="header"]
+|===
+|Address | Protocol/Port | Function
+|`*.osdsecuritylogs.splunkcloud.com`
+
+**OR**
+
+`inputs1.osdsecuritylogs.splunkcloud.com`
+`inputs2.osdsecuritylogs.splunkcloud.com`
+`inputs4.osdsecuritylogs.splunkcloud.com`
+`inputs5.osdsecuritylogs.splunkcloud.com`
+`inputs6.osdsecuritylogs.splunkcloud.com`
+`inputs7.osdsecuritylogs.splunkcloud.com`
+`inputs8.osdsecuritylogs.splunkcloud.com`
+`inputs9.osdsecuritylogs.splunkcloud.com`
+`inputs10.osdsecuritylogs.splunkcloud.com`
+`inputs11.osdsecuritylogs.splunkcloud.com`
+`inputs12.osdsecuritylogs.splunkcloud.com`
+`inputs13.osdsecuritylogs.splunkcloud.com`
+`inputs14.osdsecuritylogs.splunkcloud.com`
+`inputs15.osdsecuritylogs.splunkcloud.com`
+|tcp/9997
+|Used by the splunk-forwarder-operator as a log forwarding endpoint to be used by Red Hat SRE for log-based alerting.
+
+|`http-inputs-osdsecuritylogs.splunkcloud.com`
+|https/443
+|Used by the splunk-forwarder-operator as a log forwarding endpoint to be used by Red Hat SRE for log-based alerting.
+|===

--- a/modules/cluster-wide-proxy-updates.adoc
+++ b/modules/cluster-wide-proxy-updates.adoc
@@ -25,14 +25,6 @@ You may need to perform these actions if:
 The cluster applies the configuration to the cluster’s control plane and worker nodes. This process results in each node in the cluster temporarily being placed into an unschedulable state and drained of its workloads while applying the configuration. Each node will be restarted as part of this process.
 ====
 
-.Prerequsites
-ifdef::openshift-rosa[]
-* You have the `rosa` CLI installed and configured.
-endif::[]
-ifdef::openshift-dedicated[]
-* You have the `ocm` CLI installed and configured.
-endif::[]
-
 .Procedure
 * To edit a cluster, run the following command:
 +

--- a/modules/cluster-wide-proxy.adoc
+++ b/modules/cluster-wide-proxy.adoc
@@ -8,14 +8,6 @@
 
 You can add a proxy during cluster installation. Prior to installation, however, you should verify that the proxy is accessible from the intended cluster virtual private cloud (VPC) and its private subnets.
 
-.Prerequsites
-ifdef::openshift-rosa[]
-* You have the `rosa` CLI installed and configured.
-endif::[]
-ifdef::openshift-dedicated[]
-* You have the `ocm` CLI installed and configured.
-endif::[]
-
 [WARNING]
 ====
 Only cluster system egress traffic is proxied, including calls to the AWS API. A system-wide proxy does not affect user workloads. It only affects system components.

--- a/networking/configuring-cluster-wide-proxy.adoc
+++ b/networking/configuring-cluster-wide-proxy.adoc
@@ -9,7 +9,7 @@ endif::[]
 
 toc::[]
 
-You can configure a cluster-wide proxy during cluster installation.
+You can configure a cluster-wide proxy during cluster installation or after the cluster has been installed.
 
 //OSDOCS-2830 Customer Responsibilities
 If you use a cluster-wide proxy, you are responsible for the following:
@@ -22,18 +22,13 @@ If you use a cluster-wide proxy, you are responsible for the following:
 Cluster-wide proxy is a functionally-complete feature and suitable for production workloads. There are additional considerations that need to be added to documentation, and until then, this feature is considered a Technology Preview.
 ====
 
-[id="prerequisites_cluster-wide-proxy-configuration"]
-== Prerequisites
+include::modules/cluster-wide-proxy-preqs.adoc[leveloffset=+1]
 
-* You are the cluster owner.
-* Your account has sufficient privileges.
-* You have added the `ec2.<region>.amazonaws.com`, `elasticloadbalancing.<region>.amazonaws.com`, and `s3.<region>.amazonaws.com` endpoints to your VPC endpoint. These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works on the container level, not the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not sufficient.
+.Additional Resources
 ifdef::openshift-rosa[]
 For information about standard installation prerequisites, see xref:../rosa_getting_started/rosa-aws-prereqs.adoc#prerequisites[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prerequisites[AWS prerequisites for ROSA with STS].
 endif::[]
 ifdef::openshift-dedicated[]
-* You must have a Customer Cloud Subscription (CCS) cluster with a VPC that the proxy can access.
-
 For more information, see xref:../osd_quickstart/osd-quickstart.adoc#osd-getting-started[Getting started with {product-title}] for a basic cluster installation workflow.
 endif::[]
 


### PR DESCRIPTION
This PR adds some network requirements to the cluster-wide proxy documentation. It also restructures the prereqs to include all general and network requirements into one module.

JIRA: https://issues.redhat.com/browse/OSDOCS-3342

PREVIEWS:
* **OSD**  https://deploy-preview-43022--osdocs.netlify.app/openshift-dedicated/latest/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-prereqs_cluster-wide-proxy-configuration
* **ROSA**  https://deploy-preview-43022--osdocs.netlify.app/openshift-rosa/latest/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-prereqs_cluster-wide-proxy-configuration