### PR TITLE
BZ2066332: IBM Z/P - Change prereq for persistent storage to ODF

### DIFF
--- a/installing/installing_ibm_power/installing-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-ibm-power.adoc
@@ -20,8 +20,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * Before you begin the installation process, you must clean the installation directory. This ensures that the required installation files are created and updated during the installation process.
-* You provisioned xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS] for your cluster. To deploy a private image registry, your storage must provide
-`ReadWriteMany` access modes.
+* You provisioned xref:../../storage/persistent_storage/persistent-storage-ocs.adoc#persistent-storage-ocs[persistent storage using {rh-storage}] or other supported storage protocols for your cluster. To deploy a private image registry, you must set up persistent storage with `ReadWriteMany` access.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]

--- a/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -26,8 +26,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 ====
 Ensure that installation steps are performed on a machine with access to the installation media.
 ====
-* You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide
-`ReadWriteMany` access modes.
+* You provisioned xref:../../storage/persistent_storage/persistent-storage-ocs.adoc#persistent-storage-ocs[persistent storage using {rh-storage}] or other supported storage protocols for your cluster. To deploy a private image registry, you must set up persistent storage with `ReadWriteMany` access.
 * If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]

--- a/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -26,7 +26,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * Before you begin the installation process, you must clean the installation directory. This ensures that the required installation files are created and updated during the installation process.
-* You provisioned xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS] for your cluster. To deploy a private image registry, you must set up persistent storage with `ReadWriteMany` access.
+* You provisioned xref:../../storage/persistent_storage/persistent-storage-ocs.adoc#persistent-storage-ocs[persistent storage using {rh-storage}] or other supported storage protocols for your cluster. To deploy a private image registry, you must set up persistent storage with `ReadWriteMany` access.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 * You provisioned a {op-system-base} Kernel Virtual Machine (KVM) system that is hosted on the logical partition (LPAR) and based on {op-system-base} 8.4 or later.
 +

--- a/installing/installing_ibm_z/installing-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z.adoc
@@ -26,7 +26,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * Before you begin the installation process, you must clean the installation directory. This ensures that the required installation files are created and updated during the installation process.
-* You provisioned xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS] for your cluster. To deploy a private image registry, you must set up persistent storage with `ReadWriteMany` access.
+* You provisioned xref:../../storage/persistent_storage/persistent-storage-ocs.adoc#persistent-storage-ocs[persistent storage using {rh-storage}] or other supported storage protocols for your cluster. To deploy a private image registry, you must set up persistent storage with `ReadWriteMany` access.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 
 [NOTE]

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -32,7 +32,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 ====
 Ensure that installation steps are done from a machine with access to the installation media.
 ====
-*  You provisioned xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS] for your cluster. To deploy a private image registry, you must set up persistent storage with `ReadWriteMany` access.
+* You provisioned xref:../../storage/persistent_storage/persistent-storage-ocs.adoc#persistent-storage-ocs[persistent storage using {rh-storage}] or other supported storage protocols for your cluster. To deploy a private image registry, you must set up persistent storage with `ReadWriteMany` access.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 * You provisioned a {op-system-base} Kernel Virtual Machine (KVM) system that is hosted on the logical partition (LPAR) and based on {op-system-base} 8.4 or later.
 +

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -32,7 +32,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 ====
 Ensure that installation steps are done from a machine with access to the installation media.
 ====
-*  You provisioned xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS] for your cluster. To deploy a private image registry, you must set up persistent storage with `ReadWriteMany` access.
+* You provisioned xref:../../storage/persistent_storage/persistent-storage-ocs.adoc#persistent-storage-ocs[persistent storage using {rh-storage}] or other supported storage protocols for your cluster. To deploy a private image registry, you must set up persistent storage with `ReadWriteMany` access.
 * If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]


### PR DESCRIPTION
- OCP version for cherry-picking: enterprise-4.10 and later

- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2066332

- Preview
   - [Installing a cluster with z/VM on IBM Z and LinuxONE](https://deploy-preview-43812--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#prerequisites)
   - [Installing a cluster with z/VM on IBM Z and LinuxONE in a restricted network](https://deploy-preview-43812--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z.html#prerequisites)
   - [Installing a cluster with RHEL KVM on IBM Z and LinuxONE](https://deploy-preview-43812--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html#prerequisites)
   - [Installing a cluster with RHEL KVM on IBM Z and LinuxONE in a restricted network](https://deploy-preview-43812--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.html#prerequisites)

   - [Installing a cluster on IBM Power](https://deploy-preview-43812--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-power.html#prerequisites)
   - [Installing a cluster on IBM Power in a restricted network](https://deploy-preview-43812--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-power.html#prerequisites)

Note: The previews still says OCS and not ODF because I used the {rh-storage} attribute. Once this [PR](https://github.com/openshift/openshift-docs/pull/41858) is merged name will change. 
- QE review 
  - IBM Z: Holger Wolf
  - IBM Power: Manoj Kumar


