### PR TITLE
OSDOCS-3355: Adds RH Account Number to ROSA Roles and Policies

### DIFF
--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -9,6 +9,11 @@ This section provides details about the account-wide IAM roles and policies that
 
 The account-wide roles and policies are specific to an OpenShift minor release version, for example OpenShift 4.8, and are backward compatible. You can minimize the required STS resources by reusing the account-wide roles and policies for multiple clusters of the same minor version, regardless of their patch version.
 
+[NOTE]
+====
+The account number present in the `sts_installer_trust_policy.json` and `sts_support_trust_policy.json` samples represents the Red Hat account that is allowed to assume the required roles.
+====
+
 .ROSA installer role, policy, and policy files
 [cols="1,2",options="header"]
 |===
@@ -35,7 +40,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
-                    "arn:aws:iam::%{aws_account_id}:role/RH-Managed-OpenShift-Installer"
+                    "arn:aws:iam::710019948333:role/RH-Managed-OpenShift-Installer"
                 ]
             },
             "Action": [
@@ -419,7 +424,7 @@ The account-wide roles and policies are specific to an OpenShift minor release v
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
-                    "arn:aws:iam::%{aws_account_id}:role/RH-Technical-Support-Access"
+                    "arn:aws:iam::710019948333:role/RH-Technical-Support-Access"
                 ]
             },
             "Action": [


### PR DESCRIPTION
This PR removes the user prompt `%{aws_account_id}` and adds the external RH Account Number instead.

JIRA: https://issues.redhat.com/browse/OSDOCS-3355

Preview: https://deploy-preview-43756--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-sts-about-iam-resources#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources

* Before:
    * `sts_installer_trust_policy.json`
![image](https://user-images.githubusercontent.com/16167833/159931453-742be575-d8cf-457b-aa03-8204a71c585b.png)
    * `sts_support_trust_policy.json`
![image](https://user-images.githubusercontent.com/16167833/159931590-761a82be-13c5-4a79-aa86-ebf3d3fa272e.png)
* After:
    * `sts_installer_trust_policy.json`
![image](https://user-images.githubusercontent.com/16167833/159934087-3aa86a88-894c-46f8-bb59-1ce719b8ce8e.png)
    * `sts_support_trust_policy.json`
![image](https://user-images.githubusercontent.com/16167833/159933870-fbd6b251-6afa-409a-8bc0-75f506a6303f.png)