### PR TITLE
Fix ENVTEST_K8S_VERSION

### DIFF
--- a/modules/osdk-updating-v1101-to-v1160.adoc
+++ b/modules/osdk-updating-v1101-to-v1160.adoc
@@ -94,8 +94,8 @@ $ go mod tidy
 [source,diff]
 ----
 ...
-- ENVTEST_K8S_VERSION = 1.21`
-+ ENVTEST_K8S_VERSION = 1.22`
+
++ ENVTEST_K8S_VERSION = 1.22
 
   test: manifests generate fmt vet envtest ## Run tests.
 -   go test ./... -coverprofile cover.out


### PR DESCRIPTION
The instruction to set `ENVTEST_K8S_VERSION` to `1.22` came from the upstream [v1.14.0 migration doc](https://v1-16-x.sdk.operatorframework.io/docs/upgrading-sdk-version/v1.14.0/), however I believe the backtick in the upstream doc is just a formatting error, so correcting downstream here.

Also it looks like the `ENVTEST_K82_VERSION` was net-new with [v1.11.0](https://v1-16-x.sdk.operatorframework.io/docs/upgrading-sdk-version/v1.11.0/), so for downstream 4.10 users it wouldn't have been in their projects yet. Therefore, removing the `-` removal part of the diff, and just adding the new line. Note: The blank line after the `...` is required for the green `+` highlighting to show up correctly for the `[source,diff]`.

Preview: [Step 4d](https://deploy-preview-43482--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-upgrading-projects.html#osdk-upgrading-v1101-to-v1160_osdk-upgrading-projects)

PTAL @emmajiafan @michaelryanpeter 