### PR TITLE
CNV-16946: changed default of macspoof filtering

### DIFF
--- a/modules/virt-creating-bridge-nad-cli.adoc
+++ b/modules/virt-creating-bridge-nad-cli.adoc
@@ -2,6 +2,7 @@
 //
 // * virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
 
+
 :_content-type: PROCEDURE
 [id="virt-creating-bridge-nad-cli_{context}"]
 = Creating a Linux bridge network attachment definition in the CLI
@@ -42,7 +43,7 @@ spec:
 <3> The name for the configuration. It is recommended to match the configuration name to the `name` value of the network attachment definition.
 <4> The actual name of the Container Network Interface (CNI) plug-in that provides the network for this network attachment definition. Do not change this field unless you want to use a different CNI.
 <5> The name of the Linux bridge configured on the node.
-<6> Optional: Flag to enable MAC spoof check. When set to `true`, you cannot change the MAC address of the pod or guest interface. This attribute provides security against a MAC spoofing attack by allowing only a single MAC address to exit the pod.
+<6> Optional: Flag to enable MAC spoof check. When set to `true`, you cannot change the MAC address of the pod or guest interface. This attribute provides security against a MAC spoofing attack by allowing only a single MAC address to exit the pod. By default, this is set to `true` for {VirtProductName} 4.9 and later. For earlier versions of {VirtProductName}, explicitly set the attribute, then restart or migrate the VM.
 <7> Optional: The VLAN tag.
 
 . Create the network attachment definition:


### PR DESCRIPTION
Re: [CNV-16946](https://issues.redhat.com/browse/CNV-16946)
For 4.9 and later
Preview: https://deploy-preview-43758--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-bridge-nad-cli_virt-attaching-multiple-networks