### PR TITLE
BZ-2062756 IPI Install Procedure Replacing the Control Plane Node

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
@@ -20,6 +20,15 @@ include::modules/ipi-install-preparing-the-bare-metal-node.adoc[leveloffset=+1]
 
 * xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow[(Optional) Configuring host network interfaces in the install-config.yaml file]
 
+include::modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../post_installation_configuration/bare-metal-configuration.adoc[Bare metal configuration]
+
+* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member]
+
 include::modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc[leveloffset=+1]
 
 include::modules/ipi-install-diagnosing-duplicate-mac-address.adoc[leveloffset=+1]

--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -1,0 +1,166 @@
+// This is included in the following assemblies:
+//
+// installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+
+:_content-type: PROCEDURE
+[id="replacing-a-bare-metal-control-plane-node_{context}"]
+= Replacing a bare-metal control plane node
+
+Use the following procedure to replace an installer-provisioned {product-title} control plane node.
+
+[IMPORTANT]
+====
+If you reuse the `BareMetalHost` object definition from an existing control plane host, do not leave the `externallyProvisioned` field set to `true`.
+
+Existing control plane `BareMetalHost` objects may have the `externallyProvisioned` flag set to `true` if they were provisioned by the {product-title} installation program.
+====
+
+.Procedure
+
+. Remove the old `baremetalhost`, `machine` and `node` objects:
++
+[source,terminal]
+----
+$ oc delete node kni1-vmaster-0
+$ oc delete bmh -n openshift-machine-api vmaster-0
+$ oc delete machine -n openshift-machine-api kni1-master-0
+----
++
+. Create the new `baremetalhost` object and the secret to store the BMC credentials:
++
+[source,terminal]
+----
+$ cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kni1-master-0-bmc-secret
+  namespace: openshift-machine-api
+data:
+  password: <username>
+  username: <password>
+type: Opaque
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: kni1-master-0
+  namespace: openshift-machine-api
+spec:
+  automatedCleaningMode: disabled
+  bmc:
+    address: redfish-virtualmedia+http://192.168.124.113:8000/redfish/v1/Systems/f87eaf82-b32d-4291-ace6-b28677964e78
+    credentialsName: kni1-master-0-bmc-secret
+  bootMACAddress: aa:aa:aa:aa:ab:03
+  bootMode: UEFI
+  externallyProvisioned: false
+  hardwareProfile: unknown
+  online: true
+EOF
+----
++
+After the inspection is complete, the `baremetalhost` object is created and available to be provisioned.
+
+. View available `baremetalhost` objects:
++
+[source,terminal]
+----
+$ oc get bmh -n openshift-machine-api
+----
++
+.Example output
+[source,terminal]
+----
+NAME           STATE                    CONSUMER                   ONLINE   ERROR   AGE
+kni1-master-0  available                ocp-hkw9p-master-0         true             1h10m
+kni1-master-1  externally provisioned   ocp-hkw9p-master-1         true             4h53m
+kni1-master-2  externally provisioned   ocp-hkw9p-master-2         true             4h53m
+kni1-worker-0  provisioned              ocp-hkw9p-worker-0-ktmmx   true             4h53m
+kni1-worker-1  provisioned              ocp-hkw9p-worker-0-l2zmb   true             4h53m
+----
++
+There are no `MachineSet` objects for control plane nodes, so you must create a `Machine` object instead. You can copy the `providerSpec` from another control plane `Machine` object.
+
+. Create a `Machine` object:
++
+[source,terminal]
+----
+$ cat <<EOF | oc apply -f -
+apiVersion: machine.openshift.io/v1beta1
+kind: Machine
+metadata:
+  annotations:
+    metal3.io/BareMetalHost: openshift-machine-api/kni1-master-0
+  labels:
+    machine.openshift.io/cluster-api-cluster: kni1
+    machine.openshift.io/cluster-api-machine-role: master
+    machine.openshift.io/cluster-api-machine-type: master
+  name: kni1-master-0
+  namespace: openshift-machine-api
+spec:
+  metadata: {}
+  providerSpec:
+    value:
+      apiVersion: baremetal.cluster.k8s.io/v1alpha1
+      customDeploy:
+        method: install_coreos
+      hostSelector: {}
+      image:
+        checksum: ""
+        url: ""
+      kind: BareMetalMachineProviderSpec
+      metadata:
+        creationTimestamp: null
+      userData:
+        name: master-user-data-managed
+EOF
+----
++
+. To define and create the `BareMetalHost`, `Secret`, and `Machine` objects in a single step, create a YAML file (`example.yaml`) with their definitions and run the following command:
++
+[source,terminal]
+----
+$ oc create -f example.yaml
+----
++
+The provisioning process uses the baremetal-operator to install RHCOS and prepare the host to be added to the cluster. 
++
+. To view the `BareMetalHost` objects, run the following command:
++
+[source,terminal]
+----
+$ oc get bmh -A
+----
++
+.Example output
+[source,terminal]
+----
+NAME           STATE                    CONSUMER                   ONLINE   ERROR   AGE
+kni1-master-0  provisioned              ocp-hkw9p-master-0         true             2h53m
+kni1-master-1  externally provisioned   ocp-hkw9p-master-1         true             5h53m
+kni1-master-2  externally provisioned   ocp-hkw9p-master-2         true             5h53m
+kni1-worker-0  provisioned              ocp-hkw9p-worker-0-ktmmx   true             5h53m
+kni1-worker-1  provisioned              ocp-hkw9p-worker-0-l2zmb   true             5h53m
+----
++
+. After the RHCOS installation, verify that the `BareMetalHost` is added to the cluster:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME             STATUS      ROLES    AGE   VERSION
+kni1-master-0    available	 master   4m2s  v1.18.2
+kni1-master-1    available	 master   141m  v1.18.2
+kni1-master-2    available	 master   141m  v1.18.2
+kni1-worker-0    available	 worker   87m   v1.18.2
+----
++
+[NOTE]
+====
+After replacement of the new control plane node, the etcd pod running in the new node is in `crashloopback` status. See "Replacing an unhealthy etcd member" for more information.
+====


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2062756

For: Version 4.10+ (manual cherrypicks for [4.8](https://github.com/openshift/openshift-docs/pull/45181) and [4.9](https://github.com/openshift/openshift-docs/pull/45183))

Doc Preview: https://deploy-preview-43915--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#replacing-a-bare-metal-control-plane-node_ipi-install-expanding

Signed-off-by: Katie Tothill ktothill@redhat.com