### PR TITLE
[RHACS] fixing typo: PagerDuty should be Slack

### DIFF
--- a/modules/slack-configuring-acs.adoc
+++ b/modules/slack-configuring-acs.adoc
@@ -9,7 +9,7 @@ Create a new integration in {product-title} by using the webhook URL.
 
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
-. Scroll down to the *Notifier Integrations* section and select *PagerDuty*.
+. Scroll down to the *Notifier Integrations* section and select *Slack*.
 . Click *New Integration* (*`add`* icon).
 . Enter a name for *Integration Name*.
 . Enter the generated webhook URL in the *Default Slack Webhook* field.


### PR DESCRIPTION
Minor type / copy-paste error: this page about Slack integration mentions PagerDuty.  

Applies to 3.65 - 3.69