### PR TITLE
[GH43144] Correct OVS-DPDK ShiftStack installation assembly title

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -343,7 +343,7 @@ Topics:
     File: installing-openstack-installer-kuryr
   - Name: Installing a cluster that supports SR-IOV compute machines on OpenStack
     File: installing-openstack-installer-sr-iov
-  - Name: Installing a cluster on OpenStack that supports DPDK-connected compute machines
+  - Name: Installing a cluster on OpenStack that supports OVS-DPDK-connected compute machines
     File: installing-openstack-installer-ovs-dpdk
   - Name: Installing a cluster on OpenStack on your own infrastructure
     File: installing-openstack-user

--- a/installing/installing_openstack/installing-openstack-installer-ovs-dpdk.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-ovs-dpdk.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="installing-openstack-installer-ovs-dpdk"]
-= Installing a cluster on OpenStack that supports DPDK-connected compute machines
+= Installing a cluster on OpenStack that supports OVS-DPDK-connected compute machines
 include::_attributes/common-attributes.adoc[]
 :context: installing-openstack-installer-ovs-dpdk
 


### PR DESCRIPTION
For context, resolves #43143. I do not believe that this change requires QE.

Preview: https://deploy-preview-43144--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-ovs-dpdk.html

