### PR TITLE
Fix a small typo introduced in last PR

### DIFF
--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -66,7 +66,7 @@ Tested Cloud Platforms for {product-title} 4.x: Amazon Web Services, Microsoft A
 
 | Number of custom resource definitions (CRD)
 | There is no default value.
-| 512 ^7^
+| 512 ^[7]^
 
 |===
 [.small]


### PR DESCRIPTION
Applies to 4.9+ 
No QE is required. 
Small typo that was introduced with the merge of this PR: https://github.com/openshift/openshift-docs/pull/43451. The error is not in 4.6-4.8 since those were manual CP's and I fixed them there. 
Preview: https://deploy-preview-43525--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html#cluster-maximums-major-releases_object-limits