### PR TITLE
BZ2051452: Add subnet requirements to install procedures

### DIFF
--- a/installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc
+++ b/installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc
@@ -11,6 +11,7 @@ toc::[]
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You have read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+include::snippets/installing-subnet-requirements.adoc[]
 
 [id="choosing-a-method-to-install-ocp-on-bare-metal"]
 == Choosing a method to install {product-title} on bare metal

--- a/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
+++ b/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
@@ -17,6 +17,7 @@ toc::[]
 * If you use a firewall and plan to use Telemetry, you
 xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] required by your cluster.
 
+include::snippets/installing-subnet-requirements.adoc[]
 
 [id="choosing-a-method-to-install-ocp-on-vsphere"]
 == Choosing a method to install {product-title} on vSphere

--- a/snippets/installing-subnet-requirements.adoc
+++ b/snippets/installing-subnet-requirements.adoc
@@ -1,0 +1,8 @@
+// Text snippet included in the following assemblies:
+//
+// * installing/installing_vsphere/installing-vsphere.adoc
+// * installing/installing_bare_metal/installing-bare_metal.adoc
+
+:_content-type: SNIPPET
+
+* If you are using network multicast, you ensured no other {product-title} cluster is already running on the L2 subnet assigned to this cluster. Installing clusters on separate subnets prevents broadcast storms and Virtual Router Identifier (VRID) conflicts.


### PR DESCRIPTION
Added a reusable snippet across some of the  install assemblies.

FIXES BZ:  https://bugzilla.redhat.com/show_bug.cgi?id=2051452
Additional information presented by the person that opened the BZ : https://github.com/openshift/installer/blob/master/docs/user/metal/install_ipi.md

QUESTIONS:

- Does this apply to other install methods?  I've only added it to "bare metal" and "vsphere" for now, which is what is mentioned in the BZ, but I wonder if the general statement may be valid for any installation with user-provisioned infrastructure.

Because of this, I've added it to the top-level section of bare metal and vsphere. This means it would apply to all bare metal install procedures (ipi or not) and same for vsphere procedures.

Is this the best place to add this information? Should there be an additional mention on bare-metal ipi  just in case? Should it only apply to ipi?

List of install methods: https://deploy-preview-43386--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html

- Which versions does this apply to? 4.8 onwards?


PREVIEW: 
- https://deploy-preview-43386--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/preparing-to-install-on-bare-metal.html
- https://deploy-preview-43386--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/preparing-to-install-on-vsphere.html

VERSIONS: ???
