### PR TITLE
OSDOCS-3202: Created a CIDR addresses explainer topic

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -972,6 +972,9 @@ Topics:
 - Name: Understanding the Ingress Operator
   File: ingress-operator
   Distros: openshift-enterprise,openshift-origin
+- Name: CIDR Range Definitions
+  File: cidr-range-definitions
+  Distros: openshift-enterprise,openshift-origin
 - Name: Configuring the Ingress Controller endpoint publishing strategy
   File: nw-ingress-controller-endpoint-publishing-strategies
   Distros: openshift-enterprise,openshift-origin

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -141,6 +141,8 @@ Topics:
     File: enabling-multicast
 - Name: Configuring a cluster-wide proxy during installation
   File: configuring-cluster-wide-proxy
+- Name: CIDR Range Definitions
+  File: cidr-range-definitions
 ---
 Name: Nodes
 Dir: nodes

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -159,6 +159,8 @@ Topics:
     File: enabling-multicast
 - Name: Configuring a cluster-wide proxy during installation
   File: configuring-cluster-wide-proxy
+- Name: CIDR Range Definitions
+  File: cidr-range-definitions
 ---
 Name: Authentication and authorization
 Dir: authentication

--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -1,0 +1,30 @@
+:_content-type: ASSEMBLY
+[id="cidr-range-definitions"]
+= CIDR Range Definitions
+include::_attributes/common-attributes.adoc[]
+:context: cidr-range-definitions
+
+toc::[]
+
+You must specify non-overlapping ranges for the following CIDR ranges.
+
+[NOTE]
+====
+Machine CIDR ranges cannot be changed after creating your cluster.
+====
+
+[id="machine-cidr-description"]
+== Machine CIDR
+In the Machine CIDR field, you must specify the IP address range for machines or cluster nodes. This range must encompass all CIDR address ranges for your virtual private cloud (VPC) subnets. Subnets must be contiguous. A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones. The default is `10.0.0.0/16`. This range must not conflict with any connected networks.
+
+[id="service-cidr-description"]
+== Service CIDR
+In the Service CIDR field, you must specify the IP address range for services. The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `172.30.0.0/16`. This address block needs to be the same between clusters.
+
+[id="pod-cidr-description"]
+== Pod CIDR
+In the Pod CIDR field, you must specify the IP address range for pods. The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `10.128.0.0/14`. This address block needs to be the same between clusters.
+
+[id="host-prefix-description"]
+== Host Prefix
+In the Host Prefix field, you must Specify the subnet prefix length assigned to pods scheduled to individual machines. The host prefix determines the pod IP address pool for each machine. For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 512 cluster nodes, and 512 pods per node (both of which are beyond our maximum supported).


### PR DESCRIPTION
This PR adds a new topic that explains some of the CIDR address that are needed for the ROSA installer.

JIRA: https://issues.redhat.com/browse/OSDOCS-3202

PREVIEW: 

* **OCP**  https://deploy-preview-43137--osdocs.netlify.app/openshift-enterprise/latest/networking/cidr-range-definitions.html
* **OSD**  https://deploy-preview-43137--osdocs.netlify.app/openshift-dedicated/latest/networking/cidr-range-definitions.html
* **ROSA**  https://deploy-preview-43137--osdocs.netlify.app/openshift-rosa/latest/networking/cidr-range-definitions.html