### PR TITLE
BZ-1682920: Pods-per-core references removed from OCP docs

### DIFF
--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -734,10 +734,10 @@ maximums] page for the maximum supported limits for each version of
 {product-title}.
 ====
 
-In the *_/etc/origin/node/node-config.yaml_* file, two parameters control the
-maximum number of pods that can be scheduled to a node: `pods-per-core` and
-`max-pods`. When both options are in use, the lower of the two limits the number
-of pods on a node. Exceeding these values can result in:
+In the *_/etc/origin/node/node-config.yaml_* file, one parameter controls the
+maximum number of pods that can be scheduled to a node: `max-pods`.
+When the `max-pods` option is in use, it limits the number
+of pods on a node. Exceeding this value can result in:
 
 * Increased CPU utilization on both {product-title} and Docker.
 * Slow pod scheduling.
@@ -753,23 +753,6 @@ actual container starting. Therefore, a system running 10 pods will actually
 have 20 containers running.
 ====
 
-`pods-per-core` sets the number of pods the node can run based on the number of
-processor cores on the node. For example, if `pods-per-core` is set to `10` on
-a node with 4 processor cores, the maximum number of pods allowed on the node
-will be 40.
-
-[source,yaml]
-----
-kubeletArguments:
-  pods-per-core:
-    - "10"
-----
-
-[NOTE]
-====
-Setting `pods-per-core` to 0 disables this limit.
-====
-
 `max-pods` sets the number of pods the node can run to a fixed value, regardless
 of the properties of the node.
 xref:../scaling_performance/cluster_maximums.adoc#scaling-performance-current-cluster-maximums[Cluster
@@ -782,9 +765,7 @@ kubeletArguments:
     - "250"
 ----
 
-Using the above example, the default value for `pods-per-core` is `10` and the
-default value for `max-pods` is `250`. This means that unless the node has 25
-cores or more, by default, `pods-per-core` will be the limiting factor.
+Using the above example, the default value for `max-pods` is `250`.
 // end::admin_guide_manage_nodes[]
 
 [[managing-nodes-docker-reset]]

--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -616,16 +616,6 @@ You can also define new node group names with other labels, the following entry 
 openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']}, {'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true']}, {'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true']}, {'name': 'node-config-compute-storage', 'labels': ['node-role.kubernetes.io/compute-storage=true']}]
 ----
 
-When you set an entry in the inventory file, you can also edit the ConfigMap for
-a node group:
-
-* You can use a list, such as modifying the `node-config-compute` to set
-`kubeletArguments.pods-per-core` to `20`:
-
-----
-openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kubernetes.io/master=true']}, {'name': 'node-config-infra', 'labels': ['node-role.kubernetes.io/infra=true']}, {'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true'], 'edits': [{ 'key': 'kubeletArguments.pods-per-core','value': ['20']}]}]
-----
-
 * You can use a list to modify multiple key value pairs, such as modifying the
 `node-config-compute` group to add two parameters to the `kubelet`:
 

--- a/install/example_inventories.adoc
+++ b/install/example_inventories.adoc
@@ -384,7 +384,7 @@ openshift_master_cluster_hostname=openshift-internal.example.com
 openshift_master_cluster_public_hostname=openshift-cluster.example.com
 
 # apply updated node defaults
-openshift_node_groups=[{'name': 'node-config-all-in-one', 'labels': ['node-role.kubernetes.io/master=true', 'node-role.kubernetes.io/infra=true', 'node-role.kubernetes.io/compute=true'], 'edits': [{ 'key': 'kubeletArguments.pods-per-core','value': ['20']}]}]
+openshift_node_groups=[{'name': 'node-config-all-in-one', 'labels': ['node-role.kubernetes.io/master=true', 'node-role.kubernetes.io/infra=true', 'node-role.kubernetes.io/compute=true'], 'edits':}]
 
 # host group for masters
 [masters]

--- a/install/stand_alone_registry.adoc
+++ b/install/stand_alone_registry.adoc
@@ -197,7 +197,7 @@ openshift_master_cluster_hostname=openshift-internal.example.com
 openshift_master_cluster_public_hostname=openshift-cluster.example.com
 
 # apply updated node-config-compute group defaults
-openshift_node_groups=[{'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true'], 'edits': [{'key': 'kubeletArguments.pods-per-core','value': ['20']}, {'key': 'kubeletArguments.max-pods','value': ['250']}, {'key': 'kubeletArguments.image-gc-high-threshold', 'value':['90']}, {'key': 'kubeletArguments.image-gc-low-threshold', 'value': ['80']}]}]
+openshift_node_groups=[{'name': 'node-config-compute', 'labels': ['node-role.kubernetes.io/compute=true'], 'edits': [{'key': 'kubeletArguments.max-pods','value': ['250']}, {'key': 'kubeletArguments.image-gc-high-threshold', 'value':['90']}, {'key': 'kubeletArguments.image-gc-low-threshold', 'value': ['80']}]}]
 
 # enable ntp on masters to ensure proper failover
 openshift_clock_enabled=true


### PR DESCRIPTION
Applies to 3.11 only
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1682920
QE ack required.
Preview Links: 

- [Setting maximum pods per node](https://deploy-preview-43625--osdocs.netlify.app/openshift-enterprise/latest/admin_guide/manage_nodes.html#admin-guide-max-pods-per-node)
- [Node group definitions](https://deploy-preview-43625--osdocs.netlify.app/openshift-enterprise/latest/install/configuring_inventory_file.html#configuring-inventory-node-group-definitions)
- [Multiple Masters Using Native HA with External Clustered etcd](https://deploy-preview-43625--osdocs.netlify.app/openshift-enterprise/latest/install/example_inventories.html#multi-masters-using-native-ha-ai)