### PR TITLE
BZ-2055940 adding note about 3 node cluster to IPI install

### DIFF
--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -86,7 +86,7 @@ pullSecret: '<pull_secret>'
 sshKey: '<ssh_pub_key>'
 ----
 +
-<1> Scale the worker machines based on the number of worker nodes that are part of the {product-title} cluster.
+<1> Scale the worker machines based on the number of worker nodes that are part of the {product-title} cluster. Valid options for the `replicas` value are `0` and integers greater than or equal to `2`. Set the number of replicas to `0` to deploy a three-node cluster, which contains only three control plane machines. A three-node cluster is a smaller, more resource-efficient cluster that can be used for testing, development, and production. You cannot install the cluster with only one worker.
 ifdef::upstream[]
 <2> See the xref:bmc-addressing_{context}[BMC addressing] sections for more options.
 endif::[]


### PR DESCRIPTION
Addressing https://bugzilla.redhat.com/show_bug.cgi?id=2055940
Preview: https://deploy-preview-43695--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-the-install-config-file_ipi-install-installation-workflow

Main and 4.11 and 4.10 