### PR TITLE
Bug 2067291: EUS-to-EUS upgrade procedure requires oc 4.9 or later

### DIFF
--- a/modules/updating-eus-to-eus-upgrade.adoc
+++ b/modules/updating-eus-to-eus-upgrade.adoc
@@ -18,13 +18,14 @@ Following this procedure reduces the total update duration and the number of tim
 If your cluster is running a version earlier than {product-title} 4.8.14, you must update to a later 4.8.z version before updating to 4.9.
 The update to 4.8.14 or later is necessary to fulfill the minimum version requirements that must be performed without pausing MachineConfigPools.
 * Verify that MachineConfigPools is unpaused.
+* Update OpenShift CLI `oc` to the target version before each update.
 
 .Procedure
 
 . Upgrade any OLM Operators to versions that are compatible with both versions you are updating to.
 
-. Verify that all MachineConfigPools display a status of `UPDATED` and no MachineConfigPools display a status of `UPDATING`.
-View the status of all MachineConfigPools, run the following command:
+. Verify that all machine config pools display a status of `UPDATED` and that no machine config pool displays a status of `UPDATING`.
+To view the status of all machine config pools, run the following command:
 +
 [source,terminal]
 ----
@@ -42,7 +43,24 @@ master   rendered-master-ecbb9582781c1091e1c9f19d50cf836c       True  	  False
 worker   rendered-worker-00a3f0c68ae94e747193156b491553d5       True  	  False
 ----
 
-. Pause the MachineConfigPools you wish to skip reboots on, run the following commands:
+. Change to the `eus-4.10` channel. Run the following command:
++
+[source,terminal]
+----
+$ oc adm upgrade channel eus-4.10
+----
++
+[NOTE]
+====
+The `oc adm upgrade channel` command is only present in 4.9 or later.
+
+If you receive an error message indicating that `eus-4.10` is not one of the
+available channels, this indicates that Red Hat is still rolling out 4.8 to 4.10 EUS upgrades.
+This rollout process generally takes 45-90 days starting at the GA date.
+====
++
+
+. Pause the machine config pools that you want to skip reboots on. Run the following commands:
 +
 [NOTE]
 ====
@@ -54,14 +72,7 @@ You cannot pause the master pool.
 $ oc patch mcp/worker --type merge --patch '{"spec":{"paused":true}}'
 ----
 
-. Change to the `eus-4.10` channel, run the following command:
-+
-[source,terminal]
-----
-$ oc adm upgrade channel eus-4.10
-----
-
-. Update to 4.9, run the following command:
+. Update to version 4.9. Run the following command:
 +
 [source,terminal]
 ----
@@ -75,7 +86,7 @@ $ oc adm upgrade --to-latest
 Updating to latest version 4.9.18
 ----
 
-. Ensure the 4.9 updates are completed successfully retrieve the cluster version, run the following command:
+. Ensure that the 4.9 updates completed by reviewing the cluster version. Run the following command:
 +
 [source,terminal]
 ----
@@ -90,16 +101,16 @@ NAME  	  VERSION  AVAILABLE  PROGRESSING   SINCE   STATUS
 version   4.9.18   True       False         6m29s   Cluster version is 4.9.18
 ----
 
-. If necessary, upgrade OLM Operators using the Administrator perspective on the web console.
+. If necessary, upgrade OLM Operators by using the Administrator perspective on the web console.
 
-. Update to 4.10, run the following command:
+. Update to version 4.10. Run the following command:
 +
 [source,terminal]
 ----
 $ oc adm upgrade --to-latest
 ----
 
-. Ensure the 4.10 update is completed successfully retrieve the cluster version, run the following command:
+. Ensure that the 4.10 update completed by retrieving the cluster version. Run the following command:
 +
 [source,terminal]
 ----
@@ -114,7 +125,7 @@ NAME  	  VERSION  AVAILABLE  PROGRESSING   SINCE   STATUS
 version   4.10.1   True       False         6m29s   Cluster version is 4.10.1
 ----
 
-. Unpause all previously paused MachineConfigPools, run the following command:
+. Unpause all previously paused machine config pools. Run the following command:
 +
 [source,terminal]
 ----
@@ -123,10 +134,10 @@ $ oc patch mcp/worker --type merge --patch '{"spec":{"paused":false}}'
 +
 [NOTE]
 ====
-If pools are not unpaused, the cluster is not permitted to update to any future minors and maintenance tasks such as certificate rotation are inhibited. This puts the cluster at risk for future degradation.
+If pools are not unpaused, the cluster is not permitted to update to any future minor versions, and maintenance tasks such as certificate rotation are inhibited. This puts the cluster at risk for future degradation.
 ====
 
-. Verify that your previously paused pools have updated and your cluster completed the update to 4.10, run the following command:
+. Verify that your previously paused pools updated and that your cluster completed the update to version 4.10. Run the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Also add a note about what happens if you change channels before we've enabled EUS-to-EUS upgrades and the channel is not one of the available channels.

https://bugzilla.redhat.com/show_bug.cgi?id=2067291

Looking at the bug, it's 4.10-only.

[Preview](https://deploy-preview-43712--osdocs.netlify.app/openshift-enterprise/latest/updating/preparing-eus-eus-upgrade.html#updating-eus-to-eus-upgrade_eus-to-eus-upgrade)