### PR TITLE
OSDOCS-3202: This PR removes the CIDR range definition topic from OCP.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -974,9 +974,6 @@ Topics:
 - Name: Understanding the Ingress Operator
   File: ingress-operator
   Distros: openshift-enterprise,openshift-origin
-- Name: CIDR Range Definitions
-  File: cidr-range-definitions
-  Distros: openshift-enterprise,openshift-origin
 - Name: Configuring the Ingress Controller endpoint publishing strategy
   File: nw-ingress-controller-endpoint-publishing-strategies
   Distros: openshift-enterprise,openshift-origin
@@ -1609,7 +1606,7 @@ Topics:
   - Name: Deploying a Spring Boot application with Argo CD
     File: deploying-a-spring-boot-application-with-argo-cd
   - Name: Argo CD custom resource properties
-    File: argo-cd-custom-resource-properties  
+    File: argo-cd-custom-resource-properties
   - Name: Monitoring application health status
     File: health-information-for-resources-deployment
   - Name: Configuring SSO for Argo CD using Dex

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -141,7 +141,7 @@ Topics:
     File: enabling-multicast
 - Name: Configuring a cluster-wide proxy during installation
   File: configuring-cluster-wide-proxy
-- Name: CIDR Range Definitions
+- Name: CIDR range definitions
   File: cidr-range-definitions
 ---
 Name: Nodes

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -293,7 +293,7 @@ Topics:
     File: enabling-multicast
 - Name: Configuring a cluster-wide proxy during installation
   File: configuring-cluster-wide-proxy
-- Name: CIDR Range Definitions
+- Name: CIDR range definitions
   File: cidr-range-definitions
 ---
 Name: Troubleshooting

--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="cidr-range-definitions"]
-= CIDR Range Definitions
+= CIDR range definitions
 include::_attributes/common-attributes.adoc[]
 :context: cidr-range-definitions
 


### PR DESCRIPTION
This PR removes the CIDR range definition page from OCP.

Versions: 4.6+

Fixes #43137

Cherry Picks:
4.6 - https://github.com/openshift/openshift-docs/pull/43916
4.7 - https://github.com/openshift/openshift-docs/pull/43914
4.8 - https://github.com/openshift/openshift-docs/pull/43907
4.9 - https://github.com/openshift/openshift-docs/pull/43894
4.10 - https://github.com/openshift/openshift-docs/pull/43892
4.11 - https://github.com/openshift/openshift-docs/pull/43893

Preview: