### PR TITLE
Omit default from default CNI cluster network provider

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1068,10 +1068,10 @@ Topics:
     File: using-pod-level-bonding
   - Name: Configuring hardware offloading
     File: configuring-hardware-offloading
-- Name: OpenShift SDN default CNI network provider
+- Name: OpenShift SDN cluster network provider
   Dir: openshift_sdn
   Topics:
-  - Name: About the OpenShift SDN default CNI network provider
+  - Name: About the OpenShift SDN cluster network provider
     File: about-openshift-sdn
   - Name: Configuring egress IPs for a project
     File: assigning-egress-ips
@@ -1106,11 +1106,11 @@ Topics:
   - Name: Configuring kube-proxy
     File: configuring-kube-proxy
     Distros: openshift-enterprise,openshift-origin
-- Name: OVN-Kubernetes default CNI network provider
+- Name: OVN-Kubernetes cluster network provider
   Dir: ovn_kubernetes_network_provider
   Distros: openshift-origin,openshift-enterprise
   Topics:
-  - Name: About the OVN-Kubernetes network provider
+  - Name: About the OVN-Kubernetes cluster network provider
     File: about-ovn-kubernetes
   - Name: Migrating from the OpenShift SDN cluster network provider
     File: migrate-from-openshift-sdn

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1068,10 +1068,10 @@ Topics:
     File: using-pod-level-bonding
   - Name: Configuring hardware offloading
     File: configuring-hardware-offloading
-- Name: OpenShift SDN cluster network provider
+- Name: OpenShift SDN CNI network provider
   Dir: openshift_sdn
   Topics:
-  - Name: About the OpenShift SDN cluster network provider
+  - Name: About the OpenShift SDN CNI network provider
     File: about-openshift-sdn
   - Name: Configuring egress IPs for a project
     File: assigning-egress-ips
@@ -1106,11 +1106,11 @@ Topics:
   - Name: Configuring kube-proxy
     File: configuring-kube-proxy
     Distros: openshift-enterprise,openshift-origin
-- Name: OVN-Kubernetes cluster network provider
+- Name: OVN-Kubernetes CNI network provider
   Dir: ovn_kubernetes_network_provider
   Distros: openshift-origin,openshift-enterprise
   Topics:
-  - Name: About the OVN-Kubernetes cluster network provider
+  - Name: About the OVN-Kubernetes CNI network provider
     File: about-ovn-kubernetes
   - Name: Migrating from the OpenShift SDN cluster network provider
     File: migrate-from-openshift-sdn

--- a/networking/openshift_sdn/about-openshift-sdn.adoc
+++ b/networking/openshift_sdn/about-openshift-sdn.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="about-openshift-sdn"]
-= About the OpenShift SDN default CNI network provider
+= About the OpenShift SDN Container Network Interface (CNI) cluster network provider
 include::_attributes/common-attributes.adoc[]
 :context: about-openshift-sdn
 

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="about-ovn-kubernetes"]
-= About the OVN-Kubernetes default Container Network Interface (CNI) network provider
+= About the OVN-Kubernetes Container Network Interface (CNI) cluster network provider
 include::_attributes/common-attributes.adoc[]
 :context: about-ovn-kubernetes
 


### PR DESCRIPTION
Using _default_ is confusing, and unnecessary. Originally referred to this being the 'default' CNI plug-in referred to in the Multus configuration, but that's not really important in this context.