### PR TITLE
Github-42969:fixes typo in table 5

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -189,7 +189,7 @@ CNO:: Performs the following actions:
 |
 Reboot each node in the cluster.
 |
-Cluster:: As nodes reboot, the cluster assigns IP addresses to pods on the OVN-Kubernetes cluster network.
+Cluster:: As nodes reboot, the cluster assigns IP addresses to pods on the Openshift-SDN network.
 
 |
 Enable the MCO after all nodes in the cluster reboot.


### PR DESCRIPTION
4.8+ 

Github issue #42969

[Preview](https://deploy-preview-43698--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html)

@weliang1 can you take a look at this please for QE ack?

I'll need labels and merge. Please and thanks.