### PR TITLE
Update doc to reflect new coreos folder and jq syntax

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -72,21 +72,21 @@ The ID determines which image the installation program must download.
 +
 [source,terminal]
 ----
-$ export RHCOS_QEMU_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq .images.qemu.path | sed 's/"//g')
+$ export RHCOS_QEMU_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/coreos/rhcos.json  | jq '.architectures.x86_64.artifacts.qemu.formats["qcow2.gz"].disk.location' | sed 's/"//g' | sed 's:.*/::')
 ----
 
 . Get the path where the image is published:
 +
 [source,terminal]
 ----
-$ export RHCOS_PATH=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json | jq .baseURI | sed 's/"//g')
+$ export RHCOS_PATH=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/coreos/rhcos.json  | jq '.architectures.x86_64.artifacts.qemu.formats["qcow2.gz"].disk.location' | sed 's/"//g' | sed 's![^/]*$!!')
 ----
 
 . Get the SHA hash for the {op-system} image that will be deployed on the bootstrap VM:
 +
 [source,terminal]
 ----
-$ export RHCOS_QEMU_SHA_UNCOMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq -r '.images.qemu["uncompressed-sha256"]')
+$ export RHCOS_QEMU_SHA_UNCOMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/coreos/rhcos.json  | jq '.architectures.x86_64.artifacts.qemu.formats["qcow2.gz"].disk["uncompressed-sha256"]' | sed 's/"//g')
 ----
 
 . Download the image and place it in the `/home/kni/rhcos_image_cache` directory:

--- a/modules/ipi-install-retrieving-the-openshift-installer.adoc
+++ b/modules/ipi-install-retrieving-the-openshift-installer.adoc
@@ -11,6 +11,6 @@ available version of {product-title}:
 
 [source,terminal]
 ----
-$ export VERSION=latest-4.9
+$ export VERSION=latest-4.10
 export RELEASE_IMAGE=$(curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/release.txt | grep 'Pull From: quay.io' | awk -F ' ' '{print $3}')
 ----


### PR DESCRIPTION
The rhcos.json file moved to a new coreos directory and the formatting changed to reflect different architectures.