### PR TITLE
Markup stable/fast channel names

### DIFF
--- a/modules/update-upgrading-web.adoc
+++ b/modules/update-upgrading-web.adoc
@@ -29,7 +29,7 @@ link:https://access.redhat.com/downloads/content/290[in the errata section] of t
 +
 [IMPORTANT]
 ====
-For production clusters, you must subscribe to a stable-* or fast-* channel.
+For production clusters, you must subscribe to a `stable-\*` or `fast-*` channel.
 ====
 ifdef::openshift-origin[]
 such as `stable-4`.
@@ -52,10 +52,10 @@ If you are upgrading your cluster to the next minor version, like version 4.y to
 --
 ** If updates are available, continue to perform updates in the current channel until you can no longer update.
 ifndef::openshift-origin[]
-** If no updates are available, change the *Channel* to the stable-* or fast-* channel for the next minor version, and update to the version that you want in that channel.
+** If no updates are available, change the *Channel* to the `stable-\*` or `fast-*` channel for the next minor version, and update to the version that you want in that channel.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-** If no updates are available, change the *Channel* to the stable-* channel for the next minor version, and update to the version that you want in that channel.
+** If no updates are available, change the *Channel* to the `stable-*` channel for the next minor version, and update to the version that you want in that channel.
 endif::openshift-origin[]
 --
 +


### PR DESCRIPTION
Marking up some channel names. Some of them require `\` to escape the asterisk.

Preview: https://deploy-preview-43372--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-within-minor.html#update-upgrading-web_updating-cluster-within-minor