### PR TITLE
BZ2060478: Adds DHCP requirement for storage interface

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -113,6 +113,11 @@ Some administrators prefer to use static IP addresses so that each node's IP add
 External load balancing services and the control plane nodes must run on the same L2 network, and on the same VLAN when using VLANs to route traffic between the load balancing services and the control plane nodes.
 ====
 
+[IMPORTANT]
+====
+The storage interface requires a DHCP reservation or a static IP.
+====
+
 The following table provides an exemplary embodiment of fully qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The hostnames of the control plane and worker nodes are exemplary, so you can use any host naming convention you prefer.
 
 [width="100%", cols="3,5,2", options="header"]


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2060478#c7

For release(s): 4.10, 4.11

Preview: https://deploy-preview-43701--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-reserving-ip-addresses_ipi-install-prerequisites