### PR TITLE
BZ1698680: the guide doesn't work, and the IP doesn't match

### DIFF
--- a/dev_guide/expose_service/expose_internal_ip_load_balancer.adoc
+++ b/dev_guide/expose_service/expose_internal_ip_load_balancer.adoc
@@ -146,7 +146,7 @@ These steps assume that all of the systems are on the same subnet.
 . Restart the network to make sure the network is up.
 +
 ----
-$ service network restart
+$ systemctl restart network
 Restarting network (via systemctl):  [  OK  ]
 ----
 +
@@ -177,7 +177,7 @@ If you get a string of characters with the `Got packets out of order` message, y
 . Restart the network to make sure the network is up.
 +
 ----
-$ service network restart
+$ systemctl restart network
 Restarting network (via systemctl):  [  OK  ]
 ----
 +

--- a/dev_guide/expose_service/expose_internal_ip_service.adoc
+++ b/dev_guide/expose_service/expose_internal_ip_service.adoc
@@ -307,7 +307,7 @@ These steps assume that all of the systems are on the same subnet.
 . Restart the network to make sure the network is up.
 +
 ----
-# service network restart
+# systemctl restart network
 Restarting network (via systemctl):  [  OK  ]
 ----
 +
@@ -363,6 +363,12 @@ Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
 . Add a route between the IP address of the exposed service and the IP address of the master host:
 +
 ----
+$ route add -net <exposed_service_ip> gw <host_ip_address> eth0
+----
++
+For example:
++
+----
 $ route add -net 192.174.120.0/24 gw 10.16.41.22 eth0
 ----
 
@@ -371,7 +377,7 @@ $ route add -net 192.174.120.0/24 gw 10.16.41.22 eth0
 . Restart the network to make sure the network is up.
 +
 ----
-# service network restart
+# systemctl restart network
 Restarting network (via systemctl):  [  OK  ]
 ----
 +
@@ -403,6 +409,12 @@ Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
 . Add a route between the IP address of the exposed service and the IP address of the host system where the master node resides:
 +
 ----
+$ route add -net <exposed_service_ip> netmask 255.255.255.0 gw <host_ip_address> dev eth0
+----
++
+For example:
++
+----
 $ route add -net 192.174.120.0 netmask 255.255.255.0 gw 10.16.41.22 dev eth0
 ----
 
@@ -426,7 +438,7 @@ your service is accessible from the node.
 . Restart the network to make sure the network is up.
 +
 ----
-$ service network restart
+$ systemctl restart network
 Restarting network (via systemctl):  [  OK  ]
 ----
 +
@@ -439,6 +451,12 @@ $ route add -net 10.16.64.0 netmask 255.255.248.0 gw 10.16.71.254 eno1
 ----
 
 . Add a route between the IP address of the exposed service on master and the IP address of the master host:
++
+----
+$ route add -net <exposed_service_ip> netmask 255.255.255.0 gw <host_ip_address>
+----
++
+For example:
 +
 ----
 $ route add -net 192.174.120.0 netmask 255.255.255.0 gw 10.16.41.22


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1698680

[Configuring Networking-> On the master](https://deploy-preview-43717--osdocs.netlify.app/openshift-enterprise/latest/dev_guide/expose_service/expose_internal_ip_service.html#manually-assign-ips-network),  changed Step 1 to `systemctl restart network`;  added example after Step 4.
[Configuring Networking-> On the node](https://deploy-preview-43717--osdocs.netlify.app/openshift-enterprise/latest/dev_guide/expose_service/expose_internal_ip_service.html#manually-assign-ips-network), changed Step 1 to `systemctl restart network`; added example after Step 3.
[Configuring Networking-> On the system that is not in the cluster](https://deploy-preview-43717--osdocs.netlify.app/openshift-enterprise/latest/dev_guide/expose_service/expose_internal_ip_service.html#manually-assign-ips-network),  changed Step 1 to `systemctl restart network`; added example after Step 3.



