### PR TITLE
RHDEVDOCS-3851 Fix a handful of minor typos in the release notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -185,7 +185,7 @@ Mirroring images for a disconnected installation using the oc-mirror plug-in].
 
 You can now install a cluster on {rh-openstack-first} for which compute machines run on Open vSwitch with the Data Plane Development Kit (OVS-DPDK) networks. Workloads that run on these machines can benefit from the performance and latency improvements of OVS-DPDK.
 
-For more infromation, see xref:../installing/installing_openstack/installing-openstack-installer-ovs-dpdk.adoc#installing-openstack-installer-ovs-dpdk[Installing a cluster on {rh-openstack} that supports DPDK-connected compute machines].
+For more information, see xref:../installing/installing_openstack/installing-openstack-installer-ovs-dpdk.adoc#installing-openstack-installer-ovs-dpdk[Installing a cluster on {rh-openstack} that supports DPDK-connected compute machines].
 
 [id="ocp-4-10-installing-cluster-on-openstack-compute-machine-affinity"]
 ==== Setting compute machine affinity during installation on {rh-openstack}
@@ -202,7 +202,7 @@ You can now select compute machine affinity when you install a cluster on {rh-op
 * With this update, creating pipelines workflow has now been enhanced:
 ** You can now choose a user-defined pipeline from a drop-down list while importing your application from the *Import from Git* pipeline workflow.
 ** Default webhooks are added for the pipelines that are created using *Import from Git* workflow and the URL is visible in the side panel of the selected resources in the *Topology* view.
-** You can now opt-out of the default Tekton Hub integration by setting the parameter `enable-devconsole-integration` to `false` in the `TektonConfig` custom resource.
+** You can now opt out of the default Tekton Hub integration by setting the parameter `enable-devconsole-integration` to `false` in the `TektonConfig` custom resource.
 +
 .Example `TektonConfig` CR to opt out of Tekton Hub integration
 [source,yaml]
@@ -428,7 +428,7 @@ For more information about security and compliance, see xref:../security/index.a
 [id="ocp-4-10-networking-dual-stack-api-change"]
 ==== Dual-stack services require that ipFamilyPolicy is specified
 
-When you create a service that uses multiple IP address families, you must explicitly specify `ipFamilyPolicy: PreferDualStack` or `ipFamilyPolicy: RequireDualStack` in your Service object definition. This change breaks backwards compatibility with earlier releases of {product-title}.
+When you create a service that uses multiple IP address families, you must explicitly specify `ipFamilyPolicy: PreferDualStack` or `ipFamilyPolicy: RequireDualStack` in your Service object definition. This change breaks backward compatibility with earlier releases of {product-title}.
 
 For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2045576[BZ#2045576].
 
@@ -1448,7 +1448,7 @@ Out-of-tree Container Storage Interface (CSI) driver is the recommended way to w
 === Removed features
 
 {product-title} 4.10 removes the Jenkins Operator, which was a Technology Preview feature, from the *OperatorHub* page in the {product-title} web console interface. Bug fixes and support are no longer available.
-+
+
 Instead, you can continue to deploy Jenkins on {product-title} by using the templates provided by the Samples Operator. Alternatively, you can install the Jenkins Helm Chart from the Developer Catalog by using the *Helm* page in the *Developer* perspective of the web console.
 
 [id="ocp-4-10-oc-commands-removed"]
@@ -1582,7 +1582,7 @@ This update corrects the accepted label specification so that the plug-in import
 
 * Previously, modifying a selector changed the list of machines that a machine set observed. As a result, leaks could occur because the machine set lost track of machines it had already created. This update ensures that the selector is immutable once created. As a result, machine sets now lists the correct machines. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2005052[*BZ#2005052*])
 
-* Previously, if a virtual machine template had snapshots, an incorrect disk size was picked due to an incorrect usage of the `linkedClone` operation. With this update, the default clone operation is changed to `fullClone` for all situations. `linkedClone` must now by specified by the user. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2001008[*BZ#2001008*])
+* Previously, if a virtual machine template had snapshots, an incorrect disk size was picked due to an incorrect usage of the `linkedClone` operation. With this update, the default clone operation is changed to `fullClone` for all situations. `linkedClone` must now be specified by the user. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2001008[*BZ#2001008*])
 
 * Previously, the custom resource definition (CRD) schema requirements did not allow numeric values. Consequently, marshaling errors occurred during upgrades. This update corrects the schema requirements to allow both string and numeric values. As a result, marshaling errors are no longer reported by the API server conversion. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1999425[*BZ#1999425*])
 
@@ -2530,7 +2530,7 @@ and recreate it without a BFD profile. (link:https://bugzilla.redhat.com/show_bu
 [id="ocp-4-10-asynchronous-errata-updates"]
 == Asynchronous errata updates
 
-Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
+Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red Hat Network. All {product-title} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
 
 Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified through email whenever new errata relevant to their registered systems are released.
 


### PR DESCRIPTION
I went to fix my typo on line 1451 and fixed a few others while I was at it.
No SME/QE reviews needed.

Aligned team: Dev Tools
- For branches: 4.10 release notes only
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3851
- Direct link to doc preview: https://deploy-preview-43024--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes
- Peer reviewer/merge-person: tbd
