### PR TITLE
adding TP note for PTP to release notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2089,9 +2089,19 @@ In the table below, features are marked with the following statuses:
 |====
 |Feature |OCP 4.8 |OCP 4.9 | OCP 4.10
 
-|Precision Time Protocol (PTP)
+|Precision Time Protocol (PTP) hardware configured as ordinary clock
 |TP
+|GA
+|GA
+
+|PTP single NIC hardware configured as boundary clock
+|-
+|-
 |TP
+
+|PTP events with ordinary clock
+|-
+|-
 |TP
 
 |`oc` CLI plug-ins


### PR DESCRIPTION
The PTP feature table was not updated for 4.10 release. This PR corrects this.

Preview: https://deploy-preview-43574--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-technology-preview