### PR TITLE
Add JaegerName and JaegerShortName attributes

### DIFF
--- a/_attributes/ossm-document-attributes-1x.adoc
+++ b/_attributes/ossm-document-attributes-1x.adoc
@@ -18,6 +18,8 @@
 :DownloadURL: registry.redhat.io
 :cluster-manager-first: Red Hat OpenShift Cluster Manager
 :kebab: image:kebab.png[title="Options menu"]
+:JaegerName: Red Hat OpenShift Distributed Tracing Platform
+:JaegerShortName: Distributed Tracing Platform
 //
 // Documentation publishing attributes used in the master-docinfo.xml file
 // Note that the DocInfoProductName generates the URL for the product page.


### PR DESCRIPTION
Fixes #43404.

Add `JaegerName` and `JaegerShortName` attributes so that adoc templates using those values render correctly.