### PR TITLE
Telcodocs 529: Remove the Redfish HW Events release note

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -451,20 +451,6 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=20455
 
 After cluster installation, if you are using the OpenShift SDN cluster network provider or the OVN-Kubernetes cluster network provider, you can change your hardware MTU and your cluster network MTU values. Changing the MTU across the cluster is disruptive and requires that each node is rebooted several times. For more information, see xref:../networking/changing-cluster-network-mtu.adoc#changing-cluster-network-mtu[Changing the cluster network MTU].
 
-[id="ocp-4-10-redfish-events"]
-==== Low-latency Redfish hardware event delivery (Technology Preview)
-
-{product-title} now provides a hardware event proxy that enables applications running on bare-metal clusters to respond quickly to Redfish hardware events, such as hardware changes and failures.
-
-The hardware event proxy supports a publish-subscribe service that allows relevant applications to consume hardware events detected by Redfish. The proxy must be running on hardware that supports Redfish v1.8 and higher. An Operator manages the lifecycle of the `hw-event-proxy` container.
-
-You can use a REST API to develop applications to consume and respond to events such as breaches of temperature thresholds, fan failure, disk loss, power outages, and memory failure. Reliable end-to-end messaging without persistent stores is based on the Advanced Message Queuing Protocol (AMQP). The latency of the messaging service is in the 10 millisecond range.
-
-[NOTE]
-====
-This feature is supported for single node OpenShift clusters only.
-====
-
 [id="ocp-4-10-networking-ovn-gateway-config"]
 ==== OVN-Kubernetes support for gateway configuration
 


### PR DESCRIPTION
Removing RedFish h/w event RN as per https://issues.redhat.com/browse/TELCODOCS-529

**Preview**: https://deploy-preview-43573--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html

Section titled "Low-latency Redfish hardware event delivery" removed

Action against 4.10 