### PR TITLE
Fixing the helm repo source and version of the helm chart

### DIFF
--- a/modules/helm-creating-a-custom-helm-chart-on-openshift.adoc
+++ b/modules/helm-creating-a-custom-helm-chart-on-openshift.adoc
@@ -32,12 +32,14 @@ apiVersion: v2 <1>
 name: nodejs-ex-k <2>
 description: A Helm chart for OpenShift <3>
 icon: https://static.redhat.com/libs/redhat/brand-assets/latest/corp/logo.svg <4>
+version: 0.2.1 <5>
 ----
 +
 <1> The chart API version. It should be `v2` for Helm charts that require at least Helm 3.
 <2> The name of your chart.
 <3> The description of your chart.
 <4> The URL to an image to be used as an icon.
+<5> The Version of your chart as per the Semantic Versioning (SemVer) 2.0.0 Specification.
 
 . Verify that the chart is formatted properly:
 +

--- a/modules/helm-installing-a-helm-chart-on-an-openshift-cluster.adoc
+++ b/modules/helm-installing-a-helm-chart-on-an-openshift-cluster.adoc
@@ -13,20 +13,20 @@
 +
 [source,terminal]
 ----
-$ oc new-project mysql
+$ oc new-project vault
 ----
 
 . Add a repository of Helm charts to your local Helm client:
 +
 [source,terminal]
 ----
-$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+$ helm repo add openshift-helm-charts https://charts.openshift.io/
 ----
 +
 .Example output
 [source,terminal]
 ----
-"stable" has been added to your repositories
+"openshift-helm-charts" has been added to your repositories
 ----
 
 . Update the repository:
@@ -40,7 +40,19 @@ $ helm repo update
 +
 [source,terminal]
 ----
-$ helm install example-mysql stable/mysql
+$ helm install example-vault openshift-helm-charts/hashicorp-vault
+----
++
+.Example output
+[source,terminal]
+----
+NAME: example-vault
+LAST DEPLOYED: Fri Mar 11 12:02:12 2022
+NAMESPACE: vault
+STATUS: deployed
+REVISION: 1
+NOTES:
+Thank you for installing HashiCorp Vault!
 ----
 
 . Verify that the chart has installed successfully:
@@ -53,6 +65,6 @@ $ helm list
 .Example output
 [source,terminal]
 ----
-NAME NAMESPACE REVISION UPDATED STATUS CHART APP VERSION
-example-mysql mysql 1 2019-12-05 15:06:51.379134163 -0500 EST deployed mysql-1.5.0 5.7.27
+NAME         	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART       	APP VERSION
+example-vault	vault    	1       	2022-03-11 12:02:12.296226673 +0530 IST	deployed	vault-0.19.0	1.9.2
 ----


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: enterprise-`4.9`, 4.10 +
- **JIRA issues**: [RHDEVDOCS-3762](https://issues.redhat.com/browse/RHDEVDOCS-3762)
- **Preview pages**: [Installing a Helm chart on an OpenShift Container Platform cluster](https://deploy-preview-43087--osdocs.netlify.app/openshift-enterprise/latest/applications/working_with_helm_charts/configuring-custom-helm-chart-repositories.html#installing-a-helm-chart-on-an-openshift-cluster_configuring-custom-helm-chart-repositories), [Creating a custom Helm chart on OpenShift Container Platform](https://deploy-preview-43087--osdocs.netlify.app/openshift-enterprise/latest/applications/working_with_helm_charts/configuring-custom-helm-chart-repositories.html#creating-a-custom-helm-chart-on-openshift_configuring-custom-helm-chart-repositories)
- **SME Review**: Approved by @dperaza4dustbit 
- **QE review**: Approved by @tisutisu
- **Peer-review**:  Approved by @max-cx