### PR TITLE
Rel Notes 4.10 storage + vsphere revisions

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -150,11 +150,11 @@ Beginning with {product-title} {product-version}, if you configure a cluster wit
 
 To install a CSI driver on a cluster running on vSphere, you must have the following components installed:
 
-* Virtual hardware version 15 or greater
-* vSphere version 6.7 Update 3 or greater
-* VMware ESXi version 6.7 Update 3 or greater
+* Virtual hardware version 15 or later
+* vSphere version 6.7 Update 3 or later
+* VMware ESXi version 6.7 Update 3 or later
 
-Components with versions lower than those above are still supported, but are deprecated. Support for them will be removed in a future version of {product-title}.
+Components with versions earlier than those above are still supported, but are deprecated. These versions are still fully supported, but version 4.11 of {product-title} will require vSphere virtual hardware version 15 or later.
 
 [NOTE]
 ====
@@ -729,7 +729,7 @@ See xref:../post_installation_configuration/bare-metal-configuration.adoc#post-i
 
 [id="ocp-4-10-storage-alicloud-disk-csi-operator"]
 ==== Persistent storage using the Alibaba AliCloud Disk CSI Driver Operator
-{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for AliCloud Disk. The AliCloud Disk Driver Operator that manages this driver is generally available.
+{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for AliCloud Disk. The AliCloud Disk Driver Operator that manages this driver is generally available, and enabled by default in {product-title} 4.10.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-alicloud-disk.adoc#persistent-storage-csi-alicloud-disk[AliCloud Disk CSI Driver Operator].
 
@@ -741,7 +741,7 @@ For more information, see xref:../storage/container_storage_interface/persistent
 
 [id="ocp-4-10-storage-ibm-vpc-block-csi-operator"]
 ==== Persistent storage using the IBM VPC Block CSI Driver Operator
-{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for IBM Virtual Private Cloud (VPC) Block. The IBM VPC Block Driver Operator that manages this driver is generally available.
+{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for IBM Virtual Private Cloud (VPC) Block. The IBM VPC Block Driver Operator that manages this driver is generally available, and enabled by default in {product-title} 4.10.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-ibm-vpc-block.adoc#persistent-storage-csi-ibm-vpc-block[IBM VPC Block CSI Driver Operator].
 
@@ -765,7 +765,7 @@ Clusters are still upgraded even if the preceding conditions are not met, but it
 [id="ocp-4-10-storage-azure-disk-csi-operator"]
 ==== Persistent storage using Microsoft Azure Disk CSI Driver Operator is generally available
 
-{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for Azure Disk. This feature was previously introduced as a Technology Preview feature in {product-title} 4.8 and is now generally available and enabled by default in {product-title} 4.10.
+{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for Azure Disk. This feature was previously introduced as a Technology Preview feature in {product-title} 4.8 and is now generally available, and enabled by default in {product-title} 4.10.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-azure.adoc#persistent-storage-csi-azure-disk[Azure Disk CSI Driver Operator].
 
@@ -1394,7 +1394,7 @@ In the table, features are marked with the following statuses:
 |DEP
 |DEP
 
-|VMware ESXi 6.7 Update 2 or earlier
+|VMware ESXi 6.7 Update 3 or earlier
 |GA
 |DEP
 |DEP


### PR DESCRIPTION
4.10 only

Fixes two RN 4.10 issues:

- [BZ2065759](https://bugzilla.redhat.com/show_bug.cgi?id=2065759). This is the rel notes fix for this issue. The install section is changed in this PR: https://github.com/openshift/openshift-docs/pull/43493
- Change IBM and AliCloud CSI Driver Operators to indicate that they are enabled by default

**Preview**:

**Storage change**
https://deploy-preview-43534--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-storage

**BZ2065759**
https://deploy-preview-43534--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-installation-vsphere-csi
https://deploy-preview-43534--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-deprecated-removed-features

**PTAL**: @julienlim @racedo @jsafrane 