### PR TITLE
release_notes: generalize ARM AWS instance types

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -94,7 +94,7 @@ When configuring a Day 1 installation on bare metal only, users can now use the 
 [id="ocp-4-10-OCP-on-ARM"]
 ==== {product-title} on ARM
 
-{product-title} 4.10 is now supported on ARM based AWS EC2 A1 and bare-metal platforms. Instance availability and installation documentation can be found in xref:../installing/installing-preparing.html#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms].
+{product-title} 4.10 is now supported on ARM based AWS EC2 and bare-metal platforms. Instance availability and installation documentation can be found in xref:../installing/installing-preparing.html#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms].
 
 The following features are supported for {product-title} on ARM:
 


### PR DESCRIPTION
Applies to: 4.10

﻿A1 is the instance type only for the first generation of AWS Graviton; the second-gen Graviton2 instance types (M6g/C6g/R6g) are newer, cheaper, and more widely available.

Preview: https://deploy-preview-43355--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-OCP-on-ARM

/cc @kelbrown20
