### PR TITLE
GH-43246: Update path to rhcos.json

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -71,21 +71,21 @@ The ID determines which image the installation program must download.
 +
 [source,terminal]
 ----
-$ export RHCOS_QEMU_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq .images.qemu.path | sed 's/"//g')
+$ export RHCOS_QEMU_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/coreos/rhcos.json  | jq .images.qemu.path | sed 's/"//g')
 ----
 
 . Get the path where the image is published:
 +
 [source,terminal]
 ----
-$ export RHCOS_PATH=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json | jq .baseURI | sed 's/"//g')
+$ export RHCOS_PATH=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/coreos/rhcos.json | jq .baseURI | sed 's/"//g')
 ----
 
 . Get the SHA hash for the {op-system} image that will be deployed on the bootstrap VM:
 +
 [source,terminal]
 ----
-$ export RHCOS_QEMU_SHA_UNCOMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq -r '.images.qemu["uncompressed-sha256"]')
+$ export RHCOS_QEMU_SHA_UNCOMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/coreos/rhcos.json  | jq -r '.images.qemu["uncompressed-sha256"]')
 ----
 
 . Download the image and place it in the `/home/kni/rhcos_image_cache` directory:


### PR DESCRIPTION
Fixes #43246

OCP Version: 4.6+

Current 4.10 docs: https://docs.openshift.com/container-platform/4.10/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-creating-an-rhcos-images-cache_ipi-install-installation-workflow

Direct doc preview link: https://deploy-preview-43290--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-creating-an-rhcos-images-cache_ipi-install-installation-workflow