### PR TITLE
Suggests seeing Creating Build Inputs in docs section

### DIFF
--- a/modules/builds-buildconfig.adoc
+++ b/modules/builds-buildconfig.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 // * builds/understanding-builds.adoc
 
+:_content-type: REFERENCE
 [id="builds-buildconfig_{context}"]
 = BuildConfigs
 
@@ -54,7 +55,7 @@ spec:
 ifndef::openshift-online[]
 `Dockerfile`, to build from an inline Dockerfile,
 endif::[]
-or `Binary`, to accept binary payloads. It is possible to have multiple sources at once. See the documentation for each source type for details.
+or `Binary`, to accept binary payloads. It is possible to have multiple sources at once. For more information about each source type, see "Creating build inputs".
 <5> The `strategy` section describes the build strategy used to execute the build. You can specify a `Source`
 ifndef::openshift-online[]
 , `Docker`, or `Custom`


### PR DESCRIPTION
Issue: https://github.com/openshift/openshift-docs/issues/41545

For 4.7+

Preview: https://deploy-preview-43834--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/understanding-buildconfigs.html#builds-buildconfig_understanding-builds