### PR TITLE
CFE-374: binding options

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -41,6 +41,30 @@ If not set, the default value is based on `infrastructure.config.openshift.io/cl
 * GCP: `LoadBalancerService` (with External scope)
 * Bare metal: `NodePortService`
 * Other: `HostNetwork`
++
+[NOTE]
+====
+`HostNetwork` has a `hostNetwork` field with the following default values for the optional binding ports; `httpPort: 80`, `httpsPort: 443`, and `statsPort: 1936`.
+With the binding ports, you can deploy multiple Ingress Controllers on the same node for the `HostNetwork` strategy.
+
+.Example
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+    kind: IngressController
+    metadata:
+      name: internal
+      namespace: openshift-ingress-operator
+    spec:
+      domain: private.foo.com
+      endpointPublishingStrategy:
+        type: HostNetwork
+        hostNetwork:
+          httpPort: 80
+          httpsPort: 443
+          statsPort: 1936
+----
+====
 
 For most platforms, the `endpointPublishingStrategy` value can be updated. On GCP, you can configure the following `endpointPublishingStrategy` fields:
 

--- a/rest_api/operator_apis/ingresscontroller-operator-openshift-io-v1.adoc
+++ b/rest_api/operator_apis/ingresscontroller-operator-openshift-io-v1.adoc
@@ -12,9 +12,9 @@ toc::[]
 Description::
 +
 --
-IngressController describes a managed ingress controller for the cluster. The controller can service OpenShift Route and Kubernetes Ingress resources. 
- When an IngressController is created, a new ingress controller deployment is created to allow external traffic to reach the services that expose Ingress or Route resources. Updating this resource may lead to disruption for public facing network connections as a new ingress controller revision may be rolled out. 
- https://kubernetes.io/docs/concepts/services-networking/ingress-controllers 
+IngressController describes a managed ingress controller for the cluster. The controller can service OpenShift Route and Kubernetes Ingress resources.
+ When an IngressController is created, a new ingress controller deployment is created to allow external traffic to reach the services that expose Ingress or Route resources. Updating this resource may lead to disruption for public facing network connections as a new ingress controller revision may be rolled out.
+ https://kubernetes.io/docs/concepts/services-networking/ingress-controllers
  Whenever possible, sensible defaults for the platform are used. See each field for more details.
 --
 
@@ -73,33 +73,33 @@ Type::
 
 | `defaultCertificate`
 | `object`
-| defaultCertificate is a reference to a secret containing the default certificate served by the ingress controller. When Routes don't specify their own certificate, defaultCertificate is used. 
- The secret must contain the following keys and data: 
-   tls.crt: certificate file contents   tls.key: key file contents 
- If unset, a wildcard certificate is automatically generated and used. The certificate is valid for the ingress controller domain (and subdomains) and the generated certificate's CA will be automatically integrated with the cluster's trust store. 
- If a wildcard certificate is used and shared by multiple HTTP/2 enabled routes (which implies ALPN) then clients (i.e., notably browsers) are at liberty to reuse open connections. This means a client can reuse a connection to another route and that is likely to fail. This behaviour is generally known as connection coalescing. 
+| defaultCertificate is a reference to a secret containing the default certificate served by the ingress controller. When Routes don't specify their own certificate, defaultCertificate is used.
+ The secret must contain the following keys and data:
+   tls.crt: certificate file contents   tls.key: key file contents
+ If unset, a wildcard certificate is automatically generated and used. The certificate is valid for the ingress controller domain (and subdomains) and the generated certificate's CA will be automatically integrated with the cluster's trust store.
+ If a wildcard certificate is used and shared by multiple HTTP/2 enabled routes (which implies ALPN) then clients (i.e., notably browsers) are at liberty to reuse open connections. This means a client can reuse a connection to another route and that is likely to fail. This behaviour is generally known as connection coalescing.
  The in-use certificate (whether generated or user-specified) will be automatically integrated with OpenShift's built-in OAuth server.
 
 | `domain`
 | `string`
-| domain is a DNS name serviced by the ingress controller and is used to configure multiple features: 
- * For the LoadBalancerService endpoint publishing strategy, domain is   used to configure DNS records. See endpointPublishingStrategy. 
- * When using a generated default certificate, the certificate will be valid   for domain and its subdomains. See defaultCertificate. 
- * The value is published to individual Route statuses so that end-users   know where to target external DNS records. 
- domain must be unique among all IngressControllers, and cannot be updated. 
+| domain is a DNS name serviced by the ingress controller and is used to configure multiple features:
+ * For the LoadBalancerService endpoint publishing strategy, domain is   used to configure DNS records. See endpointPublishingStrategy.
+ * When using a generated default certificate, the certificate will be valid   for domain and its subdomains. See defaultCertificate.
+ * The value is published to individual Route statuses so that end-users   know where to target external DNS records.
+ domain must be unique among all IngressControllers, and cannot be updated.
  If empty, defaults to ingress.config.openshift.io/cluster .spec.domain.
 
 | `endpointPublishingStrategy`
 | `object`
-| endpointPublishingStrategy is used to publish the ingress controller endpoints to other networks, enable load balancer integrations, etc. 
- If unset, the default is based on infrastructure.config.openshift.io/cluster .status.platform: 
-   AWS:      LoadBalancerService (with External scope)   Azure:    LoadBalancerService (with External scope)   GCP:      LoadBalancerService (with External scope)   IBMCloud: LoadBalancerService (with External scope)   Libvirt:  HostNetwork 
- Any other platform types (including None) default to HostNetwork. 
+| endpointPublishingStrategy is used to publish the ingress controller endpoints to other networks, enable load balancer integrations, etc.
+ If unset, the default is based on infrastructure.config.openshift.io/cluster .status.platform:
+   AWS:      LoadBalancerService (with External scope)   Azure:    LoadBalancerService (with External scope)   GCP:      LoadBalancerService (with External scope)   IBMCloud: LoadBalancerService (with External scope)   Libvirt:  HostNetwork
+ Any other platform types (including None) default to HostNetwork.
  endpointPublishingStrategy cannot be updated.
 
 | `httpEmptyRequestsPolicy`
 | `string`
-| httpEmptyRequestsPolicy describes how HTTP connections should be handled if the connection times out before a request is received. Allowed values for this field are "Respond" and "Ignore".  If the field is set to "Respond", the ingress controller sends an HTTP 400 or 408 response, logs the connection (if access logging is enabled), and counts the connection in the appropriate metrics.  If the field is set to "Ignore", the ingress controller closes the connection without sending a response, logging the connection, or incrementing metrics.  The default value is "Respond". 
+| httpEmptyRequestsPolicy describes how HTTP connections should be handled if the connection times out before a request is received. Allowed values for this field are "Respond" and "Ignore".  If the field is set to "Respond", the ingress controller sends an HTTP 400 or 408 response, logs the connection (if access logging is enabled), and counts the connection in the appropriate metrics.  If the field is set to "Ignore", the ingress controller closes the connection without sending a response, logging the connection, or incrementing metrics.  The default value is "Respond".
  Typically, these connections come from load balancers' health probes or Web browsers' speculative connections ("preconnect") and can be safely ignored.  However, these requests may also be caused by network errors, and so setting this field to "Ignore" may impede detection and diagnosis of problems.  In addition, these requests may be caused by port scans, in which case logging empty requests may aid in detecting intrusion attempts.
 
 | `httpErrorCodePages`
@@ -108,7 +108,7 @@ Type::
 
 | `httpHeaders`
 | `object`
-| httpHeaders defines policy for HTTP headers. 
+| httpHeaders defines policy for HTTP headers.
  If this field is empty, the default values are used.
 
 | `logging`
@@ -117,12 +117,12 @@ Type::
 
 | `namespaceSelector`
 | `object`
-| namespaceSelector is used to filter the set of namespaces serviced by the ingress controller. This is useful for implementing shards. 
+| namespaceSelector is used to filter the set of namespaces serviced by the ingress controller. This is useful for implementing shards.
  If unset, the default is no filtering.
 
 | `nodePlacement`
 | `object`
-| nodePlacement enables explicit control over the scheduling of the ingress controller. 
+| nodePlacement enables explicit control over the scheduling of the ingress controller.
  If unset, defaults are used. See NodePlacement for more details.
 
 | `replicas`
@@ -131,23 +131,23 @@ Type::
 
 | `routeAdmission`
 | `object`
-| routeAdmission defines a policy for handling new route claims (for example, to allow or deny claims across namespaces). 
+| routeAdmission defines a policy for handling new route claims (for example, to allow or deny claims across namespaces).
  If empty, defaults will be applied. See specific routeAdmission fields for details about their defaults.
 
 | `routeSelector`
 | `object`
-| routeSelector is used to filter the set of Routes serviced by the ingress controller. This is useful for implementing shards. 
+| routeSelector is used to filter the set of Routes serviced by the ingress controller. This is useful for implementing shards.
  If unset, the default is no filtering.
 
 | `tlsSecurityProfile`
 | `object`
-| tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers. 
- If unset, the default is based on the apiservers.config.openshift.io/cluster resource. 
+| tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers.
+ If unset, the default is based on the apiservers.config.openshift.io/cluster resource.
  Note that when using the Old, Intermediate, and Modern profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied to the ingress controller, resulting in a rollout.
 
 | `tuningOptions`
 | `object`
-| tuningOptions defines parameters for adjusting the performance of ingress controller pods. All fields are optional and will use their respective defaults if not set. See specific tuningOptions fields for more details. 
+| tuningOptions defines parameters for adjusting the performance of ingress controller pods. All fields are optional and will use their respective defaults if not set. See specific tuningOptions fields for more details.
  Setting fields within tuningOptions is generally not recommended. The default values are suitable for most configurations.
 
 | `unsupportedConfigOverrides`
@@ -185,7 +185,7 @@ Required::
 
 | `clientCertificatePolicy`
 | `string`
-| clientCertificatePolicy specifies whether the ingress controller requires clients to provide certificates.  This field accepts the values "Required" or "Optional". 
+| clientCertificatePolicy specifies whether the ingress controller requires clients to provide certificates.  This field accepts the values "Required" or "Optional".
  Note that the ingress controller only checks client certificates for edge-terminated and reencrypt TLS routes; it cannot check certificates for cleartext HTTP or passthrough TLS routes.
 
 |===
@@ -217,11 +217,11 @@ Required::
 Description::
 +
 --
-defaultCertificate is a reference to a secret containing the default certificate served by the ingress controller. When Routes don't specify their own certificate, defaultCertificate is used. 
- The secret must contain the following keys and data: 
-   tls.crt: certificate file contents   tls.key: key file contents 
- If unset, a wildcard certificate is automatically generated and used. The certificate is valid for the ingress controller domain (and subdomains) and the generated certificate's CA will be automatically integrated with the cluster's trust store. 
- If a wildcard certificate is used and shared by multiple HTTP/2 enabled routes (which implies ALPN) then clients (i.e., notably browsers) are at liberty to reuse open connections. This means a client can reuse a connection to another route and that is likely to fail. This behaviour is generally known as connection coalescing. 
+defaultCertificate is a reference to a secret containing the default certificate served by the ingress controller. When Routes don't specify their own certificate, defaultCertificate is used.
+ The secret must contain the following keys and data:
+   tls.crt: certificate file contents   tls.key: key file contents
+ If unset, a wildcard certificate is automatically generated and used. The certificate is valid for the ingress controller domain (and subdomains) and the generated certificate's CA will be automatically integrated with the cluster's trust store.
+ If a wildcard certificate is used and shared by multiple HTTP/2 enabled routes (which implies ALPN) then clients (i.e., notably browsers) are at liberty to reuse open connections. This means a client can reuse a connection to another route and that is likely to fail. This behaviour is generally known as connection coalescing.
  The in-use certificate (whether generated or user-specified) will be automatically integrated with OpenShift's built-in OAuth server.
 --
 
@@ -244,10 +244,10 @@ Type::
 Description::
 +
 --
-endpointPublishingStrategy is used to publish the ingress controller endpoints to other networks, enable load balancer integrations, etc. 
- If unset, the default is based on infrastructure.config.openshift.io/cluster .status.platform: 
-   AWS:      LoadBalancerService (with External scope)   Azure:    LoadBalancerService (with External scope)   GCP:      LoadBalancerService (with External scope)   IBMCloud: LoadBalancerService (with External scope)   Libvirt:  HostNetwork 
- Any other platform types (including None) default to HostNetwork. 
+endpointPublishingStrategy is used to publish the ingress controller endpoints to other networks, enable load balancer integrations, etc.
+ If unset, the default is based on infrastructure.config.openshift.io/cluster .status.platform:
+   AWS:      LoadBalancerService (with External scope)   Azure:    LoadBalancerService (with External scope)   GCP:      LoadBalancerService (with External scope)   IBMCloud: LoadBalancerService (with External scope)   Libvirt:  HostNetwork
+ Any other platform types (including None) default to HostNetwork.
  endpointPublishingStrategy cannot be updated.
 --
 
@@ -281,21 +281,21 @@ Required::
 
 | `type`
 | `string`
-| type is the publishing strategy to use. Valid values are: 
- * LoadBalancerService 
- Publishes the ingress controller using a Kubernetes LoadBalancer Service. 
- In this configuration, the ingress controller deployment uses container networking. A LoadBalancer Service is created to publish the deployment. 
- See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer 
- If domain is set, a wildcard DNS record will be managed to point at the LoadBalancer Service's external name. DNS records are managed only in DNS zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone. 
- Wildcard DNS management is currently supported only on the AWS, Azure, and GCP platforms. 
- * HostNetwork 
- Publishes the ingress controller on node ports where the ingress controller is deployed. 
- In this configuration, the ingress controller deployment uses host networking, bound to node ports 80 and 443. The user is responsible for configuring an external load balancer to publish the ingress controller via the node ports. 
- * Private 
- Does not publish the ingress controller. 
- In this configuration, the ingress controller deployment uses container networking, and is not explicitly published. The user must manually publish the ingress controller. 
- * NodePortService 
- Publishes the ingress controller using a Kubernetes NodePort Service. 
+| type is the publishing strategy to use. Valid values are:
+ * LoadBalancerService
+ Publishes the ingress controller using a Kubernetes LoadBalancer Service.
+ In this configuration, the ingress controller deployment uses container networking. A LoadBalancer Service is created to publish the deployment.
+ See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+ If domain is set, a wildcard DNS record will be managed to point at the LoadBalancer Service's external name. DNS records are managed only in DNS zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone.
+ Wildcard DNS management is currently supported only on the AWS, Azure, and GCP platforms.
+ * HostNetwork
+ Publishes the ingress controller on node ports where the ingress controller is deployed.
+ In this configuration, the ingress controller deployment uses host networking, bound to node ports 80 and 443 by default or the port values set in the `.spec.endpointPublishingStrategy.hostNetwork` strategy. The user is responsible for configuring an external load balancer to publish the ingress controller via the node ports.
+ * Private
+ Does not publish the ingress controller.
+ In this configuration, the ingress controller deployment uses container networking, and is not explicitly published. The user must manually publish the ingress controller.
+ * NodePortService
+ Publishes the ingress controller using a Kubernetes NodePort Service.
  In this configuration, the ingress controller deployment uses container networking. A NodePort Service is created to publish the deployment. The specific node ports are dynamically allocated by OpenShift; however, to support static port allocations, user changes to the node port field of the managed NodePort Service will preserved.
 
 |===
@@ -318,13 +318,30 @@ Type::
 
 | `protocol`
 | `string`
-| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. 
- PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. 
- The following values are valid for this field: 
- * The empty string. * "TCP". * "PROXY". 
+| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol.
+ PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol.
+ The following values are valid for this field:
+ * The empty string. * "TCP". * "PROXY".
  The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.
 
+ | `httpPort`
+ | `integer`
+ | httpPort is the port on the host which is used to listen for HTTP requests. Define this field when the default port `80` is known to be used by another process. Please avoid specifying a port within the nodeport range, which defaults to 30000-32767, but could be configured differently.
+
+ | `httpsPort`
+ | `integer`
+ | httpsPort is the port on the host which is used to listen for HTTPS requests. Define this field when the default port `443` is known to be used by another process. Please avoid specifying a port within the nodeport range, which defaults to 30000-32767, but could be configured differently.
+
+ | `statsPort`
+ | `integer`
+ | statsPort is the port on the host where the statistics from the router are published. Define this field when default port `1936` is known to be used by another process. Please avoid specifying a port within the nodeport range, which defaults to 30000-32767, but could be configured differently.
+
 |===
+
+Note that if you configure an external load balancer to forward connections to this Ingress Controller, the load balancer should use `statsPort` for health checks. A load balancer can send HTTP probes to this port on a given node with the path `/healthz/ready` to determine whether the Ingress Controller is ready to receive traffic on the node.
+
+To ensure smooth operations, the load balancer must not forward traffic to a node until `/healthz/ready` reports `ready`. The load balancer must stop forwarding within a maximum of 45 seconds after `/healthz/ready` starts reporting `not ready`.
+
 === .spec.endpointPublishingStrategy.loadBalancer
 Description::
 +
@@ -346,7 +363,7 @@ Required::
 
 | `providerParameters`
 | `object`
-| providerParameters holds desired load balancer information specific to the underlying infrastructure provider. 
+| providerParameters holds desired load balancer information specific to the underlying infrastructure provider.
  If empty, defaults will be applied. See specific providerParameters fields for details about their defaults.
 
 | `scope`
@@ -358,7 +375,7 @@ Required::
 Description::
 +
 --
-providerParameters holds desired load balancer information specific to the underlying infrastructure provider. 
+providerParameters holds desired load balancer information specific to the underlying infrastructure provider.
  If empty, defaults will be applied. See specific providerParameters fields for details about their defaults.
 --
 
@@ -376,12 +393,12 @@ Required::
 
 | `aws`
 | `object`
-| aws provides configuration settings that are specific to AWS load balancers. 
+| aws provides configuration settings that are specific to AWS load balancers.
  If empty, defaults will be applied. See specific aws fields for details about their defaults.
 
 | `gcp`
 | `object`
-| gcp provides configuration settings that are specific to GCP load balancers. 
+| gcp provides configuration settings that are specific to GCP load balancers.
  If empty, defaults will be applied. See specific gcp fields for details about their defaults.
 
 | `type`
@@ -393,7 +410,7 @@ Required::
 Description::
 +
 --
-aws provides configuration settings that are specific to AWS load balancers. 
+aws provides configuration settings that are specific to AWS load balancers.
  If empty, defaults will be applied. See specific aws fields for details about their defaults.
 --
 
@@ -419,11 +436,11 @@ Required::
 
 | `type`
 | `string`
-| type is the type of AWS load balancer to instantiate for an ingresscontroller. 
- Valid values are: 
- * "Classic": A Classic Load Balancer that makes routing decisions at either   the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See   the following for additional details: 
-     https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb 
- * "NLB": A Network Load Balancer that makes routing decisions at the   transport layer (TCP/SSL). See the following for additional details: 
+| type is the type of AWS load balancer to instantiate for an ingresscontroller.
+ Valid values are:
+ * "Classic": A Classic Load Balancer that makes routing decisions at either   the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See   the following for additional details:
+     https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb
+ * "NLB": A Network Load Balancer that makes routing decisions at the   transport layer (TCP/SSL). See the following for additional details:
      https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb
 
 |===
@@ -457,7 +474,7 @@ Type::
 Description::
 +
 --
-gcp provides configuration settings that are specific to GCP load balancers. 
+gcp provides configuration settings that are specific to GCP load balancers.
  If empty, defaults will be applied. See specific gcp fields for details about their defaults.
 --
 
@@ -473,10 +490,10 @@ Type::
 
 | `clientAccess`
 | `string`
-| clientAccess describes how client access is restricted for internal load balancers. 
- Valid values are: * "Global": Specifying an internal load balancer with Global client access   allows clients from any region within the VPC to communicate with the load   balancer. 
-     https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#global_access 
- * "Local": Specifying an internal load balancer with Local client access   means only clients within the same region (and VPC) as the GCP load balancer   can communicate with the load balancer. Note that this is the default behavior. 
+| clientAccess describes how client access is restricted for internal load balancers.
+ Valid values are: * "Global": Specifying an internal load balancer with Global client access   allows clients from any region within the VPC to communicate with the load   balancer.
+     https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#global_access
+ * "Local": Specifying an internal load balancer with Local client access   means only clients within the same region (and VPC) as the GCP load balancer   can communicate with the load balancer. Note that this is the default behavior.
      https://cloud.google.com/load-balancing/docs/internal#client_access
 
 |===
@@ -499,10 +516,10 @@ Type::
 
 | `protocol`
 | `string`
-| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. 
- PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. 
- The following values are valid for this field: 
- * The empty string. * "TCP". * "PROXY". 
+| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol.
+ PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol.
+ The following values are valid for this field:
+ * The empty string. * "TCP". * "PROXY".
  The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.
 
 |===
@@ -547,7 +564,7 @@ Required::
 Description::
 +
 --
-httpHeaders defines policy for HTTP headers. 
+httpHeaders defines policy for HTTP headers.
  If this field is empty, the default values are used.
 --
 
@@ -563,23 +580,23 @@ Type::
 
 | `forwardedHeaderPolicy`
 | `string`
-| forwardedHeaderPolicy specifies when and how the IngressController sets the Forwarded, X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Proto, and X-Forwarded-Proto-Version HTTP headers.  The value may be one of the following: 
- * "Append", which specifies that the IngressController appends the   headers, preserving existing headers. 
- * "Replace", which specifies that the IngressController sets the   headers, replacing any existing Forwarded or X-Forwarded-* headers. 
- * "IfNone", which specifies that the IngressController sets the   headers if they are not already set. 
- * "Never", which specifies that the IngressController never sets the   headers, preserving any existing headers. 
+| forwardedHeaderPolicy specifies when and how the IngressController sets the Forwarded, X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Proto, and X-Forwarded-Proto-Version HTTP headers.  The value may be one of the following:
+ * "Append", which specifies that the IngressController appends the   headers, preserving existing headers.
+ * "Replace", which specifies that the IngressController sets the   headers, replacing any existing Forwarded or X-Forwarded-* headers.
+ * "IfNone", which specifies that the IngressController sets the   headers if they are not already set.
+ * "Never", which specifies that the IngressController never sets the   headers, preserving any existing headers.
  By default, the policy is "Append".
 
 | `headerNameCaseAdjustments`
 | ``
-| headerNameCaseAdjustments specifies case adjustments that can be applied to HTTP header names.  Each adjustment is specified as an HTTP header name with the desired capitalization.  For example, specifying "X-Forwarded-For" indicates that the "x-forwarded-for" HTTP header should be adjusted to have the specified capitalization. 
- These adjustments are only applied to cleartext, edge-terminated, and re-encrypt routes, and only when using HTTP/1. 
- For request headers, these adjustments are applied only for routes that have the haproxy.router.openshift.io/h1-adjust-case=true annotation.  For response headers, these adjustments are applied to all HTTP responses. 
+| headerNameCaseAdjustments specifies case adjustments that can be applied to HTTP header names.  Each adjustment is specified as an HTTP header name with the desired capitalization.  For example, specifying "X-Forwarded-For" indicates that the "x-forwarded-for" HTTP header should be adjusted to have the specified capitalization.
+ These adjustments are only applied to cleartext, edge-terminated, and re-encrypt routes, and only when using HTTP/1.
+ For request headers, these adjustments are applied only for routes that have the haproxy.router.openshift.io/h1-adjust-case=true annotation.  For response headers, these adjustments are applied to all HTTP responses.
  If this field is empty, no request headers are adjusted.
 
 | `uniqueId`
 | `object`
-| uniqueId describes configuration for a custom HTTP header that the ingress controller should inject into incoming HTTP requests. Typically, this header is configured to have a value that is unique to the HTTP request.  The header can be used by applications or included in access logs to facilitate tracing individual HTTP requests. 
+| uniqueId describes configuration for a custom HTTP header that the ingress controller should inject into incoming HTTP requests. Typically, this header is configured to have a value that is unique to the HTTP request.  The header can be used by applications or included in access logs to facilitate tracing individual HTTP requests.
  If this field is empty, no such header is injected into requests.
 
 |===
@@ -587,7 +604,7 @@ Type::
 Description::
 +
 --
-uniqueId describes configuration for a custom HTTP header that the ingress controller should inject into incoming HTTP requests. Typically, this header is configured to have a value that is unique to the HTTP request.  The header can be used by applications or included in access logs to facilitate tracing individual HTTP requests. 
+uniqueId describes configuration for a custom HTTP header that the ingress controller should inject into incoming HTTP requests. Typically, this header is configured to have a value that is unique to the HTTP request.  The header can be used by applications or included in access logs to facilitate tracing individual HTTP requests.
  If this field is empty, no such header is injected into requests.
 --
 
@@ -629,7 +646,7 @@ Type::
 
 | `access`
 | `object`
-| access describes how the client requests should be logged. 
+| access describes how the client requests should be logged.
  If this field is empty, access logging is disabled.
 
 |===
@@ -637,7 +654,7 @@ Type::
 Description::
 +
 --
-access describes how the client requests should be logged. 
+access describes how the client requests should be logged.
  If this field is empty, access logging is disabled.
 --
 
@@ -663,13 +680,13 @@ Required::
 
 | `httpCaptureHeaders`
 | `object`
-| httpCaptureHeaders defines HTTP headers that should be captured in access logs.  If this field is empty, no headers are captured. 
+| httpCaptureHeaders defines HTTP headers that should be captured in access logs.  If this field is empty, no headers are captured.
  Note that this option only applies to cleartext HTTP connections and to secure HTTP connections for which the ingress controller terminates encryption (that is, edge-terminated or reencrypt connections).  Headers cannot be captured for TLS passthrough connections.
 
 | `httpLogFormat`
 | `string`
-| httpLogFormat specifies the format of the log message for an HTTP request. 
- If this field is empty, log messages use the implementation's default HTTP log format.  For HAProxy's default HTTP log format, see the HAProxy documentation: http://cbonte.github.io/haproxy-dconv/2.0/configuration.html#8.2.3 
+| httpLogFormat specifies the format of the log message for an HTTP request.
+ If this field is empty, log messages use the implementation's default HTTP log format.  For HAProxy's default HTTP log format, see the HAProxy documentation: http://cbonte.github.io/haproxy-dconv/2.0/configuration.html#8.2.3
  Note that this format only applies to cleartext HTTP connections and to secure HTTP connections for which the ingress controller terminates encryption (that is, edge-terminated or reencrypt connections).  It does not affect the log format for TLS passthrough connections.
 
 | `logEmptyRequests`
@@ -706,10 +723,10 @@ Required::
 
 | `type`
 | `string`
-| type is the type of destination for logs.  It must be one of the following: 
- * Container 
- The ingress operator configures the sidecar container named "logs" on the ingress controller pod and configures the ingress controller to write logs to the sidecar.  The logs are then available as container logs.  The expectation is that the administrator configures a custom logging solution that reads logs from this sidecar.  Note that using container logs means that logs may be dropped if the rate of logs exceeds the container runtime's or the custom logging solution's capacity. 
- * Syslog 
+| type is the type of destination for logs.  It must be one of the following:
+ * Container
+ The ingress operator configures the sidecar container named "logs" on the ingress controller pod and configures the ingress controller to write logs to the sidecar.  The logs are then available as container logs.  The expectation is that the administrator configures a custom logging solution that reads logs from this sidecar.  Note that using container logs means that logs may be dropped if the rate of logs exceeds the container runtime's or the custom logging solution's capacity.
+ * Syslog
  Logs are sent to a syslog endpoint.  The administrator must specify an endpoint that can receive syslog messages.  The expectation is that the administrator has configured a custom syslog instance.
 
 |===
@@ -752,7 +769,7 @@ Required::
 
 | `facility`
 | `string`
-| facility specifies the syslog facility of log messages. 
+| facility specifies the syslog facility of log messages.
  If this field is empty, the facility is "local1".
 
 | `port`
@@ -764,7 +781,7 @@ Required::
 Description::
 +
 --
-httpCaptureHeaders defines HTTP headers that should be captured in access logs.  If this field is empty, no headers are captured. 
+httpCaptureHeaders defines HTTP headers that should be captured in access logs.  If this field is empty, no headers are captured.
  Note that this option only applies to cleartext HTTP connections and to secure HTTP connections for which the ingress controller terminates encryption (that is, edge-terminated or reencrypt connections).  Headers cannot be captured for TLS passthrough connections.
 --
 
@@ -780,12 +797,12 @@ Type::
 
 | `request`
 | ``
-| request specifies which HTTP request headers to capture. 
+| request specifies which HTTP request headers to capture.
  If this field is empty, no request headers are captured.
 
 | `response`
 | ``
-| response specifies which HTTP response headers to capture. 
+| response specifies which HTTP response headers to capture.
  If this field is empty, no response headers are captured.
 
 |===
@@ -793,7 +810,7 @@ Type::
 Description::
 +
 --
-namespaceSelector is used to filter the set of namespaces serviced by the ingress controller. This is useful for implementing shards. 
+namespaceSelector is used to filter the set of namespaces serviced by the ingress controller. This is useful for implementing shards.
  If unset, the default is no filtering.
 --
 
@@ -870,7 +887,7 @@ Required::
 Description::
 +
 --
-nodePlacement enables explicit control over the scheduling of the ingress controller. 
+nodePlacement enables explicit control over the scheduling of the ingress controller.
  If unset, defaults are used. See NodePlacement for more details.
 --
 
@@ -886,15 +903,15 @@ Type::
 
 | `nodeSelector`
 | `object`
-| nodeSelector is the node selector applied to ingress controller deployments. 
- If unset, the default is: 
-   kubernetes.io/os: linux   node-role.kubernetes.io/worker: '' 
+| nodeSelector is the node selector applied to ingress controller deployments.
+ If unset, the default is:
+   kubernetes.io/os: linux   node-role.kubernetes.io/worker: ''
  If set, the specified selector is used and replaces the default.
 
 | `tolerations`
 | `array`
-| tolerations is a list of tolerations applied to ingress controller deployments. 
- The default is an empty list. 
+| tolerations is a list of tolerations applied to ingress controller deployments.
+ The default is an empty list.
  See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 
 | `tolerations[]`
@@ -906,9 +923,9 @@ Type::
 Description::
 +
 --
-nodeSelector is the node selector applied to ingress controller deployments. 
- If unset, the default is: 
-   kubernetes.io/os: linux   node-role.kubernetes.io/worker: '' 
+nodeSelector is the node selector applied to ingress controller deployments.
+ If unset, the default is:
+   kubernetes.io/os: linux   node-role.kubernetes.io/worker: ''
  If set, the specified selector is used and replaces the default.
 --
 
@@ -985,8 +1002,8 @@ Required::
 Description::
 +
 --
-tolerations is a list of tolerations applied to ingress controller deployments. 
- The default is an empty list. 
+tolerations is a list of tolerations applied to ingress controller deployments.
+ The default is an empty list.
  See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 --
 
@@ -1038,7 +1055,7 @@ Type::
 Description::
 +
 --
-routeAdmission defines a policy for handling new route claims (for example, to allow or deny claims across namespaces). 
+routeAdmission defines a policy for handling new route claims (for example, to allow or deny claims across namespaces).
  If empty, defaults will be applied. See specific routeAdmission fields for details about their defaults.
 --
 
@@ -1054,18 +1071,18 @@ Type::
 
 | `namespaceOwnership`
 | `string`
-| namespaceOwnership describes how host name claims across namespaces should be handled. 
- Value must be one of: 
- - Strict: Do not allow routes in different namespaces to claim the same host. 
- - InterNamespaceAllowed: Allow routes to claim different paths of the same   host name across namespaces. 
+| namespaceOwnership describes how host name claims across namespaces should be handled.
+ Value must be one of:
+ - Strict: Do not allow routes in different namespaces to claim the same host.
+ - InterNamespaceAllowed: Allow routes to claim different paths of the same   host name across namespaces.
  If empty, the default is Strict.
 
 | `wildcardPolicy`
 | `string`
-| wildcardPolicy describes how routes with wildcard policies should be handled for the ingress controller. WildcardPolicy controls use of routes [1] exposed by the ingress controller based on the route's wildcard policy. 
- [1] https://github.com/openshift/api/blob/master/route/v1/types.go 
- Note: Updating WildcardPolicy from WildcardsAllowed to WildcardsDisallowed will cause admitted routes with a wildcard policy of Subdomain to stop working. These routes must be updated to a wildcard policy of None to be readmitted by the ingress controller. 
- WildcardPolicy supports WildcardsAllowed and WildcardsDisallowed values. 
+| wildcardPolicy describes how routes with wildcard policies should be handled for the ingress controller. WildcardPolicy controls use of routes [1] exposed by the ingress controller based on the route's wildcard policy.
+ [1] https://github.com/openshift/api/blob/master/route/v1/types.go
+ Note: Updating WildcardPolicy from WildcardsAllowed to WildcardsDisallowed will cause admitted routes with a wildcard policy of Subdomain to stop working. These routes must be updated to a wildcard policy of None to be readmitted by the ingress controller.
+ WildcardPolicy supports WildcardsAllowed and WildcardsDisallowed values.
  If empty, defaults to "WildcardsDisallowed".
 
 |===
@@ -1073,7 +1090,7 @@ Type::
 Description::
 +
 --
-routeSelector is used to filter the set of Routes serviced by the ingress controller. This is useful for implementing shards. 
+routeSelector is used to filter the set of Routes serviced by the ingress controller. This is useful for implementing shards.
  If unset, the default is no filtering.
 --
 
@@ -1150,8 +1167,8 @@ Required::
 Description::
 +
 --
-tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers. 
- If unset, the default is based on the apiservers.config.openshift.io/cluster resource. 
+tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers.
+ If unset, the default is based on the apiservers.config.openshift.io/cluster resource.
  Note that when using the Old, Intermediate, and Modern profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied to the ingress controller, resulting in a rollout.
 --
 
@@ -1167,36 +1184,36 @@ Type::
 
 | `custom`
 | ``
-| custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this: 
+| custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this:
    ciphers:     - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305     - ECDHE-RSA-AES128-GCM-SHA256     - ECDHE-ECDSA-AES128-GCM-SHA256   minTLSVersion: TLSv1.1
 
 | `intermediate`
 | ``
-| intermediate is a TLS security profile based on: 
- https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29 
- and looks like this (yaml): 
+| intermediate is a TLS security profile based on:
+ https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+ and looks like this (yaml):
    ciphers:     - TLS_AES_128_GCM_SHA256     - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256     - ECDHE-ECDSA-AES128-GCM-SHA256     - ECDHE-RSA-AES128-GCM-SHA256     - ECDHE-ECDSA-AES256-GCM-SHA384     - ECDHE-RSA-AES256-GCM-SHA384     - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305     - DHE-RSA-AES128-GCM-SHA256     - DHE-RSA-AES256-GCM-SHA384   minTLSVersion: TLSv1.2
 
 | `modern`
 | ``
-| modern is a TLS security profile based on: 
- https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility 
- and looks like this (yaml): 
-   ciphers:     - TLS_AES_128_GCM_SHA256     - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256   minTLSVersion: TLSv1.3 
+| modern is a TLS security profile based on:
+ https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+ and looks like this (yaml):
+   ciphers:     - TLS_AES_128_GCM_SHA256     - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256   minTLSVersion: TLSv1.3
  NOTE: Currently unsupported.
 
 | `old`
 | ``
-| old is a TLS security profile based on: 
- https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility 
- and looks like this (yaml): 
+| old is a TLS security profile based on:
+ https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
+ and looks like this (yaml):
    ciphers:     - TLS_AES_128_GCM_SHA256     - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256     - ECDHE-ECDSA-AES128-GCM-SHA256     - ECDHE-RSA-AES128-GCM-SHA256     - ECDHE-ECDSA-AES256-GCM-SHA384     - ECDHE-RSA-AES256-GCM-SHA384     - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305     - DHE-RSA-AES128-GCM-SHA256     - DHE-RSA-AES256-GCM-SHA384     - DHE-RSA-CHACHA20-POLY1305     - ECDHE-ECDSA-AES128-SHA256     - ECDHE-RSA-AES128-SHA256     - ECDHE-ECDSA-AES128-SHA     - ECDHE-RSA-AES128-SHA     - ECDHE-ECDSA-AES256-SHA384     - ECDHE-RSA-AES256-SHA384     - ECDHE-ECDSA-AES256-SHA     - ECDHE-RSA-AES256-SHA     - DHE-RSA-AES128-SHA256     - DHE-RSA-AES256-SHA256     - AES128-GCM-SHA256     - AES256-GCM-SHA384     - AES128-SHA256     - AES256-SHA256     - AES128-SHA     - AES256-SHA     - DES-CBC3-SHA   minTLSVersion: TLSv1.0
 
 | `type`
 | `string`
-| type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on: 
- https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations 
- The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced. 
+| type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on:
+ https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
+ The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced.
  Note that the Modern profile is currently not supported because it is not yet well adopted by common software libraries.
 
 |===
@@ -1204,7 +1221,7 @@ Type::
 Description::
 +
 --
-tuningOptions defines parameters for adjusting the performance of ingress controller pods. All fields are optional and will use their respective defaults if not set. See specific tuningOptions fields for more details. 
+tuningOptions defines parameters for adjusting the performance of ingress controller pods. All fields are optional and will use their respective defaults if not set. See specific tuningOptions fields for more details.
  Setting fields within tuningOptions is generally not recommended. The default values are suitable for most configurations.
 --
 
@@ -1220,48 +1237,48 @@ Type::
 
 | `clientFinTimeout`
 | `string`
-| clientFinTimeout defines how long a connection will be held open while waiting for the client response to the server/backend closing the connection. 
+| clientFinTimeout defines how long a connection will be held open while waiting for the client response to the server/backend closing the connection.
  If unset, the default timeout is 1s
 
 | `clientTimeout`
 | `string`
-| clientTimeout defines how long a connection will be held open while waiting for a client response. 
+| clientTimeout defines how long a connection will be held open while waiting for a client response.
  If unset, the default timeout is 30s
 
 | `headerBufferBytes`
 | `integer`
-| headerBufferBytes describes how much memory should be reserved (in bytes) for IngressController connection sessions. Note that this value must be at least 16384 if HTTP/2 is enabled for the IngressController (https://tools.ietf.org/html/rfc7540). If this field is empty, the IngressController will use a default value of 32768 bytes. 
+| headerBufferBytes describes how much memory should be reserved (in bytes) for IngressController connection sessions. Note that this value must be at least 16384 if HTTP/2 is enabled for the IngressController (https://tools.ietf.org/html/rfc7540). If this field is empty, the IngressController will use a default value of 32768 bytes.
  Setting this field is generally not recommended as headerBufferBytes values that are too small may break the IngressController and headerBufferBytes values that are too large could cause the IngressController to use significantly more memory than necessary.
 
 | `headerBufferMaxRewriteBytes`
 | `integer`
-| headerBufferMaxRewriteBytes describes how much memory should be reserved (in bytes) from headerBufferBytes for HTTP header rewriting and appending for IngressController connection sessions. Note that incoming HTTP requests will be limited to (headerBufferBytes - headerBufferMaxRewriteBytes) bytes, meaning headerBufferBytes must be greater than headerBufferMaxRewriteBytes. If this field is empty, the IngressController will use a default value of 8192 bytes. 
+| headerBufferMaxRewriteBytes describes how much memory should be reserved (in bytes) from headerBufferBytes for HTTP header rewriting and appending for IngressController connection sessions. Note that incoming HTTP requests will be limited to (headerBufferBytes - headerBufferMaxRewriteBytes) bytes, meaning headerBufferBytes must be greater than headerBufferMaxRewriteBytes. If this field is empty, the IngressController will use a default value of 8192 bytes.
  Setting this field is generally not recommended as headerBufferMaxRewriteBytes values that are too small may break the IngressController and headerBufferMaxRewriteBytes values that are too large could cause the IngressController to use significantly more memory than necessary.
 
 | `serverFinTimeout`
 | `string`
-| serverFinTimeout defines how long a connection will be held open while waiting for the server/backend response to the client closing the connection. 
+| serverFinTimeout defines how long a connection will be held open while waiting for the server/backend response to the client closing the connection.
  If unset, the default timeout is 1s
 
 | `serverTimeout`
 | `string`
-| serverTimeout defines how long a connection will be held open while waiting for a server/backend response. 
+| serverTimeout defines how long a connection will be held open while waiting for a server/backend response.
  If unset, the default timeout is 30s
 
 | `threadCount`
 | `integer`
-| threadCount defines the number of threads created per HAProxy process. Creating more threads allows each ingress controller pod to handle more connections, at the cost of more system resources being used. HAProxy currently supports up to 64 threads. If this field is empty, the IngressController will use the default value.  The current default is 4 threads, but this may change in future releases. 
+| threadCount defines the number of threads created per HAProxy process. Creating more threads allows each ingress controller pod to handle more connections, at the cost of more system resources being used. HAProxy currently supports up to 64 threads. If this field is empty, the IngressController will use the default value.  The current default is 4 threads, but this may change in future releases.
  Setting this field is generally not recommended. Increasing the number of HAProxy threads allows ingress controller pods to utilize more CPU time under load, potentially starving other pods if set too high. Reducing the number of threads may cause the ingress controller to perform poorly.
 
 | `tlsInspectDelay`
 | `string`
-| tlsInspectDelay defines how long the router can hold data to find a matching route. 
- Setting this too short can cause the router to fall back to the default certificate for edge-terminated or reencrypt routes even when a better matching certificate could be used. 
+| tlsInspectDelay defines how long the router can hold data to find a matching route.
+ Setting this too short can cause the router to fall back to the default certificate for edge-terminated or reencrypt routes even when a better matching certificate could be used.
  If unset, the default inspect delay is 5s
 
 | `tunnelTimeout`
 | `string`
-| tunnelTimeout defines how long a tunnel connection (including websockets) will be held open while the tunnel is idle. 
+| tunnelTimeout defines how long a tunnel connection (including websockets) will be held open while the tunnel is idle.
  If unset, the default timeout is 1h
 
 |===
@@ -1288,12 +1305,12 @@ Type::
 
 | `conditions`
 | `array`
-| conditions is a list of conditions and their status. 
- Available means the ingress controller deployment is available and servicing route and ingress resources (i.e, .status.availableReplicas equals .spec.replicas) 
- There are additional conditions which indicate the status of other ingress controller features and capabilities. 
-   * LoadBalancerManaged   - True if the following conditions are met:     * The endpoint publishing strategy requires a service load balancer.   - False if any of those conditions are unsatisfied. 
-   * LoadBalancerReady   - True if the following conditions are met:     * A load balancer is managed.     * The load balancer is ready.   - False if any of those conditions are unsatisfied. 
-   * DNSManaged   - True if the following conditions are met:     * The endpoint publishing strategy and platform support DNS.     * The ingress controller domain is set.     * dns.config.openshift.io/cluster configures DNS zones.   - False if any of those conditions are unsatisfied. 
+| conditions is a list of conditions and their status.
+ Available means the ingress controller deployment is available and servicing route and ingress resources (i.e, .status.availableReplicas equals .spec.replicas)
+ There are additional conditions which indicate the status of other ingress controller features and capabilities.
+   * LoadBalancerManaged   - True if the following conditions are met:     * The endpoint publishing strategy requires a service load balancer.   - False if any of those conditions are unsatisfied.
+   * LoadBalancerReady   - True if the following conditions are met:     * A load balancer is managed.     * The load balancer is ready.   - False if any of those conditions are unsatisfied.
+   * DNSManaged   - True if the following conditions are met:     * The endpoint publishing strategy and platform support DNS.     * The ingress controller domain is set.     * dns.config.openshift.io/cluster configures DNS zones.   - False if any of those conditions are unsatisfied.
    * DNSReady   - True if the following conditions are met:     * DNS is managed.     * DNS records have been successfully created.   - False if any of those conditions are unsatisfied.
 
 | `conditions[]`
@@ -1325,12 +1342,12 @@ Type::
 Description::
 +
 --
-conditions is a list of conditions and their status. 
- Available means the ingress controller deployment is available and servicing route and ingress resources (i.e, .status.availableReplicas equals .spec.replicas) 
- There are additional conditions which indicate the status of other ingress controller features and capabilities. 
-   * LoadBalancerManaged   - True if the following conditions are met:     * The endpoint publishing strategy requires a service load balancer.   - False if any of those conditions are unsatisfied. 
-   * LoadBalancerReady   - True if the following conditions are met:     * A load balancer is managed.     * The load balancer is ready.   - False if any of those conditions are unsatisfied. 
-   * DNSManaged   - True if the following conditions are met:     * The endpoint publishing strategy and platform support DNS.     * The ingress controller domain is set.     * dns.config.openshift.io/cluster configures DNS zones.   - False if any of those conditions are unsatisfied. 
+conditions is a list of conditions and their status.
+ Available means the ingress controller deployment is available and servicing route and ingress resources (i.e, .status.availableReplicas equals .spec.replicas)
+ There are additional conditions which indicate the status of other ingress controller features and capabilities.
+   * LoadBalancerManaged   - True if the following conditions are met:     * The endpoint publishing strategy requires a service load balancer.   - False if any of those conditions are unsatisfied.
+   * LoadBalancerReady   - True if the following conditions are met:     * A load balancer is managed.     * The load balancer is ready.   - False if any of those conditions are unsatisfied.
+   * DNSManaged   - True if the following conditions are met:     * The endpoint publishing strategy and platform support DNS.     * The ingress controller domain is set.     * dns.config.openshift.io/cluster configures DNS zones.   - False if any of those conditions are unsatisfied.
    * DNSReady   - True if the following conditions are met:     * DNS is managed.     * DNS records have been successfully created.   - False if any of those conditions are unsatisfied.
 --
 
@@ -1359,23 +1376,23 @@ Type::
 
 | `lastTransitionTime`
 | `string`
-| 
+|
 
 | `message`
 | `string`
-| 
+|
 
 | `reason`
 | `string`
-| 
+|
 
 | `status`
 | `string`
-| 
+|
 
 | `type`
 | `string`
-| 
+|
 
 |===
 === .status.endpointPublishingStrategy
@@ -1415,21 +1432,21 @@ Required::
 
 | `type`
 | `string`
-| type is the publishing strategy to use. Valid values are: 
- * LoadBalancerService 
- Publishes the ingress controller using a Kubernetes LoadBalancer Service. 
- In this configuration, the ingress controller deployment uses container networking. A LoadBalancer Service is created to publish the deployment. 
- See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer 
- If domain is set, a wildcard DNS record will be managed to point at the LoadBalancer Service's external name. DNS records are managed only in DNS zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone. 
- Wildcard DNS management is currently supported only on the AWS, Azure, and GCP platforms. 
- * HostNetwork 
- Publishes the ingress controller on node ports where the ingress controller is deployed. 
- In this configuration, the ingress controller deployment uses host networking, bound to node ports 80 and 443. The user is responsible for configuring an external load balancer to publish the ingress controller via the node ports. 
- * Private 
- Does not publish the ingress controller. 
- In this configuration, the ingress controller deployment uses container networking, and is not explicitly published. The user must manually publish the ingress controller. 
- * NodePortService 
- Publishes the ingress controller using a Kubernetes NodePort Service. 
+| type is the publishing strategy to use. Valid values are:
+ * LoadBalancerService
+ Publishes the ingress controller using a Kubernetes LoadBalancer Service.
+ In this configuration, the ingress controller deployment uses container networking. A LoadBalancer Service is created to publish the deployment.
+ See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+ If domain is set, a wildcard DNS record will be managed to point at the LoadBalancer Service's external name. DNS records are managed only in DNS zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone.
+ Wildcard DNS management is currently supported only on the AWS, Azure, and GCP platforms.
+ * HostNetwork
+ Publishes the ingress controller on node ports where the ingress controller is deployed.
+ In this configuration, the ingress controller deployment uses host networking, bound to node ports 80 and 443 by default or the port values set in the `.spec.endpointPublishingStrategy.hostNetwork` strategy. The user is responsible for configuring an external load balancer to publish the ingress controller via the node ports.
+ * Private
+ Does not publish the ingress controller.
+ In this configuration, the ingress controller deployment uses container networking, and is not explicitly published. The user must manually publish the ingress controller.
+ * NodePortService
+ Publishes the ingress controller using a Kubernetes NodePort Service.
  In this configuration, the ingress controller deployment uses container networking. A NodePort Service is created to publish the deployment. The specific node ports are dynamically allocated by OpenShift; however, to support static port allocations, user changes to the node port field of the managed NodePort Service will preserved.
 
 |===
@@ -1452,10 +1469,10 @@ Type::
 
 | `protocol`
 | `string`
-| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. 
- PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. 
- The following values are valid for this field: 
- * The empty string. * "TCP". * "PROXY". 
+| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol.
+ PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol.
+ The following values are valid for this field:
+ * The empty string. * "TCP". * "PROXY".
  The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.
 
 |===
@@ -1480,7 +1497,7 @@ Required::
 
 | `providerParameters`
 | `object`
-| providerParameters holds desired load balancer information specific to the underlying infrastructure provider. 
+| providerParameters holds desired load balancer information specific to the underlying infrastructure provider.
  If empty, defaults will be applied. See specific providerParameters fields for details about their defaults.
 
 | `scope`
@@ -1492,7 +1509,7 @@ Required::
 Description::
 +
 --
-providerParameters holds desired load balancer information specific to the underlying infrastructure provider. 
+providerParameters holds desired load balancer information specific to the underlying infrastructure provider.
  If empty, defaults will be applied. See specific providerParameters fields for details about their defaults.
 --
 
@@ -1510,12 +1527,12 @@ Required::
 
 | `aws`
 | `object`
-| aws provides configuration settings that are specific to AWS load balancers. 
+| aws provides configuration settings that are specific to AWS load balancers.
  If empty, defaults will be applied. See specific aws fields for details about their defaults.
 
 | `gcp`
 | `object`
-| gcp provides configuration settings that are specific to GCP load balancers. 
+| gcp provides configuration settings that are specific to GCP load balancers.
  If empty, defaults will be applied. See specific gcp fields for details about their defaults.
 
 | `type`
@@ -1527,7 +1544,7 @@ Required::
 Description::
 +
 --
-aws provides configuration settings that are specific to AWS load balancers. 
+aws provides configuration settings that are specific to AWS load balancers.
  If empty, defaults will be applied. See specific aws fields for details about their defaults.
 --
 
@@ -1553,11 +1570,11 @@ Required::
 
 | `type`
 | `string`
-| type is the type of AWS load balancer to instantiate for an ingresscontroller. 
- Valid values are: 
- * "Classic": A Classic Load Balancer that makes routing decisions at either   the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See   the following for additional details: 
-     https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb 
- * "NLB": A Network Load Balancer that makes routing decisions at the   transport layer (TCP/SSL). See the following for additional details: 
+| type is the type of AWS load balancer to instantiate for an ingresscontroller.
+ Valid values are:
+ * "Classic": A Classic Load Balancer that makes routing decisions at either   the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See   the following for additional details:
+     https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb
+ * "NLB": A Network Load Balancer that makes routing decisions at the   transport layer (TCP/SSL). See the following for additional details:
      https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb
 
 |===
@@ -1591,7 +1608,7 @@ Type::
 Description::
 +
 --
-gcp provides configuration settings that are specific to GCP load balancers. 
+gcp provides configuration settings that are specific to GCP load balancers.
  If empty, defaults will be applied. See specific gcp fields for details about their defaults.
 --
 
@@ -1607,10 +1624,10 @@ Type::
 
 | `clientAccess`
 | `string`
-| clientAccess describes how client access is restricted for internal load balancers. 
- Valid values are: * "Global": Specifying an internal load balancer with Global client access   allows clients from any region within the VPC to communicate with the load   balancer. 
-     https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#global_access 
- * "Local": Specifying an internal load balancer with Local client access   means only clients within the same region (and VPC) as the GCP load balancer   can communicate with the load balancer. Note that this is the default behavior. 
+| clientAccess describes how client access is restricted for internal load balancers.
+ Valid values are: * "Global": Specifying an internal load balancer with Global client access   allows clients from any region within the VPC to communicate with the load   balancer.
+     https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#global_access
+ * "Local": Specifying an internal load balancer with Local client access   means only clients within the same region (and VPC) as the GCP load balancer   can communicate with the load balancer. Note that this is the default behavior.
      https://cloud.google.com/load-balancing/docs/internal#client_access
 
 |===
@@ -1633,10 +1650,10 @@ Type::
 
 | `protocol`
 | `string`
-| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. 
- PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. 
- The following values are valid for this field: 
- * The empty string. * "TCP". * "PROXY". 
+| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol.
+ PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol.
+ The following values are valid for this field:
+ * The empty string. * "TCP". * "PROXY".
  The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.
 
 |===
@@ -1672,13 +1689,13 @@ Type::
 
 | `ciphers`
 | `array (string)`
-| ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml): 
+| ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml):
    ciphers:     - DES-CBC3-SHA
 
 | `minTLSVersion`
 | `string`
-| minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml): 
-   minTLSVersion: TLSv1.1 
+| minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml):
+   minTLSVersion: TLSv1.1
  NOTE: currently the highest minTLSVersion allowed is VersionTLS12
 
 |===
@@ -1936,7 +1953,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../operator_apis/ingresscontroller-operator-openshift-io-v1.adoc#ingresscontroller-operator-openshift-io-v1[`IngressController`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2008,7 +2025,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions_v2[`DeleteOptions_v2`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2077,7 +2094,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2115,7 +2132,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../operator_apis/ingresscontroller-operator-openshift-io-v1.adoc#ingresscontroller-operator-openshift-io-v1[`IngressController`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2208,7 +2225,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2246,7 +2263,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.api.autoscaling.v1.Scale_v2[`Scale_v2`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2339,7 +2356,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2377,7 +2394,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../operator_apis/ingresscontroller-operator-openshift-io-v1.adoc#ingresscontroller-operator-openshift-io-v1[`IngressController`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2391,5 +2408,3 @@ Description::
 | 401 - Unauthorized
 | Empty
 |===
-
-


### PR DESCRIPTION
- Applies only to 4.11
- [Jira](https://issues.redhat.com/browse/CFE-10)
- [Preview](https://deploy-preview-43576--osdocs.netlify.app/openshift-enterprise/latest/rest_api/operator_apis/ingresscontroller-operator-openshift-io-v1.html)
- [second preview](https://deploy-preview-43576--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html)
Two previews to indicate the two plaecholders. 

- Was [CFE-10](https://issues.redhat.com/browse/CFE-10)

@sherine-k please review  @quarterpin ptal