### PR TITLE
OSDOCS-3203: OCM and Operator Roles and Policies

### DIFF
--- a/modules/rosa-sts-account-wide-role-and-policy-commands.adoc
+++ b/modules/rosa-sts-account-wide-role-and-policy-commands.adoc
@@ -1,11 +1,17 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-about-iam-resources.adoc
-
+:_content-type: PROCEDURE
 [id="rosa-sts-account-wide-role-and-policy-aws-cli_{context}"]
 = Account-wide IAM role and policy AWS CLI reference
 
-This section lists the `aws` CLI commands that are shown in the terminal when you run the following `rosa` command using `manual` mode:
+This section lists the `aws` CLI commands that the `rosa` command generates in the terminal. You can run the command in either manual or automatic mode.
+
+[discrete]
+[id="rosa-sts-account-wide-role-and-policy-aws-cli-manual-mode_{context}"]
+== Using manual mode for account role creation
+
+The manual role creation mode generates the `aws` commands for you to review and run. The following command starts that process:
 
 [source,terminal]
 ----
@@ -14,7 +20,7 @@ $ rosa create account-roles --mode manual
 
 [NOTE]
 ====
-When using `manual` mode, the `aws` commands are printed to the terminal for your review. After reviewing the `aws` commands, you must run them manually. Alternatively, you can specify `--mode auto` with the `rosa create` command to run the `aws` commands immediately.
+The provided command examples include the `ManagedOpenShift` prefix. The `ManagedOpenShift` prefix is the default value, if you do not specify a custom prefix by using the `--prefix` option.
 ====
 
 .Command output
@@ -86,7 +92,41 @@ aws iam create-policy \
 	--tags Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value=ManagedOpenShift Key=operator_namespace,Value=openshift-image-registry Key=operator_name,Value=installer-cloud-credentials
 ----
 
+[discrete]
+[id="rosa-sts-account-wide-role-and-policy-aws-cli-auto-mode_{context}"]
+== Using auto mode for role creation
+
+When you add the `--mode auto` argument, the `rosa` CLI tool creates your roles and policies. The following command starts that process:
+
+[source,terminal]
+----
+$ rosa create account-roles --mode auto
+----
+
 [NOTE]
 ====
-The command examples provided in the table include the `ManagedOpenShift` prefix. The prefix is implied if you do not specify a custom prefix by using the `--prefix` option.
+The provided command examples include the `ManagedOpenShift` prefix. The `ManagedOpenShift` prefix is the default value, if you do not specify a custom prefix by using the `--prefix` option.
 ====
+
+.Command output
+[source,terminal]
+----
+I: Creating roles using 'arn:aws:iam::<ARN>:user/<UserID>'
+? Create the 'ManagedOpenShift-Installer-Role' role? Yes
+I: Created role 'ManagedOpenShift-Installer-Role' with ARN 'arn:aws:iam::<ARN>:role/ManagedOpenShift-Installer-Role'
+? Create the 'ManagedOpenShift-ControlPlane-Role' role? Yes
+I: Created role 'ManagedOpenShift-ControlPlane-Role' with ARN 'arn:aws:iam::<ARN>:role/ManagedOpenShift-ControlPlane-Role'
+? Create the 'ManagedOpenShift-Worker-Role' role? Yes
+I: Created role 'ManagedOpenShift-Worker-Role' with ARN 'arn:aws:iam::<ARN>:role/ManagedOpenShift-Worker-Role'
+? Create the 'ManagedOpenShift-Support-Role' role? Yes
+I: Created role 'ManagedOpenShift-Support-Role' with ARN 'arn:aws:iam::<ARN>:role/ManagedOpenShift-Support-Role'
+? Create the operator policies? Yes
+I: Created policy with ARN 'arn:aws:iam::<ARN>:policy/ManagedOpenShift-openshift-machine-api-aws-cloud-credentials'
+I: Created policy with ARN 'arn:aws:iam::<ARN>:policy/ManagedOpenShift-openshift-cloud-credential-operator-cloud-crede'
+I: Created policy with ARN 'arn:aws:iam::<ARN>:policy/ManagedOpenShift-openshift-image-registry-installer-cloud-creden'
+I: Created policy with ARN 'arn:aws:iam::<ARN>:policy/ManagedOpenShift-openshift-ingress-operator-cloud-credentials'
+I: Created policy with ARN 'arn:aws:iam::<ARN>:policy/ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credent'
+I: Created policy with ARN 'arn:aws:iam::<ARN>:policy/ManagedOpenShift-openshift-cloud-network-config-controller-cloud'
+I: To create a cluster with these roles, run the following command:
+rosa create cluster --sts
+----

