### PR TITLE
PTP: update link to AMQ Interconnect version 1.10 install docs

### DIFF
--- a/modules/cnf-installing-amq-interconnect-messaging-bus.adoc
+++ b/modules/cnf-installing-amq-interconnect-messaging-bus.adoc
@@ -15,7 +15,7 @@ To pass PTP fast event notifications between publisher and subscriber on a node,
 
 .Procedure
 
-* Install the AMQ Interconnect Operator to its own `amq-interconnect` namespace. See link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.7/html/deploying_amq_interconnect_on_openshift/installing-router-operator-router-ocp[Installing the AMQ Interconnect Operator].
+* Install the AMQ Interconnect Operator to its own `amq-interconnect` namespace. See link:https://access.redhat.com/documentation/en-us/red_hat_amq/2021.q1/html/deploying_amq_interconnect_on_openshift/adding-operator-router-ocp[Adding the Red Hat Integration - AMQ Interconnect Operator].
 
 .Verification
 


### PR DESCRIPTION
Merge to main, enterprise-4.9, enterprise-4.10, enterprise-4.11. 

Preview: https://deploy-preview-43049--osdocs.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#cnf-installing-amq-interconnect-messaging-bus_using-ptp