### PR TITLE
RHDEVDOCS-3751 Document Tekton Chains

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -70,6 +70,7 @@ endif::[]
 :pipelines-title: Red Hat OpenShift Pipelines
 :pipelines-shortname: Pipelines
 :pipelines-ver: pipelines-1.7
+:tekton-chains: Tekton Chains
 //odo
 :odo-title: odo
 //alibaba cloud

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1598,6 +1598,8 @@ Topics:
     File: securing-webhooks-with-event-listeners
   - Name: Authenticating pipelines using git secret
     File: authenticating-pipelines-using-git-secret
+  - Name: Using Tekton Chains for OpenShift Pipelines supply chain security
+    File: using-tekton-chains-for-openshift-pipelines-supply-chain-security
   - Name: Viewing pipeline logs using the OpenShift Logging Operator
     File: viewing-pipeline-logs-using-the-openshift-logging-operator
 - Name: GitOps

--- a/cicd/pipelines/installing-pipelines.adoc
+++ b/cicd/pipelines/installing-pipelines.adoc
@@ -47,6 +47,8 @@ include::modules/op-disabling-automatic-creation-of-rbac-resources.adoc[leveloff
 
 * You can learn more about installing Operators on {product-title} in the xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[adding Operators to a cluster] section.
 
+* To install Tekton Chains using the {pipelines-title} Operator, see xref:../../cicd/pipelines/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc#using-tekton-chains-for-openshift-pipelines-supply-chain-security[Using Tekton Chains for OpenShift Pipelines supply chain security].
+
 * For more information on using pipelines in a restricted environment, see:
 
 ** xref:../../cicd/pipelines/creating-applications-with-cicd-pipelines.html#op-mirroring-images-to-run-pipelines-in-restricted-environment_creating-applications-with-cicd-pipelines[Mirroring images to run pipelines in a restricted environment]

--- a/cicd/pipelines/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
+++ b/cicd/pipelines/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
@@ -1,0 +1,49 @@
+:_content-type: ASSEMBLY
+[id="using-tekton-chains-for-openshift-pipelines-supply-chain-security"]
+= Using Tekton Chains for OpenShift Pipelines supply chain security
+include::_attributes/common-attributes.adoc[]
+:context: using-tekton-chains-for-openshift-pipelines-supply-chain-security
+
+toc::[]
+
+:FeatureName: Tekton Chains
+include::snippets/technology-preview.adoc[]
+
+[role="_abstract"]
+{tekton-chains} is a Kubernetes Custom Resource Definition (CRD) controller. You can use it to manage the supply chain security of the tasks and pipelines created using {pipelines-title}.
+
+By default, {tekton-chains} observes all task run executions in your {product-title} cluster. When the task runs complete, {tekton-chains} takes a snapshot of the task runs. It then converts the snapshot to one or more standard payload formats, and finally signs and stores all artifacts. 
+
+To capture information about task runs, {tekton-chains} uses the `Result` and `PipelineResource` objects. When the objects are unavailable, {tekton-chains} the URLs and qualified digests of the OCI images.
+
+[NOTE]
+====
+The `PipelineResource` object is deprecated and will be removed in a future release; for manual use, the `Results` object is recommended.
+====
+
+[id="tc-key-features"]
+== Key features
+* You can sign task runs, task run results, and OCI registry images with cryptographic key types and services such as `cosign`.
+* You can use attestation formats such as `in-toto`.
+* You can securely store signatures and signed artifacts using OCI repository as a storage backend.
+
+include::modules/op-installing-tekton-chains-using-pipelines-operator.adoc[leveloffset=+1]
+
+include::modules/op-configuring-tekton-chains.adoc[leveloffset=+1]
+
+include::modules/op-supported-keys-tekton-chains-configuration.adoc[leveloffset=+2]
+
+include::modules/op-signing-secrets-in-tekton-chains.adoc[leveloffset=+1]
+
+include::modules/op-authenticating-to-an-oci-registry.adoc[leveloffset=+1]
+
+include::modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc[leveloffset=+1]
+
+include::modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources-tekton-chains"]
+== Additional resources
+
+* xref:../../cicd/pipelines/installing-pipelines.adoc#installing-pipelines[Installing OpenShift Pipelines]
+

--- a/modules/op-authenticating-to-an-oci-registry.adoc
+++ b/modules/op-authenticating-to-an-oci-registry.adoc
@@ -1,0 +1,69 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-tekton-chains-for-pipelines-supply-chain-security.adoc
+
+:_content-type: PROCEDURE
+[id="authenticating-to-an-oci-registry_{context}"]
+= Authenticating to an OCI registry
+
+Before pushing signatures to an OCI registry, cluster administrators must configure {tekton-chains} to authenticate with the registry. The {tekton-chains} controller uses the same service account under which the task runs execute. To set up a service account with the necessary credentials for pushing signatures to an OCI registry, perform the following steps:
+
+[discrete]
+.Procedure
+
+. Set the namespace and name of the Kubernetes service account.
++
+[source,terminal]
+----
+$ export NAMESPACE=<namespace> <1>
+$ export SERVICE_ACCOUNT_NAME=<service_account> <2>
+----
+<1> The namespace associated with the service account.
+<2> The name of the service account.
+
+. Create a Kubernetes secret.
++
+[source,terminal]
+----
+$ oc create secret registry-credentials \
+  --from-file=.dockerconfigjson \ <1>
+  --type=kubernetes.io/dockerconfigjson \
+  -n $NAMESPACE
+----
+<1> Substitute with the path to your Docker config file. Default path is `~/.docker/config.json`.
+
+. Give the the service account access to the secret.
++
+[source,terminal]
+----
+$ oc patch serviceaccount $SERVICE_ACCOUNT_NAME \
+  -p "{\"imagePullSecrets\": [{\"name\": \"registry-credentials\"}]}" -n $NAMESPACE
+----
++
+If you patch the default `pipeline` service account that {pipelines-title} assigns to all task runs, the {pipelines-title} Operator will override the service account. As a best practice, you can perform the following steps:
+
+.. Create a separate service account to assign to user's task runs.
++
+[source,terminal]
+----
+$ oc create serviceaccount <service_account_name>
+----
+
+.. Associate the service account to the task runs by setting the value of the `serviceaccountname` field in the task run template.
++
+[source,yaml]
+----
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+name: build-push-task-run-2
+spec:
+serviceAccountName: build-bot <1>
+taskRef:
+  name: build-push
+...
+----
+<1> Substitute with the name of the newly created service account.
+
+
+

--- a/modules/op-configuring-tekton-chains.adoc
+++ b/modules/op-configuring-tekton-chains.adoc
@@ -1,0 +1,19 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-tekton-chains-for-pipelines-supply-chain-security.adoc
+
+:_content-type: CONCEPT
+[id="configuring-tekton-chains_{context}"]
+= Configuring {tekton-chains}
+
+{tekton-chains} uses a `ConfigMap` object named `chains-config` in the `openshift-pipelines` namespace for configuration.
+
+To configure {tekton-chains}, use the following example:
+
+.Example: Configuring {tekton-chains}
+[source,terminal]
+----
+$ oc patch configmap chains-config -n openshift-pipelines -p='{"data":{"artifacts.oci.storage": "", "artifacts.taskrun.format":"tekton", "artifacts.taskrun.storage": "tekton"}}' <1>
+----
+<1> Use a combination of supported key-value pairs in the JSON payload.
+

--- a/modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc
+++ b/modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc
@@ -1,0 +1,92 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-tekton-chains-for-pipelines-supply-chain-security.adoc
+
+:_content-type: PROCEDURE
+[id="creating-and-verifying-task-run-signatures-without-any-additional-authentication_{context}"]
+== Creating and verifying task run signatures without any additional authentication
+
+[role="_abstract"]
+To verify signatures of task runs using {tekton-chains} with any additional authentication, perform the following tasks:
+
+* Create an encrypted x509 key pair and save it as a Kubernetes secret.
+* Configure the {tekton-chains} backend storage.
+* Create a task run, sign it, and store the signature and the payload as annotations on the task run itself.
+* Retrieve the signature and payload from the signed task run.
+* Verify the signature of the task run.
+
+[discrete]
+.Prerequisites
+Ensure that the following are installed on the cluster:
+
+* {pipelines-title} Operator
+* {tekton-chains}
+* link:https://docs.sigstore.dev/cosign/installation/[Cosign]
+
+[discrete]
+.Procedure
+
+. Create an encrypted x509 key pair and save it as a Kubernetes secret:
++
+[source,terminal]
+----
+$ cosign generate-key-pair k8s://openshift-pipelines/signing-secrets
+----
++
+Provide a password when prompted. Cosign stores the resulting private key as part of the `signing-secrets` Kubernetes secret in the `openshift-pipelines` namespace.
+
+. In the {tekton-chains} configuration, disable the OCI storage, and set the task run storage and format to `tekton`. 
++
+[source,terminal]
+----
+$ oc patch configmap chains-config -n openshift-pipelines -p='{"data":{"artifacts.oci.storage": "", "artifacts.taskrun.format":"tekton", "artifacts.taskrun.storage": "tekton"}}'
+----
+
+. Restart the {tekton-chains} controller to ensure that the modified configuration is applied.
++
+[source.terminal]
+----
+$ oc delete po -n openshift-pipelines -l app=tekton-chains-controller
+----
+
+. Create a task run. 
++
+[source,terminal]
+----
+$ oc create -f https://raw.githubusercontent.com/tektoncd/chains/main/examples/taskruns/task-output-image.yaml <1>
+taskrun.tekton.dev/build-push-run-output-image-qbjvh created
+----
+<1> Substitute with the URI or file path pointing to your task run.
+
+. Check the status of the steps, and wait till the process finishes.
++
+[source,terminal]
+----
+$ tkn tr describe --last
+[...truncated output...]
+NAME                            STATUS
+∙ create-dir-builtimage-9467f   Completed
+∙ git-source-sourcerepo-p2sk8   Completed
+∙ build-and-push                Completed
+∙ echo                          Completed
+∙ image-digest-exporter-xlkn7   Completed
+----
+
+. Retrieve the signature and payload from the object stored as `base64` encoded annotations:
++
+[source,terminal]
+----
+$ export TASKRUN_UID=$(tkn tr describe --last -o  jsonpath='{.metadata.uid}')
+$ tkn tr describe --last -o jsonpath="{.metadata.annotations.chains\.tekton\.dev/signature-taskrun-$TASKRUN_UID}" > signature
+$ tkn tr describe --last -o jsonpath="{.metadata.annotations.chains\.tekton\.dev/payload-taskrun-$TASKRUN_UID}" | base64 -d > payload
+----
+
+. Verify the signature.
++
+[source,terminal]
+----
+$ cosign verify-blob --key k8s://openshift-pipelines/signing-secrets --signature ./signature ./payload
+Verified OK
+----
+
+

--- a/modules/op-installing-tekton-chains-using-pipelines-operator.adoc
+++ b/modules/op-installing-tekton-chains-using-pipelines-operator.adoc
@@ -1,0 +1,51 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-tekton-chains-for-pipelines-supply-chain-security.adoc
+
+:_content-type: PROCEDURE
+[id="installing-tekton-chains-using-pipelines-operator_{context}"]
+= Installing {tekton-chains} using the {pipelines-title} Operator
+
+Cluster administrators can use the `TektonChain` custom resource (CR) to install and manage {tekton-chains}. 
+
+[NOTE]
+====
+{tekton-chains} is an optional component of {pipelines-title}. Currently, you cannot install it using the `TektonConfig` CR. 
+====
+
+[discrete]
+.Prerequisites
+* Ensure that the {pipelines-title} Operator is installed in the `openshift-pipelines` namespace on your cluster.
+
+[discrete]
+.Procedure
+
+. Create the `TektonChain` CR for your {product-title} cluster.
++
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonChain
+metadata:
+  name: chain
+spec:
+  targetNamespace: openshift-pipelines
+----
+
+. Apply the `TektonChain` CR.
++
+[source,terminal]
+----
+$ oc apply -f TektonChain.yaml <1>
+----
++
+<1> Substitute with the file name of the `TektonChain` CR.
+
+. Check the status of the installation.
++
+[source,terminal]
+----
+$ oc get tektonchains.operator.tekton.dev
+----
+
+

--- a/modules/op-signing-secrets-in-tekton-chains.adoc
+++ b/modules/op-signing-secrets-in-tekton-chains.adoc
@@ -1,0 +1,61 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-tekton-chains-for-pipelines-supply-chain-security.adoc
+
+:_content-type: CONCEPT
+[id="signing-secrets-in-tekton-chains_{context}"]
+= Signing secrets in {tekton-chains}
+
+[role="_abstract"]
+Cluster administrators can generate a key pair and use {tekton-chains} to sign artifacts using a Kubernetes secret. For {tekton-chains} to work, a private key and a password for encrypted keys must exist as part of the `signing-secrets` Kubernetes secret, in the `openshift-pipelines` namespace.
+
+Currently, {tekton-chains} supports the `x509` and `cosign` signature schemes.
+
+[NOTE]
+====
+Use only one of the supported signature schemes.
+====
+
+[id="chains-signing-secrets-x509_{context}"]
+== Signing using x509
+
+To use the `x509` signing scheme with {tekton-chains}, store the `x509.pem` private key of the `ed25519` or `ecdsa` type in the `signing-secrets` Kubernetes secret. Ensure that the key is stored as an unencrypted PKCS8 PEM file (`BEGIN PRIVATE KEY`).
+
+[id="chains-signing-secrets-cosign_{context}"]
+== Signing using cosign
+
+To use the `cosign` signing scheme with {tekton-chains}:
+
+. Install link:https://docs.sigstore.dev/cosign/installation/[cosign].
+
+. Generate the `cosign.key` and `cosign.pub` key pairs.
++
+[source,terminal]
+----
+$ cosign generate-key-pair k8s://openshift-pipelines/signing-secrets
+----
++
+Cosign prompts you for a password, and creates a Kubernetes secret.
+
+. Store the encrypted `cosign.key` private key and the `cosign.password` decryption password in the `signing-secrets` Kubernetes secret. Ensure that the private key is stored as an encrypted PEM file of the `ENCRYPTED COSIGN PRIVATE KEY` type.
+
+[id="chains-troubleshooting-signing_{context}"]
+== Troubleshooting signing
+
+If the signing secrets are already populated, you might get the following error:
+
+[source,yaml]
+----
+Error from server (AlreadyExists): secrets "signing-secrets" already exists
+----
+
+To resolve the error:
+
+. Delete the secrets:
++
+[source,terminal]
+----
+$ oc delete secret signing-secrets -n openshift-pipelines
+----
+
+. Recreate the key pairs and store them in the secrets using your preferred signing scheme.

--- a/modules/op-supported-keys-tekton-chains-configuration.adoc
+++ b/modules/op-supported-keys-tekton-chains-configuration.adoc
@@ -1,0 +1,56 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-tekton-chains-for-pipelines-supply-chain-security.adoc
+
+:_content-type: REFERENCE
+[id="supported-keys-tekton-chains-configuration_{context}"]
+= Supported keys for {tekton-chains} configuration
+
+Cluster administrators can use various supported keys and values to configure specifications about task runs, OCI images, and storage.
+
+[id="chains-supported-keys-task-run_{context}"]
+== Supported keys for task run
+
+.Chains configuration: Supported keys for task run
+[options="header"]
+|===
+
+| Supported keys | Description | Supported values | Default values
+
+| `artifacts.taskrun.format` | The format to store task run payloads. | `tekton`, `in-toto` | `tekton` 
+
+| `artifacts.taskrun.storage` | The storage backend for task run signatures. You can specify multiple backends as a comma-separated list, such as `“tekton,oci”`. To disable this artifact, provide an empty string `“”`. | `tekton`, `oci` | `tekton` 
+
+| `artifacts.taskrun.signer` | The signature backend to sign task run payloads. | `x509` | `x509` 
+
+|===
+
+[id="chains-supported-keys-oci_{context}"]
+== Supported keys for OCI
+
+.Chains configuration: Supported keys for OCI
+[options="header"]
+|===
+
+| Supported keys | Description | Supported values | Default values
+
+| `artifacts.oci.format` | The format to store OCI payloads. | `simplesigning` | `simplesigning` 
+
+| `artifacts.oci.storage` | The storage backend to for OCI signatures. You can specify multiple backends as a comma-separated list, such as `“oci,tekton”`. To disable the OCI artifact, provide an empty string `“”`. | `tekton`, `oci` | `oci` 
+
+| `artifacts.oci.signer` | The signature backend to sign OCI payloads. | `x509`, `cosign` | `x509` 
+
+|===
+
+[id="chains-supported-keys-storage_{context}"]
+== Supported keys for storage
+
+.Chains configuration: Supported keys for storage
+[options="header"]
+|===
+
+| Supported keys | Description | Supported values | Default values
+
+| `artifacts.oci.repository` | The OCI repository to store OCI signatures. | Currently, Chains support only the internal OpenShift OCI registry; other popular options such as link:https://quay.io/[Quay] is not supported. |  
+
+|===

--- a/modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc
+++ b/modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc
@@ -1,0 +1,143 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-tekton-chains-for-pipelines-supply-chain-security.adoc
+
+:_content-type: PROCEDURE
+[id="using-tekton-chains-to-sign-and-verify-image-and-provenance_{context}"]
+= Using {tekton-chains} to sign and verify image and provenance
+
+[role="_abstract"]
+Cluster administrators can use {tekton-chains} to sign and verify images and provenances, by performing the following tasks:
+
+* Create an encrypted x509 key pair and save it as a Kubernetes secret.
+* Set up authentication for the OCI registry to store images, image signatures, and signed image attestations.
+* Configure {tekton-chains} to generate and sign provenance.
+* Create an image with Kaniko in a task run.
+* Verify the signed image and the signed provenance.
+
+[discrete]
+.Prerequisites
+Ensure that the following are installed on the cluster:
+
+* {pipelines-title} Operator
+* {tekton-chains}
+* link:https://docs.sigstore.dev/cosign/installation/[Cosign]
+* link:https://docs.sigstore.dev/rekor/installation/[Rekor]
+* link:https://stedolan.github.io/jq/[jq]
+
+[discrete]
+.Procedure
+
+. Create an encrypted x509 key pair and save it as a Kubernetes secret:
++
+[source,terminal]
+----
+$ cosign generate-key-pair k8s://openshift-pipelines/signing-secrets
+----
++
+Provide a password when prompted. Cosign stores the resulting private key as part of the `signing-secrets` Kubernetes secret in the `openshift-pipelines` namespace, and writes the public key to the `cosign.pub` local file.
+
+. Configure authentication for the image registry.
+
+.. To configure the {tekton-chains} controller for pushing signature to an OCI registry, use the credentials associated with the service account of the task run. For detailed information, see the "Authenticating to an OCI registry" section.
+
+.. To configure authentication for a Kaniko task that builds and pushes image to the registry, create a Kubernetes secret of the docker `config.json` file containing the required credentials.
++
+[source,terminal]
+----
+$ oc create secret generic <docker_config_secret_name> \ <1>
+  --from-file <path_to_config.json> <2>
+---- 
+<1> Substitute with the name of the docker config secret.
+<2> Substitute with the path to docker `config.json` file.
+
+. Configure {tekton-chains} by setting the the `artifacts.taskrun.format`, `artifacts.taskrun.storage`, and `transparency.enabled` parameters in the `chains-config` object:
++
+[source,terminal]
+----
+$ oc patch configmap chains-config -n openshift-pipelines -p='{"data":{"artifacts.taskrun.format": "in-toto"}}'
+
+$ oc patch configmap chains-config -n openshift-pipelines -p='{"data":{"artifacts.taskrun.storage": "oci"}}'
+
+$ oc patch configmap chains-config -n openshift-pipelines -p='{"data":{"transparency.enabled": "true"}}'
+----
+
+. Start the Kaniko task.
+
+.. Apply the Kaniko task to the cluster.
++
+[source,terminal]
+----
+$ oc apply -f examples/kaniko/kaniko.yaml <1>
+----
+<1> Substitute with the URI or file path to your Kaniko task.
+
+.. Set the appropriate environment variables.
++
+[source,terminal]
+----
+$ export REGISTRY=<url_of_registry> <1>
+
+$ export DOCKERCONFIG_SECRET_NAME=<name_of_the_secret_in_docker_config_json> <2>
+----
+<1> Substitute with the URL of the registry where you want to push the image.
+<2> Substitute with the name of the secret in the docker `config.json` file.
+
+.. Start the Kaniko task.
++
+[source,terminal]
+----
+$ tkn task start --param IMAGE=$REGISTRY/kaniko-chains --use-param-defaults --workspace name=source,emptyDir="" --workspace name=dockerconfig,secret=$DOCKERCONFIG_SECRET_NAME kaniko-chains
+----
++
+Observe the logs of this task until all steps are complete. On successful authentication, the final image will be pushed to `$REGISTRY/kaniko-chains`. 
+
+. Wait for a minute to allow {tekton-chains} to generate the provenance and sign it, and then check the availability of the `chains.tekton.dev/signed=true` annotation on the task run.
++
+[source,terminal]
+----
+$ oc get tr <task_run_name> \ <1>
+-o json | jq -r .metadata.annotations
+
+{
+  "chains.tekton.dev/signed": "true",
+  ...
+}
+----
+<1> Substitute with the name of the task run.
+
+. Verify the image and the attestation.
++
+[source,terminal]
+----
+$ cosign verify --key cosign.pub $REGISTRY/kaniko-chains
+
+$ cosign verify-attestation --key cosign.pub $REGISTRY/kaniko-chains
+----
+
+. Find the provenance for the image in Rekor.
+
+.. Get the digest of the $REGISTRY/kaniko-chains image. You can search for it ing the task run, or pull the image to extract the digest.
+
+.. Search Rekor to find all entries that match the `sha256` digest of the image.
++
+[source,terminal]
+----
+$ rekor-cli search --sha <image_digest> <1>
+
+<uuid_1> <2>
+<uuid_2> <3>
+...
+----
+<1> Substitute with the `sha256` digest of the image.
+<2> The first matching universally unique identifier (UUID).
+<3> The second matching UUID.
++
+The search result displays UUIDs of the matching entries. One of those UUIDs holds the attestation.
+
+.. Check the attestation.
++
+[source,terminal]
+----
+$ rekor-cli get --uuid <uuid> --format json | jq -r .Attestation | base64 --decode | jq
+----


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`
- **JIRA issues**: [RHDEVDOCS-3751 Document Tekton Chains](https://issues.redhat.com/browse/RHDEVDOCS-3751)
- **Preview pages**: [Using Tekton Chains for OpenShift Pipelines supply chain security](https://deploy-preview-43302--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/using-tekton-chains-for-openshift-pipelines-supply-chain-security)
- **SME review**: @concaf, @piyush-garg       
- **Peer-review**: @rolfedh, @jc-berger    