### PR TITLE
WIP BZ1955363 Replaced SSLCipherSuite verbiage  & HTTPS links

### DIFF
--- a/modules/example-apache-httpd-configuration.adoc
+++ b/modules/example-apache-httpd-configuration.adoc
@@ -7,20 +7,43 @@
 
 The basic identify provider (IDP) configuration in {product-title} 4 requires
 that the IDP server respond with JSON for success and failures. You can use CGI
-scripting in Apache HTTPD to accomplish this. This section provides examples.
+scripting in Apache HTTPD to accomplish this. This section provides examples
+with an httpd server configured as a running pod in cluster.
 
-.Example `/etc/httpd/conf.d/login.conf`
+.Use project "default"
 ----
-<VirtualHost *:443>
+PROJECT=httpd-proj
+APP=httpd
+SVC=basic-auth
+IDP_NAME=basicauth-idp
+oc new-project $PROJECT
+----
+
+.Deploy & Configure the HTTPD Server
+----
+oc get is httpd -n openshift
+
+NAME    IMAGE REPOSITORY                                                   TAGS                         UPDATED
+httpd   image-registry.openshift-image-registry.svc:5000/openshift/httpd   2.4,2.4-el7,2.4-el8,latest   59 minutes ago
+
+oc create deployment $APP --image image-registry.openshift-image-registry.svc:5000/openshift/httpd:2.4 -- bash -c "cp /tmp/httpd/login.conf /etc/httpd/conf.d/ssl.conf; httpd -D FOREGROUND"
+oc expose deployment/$APP --name $SVC --port 8443
+oc annotate service $SVC service.beta.openshift.io/serving-cert-secret-name=httpd-cert
+----
+
+.Use cat > login.conf << EOF
+----
+Listen 0.0.0.0:8443 https
+
+<VirtualHost *:8443>
   # CGI Scripts in here
   DocumentRoot /var/www/cgi-bin
 
   # SSL Directives
   SSLEngine on
-  SSLCipherSuite PROFILE=SYSTEM
   SSLProxyCipherSuite PROFILE=SYSTEM
-  SSLCertificateFile /etc/pki/tls/certs/localhost.crt
-  SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+  SSLCertificateFile /etc/httpd/conf/tls/basic-auth/tls.crt
+  SSLCertificateKeyFile /etc/httpd/conf/tls/basic-auth/tls.key
 
   # Configure HTTPD to execute scripts
   ScriptAlias /basic /var/www/cgi-bin
@@ -33,28 +56,56 @@ scripting in Apache HTTPD to accomplish this. This section provides examples.
     AuthType Basic
     AuthName "Please Log In"
     AuthBasicProvider file
-    AuthUserFile /etc/httpd/conf/passwords
+    AuthUserFile /etc/httpd/conf/auth/passwords
     Require valid-user
   </Location>
 </VirtualHost>
+EOF
 ----
 
-.Example `/var/www/cgi-bin/login.cgi`
+.Use cat > login.cgi << 'EOF' With Single Quotes
 ----
 #!/bin/bash
 echo "Content-Type: application/json"
 echo ""
-echo '{"sub":"userid", "name":"'$REMOTE_USER'"}'
+echo "{\"sub\":\"$REMOTE_USER\", \"preferred_username\":\"$REMOTE_USER\", \"name\":\"Hello $REMOTE_USER\"}"
 exit 0
+EOF
 ----
 
-.Example `/var/www/cgi-bin/fail.cgi`
+.Use cat > fail.cgi << EOF
 ----
 #!/bin/bash
 echo "Content-Type: application/json"
 echo ""
 echo '{"error": "Login failure"}'
 exit 0
+EOF
+----
+
+.Add Passwords for basicauth-xxia
+----
+htpasswd -bc passwords basicauth-xxia1 redhat
+htpasswd -b passwords basicauth-xxia2 redhat
+----
+
+.Create & Set Volumes
+----
+oc create secret generic auth --from-file=passwords
+oc create cm cgi-bin --from-file=login.cgi --from-file=fail.cgi
+oc create cm login.conf --from-file=login.conf
+oc set volumes deployment/$APP --add -t secret --secret-name auth -m /etc/httpd/conf/auth
+oc set volumes deployment/$APP --add -t configmap --configmap-name cgi-bin -m /var/www/cgi-bin --default-mode 0777
+oc set volumes deployment/$APP --add -t secret --secret-name httpd-cert -m /etc/httpd/conf/tls/basic-auth
+oc set volumes deployment/$APP --add -t configmap --configmap-name login.conf -m /tmp/httpd
+----
+
+.Results
+----
+oc get pod
+
+NAME                     READY   STATUS    RESTARTS   AGE
+httpd-7d4d97bc96-4kzgq   1/1     Running   0          9
 ----
 
 == File requirements

--- a/modules/identity-provider-basic-authentication-CR.adoc
+++ b/modules/identity-provider-basic-authentication-CR.adoc
@@ -22,7 +22,7 @@ spec:
     mappingMethod: claim <2>
     type: BasicAuth
     basicAuth:
-      url: https://www.example.com/remote-idp <3>
+      url: https://<URL>/basic/login.cgi <3>
       ca: <4>
         name: ca-config-map
       tlsClientCert: <5>

--- a/modules/identity-provider-basic-authentication-troubleshooting.adoc
+++ b/modules/identity-provider-basic-authentication-troubleshooting.adoc
@@ -13,7 +13,7 @@ credentials.
 
 [source,terminal]
 ----
-$ curl --cacert /path/to/ca.crt --cert /path/to/client.crt --key /path/to/client.key -u <user>:<password> -v https://www.example.com/remote-idp
+$ curl --cacert /path/to/ca.crt --cert /path/to/client.crt --key /path/to/client.key -u <user>:<password> -v https://<URL>/basic/login.cgi
 ----
 
 *Successful responses*


### PR DESCRIPTION
versions 4.6 and beyond

Bug: https://bugzilla.redhat.com/show_bug.cgi

Direct link to doc preview: https://deploy-preview-43061--osdocs.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-basic-authentication-identity-provider.html#example-apache-httpd-configuration_configuring-basic-authentication-identity-provider

QA Contact: @xingxingxia 