### PR TITLE
BZ2028564:adding CLI procedure for deploying kmstate operator

### DIFF
--- a/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
+++ b/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
@@ -1,0 +1,101 @@
+// This is included in the following assemblies:
+//
+// networking/k8s_nmstate/k8s-nmstate-about-the-kubernetes-nmstate-operator.adoc
+
+:_content-type: PROCEDURE
+[id="installing-the-kubernetes-nmstate-operator-CLI_{context}"]
+= Installing the Kubernetes NMState Operator using the CLI
+You can also install the Kubernetes NMState Operator by using the {product-title} CLI (oc).
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You are logged in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create the `nmstate` Operator namespace:
++
+[source,terminal]
+----
+$ cat << EOF | oc apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: openshift-nmstate
+    name: openshift-nmstate
+  name: openshift-nmstate
+spec:
+  finalizers:
+  - kubernetes
+EOF
+----
+
+. Create the `OperatorGroup`:
++
+[source,terminal]
+----
+$ cat << EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: NMState.v1.nmstate.io
+  generateName: openshift-nmstate-
+  name: openshift-nmstate-tn6k8
+  namespace: openshift-nmstate
+spec:
+  targetNamespaces:
+  - openshift-nmstate
+EOF
+----
+. Subscribe to the `nmstate` Operator:
++
+[source,terminal]
+----
+$ cat << EOF| oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/kubernetes-nmstate-operator.openshift-nmstate: ""
+  name: kubernetes-nmstate-operator
+  namespace: openshift-nmstate
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: kubernetes-nmstate-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+----
+
+. Create instance of the `nmstate` operator:
++
+[source,terminal]
+----
+$ cat << EOF | oc apply -f -
+apiVersion: nmstate.io/v1
+kind: NMState
+metadata:
+  name: nmstate
+EOF
+----
+
+.Verification
+Confirm that the deployment for the `nmstate` operator is running:
+
+[source,terminal]
+----
+oc get clusterserviceversion -n openshift-nmstate \
+ -o custom-columns=Name:.metadata.name,Phase:.status.phase
+----
+
+.Example output
+[source, terminal]
+----
+Name                                             Phase
+kubernetes-nmstate-operator.4.10.0-202203120157   Succeeded
+----

--- a/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -16,5 +16,7 @@ Red Hat supports the Kubernetes NMState Operator in production environments on b
 include::snippets/technology-preview.adoc[]
 
 Before you can use NMState with {product-title}, you must install the Kubernetes NMState Operator.
-
+[id="{context}_installation_and_deployment"]
+=== Installing the nmstate operator
 include::modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc[leveloffset=+1]
+include::modules/k8s-nmstate-deploying-nmstate-CLI.adoc[leveloffset=+2]


### PR DESCRIPTION
Version: 4.10+

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2028564

Preview: https://deploy-preview-43723--osdocs.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html

Details: Adding a procedure for installing/deploying the nmstate operator via CLI.
