### PR TITLE
[enterprise-4.6] SRVCOM-1729: Fix formatting of additional resources for Jupiter

### DIFF
--- a/serverless/admin_guide/knative-serving-CR-config.adoc
+++ b/serverless/admin_guide/knative-serving-CR-config.adoc
@@ -22,5 +22,4 @@ include::modules/serverless-kourier-gateway-service-type.adoc[leveloffset=+1]
 [id="additional-resources_knative-serving-CR-config"]
 [role="_additional-resources"]
 == Additional resources
-
-* See xref:../../operators/understanding/crds/crd-managing-resources-from-crds.adoc[Managing resources from custom resource definitions].
+* xref:../../operators/understanding/crds/crd-managing-resources-from-crds.adoc[Managing resources from custom resource definitions]

--- a/serverless/admin_guide/serverless-kafka-admin.adoc
+++ b/serverless/admin_guide/serverless-kafka-admin.adoc
@@ -36,5 +36,4 @@ include::modules/serverless-kafka-broker-sasl-default-config.adoc[leveloffset=+2
 [id="additional-resources_serverless-kafka-admin"]
 [role="_additional-resources"]
 == Additional resources
-
-* See the link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red Hat AMQ Streams] documentation for more information about Kafka concepts.
+* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red Hat AMQ Streams documentation]

--- a/serverless/develop/serverless-applications.adoc
+++ b/serverless/develop/serverless-applications.adoc
@@ -62,11 +62,6 @@ include::modules/interacting-serverless-apps-http2-gRPC.adoc[leveloffset=+1]
 // Using Knative services w/ restrictive NetworkPolicies
 include::modules/serverless-services-network-policies.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../../serverless/security/serverless-ossm-with-kourier-jwt.adoc#serverless-ossm-with-kourier-jwt[Configuring JSON Web Token authentication for Knative services].
-
 // HTTPS redirection
 include::modules/serverless-https-redirect-service.adoc[leveloffset=+1]
 
@@ -78,3 +73,8 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 include::modules/kn-service-offline-about.adoc[leveloffset=+2]
 include::modules/kn-service-offline-create.adoc[leveloffset=+2]
+
+[id="additional-resources_serverless-applications"]
+[role="_additional-resources"]
+== Additional resources
+* xref:../../serverless/security/serverless-ossm-with-kourier-jwt.adoc#serverless-ossm-with-kourier-jwt[Configuring JSON Web Token authentication for Knative services]

--- a/serverless/develop/serverless-autoscaling-developer.adoc
+++ b/serverless/develop/serverless-autoscaling-developer.adoc
@@ -44,5 +44,4 @@ include::modules/serverless-target-utilization.adoc[leveloffset=+2]
 [id="additional-resources_serverless-autoscaling-developer"]
 [role="_additional-resources"]
 == Additional resources
-
-* Scale-to-zero can be enabled or disabled for the cluster by cluster administrators. For more information, see xref:../../serverless/admin_guide/serverless-admin-autoscaling.adoc#serverless-enable-scale-to-zero_serverless-admin-autoscaling[Enabling scale-to-zero].
+* xref:../../serverless/admin_guide/serverless-admin-autoscaling.adoc#serverless-enable-scale-to-zero_serverless-admin-autoscaling[Enabling scale-to-zero]

--- a/serverless/develop/serverless-configuring-routes.adoc
+++ b/serverless/develop/serverless-configuring-routes.adoc
@@ -17,8 +17,7 @@ include::modules/serverless-customize-labels-annotations-routes.adoc[leveloffset
 include::modules/serverless-openshift-routes.adoc[leveloffset=+1]
 include::modules/knative-service-cluster-local.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
 [id="additional-resources_serverless-configuring-routes"]
+[role="_additional-resources"]
 == Additional resources
-
-* For more information about supported {product-title} route annotations, see xref:../..//networking/routes/route-configuration.adoc#nw-route-specific-annotations_route-configuration[Route-specific annotations].
+* xref:../..//networking/routes/route-configuration.adoc#nw-route-specific-annotations_route-configuration[Route-specific annotations]

--- a/serverless/develop/serverless-kafka-developer.adoc
+++ b/serverless/develop/serverless-kafka-developer.adoc
@@ -56,8 +56,7 @@ include::modules/serverless-create-kafka-channel-yaml.adoc[leveloffset=+1]
 [id="additional-resources_serverless-kafka-developer"]
 [role="_additional-resources"]
 == Additional resources
-
-* See the link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red Hat AMQ Streams] documentation for more information about Kafka concepts.
-* See the Red Hat AMQ Streams link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka] documentation.
-* See the xref:../../serverless/develop/serverless-event-delivery.adoc#serverless-event-delivery[Event delivery] documentation for information about configuring event delivery parameters.
-* See the xref:../../serverless/admin_guide/serverless-kafka-admin.adoc#serverless-kafka-admin[Knative Kafka cluster administrator documentation] for information about installing Kafka components and setting default configurations if you have cluster administrator permissions.
+* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red Hat AMQ Streams documentation]
+* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[Red Hat AMQ Streams TLS and SASL on Kafka documentation]
+* xref:../../serverless/develop/serverless-event-delivery.adoc#serverless-event-delivery[Event delivery]
+* xref:../../serverless/admin_guide/serverless-kafka-admin.adoc#serverless-kafka-admin[Knative Kafka cluster administrator documentation]