--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -9,6 +9,43 @@ This section provides details about the account-wide IAM roles and policies that
 
 The account-wide roles and policies are specific to an OpenShift minor release version, for example OpenShift 4.8, and are backward compatible. You can minimize the required STS resources by reusing the account-wide roles and policies for multiple clusters of the same minor version, regardless of their patch version.
 
+[id="rosa-sts-account-wide-roles-and-policies-creation-methods_{context}"]
+== Methods of account-wide role creation
+
+// Commenting out until ROSA UI release
+//
+// You can create account-wide roles by using the `rosa` CLI tool or the {cluster-manager-url} guided installation. You can create the roles manually or by using an automatic process that uses pre-defined names for these roles and polices.
+//
+//  Commenting out until ROSA UI release
+
+You can create account-wide roles by using the `rosa` CLI tool. You can create the roles manually or by using an automatic process that uses pre-defined names for these roles and polices.
+
+[discrete]
+[id="rosa-sts-account-wide-roles-and-policies-creation-methods-manual_{context}"]
+=== Manual ocm-role resource creation
+
+// Commenting out until ROSA UI release
+//
+// You can use the manual creation method if you have the necessary CLI access to create these roles on your system. You can run this option in your desired CLI tool or from {cluster-manager}. After you start the manual creation process, the CLI presents a series of commands for you to run that create the roles and link them to the needed policies.
+//
+//  Commenting out until ROSA UI release
+
+You can use the manual creation method if you have the necessary CLI access to create these roles on your system. You can run this option in your desired CLI tool or from {cluster-manager}. After you start the manual creation process, the CLI presents a series of commands for you to run that create the roles and link them to the needed policies.
+
+[discrete]
+[id="rosa-sts-account-wide-roles-and-policies-creation-methods-auto_{context}"]
+=== Automatic ocm-role resource creation
+
+// Commenting out until ROSA UI release
+//
+// If you created an `ocm-role` resource with administrative permissions, you can use the automatic creation method in the CLI and from {cluster-manager}. Selecting this method creates the roles and policies that uses the default names.
+//
+// If you use the ROSA guided installation on {cluster-manager}, you must have created an `ocm-role` resource with administrative permissions in the first step of the guided cluster installation. Without this role, you cannot use the automatic Operator role and policy creation option.
+//
+//  Commenting out until ROSA UI release
+
+If you created an `ocm-role` resource with administrative permissions, you can use the automatic creation method in the CLI. Selecting this method creates the roles and policies that uses the default names.
+
 [NOTE]
 ====
 The account number present in the `sts_installer_trust_policy.json` and `sts_support_trust_policy.json` samples represents the Red Hat account that is allowed to assume the required roles.

--- a/modules/rosa-sts-aws-requirements.adoc
+++ b/modules/rosa-sts-aws-requirements.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc
-
+:_content-type: CONCEPT
 [id="rosa-sts-customer-requirements_{context}"]
 = Customer requirements when using STS for deployment
 
@@ -19,6 +19,105 @@ The following prerequisites must be complete before you deploy a {product-title}
 [NOTE]
 ====
 Customers are encouraged, but not mandated, to deploy resources in a Virtual Private Cloud (VPC) separate from the VPC hosting {product-title} and other Red Hat supported services.
