### PR TITLE
Moving IBM Cloud on IPI to TP in Release Notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -115,9 +115,16 @@ The following Operators are supported for {product-title} on ARM:
 * Service Binding Operator
 
 [id="ocp-4-10-ibm-cloud-installation"]
-==== Installing a cluster on IBM Cloud using installer-provisioned infrastructure
+==== Installing a cluster on IBM Cloud using installer-provisioned infrastructure (Technology Preview)
 
-{product-title} 4.10 introduces support for installing a cluster on IBM Cloud using installer-provisioned infrastructure.
+{product-title} 4.10 introduces support for installing a cluster on IBM Cloud using installer-provisioned infrastructure (IPI).
+
+The following limitations apply for IBM Cloud using IPI:
+
+* Deploying IBM Cloud using IPI on a previously existing network is not supported.
+* The Cloud Credential Operator (CCO) can use only Manual mode. Mint mode or STS are not supported.
+* IBM Cloud DNS Services is not supported. An instance of IBM Cloud Internet Services is required.
+* Private or disconnected deployments are not supported. 
 
 For more information, see xref:../installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc#preparing-to-install-on-ibm-cloud[Preparing to install on IBM Cloud].
 


### PR DESCRIPTION
Per @tkatarki and @sjstout the  IBM Cloud using installer-provisioned infrastructure feature needs to be moved from GA to TP for 4.10.  This PR edits the 4.10 release notes. See aslo: https://github.com/openshift/openshift-docs/pull/43067