### PR TITLE
Adds 4.10.4 release notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -124,7 +124,7 @@ The following limitations apply for IBM Cloud using IPI:
 * Deploying IBM Cloud using IPI on a previously existing network is not supported.
 * The Cloud Credential Operator (CCO) can use only Manual mode. Mint mode or STS are not supported.
 * IBM Cloud DNS Services is not supported. An instance of IBM Cloud Internet Services is required.
-* Private or disconnected deployments are not supported. 
+* Private or disconnected deployments are not supported.
 
 For more information, see xref:../installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc#preparing-to-install-on-ibm-cloud[Preparing to install on IBM Cloud].
 
@@ -2571,3 +2571,19 @@ Issued: 2022-03-10
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/6765671[{product-title} 4.10.3 container image list]
+
+[id="ocp-4-10-4"]
+=== RHBA-2022:0811 - {product-title} 4.10.4 bug fix and security update
+
+Issued: 2022-03-15
+
+{product-title} release 4.10.4, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0811[RHBA-2022:0811] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0810[RHSA-2022:0810] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6815061[{product-title} 4.10.4 container image list]
+
+[id="ocp-4-10-4-updating"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ

To be merged on 03-15

OCP version: **Applicable only to 4.10**

Direct Doc Preview Link: https://deploy-preview-43242--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-4