### PR TITLE
CCXDEV-7484 Update simple content doc with link to builds doc

### DIFF
--- a/support/remote_health_monitoring/insights-operator-simple-access.adoc
+++ b/support/remote_health_monitoring/insights-operator-simple-access.adoc
@@ -7,14 +7,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Insights Operator can import your RHEL Simple Content Access (SCA) certificates from {cluster-manager-url}. SCA is a capability in Red Hat’s subscription tools which simplifies the behavior of the entitlement tooling. It is easier to consume the content provided by your Red Hat subscriptions without the complexity of configuring subscription tooling. After importing the certificates, they are stored in the `etc-pki-entitlement` secret in the `openshift-config-managed` namespace.
+Insights Operator periodically imports your simple content access certificates from {cluster-manager-url} and stores them in the `etc-pki-entitlement` secret in the `openshift-config-managed` namespace. Simple content access is a capability in Red Hat subscription tools which simplifies the behavior of the entitlement tooling. This feature makes it easier to consume the content provided by your Red Hat subscriptions without the complexity of configuring subscription tooling.
 
 Insights Operator imports simple content access certificates every 8 hours by default, but can be configured or disabled using the `support` secret in the `openshift-config` namespace.
 
-For more information about simple content access, see link:https://access.redhat.com/documentation/en-us/subscription_central/2021/html-single/getting_started_with_simple_content_access/index#assembly-about-simplecontent[_About simple content access_] in the Red Hat Subscription Central documentation.
+[role="_additional-resources"]
+.Additional resources
 
-// This is a placeholder for when the Build Entitlements doc is updated to reference simple content access certificates
-// For information on using simple content access certificates in {product-title} see (xref to entitlements doc)
+* See link:https://access.redhat.com/documentation/en-us/subscription_central/2021/html-single/getting_started_with_simple_content_access/index#assembly-about-simplecontent[About simple content access] in the Red Hat Subscription Central documentation, for more information about simple content access.
+
+* See xref:../../cicd/builds/running-entitled-builds.adoc[Using Red Hat subscriptions in builds], for more information about using simple content access certificates in {product-title} entitled builds.
 
 include::modules/insights-operator-configuring-sca.adoc[leveloffset=+1]
 


### PR DESCRIPTION
versions: `enterprise-4.10`, `enterprise-4.11`

This is a small update to add a link to the build doc from our SCA docs. Also, fixes text that was reverted somehow to the old version. 

Jira: https://issues.redhat.com/browse/CCXDEV-7484

Preview: https://deploy-preview-43459--osdocs.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/insights-operator-simple-access.html

SME: tremes 
QE: JoaoFula 