### PR TITLE
BZ-1906726: Adding a note to the Getting Started with CLI about namespaces

### DIFF
--- a/modules/cli-using-cli.adoc
+++ b/modules/cli-using-cli.adoc
@@ -45,6 +45,11 @@ $ oc new-app https://github.com/sclorg/cakephp-ex
 
 Use the `oc get pods` command to view the pods for the current project.
 
+[NOTE]
+====
+When you run `oc` inside a pod and do not specify a namespace, the namespace of the pod is used by default.
+====
+
 [source,terminal]
 ----
 $ oc get pods -o wide


### PR DESCRIPTION
Applies to 4.6+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1906726
Preview Link: [Viewing pods](https://deploy-preview-43559--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/getting-started-cli.html#viewing-pods)
QE ack needed.