### PR TITLE
OSDOCS-3341: Move IBM API key rotation procedure

### DIFF
--- a/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
@@ -14,14 +14,18 @@ include::snippets/technology-preview.adoc[]
 include::modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_configuring-iam-ibm-cloud"]
+[id="additional-resources_configuring-iam-ibm-cloud-about-cco"]
 .Additional resources
 * xref:../../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator]
 
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+1]
-include::modules/refreshing-service-ids-ibm-cloud.adoc[leveloffset=+1]
 //include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
 // Will need to revisit upgrade scenario for IBM Cloud; not needed until OCP 4.11. Tentative instructions have been added for reference later.
+
+[role="_additional-resources"]
+[id="additional-resources_configuring-iam-ibm-cloud-refreshing-ids"]
+.Additional resources
+* xref:../../post_installation_configuration/cluster-tasks.adoc#refreshing-service-ids-ibm-cloud_post-install-cluster-tasks[Rotating API keys for IBM Cloud]
 
 [id="next-steps_configuring-iam-ibm-cloud"]
 == Next steps

--- a/modules/refreshing-service-ids-ibm-cloud.adoc
+++ b/modules/refreshing-service-ids-ibm-cloud.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
+// * post_installation_configuration/cluster-tasks.adoc
 
 :_content-type: PROCEDURE
 [id="refreshing-service-ids-ibm-cloud_{context}"]

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -604,6 +604,14 @@ After installing {product-title}, some organizations require the rotation or rem
 
 To allow the cluster to use the new credentials, you must update the secrets that the xref:../operators/operator-reference.adoc#cloud-credential-operator_platform-operators-ref[Cloud Credential Operator (CCO)] uses to manage cloud provider credentials.
 
+[id="ccoctl-rotate-remove-cloud-creds"]
+=== Rotating cloud provider credentials with the Cloud Credential Operator utility
+
+// Right now only IBM can do this, but it makes sense to set this up so that other clouds can be added.
+The Cloud Credential Operator (CCO) utility `ccoctl` supports updating secrets for clusters installed on IBM Cloud.
+
+include::modules/refreshing-service-ids-ibm-cloud.adoc[leveloffset=+3]
+
 include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+2]
 
 include::modules/manually-removing-cloud-creds.adoc[leveloffset=+2]


### PR DESCRIPTION
For [OSDOCS-3341](https://issues.redhat.com/browse/OSDOCS-3341)

Previews: 
- New section **Rotating or removing cloud provider credentials >** [**Rotating cloud provider credentials with the Cloud Credential Operator utility**](https://deploy-preview-43058--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#ccoctl-rotate-remove-cloud-creds) in **Post-installation cluster tasks**. Currently it just holds the IBM-specific procedure, but we can use this heading to add other platforms as needed.
- Added additional resources under [**Configuring the Cloud Credential Operator utility**](https://deploy-preview-43058--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.html#cco-ccoctl-configuring_configuring-iam-ibm-cloud) to call users' attention to this capability.