### PR TITLE
Adds missing context element to an assembly

### DIFF
--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -3,7 +3,7 @@
 = Recommended host practices
 include::_attributes/common-attributes.adoc[]
 include::_attributes/ossm-document-attributes.adoc[]
-:context:
+:context: recommended-host-practices
 
 toc::[]
 


### PR DESCRIPTION
Noticed while reviewing #43637 that the assembly ` scalability_and_performance/recommended-host-practices.adoc` is missing its `context` value. Didn't break anything but still ought to be in there.

Preview: https://deploy-preview-43663--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices.html