### PR TITLE
Updated IBM Cloud release note to include Technology Preview

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -117,14 +117,14 @@ The following Operators are supported for {product-title} on ARM:
 [id="ocp-4-10-ibm-cloud-installation"]
 ==== Installing a cluster on IBM Cloud using installer-provisioned infrastructure (Technology Preview)
 
-{product-title} 4.10 introduces support for installing a cluster on IBM Cloud using installer-provisioned infrastructure (IPI).
+{product-title} 4.10 introduces support for installing a cluster on IBM Cloud using installer-provisioned infrastructure in Technology Preview.
 
 The following limitations apply for IBM Cloud using IPI:
 
 * Deploying IBM Cloud using IPI on a previously existing network is not supported.
 * The Cloud Credential Operator (CCO) can use only Manual mode. Mint mode or STS are not supported.
 * IBM Cloud DNS Services is not supported. An instance of IBM Cloud Internet Services is required.
-* Private or disconnected deployments are not supported. 
+* Private or disconnected deployments are not supported.
 
 For more information, see xref:../installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc#preparing-to-install-on-ibm-cloud[Preparing to install on IBM Cloud].
 


### PR DESCRIPTION
CP to 4.10

While the heading of this release note included `(Technology Preview)`, the text did not.

- Updated the release note text to include `in Technology Preview`.
- Removed reference to IPI, as this acronym is used internally only.

Preview
[Installing a cluster on IBM Cloud using installer-provisioned infrastructure (Technology Preview)](https://deploy-preview-43281--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-ibm-cloud-installation)

No QE ack is required.