### PR TITLE
BZ1753105: Openshift 3.11 installation ignores nodeIP edits in configmap

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1451,11 +1451,6 @@ node resources section in the Cluster Administrator guide] for more information.
 |`*NodeConfig*`
 |The fully specified configuration starting an {product-title} node.
 
-|`*NodeIP*`
-|Node may have multiple IPs, so this specifies the IP to use for pod traffic
-routing. If not specified, network parse/lookup on the *nodeName* is performed
-and the first non-loopback address is used.
-
 |`*NodeName*`
 |The value used to identify this particular node in the cluster. If possible,
 this should be your fully qualified hostname. If you are describing a set of


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1753105

Preview: https://deploy-preview-43136--osdocs.netlify.app/openshift-enterprise/latest/install_config/master_node_configuration.html#node-config-pod-and-node-config