### PR TITLE
BZ-2068405: the 5th step should not appear in the section of Creating an infrastructure node

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -65,6 +65,11 @@ include::modules/machineset-creating.adoc[leveloffset=+2]
 
 include::modules/creating-an-infra-node.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:moving-resources-to-infrastructure-machinesets[Moving resources to infrastructure machine sets]
+
 include::modules/creating-infra-machines.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/modules/creating-an-infra-node.adoc
+++ b/modules/creating-an-infra-node.adoc
@@ -71,4 +71,4 @@ spec:
 
 .. Save the file to apply the changes.
 
-. Move infrastructure resources to the newly labeled `infra` nodes.
+You can now move infrastructure resources to the newly labeled `infra` nodes.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2068405

Preview: Changes at the end of the [Creating an infrastructure node section](https://deploy-preview-43899--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#creating-an-infra-node_creating-infrastructure-machinesets)