### PR TITLE
[enterprise-4.7] Fix non-groupified API references #43819

### DIFF
--- a/modules/builds-chaining-builds.adoc
+++ b/modules/builds-chaining-builds.adoc
@@ -23,7 +23,7 @@ The first build takes the application source and produces an image containing a 
 
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: artifact-build
@@ -47,7 +47,7 @@ The second build uses image source with a path to the WAR file inside the output
 
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: image-build

--- a/modules/builds-use-custom-builder-image.adoc
+++ b/modules/builds-use-custom-builder-image.adoc
@@ -21,7 +21,7 @@ You can define a `BuildConfig` object that uses the custom strategy in conjuncti
 [source,yaml]
 ----
 kind: BuildConfig
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 metadata:
   name: sample-custom-build
   labels:
@@ -56,7 +56,7 @@ $ oc create -f buildconfig.yaml
 [source,yaml]
 ----
 kind: ImageStream
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: sample-custom
 spec: {}

--- a/modules/builds-using-secrets-as-environment-variables.adoc
+++ b/modules/builds-using-secrets-as-environment-variables.adoc
@@ -19,7 +19,7 @@ This method shows the secrets as plain text in the output of the build pod conso
 +
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: secret-example-bc

--- a/modules/builds-using-secrets.adoc
+++ b/modules/builds-using-secrets.adoc
@@ -105,7 +105,7 @@ spec:
 .YAML of a Build Config Populating Environment Variables with Secret Data
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: secret-example-bc

--- a/modules/cluster-logging-eventrouter-deploy.adoc
+++ b/modules/cluster-logging-eventrouter-deploy.adoc
@@ -23,7 +23,7 @@ The following Template object creates the service account, cluster role, and clu
 [source,yaml]
 ----
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   name: eventrouter-template
   annotations:
@@ -36,7 +36,7 @@ objects:
       name: eventrouter
       namespace: ${NAMESPACE}
   - kind: ClusterRole <2>
-    apiVersion: v1
+    apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       name: event-reader
     rules:
@@ -44,7 +44,7 @@ objects:
       resources: ["events"]
       verbs: ["get", "watch", "list"]
   - kind: ClusterRoleBinding  <3>
-    apiVersion: v1
+    apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       name: event-reader-binding
     subjects:

--- a/modules/deployments-deploymentconfigs.adoc
+++ b/modules/deployments-deploymentconfigs.adoc
@@ -35,7 +35,7 @@ replication controller, scaling up the new one, and running hooks). The deployme
 .Example `DeploymentConfig` definition
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   name: frontend

--- a/modules/deployments-lifecycle-hooks.adoc
+++ b/modules/deployments-lifecycle-hooks.adoc
@@ -44,7 +44,7 @@ The following simplified example deployment uses the rolling strategy. Triggers 
 [source,yaml]
 ----
 kind: DeploymentConfig
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 metadata:
   name: frontend
 spec:

--- a/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
+++ b/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
@@ -83,7 +83,7 @@ links in the deployment's service specification file to overcome this:
 [source,yaml]
 ----
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: deployment-config-template
@@ -92,7 +92,7 @@ metadata:
     description: This template will create a deploymentConfig with 1 replica, 4 env vars and a service.
     tags: ''
 objects:
-- apiVersion: v1
+- apiVersion: apps.openshift.io/v1
   kind: DeploymentConfig
   metadata:
     name: deploymentconfig${IDENTIFIER}

--- a/modules/images-imagestream-configure.adoc
+++ b/modules/images-imagestream-configure.adoc
@@ -11,7 +11,7 @@ An `ImageStream` object file contains the following elements.
 
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   annotations:

--- a/modules/images-imagestream-mapping.adoc
+++ b/modules/images-imagestream-mapping.adoc
@@ -19,7 +19,7 @@ The following image stream mapping example results in an image being tagged as `
 
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStreamMapping
 metadata:
   creationTimestamp: null

--- a/modules/images-managing-images-enabling-imagestreams-kube.adoc
+++ b/modules/images-managing-images-enabling-imagestreams-kube.adoc
@@ -35,7 +35,7 @@ This sets the `Imagestream.spec.lookupPolicy.local` field to true.
 .Imagestream with image lookup enabled
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   annotations:

--- a/modules/images-other-jenkins-customize-s2i.adoc
+++ b/modules/images-other-jenkins-customize-s2i.adoc
@@ -32,7 +32,7 @@ The contents of the `configuration/` directory is copied to the `/var/lib/jenkin
 .Sample build configuration customizes the Jenkins image in {product-title}
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: custom-jenkins-build

