### PR TITLE
CNV-16554 Removing TP snippet from Backup Restore overview

### DIFF
--- a/virt/backup_restore/virt-backup-restore-overview.adoc
+++ b/virt/backup_restore/virt-backup-restore-overview.adoc
@@ -9,9 +9,6 @@ toc::[]
 As a cluster administrator, you back up and restore {VirtProductName} virtual machines (VMs) by using the OpenShift API for Data Protection (OADP).
 // Non-admin user [https://issues.redhat.com/browse/OADP-203] is targeted for OADP 1.1.
 
-:FeatureName: OADP for {VirtProductName}
-include::snippets/technology-preview.adoc[]
-
 You install the OADP Operator by using Operator Lifecycle Manager. The Operator installs link:https://velero.io/docs/v1.7/[Velero 1.7]. You create a `Secret` for the backup storage provider and then you install the Data Protection Application.
 
 You back up VMs by creating a `Backup` custom resource (CR).


### PR DESCRIPTION
For 4.11 only.

Jira: https://issues.redhat.com/browse/CNV-16554

Tagging @apinnick for Code Review. Let me know if a QE Review is needed (I wouldn't think so).

I'm thinking maybe "overview" is not needed in the title as well.

Direct doc preview link: https://deploy-preview-43358--osdocs.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-overview.html