### PR TITLE
BZ1941463 - Remove and move sso URL from registry chart

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -30,10 +30,6 @@ There are no special configuration considerations for services running on only c
 |443, 80
 |Provides core container images
 
-|`sso.redhat.com`
-|443, 80
-|The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`
-
 |`*.openshiftapps.com`
 |443, 80
 |Provides {op-system-first} images
@@ -146,6 +142,11 @@ CDN hostnames, such as `cdn01.quay.io`, are covered when you add a wildcard entr
 |`registry.access.redhat.com`
 |443, 80
 |Required for `odo` CLI.
+
+|`sso.redhat.com`
+|443, 80
+|The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`
+
 |===
 Operators require route access to perform health checks. Specifically, the
 authentication and web console Operators connect to two routes to verify that


### PR DESCRIPTION
For Versions 4.6+
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1941463

Description: Removing `sso.redhat.com` from registry URL chart and move it to "Allowlist the following URLs" 

Preview: https://deploy-preview-43624--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html
