### PR TITLE
rm wip banner from 4-10 docs

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -59,7 +59,7 @@
   <div class="container">
     <button id="hc-open-btn" class="open-btn-sm" onclick="openNav()" aria-label="Open"><span class="fa fa-bars" /></button>
     <ol class="breadcrumb hide-for-print">
-      <% if (version == "4.10" || distro_key == "openshift-webscale" || distro_key == "openshift-dpu") %>
+      <% if (version == "4.11" || distro_key == "openshift-webscale" || distro_key == "openshift-dpu") %>
       <span>
         <div class="alert alert-danger" role="alert" id="support-alert">
           <strong>This documentation is work in progress and might not be complete or fully tested.</strong> The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html" class="link-primary" style="color: #545454 !important;">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.


### PR DESCRIPTION
The WIP banner should not appear in docs.openshift.com for OCP 4.10. Moving the distro_key to 4.11 for now.