### PR TITLE
[BZ2060048] Fix ShiftStack machine set CR YAML indentation

### DIFF
--- a/modules/machineset-yaml-osp.adoc
+++ b/modules/machineset-yaml-osp.adoc
@@ -64,10 +64,10 @@ ifdef::infra[]
         machine.openshift.io/cluster-api-machine-type: <infra> <2>
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <3>
     spec:
-    metadata:
-      creationTimestamp: null
-      labels:
-        node-role.kubernetes.io/infra: ""
+      metadata:
+        creationTimestamp: null
+        labels:
+          node-role.kubernetes.io/infra: ""
       taints: <4>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule


### PR DESCRIPTION
Resolves [BZ2060048](https://bugzilla.redhat.com/show_bug.cgi?id=2060048)

Preview: https://deploy-preview-43142--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-osp_creating-infrastructure-machinesets