### PR TITLE
Remove invalid field "type" from configmap yaml

### DIFF
--- a/modules/identity-provider-config-map.adoc
+++ b/modules/identity-provider-config-map.adoc
@@ -48,7 +48,6 @@ kind: ConfigMap
 metadata:
   name: ca-config-map
   namespace: openshift-config
-type: Opaque
 data:
   ca.crt: |
     <CA_certificate_PEM>

--- a/modules/identity-provider-configuring-apache-request-header.adoc
+++ b/modules/identity-provider-configuring-apache-request-header.adoc
@@ -41,7 +41,6 @@ kind: ConfigMap
 metadata:
   name: ca-config-map
   namespace: openshift-config
-type: Opaque
 data:
   ca.crt: |
     <CA_certificate_PEM>


### PR DESCRIPTION
Configmap does not have a field named "type". I find this while reviewing https://github.com/openshift/openshift-docs/pull/43279 when examining https://docs.openshift.com/container-platform/4.10/authentication/identity_providers/configuring-request-header-identity-provider.html and https://docs.openshift.com/container-platform/4.10/authentication/identity_providers/configuring-basic-authentication-identity-provider.html
@Wiharris help review / merge
CC @y4sht
Thanks!