### PR TITLE
clarifying xrefs in snippets and symlink guidance

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -165,7 +165,7 @@ It is acceptable to group related attributes in the `common-attributes.adoc` fil
 :gitops-shortname: GitOps
 ----
 
-It is also acceptable to enclose attributes in a xref:product-name-and-version[distro-based] conditional. The following example shows how to set a different value for the `:op-system-base:` attribute for OKD:
+It is also acceptable to enclose attributes in a xref:product-name-and-version[distro-based] conditional, but you must place attribute definitions for the `openshift-enterprise` distro first. The following example shows how to set a different value for the `:op-system-base:` attribute for OKD:
 
 ----
 :op-system-base: RHEL
@@ -182,11 +182,12 @@ Try to shorten the file name as much as possible _without_ abbreviating importan
 
 If you create a directory with a multiple-word name, separate each word with an underscore, for example `backup_and_restore`. Do not create a top-level directory in the repository without checking with the docs team. In the main OpenShift docs, you can create one level of subdirectories. In the docs for features that are designed to be used with OpenShift, such as Service Mesh and OpenShift virtualization, you can create two levels of subdirectories.
 
-When creating a new directory or subdirectory, you must create two symbolic links in it:
+When creating a new directory or subdirectory, you must create four symbolic links in it:
 
 * An `images` symbolic link to the top-level `images/` directory
 * A `modules` symbolic link to the top-level `modules/` directory
-* If you are including a text snippet in your modules or assemblies, a `snippets` symbolic link to the top-level `snippets/` directory
+* A `snippets` symbolic link to the top-level `snippets/` directory
+* An `_attributes` symbolic link to the top-level `_attributes/` directory
 
 If the directory that contains an assembly does not have the `images` symbolic link, any images in that assembly or its modules will not be included properly when building the docs.
 
@@ -207,6 +208,7 @@ For example, if you are creating the links in a directory that is two levels dee
 $ ln -s ../../images/ images
 $ ln -s ../../modules/ modules
 $ ln -s ../../snippets/ snippets
+$ ln -s ../../_attributes/ attributes
 ----
 +
 Be sure to adjust the number of levels to back up (`../`) depending on how deep your directory is.
@@ -357,9 +359,9 @@ When needed, use `.Prerequisites`, `.Next steps`, or `.Additional resources` syn
 
 [id="writing-text-snippets"]
 == Writing text snippets
-A _text snippet_ is an optional component that lets you reuse content in multiple modules and assemblies. Text snippets are not a substitute for modules, but instead are a more granular form of content reuse. While a module is content that a reader can understand on its own (like an article) or as part of a larger body of work (like an assembly), a text snippet is not self-contained and is not intended to be published or cross referenced on its own.
+A _text snippet_ is an optional component that lets you reuse content in multiple modules and assemblies. Text snippets are not a substitute for modules but instead are a more granular form of content reuse. While a module is content that a reader can understand on its own (like an article) or as part of a larger body of work (like an assembly), a text snippet is not self-contained and is not intended to be published or cross referenced on its own.
 
-In the context of modules and assemblies, text snippets do not include headings or anchor IDs. This type of component is text only. Examples include the following:
+In the context of modules and assemblies, text snippets do not include headings or anchor IDs. Text snippets also cannot contain xrefs. This type of component is text only. Examples include the following:
 
 * Admonitions that appear in multiple modules.
 * An introductory paragraph that appears in multiple assemblies.
@@ -377,7 +379,7 @@ In {product-title} version {product-version}, you can install a cluster on {clou
 
 [NOTE]
 ====
-In the example, `cloud-provider-first` and `cloud-provider` are not defined by the `common-attributes` module. If you use an attribute that is not common to OpenShift docs, make sure to define it locally in either the assembly or module, depending on where the text snippet is included.
+In the example, `cloud-provider-first` and `cloud-provider` are not defined by the `common-attributes` module. If you use an attribute that is not common to OpenShift docs, make sure to define it locally in either the assembly or module, depending on where the text snippet is included. Because of this, consider adding all attributes that you add to snippets to the `common-attributes.adoc` file.
 ====
 
 For more information about creating text snippets, see the


### PR DESCRIPTION
Because snippets can be contained in modules, the ban on xrefs in modules applies to snippets. This PR makes that explicit.