### PR TITLE
 removed master word from the term Control plane in the OCP Glossary

### DIFF
--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -423,16 +423,13 @@ When referencing as a prerequisite for a procedure module, use the following
 construction: Install the OpenShift CLI (`oc`).
 
 ''''
-=== OpenShift control plane (also known as master)
+=== control plane
 
-Usage: OpenShift control plane
+Usage: control plane
 
-Provides a REST endpoint for interacting with the system and manages the state
-of the system, ensuring that all containers expected to be running are actually
-running and that other requests such as builds and deployments are serviced.
-New deployments and configurations are created with the REST API, and the state
-of the system can be interrogated through this endpoint as well.  An OpenShift
-control plane comprises the API server, scheduler, and SkyDNS.
+The control plane, which is composed of control plane machines, manages the {product-title} cluster. The control plane machines manage workloads on the compute machines, which are also known as worker machines.
+
+Note that the OpenShift "control plane" was previously known as "master" and could still be in the code.
 
 ''''
 === Operator


### PR DESCRIPTION
- Merge to main 

The term **control plane** title also has **(also known as the master)** .  We need to remove this to give clarity on the usage of the term. 

@bergerhoffer wrt to the slack discussion I have raised a PR ,ptal. 