### PR TITLE
Fix list of possible architectures in Optional configuration parameters sections

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -484,11 +484,23 @@ ifdef::rhv[]
 For details, see the "Additional RHV parameters for machine pools" table.
 endif::rhv[]
 
-ifndef::ibm-z,ibm-power[]
+ifndef::aws,bare,ibm-power,ibm-z[]
+|`compute.architecture`
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
+|String
+endif::aws,bare,ibm-power,ibm-z[]
+
+ifdef::aws[]
 |`compute.architecture`
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
 |String
-endif::ibm-z,ibm-power[]
+endif::aws[]
+
+ifdef::bare[]
+|`compute.architecture`
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
+|String
+endif::bare[]
 
 ifdef::ibm-z[]
 |`compute.architecture`
@@ -530,11 +542,23 @@ ifdef::rhv[]
 For details, see the "Additional RHV parameters for machine pools" table.
 endif::rhv[]
 
-ifndef::ibm-z,ibm-power[]
+ifndef::aws,bare,ibm-z,ibm-power[]
+|`controlPlane.architecture`
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
+|String
+endif::aws,bare,ibm-z,ibm-power[]
+
+ifdef::aws[]
 |`controlPlane.architecture`
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
 |String
-endif::ibm-z,ibm-power[]
+endif::aws[]
+
+ifdef::bare[]
+|`controlPlane.architecture`
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
+|String
+endif::bare[]
 
 ifdef::ibm-z[]
 |`controlPlane.architecture`


### PR DESCRIPTION
Applies to: 4.10+

﻿arm64 is only supported on AWS and Bare Metal; all other platforms (besides IBM Power and IBM Z) are still limited to amd64.

Preview (check `compute.architecture` and `controlPlane.architecture`):
https://deploy-preview-43724--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-customizations.html#installation-configuration-parameters-optional_installing-alibaba-customizations
https://deploy-preview-43724--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-configuration-parameters-optional_installing-aws-customizations
https://deploy-preview-43724--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations.html#installation-configuration-parameters-optional_installing-azure-customizations
https://deploy-preview-43724--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.html#installation-configuration-parameters-optional_installing-azure-stack-hub-network-customizations
https://deploy-preview-43724--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-configuration-parameters-optional_installing-gcp-customizations
https://deploy-preview-43724--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.html#installation-configuration-parameters-optional_installing-ibm-cloud-customizations
https://deploy-preview-43724--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-configuration-parameters-optional_installing-bare-metal
https://deploy-preview-43724--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#installation-configuration-parameters-optional_installing-openstack-installer-custom
https://deploy-preview-43724--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-customizations.html#installation-configuration-parameters-optional_installing-rhv-customizations
https://deploy-preview-43724--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-configuration-parameters-optional_installing-vsphere-installer-provisioned-customizations
https://deploy-preview-43724--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-customizations.html#installation-configuration-parameters-optional_installing-vmc-customizations

/cc @kelbrown20
