### PR TITLE
Fix vsphere release note

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -758,7 +758,7 @@ vSphere CSI Driver Operator installation requires:
 
 * Removal of any non-Red Hat vSphere CSI driver (xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a non-Red Hat vSphere CSI Operator Driver])
 
-* (Optional, if it is desired to keep existing storage class) removal of any storage class named `thin-csi`
+* Removal of any storage class named `thin-csi`
 
 Clusters are still upgraded even if the preceding conditions are not met, but it is recommended that you meet these conditions to have a supported vSphere CSI Operator Driver.
 


### PR DESCRIPTION
The step is in fact not optional. We still degrade the cluster if storage class name collides during update.