### PR TITLE
Added notes for release 4.7.45

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -3125,3 +3125,28 @@ link:https://access.redhat.com/solutions/6772591[{product-title} 4.7.44 containe
 ==== Updating
 
 To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-7-45"]
+=== RHBA-2022:0873 - {product-title} 4.7.45 bug fix and security update
+
+Issued: 2022-03-22
+
+{product-title} release 4.7.45, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0873[RHBA-2022:0873] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0870[RHSA-2022:0870] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6834871[{product-title} 4.7.45 container image list]
+
+[id="ocp-4-7-45-bug-fixes"]
+==== Bug fixes
+
+* Previously, a race condition led to the OpenStack cloud provider not being provisioned with OpenStack credentials.
+This made it impossible to create load balancing services with Octavia.
+In this update, those credentials are fetched repeatedly.
+The components initualize successfully, and `LoadBalancer`-type services are able to be created.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2054669[*BZ#2054669*])
+
+[id="ocp-4-7-45-updating"]
+==== Updating
+
+To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
These are the notes for release 4.7.45.

Applies only to `enterprise-4.7`

Preview: https://deploy-preview-43589--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes#ocp-4-7-45