### PR TITLE
Verifying if the OSD and ROSA live builds are from enterprise-4.10

### DIFF
--- a/modules/rosa-adding-node-labels.adoc
+++ b/modules/rosa-adding-node-labels.adoc
@@ -9,7 +9,7 @@
 
 Add or edit labels for worker nodes at any time to manage the nodes in a manner that is relevant to you. For example, you can assign types of workloads to specific nodes.
 
-Labels are assigned as key=value pairs. Each key must be unique to the object it is assigned to. Labels do not change or impact the core system values, such as a machine pool ID.
+Labels are assigned as key-value pairs. Each key must be unique to the object it is assigned to. Labels do not change or impact the core system values, such as a machine pool ID.
 
 [NOTE]
 ====


### PR DESCRIPTION
This relates to `enterprise-4.10` only.

This pull request test if the OSD and ROSA live builds are now building from the `enterprise-4.10` branch, now that the target branches for the distros have been updated through https://github.com/openshift/openshift-docs/pull/43054.

The previews are as follows:

- OSD: https://deploy-preview-43080--osdocs.netlify.app/openshift-dedicated/latest/nodes/rosa-managing-worker-nodes.html#rosa-adding-node-labels_rosa-managing-worker-nodes
- ROSA: https://deploy-preview-43080--osdocs.netlify.app/openshift-rosa/latest/nodes/rosa-managing-worker-nodes.html#rosa-adding-node-labels_rosa-managing-worker-nodes