### PR TITLE
BZ2062137: This text is at least misleading.

### DIFF
--- a/modules/nodes-pods-priority-about.adoc
+++ b/modules/nodes-pods-priority-about.adoc
@@ -50,13 +50,6 @@ A number of critical components include the `system-cluster-critical` priority c
 
 * *cluster-logging* - This priority is used by Fluentd to make sure Fluentd pods are scheduled to nodes over other apps.
 
-[NOTE]
-====
-If you upgrade your existing cluster, the priority of your existing pods is effectively zero. However, existing pods with
-the `scheduler.alpha.kubernetes.io/critical-pod` annotation are automatically converted to `system-cluster-critical` class.
-Fluentd OpenShift Logging pods with the annotation are converted to the `cluster-logging` priority class.
-====
-
 [id="admin-guide-priority-preemption-names_{context}"]
 == Pod priority names
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2062137 "Please remove this section, as support for this annotation was dropped in Kubernetes 1.16 / OpenShift 4.3"

Preview: Removed note after the "cluster-logging" bullet at the [end of this section](https://docs.openshift.com/container-platform/4.10/nodes/pods/nodes-pods-priority.html#admin-guide-priority-preemption-priority-class_nodes-pods-priority)