### PR TITLE
Removing OSD and ROSA from the 4.9 distro map

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -9,26 +9,3 @@ openshift-enterprise:
     enterprise-4.1:
       name: '4.1'
       dir: container-platform/4.1
-openshift-dedicated:
-  name: OpenShift Dedicated
-  author: OpenShift Documentation Project <openshift-docs@redhat.com>
-  site: commercial
-  site_name: Documentation
-  site_url: https://docs.openshift.com/
-  branches:
-    enterprise-3.11:
-      name: '3'
-      dir: dedicated/3
-    enterprise-4.9:
-      name: ''
-      dir: dedicated/
-openshift-rosa:
-  name: Red Hat OpenShift Service on AWS
-  author: OpenShift Documentation Project <openshift-docs@redhat.com>
-  site: commercial
-  site_name: Documentation
-  site_url: https://docs.openshift.com/
-  branches:
-    enterprise-4.9:
-      name: ''
-      dir: rosa/


### PR DESCRIPTION
This applies to `enterprise-4.9` only.

This pull request removes the OSD and ROSA stanzas from the distro map for 4.9. The OSD and ROSA live docs are now published from the `enterprise-4.10` branch. Given this, there is no longer a requirement to review OSD and ROSA preview builds in PRs that are based on `enterprise-4.9`. Removing these lines might improve build performance for OCP 4.9 previews.