### PR TITLE
Adds notes for 4.7.46 release

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -3120,7 +3120,6 @@ link:https://access.redhat.com/solutions/6772591[{product-title} 4.7.44 containe
 ==== Bug fixes
 * Previously, a `reclaimPolicy` value was missing in the `standard-csi` storage class. Consequently, OpenStack Cinder CSI Driver Operator continuously printed `StorageClassUpdated` events in the logs. With this update, a default value for `reclaimPolicy` in the `standard-csi` storage class is set. As a result, OpenStack Cinder CSI Driver Operator does not spam the logs with `StorageClassUpdated` events. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049879[*BZ#2049879*])
 
-
 [id="ocp-4-7-44-updating"]
 ==== Updating
 
@@ -3150,3 +3149,19 @@ The components initualize successfully, and `LoadBalancer`-type services are abl
 ==== Updating
 
 To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-7-46"]
+=== RHBA-2022:1018 - {product-title} 4.7.46 bug fix update
+
+Issued: 2022-04-01
+
+{product-title} release 4.7.46 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1018[RHBA-2022:1018] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1017[RHBA-2022:1017] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6844051[{product-title} 4.7.46 container image list]
+
+[id="ocp-4-7-46-updating"]
+==== Updating
+
+To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.7.46 release. Adds removed feature with change management ACKs #43289. 

Hold merge till outage is fixed. 

Applies to enterprise 4.7

[Preview](https://deploy-preview-43854--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-46)