### PR TITLE
BZ-2062563: Fixing an external link

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1278,7 +1278,7 @@ Additional VMware vSphere configuration parameters are described in the followin
 |`platform.vsphere.username`
 |The user name to use to connect to the vCenter instance with. This user must have at least
 the roles and privileges that are required for
-link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/vcp-roles.html[static or dynamic persistent volume provisioning]
+link:https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/vcp-roles.md[static or dynamic persistent volume provisioning]
 in vSphere.
 |String
 

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -134,7 +134,7 @@ value must match the number of control plane machines that you deploy.
 <7> The fully-qualified hostname or IP address of the vCenter server.
 <8> The name of the user for accessing the server. This user must have at least
 the roles and privileges that are required for
-link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/vcp-roles.html[static or dynamic persistent volume provisioning]
+link:https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/vcp-roles.md[static or dynamic persistent volume provisioning]
 in vSphere.
 <9> The password associated with the vSphere user.
 <10> The vSphere datacenter.


### PR DESCRIPTION
Applies to 4.6+ 
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=2062563
Preview Links:

- [Additional VMware vSphere configuration parameters](https://deploy-preview-43469--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-configuration-parameters-additional-vsphere_installing-vsphere-installer-provisioned-customizations), 2nd row in the table. 
- [Sample install-config.yaml file for VMware vSphere](https://deploy-preview-43469--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-config-yaml_installing-vsphere), number 8 below the sample YAML file.

QE ack required.
