### PR TITLE
[Enterprise-4.9] OSDOCS-3202: This PR removes the CIDR range definition topic from OCP.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -913,9 +913,6 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
 - Name: Verifying connectivity to an endpoint
   File: verifying-connectivity-endpoint
-- Name: CIDR Range Definitions
-  File: cidr-range-definitions
-  Distros: openshift-enterprise,openshift-origin
 - Name: Configuring the node port service range
   File: configuring-node-port-service-range
 - Name: Configuring IP failover
@@ -1505,7 +1502,7 @@ Topics:
   - Name: Deploying a Spring Boot application with Argo CD
     File: deploying-a-spring-boot-application-with-argo-cd
   - Name: Argo CD custom resource properties
-    File: argo-cd-custom-resource-properties  
+    File: argo-cd-custom-resource-properties
   - Name: Monitoring application health status
     File: health-information-for-resources-deployment
   - Name: Configuring SSO for Argo CD using Dex

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -141,7 +141,7 @@ Topics:
     File: enabling-multicast
 - Name: Configuring a cluster-wide proxy during installation
   File: configuring-cluster-wide-proxy
-- Name: CIDR Range Definitions
+- Name: CIDR range definitions
   File: cidr-range-definitions
 ---
 Name: Nodes

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -159,7 +159,7 @@ Topics:
     File: enabling-multicast
 - Name: Configuring a cluster-wide proxy during installation
   File: configuring-cluster-wide-proxy
-- Name: CIDR Range Definitions
+- Name: CIDR range definitions
   File: cidr-range-definitions
 ---
 Name: Authentication and authorization

--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="cidr-range-definitions"]
-= CIDR Range Definitions
+= CIDR range definitions
 include::_attributes/common-attributes.adoc[]
 :context: cidr-range-definitions
 


### PR DESCRIPTION
This is a manual cherrypick of #43754 for the `enterprise-4.9` branch.