### PR TITLE
Fixing typo that was introduced by a merge from earlier

### DIFF
--- a/modules/updating-eus-to-eus-upgrade.adoc
+++ b/modules/updating-eus-to-eus-upgrade.adoc
@@ -15,7 +15,7 @@ Following this procedure reduces the total update duration and the number of tim
 * Review the release notes and product lifecycles for any layered products and OLM Operators. Some may require updates either before or during an EUS-to-EUS update.
 * Ensure that you are familiar with version-specific prerequisites, such as link:https://docs.openshift.com/container-platform/4.9/updating/updating-cluster-prepare.html#update-preparing-migrate_updating-cluster-prepare[administrator acknowledgement] that is required prior to updating from {product-title} 4.8 to 4.9.
 * Verify that your cluster is running {product-title} version 4.8.14 or later.
-If your cluster is running a version earlier than {product-title} 4.8.14, you must update to a later 4.8.z version before to updating to 4.9.
+If your cluster is running a version earlier than {product-title} 4.8.14, you must update to a later 4.8.z version before updating to 4.9.
 The update to 4.8.14 or later is necessary to fulfill the minimum version requirements that must be performed without pausing MachineConfigPools.
 * Verify that MachineConfigPools is unpaused.
 


### PR DESCRIPTION
Fixing a typo that was introduced by this merge: https://github.com/openshift/openshift-docs/pull/43851
Applies to 4.8, 4.10, and 4.11. 4.9 was fixed during manual CP (https://github.com/openshift/openshift-docs/pull/43860).
No QE needed.
Preview Link:
https://deploy-preview-43862--osdocs.netlify.app/openshift-enterprise/latest/updating/preparing-eus-eus-upgrade.html#updating-eus-to-eus-upgrade_eus-to-eus-upgrade