### PR TITLE
[RHACS] Added Liveness Probe, Readiness Probe, Replicas

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -487,6 +487,30 @@ For example `oc`, or `kubectl`.
 | ✕
 | Deploy
 
+| Liveness Probe
+| Whether the container defines a liveness probe.
+| 3.69 and newer
+| ✕
+| ✕
+| ✕
+| Deploy
+
+| Readiness Probe
+| Whether the container defines a readiness probe.
+| 3.69 and newer
+| ✕
+| ✕
+| ✕
+| Deploy
+
+| Replicas
+| The number of deployment replicas.
+| 3.69 and newer
+| ✕
+| ✓
+| ✓
+| Deploy
+
 |===
 
 [NOTE]


### PR DESCRIPTION
Applies to RHACS 3.69


<hr>

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
