### PR TITLE
RHDEVDOCS-3827 - fix incorrect indent in tls config sample

### DIFF
--- a/modules/monitoring-configuring-remote-write-storage.adoc
+++ b/modules/monitoring-configuring-remote-write-storage.adoc
@@ -6,6 +6,7 @@
 [id="configuring_remote_write_storage_{context}"]
 = Configuring remote write storage
 
+[role="_abstract"]
 You can configure remote write storage to enable Prometheus to send ingested metrics to remote systems for long-term storage. 
 Doing so has no impact on how or for how long Prometheus stores metrics.
 
@@ -121,18 +122,18 @@ data:
     prometheusK8s:
       remoteWrite:
       - url: "https://remote-write.endpoint"
-      tlsConfig:
-        ca:
-          secret:
+        tlsConfig:
+          ca:
+            secret:
+              name: selfsigned-mtls-bundle
+              key: ca.crt
+          cert:
+            secret:
+              name: selfsigned-mtls-bundle
+              key: client.crt
+          keySecret:
             name: selfsigned-mtls-bundle
-            key: ca.crt
-        cert:
-          secret:
-            name: selfsigned-mtls-bundle
-            key: client.crt
-        keySecret:
-          name: selfsigned-mtls-bundle
-          key: client.key
+            key: client.key
 ----
 
 . Add write relabel configuration values after the authentication credentials:

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -112,7 +112,7 @@ include::modules/monitoring-modifying-retention-time-for-prometheus-metrics-data
 * xref:../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
 
 // Configuring remote write storage for Prometheus
-include::modules/monitoring-configuring-remote-write.adoc[leveloffset=+1]
+include::modules/monitoring-configuring-remote-write-storage.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
**Summary**: This PR fixes an issue with incorrect indentation in the tlsConfig section of sample code in the "Configuring remote write storage" topic. It also renames the file to be consistent with OpenShift docs file naming standards and updates the assembly file with the changed file name.

- Aligned team: DevTools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3827
- Direct link to doc preview: https://deploy-preview-43845--osdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#configuring_remote_write_storage_configuring-the-monitoring-stack
- SME review: @jan--f (approved)
- QE review: @juzhao (approved)
- Peer review: @rolfedh (approved)
- <All reviews complete. Please merge now>