### PR TITLE
BZ2065757: Remove enabling vSphere info

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
@@ -38,15 +38,9 @@ include::modules/persistent-storage-csi-vsphere-stor-policy.adoc[leveloffset=+1]
 
 include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-
-* To remove a third-party CSI driver, see xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
+To remove a third-party CSI driver, see xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
 
 include::modules/persistent-storage-csi-vsphere-install-issues.adoc[leveloffset=+1]
-
-:FeatureName: vSphere
-include::modules/persistent-storage-csi-tp-enable.adoc[leveloffset=+1]
 
 == Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]


### PR DESCRIPTION
4.10+

[BZ2065757](https://bugzilla.redhat.com/show_bug.cgi?id=2065757) removes enabling vSphere CSI driver oper info due to GA status

**Preview**: https://deploy-preview-43595--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html

**PTAL**: @gnufied @Phaow