### PR TITLE
Adds notes for 4.10.5 release

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2590,3 +2590,29 @@ link:https://access.redhat.com/solutions/6815061[{product-title} 4.10.4 containe
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-5"]
+=== RHBA-2022:0982 - {product-title} 4.10.5 bug fix and security update
+
+Issued: 2022-03-21
+
+{product-title} release 4.10.5, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0982[RHBA-2022:0982] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0927[RHSA-2022:0927] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6828301[{product-title} 4.10.5 container image list]
+
+[id="ocp-4-10-5-known-issues"]
+==== Known issues
+
+* There is an issue adding a cluster through zero touch provisioning (ZTP) with the name `ztp*`. Adding `ztp` as the name of a cluster causes a situation where `ArgoCD` deletes policies that ACM copies in to the cluster namespace. Naming the cluster with `ztp` leads to a reconciliation loop, and the policies will not be compliant. As a workaround, do not name clusters with `ztp` at the beginning of the name. By renaming the cluster, collision will stop the reconciliation loop and the policies will be compliant. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049154[*BZ#2049154*])
+
+[id="ocp-4-10-5-bug-fixes"]
+==== Bug fixes
+
+* Previously, the *Observer* dashboard from the *Topology* view in the *Developer* console opened to the last viewed workload rather than the selected one. With this update, the *Observe* dashboard in the *Developer* console always opens to the selected workload from the *Topology* view. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2059805[*BZ#2059805*])
+
+[id="ocp-4-10-5-updating"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for Monday 22.03.21 z-stream release.

- Applies to `enterprise-4.10` only
- [Preview link](https://deploy-preview-43483--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-5)

