### PR TITLE
SRVCOM-1728: Update serverless abstracts to align with Jupiter requirements

### DIFF
--- a/modules/apiserversource-yaml.adoc
+++ b/modules/apiserversource-yaml.adoc
@@ -13,7 +13,7 @@ You can use the following procedure to create an API server source by using YAML
 * The {ServerlessOperatorName} and Knative Eventing are installed on the cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 * You have created the `default` broker in the same namespace as the one defined in the API server source YAML file.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/creating-serverless-apps-yaml.adoc
+++ b/modules/creating-serverless-apps-yaml.adoc
@@ -8,6 +8,10 @@
 
 To create a serverless application by using YAML, you must create a YAML file that defines a `Service` object, then apply it by using `oc apply`.
 
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
 .Procedure
 
 . Create a YAML file containing the following sample code:

--- a/modules/interacting-serverless-apps-http2-gRPC.adoc
+++ b/modules/interacting-serverless-apps-http2-gRPC.adoc
@@ -28,6 +28,10 @@ spec:
 ----
 ====
 
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
 .Procedure
 
 . Find the application host. See the instructions in _Verifying your serverless application deployment_.

--- a/modules/knative-serving-advanced-config.adoc
+++ b/modules/knative-serving-advanced-config.adoc
@@ -6,7 +6,8 @@
 [id="knative-serving-advanced-config_{context}"]
 = Advanced configuration options
 
-This section provides information about advanced configuration options for Knative Serving.
+You can install Knative Serving by using the default settings or configure more advanced settings in the `KnativeServing` custom resource (CR). By configuring these advanced settings, you can modify functionality such as use of certificates for your Knative Serving deployment and the number of high availability replicas that are available.
+// needs an update once more options are documented here
 
 [id="knative-serving-controller-custom-certs_{context}"]
 == Controller custom certs

--- a/modules/serverless-about-collecting-data.adoc
+++ b/modules/serverless-about-collecting-data.adoc
@@ -8,6 +8,10 @@
 
 You can use the `oc adm must-gather` CLI command to collect information about your cluster, including features and objects associated with {ServerlessProductName}. To collect {ServerlessProductName} data with `must-gather`, you must specify the {ServerlessProductName} image and the image tag for your installed version of {ServerlessProductName}.
 
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
 .Procedure
 
 * Collect data by using the `oc adm must-gather` command:

