### PR TITLE
Corrects callout numbers in procedure

### DIFF
--- a/modules/migration-migrating-applications-api.adoc
+++ b/modules/migration-migrating-applications-api.adoc
@@ -56,23 +56,23 @@ $ cat << EOF | oc apply -f -
 apiVersion: migration.openshift.io/v1alpha1
 kind: MigCluster
 metadata:
-  name: <remote_cluster> <.>
+  name: <remote_cluster> <1>
   namespace: openshift-migration
 spec:
-  exposedRegistryPath: <exposed_registry_route> <.>
-  insecure: false <.>
+  exposedRegistryPath: <exposed_registry_route> <2>
+  insecure: false <3>
   isHostCluster: false
   serviceAccountSecretRef:
-    name: <remote_cluster_secret> <.>
+    name: <remote_cluster_secret> <4>
     namespace: openshift-config
-  url: <remote_cluster_url> <.>
+  url: <remote_cluster_url> <5>
 EOF
 ----
-<.> Specify the `Cluster` CR of the remote cluster.
-<.> Optional: For direct image migration, specify the exposed registry route.
-<.> SSL verification is enabled if `false`. CA certificates are not required or checked if `true`.
-<.> Specify the `Secret` object of the remote cluster.
-<.> Specify the URL of the remote cluster.
+<1> Specify the `Cluster` CR of the remote cluster.
+<2> Optional: For direct image migration, specify the exposed registry route.
+<3> SSL verification is enabled if `false`. CA certificates are not required or checked if `true`.
+<4> Specify the `Secret` object of the remote cluster.
+<5> Specify the URL of the remote cluster.
 
 . Verify that all clusters are in a `Ready` state:
 +


### PR DESCRIPTION
Bug fix
MTC 1.6+

OCP versions: 4.6+. 

The callouts in step 3 of "Migrating an application by using the MTC API" (section 9.2.4) are missing numerals. This PR adds them. 

Preview: https://deploy-preview-43044--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/advanced-migration-options-mtc.html see  "Migrating an application by using the MTC API," step 3.

