### PR TITLE
[enterprise-4.7] BZ2051339: Add a note regarding third party registries

### DIFF
--- a/modules/installation-about-mirror-registry.adoc
+++ b/modules/installation-about-mirror-registry.adoc
@@ -22,3 +22,8 @@ If choosing a container registry that is not the _mirror registry for Red Hat Op
 When you populate your mirror registry with {product-title} images, you can follow two scenarios. If you have a host that can access both the internet and your mirror registry, but not your cluster nodes, you can directly mirror the content from that machine. This process is referred to as _connected mirroring_. If you have no such host, you must mirror the images to a file system and then bring that host or removable media into your restricted environment. This process is referred to as _disconnected mirroring_.
 
 For mirrored registries, to view the source of pulled images, you must review the `Trying to access` log entry in the CRI-O logs. Other methods to view the image pull source, such as using the `crictl images` command on a node, show the non-mirrored image name, even though the image is pulled from the mirrored location.
+
+[NOTE]
+====
+Red Hat does not test third party registries with {product-title}.
+====


### PR DESCRIPTION
CP PR for https://github.com/openshift/openshift-docs/pull/42413

ztp-disconnected-environment-prereqs.adoc module is not present in 4.6. Hence just one file in the PR.