### PR TITLE
[enterprise-4.6] docs: correct spelling in multiple modules

### DIFF
--- a/modules/authentication-kubeadmin.adoc
+++ b/modules/authentication-kubeadmin.adoc
@@ -1,4 +1,4 @@
-// Module included in the following assmeblies:
+// Module included in the following assemblies:
 //
 // * authentication/removing-kubeadmin.adoc
 // * post_installation_configuration/preparing-for-users.adoc

--- a/modules/cnf-associating-secondary-interfaces-metrics-to-network-attachments.adoc
+++ b/modules/cnf-associating-secondary-interfaces-metrics-to-network-attachments.adoc
@@ -14,7 +14,7 @@ When adding secondary interfaces, their names depend on the order in which they 
 
 With `pod_network_name_info` it is possible to extend the current metrics with the additional information that identifies the interface type. In this way, it is possible to aggregate the metrics and to add specific alarms to specific interface types.
 
-The network type is generated using the name of the related `NetworkAttachementDefinition`, that in turn is used to differentiate different classes of secondary networks. For example, different interfaces belonging to different networks or using different CNIs use different network attachment definition names.
+The network type is generated using the name of the related `NetworkAttachmentDefinition`, that in turn is used to differentiate different classes of secondary networks. For example, different interfaces belonging to different networks or using different CNIs use different network attachment definition names.
 
 [id="cnf-associating-secondary-interfaces-metrics-to-network-attachments-network-metrics-daemon_{context}"]
 == Network Metrics Daemon

--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -27,7 +27,7 @@ Before you install an {product-title} cluster on your vCenter that uses infrastr
 
 To install an {product-title} cluster in a vCenter, the installation program requires access to an account with privileges to read and create the required resources. Using an account that has global administrative privileges is the simplest way to access all of the necessary permissions.
 
-If you cannot use an account with global adminstrative privileges, you must create roles to grant the privileges necessary for {product-title} cluster installation. While most of the privileges are always required, some are required only if you plan for the installation program to provision a folder to contain the {product-title} cluster on your vCenter instance, which is the default behavior. You must create or amend vSphere roles for the specified objects to grant the required privileges.
+If you cannot use an account with global administrative privileges, you must create roles to grant the privileges necessary for {product-title} cluster installation. While most of the privileges are always required, some are required only if you plan for the installation program to provision a folder to contain the {product-title} cluster on your vCenter instance, which is the default behavior. You must create or amend vSphere roles for the specified objects to grant the required privileges.
 
 An additional role is required if the installation program is to create a vSphere virtual machine folder.
 

--- a/modules/ldap-syncing-spec.adoc
+++ b/modules/ldap-syncing-spec.adoc
@@ -120,7 +120,7 @@ if not set.
 |string
 
 |`derefAliases`
-|The optional behavior of the search with regards to alisases. Can be `never`:
+|The optional behavior of the search with regards to aliases. Can be `never`:
 never dereference aliases, `search`: only dereference in searching, `base`:
 only dereference in finding the base object, `always`: always dereference.
 Defaults to `always` if not set.

--- a/modules/osdk-ansible-watches-file.adoc
+++ b/modules/osdk-ansible-watches-file.adoc
@@ -78,7 +78,7 @@ Some features can be overridden per resource using an annotation on that CR. The
 |Reconcile period
 |`reconcilePeriod`
 |Time between reconcile runs for a particular CR.
-|`ansbile.operator-sdk/reconcile-period`
+|`ansible.operator-sdk/reconcile-period`
 |`1m`
 
 |Manage status

--- a/modules/private-clusters-about-azure.adoc
+++ b/modules/private-clusters-about-azure.adoc
@@ -32,5 +32,5 @@ Is this also valid in Azure?
 
 The ability to add public functionality to a private cluster is limited.
 
-* You cannot make the Kubernetes API endpoints public after installation without taking additional actions, including creating public subnets in the VNet for each availablity zone in use, creating a public load balancer, and configuring the control plane security groups to allow traffic from Internet on 6443 (Kubernetes API port).
+* You cannot make the Kubernetes API endpoints public after installation without taking additional actions, including creating public subnets in the VNet for each availability zone in use, creating a public load balancer, and configuring the control plane security groups to allow traffic from the internet on 6443 (Kubernetes API port).
 ////

--- a/modules/private-clusters-about-gcp.adoc
+++ b/modules/private-clusters-about-gcp.adoc
@@ -36,5 +36,5 @@ Is this also valid in GCP?
 
 The ability to add public functionality to a private cluster is limited.
 
-* You cannot make the Kubernetes API endpoints public after installation without taking additional actions, including creating public subnets in the VPC for each availablity zone in use, creating a public load balancer, and configuring the control plane security groups to allow traffic from Internet on 6443 (Kubernetes API port).
+* You cannot make the Kubernetes API endpoints public after installation without taking additional actions, including creating public subnets in the VPC for each availability zone in use, creating a public load balancer, and configuring the control plane security groups to allow traffic from the internet on 6443 (Kubernetes API port).
 ////

--- a/modules/serverless-install-eventing-web-console.adoc
+++ b/modules/serverless-install-eventing-web-console.adoc
@@ -38,7 +38,7 @@ Optional. If you are configuring the `KnativeEventing` object by editing the YAM
 
 . Click *Create*.
 
-. After you have installed Knative Eventing, the `KnativeEventing` object is created, and you are automically directed to the *Knative Eventing* tab. You will see the `knative-eventing` custom resource in the list of resources.
+. After you have installed Knative Eventing, the `KnativeEventing` object is created, and you are automatically directed to the *Knative Eventing* tab. You will see the `knative-eventing` custom resource in the list of resources.
 
 .Verification
 

--- a/modules/serverless-install-serving-web-console.adoc
+++ b/modules/serverless-install-serving-web-console.adoc
@@ -39,7 +39,7 @@ After you complete the form, or have finished modifying the YAML, click *Create*
 For more information about configuration options for the KnativeServing custom resource definition, see the documentation on _Advanced installation configuration options_.
 ====
 
-. After you have installed Knative Serving, the `KnativeServing` object is created, and you are automically directed to the *Knative Serving* tab. You will see the `knative-serving` custom resource in the list of resources.
+. After you have installed Knative Serving, the `KnativeServing` object is created, and you are automatically directed to the *Knative Serving* tab. You will see the `knative-serving` custom resource in the list of resources.
 
 .Verification
 


### PR DESCRIPTION
Cherry picked from 666c6cc8471f87ee636c8af78f26478190f41d78 xref: https://github.com/openshift/openshift-docs/pull/42258