### PR TITLE
Clarify user-replaceables in osdocs guide

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -180,7 +180,14 @@ Try to shorten the file name as much as possible _without_ abbreviating importan
 
 == Directory names
 
-If you create a directory with a multiple-word name, separate each word with an underscore, for example `backup_and_restore`. Do not create a top-level directory in the repository without checking with the docs team. In the main OpenShift docs, you can create one level of subdirectories. In the docs for features that are designed to be used with OpenShift, such as Service Mesh and OpenShift Virtualization, you can create two levels of subdirectories.
+If you create a directory with a multiple-word name, separate each word with an underscore, for example `backup_and_restore`.
+
+[NOTE]
+====
+Do not italicize user-replaced values. This guideline is an exception to the link:https://redhat-documentation.github.io/supplementary-style-guide/#user-replaced-values[Red Hat supplementary style guide].
+====
+
+Do not create a top-level directory in the repository without checking with the docs team. In the main OpenShift docs, you can create one level of subdirectories. In the docs for features that are designed to be used with OpenShift, such as Service Mesh and OpenShift Virtualization, you can create two levels of subdirectories.
 
 When creating a new directory or subdirectory, you must create four symbolic links in it:
 
@@ -1035,7 +1042,7 @@ Now using project "my-project" on server "https://openshift.example.com:6443".
 ----
 ....
 
-* To mark up command syntax, use the code block and wrap any replaceable values in angle brackets (`<>`) with the required command parameter, using underscores (`_`) between words as necessary for legibility. For example:
+* To mark up command syntax, use the code block and wrap any replaceable values in angle brackets (`<>`) with the required command parameter, using underscores (`_`) between words as necessary for legibility. Do not italicize user-replaced values. For example:
 +
 ....
 To view a list of objects for the specified object type, enter the following command:


### PR DESCRIPTION
`main` branch only, no preview build as this is just our guidelines doc.

In the contrib guide, this PR clarifies an exception to the Red Hat supplementary style guide in which we do not want to use italics when referring to user-replaceable values both in and out of code blocks. 