### PR TITLE
Fix bare-metal conditional in installation-configuration-parameters

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -92,24 +92,15 @@ endif::[]
 ifeval::["{context}" == "installing-gcp-customizations"]
 :gcp:
 endif::[]
-// OSDOCS-1640 - IPv4/IPv6 dual-stack bare metal only
-// But only for installer-provisioned
-// https://bugzilla.redhat.com/show_bug.cgi?id=2020416
-//ifeval::["{context}" == "installing-bare-metal"]
-//:bare:
-//endif::[]
-// OSDOCS-1640 - IPv4/IPv6 dual-stack bare metal only
-// But only for installer-provisioned
-// https://bugzilla.redhat.com/show_bug.cgi?id=2020416
-//ifeval::["{context}" == "installing-bare-metal-network-customizations"]
-//:bare:
-//endif::[]
-// OSDOCS-1640 - IPv4/IPv6 dual-stack bare metal only
-// But only for installer-provisioned
-// https://bugzilla.redhat.com/show_bug.cgi?id=2020416
-//ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
-//:bare:
-//endif::[]
+ifeval::["{context}" == "installing-bare-metal"]
+:bare:
+endif::[]
+ifeval::["{context}" == "installing-bare-metal-network-customizations"]
+:bare:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:bare:
+endif::[]
 ifeval::["{context}" == "installing-gcp-private"]
 :gcp:
 endif::[]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -276,8 +276,13 @@ endif::[]
 
 You can customize your installation configuration based on the requirements of your existing network infrastructure. For example, you can expand the IP address block for the cluster network or provide different IP address blocks than the defaults.
 
-ifndef::bare[]
+// OSDOCS-1640 - IPv4/IPv6 dual-stack bare metal only
+// But only for installer-provisioned
+// https://bugzilla.redhat.com/show_bug.cgi?id=2020416
+// Once BM UPI supports dual-stack, uncomment all the following conditionals and blocks
+//ifndef::bare[]
 Only IPv4 addresses are supported.
+////
 endif::bare[]
 ifdef::bare[]
 If you use the OVN-Kubernetes cluster network provider, both IPv4 and IPv6 address families are supported.
@@ -303,6 +308,7 @@ networking:
   - fd00:172:16::/112
 ----
 endif::bare[]
+////
 
 .Network parameters
 [cols=".^2,.^3a,.^3a",options="header"]
@@ -339,51 +345,51 @@ If you specify multiple IP address blocks, the blocks must not overlap.
 
 [source,yaml]
 ----
-ifndef::bare[]
+//ifndef::bare[]
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-endif::bare[]
-ifdef::bare[]
-networking:
-  clusterNetwork:
-  - cidr: 10.128.0.0/14
-    hostPrefix: 23
-  - cidr: fd01::/48
-    hostPrefix: 64
-endif::bare[]
+//endif::bare[]
+//ifdef::bare[]
+//networking:
+//  clusterNetwork:
+//  - cidr: 10.128.0.0/14
+//    hostPrefix: 23
+//  - cidr: fd01::/48
+//    hostPrefix: 64
+//endif::bare[]
 ----
 
 |`networking.clusterNetwork.cidr`
 |
 Required if you use `networking.clusterNetwork`. An IP address block.
 
-ifndef::bare[]
+//ifndef::bare[]
 An IPv4 network.
-endif::bare[]
-ifdef::bare[]
-If you use the OpenShift SDN network provider, specify an IPv4 network. If you use the OVN-Kubernetes network provider, you can specify IPv4 and IPv6 networks.
-endif::bare[]
+//endif::bare[]
+//ifdef::bare[]
+//If you use the OpenShift SDN network provider, specify an IPv4 network. If you use the OVN-Kubernetes network provider, you can specify IPv4 and IPv6 networks.
+//endif::bare[]
 |
 An IP address block in Classless Inter-Domain Routing (CIDR) notation.
 The prefix length for an IPv4 block is between `0` and `32`.
-ifdef::bare[]
-The prefix length for an IPv6 block is between `0` and `128`. For example, `10.128.0.0/14` or `fd01::/48`.
-endif::bare[]
+//ifdef::bare[]
+//The prefix length for an IPv6 block is between `0` and `128`. For example, `10.128.0.0/14` or `fd01::/48`.
+//endif::bare[]
 
 |`networking.clusterNetwork.hostPrefix`
 |The subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23` then each node is assigned a `/23` subnet out of the given `cidr`. A `hostPrefix` value of `23` provides 510 (2^(32 - 23) - 2) pod IP addresses.
 |
 A subnet prefix.
 
-ifndef::bare[]
+//ifndef::bare[]
 The default value is `23`.
-endif::bare[]
-ifdef::bare[]
-For an IPv4 network the default value is `23`.
-For an IPv6 network the default value is `64`. The default value is also the minimum value for IPv6.
-endif::bare[]
+//endif::bare[]
+//ifdef::bare[]
+//For an IPv4 network the default value is `23`.
+//For an IPv6 network the default value is `64`. The default value is also the minimum value for IPv6.
+//endif::bare[]
 
 |`networking.serviceNetwork`
 |
@@ -391,26 +397,26 @@ The IP address block for services. The default value is `172.30.0.0/16`.
 
 The OpenShift SDN and OVN-Kubernetes network providers support only a single IP address block for the service network.
 
-ifdef::bare[]
-If you use the OVN-Kubernetes network provider, you can specify an IP address block for both of the IPv4 and IPv6 address families.
-endif::bare[]
+//ifdef::bare[]
+//If you use the OVN-Kubernetes network provider, you can specify an IP address block for both of the IPv4 and IPv6 address families.
+//endif::bare[]
 
 |
 An array with an IP address block in CIDR format. For example:
 
 [source,yaml]
 ----
-ifndef::bare[]
+//ifndef::bare[]
 networking:
   serviceNetwork:
    - 172.30.0.0/16
-endif::bare[]
-ifdef::bare[]
-networking:
-  serviceNetwork:
-   - 172.30.0.0/16
-   - fd02::/112
-endif::bare[]
+//endif::bare[]
+//ifdef::bare[]
+//networking:
+//  serviceNetwork:
+//   - 172.30.0.0/16
+//   - fd02::/112
+//endif::bare[]
 ----
 
 |`networking.machineNetwork`
@@ -437,12 +443,12 @@ Required if you use `networking.machineNetwork`. An IP address block. The defaul
 |
 An IP network block in CIDR notation.
 
-ifndef::bare[]
+//ifndef::bare[]
 For example, `10.0.0.0/16`.
-endif::bare[]
-ifdef::bare[]
-For example, `10.0.0.0/16` or `fd00::/48`.
-endif::bare[]
+//endif::bare[]
+//ifdef::bare[]
+//For example, `10.0.0.0/16` or `fd00::/48`.
+//endif::bare[]
 
 [NOTE]
 ====


### PR DESCRIPTION
Applies to: 4.8+ (based on scope of #38463)

﻿https://github.com/openshift/openshift-docs/pull/38463 ended up disabling all sections that were conditional on "bare" instead of limiting the changes to dual-stack related sections.  This prevents other uses of the "bare" conditional from working as expected.

Preview:
https://deploy-preview-43728--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-configuration-parameters-network_installing-bare-metal-network-customizations

This also blocks https://github.com/openshift/openshift-docs/pull/43724 .
