### PR TITLE
BZ-1910188: Adding Basic Audit clarifications

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1148,11 +1148,40 @@ AUDIT: id="5c3b8227-4af9-4322-8a71-542231c3887b" ip="127.0.0.1" method="GET" use
 AUDIT: id="5c3b8227-4af9-4322-8a71-542231c3887b" response="200"
 ----
 
-To enable and configure audit, edit the *_/etc/origin/master/master-config.yaml_*
-file or use a command similar to the following:
+[[proc-master-node-config-audit-config]]
+==== Enable Basic Auditing
 
+The following procedure enables basic auditing post installation.
+
+[NOTE]
+====
+Advanced Audit must be enabled during installation.
+====
+
+. Edit the *_/etc/origin/master/master-config.yaml_* file on all master nodes as shown in the following example:
++
+[source,terminal]
 ----
-$ openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/log/origin/audit-ocp.log", "maximumFileRetentionDays": 14, "maximumFileSizeMegabytes": 500, "maximumRetainedFiles": 15}
+auditConfig:
+  auditFilePath: "/var/log/origin/audit-ocp.log"
+  enabled: true
+  maximumFileRetentionDays: 14
+  maximumFileSizeMegabytes: 500
+  maximumRetainedFiles: 15
+----
+
+. Restart the API pods in your cluster.
++
+[source,terminal]
+----
+# /usr/local/bin/master-restart api
+----
+
+To enable basic auditing during installation, add the following variable declaration to your inventory file. Adjust values as appropriate.
+
+[source,terminal]
+----
+openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/lib/origin/openpaas-oscp-audit.log", "maximumFileRetentionDays": 14, "maximumFileSizeMegabytes": 500, "maximumRetainedFiles": 5}
 ----
 
 The audit configuration takes the following parameters:


### PR DESCRIPTION
Applies to 3.11
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1910188
QE ack required.
Preview Link: [Enable Basic Auditing](https://deploy-preview-43452--osdocs.netlify.app/openshift-enterprise/latest/install_config/master_node_configuration.html#proc-master-node-config-audit-config)