### PR TITLE
OSDOCS-3174: Typo fix

### DIFF
--- a/modules/rosa-policy-identity-access-management.adoc
+++ b/modules/rosa-policy-identity-access-management.adoc
@@ -36,7 +36,7 @@ Each of these access types have different levels of access to components:
 
 | {cluster-manager} | R/W | No access | No access | No access
 | OpenShift console | No access | R/W | R/W | No access
-| Node Operating  system | No access | A specific list of elevated OS and network permissions. | A specific list of elevated OS and network permissions. | No access
+| Node operating system | No access | A specific list of elevated OS and network permissions. | A specific list of elevated OS and network permissions. | No access
 | AWS Console | No access | No access, but this is the account used to request cloud provider access. | No access | All cloud provider permissions using the SRE identity.
 
 |===


### PR DESCRIPTION
This applies to main, enterprise-4.10 and enterprise-4.9.

This relates to https://issues.redhat.com/browse/OSDOCS-3174. Fixes #41152 that required PR squashes as submitted by @arendej .