+====
+
+[id="rosa-associating-account_{context}"]
+== Associating your AWS account
+
+To perform {product-title} (ROSA) cluster provisioning tasks, you must create `ocm-role` and `user-role` IAM resources in your AWS account and link them to your Red Hat organization.
+
+The `ocm-role` ARN is stored as a label in your Red Hat organization while the `user-role` ARN is stored as a label inside your Red Hat user account. Red Hat uses these ARN labels to confirm that the user is a valid account holder and that the correct permissions are available to perform the necessary tasks in the AWS account.
+
+.Prerequisites
+
+* You have an AWS account.
+* You have the permissions required to install AWS account-wide roles.
+* You have installed and configured the latest AWS (`aws`) and ROSA (`rosa`) CLIs on your installation host.
+* You have created your `ocm-role` and `user-role` IAM roles.
+
+// Commenting out until ROSA UI release
+//
+// * You have an AWS account.
+// * You are using {cluster-manager-url} to create clusters.
+// * You have the permissions required to install AWS account-wide roles.
+// * You have installed and configured the latest AWS (`aws`) and ROSA (`rosa`) CLIs on your installation host.
+// * You have created your `ocm-role` and `user-role` IAM roles.
+//
+//  Commenting out until ROSA UI release
+
+.Procedures
+
+1. From the CLI, link your `ocm-role` resource to your Red Hat organization by using your Amazon Resource Name (ARN):
++
+[NOTE]
+====
+You must have organization administrator privileges to run the `rosa link` command. After you link the `ocm-role` resource with your AWS account, it is visible for all users in the organization.
+====
++
+[source,terminal]
+----
+$ rosa link ocm-role --role-arn <arn>
+----
++
+.Example output
+[source,terminal]
+----
+I: Linking OCM role
+? Link the '<AWS ACCOUNT ID>` role with organization '<ORG ID>'? Yes
+I: Successfully linked role-arn '<AWS ACCOUNT ID>' with organization account '<ORG ID>'
+----
+1. From the CLI, link your `user-role` resource to your Red Hat user account by using your Amazon Resource Name (ARN):
++
+[source,terminal]
+----
+$ rosa link user-role --role-arn <arn>
+----
++
+.Example output
+[source,terminal]
+----
+I: Linking User role
+? Link the 'arn:aws:iam::<ARN>:role/ManagedOpenShift-User-Role-125' role with organization '<AWS ID>'? Yes
+I: Successfully linked role-arn 'arn:aws:iam::<ARN>:role/ManagedOpenShift-User-Role-125' with organization account '<AWS ID>'
+----
+
+[id="rosa-associating-multiple-account_{context}"]
+=== Associating multiple AWS accounts with your Red Hat organization
+
+You can associate multiple AWS accounts with your Red Hat organization. Associating multiple accounts lets you create {product-title} (ROSA) clusters on any of the associated AWS accounts from your Red Hat organization.
+
+With this feature, you can create clusters in different AWS regions by using multiple AWS profiles as region-bound environments.
+
+.Specifying an AWS profile name when creating the OCM, user, and account roles
+
+To associate an additional AWS account, first create a profile in your local AWS configuration. Then, associate the account with your Red Hat organization by creating the `ocm-role`, user, and account roles in the additional AWS account.
+
+To create the roles in an additional region, specify the `--profile <aws-profile>` parameter when running the `rosa create` commands and replace `<aws_profile>` with the additional account profile name:
+
+* To specify an AWS account profile when creating an {cluster-manager} role:
++
+[source,terminal]
+----
+$ rosa create --profile <aws_profile> ocm-role
+----
+
+* To specify an AWS account profile when creating a user role:
++
+[source,terminal]
+----
+$ rosa create --profile <aws_profile> user-role
+----
+
+* To specify an AWS account profile when creating the account roles:
++
+[source,terminal]
+----
+$ rosa create --profile <aws_profile> account-roles
+----
+
+[NOTE]
+====
+If you do not specify a profile, the default AWS profile is used.
 ====
 
 [id="rosa-access-requirements_{context}"]

