### PR TITLE
HPA autoscaling/v2beta2 is deprecated; change to v2

### DIFF
--- a/modules/nodes-pods-autoscaling-about.adoc
+++ b/modules/nodes-pods-autoscaling-about.adoc
@@ -44,11 +44,11 @@ The following metrics are supported by horizontal pod autoscalers:
 
 |CPU utilization
 |Number of CPU cores used. Can be used to calculate a percentage of the pod's requested CPU.
-|`autoscaling/v1`, `autoscaling/v2beta2`
+|`autoscaling/v1`, `autoscaling/v2`
 
 |Memory utilization
 |Amount of memory used. Can be used to calculate a percentage of the pod's requested memory.
-|`autoscaling/v2beta2`
+|`autoscaling/v2`
 |===
 
 [IMPORTANT]

--- a/modules/nodes-pods-autoscaling-creating-cpu.adoc
+++ b/modules/nodes-pods-autoscaling-creating-cpu.adoc
@@ -89,7 +89,7 @@ $ oc autoscale deployment/image-registry --min=5 --max=7 --cpu-percent=75
 +
 [source,yaml,options="nowrap"]
 ----
-apiVersion: autoscaling/v2beta2 <1>
+apiVersion: autoscaling/v2 <1>
 kind: HorizontalPodAutoscaler
 metadata:
   name: cpu-autoscale <2>
@@ -109,7 +109,7 @@ spec:
         type: AverageValue <10>
         averageValue: 500m <11>
 ----
-<1> Use the `autoscaling/v2beta2` API.
+<1> Use the `autoscaling/v2` API.
 <2> Specify a name for this horizontal pod autoscaler object.
 <3> Specify the API version of the object to scale:
 * For a `Deployment`, `ReplicaSet`, `Statefulset` object, use `apps/v1`.

--- a/modules/nodes-pods-autoscaling-creating-memory.adoc
+++ b/modules/nodes-pods-autoscaling-creating-memory.adoc
@@ -70,7 +70,7 @@ To create a horizontal pod autoscaler for memory utilization:
 +
 [source,yaml,options="nowrap"]
 ----
-apiVersion: autoscaling/v2beta2 <1>
+apiVersion: autoscaling/v2 <1>
 kind: HorizontalPodAutoscaler
 metadata:
   name: hpa-resource-metrics-memory <2>
@@ -101,7 +101,7 @@ spec:
         periodSeconds: 60
       selectPolicy: Max
 ----
-<1> Use the `autoscaling/v2beta2` API.
+<1> Use the `autoscaling/v2` API.
 <2> Specify a name for this horizontal pod autoscaler object.
 <3> Specify the API version of the object to scale:
 * For a `Deployment`, `ReplicaSet`, or `Statefulset` object, use `apps/v1`.
@@ -122,7 +122,7 @@ spec:
 +
 [source,yaml,options="nowrap"]
 ----
-apiVersion: autoscaling/v2beta2 <1>
+apiVersion: autoscaling/v2 <1>
 kind: HorizontalPodAutoscaler
 metadata:
   name: memory-autoscale <2>
@@ -153,7 +153,7 @@ spec:
         periodSeconds: 120
       selectPolicy: Max
 ----
-<1> Use the `autoscaling/v2beta2` API.
+<1> Use the `autoscaling/v2` API.
 <2> Specify a name for this horizontal pod autoscaler object.
 <3> Specify the API version of the object to scale:
 * For a ReplicationController, use `v1`.

--- a/modules/nodes-pods-autoscaling-policies.adoc
+++ b/modules/nodes-pods-autoscaling-policies.adoc
@@ -5,12 +5,12 @@
 [id="nodes-pods-autoscaling-policies_{context}"]
 = Scaling policies
 
-The `autoscaling/v2beta2` API allows you to add _scaling policies_ to a horizontal pod autoscaler. A scaling policy controls how the {product-title} horizontal pod autoscaler (HPA) scales pods. Scaling policies allow you to restrict the rate that HPAs scale pods up or down by setting a specific number or specific percentage to scale in a specified period of time. You can also define a _stabilization window_, which uses previously computed desired states to control scaling if the metrics are fluctuating. You can create multiple policies for the same scaling direction, and determine which policy is used, based on the amount of change. You can also restrict the scaling by timed iterations. The HPA scales pods during an iteration, then performs scaling, as needed, in further iterations. 
+The `autoscaling/v2` API allows you to add _scaling policies_ to a horizontal pod autoscaler. A scaling policy controls how the {product-title} horizontal pod autoscaler (HPA) scales pods. Scaling policies allow you to restrict the rate that HPAs scale pods up or down by setting a specific number or specific percentage to scale in a specified period of time. You can also define a _stabilization window_, which uses previously computed desired states to control scaling if the metrics are fluctuating. You can create multiple policies for the same scaling direction, and determine which policy is used, based on the amount of change. You can also restrict the scaling by timed iterations. The HPA scales pods during an iteration, then performs scaling, as needed, in further iterations. 
 
 .Sample HPA object with a scaling policy
 [source, yaml]
 ----
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: hpa-resource-metrics-memory
@@ -54,7 +54,7 @@ spec:
 .Example policy for scaling down
 [source,yaml]
 ----
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: hpa-resource-metrics-memory

--- a/modules/nodes-pods-autoscaling-status-about.adoc
+++ b/modules/nodes-pods-autoscaling-status-about.adoc
@@ -11,7 +11,7 @@ You can use the status conditions set to determine
 whether or not the horizontal pod autoscaler (HPA) is able to scale and whether or not it is currently restricted
 in any way.
 
-The HPA status conditions are available with the `v2beta1` version of the
+The HPA status conditions are available with the `v2` version of the
 autoscaling API.
 
 The HPA responds with the following status conditions:

--- a/modules/nodes-pods-autoscaling-status-viewing.adoc
+++ b/modules/nodes-pods-autoscaling-status-viewing.adoc
@@ -11,8 +11,7 @@ You can view the status conditions set on a pod by the horizontal pod autoscaler
 
 [NOTE]
 ====
-The horizontal pod autoscaler status conditions are available with the `v2beta1` version of the
-autoscaling API.
+The horizontal pod autoscaler status conditions are available with the `v2` version of the autoscaling API.
 ====
 
 .Prerequisites


### PR DESCRIPTION
The `autoscaing/v2beta2` API is deprecated in [Kubernetes 1.23/](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#horizontalpodautoscalerspec-v2-autoscaling)OCP 4.10. 
```
$ oc create -f hpa.yaml
Warning: autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler
```