--- a/modules/images-other-jenkins-kubernetes-plugin.adoc
+++ b/modules/images-other-jenkins-kubernetes-plugin.adoc
@@ -14,11 +14,11 @@ kind: List
 apiVersion: v1
 items:
 - kind: ImageStream
-  apiVersion: v1
+  apiVersion: image.openshift.io/v1
   metadata:
     name: openshift-jee-sample
 - kind: BuildConfig
-  apiVersion: v1
+  apiVersion: build.openshift.io/v1
   metadata:
     name: openshift-jee-sample-docker
   spec:
@@ -37,7 +37,7 @@ items:
         kind: ImageStreamTag
         name: openshift-jee-sample:latest
 - kind: BuildConfig
-  apiVersion: v1
+  apiVersion: build.openshift.io/v1
   metadata:
     name: openshift-jee-sample
   spec:
@@ -60,7 +60,7 @@ It is also possible to override the specification of the dynamically created Jen
 [source,yaml]
 ----
 kind: BuildConfig
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 metadata:
   name: openshift-jee-sample
 spec:

--- a/modules/nodes-pods-autoscaling-about.adoc
+++ b/modules/nodes-pods-autoscaling-about.adoc
@@ -91,7 +91,7 @@ spec:
   maxReplicas: 7
   minReplicas: 3
   scaleTargetRef:
-    apiVersion: apps.openshift.io/v1
+    apiVersion: apps/v1
     kind: DeploymentConfig
     name: image-registry
   targetCPUUtilizationPercentage: 75

--- a/modules/nodes-pods-autoscaling-creating-cpu.adoc
+++ b/modules/nodes-pods-autoscaling-creating-cpu.adoc
@@ -91,7 +91,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: v1 <3>
+    apiVersion: apps/v1 <3>
     kind: ReplicaSet <4>
     name: example <5>
   minReplicas: 1 <6>

--- a/modules/nodes-pods-autoscaling-creating-memory.adoc
+++ b/modules/nodes-pods-autoscaling-creating-memory.adoc
@@ -71,7 +71,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: v1 <3>
+    apiVersion: apps/v1 <3>
     kind: ReplicationController <4>
     name: example <5>
   minReplicas: 1 <6>
@@ -122,7 +122,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps.openshift.io/v1 <3>
+    apiVersion: apps/v1 <3>
     kind: DeploymentConfig <4>
     name: example <5>
   minReplicas: 1 <6>

--- a/modules/nodes-pods-secrets-about.adoc
+++ b/modules/nodes-pods-secrets-about.adoc
@@ -159,7 +159,7 @@ spec:
 
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: secret-example-bc

--- a/modules/nw-http2-haproxy.adoc
+++ b/modules/nw-http2-haproxy.adoc
@@ -40,3 +40,19 @@ Enable HTTP/2 on the entire cluster.
 ----
 $ oc annotate ingresses.config/cluster ingress.operator.openshift.io/default-enable-http2=true
 ----
+<<<<<<< HEAD
+=======
++
+[TIP]
+====
+You can alternatively apply the following YAML to add the annotation:
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  annotations:
+    ingress.operator.openshift.io/default-enable-http2: "true"
+----
+====
+>>>>>>> 5b09f67528 (Fix non-groupified API references)

--- a/modules/nw-ingress-creating-a-passthrough-route.adoc
+++ b/modules/nw-ingress-creating-a-passthrough-route.adoc
@@ -26,7 +26,7 @@ If you examine the resulting `Route` resource, it should look similar to the fol
 .A Secured Route Using Passthrough Termination
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: route-passthrough-secured <1>

--- a/modules/nw-ingress-creating-a-reencrypt-route-with-a-custom-certificate.adoc
+++ b/modules/nw-ingress-creating-a-reencrypt-route-with-a-custom-certificate.adoc
@@ -58,7 +58,7 @@ following:
 .YAML Definition of the Secure Route
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: frontend

--- a/modules/nw-ingress-creating-an-edge-route-with-a-custom-certificate.adoc
+++ b/modules/nw-ingress-creating-an-edge-route-with-a-custom-certificate.adoc
@@ -56,7 +56,7 @@ following:
 .YAML Definition of the Secure Route
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: frontend

