### PR TITLE
BZ-2067103: Fixed bullet list that wasn't rendering properly

### DIFF
--- a/modules/sandboxed-containers-preparing-openshift-cluster.adoc
+++ b/modules/sandboxed-containers-preparing-openshift-cluster.adoc
@@ -61,6 +61,7 @@ The following table lists some the default values for resource allocation.
 --
 
 File buffers appear and are accounted for in multiple locations:
+
 * In the guest where it appears as file buffer cache.
 * In the `virtiofsd` daemon that maps allowed user-space file I/O operations.
 * In the QEMU process as guest memory.


### PR DESCRIPTION
Update to Main, 4.9, and 4.10 for [BZ-2067103](https://bugzilla.redhat.com/show_bug.cgi?id=2067103).

Preview link: https://deploy-preview-43652--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html#sandboxed-containers-resource-requirements_deploying-sandboxed-containers

This change only required adding a space before the bullet list and doesn't require QE review.