### PR TITLE
CNV-13856: Adding SVVP certification to 4.10 RN

### DIFF
--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -37,7 +37,7 @@ Red Hat is committed to replacing problematic language in our code, documentatio
 +
 The SVVP Certification applies to:
 +
-** Red Hat Enterprise Linux CoreOS workers. In the Microsoft SVVP Catalog, they are named __Red Hat OpenShift Container Platform 4 on RHEL CoreOS__.
+** Red Hat Enterprise Linux CoreOS workers. In the Microsoft SVVP Catalog, they are named __Red Hat OpenShift Container Platform 4 on RHEL CoreOS 8__.
 ** Intel and AMD CPUs.
 
 //CNV-14881 Service Mesh for VMs on the primary network with IPv4 (Done in CNV-8577 for 4.9 then reverted in CNV-14481)


### PR DESCRIPTION
For 4.10 only.

Jira: https://issues.redhat.com/browse/CNV-13856

Adding "8" per QE Review for the SVVP blurb for 4.10 RN.

Only need peer review and merge.

Direct doc preview link:https://deploy-preview-43274--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-10-release-notes.html'