### PR TITLE
GH #43050: Fixing broken install docs OKD4.6-4.8

### DIFF
--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -68,7 +68,6 @@ ifndef::ibm-z,ibm-z-kvm[* You have a computer that runs Linux or macOS, with 500
 
 ifndef::openshift-origin[]
 . Access the link:https://console.redhat.com/openshift/install[Infrastructure Provider] page on the {cluster-manager} site. If you have a Red Hat account, log in with your credentials. If you do not, create an account.
-ifndef::ash[]
 . Select your infrastructure provider.
 . Navigate to the page for your installation type, download the installation program for your operating system, and place the file in the directory where you will store the installation configuration files.
 endif::[]


### PR DESCRIPTION
The OKD installation docs are stopping at the _Obtaining the installation program_ topic. Adding an `ifdef` to [match the file in main](https://github.com/openshift/openshift-docs/blame/main/modules/installation-obtaining-installer.adoc#L88), which does work.

https://github.com/openshift/openshift-docs/issues/43050

![image](https://user-images.githubusercontent.com/25209155/157758109-2ff3c9bd-8750-4e4c-b3ad-08965c20945b.png)

Preview:
[AWS](https://deploy-preview-43101--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-default.html#installation-obtaining-installer_installing-aws