--- a/modules/serverless-blue-green-deploy.adoc
+++ b/modules/serverless-blue-green-deploy.adoc
@@ -11,6 +11,7 @@ You can safely reroute traffic from a production version of an app to a new vers
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* Install the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/serverless-create-default-channel-yaml.adoc
+++ b/modules/serverless-create-default-channel-yaml.adoc
@@ -11,7 +11,7 @@ You can create a channel with the cluster default configuration by using YAML.
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Eventing are installed on the cluster.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-create-domain-mapping.adoc
+++ b/modules/serverless-create-domain-mapping.adoc
@@ -11,7 +11,7 @@ To map a custom domain name to a custom resource (CR), you must create a `Domain
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on your cluster.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 * You have created a Knative service and control a custom domain that you want to map to that service.
 +

--- a/modules/serverless-create-kafka-channel-yaml.adoc
+++ b/modules/serverless-create-kafka-channel-yaml.adoc
@@ -12,7 +12,7 @@ You can create a Knative Eventing channel that is backed by Kafka topics. To do 
 .Prerequisites
 
 * The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {product-title} cluster.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-creating-broker-annotation.adoc
+++ b/modules/serverless-creating-broker-annotation.adoc
@@ -17,7 +17,7 @@ If you delete the broker without having a cluster administrator remove this anno
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Eventing are installed on your {product-title} cluster.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-creating-broker-labeling.adoc
+++ b/modules/serverless-creating-broker-labeling.adoc
@@ -16,7 +16,7 @@ Brokers created using this method are not removed if you remove the label. You m
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Eventing are installed on your {product-title} cluster.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 ifdef::openshift-dedicated[]

--- a/modules/serverless-creating-subscriptions-yaml.adoc
+++ b/modules/serverless-creating-subscriptions-yaml.adoc
@@ -11,7 +11,7 @@ You can create a subscription to connect a channel to a sink by using YAML.
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Eventing are installed on the cluster.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-customize-labels-annotations-routes.adoc
+++ b/modules/serverless-customize-labels-annotations-routes.adoc
@@ -11,6 +11,7 @@
 .Prerequisites
 
 * You must have the {ServerlessOperatorName} and Knative Serving installed on your {product-title} cluster.
+* Install the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/serverless-deleting-broker-injection.adoc
+++ b/modules/serverless-deleting-broker-injection.adoc
@@ -8,6 +8,10 @@
 
 If you create a broker by injection and later want to delete it, you must delete it manually. Brokers created by using a namespace label or trigger annotation are not deleted permanently if you remove the label or annotation.
 
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
 .Procedure
 
 . Remove the `eventing.knative.dev/injection=enabled` label from the namespace:

--- a/modules/serverless-deleting-crds.adoc
+++ b/modules/serverless-deleting-crds.adoc
@@ -15,6 +15,8 @@ Removing the Operator and API CRDs also removes all resources that were defined 
 
 .Prerequisites
 
+* Install the OpenShift CLI (`oc`).
+
 ifdef::openshift-enterprise[]
 * You have access to an {product-title} account with cluster administrator access.
 endif::[]

--- a/modules/serverless-domain-mapping-custom-tls-cert.adoc
+++ b/modules/serverless-domain-mapping-custom-tls-cert.adoc
@@ -16,6 +16,8 @@ You can add an existing TLS certificate with a `DomainMapping` custom resource (
 
 * You have obtained the `cert` and `key` files from your Certificate Authority provider, or a self-signed certificate.
 
+* Install the OpenShift CLI (`oc`).
+
 .Procedure
 
 . Create a Kubernetes TLS secret:

--- a/modules/serverless-install-eventing-web-console.adoc
+++ b/modules/serverless-install-eventing-web-console.adoc
@@ -6,7 +6,7 @@
 [id="serverless-install-eventing-web-console_{context}"]
 = Installing Knative Eventing by using the web console
 
-You can use the following procedure to install Knative Eventing by using the {product-title} web console.
+After you install the {ServerlessOperatorName}, install Knative Eventing by using the {product-title} web console. You can install Knative Eventing by using the default settings or configure more advanced settings in the `KnativeEventing` custom resource (CR).
 
 .Prerequisites
 

--- a/modules/serverless-install-eventing-yaml.adoc
+++ b/modules/serverless-install-eventing-yaml.adoc
@@ -6,7 +6,7 @@
 [id="serverless-install-eventing-yaml_{context}"]
 = Installing Knative Eventing by using YAML
 
-You can use the following procedure to install Knative Eventing by applying YAML files.
+After you install the {ServerlessOperatorName}, you can install Knative Eventing by using the default settings, or configure more advanced settings in the `KnativeEventing` custom resource (CR). You can use the following procedure to install Knative Eventing by using YAML files and the `oc` CLI.
 
 .Prerequisites
 
@@ -19,6 +19,7 @@ ifdef::openshift-dedicated[]
 endif::[]
 
 * You have installed the {ServerlessOperatorName}.
+* Install the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/serverless-install-kafka-odc.adoc
+++ b/modules/serverless-install-kafka-odc.adoc
@@ -49,6 +49,7 @@ The `replicationFactor` value must be less than or equal to the number of nodes 
 
 * You have installed the {ServerlessOperatorName} and Knative Eventing on your cluster.
 * You have access to a Red Hat AMQ Streams cluster.
+* Install the OpenShift CLI (`oc`) if you want to use the verification steps.
 
 // OCP
 ifdef::openshift-enterprise[]

--- a/modules/serverless-install-serving-web-console.adoc
+++ b/modules/serverless-install-serving-web-console.adoc
@@ -6,7 +6,7 @@
 [id="serverless-install-serving-web-console_{context}"]
 = Installing Knative Serving by using the web console
 
-You can use the following procedure to install Knative Serving by using the {product-title} web console.
+After you install the {ServerlessOperatorName}, install Knative Serving by using the {product-title} web console. You can install Knative Serving by using the default settings or configure more advanced settings in the `KnativeServing` custom resource (CR).
 
 .Prerequisites
 

--- a/modules/serverless-install-serving-yaml.adoc
+++ b/modules/serverless-install-serving-yaml.adoc
@@ -6,7 +6,7 @@
 [id="serverless-install-serving-yaml_{context}"]
 = Installing Knative Serving by using YAML
 
-You can use the following procedure to install Knative Serving by applying YAML files.
+After you install the {ServerlessOperatorName}, you can install Knative Serving by using the default settings, or configure more advanced settings in the `KnativeServing` custom resource (CR). You can use the following procedure to install Knative Serving by using YAML files and the `oc` CLI.
 
 .Prerequisites
 
@@ -19,6 +19,7 @@ ifdef::openshift-dedicated[]
 endif::[]
 
 * You have installed the {ServerlessOperatorName}.
+* Install the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/serverless-jaeger-config.adoc
+++ b/modules/serverless-jaeger-config.adoc
@@ -20,7 +20,7 @@ endif::[]
 
 * You have installed the {ServerlessOperatorName} and Knative Serving.
 * You have installed the Jaeger Operator.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-kafka-broker-sasl-default-config.adoc
+++ b/modules/serverless-kafka-broker-sasl-default-config.adoc
@@ -30,6 +30,7 @@ endif::[]
 * You have a username and password for a Kafka cluster.
 * You have chosen the SASL mechanism to use, for example `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
 * If TLS is enabled, you also need the `ca.crt` certificate file for the Kafka cluster.
