### PR TITLE
BZ2060478: Adds DHCP reservation requirement for storage interface

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -125,6 +125,8 @@ External load balancing services and the control plane nodes must run on the sam
 .Do not change IP addresses manually after deployment
 ====
 Do not change a worker node's IP address manually after deployment. To change the IP address of a worker node after deployment, you must mark the worker node unschedulable, evacuate the pods, delete the node, and recreate it with the new IP address. See "Working with nodes" for additional details. To change the IP address of a control plane node after deployment, contact support.
+
+The storage interface requires a DHCP reservation. 
 ====
 
 The following table provides an exemplary embodiment of fully qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The hostnames of the control plane and worker nodes are exemplary, so you can use any host naming convention you prefer.


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2060478#c7

For release(s): 4.9

Preview: https://deploy-preview-43699--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-reserving-ip-addresses_ipi-install-prerequisites

