### PR TITLE
OSDOCS-3428: Adds clarity to multicluster release note

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -76,7 +76,7 @@ This includes the ability to customize the installation to fetch Ignition config
 [id="ocp-4-10-rhcos-rhel-8-4-packages"]
 ==== {op-system} now uses {op-system-base} 8.4
 
-{op-system} now uses {op-system-base-full} 8.4 packages in {product-title} 4.10. These packages provide you the latest fixes, features, and enhancements, such as NetworkManager features, as well as the latest hardware support and driver updates. 
+{op-system} now uses {op-system-base-full} 8.4 packages in {product-title} 4.10. These packages provide you the latest fixes, features, and enhancements, such as NetworkManager features, as well as the latest hardware support and driver updates.
 
 [id="ocp-4-10-installation-and-upgrade"]
 === Installation and upgrade
@@ -251,7 +251,7 @@ For more information about the dynamic plug-in, see xref:../web_console/dynamic-
 
 [id="ocp-4-10-multicluster-console-technology-preview"]
 ==== Multicluster console (Technology Preview)
-Starting with {product-title} 4.10, the multicluster console is now available as a Technology Preview feature. By enabling this feature, you can connect to remote clusters' API servers from a single {product-title} console.
+Starting with {product-title} 4.10, the multicluster console is now available as a Technology Preview feature. By enabling this feature, you can connect to remote clusters' API servers from a single {product-title} console. You must have Red Hat Advanced Cluster Management (ACM) or the multicluster engine (MCE) Operator installed to enable this feature.
 
 [id="pod-debug-mode-web-console"]
 ==== Running a pod in debug mode


### PR DESCRIPTION
[OSDOCS:3428](https://issues.redhat.com/browse/OSDOCS-3428)

- Applies to `enterprise-4.10` only.
- [Preview link](http://file.rdu.redhat.com/opayne/console-RN-clarification/release_notes/ocp-4-10-release-notes.html#ocp-4-10-multicluster-console-technology-preview)