--- a/serverless/develop/serverless-using-brokers.adoc
+++ b/serverless/develop/serverless-using-brokers.adoc
@@ -18,13 +18,6 @@ include::modules/serverless-broker-types.adoc[leveloffset=+1]
 :FeatureName: Kafka broker
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
-
-* See the xref:../../serverless/develop/serverless-event-delivery.adoc#serverless-event-delivery[Event delivery] documentation for more information about delivery guarantees.
-
-* See the xref:../../serverless/develop/serverless-kafka-developer.adoc#serverless-kafka-developer-broker[Kafka broker] documentation for information about using Kafka brokers.
-
 [id="serverless-using-brokers-creating-brokers"]
 == Creating a broker that uses default settings
 
@@ -42,3 +35,9 @@ The `kn` CLI provides commands that can be used to list, describe, update, and d
 
 include::modules/serverless-list-broker-kn.adoc[leveloffset=+2]
 include::modules/serverless-describe-broker-kn.adoc[leveloffset=+2]
+
+[id="additional-resources_serverless-using-brokers"]
+[role="_additional-resources"]
+== Additional resources
+* xref:../../serverless/develop/serverless-event-delivery.adoc#serverless-event-delivery[Event delivery]
+* xref:../../serverless/develop/serverless-kafka-developer.adoc#serverless-kafka-developer-broker[Kafka broker]

--- a/serverless/functions/serverless-functions-getting-started.adoc
+++ b/serverless/functions/serverless-functions-getting-started.adoc
@@ -24,7 +24,7 @@ include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-kn-func-emit.adoc[leveloffset=+1]
 include::modules/serverless-functions-using-integrated-registry.adoc[leveloffset=+1]
 
+[id="additional-resources_serverless-functions-getting-started"]
 [role="_additional-resources"]
 == Additional resources
-
-* See xref:../../registry/securing-exposing-registry.adoc#securing-exposing-registry[Exposing a default registry manually].
+* xref:../../registry/securing-exposing-registry.adoc#securing-exposing-registry[Exposing a default registry manually]

--- a/serverless/functions/serverless-functions-yaml.adoc
+++ b/serverless/functions/serverless-functions-yaml.adoc
@@ -12,10 +12,11 @@ The `func.yaml` file contains the configuration for your function project. These
 include::modules/serverless-functions-func-yaml-fields.adoc[leveloffset=+1]
 include::modules/serverless-functions-func-yaml-environment-variables.adoc[leveloffset=+1]
 
+[id="additional-resources_serverless-functions-project-configuration"]
 [role="_additional-resources"]
-.Additional resources
-
-* For information on overriding values in the `func.yaml` file, see xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-functions-getting-started[Getting started with functions].
-* For more information on accessing data in secrets and config maps, see xref:../../serverless/functions/serverless-functions-accessing-secrets-configmaps.adoc#serverless-functions-accessing-secrets-configmaps[Accessing secrets and config maps from Serverless functions].
-* For more information on the `scale` set of options, see the link:https://knative.dev/docs/serving/autoscaling/[Knative documentation on Autoscaling].
-* For more information on the `resources` set of options, see the link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes documentation on managing resources for containers] and the link:https://knative.dev/docs/serving/autoscaling/concurrency/[Knative documentation on configuring concurrency].
+== Additional resources
+* xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-functions-getting-started[Getting started with functions]
+* xref:../../serverless/functions/serverless-functions-accessing-secrets-configmaps.adoc#serverless-functions-accessing-secrets-configmaps[Accessing secrets and config maps from Serverless functions]
+* link:https://knative.dev/docs/serving/autoscaling/[Knative documentation on Autoscaling]
+* link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes documentation on managing resources for containers]
+* link:https://knative.dev/docs/serving/autoscaling/concurrency/[Knative documentation on configuring concurrency]

--- a/serverless/install/install-serverless-operator.adoc
+++ b/serverless/install/install-serverless-operator.adoc
@@ -30,10 +30,8 @@ include::modules/serverless-install-web-console.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_install-serverless-operator"]
 == Additional resources
-
-* For more information about using {ServerlessProductName} on a restricted network environment, see xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
-
-* HA is enabled for some Knative components by default. You can configure HA by following the documentation on xref:../../serverless/admin_guide/serverless-ha.adoc#serverless-ha[Configuring high availability replicas on {ServerlessProductName}].
+* xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+* xref:../../serverless/admin_guide/serverless-ha.adoc#serverless-ha[Configuring high availability replicas on {ServerlessProductName}]
 
 [id="next-steps_install-serverless-operator"]
 == Next steps

