### PR TITLE
Adds 4.10.6 release notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2622,3 +2622,39 @@ link:https://access.redhat.com/solutions/6828301[{product-title} 4.10.5 containe
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-6"]
+=== RHBA-2022:1026 - {product-title} 4.10.6 bug fix and security update
+
+Issued: 2022-03-28
+
+{product-title} release 4.10.6, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1026[RHBA-2022:1026] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:1025[RHSA-2022:1025] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6849321[{product-title} 4.10.6 container image list]
+
+[id="ocp-4-10-6-features"]
+==== Features
+
+[id="ocp-kubernetes-1-23-5-updates"]
+==== Updates from Kubernetes 1.23.5
+This update contains changes from Kubernetes 1.23.3 up to 1.23.5. More information can be found in the following changelogs: link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#v1234[1.23.4] and link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#v1235[1.23.5]
+
+
+[id="ocp-4-10-6-bug-fixes"]
+==== Bug fixes
+* Previously, the query for subnets in Cisco ACI's neutron implementation, which is avaiable in {rh-openstack-first}-16, returned unexpected results for a given network. Consequently, the {rh-openstack} `cluster-api-provider` could potentially try to provision instances with duplicated ports on the same subnet, which caused failed provision. With this update, an additional filter is added in the {rh-openstack} `cluster-api-provider` to ensure there is only one port per subnet. As a result, it is now possible to deploy {product-title} on {rh-openstack}-16 with Cisco ACI. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2050064[*BZ#2050064*])
+
+* Previously, `oc adm must gather` fell back to the `oc adm inspect` command when the specified image could not run. Consequently, it was difficult to understand information from the logs when the fall back happened. With this update, the logs are improved to make it explicit when a fall back inspection is performed. As a result, the output of `oc adm must gather` is easier to understand. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049427[*BZ#2049427*])
+
+* Previously, the `oc debug node` command did not have timeout specified on idle. Consequently, the users were never logged out of the cluster. With this update, a `TMOUT` environment variable for debug pod has been added to counter inactivity timeout. As a result, the session will be automatically terminated after `TMOUT` inactivity. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2060888[*BZ#2060888*])
+
+* Previously, the Ingress Operator performed health checks against the Ingress canary route. When the health check completed, the Ingress Operator did not close the TCP connection to the `LoadBalancer` because `keepalive` packets were enabled on the connection. While performing the next health check, a new connection was established to the `LoadBalancer` instead of using the existing connection. Consequently, this caused connections to accumulate on the `LoadBalancer`. Over time, this exhausted the number of connections on the `LoadBalancer`. With this update, Keepalive is disabled when connecting to the Ingress canary route. As a result, a new connection is made and closed each time the canary probe is run. While Keepalive is disabled, there is no longer an accumulation of established connections. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2063283[*BZ#2063283*])
+
+* Previously, the sink for event sources in the `Trigger/Subscription` modal in the *Topology* UI showed all resources, irrespective of whether they were created as a standalone or an underlying resource included with back KSVC, Broker, or KameletBinding. Consequently, users could sink to the underlying addressable resources as they showed up in the sink drop-down menu. With this update, a resource filter has been added to show only standalone resource sink events. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2059807[*BZ#2059807*])
+
+[id="ocp-4-10-6-updating"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Release Notes for 4.10.6

To be merged on 03-28

OCP version: **Applicable only to 4.10**

Direct Doc Preview: https://deploy-preview-43887--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-6