### PR TITLE
Bug 2064395: Fixed formatting for install support matrix in OKD and added missing entries

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -120,13 +120,10 @@ Not all installation options are supported for all platforms, as shown in the fo
 ====
 
 .Installer-provisioned infrastructure options
-|===
+//This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
+|===
 ||Alibaba |AWS (x86_64) |AWS (arm64) |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal |vSphere |VMC |IBM Cloud |IBM Z |IBM Power
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-||Alibaba||AWS |Azure |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |oVirt |Bare metal |vSphere |VMC |IBM Cloud |IBM Z |IBM Power
-endif::openshift-origin[]
 
 |Default
 |xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[X]
@@ -247,6 +244,23 @@ endif::openshift-origin[]
 |
 |
 
+|Secret regions
+|
+|xref:../installing/installing_aws/installing-aws-secret-region.adoc#installing-aws-secret-region[X]
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
 |China regions
 |
 |xref:../installing/installing_aws/installing-aws-china.adoc#installing-aws-china-region[X]
@@ -264,16 +278,164 @@ endif::openshift-origin[]
 |
 |
 |===
+endif::openshift-origin[]
+
+//This table is for OKD only. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
+ifdef::openshift-origin[]
+|===
+||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |oVirt |Bare metal |vSphere |VMC |IBM Cloud |IBM Z |IBM Power
+
+|Default
+|xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[X]
+|xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[X]
+|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[X]
+|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[X]
+|xref:../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[X]
+|
+|
+|xref:../installing/installing_rhv/installing-rhv-default.adoc#installing-rhv-default[X]
+|xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[X]
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc#installing-vsphere-installer-provisioned[X]
+|xref:../installing/installing_vmc/installing-vmc.adoc#installing-vmc[X]
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[X]
+|
+|
+
+|Custom
+|xref:../installing/installing_alibaba/installing-alibaba-customizations.adoc#installing-alibaba-customizations[X]
+|xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[X]
+|xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[X]
+|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[X]
+|xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[X]
+|xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#installing-openstack-installer-custom[X]
+|xref:../installing/installing_openstack/installing-openstack-installer-sr-iov.adoc#installing-openstack-installer-sr-iov[X]
+|xref:../installing/installing_rhv/installing-rhv-customizations.adoc#installing-rhv-customizations[X]
+|
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installing-vsphere-installer-provisioned-customizations[X]
+|xref:../installing/installing_vmc/installing-vmc-customizations.adoc#installing-vmc-customizations[X]
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[X]
+|
+|
+
+|Network customization
+|xref:../installing/installing_alibaba/installing-alibaba-network-customizations.adoc#installing-alibaba-network-customizations[X]
+|xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[X]
+|xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[X]
+|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc#installing-azure-stack-hub-network-customizations[X]
+|xref:../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[X]
+|xref:../installing/installing_openstack/installing-openstack-installer-kuryr.adoc#installing-openstack-installer-kuryr[X]
+|
+|
+|
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#installing-vsphere-installer-provisioned-network-customizations[X]
+|xref:../installing/installing_vmc/installing-vmc-network-customizations.adoc#installing-vmc-network-customizations[X]
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc#installing-ibm-cloud-network-customizations[X]
+|
+|
+
+|Restricted network
+|
+|xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[X]
+|
+|
+|xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[X]
+|xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[X]
+|
+|xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[X]
+|
+|xref:../installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[X]
+|xref:../installing/installing_vmc/installing-restricted-networks-vmc.adoc#installing-restricted-networks-vmc[X]
+|
+|
+|
+
+|Private clusters
+|
+|xref:../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[X]
+|xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[X]
+|
+|xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[X]
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+|Existing virtual private networks
+|
+|xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[X]
+|xref:../installing/installing_azure/installing-azure-vnet.adoc#installing-azure-vnet[X]
+|
+|xref:../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[X]
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+|Government regions
+|
+|xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[X]
+|xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[X]
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+|Secret regions
+|
+|xref:../installing/installing_aws/installing-aws-secret-region.adoc#installing-aws-secret-region[X]
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+
+|China regions
+|
+|xref:../installing/installing_aws/installing-aws-china.adoc#installing-aws-china-region[X]
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|===
+endif::openshift-origin[]
 
 .User-provisioned infrastructure options
