### PR TITLE
BZ2066952 ComplianceCheckResult updates

### DIFF
--- a/modules/compliance-filtering-results.adoc
+++ b/modules/compliance-filtering-results.adoc
@@ -2,8 +2,9 @@
 //
 // * security/compliance_operator/compliance-operator-remediation.adoc
 
-[id="filtering-failed-compliance-check-results_{context}"]
-= Filters for failed compliance check results
+:_content-type: PROCEDURE
+[id="filtering-compliance-check-results_{context}"]
+= Filters for compliance check results
 
 By default, the `ComplianceCheckResult` objects are labeled with several useful labels that allow you to query the checks and decide on the next steps after the results are generated.
 
@@ -38,3 +39,23 @@ $ oc get compliancecheckresults -l 'compliance.openshift.io/check-status=FAIL,!c
 ----
 
 The manual remediation steps are typically stored in the `description` attribute in the `ComplianceCheckResult` object.
+
+.ComplianceCheckResult Status
+[cols="1,1",options="header"]
+|===
+| ComplianceCheckResult Status | Description
+| PASS
+| Compliance check ran to completion and passed.
+| FAIL
+| Compliance check ran to completion and failed.
+| INFO
+| Compliance check ran to completion and found something not severe enough to be considered an error.
+| MANUAL
+| Compliance check does not have a way to automatically assess the success or failure and must be checked manually.
+| INCONSISTENT
+| Compliance check reports different results from different sources, typically cluster nodes.
+| ERROR
+| Compliance check ran, but could not complete properly.
+| NOT-APPLICABLE
+| Compliance check did not run because it is not applicable or not selected.
+|===

--- a/modules/compliance-inconsistent.adoc
+++ b/modules/compliance-inconsistent.adoc
@@ -2,8 +2,9 @@
 //
 // * security/compliance_operator/compliance-operator-remediation.adoc
 
+:_content-type: PROCEDURE
 [id="compliance-inconsistent_{context}"]
-= Inconsistent remediations
+= Inconsistent ComplianceScan
 The `ScanSetting` object lists the node roles that the compliance scans generated from the `ScanSetting` or `ScanSettingBinding` objects would scan. Each node role usually maps to a machine config pool.
 
 [IMPORTANT]

--- a/security/compliance_operator/compliance-operator-remediation.adoc
+++ b/security/compliance_operator/compliance-operator-remediation.adoc
@@ -1,12 +1,14 @@
 :_content-type: ASSEMBLY
 [id="compliance-operator-remediation"]
-= Managing Compliance Operator remediation
+= Managing Compliance Operator result and remediation
 include::_attributes/common-attributes.adoc[]
 :context: compliance-remediation
 
 toc::[]
 
 Each `ComplianceCheckResult` represents a result of one compliance rule check. If the rule can be remediated automatically, a `ComplianceRemediation` object with the same name, owned by the `ComplianceCheckResult` is created. Unless requested, the remediations are not applied automatically, which gives an {product-title} administrator the opportunity to review what the remediation does and only apply a remediation once it has been verified.
+
+include::modules/compliance-filtering-results.adoc[leveloffset=+1]
 
 include::modules/compliance-review.adoc[leveloffset=+1]
 
@@ -24,9 +26,7 @@ include::modules/compliance-removing-kubeletconfig.adoc[leveloffset=+1]
 
 include::modules/compliance-inconsistent.adoc[leveloffset=+1]
 
-include::modules/compliance-filtering-failed-results.adoc[leveloffset=+1]
-
 [role="_additional-resources"]
 == Additional resources
 
-*  For more information about `KubeletConfig` objects, see xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing-about_nodes-nodes-jobs[Modifying nodes].
+*  xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing-about_nodes-nodes-jobs[Modifying nodes].


### PR DESCRIPTION
please cherry-pick to 4.6+

Per [BZ2066952](https://bugzilla.redhat.com/show_bug.cgi?id=2066952):
Preview: https://deploy-preview-43888--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-remediation.html

* Changed the title of `Managing Compliance Operator remediation` to `Managing Compliance Operator result and remediation`
* Changed the  name of `Inconsistent Remediations` to `Inconsistent ComplianceScan`
* Moved the `Filters for failed compliance check results` to the first section
* Included a table in `Filters for failed compliance check results` to describe each status
* Renamed `Filters for failed compliance check results` to `Filters for compliance check results`