+* Install the OpenShift CLI (`oc`).
 
 [NOTE]
 ====

--- a/modules/serverless-kafka-broker-tls-default-config.adoc
+++ b/modules/serverless-kafka-broker-tls-default-config.adoc
@@ -29,6 +29,7 @@ endif::[]
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 * You have a Kafka cluster CA certificate stored as a `.pem` file.
 * You have a Kafka cluster client certificate and a key stored as `.pem` files.
+* Install the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/serverless-kafka-broker.adoc
+++ b/modules/serverless-kafka-broker.adoc
@@ -13,7 +13,7 @@ You can create a Kafka broker by using YAML files.
 
 * The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/serverless-kafka-sasl.adoc
+++ b/modules/serverless-kafka-sasl.adoc
@@ -13,6 +13,7 @@ You can use the following procedure to configure SASL authentication for a Kafka
 * You have a username and password for the Kafka cluster.
 * You have chosen the SASL mechanism to use, for example `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
 * If TLS is enabled, you also need the `ca.crt` certificate file for the Kafka cluster.
+* Install the OpenShift CLI (`oc`).
 
 [NOTE]
 ====

--- a/modules/serverless-kafka-sink.adoc
+++ b/modules/serverless-kafka-sink.adoc
@@ -13,7 +13,7 @@ You can create an event sink called a Kafka sink, that sends events to a Kafka t
 * The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource (CR) are installed on your cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 * You have access to a Red Hat AMQ Streams (Kafka) cluster that produces the Kafka messages you want to import.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/serverless-kafka-source-yaml.adoc
+++ b/modules/serverless-kafka-source-yaml.adoc
@@ -13,7 +13,7 @@ You can create a Kafka event source by using YAML.
 * The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 * You have access to a Red Hat AMQ Streams (Kafka) cluster that produces the Kafka messages you want to import.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/serverless-kafka-tls.adoc
+++ b/modules/serverless-kafka-tls.adoc
@@ -12,6 +12,7 @@ You can use the following procedure to configure TLS authentication for a Kafka 
 
 * You have a Kafka cluster CA certificate stored as a `.pem` file.
 * You have a Kafka cluster client certificate and a key stored as `.pem` files.
+* Install the OpenShift CLI (`oc`).
 
 .Procedure
 
@@ -19,7 +20,7 @@ You can use the following procedure to configure TLS authentication for a Kafka 
 +
 [source,terminal]
 ----
-$ kubectl create secret -n <namespace> generic <kafka_auth_secret> \
+$ oc create secret -n <namespace> generic <kafka_auth_secret> \
   --from-file=ca.crt=caroot.pem \
   --from-file=user.crt=certificate.pem \
   --from-file=user.key=key.pem

--- a/modules/serverless-openshift-routes.adoc
+++ b/modules/serverless-openshift-routes.adoc
@@ -16,6 +16,7 @@ When you complete the following procedure, the default {product-title} route in 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving component must be installed on your {product-title} cluster.
+* Install the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/serverless-ossm-enable-sidecar-injection-with-kourier.adoc
+++ b/modules/serverless-ossm-enable-sidecar-injection-with-kourier.adoc
@@ -20,7 +20,7 @@ endif::[]
 .Prerequisites
 
 * You have installed the {ServerlessOperatorName} and Knative Serving.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-ossm-enabling-serving-metrics.adoc
+++ b/modules/serverless-ossm-enabling-serving-metrics.adoc
@@ -21,7 +21,7 @@ ifdef::openshift-dedicated[]
 * You have access to an {product-title} account with cluster or dedicated administrator access.
 endif::[]
 
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-ossm-setup-with-kourier.adoc
+++ b/modules/serverless-ossm-setup-with-kourier.adoc
@@ -16,7 +16,7 @@ ifdef::openshift-dedicated[]
 * You have access to an {product-title} account with cluster or dedicated administrator access.
 endif::[]
 
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 * You have installed the {ServerlessOperatorName} and Knative Serving on your cluster.
 * You have installed {ProductName}. {ServerlessProductName} with {ProductShortName} and Kourier is supported for use with both {ProductName} versions 1.x and 2.x.

--- a/modules/serverless-ossm-setup.adoc
+++ b/modules/serverless-ossm-setup.adoc
@@ -26,7 +26,7 @@ endif::[]
 ====
 Do not install the Knative Serving component before completing the following procedures. There are additional steps required when creating the `KnativeServing` custom resource defintion (CRD) to integrate Knative Serving with {ProductShortName}, which are not covered in the general Knative Serving installation procedure of the _Administration guide_.
 ====
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-ossm-v1x-jwt.adoc
+++ b/modules/serverless-ossm-v1x-jwt.adoc
@@ -11,7 +11,7 @@ You can use the following procedure to enable using JSON Web Token authenticatio
 .Prerequisites
 
 * You have installed the {ServerlessOperatorName} and Knative Serving.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-ossm-v2x-jwt.adoc
+++ b/modules/serverless-ossm-v2x-jwt.adoc
@@ -11,7 +11,7 @@ You can use the following procedure to enable using JSON Web Token authenticatio
 .Prerequisites
 
 * You have installed the {ServerlessOperatorName} and Knative Serving.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-pingsource-yaml.adoc
+++ b/modules/serverless-pingsource-yaml.adoc
@@ -11,6 +11,7 @@ The following sections describe how to create a basic ping source using YAML fil
 .Prerequisites
 
 * The {ServerlessOperatorName}, Knative Serving and Knative Eventing are installed on the cluster.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-services-network-policies.adoc
+++ b/modules/serverless-services-network-policies.adoc
@@ -32,6 +32,10 @@ A network policy that denies requests to non-Knative services on your cluster st
 If you do not want to allow access to your Knative application from all namespaces on the cluster, you might want to use _JSON Web Token authentication for Knative services_ instead. JSON Web Token authentication for Knative services requires Service Mesh.
 ====
 
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
 .Procedure
 
 . Add the `knative.openshift.io/system-namespace=true` label to each Knative system namespace that requires access to your application:

--- a/modules/serverless-sinkbinding-yaml.adoc
+++ b/modules/serverless-sinkbinding-yaml.adoc
@@ -11,7 +11,7 @@ This guide describes the steps required to create a sink binding instance by usi
 .Prerequisites
 
 * The {ServerlessOperatorName}, Knative Serving and Knative Eventing are installed on the cluster.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-uninstalling-knative-eventing.adoc
+++ b/modules/serverless-uninstalling-knative-eventing.adoc
@@ -6,7 +6,7 @@
 [id="serverless-uninstalling-knative-eventing_{context}"]
 = Uninstalling Knative Eventing
 
-To uninstall Knative Eventing, you must remove its custom resource (CR) and delete the `knative-eventing` namespace.
+Before you can remove the {ServerlessOperatorName}, you must remove Knative Eventing. To uninstall Knative Eventing, you must remove the `KnativeEventing` custom resource (CR) and delete the `knative-eventing` namespace.
 
 .Prerequisites
 
@@ -18,9 +18,11 @@ ifdef::openshift-dedicated[]
 * You have access to an {product-title} account with cluster administrator or dedicated administrator access.
 endif::[]
 
+* Install the OpenShift CLI (`oc`).
+
 .Procedure
 
-. Delete the `knative-eventing` CR:
+. Delete the `KnativeEventing` CR:
 +
 [source,terminal]
 ----

--- a/modules/serverless-uninstalling-knative-serving.adoc
+++ b/modules/serverless-uninstalling-knative-serving.adoc
@@ -6,7 +6,7 @@
 [id="serverless-uninstalling-knative-serving_{context}"]
 = Uninstalling Knative Serving
 
-To uninstall Knative Serving, you must remove its custom resource (CR) and delete the `knative-serving` namespace.
+Before you can remove the {ServerlessOperatorName}, you must remove Knative Serving. To uninstall Knative Serving, you must remove the `KnativeServing` custom resource (CR) and delete the `knative-serving` namespace.
 
 .Prerequisites
 
@@ -18,9 +18,11 @@ ifdef::openshift-dedicated[]
 * You have access to an {product-title} account with cluster administrator or dedicated administrator access.
 endif::[]
 
+* Install the OpenShift CLI (`oc`).
+
 .Procedure
 
-. Delete the `knative-serving` CR:
+. Delete the `KnativeServing` CR:
 +
 [source,terminal]
 ----

--- a/modules/serverless-using-cluster-logging-find-logs-knative-serving-components.adoc
+++ b/modules/serverless-using-cluster-logging-find-logs-knative-serving-components.adoc
@@ -6,6 +6,10 @@
 [id="using-cluster-logging-to-find-logs-for-knative-serving-components_{context}"]
 = Using OpenShift Logging to find logs for Knative Serving components
 
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
 .Procedure
 
 . Get the Kibana route:

--- a/modules/serverless-using-cluster-logging-find-logs-services-deployed.adoc
+++ b/modules/serverless-using-cluster-logging-find-logs-services-deployed.adoc
@@ -8,6 +8,10 @@
 
 With OpenShift Logging, the logs that your applications write to the console are collected in Elasticsearch. The following procedure outlines how to apply these capabilities to applications deployed by using Knative Serving.
 
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
 .Procedure
 
 . Get the Kibana route:

--- a/modules/serverlesss-ossm-external-certs.adoc
+++ b/modules/serverlesss-ossm-external-certs.adoc
@@ -19,7 +19,7 @@ ifdef::openshift-dedicated[]
 endif::[]
 
 * You have installed the {ServerlessOperatorName} and Knative Serving.
-* You have installed the `oc` CLI.
+* Install the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/verifying-serverless-app-deployment.adoc
+++ b/modules/verifying-serverless-app-deployment.adoc
@@ -13,6 +13,10 @@ To verify that your serverless application has been deployed successfully, you m
 {ServerlessProductName} supports the use of both HTTP and HTTPS URLs, however the output from `oc get ksvc` will always print URLs using the `http://` format.
 ====
 
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
 .Procedure
 
 . Find the application URL:

