### PR TITLE
Fix Table 1 Required DNS records

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -63,7 +63,7 @@ Installer-provisioned installation includes functionality that uses cluster memb
 |Record
 |Description
 
-.2+a|Kubernetes API
+|Kubernetes API
 |`api.<cluster_name>.<base_domain>.`
 |An A/AAAA record, and a PTR record, identify the API load balancer. These records must be resolvable by both clients external to the cluster and from all the nodes within the cluster.
 


### PR DESCRIPTION
Appears the table is malformed in branches `enterprise-4.7`, `enterprise-4.8`, `enterprise-4.9` and `enterprise-4.10`