### PR TITLE
OSDOCS-2173: Added release notes for Intel E810 NICs for SRIOV

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -451,9 +451,9 @@ For more information, see xref:../networking/multiple_networks/configuring-multi
 [id="ocp-4-8-supported-hardware-sriov"]
 ==== Supported hardware for SR-IOV
 
-{product-title} {product-version} adds support for additional Intel and Mellanox hardware.
+{product-title} {product-version} adds support for additional Intel and Mellanox network interface controllers.
 
-* Intel X710 and XL710 controllers
+* Intel X710, XL710, and E810
 * Mellanox ConnectX-5 Ex
 
 For more information, see the xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[supported devices].


### PR DESCRIPTION
This PR, together with https://github.com/openshift/openshift-docs/pull/43206, is a rearrangement of two closed PRs: https://github.com/openshift/openshift-docs/pull/41333 and https://github.com/openshift/openshift-docs/pull/41332

All acks for this PR's content in https://github.com/openshift/openshift-docs/pull/41333

Applies only to `enterprise-4.8`

Preview: