### PR TITLE
JIRA-OSDOCS3384: Updated limited support status in service definition

### DIFF
--- a/modules/life-cycle-limited-support.adoc
+++ b/modules/life-cycle-limited-support.adoc
@@ -5,11 +5,14 @@
 [id="rosa-limited-support_{context}"]
 = Limited support status
 
-While operating outside of the supported versions list, you may be asked to upgrade the cluster to
-a supported version when requesting support. Additionally, Red Hat does not make any runtime or SLA
-guarantees for clusters outside of the supported versions list at the end of their 9 month end of
-life cycle date.
+When a cluster transitions to a _Limited Support_ status, it means that the SLA is no longer applicable and credits requested against the SLA are denied. It does not mean that you no longer have product support. You can return the cluster to a fully-supported status by remediating the violating factors.
 
-Red Hat provides commercially reasonable support to ensure an upgrade path from an unsupported
-release to a supported release is available. However, if a supported upgrade path is no longer
-available, you may be required to create a new cluster and migrate your workloads.
+A cluster transitions to a Limited Support status in the following scenarios:
+
+If you do not upgrade a cluster to a supported version before the end-of-life date:: Red Hat does not make any runtime or SLA guarantees for versions after their end-of-life date. To receive continued support, upgrade the cluster to a supported version within the 9-month period. If you do not upgrade the cluster within the 9-month period, the cluster transitions to a Limited Support status until you upgrade it to a supported version.
++
+Red Hat provides commercially reasonable support to upgrade from an unsupported version to a supported version. However, if a supported upgrade path is no longer available, you might have to create a new cluster and migrate your workloads.
+
+If you remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat:: If you used the cluster administrator rights, Red Hat is not responsible for any of your or your authorized users’ actions, including those that affect infrastructure services, service availability, or data loss. If Red Hat detects any such actions, the cluster transitions to a Limited Support status. Red Hat notifies you of the status change and you should either revert the action or create a support case to remediate the issue.
+
+If you have questions about the violating factors that cause a cluster to transition to a Limited Support status or need further assistance, open a support ticket.

--- a/modules/rosa-sdpolicy-account-management.adoc
+++ b/modules/rosa-sdpolicy-account-management.adoc
@@ -134,10 +134,17 @@ Any SLAs for the service itself are defined in Appendix 4 of the link:https://ww
 [id="rosa-limited-support_{context}"]
 == Limited support status
 
-You must not remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat. If using cluster administration rights, Red Hat is not responsible for any actions taken by you or any of your authorized users, including actions that might affect infrastructure services, service availability, and data loss.
+When a cluster transitions to a _Limited Support_ status, it means that the SLA is no longer applicable and credits requested against the SLA are denied. It does not mean that you no longer have product support. You can return the cluster to a fully-supported status by remediating the violating factors.
 
-If any actions that affect infrastructure services, service availability, or data loss are detected, Red Hat will notify the customer of such and request either that the action be reverted or to create a support case to work with Red Hat to remedy any issues.
+A cluster transitions to a Limited Support status in the following scenarios:
 
+If you do not upgrade a cluster to a supported version before the end-of-life date:: Red Hat does not make any runtime or SLA guarantees for versions after their end-of-life date. To receive continued support, upgrade the cluster to a supported version within the 9-month period. If you do not upgrade the cluster within the 9-month period, the cluster transitions to a Limited Support status until you upgrade it to a supported version.
++
+Red Hat provides commercially reasonable support to upgrade from an unsupported version to a supported version. However, if a supported upgrade path is no longer available, you might have to create a new cluster and migrate your workloads.
+
+If you remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat:: If you used the cluster administrator rights, Red Hat is not responsible for any of your or your authorized users’ actions, including those that affect infrastructure services, service availability, or data loss. If Red Hat detects any such actions, the cluster transitions to a Limited Support status. Red Hat notifies you of the status change and you should either revert the action or create a support case to remediate the issue.
+
+If you have questions about the violating factors that cause a cluster to transition to a Limited Support status or need further assistance, open a support ticket.
 
 [id="rosa-sdpolicy-support_{context}"]
 == Support

--- a/modules/sdpolicy-account-management.adoc
+++ b/modules/sdpolicy-account-management.adoc
@@ -195,9 +195,17 @@ Any SLAs for the service itself are defined in Appendix 4 of the link:https://ww
 [id="limited-support_{context}"]
 == Limited support status
 
-You must not remove or replace any native {product-title} components or any other component installed and managed by Red Hat. If using cluster administration rights, Red Hat is not responsible for any actions taken by you or any of your authorized users, including actions that might affect infrastructure services, service availability, and data loss.
+When a cluster transitions to a _Limited Support_ status, it means that the SLA is no longer applicable and credits requested against the SLA are denied. It does not mean that you no longer have product support. You can return the cluster to a fully-supported status by remediating the violating factors.
 
-If any actions that affect infrastructure services, service availability, or data loss are detected, Red Hat will notify the customer of such and request either that the action be reverted or to create a support case to work with Red Hat to remedy any issues.
+A cluster transitions to a Limited Support status in the following scenarios:
+
+If you do not upgrade a cluster to a supported version before the end-of-life date:: Red Hat does not make any runtime or SLA guarantees for versions after their end-of-life date. To receive continued support, upgrade the cluster to a supported version within the 9-month period. If you do not upgrade the cluster within the 9-month period, the cluster transitions to a Limited Support status until you upgrade it to a supported version.
++
+Red Hat provides commercially reasonable support to upgrade from an unsupported version to a supported version. However, if a supported upgrade path is no longer available, you might have to create a new cluster and migrate your workloads.
+
+If you remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat:: If you used the cluster administrator rights, Red Hat is not responsible for any of your or your authorized users’ actions, including those that affect infrastructure services, service availability, or data loss. If Red Hat detects any such actions, the cluster transitions to a Limited Support status. Red Hat notifies you of the status change and you should either revert the action or create a support case to remediate the issue.
+
+If you have questions about the violating factors that cause a cluster to transition to a Limited Support status or need further assistance, open a support ticket.
 
 [id="support_{context}"]
 == Support


### PR DESCRIPTION
This PR is to address the JIRA issue: https://issues.redhat.com/browse/OSDOCS-3384

Following is the change:
Updated the 'Limited Support Status' section in both OSD and ROSA docs with #1: an additional reason for a cluster going into limited support status. That reason is "The customer failed to upgrade the cluster in the required support time frame." and #2: made the section consistent across OSD and ROSA docs. 

The change is seen in the following topics:
ROSA topics:
- https://deploy-preview-43911--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-life-cycle.html#rosa-limited-support_rosa-life-cycle
- https://deploy-preview-43911--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-service-definition.html#rosa-limited-support_rosa-service-definition

OSD topics:
- https://deploy-preview-43911--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/osd-life-cycle.html#rosa-limited-support_osd-life-cycle
- https://deploy-preview-43911--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/osd-service-definition.html#limited-support_osd-service-definition

Repo: Request cherrypick to enterprise-4.10 and enterprise-4.11