### PR TITLE
[enterprise-4.9] BZ2063509: Updated procedure steps for Creating RHCOS images cache

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -54,56 +54,32 @@ $ sudo semanage fcontext -a -t httpd_sys_content_t "/home/kni/rhcos_image_cache(
 $ sudo restorecon -Rv /home/kni/rhcos_image_cache/
 ----
 
-
-. Get the commit ID from the installer:
+. Get the URI for the {op-system} image that the installation program will deploy on the bootstrap VM:
 +
 [source,terminal]
 ----
-$ export COMMIT_ID=$(/usr/local/bin/openshift-baremetal-install version | grep '^built from commit' | awk '{print $4}')
-----
-+
-The ID determines which images the installer needs to download.
-
-. Get the URI for the {op-system} image that the installer will deploy on the nodes:
-+
-[source,terminal]
-----
-$ export RHCOS_OPENSTACK_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq .images.openstack.path | sed 's/"//g')
-----
-
-. Get the URI for the {op-system} image that the installer will deploy on the bootstrap VM:
-+
-[source,terminal]
-----
-$ export RHCOS_QEMU_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq .images.qemu.path | sed 's/"//g')
-----
-
-. Get the path where the images are published:
-+
-[source,terminal]
-----
-$ export RHCOS_PATH=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json | jq .baseURI | sed 's/"//g')
+$ export RHCOS_QEMU_URI=$(/usr/local/bin/openshift-baremetal-install coreos print-stream-json | jq -r --arg ARCH "$(arch)" '.architectures[$ARCH].artifacts.qemu.formats["qcow2.gz"].disk.location')
 ----
 
 . Get the SHA hash for the {op-system} image that will be deployed on the bootstrap VM:
 +
 [source,terminal]
 ----
-$ export RHCOS_QEMU_SHA_UNCOMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq -r '.images.qemu["uncompressed-sha256"]')
+$ export RHCOS_QEMU_PATH=$(/usr/local/bin/openshift-baremetal-install coreos print-stream-json | jq -r --arg ARCH "$(arch)" '.architectures[$ARCH].artifacts.qemu.formats["qcow2.gz"].disk["sha256"]')
 ----
 
 . Get the SHA hash for the {op-system} image that will be deployed on the nodes:
 +
 [source,terminal]
 ----
-$ export RHCOS_OPENSTACK_SHA_COMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq -r '.images.openstack.sha256')
+$ export RHCOS_QEMU_UNCOMPRESSED_SHA256=$(/usr/local/bin/openshift-baremetal-install coreos print-stream-json | jq -r --arg ARCH "$(arch)" '.architectures[$ARCH].artifacts.qemu.formats["qcow2.gz"].disk["uncompressed-sha256"]')
 ----
 
 . Download the images and place them in the `/home/kni/rhcos_image_cache` directory:
 +
 [source,terminal]
 ----
-$ curl -L ${RHCOS_PATH}${RHCOS_QEMU_URI} -o /home/kni/rhcos_image_cache/${RHCOS_QEMU_URI}
+$ curl -L ${RHCOS_QEMU_URI} -o /home/kni/rhcos_image_cache/${RHCOS_QEMU_PATH}
 ----
 +
 [source,terminal]
@@ -141,22 +117,7 @@ $ export BAREMETAL_IP=$(ip addr show dev baremetal | awk '/inet /{print $2}' | c
 +
 [source,terminal]
 ----
-$ export RHCOS_OPENSTACK_SHA256=$(zcat /home/kni/rhcos_image_cache/${RHCOS_OPENSTACK_URI} | sha256sum | awk '{print $1}')
-----
-+
-[source,terminal]
-----
-$ export RHCOS_QEMU_SHA256=$(zcat /home/kni/rhcos_image_cache/${RHCOS_QEMU_URI} | sha256sum | awk '{print $1}')
-----
-+
-[source,terminal]
-----
-$ export CLUSTER_OS_IMAGE="http://${BAREMETAL_IP}:8080/${RHCOS_OPENSTACK_URI}?sha256=${RHCOS_OPENSTACK_SHA256}"
-----
-+
-[source,terminal]
-----
-$ export BOOTSTRAP_OS_IMAGE="http://${BAREMETAL_IP}:8080/${RHCOS_QEMU_URI}?sha256=${RHCOS_QEMU_SHA256}"
+$ export BOOTSTRAP_OS_IMAGE="http://${BAREMETAL_IP}:8080/${RHCOS_QEMU_PATH}?sha256=${RHCOS_QEMU_UNCOMPRESSED_SHA256}"
 ----
 +
 [source,terminal]
@@ -180,8 +141,7 @@ $ echo "    clusterOSImage=${CLUSTER_OS_IMAGE}"
 ----
 platform:
   baremetal:
-    bootstrapOSImage: http://<BAREMETAL_IP>:8080/<RHCOS_QEMU_URI>?sha256=<RHCOS_QEMU_SHA256>
-    clusterOSImage: http://<BAREMETAL_IP>:8080/<RHCOS_OPENSTACK_URI>?sha256=<RHCOS_OPENSTACK_SHA256>
+    bootstrapOSImage: http://<BAREMETAL_IP>:8080/<RHCOS_QEMU_PATH>?sha256=<RHCOS_QEMU_UNCOMPRESSED_SHA256>
 ----
 +
 See the "Configuration files" section for additional details.


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/pull/43705

For release: 4.9