### PR TITLE
TELCODOCS:523 - Addition of RHSA advisory for OSC release 1.2.0 to OS…

### DIFF
--- a/sandboxed_containers/sandboxed-containers-release-notes.adoc
+++ b/sandboxed_containers/sandboxed-containers-release-notes.adoc
@@ -35,8 +35,7 @@ Administrators can now collect enhanced logs for {sandboxed-containers-first} ru
 
 Administrators can now check the eligibility of cluster nodes to run {sandboxed-containers-first}. This feature uses the Node Feature Discovery (NFD) Operator to detect  node capabilities. Eligible nodes are labeled with `feature.node.kubernetes.io/runtime.kata`, and the {sandboxed-containers-operator} uses this label to select candidate nodes for installation.
 
-The administrator must deploy the NFD Operator to use this feature, create a specific `NodeFeatureDiscovery` custom resource, and enable `checkNodeEligibility` when creating the `KataConfig` custom resource.
-//For more information, see xref:../sandboxed_containers/deploying-sandboxed-container-workloads.adoc#sandboxed-containers-check-nodes_deploying-sandboxed-containers[Checking the eligibility of cluster nodes to run {sandboxed-containers-first}].
+The administrator must deploy the NFD Operator to use this feature, create a specific `NodeFeatureDiscovery` custom resource, and enable `checkNodeEligibility` when creating the `KataConfig` custom resource. For more information, see xref:../sandboxed_containers/deploying-sandboxed-container-workloads.adoc#sandboxed-containers-check-node-eligiblilty_deploying-sandboxed-containers[Checking the eligibility of cluster nodes to run {sandboxed-containers-first}].
 
 [id="OSC-compatibility-with-CNV"]
 === {sandboxed-containers-first} compatibility with {VirtProductName}
@@ -93,7 +92,7 @@ $ oc scale deployments/machine-config-operator -n openshift-machine-config-opera
 $ oc scale deployments/machine-config-operator -n openshift-machine-config-operator --replicas=1
 ----
 
-. Revert the 'seLinuxOptions' strategy of the `sandboxed-containers-operator-scc` to its original value of 'MustRunAs' by running the following command:
+. Revert the `seLinuxOptions` strategy of the `sandboxed-containers-operator-scc` to its original value of `MustRunAs` by running the following command:
 +
 [source,terminal]
 ----
@@ -110,7 +109,7 @@ openshift.io/scc: hostmount-anyuid
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057545[*BZ#2057545*])
 
-* The {sandboxed-containers-operator} pods that use container CPU resource limits to increase the number of available CPUs for the pod might receive fewer CPUs than requested. If the functionality is available inside the container, you can diagnose CPU resources by using `oc rsh <pod>` and running running the `lscpu` command.
+* The {sandboxed-containers-operator} pods that use container CPU resource limits to increase the number of available CPUs for the pod might receive fewer CPUs than requested. If the functionality is available inside the container, you can diagnose CPU resources by using `oc rsh <pod>` and running the `lscpu` command.
 +
 [source,terminal]
 ----
@@ -163,11 +162,11 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 
 This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {sandboxed-containers-first} {sandboxed-containers-version}.
 
-//[id="sandboxed-containers-1-2-0"]
-//=== RHSA-2022:87419-07 - {sandboxed-containers-first} {sandboxed-containers-version}.0 image release, security update, bug fix,and enhancement advisory
+[id="sandboxed-containers-1-2-0"]
+=== RHSA-2022:0855 - {sandboxed-containers-first} {sandboxed-containers-version}.0 image release, security update, bug fix, and enhancement advisory.
 
-//Issued: 2022-03-14
+Issued: 2022-03-14
 
-//{sandboxed-containers-first} release {sandboxed-containers-version}.0 is now available. This advisory contains an update for {sandboxed-containers-first} with security fixes, enhancements, and bug fixes.
+{sandboxed-containers-first} release {sandboxed-containers-version}.0 is now available. This advisory contains an update for {sandboxed-containers-first} with enhancements, security updates, and bug fixes.
 
-//The list of bug fixes included in the update is documented in the link:https://access.redhat.com/errata/?????[RHSA-2022:87419-07] advisory.
+The list of bug fixes included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:0855[RHSA-2022:0855] advisory.


### PR DESCRIPTION
Addition of RHSA advisory for OSC 1.2.0 to OSC release notes.

This PR also includes an added x-ref in the RN to a recently merged PR, as well as 2 edits for small non-blocker comments from a previous PR made by @bobfuru: https://github.com/openshift/openshift-docs/pull/42866#pullrequestreview-908158966

Content is reviewed and approved.

Preview link: https://deploy-preview-43247--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/sandboxed-containers-release-notes.html#sandboxed-containers-1-2-0