### PR TITLE
RNs-4.6.56 Added with Bug Fixes

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3467,7 +3467,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2022-02-23
 
-{product-title} release 4.6.55, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0566[RHBA-2022:0566] advisory. There are no RPM packages for this release. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0565[RHSA-2022:0565] advisory.
+{product-title} release 4.6.55, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0566[RHBA-2022:0566] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0565[RHSA-2022:0565] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -3485,6 +3485,26 @@ Now these IP addresses are periodically collected and made available to be reall
 (https://bugzilla.redhat.com/show_bug.cgi?id=2028968[*BZ#2028968*])
 
 [id="ocp-4-6-55-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-6-56"]
+=== RHBA-2022:0867 - {product-title} 4.6.56 bug fix and security update
+
+Issued: 2022-03-23
+
+{product-title} release 4.6.56, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0867[RHBA-2022:0867] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0866[RHSA-2022:0866] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6833311[{product-title} 4.6.56 container image list]
+
+[id="ocp-4-6-56-bug-fixes"]
+==== Bug fixes
+ * Previously, an error between {rh-openstack-first} credentials secret creation and `kube-controller-manager` startup prevented {rh-openstack} credentials from configuring properly. Consequently, `LoadBalancer` services were not created in {rh-openstack}. This updates fetches the {rh-openstack} credentials when `kube-controller-manager` starts. As a result, {rh-openstack} secret credentials now initialize properly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2059677[*BZ#2059677*])
+
+[id="ocp-4-6-56-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
To be merged on **03-23**

OCP version: Applicable only to **enterprise-4.6**

Direct Doc Preview Link: https://deploy-preview-43631--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes#ocp-4-6-56