### PR TITLE
BZ2065025: AWS Instance - fix references to current type (M6i)

### DIFF
--- a/modules/aws-limits.adoc
+++ b/modules/aws-limits.adoc
@@ -27,7 +27,7 @@ The following table summarizes the AWS components whose limits can impact your a
 
 These instance type counts are within a new account's default limit. To deploy more worker nodes, deploy large workloads, or use a different instance type, review your account limits to ensure that your cluster can deploy the machines that you need.
 
-In most regions, the bootstrap and worker machines uses an `m4.large` machines and the master machines use `m4.xlarge` instances. In some regions, including all regions that do not support these instance types, `m5.large` and `m5.xlarge` instances are used instead.
+In most regions, the worker machines use an `m6i.large` machine and the bootstrap and master machines use `m6i.xlarge` instances. In some regions, including all regions that do not support these instance types, `m5.large` and `m5.xlarge` instances are used instead.
 
 |Elastic IPs (EIPs)
 |0 to 1

--- a/modules/increasing-aws-flavor-size.adoc
+++ b/modules/increasing-aws-flavor-size.adoc
@@ -26,6 +26,6 @@ It is recommended to backup etcd before increasing the flavor size of the AWS ma
 
 . Select the stopped instance, and click *Actions* -> *Instance Settings* -> *Change instance type*.
 
-. Change the instance to a larger type, ensuring that the type is the same base as the previous selection, and apply changes. For example, you can change `m5.xlarge` to `m5.2xlarge` or `m5.4xlarge`.
+. Change the instance to a larger type, ensuring that the type is the same base as the previous selection, and apply changes. For example, you can change `m6i.xlarge` to `m6i.2xlarge` or `m6i.4xlarge`.
 
 . Backup the instance, and repeat the steps for the next master instance.

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -93,7 +93,7 @@ endif::gov,china,secret[]
         iops: 4000
         size: 500
         type: io1 <6>
-      type: m5.xlarge
+      type: m6i.xlarge
   replicas: 3
 compute: <3>
 - hyperthreading: Enabled <5>

--- a/modules/installation-aws-limits.adoc
+++ b/modules/installation-aws-limits.adoc
@@ -34,8 +34,8 @@ more worker nodes, enable autoscaling, deploy large workloads, or use a
 different instance type, review your account limits to ensure that your cluster
 can deploy the machines that you need.
 
-In most regions, the bootstrap and worker machines uses an `m4.large` machines
-and the control plane machines use `m4.xlarge` instances. In some regions, including
+In most regions, the worker machines use an `m6i.large` instance
+and the bootstrap and control plane machines use `m6i.xlarge` instances. In some regions, including
 all regions that do not support these instance types, `m5.large` and `m5.xlarge`
 instances are used instead.
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -690,7 +690,7 @@ When running on ARM based AWS instances, ensure that you enter a region where AW
 
 |`controlPlane.platform.aws.type`
 |The EC2 instance type for the control plane machines.
-|Valid AWS instance type, such as `m5.xlarge`. See the *Supported AWS machine types* table that follows.
+|Valid AWS instance type, such as `m6i.xlarge`. See the *Supported AWS machine types* table that follows.
 //add an xref when possible
 
 |`controlPlane.platform.aws.zones`

--- a/modules/installation-creating-aws-control-plane.adoc
+++ b/modules/installation-creating-aws-control-plane.adoc
@@ -92,7 +92,7 @@ requires:
   },
   {
     "ParameterKey": "MasterInstanceType", <21>
-    "ParameterValue": "m5.xlarge" <22>
+    "ParameterValue": "m6i.xlarge" <22>
   },
   {
     "ParameterKey": "AutoRegisterELB", <23>
@@ -150,58 +150,8 @@ directory. This value is the long string with the format
 <20> Specify the `MasterInstanceProfile` parameter value from the output of
 the CloudFormation template for the security group and roles.
 <21> The type of AWS instance to use for the control plane machines.
-<22> Allowed values:
-* `m4.xlarge`
-* `m4.2xlarge`
-* `m4.4xlarge`
-* `m4.10xlarge`
-* `m4.16xlarge`
-* `m5.xlarge`
-* `m5.2xlarge`
-* `m5.4xlarge`
-* `m5.8xlarge`
-* `m5.12xlarge`
-* `m5.16xlarge`
-* `m5a.xlarge`
-* `m5a.2xlarge`
-* `m5a.4xlarge`
-* `m5a.8xlarge`
-* `m5a.12xlarge`
-* `m5a.16xlarge`
-* `c4.2xlarge`
-* `c4.4xlarge`
-* `c4.8xlarge`
-* `c5.2xlarge`
-* `c5.4xlarge`
-* `c5.9xlarge`
-* `c5.12xlarge`
-* `c5.18xlarge`
-* `c5.24xlarge`
-* `c5a.2xlarge`
-* `c5a.4xlarge`
-* `c5a.8xlarge`
-* `c5a.12xlarge`
-* `c5a.16xlarge`
-* `c5a.24xlarge`
-* `r4.xlarge`
-* `r4.2xlarge`
-* `r4.4xlarge`
-* `r4.8xlarge`
-* `r4.16xlarge`
-* `r5.xlarge`
-* `r5.2xlarge`
-* `r5.4xlarge`
-* `r5.8xlarge`
-* `r5.12xlarge`
-* `r5.16xlarge`
-* `r5.24xlarge`
-* `r5a.xlarge`
-* `r5a.2xlarge`
-* `r5a.4xlarge`
-* `r5a.8xlarge`
-* `r5a.12xlarge`
-* `r5a.16xlarge`
-* `r5a.24xlarge`
+<22> The instance type value corresponds to the minimum resource requirements for
+control plane machines.
 <23> Whether or not to register a network load balancer (NLB).
 <24> Specify `yes` or `no`. If you specify `yes`, you must provide a Lambda
 Amazon Resource Name (ARN) value.

--- a/modules/installation-creating-aws-worker.adoc
+++ b/modules/installation-creating-aws-worker.adoc
@@ -78,7 +78,7 @@ template requires:
   },
   {
     "ParameterKey": "WorkerInstanceType", <15>
-    "ParameterValue": "m4.2xlarge" <16>
+    "ParameterValue": "m6i.large" <16>
   }
 ]
 ----
