### PR TITLE
[enterprise-4.8] OSDOCS-3385: Removing back ported feature that is not supported

### DIFF
--- a/updating/understanding-upgrade-channels-release.adoc
+++ b/updating/understanding-upgrade-channels-release.adoc
@@ -18,8 +18,6 @@ ifndef::openshift-origin[]
 * `stable-{product-version}`
 * `eus-4.y` (only when running an even-numbered 4.y cluster release, like 4.8)
 
-If you do not want the Cluster Version Operator to fetch available updates from the upgrade recommendation service, you can use the `oc adm upgrade channel` command in the OpenShift CLI to configure an empty channel. This configuration can be helpful if, for example, a cluster has restricted network access and there is no local, reachable upgrade recommendation service.
-
 [WARNING]
 ====
 Red Hat recommends upgrading to versions suggested by Openshift Update Service only. For minor version upgrade, versions must be contiguous. Red Hat does not test upgrades to noncontiguous versions and cannot guarantee compatibility with earlier versions.


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OSDOCS-3385
Applies to 4.8.
Preview Link: [Understanding upgrade channels and releases](https://deploy-preview-43340--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release.html)
SME required.