### PR TITLE
Adds notes for 4.9.24 which includes feature removal

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1121,6 +1121,11 @@ In the table, features are marked with the following statuses:
 |DEP
 |DEP
 
+|Minting credentials for Microsoft Azure clusters
+|GA
+|GA
+|xref:../release_notes/ocp-4-9-release-notes.adoc#ocp-4-9-24-removed-feature-azure-mint-mode[REM]
+
 |====
 
 [id="ocp-4-9-deprecated-features"]
@@ -1279,6 +1284,54 @@ Therefore, update scripts and jobs that inspect `buildConfig.spec.triggers[i].im
 ==== Use of v1 without a group for apiVersion for {product-title} resources
 
 Support for using `v1` without a group for `apiVersion` for {product-title} resources has been removed. Every resource that includes `*.openshift.io` must match the `apiVersion` value found in the xref:../rest_api/index.adoc#index[API index].
+
+[id="ocp-4-9-removed-feature-azure-mint-mode"]
+==== Support for minting credentials for Microsoft Azure removed
+
+Starting with {product-title} 4.9.24, support for using the Cloud Credential Operator (CCO) in mint mode on Microsoft Azure clusters has been removed from {product-title} 4.9. This change is due to the planned link:https://azure.microsoft.com/en-us/updates/update-your-apps-to-use-microsoft-graph-before-30-june-2022/[retirement of the Azure AD Graph API by Microsoft on 30 June 2022] and is being backported to all supported versions of {product-title} in z-stream updates.
+
+For previously installed Azure clusters that use mint mode, the CCO attempts to update existing secrets. If a secret contains the credentials of previously minted app registration service principals, it is updated with the contents of the secret in `kube-system/azure-credentials`. This behavior is similar to passthrough mode.
+
+For clusters with the credentials mode set to its default value of `""`, the updated CCO automatically changes from operating in mint mode to operating in passthrough mode. If your cluster has the credentials mode explicitly set to mint mode (`"Mint"`), you must change the value to `""` or `"Passthrough"`.
+
+[NOTE]
+====
+In addition to the `Contributor` role that is required by mint mode, the modified app registration service principals now require the `User Access Administrator` role that is used for passthrough mode.
+====
+
+While the Azure AD Graph API is still available, the CCO in upgraded versions of {product-title} attempts to clean up previously minted app registration service principals. Upgrading your cluster before the Azure AD Graph API is retired might avoid the need to clean up resources manually.
+
+If the cluster is upgraded to a version of {product-title} that no longer supports mint mode after the Azure AD Graph API is retired, the CCO sets an `OrphanedCloudResource` condition on the associated `CredentialsRequest` but does not treat the error as fatal. The condition includes a message similar to `unable to clean up App Registration / Service Principal: <app_registration_name>`. Cleanup after the Azure AD Graph API is retired requires manual intervention using the Azure CLI tool or the Azure web console to remove any remaining app registration service principals.
+
+To clean up resources manually, you must find and delete the affected resources.
+
+. Using the Azure CLI tool, filter the app registration service principals that use the `<app_registration_name>` from an `OrphanedCloudResource` condition message by running the following command:
++
+[source,terminal]
+----
+$ az ad app list --filter "displayname eq '<app_registration_name>'" --query '[].objectId'
+----
++
+.Example output
++
+[source,terminal]
+----
+[
+  "038c2538-7c40-49f5-abe5-f59c59c29244"
+]
+----
+
+. Delete the app registration service principal by running the following command:
++
+[source,terminal]
+----
+$ az ad app delete --id 038c2538-7c40-49f5-abe5-f59c59c29244
+----
+
+[NOTE]
+====
+After cleaning up resources manually, the `OrphanedCloudResource` condition persists because the CCO cannot verify that the resources were cleaned up.
+====
 
 [id="ocp-4-9-bug-fixes"]
 == Bug fixes
@@ -2578,6 +2631,39 @@ link:https://access.redhat.com/solutions/6762051[{product-title} 4.9.23 containe
 * Previously, installation failed when installing to a region that had local zone enabled. With this update, the installation program considers only availability zones and not local zones. Now, installation with local zones enabled will only install to the availability zones in that region and not to any local zones. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2052307[BZ#*2052307*])
 
 [id="ocp-4-9-23-updating"]
+==== Updating
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-9-24"]
+=== RHBA-2022:0798 - {product-title} 4.9.24 bug fix update
+
+Issued: 2022-03-16
+
+{product-title} release 4.9.24 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0798[RHBA-2022:0798] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0794[RHBA-2022:0794] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6818041[{product-title} 4.9.24 container image list]
+
+[id="ocp-4-9-24-features"]
+==== Features
+
+This update contains changes from Kubernetes 1.22.5. More information can be found in the following changelog: link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#changelog-since-v1225[1.22.3].
+
+[id="ocp-4-9-24-removed-feature-azure-mint-mode"]
+==== Removed features
+
+Starting with {product-title} 4.9.24, support for using the Cloud Credential Operator (CCO) in mint mode on Microsoft Azure clusters has been removed from {product-title} 4.9. This change is due to the planned link:https://azure.microsoft.com/en-us/updates/update-your-apps-to-use-microsoft-graph-before-30-june-2022/[retirement of the Azure AD Graph API by Microsoft on 30 June 2022] and is being backported to all supported versions of {product-title} in z-stream updates. For more information, see xref:../release_notes/ocp-4-9-release-notes.adoc#ocp-4-9-removed-feature-azure-mint-mode[Support for minting credentials for Microsoft Azure removed].
+
+[id="ocp-4-9-24-bug-fixes"]
+==== Bug fixes
+
+* Previously, the console failed to upload an edit page for *Deployment*, *DeploymentConfig*, and *Serverless Service*. This update adds a check for a loading error, and the page now displays a *Not Found* message rather than failing to load. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2002273[*BZ#2002273*])
+
+* Previously, a rewrite in the `kube-apiserver` caused a user-facing API change. Users must explicitly specify either `ipFamilyPolicy:PreferDualStack` or `ipFamilyPolicy:RequireDualStack` for DualStack services to be `valid.Users`. With this update, a warning is displayed through the API that notifies users of the imminent API change. Now, users cannot create DualStack services without explicitly specifying `ipFamilyPolicy:PreferDualStack` or `ipFamilyPolicy:RequireDualStack`.(link:https://bugzilla.redhat.com/show_bug.cgi?id=2045576[*BZ#2045576*])
+
+[id="ocp-4-9-24-updating"]
 ==== Updating
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
RNs for 4.9.24 release.

- Adds a backported removed feature. See #42692
- Applies to `enterprise-4.9` only
- [Preview link to table](https://deploy-preview-43289--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-deprecated-removed-features)
- [Preview link to *Support for minting credentials for Microsoft Azure removed* ](https://deploy-preview-43289--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-deprecated-removed-features)
- [Preview link to 4.9.24 rel notes](https://deploy-preview-43289--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-24)