### PR TITLE
GH-42367: Fix broken links

### DIFF
--- a/modules/investigating-kernel-crashes.adoc
+++ b/modules/investigating-kernel-crashes.adoc
@@ -13,7 +13,7 @@ The `kdump` service, included in `kexec-tools`, provides a crash-dumping mechani
 The `kdump` service is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 
 For more information about the support scope of Red Hat Technology Preview
-features, see https://access.redhat.com/support/offerings/techpreview/.
+features, see link:https://access.redhat.com/support/offerings/techpreview/[].
 
 {op-system} ships with `kexec-tools`, but manual configuration is required to enable `kdump`.
 
@@ -37,7 +37,7 @@ Network dumps are required when using LUKS. `kdump` does not support local crash
 +
 For details on configuring the `kdump` service, see the comments in `/etc/sysconfig/kdump`, `/etc/kdump.conf`, and the `kdump.conf` manual page.
 ifdef::openshift-enterprise[]
-Also refer to the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/installing-and-configuring-kdump_system-design-guide#configuring-the-kdump-target_configuring-kdump-on-the-command-line[RHEL `kdump` documentation] for further information on configuring the dump target.
+Also refer to the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/configuring-kdump-on-the-command-line_managing-monitoring-and-updating-the-kernel[RHEL `kdump` documentation] for further information on configuring the dump target.
 endif::[]
 
 . Enable the `kdump` systemd service.
@@ -131,7 +131,7 @@ $ butane 99-worker-kdump.bu -o 99-worker-kdump.yaml
 == Testing the kdump configuration
 
 ifdef::openshift-enterprise[]
-See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/installing-and-configuring-kdump_system-design-guide#testing-the-kdump-configuration_installing-and-configuring-kdump[Testing the kdump configuration] section in the {op-system-base} documentation for `kdump`.
+See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/configuring-kdump-on-the-command-line_managing-monitoring-and-updating-the-kernel#testing-the-kdump-configuration_configuring-kdump-on-the-command-line[Testing the kdump configuration] section in the {op-system-base} documentation for `kdump`.
 endif::[]
 
 ifdef::openshift-origin[]
@@ -141,7 +141,7 @@ endif::[]
 == Analyzing a core dump
 
 ifdef::openshift-enterprise[]
-See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/installing-and-configuring-kdump_system-design-guide#analyzing-a-core-dump_installing-and-configuring-kdump[Analyzing a core dump] section in the {op-system-base} documentation for `kdump`.
+See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/analyzing-a-core-dump_managing-monitoring-and-updating-the-kernel[Analyzing a core dump] section in the {op-system-base} documentation for `kdump`.
 endif::[]
 
 ifdef::openshift-origin[]
@@ -155,7 +155,7 @@ ifdef::openshift-origin[]
 * link:https://fedoraproject.org/wiki/How_to_use_kdump_to_debug_kernel_crashes[Setting up kdump in Fedora]
 endif::[]
 ifdef::openshift-enterprise[]
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/installing-and-configuring-kdump_system-design-guide[Setting up kdump in RHEL]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/configuring-kdump-on-the-command-line_managing-monitoring-and-updating-the-kernel[Setting up kdump in RHEL]
 endif::[]
 * link:https://www.kernel.org/doc/html/latest/admin-guide/kdump/kdump.html[Linux kernel documentation for kdump]
 * kdump.conf(5) — a manual page for the `/etc/kdump.conf` configuration file containing the full documentation of available options


### PR DESCRIPTION
Fixes #42367

OCP Version: 4.6+

Current 4.10 docs: https://docs.openshift.com/container-platform/4.10/support/troubleshooting/troubleshooting-operating-system-issues.html#enabling-kdump

Direct doc preview link: https://deploy-preview-43448--osdocs.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operating-system-issues#enabling-kdump