### PR TITLE
RHDEVDOCS-3814 - Added steps to configure argo cd rbac

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1612,6 +1612,8 @@ Topics:
     File: configuring-sso-on-argo-cd-using-dex
   - Name: Configuring SSO for Argo CD using Keycloak
     File: configuring-sso-for-argo-cd-using-keycloak
+  - Name: Configuring Argo CD RBAC
+    File: configuring-argo-cd-rbac
   - Name: Running Control Plane Workloads on Infra nodes
     File: run-gitops-control-plane-workload-on-infra-nodes
 ---

--- a/cicd/gitops/configuring-argo-cd-rbac.adoc
+++ b/cicd/gitops/configuring-argo-cd-rbac.adoc
@@ -1,0 +1,13 @@
+:_content-type: ASSEMBLY
+[id="configuring-argo-cd-rbac"]
+= Configuring Argo CD RBAC
+include::_attributes/common-attributes.adoc[]
+:context: configuring-argo-cd-rbac
+
+toc::[]
+
+[role="_abstract"]
+By default, if you are logged into Argo CD using RHSSO, you are a read-only user. You can change and manage the user level access.
+
+include::modules/configuring-user-level-access.adoc[leveloffset=+1]
+include::modules/modify-rhsso-requests-limits.adoc[leveloffset=+1]

--- a/modules/configuring-user-level-access.adoc
+++ b/modules/configuring-user-level-access.adoc
@@ -1,0 +1,47 @@
+// Module is included in the following assemblies:
+//
+// * installing-red-hat-openshift-gitops
+
+:_content-type: PROCEDURE
+[id="configuring-user-level-access_{context}"]
+= Configuring user level access
+
+[role="_abstract"]
+To manage and modify the user level access, configure the RBAC section in Argo CD custom resource.
+
+.Procedure
+
+* Edit the `argocd` Custom Resource:
++
+[source,terminal]
+----
+$ oc edit argocd [argocd-instance-name] -n [namespace]
+----
+.Output
++
+[source,yaml]
+----
+metadata
+...
+...
+  rbac:
+    policy: 'g, rbacsystem:cluster-admins, role:admin'
+    scopes: '[groups]'
+----
++
+* Add the `policy` configuration to the `rbac` section and add the `name`, `email` and the `role` of the user: 
++
+[source,yaml]
+----
+metadata
+...
+...
+rbac:
+    policy: <name>, <email>, role:<admin>
+    scopes: '[groups]'
+----
+
+[NOTE]
+====
+Currently, RHSSO cannot read the group information of {gitops-title} users. Therefore, configure the RBAC at the user level.
+====

--- a/modules/modify-rhsso-requests-limits.adoc
+++ b/modules/modify-rhsso-requests-limits.adoc
@@ -1,0 +1,30 @@
+// Module is included in the following assemblies:
+//
+// * installing-red-hat-openshift-gitops
+
+:_content-type: PROCEDURE
+[id="modifying-rhsso-resource-requests-limits_{context}"]
+= Modifying RHSSO resource requests/limits
+
+[role="_abstract"]
+By default, the RHSSO container is created with resource requests and limitations. You can change and manage the resource requests.
+
+|===
+|*Resource* |*Requests* |*Limits*
+
+|CPU|500|1000m
+|Memory|512 Mi|1024 Mi
+
+|===
+.Procedure
+Modify the default resource requirements patching the Argo CD CR:
+
+[source,terminal]
+----
+$ oc -n openshift-gitops patch argocd openshift-gitops --type='json' -p='[{"op": "add", "path": "/spec/sso", "value": {"provider": "keycloak", "resources": {"requests": {"cpu": "512m", "memory": "512Mi"}, "limits": {"cpu": "1024m", "memory": "1024Mi"}} }}]'
+----
+
+[NOTE]
+====
+RHSSO created by the {gitops-title} only persists the changes that are made by the operator. If the RHSSO restarts, any additional configuration created by the Admin in RHSSO is deleted.
+====


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.9, 4.10, 4.11
JIRA issue: https://issues.redhat.com/browse/RHDEVDOCS-3814

Preview pages: https://deploy-preview-43305--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring-argo-cd-rbac.html

SME+QE review: @iam-veeramalla , @varshab1210 
Peer-review: @jc-berger 