### PR TITLE
[enterprise-4.8] SRVCOM-1735: Fix deprecated table, add table for GA + TP

### DIFF
--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -6,61 +6,25 @@
 [id="serverless-deprecated-removed-features_{context}"]
 = Deprecated and removed features
 
-Some features available in previous releases have been deprecated or removed.
+Some features that were Generally Available (GA) or a Technology Preview (TP) in previous releases have been deprecated or removed. Deprecated functionality is still included in {ServerlessProductName} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
 
-Deprecated functionality is still included in {ServerlessProductName} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. For the most recent list of major functionality deprecated and removed within {ServerlessProductName}, refer to the table below.
-
-In the table, features are marked with the following statuses:
-
-* *-*: _Not yet available_
-* *TP*: _Technology Preview_
-* *GA*: _General Availability_
-* *DEP*: _Deprecated_
-* *REM*: _Removed_
+For the most recent list of major functionality deprecated and removed within {ServerlessProductName}, refer to the following table:
 
 .Deprecated and removed features tracker
-[cols="3,1,1,1",options="header"]
+[cols="3,1,1,1,1",options="header"]
 |====
-|Feature |1.18|1.19|1.20
+|Feature |1.18|1.19|1.20|1.21
+
+|`KafkaBinding` API
+|GA
+|Deprecated
+|Deprecated
+|Deprecated
 
 |`kn func emit` (`kn func invoke` in 1.21+)
 |TP
 |TP
-|TP
-
-|Service Mesh mTLS
-|GA
-|GA
-|GA
-
-|`kn func` TypeScript templates
-|TP
-|TP
-|TP
-
-|`kn func` Rust templates
-|TP
-|TP
-|TP
-
-|`emptyDir` volumes
-|GA
-|GA
-|GA
-
-|`KafkaBinding` API
-|GA
-|DEP
-|DEP
-
-|HTTPS redirection
-|-
-|GA
-|GA
-
-|Kafka broker
-|-
-|-
-|TP
+|Deprecated
+|Removed
 
 |====

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-tech-preview-features_{context}"]
+= Generally Available and Technology Preview features
+
+Features which are Generally Available (GA) are fully supported and are suitable for production use. Technology Preview (TP) features are experimental features and are not intended for production use. See the link:https://access.redhat.com/support/offerings/techpreview[Technology Preview scope of support on the Red Hat Customer Portal] for more information about TP features.
+
+The following table provides information about which {ServerlessProductName} features are GA and which are TP:
+
+.Generally Available and Technology Preview features tracker
+[cols="3,1,1,1,1",options="header"]
+|====
+|Feature |1.18|1.19|1.20|1.21
+
+|`kn func`
+|TP
+|TP
+|TP
+|TP
+
+|`kn func invoke`
+|-
+|-
+|-
+|TP
+
+|Service Mesh mTLS
+|GA
+|GA
+|GA
+|GA
+
+|`emptyDir` volumes
+|GA
+|GA
+|GA
+|GA
+
+|HTTPS redirection
+|-
+|GA
+|GA
+|GA
+
+|Kafka broker
+|-
+|-
+|TP
+|TP
+
+|Kafka sink
+|-
+|-
+|-
+|TP
+
+|====

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -19,9 +19,7 @@ For details about the latest Knative component releases, see the link:https://kn
 ====
 
 include::modules/serverless-api-versions.adoc[leveloffset=+1]
-
-// Deprecated and removed feature trackers
-// OCP
+include::modules/serverless-tech-preview-features.adoc[leveloffset=+1]
 include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent


### PR DESCRIPTION
Cherry picked from https://github.com/openshift/openshift-docs/pull/43229/commits/997f9255ed4b2e536a02ec11cabc20e88906bf9b xref: https://github.com/openshift/openshift-docs/pull/43229