--- a/modules/nw-path-based-routes.adoc
+++ b/modules/nw-path-based-routes.adoc
@@ -25,7 +25,7 @@ The following table shows example routes and their accessibility:
 
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: route-unsecured

--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -99,7 +99,7 @@ Some effective timeout values can be the sum of certain variables, rather than t
 .A route setting custom timeout
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   annotations:
@@ -149,7 +149,7 @@ metadata:
 .A route specifying a rewrite target
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   annotations:

--- a/modules/op-adding-triggers.adoc
+++ b/modules/op-adding-triggers.adoc
@@ -202,7 +202,7 @@ Alternatively, you can create a re-encrypt TLS termination YAML file to create a
 .Example Re-encrypt TLS Termination YAML of the Secured Route
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: route-passthrough-secured <1>

--- a/modules/templates-exposing-object-fields.adoc
+++ b/modules/templates-exposing-object-fields.adoc
@@ -29,7 +29,7 @@ The following is an example of different objects' fields being exposed:
 [source,yaml]
 ----
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   name: my-template
 objects:
@@ -60,7 +60,7 @@ objects:
     - name: "web"
       port: 8080
 - kind: Route
-  apiVersion: v1
+  apiVersion: route.openshift.io/v1
   metadata:
     name: my-template-route
     annotations:

--- a/modules/templates-waiting-for-readiness.adoc
+++ b/modules/templates-waiting-for-readiness.adoc
@@ -56,12 +56,12 @@ The following is an example template extract, which uses the `wait-for-ready` an
 [source,yaml]
 ----
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   name: my-template
 objects:
 - kind: BuildConfig
-  apiVersion: v1
+  apiVersion: build.openshift.io/v1
   metadata:
     name: ...
     annotations:
@@ -71,7 +71,7 @@ objects:
   spec:
     ...
 - kind: DeploymentConfig
-  apiVersion: v1
+  apiVersion: apps.openshift.io/v1
   metadata:
     name: ...
     annotations:

--- a/modules/templates-writing-description.adoc
+++ b/modules/templates-writing-description.adoc
@@ -12,7 +12,7 @@ The following is an example of template description metadata:
 [source,yaml]
 ----
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   name: cakephp-mysql-example <1>
   annotations:

--- a/modules/templates-writing-parameters.adoc
+++ b/modules/templates-writing-parameters.adoc
@@ -87,12 +87,12 @@ Here is an example of a full template with parameter definitions and references:
 [source,yaml]
 ----
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   name: my-template
 objects:
   - kind: BuildConfig
-    apiVersion: v1
+    apiVersion: build.openshift.io/v1
     metadata:
       name: cakephp-mysql-example
       annotations:
@@ -105,7 +105,7 @@ objects:
           ref: "${SOURCE_REPOSITORY_REF}"
         contextDir: "${CONTEXT_DIR}"
   - kind: DeploymentConfig
-    apiVersion: v1
+    apiVersion: apps.openshift.io/v1
     metadata:
       name: frontend
     spec:

--- a/modules/templates-writing.adoc
+++ b/modules/templates-writing.adoc
@@ -11,7 +11,7 @@ The following is an example of a simple template object definition (YAML):
 
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: redis-template

--- a/modules/using-wildcard-routes.adoc
+++ b/modules/using-wildcard-routes.adoc
@@ -59,7 +59,7 @@ The instructions on how to do this are specific to your certificate authority an
 +
 ----
 $ cat > route.yaml  <<REOF
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name:  my-service

--- a/modules/virt-attaching-vm-secondary-network-cli.adoc
+++ b/modules/virt-attaching-vm-secondary-network-cli.adoc
@@ -20,7 +20,7 @@ This procedure uses a YAML file to demonstrate editing the configuration and app
 +
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
     name: example-vm

--- a/modules/virt-setting-policy-attributes.adoc
+++ b/modules/virt-setting-policy-attributes.adoc
@@ -14,7 +14,7 @@ You can set a policy attribute and CPU feature for each virtual machine (VM) to 
 +
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   name: myvmi


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/openshift-docs/commit/5b09f67528e9c2539208c3c8843ace9a914d20a0 | xref: https://github.com/openshift/openshift-docs/pull/39200

Use of non-groupified non-core objects was deprecated in OCP 4.7.