### PR TITLE
Disabling automerging of PRs by the openshift-cherrypick-robot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 cache: pip
-env:
-  - PR_AUTHOR=${TRAVIS_PULL_REQUEST_SLUG::-15}
+# env:
+#   - PR_AUTHOR=${TRAVIS_PULL_REQUEST_SLUG::-15}
 
 jobs:
   include:
@@ -34,10 +34,11 @@ jobs:
         - pip3 install aura.tar.gz
       script:
         - python3 build.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch && python3 makeBuild.py
-    - stage: automerge
-      if: env(PR_AUTHOR)=openshift-cherrypick-robot
-      script: bash ./automerge.sh
+    # Commenting out to disable auto-merging of PRs
+    # - stage: automerge
+    #   if: env(PR_AUTHOR)=openshift-cherrypick-robot
+    #   script: bash ./automerge.sh
 
 stages:
   - build
-  - automerge
+  # - automerge


### PR DESCRIPTION
See #43642 for disabling versions 4.6-4.8 and #43643 for disabling on the rhacs-docs branches.