--- a/modules/rosa-sts-ocm-role-creation.adoc
+++ b/modules/rosa-sts-ocm-role-creation.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// rosa_architecture/rosa-sts-about-iam-resources.adoc
+//
+:_content-type: PROCEDURE
+[id="rosa-sts-ocm-roles-and-permissions-iam-basic-role_{context}"]
+= Creating an {cluster-manager} IAM role
+
+You create your {cluster-manager} IAM roles by using the command-line interface (CLI).
+
+.Prerequisites
+
+* You have an AWS account.
+* You have organization administrator privileges in the {cluster-manager} organization.
+* You have the permissions required to install AWS account-wide roles.
+* You have installed and configured the latest AWS (`aws`) and ROSA (`rosa`) CLIs on your installation host.
+
+.Procedure
+* To create an ocm-role IAM role with basic privileges, run the following command:
+[source,terminal]
+----
+$ rosa create ocm-role
+----
+
+* To create an ocm-role IAM role with admin privileges, run the following command:
+
+[source,terminal]
+----
+$ rosa create ocm-role --admin
+----
+
+This command lets you create the role by specifying specific attribues. The following example output shows the "auto mode" selected, which lets the `rosa` CLI to create your Operator roles and policies. See "Understanding the auto and manual deployment modes" in the Additional resources for more information.
+
+.Example output
+[source,terminal]
+----
+I: Creating ocm role
+? Role prefix: ManagedOpenShift <1>
+? Enable admin capabilities for the OCM role (optional): No <2>
+? Permissions boundary ARN (optional):  <3>
+? Role creation mode: auto <4>
+I: Creating role using 'arn:aws:iam::<ARN>:user/<UserName>'
+? Create the 'ManagedOpenShift-OCM-Role-182' role? Yes <5>
+I: Created role 'ManagedOpenShift-OCM-Role-182' with ARN  'arn:aws:iam::<ARN>:role/ManagedOpenShift-OCM-Role-182'
+I: Linking OCM role
+? OCM Role ARN: arn:aws:iam::<ARN>:role/ManagedOpenShift-OCM-Role-182 <6>
+? Link the 'arn:aws:iam::<ARN>:role/ManagedOpenShift-OCM-Role-182' role with organization '<AWS ARN'? Yes <7>
+I: Successfully linked role-arn 'arn:aws:iam::<ARN>:role/ManagedOpenShift-OCM-Role-182' with organization account '<AWS ARN>'
+----
+<1> A prefix value for all of the created AWS resources. In this example, `ManagedOpenShift` prepends all of the AWS resources.
+<2> Choose if you want this role to have the additional admin permissions.
++
+[NOTE]
+====
+You do not see this prompt if you used the `--admin` option.
+====
++
+<3> The Amazon Resource Name (ARN) of the policy to set permission boundaries.
+<4> Choose the method of how to create your AWS roles. Using `auto`, the `rosa` CLI tool generates and links the roles and policies. In the `auto` mode, you receive some different prompts to create the AWS roles.
+<5> The auto method asks if you want to create a specific `ocm-role` using your prefix.
+<6> Confirm that you want to associate your IAM role with your {cluster-manager}.
+<7> Links the created role with your AWS organization.

