### PR TITLE
Bz2063995 - Updated commands in Config Basic Auth. Section

### DIFF
--- a/modules/identity-provider-secret.adoc
+++ b/modules/identity-provider-secret.adoc
@@ -8,6 +8,10 @@
 // * authentication/identity_providers/configuring-oidc-identity-provider.adoc
 // * authentication/identity_providers/configuring-request-header-identity-provider.adoc
 
+ifeval::["{context}" == "configuring-basic-authentication-identity-provider"]
+:basic:
+endif::[]
+
 [id="identity-provider-creating-secret_{context}"]
 = Creating the secret
 
@@ -17,15 +21,33 @@ namespace to contain the client secret, client certificates, and keys.
 * You can define an {product-title} `Secret` object containing a string
 by using the following command.
 +
+====
 [source,terminal]
 ----
+ifndef::basic[]
 $ oc create secret generic <secret_name> --from-literal=clientSecret=<secret> -n openshift-config
+endif::basic[]
+ifdef::basic[]
+$ oc create secret tls <secret_name> --from-literal=tls.crt=<secret> --from-literal=tls.key=<secret> -n openshift-config
+endif::basic[]
 ----
+====
 
 * You can define an {product-title} `Secret` object containing the contents of a
 file, such as a certificate file, by using the following command.
 +
+====
 [source,terminal]
 ----
-$ oc create secret generic <secret_name> --from-file=/path/to/file -n openshift-config
+ifndef::basic[]
+$ oc create secret generic <secret_name> --from-file=<path_to_file> -n openshift-config
+endif::basic[]
+ifdef::basic[]
+$ oc create secret tls <secret_name> --from-file=tls.crt=<path_to_file> --from-file=tls.key=<path_to_file> -n openshift-config
+endif::basic[]
 ----
+====
+
+ifeval::["{context}" == "configuring-basic-authentication-identity-provider"]
+:!basic:
+endif::[]


### PR DESCRIPTION
Only for versions 4.6 and 4.7

**Bug**: https://bugzilla.redhat.com/show_bug.cgi?id=2063995

**Direct link to doc preview:** https://deploy-preview-43490--osdocs.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-basic-authentication-identity-provider.html#identity-provider-creating-secret_configuring-basic-authentication-identity-provider

QA Contact: @xingxingxia

This replaces PR: https://github.com/openshift/openshift-docs/pull/43279