### PR TITLE
OSDOCS-3378: Post-4.10 GA RN fixes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -124,7 +124,7 @@ The following limitations apply for IBM Cloud using IPI:
 * Deploying IBM Cloud using IPI on a previously existing network is not supported.
 * The Cloud Credential Operator (CCO) can use only Manual mode. Mint mode or STS are not supported.
 * IBM Cloud DNS Services is not supported. An instance of IBM Cloud Internet Services is required.
-* Private or disconnected deployments are not supported. 
+* Private or disconnected deployments are not supported.
 
 For more information, see xref:../installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc#preparing-to-install-on-ibm-cloud[Preparing to install on IBM Cloud].
 
@@ -879,17 +879,8 @@ The `SharedSecret` objects and OpenShift Shared Resources feature are only avail
 
 * With this update, you can run Jenkins agents as sidecar containers. You can use this capability to run any container image in a Jenkins pipeline that has a correctly configured pod template and Jenkins file. Now, to compile code, you can run two new pod templates named `java-build` and `nodejs-builder` as sidecar containers with Jenkins. These two pod templates use the latest Java and NodeJS versions provided by the `java` and `nodejs` image streams in the `openshift` namespace. The previous non-sidecar `maven` and `nodejs` pod templates have been deprecated. (link:https://issues.redhat.com/browse/JKNS-132[JKNS-132])
 
-[id="ocp-4-10-machine-config-operator"]
-=== Machine Config Operator
-
-[id="ocp-4-10-mco-config-drift"]
-==== Enhanced configuration drift detection
-
-With this enhancement, the Machine Config Daemon (MCD) now checks nodes for configuration drift if a filesystem write event occurs for any of the files specified in the machine config and before a new machine config is applied, in addition to node bootup. Previously, the MCD checked for configuration drift only at node bootup. This change was made because node reboots do not occur frequently enough to avoid the problems caused by configuration drift until an administrator can correct the issue.
-
-Configuration drift occurs when the on-disk state of a node differs from what is configured in the machine config. The Machine Config Operator (MCO) uses the MCD to check nodes for configuration drift and, if detected, sets that node and machine config pool (MCP) to `degraded`.
-
-For more information about configuration drift, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-drift-detection_post-install-machine-configuration-tasks[Understanding configuration drift detection].
+[id="ocp-4-10-machine-api"]
+=== Machine API
 
 [id="ocp-4-10-machine-mgmt-azure-ephemeral-os"]
 ==== Azure Ephemeral OS disk support
@@ -923,6 +914,18 @@ For more information, see xref:../machine_management/creating_machinesets/creati
 With this enhancement, you can specify a node utilization threshold in the `ClusterAutoscaler` resource definition. This threshold represents the node utilization level below which an unnecessary node is eligible for deletion.
 
 For more information, see xref:../machine_management/applying-autoscaling.adoc#cluster-autoscaler-about_applying-autoscaling[About the cluster autoscaler].
+
+[id="ocp-4-10-machine-config-operator"]
+=== Machine Config Operator
+
+[id="ocp-4-10-mco-config-drift"]
+==== Enhanced configuration drift detection
+
+With this enhancement, the Machine Config Daemon (MCD) now checks nodes for configuration drift if a filesystem write event occurs for any of the files specified in the machine config and before a new machine config is applied, in addition to node bootup. Previously, the MCD checked for configuration drift only at node bootup. This change was made because node reboots do not occur frequently enough to avoid the problems caused by configuration drift until an administrator can correct the issue.
+
+Configuration drift occurs when the on-disk state of a node differs from what is configured in the machine config. The Machine Config Operator (MCO) uses the MCD to check nodes for configuration drift and, if detected, sets that node and machine config pool (MCP) to `degraded`.
+
+For more information about configuration drift, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-drift-detection_post-install-machine-configuration-tasks[Understanding configuration drift detection].
 
 [id="ocp-4-10-nodes"]
 === Nodes
@@ -1245,9 +1248,7 @@ Because it uses Kubernetes 1.23, {product-title} 4.10 does not allow this under 
 [id="ocp-4-10-cluster-cloud-controller-manager-operator"]
 ==== Cloud controller managers for additional cloud providers
 
-The Kubernetes community plans to deprecate the Kubernetes controller manager in favor of using cloud controller managers to interact with underlying cloud platforms. As a result, there is no plan to add Kubernetes controller manager support for any new cloud platforms. The IBM Cloud implementation that is added in this release of {product-title} uses cloud controller managers.
-
-In addition, this release supports using cloud controller managers for Google Cloud Platform (GCP), VMware vSphere, and Alibaba Cloud as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview].
+The Kubernetes community plans to deprecate the Kubernetes controller manager in favor of using cloud controller managers to interact with underlying cloud platforms. As a result, there is no plan to add Kubernetes controller manager support for any new cloud platforms. The  implementation that is added in this release of {product-title} supports using cloud controller managers for Google Cloud Platform (GCP), VMware vSphere, IBM Cloud, and Alibaba Cloud as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview].
 
 To learn more about the cloud controller manager, see the link:https://kubernetes.io/docs/concepts/architecture/cloud-controller/[Kubernetes Cloud Controller Manager documentation].
 
@@ -1503,6 +1504,8 @@ Instead, you can navigate to the *Observe* section of the {product-title} web co
 Support for using the Cloud Credential Operator (CCO) in mint mode on Microsoft Azure clusters has been removed. This change is due to the planned link:https://azure.microsoft.com/en-us/updates/update-your-apps-to-use-microsoft-graph-before-30-june-2022/[retirement of the Azure AD Graph API by Microsoft on 30 June 2022] and is being backported to all supported versions of {product-title} in z-stream updates.
 
 For previously installed Azure clusters that use mint mode, the CCO attempts to update existing secrets. If a secret contains the credentials of previously minted app registration service principals, it is updated with the contents of the secret in `kube-system/azure-credentials`. This behavior is similar to passthrough mode.
+
+For clusters with the credentials mode set to its default value of `""`, the updated CCO automatically changes from operating in mint mode to operating in passthrough mode. If your cluster has the credentials mode explicitly set to mint mode (`"Mint"`), you must change the value to `""` or `"Passthrough"`.
 
 [NOTE]
 ====
@@ -2309,7 +2312,7 @@ In the table below, features are marked with the following statuses:
 |Cloud controller manager for IBM Cloud
 |-
 |-
-|GA
+|TP
 
 |Cloud controller manager for Microsoft Azure
 |-


### PR DESCRIPTION
For [OSDOCS-3378](https://issues.redhat.com/browse/OSDOCS-3378)

Previews:
- Restored [Machine API](https://deploy-preview-43277--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-machine-api) header, moved MCO to its own section following
- Tweaked [CCMs text](https://deploy-preview-43277--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-cluster-cloud-controller-manager-operator), updated [table](https://deploy-preview-43277--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-technology-preview) to reflect TP status
- Additional detail for [Azure mint mode deprecation](https://deploy-preview-43277--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-removed-feature-azure-mint-mode) (Followup on #42692)
