### PR TITLE
BZ-1691503: Replacing incorrect command

### DIFF
--- a/day_two_guide/topics/proc_removing-etcd-host.adoc
+++ b/day_two_guide/topics/proc_removing-etcd-host.adoc
@@ -34,10 +34,10 @@ endif::[]
 for each etcd node:
 +
 ----
-# etcdctl -C https://<surviving host IP address>:2379 \
-  --ca-file=/etc/etcd/ca.crt     \
-  --cert-file=/etc/etcd/peer.crt     \
-  --key-file=/etc/etcd/peer.key member remove <failed member ID>
+# etcdctl3 --endpoints=https://<surviving host IP>:2379
+  --cacert=/etc/etcd/ca.crt
+  --cert=/etc/etcd/peer.crt
+  --key=/etc/etcd/peer.key member remove <failed member ID>
 ----
 
 ifeval::["{context}" == "day-two-host-level-tasks"]


### PR DESCRIPTION
Applies to 3.11 only
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1691503
Preview Link: [Removing an etcd host](https://deploy-preview-43557--osdocs.netlify.app/openshift-enterprise/latest/day_two_guide/host_level_tasks.html#removing-etcd-host_replacing-etcd-host); Step 1. 
QE required.