@@ -104,77 +104,9 @@ directory. This value is the long string with the format
 <13> The IAM profile to associate with worker nodes.
 <14> Specify the `WorkerInstanceProfile` parameter value from the output of
 the CloudFormation template for the security group and roles.
-<15> The type of AWS instance to use for the control plane machines.
-<16> Allowed values:
-* `m4.large`
-* `m4.xlarge`
-* `m4.2xlarge`
-* `m4.4xlarge`
-* `m4.10xlarge`
-* `m4.16xlarge`
-* `m5.large`
-* `m5.xlarge`
-* `m5.2xlarge`
-* `m5.4xlarge`
-* `m5.8xlarge`
-* `m5.12xlarge`
-* `m5.16xlarge`
-* `m5a.large`
-* `m5a.xlarge`
-* `m5a.2xlarge`
-* `m5a.4xlarge`
-* `m5a.8xlarge`
-* `m5a.12xlarge`
-* `m5a.16xlarge`
-* `c4.large`
-* `c4.xlarge`
-* `c4.2xlarge`
-* `c4.4xlarge`
-* `c4.8xlarge`
-* `c5.large`
-* `c5.xlarge`
-* `c5.2xlarge`
-* `c5.4xlarge`
-* `c5.9xlarge`
-* `c5.12xlarge`
-* `c5.18xlarge`
-* `c5.24xlarge`
-* `c5a.large`
-* `c5a.xlarge`
-* `c5a.2xlarge`
-* `c5a.4xlarge`
-* `c5a.8xlarge`
-* `c5a.12xlarge`
-* `c5a.16xlarge`
-* `c5a.24xlarge`
-* `r4.large`
-* `r4.xlarge`
-* `r4.2xlarge`
-* `r4.4xlarge`
-* `r4.8xlarge`
-* `r4.16xlarge`
-* `r5.large`
-* `r5.xlarge`
-* `r5.2xlarge`
-* `r5.4xlarge`
-* `r5.8xlarge`
-* `r5.12xlarge`
-* `r5.16xlarge`
-* `r5.24xlarge`
-* `r5a.large`
-* `r5a.xlarge`
-* `r5a.2xlarge`
-* `r5a.4xlarge`
-* `r5a.8xlarge`
-* `r5a.12xlarge`
-* `r5a.16xlarge`
-* `r5a.24xlarge`
-* `t3.large`
-* `t3.xlarge`
-* `t3.2xlarge`
-* `t3a.large`
-* `t3a.xlarge`
-* `t3a.2xlarge`
+<15> The type of AWS instance to use for the compute machines.
+<16> The instance type value corresponds to the minimum resource requirements
+for compute machines.
 
 . Copy the template from the *CloudFormation template for worker machines*
 section of this topic and save it as a YAML file on your computer. This template

--- a/modules/installation-supported-aws-machine-types.adoc
+++ b/modules/installation-supported-aws-machine-types.adoc
@@ -130,6 +130,11 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 |x
 |x
 
+|`m6i.large`
+|
+|
+|x
+
 |`m6i.xlarge`
 |
 |x
@@ -146,6 +151,11 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 |x
 
 |`m6i.8xlarge`
+|
+|x
+|x
+
+|`m6i.12xlarge`
 |
 |x
 |x

--- a/modules/machine-node-custom-partition.adoc
+++ b/modules/machine-node-custom-partition.adoc
@@ -170,7 +170,7 @@ spec:
           deviceIndex: 0
           iamInstanceProfile:
             id: auto-52-92tf4-worker-profile
-          instanceType: m5.large
+          instanceType: m6i.large
           kind: AWSMachineProviderConfig
           metadata:
             creationTimestamp: null

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -95,7 +95,7 @@ endif::infra[]
           deviceIndex: 0
           iamInstanceProfile:
             id: <infrastructure_id>-worker-profile <1>
-          instanceType: m4.large
+          instanceType: m6i.large
           kind: AWSMachineProviderConfig
           placement:
             availabilityZone: us-east-1a


### PR DESCRIPTION
Review references to current instance types on AWS for 4.10.

References:
- Current BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2065025
- Fix BZ / PR: https://bugzilla.redhat.com/show_bug.cgi?id=2022560 / https://github.com/openshift/openshift-docs/pull/40007
- PR to change the default type to M6i: https://github.com/openshift/installer/pull/5327
- PR to change the bootstrap size to `xlarge`: https://github.com/openshift/installer/pull/5334

cc related teams: @staebler @patrickdillon @JoelSpeed @sdodson 