### PR TITLE
RHDEVDOCS-3855 Remove a reference to Jenkins Operator, which was remo…

### DIFF
--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -288,7 +288,6 @@ s| Feature s| {oke} s| {product-title} s| Operator name
 s| Feature s| {oke} s| {product-title} s| Operator name
 | Red Hat OpenShift Serverless | Not Included | Included | OpenShift Serverless Operator
 | Web Terminal provided by Red Hat | Not Included | Included | Web Terminal Operator
-| Jenkins Operator provided by Red Hat | Not Included | Included | Jenkins Operator
 | Red Hat OpenShift Pipelines Operator | Not Included | Included | OpenShift Pipelines Operator
 | Embedded Component of IBM Cloud Pak and RHT MW Bundles | Not Included | Included | N/A
 | Red Hat OpenShift GitOps | Not Included | Included | OpenShift GitOps


### PR DESCRIPTION
…ved from OpenShift in 4.10

 Aligned team: Dev Tools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3855
- Direct link to doc preview: https://deploy-preview-43030--osdocs.netlify.app/openshift-enterprise/latest/welcome/oke_about
- SME review: Not needed
- QE review: @prietyc123 
- Peer review: @ 	tbd
- <All reviews complete. Please merge now>