### PR TITLE
BZ-2013110:removes hostname from command copy button

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -57,14 +57,14 @@ It is not required to manually stop the pods on the recovery host. The recovery 
 +
 [source,terminal]
 ----
-[core@ip-10-0-154-194 ~]$ sudo mv /etc/kubernetes/manifests/etcd-pod.yaml /tmp
+$ sudo mv /etc/kubernetes/manifests/etcd-pod.yaml /tmp
 ----
 
 .. Verify that the etcd pods are stopped.
 +
 [source,terminal]
 ----
-[core@ip-10-0-154-194 ~]$ sudo crictl ps | grep etcd | grep -v operator
+$ sudo crictl ps | grep etcd | grep -v operator
 ----
 +
 The output of this command should be empty. If it is not empty, wait a few minutes and check again.
@@ -73,14 +73,14 @@ The output of this command should be empty. If it is not empty, wait a few minut
 +
 [source,terminal]
 ----
-[core@ip-10-0-154-194 ~]$ sudo mv /etc/kubernetes/manifests/kube-apiserver-pod.yaml /tmp
+$ sudo mv /etc/kubernetes/manifests/kube-apiserver-pod.yaml /tmp
 ----
 
 .. Verify that the Kubernetes API server pods are stopped.
 +
 [source,terminal]
 ----
-[core@ip-10-0-154-194 ~]$ sudo crictl ps | grep kube-apiserver | grep -v operator
+$ sudo crictl ps | grep kube-apiserver | grep -v operator
 ----
 +
 The output of this command should be empty. If it is not empty, wait a few minutes and check again.
@@ -89,7 +89,7 @@ The output of this command should be empty. If it is not empty, wait a few minut
 +
 [source,terminal]
 ----
-[core@ip-10-0-154-194 ~]$ sudo mv /var/lib/etcd/ /tmp
+$ sudo mv /var/lib/etcd/ /tmp
 ----
 
 .. Repeat this step on each of the other control plane hosts that is not the recovery host.
@@ -108,7 +108,7 @@ You can check whether the proxy is enabled by reviewing the output of `oc get pr
 +
 [source,terminal]
 ----
-[core@ip-10-0-143-125 ~]$ sudo -E /usr/local/bin/cluster-restore.sh /home/core/backup
+$ sudo -E /usr/local/bin/cluster-restore.sh /home/core/backup
 ----
 +
 .Example script output
@@ -146,7 +146,7 @@ static-pod-resources/kube-scheduler-pod-8/kube-scheduler-pod.yaml
 +
 [source,terminal]
 ----
-[core@ip-10-0-143-125 ~]$ sudo systemctl restart kubelet.service
+$ sudo systemctl restart kubelet.service
 ----
 
 .. Repeat this step on all other control plane hosts.
@@ -201,7 +201,7 @@ $ oc adm certificate approve <csr_name>
 +
 [source,terminal]
 ----
-[core@ip-10-0-143-125 ~]$ sudo crictl ps | grep etcd | grep -v operator
+$ sudo crictl ps | grep etcd | grep -v operator
 ----
 +
 .Example output
@@ -214,7 +214,7 @@ $ oc adm certificate approve <csr_name>
 +
 [source,terminal]
 ----
-[core@ip-10-0-143-125 ~]$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
 ----
 +
 [NOTE]


### PR DESCRIPTION
4.6+

BZ 2013110 https://bugzilla.redhat.com/show_bug.cgi?id=2013110

**Preview** file: https://deploy-preview-43025--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html

Removes hostname from commands to avoid copying them. 

I will need labels and milestones as well as a merge, please and thanks.