### PR TITLE
BZ2060478: Adds an admonishment not to change the IP address after deployment.

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -119,6 +119,12 @@ Your DHCP server must provide a DHCP expiration time of 4294967295 seconds to pr
 External load balancing services and the control plane nodes must run on the same L2 network, and on the same VLAN when using VLANs to route traffic between the load balancing services and the control plane nodes.
 ====
 
+[IMPORTANT]
+.Do not change IP addresses manually after deployment
+====
+Do not change a worker node's IP address manually after deployment. To change the IP address of a worker node after deployment, you must mark the worker node unschedulable, evacuate the pods, delete the node, and recreate it with the new IP address. See "Working with nodes" for additional details. To change the IP address of a control plane node after deployment, contact support.
+====
+
 The following table provides an exemplary embodiment of fully qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The hostnames of the control plane and worker nodes are exemplary, so you can use any host naming convention you prefer.
 
 [width="100%", cols="3,5,2", options="header"]


### PR DESCRIPTION
Adds an admonishment not to change the IP address after deployment.
Fixes: BZ2060478

See https://bugzilla.redhat.com/show_bug.cgi?id=2060478 for details.

For release: 4.8

This is the 4.8 version for already SME and QE reviewed version for 4.7. https://github.com/openshift/openshift-docs/pull/42932

Preview URL: https://deploy-preview-43026--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites#network-requirements-reserving-ip-addresses_ipi-install-prerequisites

Signed-off-by: John Wilkins <jowilkin@redhat.com>