### PR TITLE
OSDOCS-3378: Post-4.10 GA CCM fixes

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -10,9 +10,9 @@
 
 [NOTE]
 ====
-This Operator is only fully supported for Microsoft Azure Stack Hub and IBM Cloud.
+This Operator is only fully supported for Microsoft Azure Stack Hub.
 
-It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, {rh-openstack-first}, and VMware vSphere.
+It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), IBM Cloud, Microsoft Azure, {rh-openstack-first}, and VMware vSphere.
 ====
 
 The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).

--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -23,9 +23,13 @@ The following Technology Preview features are enabled by this feature set:
 *** Google Cloud Platform Persistent Disk (CSI)
 *** VMware vSphere
 ** Cluster Cloud Controller Manager Operator. Enables the Cluster Cloud Controller Manager Operator rather than the in-tree cloud controller. Available as a Technology Preview for:
+*** Alibaba Cloud
 *** Amazon Web Services (AWS)
+*** Google Cloud Platform (GCP)
+*** IBM Cloud
 *** Microsoft Azure
-*** Red Hat OpenStack Platform (RHOSP)
+*** {rh-openstack-first}
+*** VMware vSphere
 ** Shared resource CSI driver
 ** CSI volume support for the {product-title} build system
 ** Swap memory on nodes


### PR DESCRIPTION
For [OSDOCS-3378](https://issues.redhat.com/browse/OSDOCS-3378)

Changes mostly related to the late change of IBM Cloud to TP in 4.10. Also updated feature gate list to match.

Previews:
- [Cluster Cloud Controller Manager Operator](https://deploy-preview-43278--osdocs.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-cloud-controller-manager-operator_platform-operators-ref)
- [Understanding feature gates](https://deploy-preview-43278--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)