### PR TITLE
RHDEVDOCS-3784 - Add note about Alertmanager to log levels settings procedure

### DIFF
--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -8,6 +8,11 @@
 
 You can configure the log level for Prometheus Operator, Prometheus, Thanos Querier, and Thanos Ruler.
 
+[NOTE]
+=====
+You cannot use this procedure to configure the log level for the Alertmanager component.
+=====
+
 The following log levels can be applied to each of those components in the `cluster-monitoring-config` and `user-workload-monitoring-config` `ConfigMap` objects:
 
 * `debug`. Log debug, informational, warning, and error messages.


### PR DESCRIPTION
This PR adds a note to the procedure about configuring log levels for monitoring components that excludes Alertmanager from the list of components. This is for OCP 4.7 and 4.8 ONLY.
 
- Aligned team: DevTools
- For branches: OpenShift 4.7 and 4.8 ONLY
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3784
- Direct link to doc preview: https://deploy-preview-43363--osdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack#setting-log-levels-for-monitoring-components_configuring-the-monitoring-stack
- SME review: not required
- QE review: @juzhao 
- Peer review: @jc-berger (approved)
- <All reviews complete. Please merge now>