--- a/serverless/admin_guide/serverless-cluster-admin-serving.adoc
+++ b/serverless/admin_guide/serverless-cluster-admin-serving.adoc
@@ -8,11 +8,11 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 ifdef::openshift-enterprise[]
-If you have cluster administrator permissions on an {product-title} cluster, you can create Knative Serving components with {ServerlessProductName} in the *Administrator* perspective of the web console or by using the `kn` and `oc` CLIs.
+If you have cluster administrator permissions on an {product-title} cluster, you can create Knative Serving components with {ServerlessProductName} in the *Administrator* perspective of the web console or by using the Knative (`kn`) and OpenShift (`oc`) CLIs.
 endif::[]
 
 ifdef::openshift-dedicated[]
-If you have cluster or dedicated administrator permissions on an {product-title} cluster, you can create Knative Serving components with {ServerlessProductName} in the *Administrator* perspective of the web console or by using the `kn` and `oc` CLIs.
+If you have cluster or dedicated administrator permissions on an {product-title} cluster, you can create Knative Serving components with {ServerlessProductName} in the *Administrator* perspective of the web console or by using the Knative (`kn`) and OpenShift (`oc`) CLIs.
 endif::[]
 
 // Create services as an admin

--- a/serverless/install/installing-knative-eventing.adoc
+++ b/serverless/install/installing-knative-eventing.adoc
@@ -7,9 +7,9 @@ include::_attributes/serverless-document-attributes.adoc[]
 
 toc::[]
 
