### PR TITLE
unhide winc content for 5.0.0 GA WMCO

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1598,7 +1598,7 @@ Topics:
   - Name: Deploying a Spring Boot application with Argo CD
     File: deploying-a-spring-boot-application-with-argo-cd
   - Name: Argo CD custom resource properties
-    File: argo-cd-custom-resource-properties  
+    File: argo-cd-custom-resource-properties
   - Name: Monitoring application health status
     File: health-information-for-resources-deployment
   - Name: Configuring SSO for Argo CD using Dex
@@ -1981,38 +1981,38 @@ Topics:
   - Name: Using remote worker node at the network edge
     File: nodes-edge-remote-workers
 ---
-#Name: Windows Container Support for OpenShift
-#Dir: windows_containers
-#Distros: openshift-origin,openshift-enterprise
-#Topics:
-#- Name: Windows Container Support for Openshift overview
-#  File: index
-#- Name: Windows Container Support for OpenShift release notes
-#  File: windows-containers-release-notes-4-x
-#- Name: Understanding Windows container workloads
-#  File: understanding-windows-container-workloads
-#- Name: Enabling Windows container workloads
-#  File: enabling-windows-container-workloads
-#- Name: Creating Windows MachineSet objects
-#  Dir: creating_windows_machinesets
-#  Topics:
-#  - Name: Creating a Windows MachineSet object on AWS
-#    File: creating-windows-machineset-aws
-#  - Name: Creating a Windows MachineSet object on Azure
-#    File: creating-windows-machineset-azure
-#  - Name: Creating a Windows MachineSet object on vSphere
-#    File: creating-windows-machineset-vsphere
-#- Name: Scheduling Windows container workloads
-#  File: scheduling-windows-workloads
-#- Name: Windows node upgrades
-#  File: windows-node-upgrades
-#- Name: Using Bring-Your-Own-Host Windows instances as nodes
-#  File: byoh-windows-instance
-#- Name: Removing Windows nodes
-#  File: removing-windows-nodes
-#- Name: Disabling Windows container workloads
-#  File: disabling-windows-container-workloads
-
+Name: Windows Container Support for OpenShift
+Dir: windows_containers
+Distros: openshift-origin,openshift-enterprise
+Topics:
+- Name: Windows Container Support for Openshift overview
+  File: index
+- Name: Windows Container Support for OpenShift release notes
+  File: windows-containers-release-notes-4-x
+- Name: Understanding Windows container workloads
+  File: understanding-windows-container-workloads
+- Name: Enabling Windows container workloads
+  File: enabling-windows-container-workloads
+- Name: Creating Windows MachineSet objects
+  Dir: creating_windows_machinesets
+  Topics:
+  - Name: Creating a Windows MachineSet object on AWS
+    File: creating-windows-machineset-aws
+  - Name: Creating a Windows MachineSet object on Azure
+    File: creating-windows-machineset-azure
+  - Name: Creating a Windows MachineSet object on vSphere
+    File: creating-windows-machineset-vsphere
+- Name: Scheduling Windows container workloads
+  File: scheduling-windows-workloads
+- Name: Windows node upgrades
+  File: windows-node-upgrades
+- Name: Using Bring-Your-Own-Host Windows instances as nodes
+  File: byoh-windows-instance
+- Name: Removing Windows nodes
+  File: removing-windows-nodes
+- Name: Disabling Windows container workloads
+  File: disabling-windows-container-workloads
+---
 Name: Sandboxed Containers Support for OpenShift
 Dir: sandboxed_containers
 Distros: openshift-enterprise

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -64,12 +64,12 @@ include::modules/nw-aws-nlb-new-cluster.adoc[leveloffset=+1]
 
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-////
+
 [NOTE]
 ====
-For more information on using Linux and Windows nodes in the same cluster, see ../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information on using Linux and Windows nodes in the same cluster, see xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
-////
+
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/installing-azure-network-customizations.adoc
@@ -46,12 +46,12 @@ include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-////
+
 [NOTE]
 ====
-For more information on using Linux and Windows nodes in the same cluster, see ../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information on using Linux and Windows nodes in the same cluster, see xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
-////
+
 
 // Enabling Accelerated Networking during install
 include::modules/machineset-azure-enabling-accelerated-networking-new-install.adoc[leveloffset=+1]

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
@@ -52,12 +52,12 @@ include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-////
+
 [NOTE]
 ====
-For more information on using Linux and Windows nodes in the same cluster, see xref ../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information on using Linux and Windows nodes in the same cluster, see xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
-////
+
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 


### PR DESCRIPTION
WMCO is going to be GA'd on 28th so we need to unhide the WINC content in our OCP repository. 
This PR unhides the WINC book as well as three xref links to winc.
[Preview](https://deploy-preview-43743--osdocs.netlify.app/openshift-enterprise/latest/welcome/index.html)
@mburke5678 we need to merge this post errata going live/shipped.

Relates to: https://github.com/openshift/openshift-docs/pull/42143 and  https://github.com/openshift/openshift-docs/pull/42849.