### PR TITLE
BZ2015178: Added note about Node Health Check Operator

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -23,11 +23,12 @@ xref:../../installing/installing_bare_metal/preparing-to-install-on-bare-metal.a
 ifdef::openshift-enterprise[]
 :FeatureName: Installing OpenShift Virtualization on AWS bare metal instances
 include::snippets/technology-preview.adoc[leveloffset=+2]
+:!FeatureName:
 endif::[]
 --
 
 
-* Additionally, there are two options to maintain high availability (HA) of virtual machines:
+* Additionally, there are three options to maintain high availability (HA) of virtual machines:
 
 ** Use xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[installer-provisioned infrastructure] and xref:../../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[deploy machine health checks].
 +
@@ -42,6 +43,16 @@ In {VirtProductName} clusters installed using installer-provisioned infrastructu
 ====
 Without an external monitoring system or a qualified human monitoring node health, virtual machines lose high availability.
 ====
+
+** Use the xref:../../nodes/nodes/eco-node-health-check-operator.adoc#node-health-check-operator[Node Health Check Operator] on any {product-title} cluster to deploy the `NodeHealthCheck` controller. The controller identifies unhealthy nodes and uses the Poison Pill Operator to remediate the unhealthy nodes.
++
+--
+ifdef::openshift-enterprise[]
+:FeatureName: Node Health Check Operator
+include::snippets/technology-preview.adoc[leveloffset=+2]
+:!FeatureName:
+endif::[]
+--
 
 * Shared storage is required to enable live migration.
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2015178

Updated the "Preparing your cluster for OpenShift Virtualization" assembly to add another option for high-availability of VMs.

CP to 4.11, 4.10, 4.9

Direct preview link: https://deploy-preview-43511--osdocs.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html