--- a/serverless/integrations/gpu-resources.adoc
+++ b/serverless/integrations/gpu-resources.adoc
@@ -15,5 +15,4 @@ include::modules/serverless-gpu-resources-kn.adoc[leveloffset=+1]
 [id="additional-requirements_gpu-resources"]
 [role="_additional-resources"]
 == Additional resources
-
-* For more information about limits, see xref:../../applications/quotas/quotas-setting-per-project.adoc[Setting resource quotas for extended resources].
+* xref:../../applications/quotas/quotas-setting-per-project.adoc[Setting resource quotas for extended resources]

--- a/serverless/monitor/serverless-autoscaling-dashboard.adoc
+++ b/serverless/monitor/serverless-autoscaling-dashboard.adoc
@@ -23,17 +23,7 @@ The dashboard demonstrations in this section use an {product-title} cluster with
 
 The sample application has a concurrency limit of 5 requests. When the limit is exceeded, autoscaling requests additional pods for Knative from Kubernetes.
 
-[role="_additional-resources"]
-.Additional resources
-
-* See link:https://knative.dev/docs/serving/autoscaling/autoscale-go/[detailed information about autoscale-go].
-
 include::modules/serverless-autoscaling-dashboard-navigating.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../../serverless/admin_guide/serverless-admin-metrics.adoc#serverless-admin-metrics[detailed information about metrics].
 
 include::modules/serverless-autoscaling-dashboard-pod-information.adoc[leveloffset=+1]
 
@@ -43,16 +33,14 @@ include::modules/serverless-autoscaling-dashboard-scrape-time.adoc[leveloffset=+
 
 include::modules/serverless-autoscaling-dashboard-panic-mode.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-
-* See an link:https://knative.dev/docs/serving/autoscaling/kpa-specific/#modes[overview of Knative Pod Autoscaling modes].
-
 include::modules/serverless-autoscaling-dashboard-activator-metrics.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../../serverless/admin_guide/serverless-admin-metrics.adoc#serverless-activator-metrics_serverless-admin-metrics[detailed information about activator metrics].
-
 include::modules/serverless-autoscaling-dashboard-observed-rps.adoc[leveloffset=+1]
+
+[id="additional-resources_serverless-autoscaling-dashboard"]
+[role="_additional-resources"]
+== Additional resources
+* link:https://knative.dev/docs/serving/autoscaling/autoscale-go/[Detailed information about autoscale-go]
+* xref:../../serverless/admin_guide/serverless-admin-metrics.adoc#serverless-admin-metrics[Detailed information about metrics]
+* link:https://knative.dev/docs/serving/autoscaling/kpa-specific/#modes[Overview of Knative Pod Autoscaling modes]
+* xref:../../serverless/admin_guide/serverless-admin-metrics.adoc#serverless-activator-metrics_serverless-admin-metrics[detailed information about activator metrics]

--- a/serverless/monitor/serverless-service-monitoring.adoc
+++ b/serverless/monitor/serverless-service-monitoring.adoc
@@ -32,11 +32,7 @@ include::modules/serverless-monitoring-services-examining-metrics-dashboard.adoc
 [role="_additional-resources"]
 [id="additional-resources_serverless-service-monitoring"]
 == Additional resources
-
-* For more information on {product-title} monitoring stack, see xref:../../monitoring/monitoring-overview.adoc#monitoring-overview[Monitoring overview].
-
-* For information on monitoring the components of Serverless itself, as opposed to Knative services, see xref:../../serverless/admin_guide/serverless-admin-monitoring.adoc#serverless-admin-monitoring[Monitoring serverless components].
-
+* xref:../../monitoring/monitoring-overview.adoc#monitoring-overview[Monitoring overview]
+* xref:../../serverless/admin_guide/serverless-admin-monitoring.adoc#serverless-admin-monitoring[Monitoring serverless components]
 * xref:../../monitoring/managing-metrics.adoc#specifying-how-a-service-is-monitored[Enabling monitoring for user-defined projects]
-
 * xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Specifying how a service is monitored]

--- a/serverless/security/serverless-kafka-security.adoc
+++ b/serverless/security/serverless-kafka-security.adoc
@@ -21,5 +21,4 @@ include::modules/serverless-kafka-sasl-public-certs.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_serverless-kafka-security"]
 == Additional resources
-
 * link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka]


### PR DESCRIPTION
Cherry picked from https://github.com/openshift/openshift-docs/pull/43271/commits/fc365569a16418dbadb9d9c18aa64d87cbdcdc3a xref: https://github.com/openshift/openshift-docs/pull/43271

NOTE: based on https://github.com/openshift/openshift-docs/pull/43208, but #43208 has differences from 4.8 and older versions