### PR TITLE
OSDOCS-3167 follow up to fix missing comma in JSON

### DIFF
--- a/modules/machine-node-custom-partition.adoc
+++ b/modules/machine-node-custom-partition.adoc
@@ -52,22 +52,6 @@ Do not change the values in the `ignition` stanza.
       "tls": {
         "certificateAuthorities": [
           {
-            "source": "data:text/plain;charset=utf-8;base64,LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFRENDQWZpZ0F3SUJBZ0lJTjRGN3RORnlWMGd3RFFZSktvWklodmNOQVFFTEJRQXdKakVTTUJBR0ExVUUKQ3hNSmIzQmxibk5vYVdaME1SQXdEZ1lEVlFRREV3ZHliMjkwTFdOaE1CNFhEVEl5TURFeE56RTVOREF4T1ZvWApEVE15TURFeE5URTVOREF4T1Zvd0pqRVNNQkFHQTFVRUN4TUpiM0JsYm5Ob2FXWjBNUkF3RGdZRFZRUURFd2R5CmIyOTBMV05oTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF3OFBRODR2SkM4WVkKL3lQK3lSeHpoMWdKa2RHcmJVRVNNzUnh5c0l6YW0rczFISGVtcS90MWN3SEh1NCtrRTNVVllCanlpdE9=="
-          }
-        ]
-      }
-    },
-    "version": "3.2.0"
-  }
-}
-
-        }
-      ]
-    },
-    "security": {
-      "tls": {
-        "certificateAuthorities": [
-          {
             "source": "data:text/plain;charset=utf-8;base64,.....=="
           }
         ]
@@ -82,7 +66,7 @@ Do not change the values in the `ignition` stanza.
         "partitions": [
           {
             "label": "var",
-            "sizeMiB": 50000 <2>
+            "sizeMiB": 50000, <2>
             "startMiB": 0 <3>
           }
         ]


### PR DESCRIPTION
[Missing comma in a JSON example](https://github.com/openshift/openshift-docs/pull/40644/files#r822928093). Then I noticed the JSON looked odd and failed a JSON validator.  Removed an erroneous stanza.