### PR TITLE
BZ2063509: Updated procedure steps for Creating RHCOS images cache

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -57,42 +57,32 @@ $ sudo semanage fcontext -a -t httpd_sys_content_t "/home/kni/rhcos_image_cache(
 $ sudo restorecon -Rv /home/kni/rhcos_image_cache/
 ----
 
-
-. Get the commit ID from the installation program:
-+
-[source,terminal]
-----
-$ export COMMIT_ID=$(/usr/local/bin/openshift-baremetal-install version | grep '^built from commit' | awk '{print $4}')
-----
-+
-The ID determines which image the installation program must download.
-
 . Get the URI for the {op-system} image that the installation program will deploy on the bootstrap VM:
 +
 [source,terminal]
 ----
-$ export RHCOS_QEMU_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/coreos/rhcos.json  | jq -r '.architectures.x86_64.artifacts.qemu.formats["qcow2.gz"].disk.location'
+$ export RHCOS_QEMU_URI=$(/usr/local/bin/openshift-baremetal-install coreos print-stream-json | jq -r --arg ARCH "$(arch)" '.architectures[$ARCH].artifacts.qemu.formats["qcow2.gz"].disk.location')
 ----
 
 . Get the path where the image is published:
 +
 [source,terminal]
 ----
-$ export RHCOS_PATH=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/coreos/rhcos.json | jq .baseURI | sed 's/"//g')
+$ export RHCOS_QEMU_PATH=$(/usr/local/bin/openshift-baremetal-install coreos print-stream-json | jq -r --arg ARCH "$(arch)" '.architectures[$ARCH].artifacts.qemu.formats["qcow2.gz"].disk["sha256"]')
 ----
 
 . Get the SHA hash for the {op-system} image that will be deployed on the bootstrap VM:
 +
 [source,terminal]
 ----
-$ export RHCOS_QEMU_SHA_UNCOMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/coreos/rhcos.json  | jq -r '.images.qemu["uncompressed-sha256"]')
+$ export RHCOS_QEMU_UNCOMPRESSED_SHA256=$(/usr/local/bin/openshift-baremetal-install coreos print-stream-json | jq -r --arg ARCH "$(arch)" '.architectures[$ARCH].artifacts.qemu.formats["qcow2.gz"].disk["uncompressed-sha256"]')
 ----
 
 . Download the image and place it in the `/home/kni/rhcos_image_cache` directory:
 +
 [source,terminal]
 ----
-$ curl -L ${RHCOS_PATH}${RHCOS_QEMU_URI} -o /home/kni/rhcos_image_cache/${RHCOS_QEMU_URI}
+$ curl -L ${RHCOS_QEMU_URI} -o /home/kni/rhcos_image_cache/${RHCOS_QEMU_PATH}
 ----
 
 . Confirm SELinux type is of `httpd_sys_content_t` for the new file:
@@ -125,12 +115,7 @@ $ export BAREMETAL_IP=$(ip addr show dev baremetal | awk '/inet /{print $2}' | c
 +
 [source,terminal]
 ----
-$ export RHCOS_QEMU_SHA256=$(zcat /home/kni/rhcos_image_cache/${RHCOS_QEMU_URI} | sha256sum | awk '{print $1}')
-----
-+
-[source,terminal]
-----
-$ export BOOTSTRAP_OS_IMAGE="http://${BAREMETAL_IP}:8080/${RHCOS_QEMU_URI}?sha256=${RHCOS_QEMU_SHA256}"
+$ export BOOTSTRAP_OS_IMAGE="http://${BAREMETAL_IP}:8080/${RHCOS_QEMU_PATH}?sha256=${RHCOS_QEMU_UNCOMPRESSED_SHA256}"
 ----
 +
 [source,terminal]
@@ -144,7 +129,7 @@ $ echo "    bootstrapOSImage=${BOOTSTRAP_OS_IMAGE}"
 ----
 platform:
   baremetal:
-    bootstrapOSImage: http://<BAREMETAL_IP>:8080/<RHCOS_QEMU_URI>?sha256=<RHCOS_QEMU_SHA256>
+    bootstrapOSImage: http://<BAREMETAL_IP>:8080/<RHCOS_QEMU_PATH>?sha256=<RHCOS_QEMU_UNCOMPRESSED_SHA256>
 ----
 +
 See the "Configuration files" section for additional details.


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2063509

For releases: 4.10, 4.11

For 4.9: https://github.com/openshift/openshift-docs/pull/43920

Preview: https://deploy-preview-43705--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-creating-an-rhcos-images-cache_ipi-install-installation-workflow