### PR TITLE
BZ1964226 - Adding CSI Tech Preview note in vCenter privileges section

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
@@ -16,4 +16,9 @@ include::modules/machineset-yaml-vsphere.adoc[leveloffset=+1]
 
 include::modules/machineset-vsphere-required-permissions.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about CSI driver and feature support, see xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#csi-drivers-supported_persistent-storage-csi[CSI drivers supported by {product-title}].
+
 include::modules/machineset-creating.adoc[leveloffset=+1]

--- a/modules/machineset-vsphere-required-permissions.adoc
+++ b/modules/machineset-vsphere-required-permissions.adoc
@@ -76,6 +76,11 @@ If you cannot use an account with global administrative privileges, you must cre
 
 3+a|
 ^1^ The `StorageProfile.Update` and `StorageProfile.View` permissions are required only for storage backends that use the Container Storage Interface (CSI).
+
+[IMPORTANT]
+=====
+Some CSI drivers and features are in Technology Preview in {product-title} {product-version}. For more information, see _CSI drivers supported by {product-title}_.
+=====
 |===
 ====
 


### PR DESCRIPTION
This applies to `enterprise-4.9` and `enterprise-4.10` only.

This relates to https://bugzilla.redhat.com/show_bug.cgi?id=1964226. This pull request adds a note about CSI driver and feature Technology Preview status for 4.9 in the "Minimum required vCenter privileges for machine set management" section.

The preview is [here](https://deploy-preview-43811--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere#machineset-vsphere-requirements-user-provisioned-machine-sets_creating-machineset-vsphere).