### PR TITLE
[enterprise-4.9] Added tuneD debug option 

### DIFF
--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -68,6 +68,8 @@ The individual items of the list:
     <match> <4>
   priority: <priority> <5>
   profile: <tuned_profile_name> <6>
+  operand: <7>
+    debug: <bool> <8>
 ----
 <1> Optional.
 <2> A dictionary of key/value `MachineConfig` labels. The keys must be unique.
@@ -75,6 +77,8 @@ The individual items of the list:
 <4> An optional list.
 <5> Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
 <6> A TuneD profile to apply on a match. For example `tuned_profile_1`.
+<7> Optional operand configuration.
+<8> Turn debugging on or off for the TuneD daemon. Options are `true` for on or `false` for off. The default is `false`.
 
 `<match>` is an optional list recursively defined as follows:
 


### PR DESCRIPTION
This backports the change in  https://github.com/openshift/openshift-docs/pull/43408 (originally in https://github.com/openshift/openshift-docs/pull/41687) to 4.9