-|===
+//This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
+|===
 ||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |oVirt |Bare metal |vSphere |VMC |IBM Cloud |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
-endif::openshift-origin[]
-
 
 |Custom
 |
@@ -353,6 +515,88 @@ endif::openshift-origin[]
 |
 |
 |===
+endif::openshift-origin[]
+
+//This table is for OKD only. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
+ifdef::openshift-origin[]
+|===
+||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |oVirt |Bare metal |vSphere |VMC |IBM Cloud |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
+
+|Custom
+|
+|xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[X]
+|xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[X]
+|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installing-azure-stack-hub-user-infra[X]
+|xref:../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[X]
+|xref:../installing/installing_openstack/installing-openstack-user.adoc#installing-openstack-user[X]
+|xref:../installing/installing_openstack/installing-openstack-user-sr-iov.adoc#installing-openstack-user-sr-iov[X]
+|xref:../installing/installing_rhv/installing-rhv-user-infra.adoc#installing-rhv-user-infra[X]
+|xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[X]
+|xref:../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[X]
+|xref:../installing/installing_vmc/installing-vmc-user-infra.adoc#installing-vmc-user-infra[X]
+|
+|xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[X]
+|xref:../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[X]
+|xref:../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power[X]
+|xref:../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installing-platform-agnostic[X]
+
+// Add RHV UPI link when docs are available: https://github.com/openshift/openshift-docs/pull/26484
+
+|Network customization
+|
+|
+|
+|
+|
+|xref:../installing/installing_openstack/installing-openstack-user-kuryr.adoc#installing-openstack-user-kuryr[X]
+|
+|
+|xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[X]
+|xref:../installing/installing_vsphere/installing-vsphere-network-customizations.adoc#installing-vsphere-network-customizations[X]
+|xref:../installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc#installing-vmc-network-customizations-user-infra[X]
+|
+|
+|
+|
+|
+
+|Restricted network
+|
+|xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[X]
+|
+|
+|xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[X]
+|
+|
+|
+|xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[X]
+|xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[X]
+|xref:../installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc#installing-restricted-networks-vmc-user-infra[X]
+|
+|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[X]
+|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[X]
+|xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[X]
+|
+
+|Shared VPC hosted outside of cluster project
+|
+|
+|
+|
+|xref:../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[X]
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|===
+endif::openshift-origin[]
 
 ////
 .Special use cases


### PR DESCRIPTION
CP to 4.10 and 4.11

This PR addresses [BZ2064395](https://bugzilla.redhat.com/show_bug.cgi?id=2064395)

Beginning with 4.10, AWS supports an arm64 IPI installation and bare metal supports an arm64 UPI installation. As such, updates where made to the IPI[1] and UPI[2] tables in _Selecting a cluster installation method and preparing it for users_ > _Supported installation methods for different platforms section_.

The latter updates inadvertently broke the table in the OKD version of the doc. While the OCP version of the table requires a column for x86_64 and arm64 for AWS and bare metal, the OKD version does not. The additional table row added to accommodate arm64 resulted in tables row shifting in the OKD.

To resolve the discrepancy, this PR introduces a separate OKD table for both IPI and UPI. This is a deliberate design choice, as adding additional conditional statements to the shared table would only further complicate future updates.

Updates include the following:

- **OKD**: Fixed the formatting in Table 1. Installer-provisioned infrastructure options. Added a column for Azure Stack Hub. OKD supports ASH in 4.10. The lack of an entry in this table was an oversight.
- **OKD**: Fixed the formatting in Table 2. User-provisioned infrastructure options.
- **OCP and OKD**: Added a row for Secret regions in Table 1. Beginning with 4.10, the AWS Government and Top Secret Region content was split into separate help topics. The lack of an explicit Secret regions column in IPI tabl e was an oversight. Previous to 4.10, the Government regions row served to indicate support for both the GovCloud and Top Secret regions.

**OKD preview**
[Supported installation methods for different platforms](http://file.rdu.redhat.com/~ahardin/Mar-17-2022/installing/installing-preparing.html#supported-installation-methods-for-different-platforms)

**OCP preview**
[Supported installation methods for different platforms](https://deploy-preview-43337--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#supported-installation-methods-for-different-platforms)


[1] https://github.com/openshift/openshift-docs/pull/40786
[2] https://github.com/openshift/openshift-docs/pull/41149