### PR TITLE
[OSDOCS-3360] HIPAA should not be included in compliance table

### DIFF
--- a/modules/policy-security-regulation-compliance.adoc
+++ b/modules/policy-security-regulation-compliance.adoc
@@ -65,8 +65,6 @@ Any issues that are discovered are prioritized based on severity. Any issues fou
 
 | SOC 2 Type 2 | Yes | Yes
 
-| HIPAA | Yes | Yes
-
 |===
 
 [role="_additional-resources"]

--- a/modules/rosa-policy-security-regulation-compliance.adoc
+++ b/modules/rosa-policy-security-regulation-compliance.adoc
@@ -62,8 +62,6 @@ Any issues that may be discovered are prioritized based on severity. Any issues 
 
 | SOC 2 Type 2 | Yes
 
-| HIPAA | Yes
-
 |===
 
 [role="_additional-resources"]


### PR DESCRIPTION
This PR removes HIPAA from the compliance table on OSD and ROSA until remaining legal issues are resolved. 

JIRA: https://issues.redhat.com/browse/OSDOCS-3360

PREVIEWS:
- **OSD:** https://deploy-preview-43102--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/policy-process-security.html#compliance_policy-process-security
- **ROSA:** https://deploy-preview-43102--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-policy-process-security.html#rosa-policy-compliance_rosa-policy-process-security