### PR TITLE
[enterprise-4.8] Bug 2061244: Release notes: Universal toleration for DNS pods

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -568,6 +568,11 @@ $ oc -n openshift-ingress-operator patch ingresscontroller/default --type=merge 
 
 In {product-title} 4.8, you can use a custom node selector and tolerations to configure the daemon set for CoreDNS to run or not run on certain nodes.
 
+[IMPORTANT]
+====
+Previous versions of {product-title} configured the CoreDNS daemon set with a toleration for all taints so that DNS pods ran on all nodes in the cluster, irrespective of xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[node taints].  {product-title} 4.8 no longer configures this toleration for all taints by default.  Instead, the default is to tolerate only the `node-role.kubernetes.io/master` taint.  To make DNS pods run on nodes with other taints, you must configure custom tolerations.
+====
+
 For more information, see xref:../networking/dns-operator.adoc#nw-controlling-dns-pod-placement_dns-operator[Controlling DNS pod placement].
 
 [id="ocp-4-8-networking-openstack-provider-networks"]


### PR DESCRIPTION
* `release_notes/ocp-4-8-release-notes.adoc`: Add an important note that the default universal toleration for DNS pods has been removed.