-After you install the {ServerlessOperatorName}, you can install Knative Eventing by following the procedures described in this guide.
+To use event-driven architecture on your cluster, install Knative Eventing. You can create Knative components such as event sources, brokers, and channels and then use them to send events to applications or external systems.
 
-This guide provides information about installing Knative Eventing using the default settings.
+After you install the {ServerlessOperatorName}, install Knative Eventing by using the {product-title} web console. You can install Knative Eventing by using the default settings or configure more advanced settings in the `KnativeEventing` custom resource (CR).
 
 include::modules/serverless-install-eventing-web-console.adoc[leveloffset=+1]
 include::modules/serverless-install-eventing-yaml.adoc[leveloffset=+1]

--- a/serverless/install/installing-knative-serving.adoc
+++ b/serverless/install/installing-knative-serving.adoc
@@ -7,7 +7,9 @@ include::_attributes/serverless-document-attributes.adoc[]
 
 toc::[]
 
-This guide provides information about installing Knative Serving using the default settings. However, you can configure more advanced settings in the `KnativeServing` custom resource (CR). For more information about configuration options for the `KnativeServing` CR, see xref:../../serverless/install/installing-knative-serving.adoc#knative-serving-advanced-config_installing-knative-serving[Advanced configuration options].
+Installing Knative Serving allows you to create Knative services and functions on your cluster. It also allows you to use additional functionality such as autoscaling and networking options for your applications.
+
+After you install the {ServerlessOperatorName}, you can install Knative Serving by using the default settings, or configure more advanced settings in the `KnativeServing` custom resource (CR). For more information about configuration options for the `KnativeServing` CR, see xref:../../serverless/install/installing-knative-serving.adoc#knative-serving-advanced-config_installing-knative-serving[Advanced configuration options].
 
 include::modules/serverless-install-serving-web-console.adoc[leveloffset=+1]
 include::modules/serverless-install-serving-yaml.adoc[leveloffset=+1]

