### PR TITLE
Adds 4.8.35 release notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -3218,3 +3218,20 @@ Starting with {product-title} 4.8.34, support for using the Cloud Credential Ope
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-8-35"]
+=== RHBA-2022:0872 - {product-title} 4.8.35 bug fix and security update
+
+Issued: 2022-03-22
+
+{product-title} release 4.8.35, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0872[RHBA-2022:0872] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0871[RHSA-2022:0871] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6834631[{product-title} 4.8.35 container image list]
+
+
+[id="ocp-4-8-35-updating"]
+==== Updating
+
+To update an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

To be merged on 03-22

OCP version: **Applicable only to enterprise-4.8**

Direct Doc Preview Link: https://deploy-preview-43575--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-35