### PR TITLE
BZ2066093: Correcting improper Asciidoc formatting in VM SSH procedure

### DIFF
--- a/modules/virt-accessing-vmi-ssh.adoc
+++ b/modules/virt-accessing-vmi-ssh.adoc
@@ -35,7 +35,7 @@ $ virtctl expose vm <fedora-vm> --port=22 --name=fedora-vm-ssh --type=NodePort <
 ----
 $ oc get svc
 ----
-
++
 .Example output
 [source,terminal]
 ----


### PR DESCRIPTION
This PR relates to [BZ2066093](https://bugzilla.redhat.com/show_bug.cgi?id=2066093).

The bugs asks for a small correction to the incorrectly rendered 2nd step of the procedure in [Accessing a virtual machine instance via SSH](https://docs.openshift.com/container-platform/4.10/virt/virtual_machines/virt-accessing-vm-consoles.html#virt-accessing-vmi-ssh_virt-accessing-vm-consoles). Currently, there is a + sign incorrectly rendering prior to the line beginning with "In this example, the service..."

CP: 4.9, 4.10, 4.11

Preview: 2nd step in the Procedure section of https://deploy-preview-43605--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-consoles.html#virt-accessing-vmi-ssh_virt-accessing-vm-consoles