--- a/serverless/install/removing-openshift-serverless.adoc
+++ b/serverless/install/removing-openshift-serverless.adoc
@@ -7,12 +7,7 @@ include::_attributes/serverless-document-attributes.adoc[]
 
 toc::[]
 
-This guide provides details of how to remove the {ServerlessOperatorName} and other {ServerlessProductName} components.
-
-[NOTE]
-====
-Before you can remove the {ServerlessOperatorName}, you must remove Knative Serving and Knative Eventing.
-====
+If you need to remove {ServerlessProductName} from your cluster, you can do so by manually removing the {ServerlessOperatorName} and other {ServerlessProductName} components. Before you can remove the {ServerlessOperatorName}, you must remove Knative Serving and Knative Eventing.
 
 // Uninstalling Knative Serving
 include::modules/serverless-uninstalling-knative-serving.adoc[leveloffset=+1]
@@ -22,12 +17,7 @@ include::modules/serverless-uninstalling-knative-eventing.adoc[leveloffset=+1]
 [id="removing-openshift-serverless-removing-the-operator"]
 == Removing the {ServerlessOperatorName}
 
-You can remove the {ServerlessOperatorName} from the host cluster by using the web console or the `oc` CLI.
-
-[NOTE]
-====
-Before you can remove the {ServerlessOperatorName}, you must remove Knative Serving and Knative Eventing.
-====
+After you have removed Knative Serving and Knative Eventing, you can remove the {ServerlessOperatorName}. You can do this by using the {product-title} web console or the `oc` CLI.
 
 include::modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc[leveloffset=+2]
 include::modules/olm-deleting-operators-from-a-cluster-using-cli.adoc[leveloffset=+2]


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVCOM-1728

Applies for versions OCP 4.6+

Direct previews:
- https://deploy-preview-43535--osdocs.netlify.app/openshift-enterprise/latest/serverless/install/installing-knative-serving.html
- https://deploy-preview-43535--osdocs.netlify.app/openshift-enterprise/latest/serverless/install/installing-knative-eventing.html
- https://deploy-preview-43535--osdocs.netlify.app/openshift-enterprise/latest/serverless/install/removing-openshift-serverless.html