### PR TITLE
removing failed, unused files from the build.yml file

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -100,6 +100,8 @@ variants:
        - networking/external_dns_operator/nw-creating-dns-records-on-aws.adoc
        - networking/external_dns_operator/nw-configuration-parameters.adoc
        - networking/external_dns_operator/nw-creating-dns-records-on-gcp.adoc
+       - nodes/clusters/modules/nodes-cluster-features-about.adoc
+       - logging/modules/efk-logging-deploy-subscription.adoc
        - updating/updating-cluster-prepare.adoc
        - service_mesh/v1x/ossm-config.adoc
  - name: openshift-dedicated


### PR DESCRIPTION
These two files are no longer in the _topic_map.yml, and the Jupiter build is failing because it's still trying to build them.

This error is only appearing in 4.10.