### PR TITLE
OSDOCS-3412:Removing AWS-only language from appsDomain ingress config

### DIFF
--- a/modules/nw-ingress-configuring-application-domain.adoc
+++ b/modules/nw-ingress-configuring-application-domain.adoc
@@ -5,18 +5,18 @@
 
 :_content-type: PROCEDURE
 [id="nw-ingress-configuring-application-domain_{context}"]
-= Configuring application domain for the Ingress Controller Operator on AWS
+= Configuring application domain for the Ingress Controller Operator
 
 //OpenShift Dedicated or Amazon RH OpenShift cluster administrator
 
-As a cluster administrator, you can specify an alternative to the default cluster domain for user-created routes by configuring the `appsDomain` field. The `appsDomain` field is an optional domain for AWS infrastructure to use instead of the default, which is specified in the `domain` field. If you specify an alternative domain, it overrides the default cluster domain for the purpose of determining the default host for a new route.
+As a cluster administrator, you can specify an alternative to the default cluster domain for user-created routes by configuring the `appsDomain` field. The `appsDomain` field is an optional domain for {product-title} to use instead of the default, which is specified in the `domain` field. If you specify an alternative domain, it overrides the default cluster domain for the purpose of determining the default host for a new route.
 
 For example, you can use the DNS domain for your company as the default domain for routes and ingresses for applications running on your cluster.
 
 .Prerequisites
 
 //* You deployed an {OSD} cluster.
-* You deployed an {product-title} cluster on AWS infrastructure.
+* You deployed an {product-title} cluster.
 * You installed the `oc` command line interface.
 
 .Procedure
@@ -44,7 +44,7 @@ spec:
   appsDomain: <test.example.com>      <2>
 ----
 <1> Default domain
-<2> Optional: Domain for AWS infrastructure to use for application routes. Instead of the default prefix, `apps`, you can use an alternative prefix like `test`.
+<2> Optional: Domain for {product-title} infrastructure to use for application routes. Instead of the default prefix, `apps`, you can use an alternative prefix like `test`.
 +
 . Verify that an existing route contains the domain name specified in the `appsDomain` field by exposing the route and verifying the route domain change:
 //+

--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -26,7 +26,7 @@ The `domain` value must be unique among all Ingress Controllers and cannot be up
 If empty, the default value is `ingress.config.openshift.io/cluster` `.spec.domain`.
 
 |`appsDomain`
-|`appsDomain` is an optional domain for AWS infrastructure to use instead of the one specified in the `domain` field when a Route is created without specifying an explicit host. If a value is entered for `appsDomain`, this value is used to generate default host values for the Route. Unlike `domain`, `appsDomain` can be modified after installation. You can use this parameter only if you set up a new Ingress Controller that uses a wildcard certificate.
+|`appsDomain` is an optional domain for {product-title} to use instead of the one specified in the `domain` field when a Route is created without specifying an explicit host. If a value is entered for `appsDomain`, this value is used to generate default host values for the Route. Unlike `domain`, `appsDomain` can be modified after installation. You can use this parameter only if you set up a new Ingress Controller that uses a wildcard certificate.
 
 |`replicas`
 |`replicas` is the desired number of Ingress Controller replicas. If not set, the default value is `2`.


### PR DESCRIPTION
Version: 4.7+

https://issues.redhat.com/browse/OSDOCS-3412

Details: Incorrect info about the `appsDomain` configuration that needed updating from AWS-only config to a config for all cloud platforms brought to light by a discussion on forum-network-edge: https://coreos.slack.com/archives/CCH60A77E/p1647619433720409

Preview:
Application domain topic: https://deploy-preview-43867--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-configuring-application-domain_configuring-ingress

Configuration parameters table: https://deploy-preview-43867--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress

@Miciah Can you take a look at this and make sure the information is corrected?
@quarterpin can you PTAL at this for QA?