--- a/modules/rosa-sts-understanding-ocm-role.adoc
+++ b/modules/rosa-sts-understanding-ocm-role.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// rosa_architecture/rosa-sts-about-iam-resources.adoc
+//
+:_content-type: CONCEPT
+[id="rosa-sts-understanding-ocm-role_{context}"]
+= Understanding the {cluster-manager} role
+
+Creating ROSA clusters in {cluster-manager-url} require an `ocm-role` IAM role. The basic `ocm-role` IAM role permissions let you to perform cluster maintenance within {cluster-manager}. To automatically create the operator roles and OpenID Connect (OIDC) provider, you must add the `--admin` option to the `rosa create` command. This command creates an `ocm-role` resource with additional permissions needed for administrative tasks.
+
+[NOTE]
+====
+This elevated IAM role allows {cluster-manager} to automatically create the cluster-specific Operator roles and OIDC provider during cluster creation. For more information about this automatic role and policy creation, see the "Understanding the auto and manual deployment modes" link in Additional resources.
+====
+
+[id="rosa-sts-understanding-user-role_{context}"]
+== Understanding the user role
+
+In addition to an `ocm-role` IAM role, you must create a user role so that {product-title} can verify your AWS identity. This role has no permissions, and it is only used to create a trust relationship between the installer account and your `ocm-role` resources.
+
+The following tables show the associated basic and administrative permissions for the `ocm-role` resource.
+
+.Associated permissions for the basic `ocm-role` resource
+[cols="1,2",options="header"]
+|===
+
+|Resource|Description
+
+| `iam:GetOpenIDConnectProvider`
+| This permission allows the basic role to retrieve information about the specified OpenID Connect (OIDC) provider.
+| `iam:GetRole`
+| This permission allows the basic role to retrieve any information for a specified role. Some of the data returned include the role's path, GUID, ARN, and the role's trust policy that grants permission to assume the role.
+| `iam:ListRoles`
+| This permission allows the basic role to list the roles within a path prefix.
+| `iam:ListRoleTags`
+| This permission allows the basic role to list the tags on a specified role.
+| `ec2:DescribeRegions`
+| This permission allows the basic role to return information about all of the enabled regions on your account.
+| `ec2:DescribeRouteTables`
+| This permission allows the basic role to return information about all of your route tables.
+| `ec2:DescribeSubnets`
+| This permission allows the basic role to return information about all of your subnets.
+| `ec2:DescribeVpcs`
+| This permission allows the basic role to return information about all of your virtual private clouds (VPCs).
+| `sts:AssumeRole`
+| This permission allows the basic role to retrieve temporary security credentials to access AWS resources that are beyond its normal permissions.
+| `sts:AssumeRoleWithWebIdentity`
+| This permission allows the basic role to retrieve temporary security credentials for users authenticated their account with a web identity provider.
+
+|===
+
+.Additional permissions for the admin `ocm-role` resource
+[cols="1,2",options="header"]
+|===
+
+|Resource|Description
+
+| `iam:AttachRolePolicy`
+| This permission allows the admin role to attach a specified policy to the desired IAM role.
+| `iam:CreateOpenIDConnectProvider`
+| This permission creates a resource that describes an identity provider, which supports OpenID Connect (OIDC). When you create an OIDC provider with this permission, this provider establishes a trust relationship between the provider and AWS.
+| `iam:CreateRole`
+| This permission allows the admin role to create a role for your AWS account.
+| `iam:ListPolicies`
+| This permission allows the admin role to list any policies associated with your AWS account.
+| `iam:ListPolicyTags`
+| This permission allows the admin role to list any tags on a designated policy.
+| `iam:PutRolePermissionsBoundary`
+| This permission allows the admin role to change the permissions boundary for a user based on a specified policy.
+| `iam:TagRole`
+| This permission allows the admin role to add tags to an IAM role.
+
+|===

--- a/rosa_architecture/rosa-sts-about-iam-resources.adoc
+++ b/rosa_architecture/rosa-sts-about-iam-resources.adoc
@@ -11,6 +11,9 @@ To deploy a {product-title} (ROSA) cluster that uses the AWS Security Token Serv
 * Specific account-wide IAM roles and policies that provide the STS permissions required for ROSA support, installation, control plane, and compute functionality. This includes account-wide Operator policies.
 * Cluster-specific Operator IAM roles that permit the ROSA cluster Operators to carry out core OpenShift functionality.
 * An OpenID Connect (OIDC) provider that the cluster Operators use to authenticate.
+* If you deploy ROSA by using {cluster-manager}, you must create the additional resources:
+** An {cluster-manager} IAM role to complete the installation on your cluster.
+** A user role without any permissions to verify your AWS account identity.
 
 This document provides reference information about the IAM resources that you must deploy when you create a ROSA cluster that uses STS. It also includes the `aws` CLI commands that are generated when you use `manual` mode with the `rosa create` command.
 
@@ -19,6 +22,44 @@ This document provides reference information about the IAM resources that you mu
 
 * For steps to quickly create a ROSA cluster with STS, including the AWS IAM resources, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[Creating a ROSA cluster with STS quickly].
 * For steps to create a ROSA cluster with STS using customizations, including the AWS IAM resources, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-a-cluster-with-customizations[Creating a ROSA cluster with STS using customizations].
