### PR TITLE
Rm rosa_getting_started_sts redirects

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -167,9 +167,6 @@ AddType text/vtt                            vtt
     # PR https://github.com/openshift/openshift-docs/pull/35208/files for oc-compliance plugin
     RewriteRule ^container-platform/4\.8/security/oc_compliance_plug_in/oc-compliance-plug-in-using.html /container-platform/4.8/security/compliance_operator/oc-compliance-plug-in-using.html [NE,R=302]
 
-    # ROSA STS redirects
-    RewriteRule rosa/rosa_getting_started/rosa-sts-?(.*)$ rosa/rosa_getting_started_sts/rosa-sts-$1 [NE,R=301]
-
     # OSD redirects for new content
     RewriteRule dedicated/4/cloud_infrastructure_access/dedicated-aws-vpn.html dedicated/osd_private_connections/aws-private-connections.html [NE,R=302]
 


### PR DESCRIPTION
Enables the ROSA STS restructure that was merged via https://github.com/openshift/openshift-docs/pull/41923. Basically reverts part of last year's https://github.com/openshift/openshift-docs/pull/34855.