### PR TITLE
JIRA-OSDOCS3365: Updated life cycle docs for 4.10 release

### DIFF
--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -8,6 +8,7 @@
 [options="header"]
 |===
 |Version    |General availability   |End of life
+|4.10       |Mar 10, 2022           |Dec 10, 2022
 |4.9        |Oct 18, 2021           |Jul 18, 2022
 |4.8        |Jul 27, 2021           |May 27, 2022
 


### PR DESCRIPTION
This PR is to address the JIRA issue: https://issues.redhat.com/browse/OSDOCS-3365

File updated: modules/life-cycle-dates.adoc

The change is seen in the following topics: 

- https://deploy-preview-43703--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/osd-life-cycle.html#rosa-life-cycle-dates_osd-life-cycle
- https://deploy-preview-43703--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-life-cycle.html#rosa-life-cycle-dates_rosa-life-cycle

The exact change is as follows:

- Added GA date and End Of Life date for 4.10 release.

Repo: Request cherrypick to enterprise-4.10 and enterprise-4.11