+
+[id="rosa-sts-ocm-roles-and-permissions_{context}"]
+== {cluster-manager} roles and permissions
+
+// Commenting out until ROSA UI release
+// If you create ROSA clusters by using {cluster-manager-url}, you must have the following AWS IAM roles linked to your AWS account to create and manage the clusters. For more information about linking your IAM roles to your AWS account, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-associating-account_rosa-sts-aws-prereqs[Associating your AWS account].
+//
+// [TIP]
+//====
+// If you only use the `rosa` CLI tool, then you do not need to create these IAM roles.
+// ====
+//
+// These AWS IAM roles are as follows:
+//
+// * The ROSA user role is an AWS role used by Red Hat to verify the customer's AWS identity. This role has no additional permissions, and the role has a trust relationship with the Red Hat installer account.
+// * An `ocm-role` resource grants the required permissions for installation of ROSA clusters in {cluster-manager}. You can apply basic or administrative permissions to the `ocm-role` resource. If you create an administrative `ocm-role` resource, {cluster-manager} can create the needed AWS Operator roles and OpenID Connect (OIDC) provider. This IAM role also creates a trust relationship with the Red Hat installer account as well.
+//
+// You must create this user role as well as an administrative `ocm-role` resource, if you want to use the auto mode in {cluster-manager} to create your Operator role policies and OIDC provider.
+//
+// include::modules/rosa-sts-understanding-ocm-role.adoc[leveloffset=+2]
+// [discrete]
+// include::modules/rosa-sts-ocm-role-creation.adoc[leveloffset=+2]
+//
+//  Commenting out until ROSA UI release
+
+AWS IAM roles link to your AWS account to create and manage the clusters. For more information about linking your IAM roles to your AWS account, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-associating-account_rosa-sts-aws-prereqs[Associating your AWS account].
+
+include::modules/rosa-sts-ocm-role-creation.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+== Additional resources
+* link:https://docs.aws.amazon.com/IAM/latest/APIReference/API_Types.html[AWS Identity and Access Management Data Types]
+* link:https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Types.html[Amazon Elastic Computer Cloud Data Types]
+* link:https://docs.aws.amazon.com/STS/latest/APIReference/API_Types.html[AWS Token Security Service Data Types]
+//
+// Keep this commented out until PR # 45306 is merged
+//
+//* xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-a-cluster-with-customizations[Understanding the auto and manual deployment modes]
 
 include::modules/rosa-sts-account-wide-roles-and-policies.adoc[leveloffset=+1]
 

--- a/sts_ocm_admin_permission_policy.json
+++ b/sts_ocm_admin_permission_policy.json
@@ -1,0 +1,22 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole",
+        "iam:CreateRole",
+        "iam:PutRolePermissionsBoundary",
+        "iam:TagRole",
+        "iam:ListPolicies",
+        "iam:ListPolicyTags",
+        "iam:AttachRolePolicy",
+        "iam:GetOpenIDConnectProvider",
+        "iam:CreateOpenIDConnectProvider",
+        "iam:TagOpenIDConnectProvider",
+        "iam:GetPolicy"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/sts_ocm_permission_policy.json
+++ b/sts_ocm_permission_policy.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:ListRoles",
+        "iam:GetRole",
+        "iam:ListRoleTags",
+        "iam:GetOpenIDConnectProvider",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeRegions",
+        "ec2:DescribeRouteTables",
+        "sts:AssumeRole",
+        "sts:AssumeRoleWithWebIdentity"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/sts_ocm_trust_policy.json
+++ b/sts_ocm_trust_policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::710019948333:role/RH-Managed-OpenShift-Installer"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Condition": {"StringEquals": {"sts:ExternalId": "1xJPTZZdq6sW8bJh8X32Q05bxuo"}}
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a UI friendly page to the ROSA documentation that highlights the information around creating cluster roles and OIDC provider.

JIRA: [OSDOCS 3201](https://issues.redhat.com/browse/OSDOCS-3201) and [OSDOCS 3203](https://issues.redhat.com/browse/OSDOCS-3203)

PREVIEW: 

- **_OCM Roles ([OSDOCS-3201](https://issues.redhat.com//browse/OSDOCS-3201))_** - https://deploy-preview-43476--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-ocm-roles-and-permissions_rosa-sts-about-iam-resources
- **_Operator Roles and Policies ([OSDOCS-3203](https://issues.redhat.com//browse/OSDOCS-3203))_** - 
    - https://deploy-preview-43476--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html#methods-of-account-wide-role-creation
    - See #45306. A link to that content will be added when that PR is merged.
- **_Associating AWS Account_** **_([OSDOCS-3198](https://issues.redhat.com/browse/OSDOCS-3198))_** - https://deploy-preview-43476--osdocs.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#rosa-associating-account_rosa-sts-aws-prereqs
    - **_Associating multiple AWS accounts_** **_([OSDOCS-3604](https://issues.redhat.com/browse/OSDOCS-3604))_**-  https://deploy-preview-43476--osdocs.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#rosa-associating-multiple-account_rosa-sts-aws-prereqs