### PR TITLE
Removing legacy redirect for creating ROSA STS assembly

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -170,9 +170,6 @@ AddType text/vtt                            vtt
     # OSD redirects for new content
     RewriteRule dedicated/4/cloud_infrastructure_access/dedicated-aws-vpn.html dedicated/osd_private_connections/aws-private-connections.html [NE,R=302]
 
-    # ROSA STS Creating Cluster to multiple pages - https://github.com/openshift/openshift-docs/pull/36955
-    RewriteRule rosa/rosa_getting_started_sts/rosa-sts-creating-cluster\.html rosa/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-creating-a-cluster-quickly.html [NE,R=302]
-
     # ACS welcome page redirect to StackRox docs
     # RewriteRule ^acs/?(.*)$ https://help.stackrox.com/ [NE,R=301]
 


### PR DESCRIPTION
This applies to `main` only.

This pull request removes a legacy redirect that refers to a target page that no longer exists. The page was moved in the recent ROSA restructuring through https://github.com/openshift/openshift-docs/pull/41923, along with many other relocations.