### PR TITLE
Moving IBM Cloud on IPI to TP

### DIFF
--- a/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 In environments where the cloud identity and access management (IAM) APIs are not reachable, you must put the Cloud Credential Operator (CCO) into manual mode before you install the cluster.
 
+:FeatureName: IBM Cloud using installer-provisioned infrastructure
+include::snippets/technology-preview.adoc[]
+
 include::modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 Before you can install {product-title}, you must configure an IBM Cloud account.
 
+:FeatureName: IBM Cloud using installer-provisioned infrastructure
+include::snippets/technology-preview.adoc[]
+
 [id="prerequisites_installing-ibm-cloud-account"]
 == Prerequisites
 

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 In {product-title} version {product-version}, you can install a customized cluster on infrastructure that the installation program provisions on IBM Cloud. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
+:FeatureName: IBM Cloud using installer-provisioned infrastructure
+include::snippets/technology-preview.adoc[]
+
 [id="prerequisites_installing-ibm-cloud-customizations"]
 == Prerequisites
 

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
@@ -11,6 +11,9 @@ customized network configuration on infrastructure that the installation program
 
 You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
 
+:FeatureName: IBM Cloud using installer-provisioned infrastructure
+include::snippets/technology-preview.adoc[]
+
 [id="prerequisites_installing-ibm-cloud-network-customizations"]
 == Prerequisites
 

--- a/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc
@@ -13,6 +13,9 @@ toc::[]
 
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
+:FeatureName: IBM Cloud using installer-provisioned infrastructure
+include::snippets/technology-preview.adoc[]
+
 [IMPORTANT]
 ====
 The installation workflows documented in this section are for IBM Cloud VPC infrastructure environments. IBM Cloud Classic is not supported at this time. For more information on the difference between Classic and VPC infrastructures, see IBM's link:https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure[documentation].


### PR DESCRIPTION
Per @tkatarki and @sjstout the  IBM Cloud using installer-provisioned infrastructure feature needs to be moved from GA to TP for 4.10.  For release notes, see https://github.com/openshift/openshift-docs/pull/43068