### PR TITLE
Adding redirects for the ROSA restructure

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -170,6 +170,40 @@ AddType text/vtt                            vtt
     # OSD redirects for new content
     RewriteRule dedicated/4/cloud_infrastructure_access/dedicated-aws-vpn.html dedicated/osd_private_connections/aws-private-connections.html [NE,R=302]
 
+    # Redirects for the ROSA restructure that was applied in https://github.com/openshift/openshift-docs/pull/41923
+    RewriteRule rosa/rosa_policy/?(.*)$ rosa/rosa_architecture/$1 [NE,R=302]
+    RewriteRule rosa/rosa_support/rosa-getting-support.html rosa/rosa_architecture/rosa-getting-support.html [NE,R=302]
+
+    RewriteRule rosa/rosa_getting_started_sts/rosa-sts-getting-started-workflow.html rosa/rosa_architecture/rosa-sts-getting-started-workflow.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started_sts/rosa-sts-aws-prereqs.html rosa/rosa_planning/rosa-sts-aws-prereqs.html [NE,R=302]
+
+    RewriteRule rosa/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/?(.*)$ rosa/rosa_getting_started/$1 [NE,R=302]
+
+    RewriteRule rosa/rosa_getting_started_sts/?(.*)$ rosa/rosa_getting_started/$1 [NE,R=302]
+
+    RewriteRule rosa/rosa_getting_started/rosa-aws-prereqs.html rosa/rosa_planning/rosa-aws-prereqs.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-getting-started-workflow.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-getting-started-workflow.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-required-aws-service-quotas.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-required-aws-service-quotas.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-config-aws-account.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-config-aws-account.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-installing-rosa.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-installing-rosa.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-creating-cluster.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-creating-cluster.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-aws-privatelink-creating-cluster.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-aws-privatelink-creating-cluster.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-accessing-cluster.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-accessing-cluster.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-config-identity-providers.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-config-identity-providers.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-deleting-access-cluster.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-deleting-access-cluster.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-deleting-cluster.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-deleting-cluster.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-quickstart.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-quickstart.html [NE,R=302]
+
+    RewriteRule rosa/logging/?(.*)$ rosa/rosa_cluster_admin/rosa_logging/$1 [NE,R=302]
+
+    RewriteRule rosa/monitoring/osd?(.*)$ rosa/rosa_cluster_admin/rosa_monitoring/rosa$1 [NE,R=302]
+
+    RewriteRule rosa/cloud_infrastructure_access/?(.*)$ rosa/rosa_cluster_admin/cloud_infrastructure_access/$1 [NE,R=302]
+
+    RewriteRule rosa/nodes/nodes-machinepools-about.html rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.html [NE,R=302]
+    RewriteRule rosa/nodes/rosa-managing-worker-nodes.html rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html [NE,R=302]
+    RewriteRule rosa/nodes/nodes-about-autoscaling-nodes.html rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.html [NE,R=302]
+
     # ACS welcome page redirect to StackRox docs
     # RewriteRule ^acs/?(.*)$ https://help.stackrox.com/ [NE,R=301]
 


### PR DESCRIPTION
This applies to `main` only.

This pull request adds temporary (302) redirects relating to the ROSA restructure that was applied in https://github.com/openshift/openshift-docs/pull/41923.