### PR TITLE
BZ1990485: Change commands for getting metrics for systemContainer kubelet and runtime

### DIFF
--- a/modules/nodes-nodes-resources-configuring-setting.adoc
+++ b/modules/nodes-nodes-resources-configuring-setting.adoc
@@ -9,25 +9,11 @@
 {product-title} supports the CPU and memory resource types for allocation. The `ephemeral-resource` resource type is supported as well. For the `cpu` type, the resource quantity is specified in units of cores, such as `200m`, `0.5`, or `1`. For `memory` and `ephemeral-storage`, it is specified in units of bytes, such as `200Ki`, `50Mi`, or `5Gi`.
 
 As an administrator, you can set these using a custom resource (CR) through a set of `<resource_type>=<resource_quantity>` pairs
-(e.g., *cpu=200m,memory=512Mi*).
+(e.g., `cpu=200m,memory=512Mi`). 
+
+For details on the recommended `system-reserved` values, refer to the link:https://access.redhat.com/solutions/5843241[recommended system-reserved values].
 
 .Prerequisites
-
-. To help you determine values for the `system-reserved` setting, you can introspect the resource use for a node by using the node summary API. Enter the following command for your node:
-+
-[source,terminal]
-----
-$ oc get --raw /api/v1/nodes/<node>/proxy/stats/summary
-----
-+
-For example, to access the resources from `cluster.node22` node, you can enter:
-+
-[source,terminal]
-----
-$ oc get --raw /api/v1/nodes/cluster.node22/proxy/stats/summary
-----
-+
-For more details, refer to the link:https://access.redhat.com/solutions/5843241[recommended system-reserved values]
 
 . Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure.
 Perform one of the following steps:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1990485

Preview: https://deploy-preview-43895--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-configuring.html#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring