### PR TITLE
Fix jq filter

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -71,7 +71,7 @@ The ID determines which image the installation program must download.
 +
 [source,terminal]
 ----
-$ export RHCOS_QEMU_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/coreos/rhcos.json  | jq .images.qemu.path | sed 's/"//g')
+$ export RHCOS_QEMU_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/coreos/rhcos.json  | jq -r '.architectures.x86_64.artifacts.qemu.formats["qcow2.gz"].disk.location'
 ----
 
 . Get the path where the image is published:


### PR DESCRIPTION
A part of #43246, this PR fixes the `jq` filter in step 6 of the procedure.

OCP Version: 4.10+

Current 4.10 docs: https://docs.openshift.com/container-platform/4.10/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-creating-an-rhcos-images-cache_ipi-install-installation-workflow

Direct doc preview link: https://deploy-preview-43776--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-creating-an-rhcos-images-cache_ipi-install-installation-workflow