### PR TITLE
RHDEVDOCS-3873 - Added 1.4.3 release notes

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 {gitops-title} is a declarative way to implement continuous deployment for cloud native applications. {gitops-title} ensures consistency in applications when you deploy them to different clusters in different environments, such as: development, staging, and production. {gitops-title} helps you automate the following tasks:
 
 * Ensure that the clusters have similar states for configuration, monitoring, and storage
@@ -22,6 +23,8 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-4-3.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-4-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-4-1.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-4-2.adoc
+++ b/modules/gitops-release-notes-1-4-2.adoc
@@ -5,6 +5,7 @@
 [id="gitops-release-notes-1-4-2_{context}"]
 = Release notes for {gitops-title} 1.4.2
 
+[role="_abstract"]
 {gitops-title} 1.4.2 is now available on {product-title} 4.7, 4.8, and 4.9.
 
 [id="fixed-issues-1-4-2_{context}"]
@@ -14,4 +15,4 @@ The following issue has been resolved in the current release:
 
 * All versions of Argo CD are vulnerable to a path traversal bug that allows to pass arbitrary values to be consumed by Helm charts. This update fixes the `CVE-2022-24348 gitops` error, path traversal and dereference of symlinks when passing Helm value files. link:https://issues.redhat.com/browse/GITOPS-1756[GITOPS-1756]
 
-* Before this update, the *Route* resources got stuck in `Progressing` Health status if more than one `Ingress` is attached to the route.  This update fixes the health check and reports the correct health status of *Route* resource. link:https://issues.redhat.com/browse/GITOPS-1751[GITOPS-1751]
+* Before this update, the *Route* resources got stuck in `Progressing` Health status if more than one `Ingress` were attached to the route.  This update fixes the health check and reports the correct health status of the *Route* resources. link:https://issues.redhat.com/browse/GITOPS-1751[GITOPS-1751]

--- a/modules/gitops-release-notes-1-4-3.adoc
+++ b/modules/gitops-release-notes-1-4-3.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-4-3_{context}"]
+= Release notes for {gitops-title} 1.4.3
+
+[role="_abstract"]
+{gitops-title} 1.4.3 is now available on {product-title} 4.7, 4.8, and 4.9.
+
+[id="fixed-issues-1-4-3_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* Before this update, the TLS certificate in the `argocd-tls-certs-cm` configuration map was deleted by the {gitops-title} unless the certificate was configured in the ArgoCD CR specification `tls.initialCerts` field. This update fixes this issue. link:https://issues.redhat.com/browse/GITOPS-1725[GITOPS-1725]


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.9, 4.10, 4.11
JIRA issues: https://issues.redhat.com/browse/RHDEVDOCS-3873

Preview pages: https://deploy-preview-43383--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes#gitops-release-notes-1-4-3_gitops-release-notes

SME+QE review: 

Peer-review: 