### PR TITLE
installation: generalize ARM AWS instance types

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -676,7 +676,7 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |Any valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS region], such as `us-east-1`.
 [IMPORTANT]
 ====
-When running on ARM based AWS A1 instances, ensure that you enter a region where AWS Graviton processors are available. See link:https://aws.amazon.com/ec2/graviton/#Global_availability[Global availability] map in the AWS documentation.
+When running on ARM based AWS instances, ensure that you enter a region where AWS Graviton processors are available. See link:https://aws.amazon.com/ec2/graviton/#Global_availability[Global availability] map in the AWS documentation.
 ====
 
 


### PR DESCRIPTION
Applies to: 4.10, 4.11.

﻿A1 is the instance type only for the first generation of AWS Graviton; the second-gen Graviton2 instance types (M6g/C6g/R6g) are newer, cheaper, and more widely available.

Preview: https://deploy-preview-43354--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-configuration-parameters-optional-aws_installing-aws-customizations

/cc @kelbrown20
