### PR TITLE
BZ2067085 - Updating tech preview message for CloudStorage API

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -17,7 +17,7 @@ To back up Kubernetes resources and internal images, you must have object storag
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway]
 * S3-compatible object storage, such as Noobaa or Minio
 
-:FeatureName: The `CloudStorage` API for S3 storage
+:FeatureName: The `CloudStorage` API, which automates the creation of a bucket for object storage,
 include::snippets/technology-preview.adoc[]
 
 You can back up persistent volumes (PVs) by using snapshots or Restic.

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
@@ -14,7 +14,7 @@ You install the Openshift API for Data Protection (OADP) with Multicloud Object 
 
 You configure xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway] as a backup location.
 
-:FeatureName: The `CloudStorage` API for S3 storage
+:FeatureName: The `CloudStorage` API, which automates the creation of a bucket for object storage,
 include::snippets/technology-preview.adoc[]
 
 You create a `Secret` for the backup location and then you install the Data Protection Application.

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -14,7 +14,7 @@ You install the Openshift API for Data Protection (OADP) with OpenShift Containe
 
 You can configure xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway] or any S3-compatible object storage as a backup location.
 
-:FeatureName: The `CloudStorage` API for S3 storage
+:FeatureName: The `CloudStorage` API, which automates the creation of a bucket for object storage,
 include::snippets/technology-preview.adoc[]
 
 You create a `Secret` for the backup location and then you install the Data Protection Application.


### PR DESCRIPTION
For versions 4.10+ 
[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2067085)
More details here: [OADP-300](https://issues.redhat.com/browse/OADP-300)

**Description**: Updating the tech CloudStorage API tech preview becuase S3 storage is supported

SME acked
No QE required, wording change
**Previews:**
- [About installing OADP](https://deploy-preview-43704--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html)
- [Installing and configuring he OpenShift API data Protection Multicloud Object Gateway](https://deploy-preview-43704--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.html)
- [Installing and configuring the OpenShift API for Data Protection with OpenShift Container Storage](https://deploy-preview-43704--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html)


