### PR TITLE
 corrected wrong instances of Ingress Controller

### DIFF
--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -127,7 +127,7 @@ include::modules/installation-gcp-user-infra-adding-ingress.adoc[leveloffset=+1]
 
 [id="installation-gcp-user-infra-vpc-adding-firewall-rules"]
 == Adding ingress firewall rules
-The cluster requires several firewall rules. If you do not use a shared VPC, these rules are created by the ingress controller via the GCP cloud provider. When you use a shared VPC, you can either create cluster-wide firewall rules for all services now or create each rule based on events, when the cluster requests access. By creating each rule when the cluster requests access, you know exactly which firewall rules are required. By creating cluster-wide firewall rules, you can apply the same rule set across multiple clusters.
+The cluster requires several firewall rules. If you do not use a shared VPC, these rules are created by the Ingress Controller via the GCP cloud provider. When you use a shared VPC, you can either create cluster-wide firewall rules for all services now or create each rule based on events, when the cluster requests access. By creating each rule when the cluster requests access, you know exactly which firewall rules are required. By creating cluster-wide firewall rules, you can apply the same rule set across multiple clusters.
 
 If you choose to create each rule based on events, you must create firewall rules after you provision the cluster and during the life of the cluster when the console notifies you that rules are missing. Events that are similar to the following event are displayed, and you must add the firewall rules that are required:
 

--- a/modules/ingress-operator.adoc
+++ b/modules/ingress-operator.adoc
@@ -46,9 +46,9 @@ The Ingress Operator sets up the router in the `openshift-ingress` project and c
 $ oc get deployment -n openshift-ingress
 ----
 
-The Ingress Operator uses the `clusterNetwork[].cidr` from the `network/cluster` status to determine what mode (IPv4, IPv6, or dual stack) the managed ingress controller (router) should operate in. For example, if `clusterNetwork` contains only a v6 `cidr`, then the ingress controller operate in IPv6-only mode.
+The Ingress Operator uses the `clusterNetwork[].cidr` from the `network/cluster` status to determine what mode (IPv4, IPv6, or dual stack) the managed Ingress Controller (router) should operate in. For example, if `clusterNetwork` contains only a v6 `cidr`, then the ingress controller operate in IPv6-only mode.
 
-In the following example, ingress controllers managed by the Ingress Operator will run in IPv4-only mode because only one cluster network exists and the network is an IPv4 `cidr`:
+In the following example, Ingress Controllers managed by the Ingress Operator will run in IPv4-only mode because only one cluster network exists and the network is an IPv4 `cidr`:
 
 [source,terminal]
 ----

--- a/modules/migration-setting-up-target-cluster-to-accept-source-dns-domain.adoc
+++ b/modules/migration-setting-up-target-cluster-to-accept-source-dns-domain.adoc
@@ -26,11 +26,11 @@ In addition, when you migrate the application, another route is created in the t
 
 . Create a DNS record with your DNS provider that points the application's FQDN in the source cluster to the IP address of the default load balancer of the target cluster. This will redirect traffic away from your source cluster to your target cluster.
 +
-The FQDN of the application resolves to the load balancer of the target cluster. The default ingress controller router accept requests for that FQDN because a route for that hostname is exposed.
+The FQDN of the application resolves to the load balancer of the target cluster. The default Ingress Controller router accept requests for that FQDN because a route for that hostname is exposed.
 
 For secure HTTPS access, perform the following additional step:
 
-. Replace the x509 certificate of the default ingress controller created during the installation process with a custom certificate.
+. Replace the x509 certificate of the default Ingress Controller created during the installation process with a custom certificate.
 . Configure this certificate to include the wildcard DNS domains for both the source and target clusters in the `subjectAltName` field.
 +
 The new certificate is valid for securing connections made using either DNS domain.

--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -115,7 +115,7 @@ The Ingress Operator converts the TLS `1.0` of an `Old` or `Custom` profile to `
 `clientTLS` has the required subfields, `spec.clientTLS.clientCertificatePolicy` and `spec.clientTLS.ClientCA`.
 
 The `ClientCertificatePolicy` subfield accepts one of the two values: `Required` or `Optional`. The `ClientCA` subfield specifies a config map that is in the openshift-config namespace. The config map should contain a CA certificate bundle.
-The `AllowedSubjectPatterns` is an optional value that specifies a list of regular expressions, which are matched against the distinguished name on a valid client certificate to filter requests. The regular expressions must use PCRE syntax. At least one pattern must match a client certificate's distinguished name; otherwise, the ingress controller rejects the certificate and denies the connection. If not specified, the ingress controller does not reject certificates based on the distinguished name.
+The `AllowedSubjectPatterns` is an optional value that specifies a list of regular expressions, which are matched against the distinguished name on a valid client certificate to filter requests. The regular expressions must use PCRE syntax. At least one pattern must match a client certificate's distinguished name; otherwise, the Ingress Controller rejects the certificate and denies the connection. If not specified, the Ingress Controller does not reject certificates based on the distinguished name.
 
 |`routeAdmission`
 |`routeAdmission` defines a policy for handling new route claims, such as allowing or denying claims across namespaces.
@@ -150,7 +150,7 @@ The `AllowedSubjectPatterns` is an optional value that specifies a list of regul
 |`httpHeaders`
 |`httpHeaders` defines the policy for HTTP headers.
 
-By setting the `forwardedHeaderPolicy` for the `IngressControllerHTTPHeaders`, you specify when and how the Ingress controller sets the `Forwarded`, `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Proto`, and `X-Forwarded-Proto-Version` HTTP headers.
+By setting the `forwardedHeaderPolicy` for the `IngressControllerHTTPHeaders`, you specify when and how the Ingress Controller sets the `Forwarded`, `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Proto`, and `X-Forwarded-Proto-Version` HTTP headers.
 
 By default, the policy is set to `Append`.
 

--- a/modules/nw-ingress-controller-endpoint-publishing-strategies.adoc
+++ b/modules/nw-ingress-controller-endpoint-publishing-strategies.adoc
@@ -32,4 +32,4 @@ For more information, see the link:https://kubernetes.io/docs/concepts/services-
 
 The `HostNetwork` endpoint publishing strategy publishes the Ingress Controller on node ports where the Ingress Controller is deployed.
 
-An Ingress controller with the `HostNetwork` endpoint publishing strategy can have only one pod replica per node. If you want _n_ replicas, you must use at least _n_ nodes where those replicas can be scheduled. Because each pod replica requests ports `80` and `443` on the node host where it is scheduled, a replica cannot be scheduled to a node if another pod on the same node is using those ports.
+An Ingress Controller with the `HostNetwork` endpoint publishing strategy can have only one pod replica per node. If you want _n_ replicas, you must use at least _n_ nodes where those replicas can be scheduled. Because each pod replica requests ports `80` and `443` on the node host where it is scheduled, a replica cannot be scheduled to a node if another pod on the same node is using those ports.

--- a/modules/nw-using-ingress-and-routes.adoc
+++ b/modules/nw-using-ingress-and-routes.adoc
@@ -23,7 +23,7 @@ The administrator can create a wildcard DNS entry and then set up an Ingress
 Controller. Then, you can work with the edge Ingress Controller without
 having to contact the administrators.
 
-By default, every ingress controller in the cluster can admit any route created in any project in the cluster.
+By default, every Ingress Controller in the cluster can admit any route created in any project in the cluster.
 
 The Ingress Controller:
 

--- a/modules/ossm-architecture.adoc
+++ b/modules/ossm-architecture.adoc
@@ -20,7 +20,7 @@ The data plane is implemented in such a way that it intercepts all inbound (ingr
 
 ** *Gateways* are proxies operating as load balancers receiving incoming or outgoing HTTP/TCP connections. Gateway configurations are applied to standalone Envoy proxies that are running at the edge of the mesh, rather than sidecar Envoy proxies running alongside your service workloads. You use a Gateway to manage inbound and outbound traffic for your mesh, letting you specify which traffic you want to enter or leave the mesh.
 
-*** *Ingress-gateway* - Also known as an ingress controller, the Ingress Gateway is a dedicated Envoy proxy that receives and controls traffic entering the service mesh. An Ingress Gateway allows features such as monitoring and route rules to be applied to traffic entering the cluster.
+*** *Ingress-gateway* - Also known as an Ingress Controller, the Ingress Gateway is a dedicated Envoy proxy that receives and controls traffic entering the service mesh. An Ingress Gateway allows features such as monitoring and route rules to be applied to traffic entering the cluster.
 
 *** *Egress-gateway* - Also known as an egress controller, the Egress Gateway is a dedicated Envoy proxy that manages traffic leaving the service mesh. An Egress Gateway allows features such as monitoring and route rules to be applied to traffic exiting the mesh.
 

--- a/modules/security-network-policies.adoc
+++ b/modules/security-network-policies.adoc
@@ -7,5 +7,5 @@
 
 Using _network policies_, you can isolate pods from each other in the same project.
 Network policies can deny all network access to a pod,
-only allow connections for the ingress controller, reject connections from
+only allow connections for the Ingress Controller, reject connections from
 pods in other projects, or set similar rules for how networks behave.

--- a/networking/external_dns_operator/nw-control-dns-records-public-hosted-zone-aws.adoc
+++ b/networking/external_dns_operator/nw-control-dns-records-public-hosted-zone-aws.adoc
@@ -85,7 +85,7 @@ spec:
 <5> Defines the `AWS Route53` DNS provider.
 <6> Defines options for the source of DNS records.
 <7> Defines OpenShift `route` resource as the source for the DNS records which gets created in the previously specified DNS provider.
-<8> If the source is `OpenShiftRoute`, then you can pass the OpenShift ingress controller name. External DNS Operator selects the canonical hostname of that router as the target while creating CNAME record.
+<8> If the source is `OpenShiftRoute`, then you can pass the OpenShift Ingress Controller name. External DNS Operator selects the canonical hostname of that router as the target while creating CNAME record.
 
 . Check the records created for OCP routes using the following command:
 +

--- a/networking/external_dns_operator/nw-control-dns-records-public-hosted-zone-azure.adoc
+++ b/networking/external_dns_operator/nw-control-dns-records-public-hosted-zone-azure.adoc
@@ -84,7 +84,7 @@ spec:
 <2> Define the zone ID.
 <3> defines the Azure DNS provider.
 <4> You can define options for the source of DNS records.
-<5> If the source is `OpenShiftRoute` then you can pass the OpenShift ingress controller name. External DNS selects the canonical hostname of that router as the target while creating CNAME record.
+<5> If the source is `OpenShiftRoute` then you can pass the OpenShift Ingress Controller name. External DNS selects the canonical hostname of that router as the target while creating CNAME record.
 <6> Defines OpenShift `route` resource as the source for the DNS records which gets created in the previously specified DNS provider.
 
 . Check the records created for OCP routes using the following command:

--- a/networking/external_dns_operator/nw-control-dns-records-public-managed-zone-gcp.adoc
+++ b/networking/external_dns_operator/nw-control-dns-records-public-managed-zone-gcp.adoc
@@ -100,7 +100,7 @@ spec:
 <4> Specify the exact domain of the zone you want to update. The hostname of the routes must be subdomains of the specified domain.
 <5> Defines Google Cloud DNS provider.
 <6> You can define options for the source of DNS records.
-<7> If the source is `OpenShiftRoute` then you can pass the OpenShift ingress controller name. External DNS selects the canonical hostname of that router as the target while creating CNAME record.
+<7> If the source is `OpenShiftRoute` then you can pass the OpenShift Ingress Controller name. External DNS selects the canonical hostname of that router as the target while creating CNAME record.
 <8> Defines OpenShift `route` resource as the source for the DNS records which gets created in the previously specified DNS provider.
 
 . Check the records created for OCP routes using the following command:

--- a/networking/external_dns_operator/nw-external-dns-operator-configuration-parameters.adoc
+++ b/networking/external_dns_operator/nw-external-dns-operator-configuration-parameters.adoc
@@ -99,6 +99,6 @@ source:
 ----
 
 <1> ExternalDNS` uses type `route` as source for creating dns records.
-<2> If the source is `OpenShiftRoute`, then you can pass the ingress controller name. The `ExternalDNS` uses canonical name of ingress controller as the target for CNAME record.
+<2> If the source is `OpenShiftRoute`, then you can pass the Ingress Controller name. The `ExternalDNS` uses canonical name of Ingress Controller as the target for CNAME record.
 
 |===

--- a/rest_api/config_apis/infrastructure-config-openshift-io-v1.adoc
+++ b/rest_api/config_apis/infrastructure-config-openshift-io-v1.adoc
@@ -12,7 +12,7 @@ toc::[]
 Description::
 +
 --
-Infrastructure holds cluster-wide information about Infrastructure.  The canonical name is `cluster` 
+Infrastructure holds cluster-wide information about Infrastructure.  The canonical name is `cluster`
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -69,7 +69,7 @@ Type::
 
 | `cloudConfig`
 | `object`
-| cloudConfig is a reference to a ConfigMap containing the cloud provider configuration file. This configuration file is used to configure the Kubernetes cloud provider integration when using the built-in cloud provider integration or the external cloud controller manager. The namespace for this config map is openshift-config. 
+| cloudConfig is a reference to a ConfigMap containing the cloud provider configuration file. This configuration file is used to configure the Kubernetes cloud provider integration when using the built-in cloud provider integration or the external cloud controller manager. The namespace for this config map is openshift-config.
  cloudConfig should only be consumed by the kube_cloud_config controller. The controller is responsible for using the user configuration in the spec for various platforms and combining that with the user provided ConfigMap in this field to create a stitched kube cloud config. The controller generates a ConfigMap `kube-cloud-config` in `openshift-config-managed` namespace with the kube cloud config is stored in `cloud.conf` key. All the clients are expected to use the generated ConfigMap only.
 
 | `platformSpec`
@@ -81,7 +81,7 @@ Type::
 Description::
 +
 --
-cloudConfig is a reference to a ConfigMap containing the cloud provider configuration file. This configuration file is used to configure the Kubernetes cloud provider integration when using the built-in cloud provider integration or the external cloud controller manager. The namespace for this config map is openshift-config. 
+cloudConfig is a reference to a ConfigMap containing the cloud provider configuration file. This configuration file is used to configure the Kubernetes cloud provider integration when using the built-in cloud provider integration or the external cloud controller manager. The namespace for this config map is openshift-config.
  cloudConfig should only be consumed by the kube_cloud_config controller. The controller is responsible for using the user configuration in the spec for various platforms and combining that with the user provided ConfigMap in this field to create a stitched kube cloud config. The controller generates a ConfigMap `kube-cloud-config` in `openshift-config-managed` namespace with the kube cloud config is stored in `cloud.conf` key. All the clients are expected to use the generated ConfigMap only.
 --
 
@@ -101,7 +101,7 @@ Type::
 
 | `name`
 | `string`
-| 
+|
 
 |===
 === .spec.platformSpec
@@ -425,7 +425,7 @@ Type::
 
 | `platform`
 | `string`
-| platform is the underlying infrastructure provider for the cluster. 
+| platform is the underlying infrastructure provider for the cluster.
  Deprecated: Use platformStatus.type instead.
 
 | `platformStatus`
@@ -496,7 +496,7 @@ Type::
 
 | `type`
 | `string`
-| type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere", "oVirt", "EquinixMetal", "PowerVS", "AlibabaCloud" and "None". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform. 
+| type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere", "oVirt", "EquinixMetal", "PowerVS", "AlibabaCloud" and "None". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.
  This value will be synced with to the `status.platform` and `status.platformStatus.type`. Currently this value cannot be changed once set.
 
 | `vsphere`
@@ -1227,7 +1227,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../config_apis/infrastructure-config-openshift-io-v1.adoc#infrastructure-config-openshift-io-v1[`Infrastructure`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -1296,7 +1296,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions_v2[`DeleteOptions_v2`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -1365,7 +1365,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -1403,7 +1403,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../config_apis/infrastructure-config-openshift-io-v1.adoc#infrastructure-config-openshift-io-v1[`Infrastructure`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -1493,7 +1493,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -1531,7 +1531,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../config_apis/infrastructure-config-openshift-io-v1.adoc#infrastructure-config-openshift-io-v1[`Infrastructure`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -1545,5 +1545,3 @@ Description::
 | 401 - Unauthorized
 | Empty
 |===
-
-

--- a/rest_api/machine_apis/kubeletconfig-machineconfiguration-openshift-io-v1.adoc
+++ b/rest_api/machine_apis/kubeletconfig-machineconfiguration-openshift-io-v1.adoc
@@ -84,9 +84,9 @@ Type::
 
 | `tlsSecurityProfile`
 | `object`
-| tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers. 
- If unset, the default is based on the apiservers.config.openshift.io/cluster resource. 
- Note that when using the Old, Intermediate, and Modern profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied to the ingress controller, resulting in a rollout. 
+| tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers.
+ If unset, the default is based on the apiservers.config.openshift.io/cluster resource.
+ Note that when using the Old, Intermediate, and Modern profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied to the ingress controller, resulting in a rollout.
  Note that the minimum TLS version for ingress controllers is 1.1, and the maximum TLS version is 1.2.  An implication of this restriction is that the Modern TLS profile type cannot be used because it requires TLS 1.3.
 
 |===
@@ -170,9 +170,9 @@ Required::
 Description::
 +
 --
-tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers. 
- If unset, the default is based on the apiservers.config.openshift.io/cluster resource. 
- Note that when using the Old, Intermediate, and Modern profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied to the ingress controller, resulting in a rollout. 
+tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers.
+ If unset, the default is based on the apiservers.config.openshift.io/cluster resource.
+ Note that when using the Old, Intermediate, and Modern profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied to the ingress controller, resulting in a rollout.
  Note that the minimum TLS version for ingress controllers is 1.1, and the maximum TLS version is 1.2.  An implication of this restriction is that the Modern TLS profile type cannot be used because it requires TLS 1.3.
 --
 
@@ -188,36 +188,36 @@ Type::
 
 | `custom`
 | ``
-| custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this: 
+| custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this:
    ciphers:     - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305     - ECDHE-RSA-AES128-GCM-SHA256     - ECDHE-ECDSA-AES128-GCM-SHA256   minTLSVersion: TLSv1.1
 
 | `intermediate`
 | ``
-| intermediate is a TLS security profile based on: 
- https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29 
- and looks like this (yaml): 
+| intermediate is a TLS security profile based on:
+ https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+ and looks like this (yaml):
    ciphers:     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256     - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256   minTLSVersion: TLSv1.2
 
 | `modern`
 | ``
-| modern is a TLS security profile based on: 
- https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility 
- and looks like this (yaml): 
-   ciphers:     - TLS_AES_128_GCM_SHA256     - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256   minTLSVersion: TLSv1.3 
+| modern is a TLS security profile based on:
+ https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+ and looks like this (yaml):
+   ciphers:     - TLS_AES_128_GCM_SHA256     - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256   minTLSVersion: TLSv1.3
  NOTE: Currently unsupported.
 
 | `old`
 | ``
-| old is a TLS security profile based on: 
- https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility 
- and looks like this (yaml): 
+| old is a TLS security profile based on:
+ https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
+ and looks like this (yaml):
    ciphers:     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256     - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256     - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA     - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA     - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA     - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA     - TLS_RSA_WITH_AES_128_GCM_SHA256     - TLS_RSA_WITH_AES_256_GCM_SHA384     - TLS_RSA_WITH_AES_128_CBC_SHA256     - TLS_RSA_WITH_AES_128_CBC_SHA     - TLS_RSA_WITH_AES_256_CBC_SHA     - TLS_RSA_WITH_3DES_EDE_CBC_SHA   minTLSVersion: TLSv1.0
 
 | `type`
 | `string`
-| type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on: 
- https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations 
- The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced. 
+| type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on:
+ https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
+ The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced.
  Note that the Modern profile is currently not supported because it is not yet well adopted by common software libraries.
 
 |===
@@ -477,7 +477,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../machine_apis/kubeletconfig-machineconfiguration-openshift-io-v1.adoc#kubeletconfig-machineconfiguration-openshift-io-v1[`KubeletConfig`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -546,7 +546,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions_v2[`DeleteOptions_v2`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -615,7 +615,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -653,7 +653,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../machine_apis/kubeletconfig-machineconfiguration-openshift-io-v1.adoc#kubeletconfig-machineconfiguration-openshift-io-v1[`KubeletConfig`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -743,7 +743,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -781,7 +781,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../machine_apis/kubeletconfig-machineconfiguration-openshift-io-v1.adoc#kubeletconfig-machineconfiguration-openshift-io-v1[`KubeletConfig`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -795,5 +795,3 @@ Description::
 | 401 - Unauthorized
 | Empty
 |===
-
-

--- a/rest_api/network_apis/ingress-networking-k8s-io-v1.adoc
+++ b/rest_api/network_apis/ingress-networking-k8s-io-v1.adoc
@@ -678,7 +678,7 @@ Defaults to unset
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions[`DeleteOptions`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -775,7 +775,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../network_apis/ingress-networking-k8s-io-v1.adoc#ingress-networking-k8s-io-v1[`Ingress`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -920,7 +920,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions[`DeleteOptions`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -980,7 +980,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -1020,7 +1020,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../network_apis/ingress-networking-k8s-io-v1.adoc#ingress-networking-k8s-io-v1[`Ingress`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -1180,7 +1180,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -1220,7 +1220,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../network_apis/ingress-networking-k8s-io-v1.adoc#ingress-networking-k8s-io-v1[`Ingress`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -1234,5 +1234,3 @@ Description::
 | 401 - Unauthorized
 | Empty
 |===
-
-

--- a/rest_api/operator_apis/ingresscontroller-operator-openshift-io-v1.adoc
+++ b/rest_api/operator_apis/ingresscontroller-operator-openshift-io-v1.adoc
@@ -12,9 +12,9 @@ toc::[]
 Description::
 +
 --
-IngressController describes a managed ingress controller for the cluster. The controller can service OpenShift Route and Kubernetes Ingress resources. 
- When an IngressController is created, a new ingress controller deployment is created to allow external traffic to reach the services that expose Ingress or Route resources. Updating this resource may lead to disruption for public facing network connections as a new ingress controller revision may be rolled out. 
- https://kubernetes.io/docs/concepts/services-networking/ingress-controllers 
+IngressController describes a managed ingress controller for the cluster. The controller can service OpenShift Route and Kubernetes Ingress resources.
+ When an IngressController is created, a new ingress controller deployment is created to allow external traffic to reach the services that expose Ingress or Route resources. Updating this resource may lead to disruption for public facing network connections as a new ingress controller revision may be rolled out.
+ https://kubernetes.io/docs/concepts/services-networking/ingress-controllers
  Whenever possible, sensible defaults for the platform are used. See each field for more details.
 --
 
@@ -73,33 +73,33 @@ Type::
 
 | `defaultCertificate`
 | `object`
-| defaultCertificate is a reference to a secret containing the default certificate served by the ingress controller. When Routes don't specify their own certificate, defaultCertificate is used. 
- The secret must contain the following keys and data: 
-   tls.crt: certificate file contents   tls.key: key file contents 
- If unset, a wildcard certificate is automatically generated and used. The certificate is valid for the ingress controller domain (and subdomains) and the generated certificate's CA will be automatically integrated with the cluster's trust store. 
- If a wildcard certificate is used and shared by multiple HTTP/2 enabled routes (which implies ALPN) then clients (i.e., notably browsers) are at liberty to reuse open connections. This means a client can reuse a connection to another route and that is likely to fail. This behaviour is generally known as connection coalescing. 
+| defaultCertificate is a reference to a secret containing the default certificate served by the ingress controller. When Routes don't specify their own certificate, defaultCertificate is used.
+ The secret must contain the following keys and data:
+   tls.crt: certificate file contents   tls.key: key file contents
+ If unset, a wildcard certificate is automatically generated and used. The certificate is valid for the ingress controller domain (and subdomains) and the generated certificate's CA will be automatically integrated with the cluster's trust store.
+ If a wildcard certificate is used and shared by multiple HTTP/2 enabled routes (which implies ALPN) then clients (i.e., notably browsers) are at liberty to reuse open connections. This means a client can reuse a connection to another route and that is likely to fail. This behaviour is generally known as connection coalescing.
  The in-use certificate (whether generated or user-specified) will be automatically integrated with OpenShift's built-in OAuth server.
 
 | `domain`
 | `string`
-| domain is a DNS name serviced by the ingress controller and is used to configure multiple features: 
- * For the LoadBalancerService endpoint publishing strategy, domain is   used to configure DNS records. See endpointPublishingStrategy. 
- * When using a generated default certificate, the certificate will be valid   for domain and its subdomains. See defaultCertificate. 
- * The value is published to individual Route statuses so that end-users   know where to target external DNS records. 
- domain must be unique among all IngressControllers, and cannot be updated. 
+| domain is a DNS name serviced by the ingress controller and is used to configure multiple features:
+ * For the LoadBalancerService endpoint publishing strategy, domain is   used to configure DNS records. See endpointPublishingStrategy.
+ * When using a generated default certificate, the certificate will be valid   for domain and its subdomains. See defaultCertificate.
+ * The value is published to individual Route statuses so that end-users   know where to target external DNS records.
+ domain must be unique among all IngressControllers, and cannot be updated.
  If empty, defaults to ingress.config.openshift.io/cluster .spec.domain.
 
 | `endpointPublishingStrategy`
 | `object`
-| endpointPublishingStrategy is used to publish the ingress controller endpoints to other networks, enable load balancer integrations, etc. 
- If unset, the default is based on infrastructure.config.openshift.io/cluster .status.platform: 
-   AWS:      LoadBalancerService (with External scope)   Azure:    LoadBalancerService (with External scope)   GCP:      LoadBalancerService (with External scope)   IBMCloud: LoadBalancerService (with External scope)   Libvirt:  HostNetwork 
- Any other platform types (including None) default to HostNetwork. 
+| endpointPublishingStrategy is used to publish the ingress controller endpoints to other networks, enable load balancer integrations, etc.
+ If unset, the default is based on infrastructure.config.openshift.io/cluster .status.platform:
+   AWS:      LoadBalancerService (with External scope)   Azure:    LoadBalancerService (with External scope)   GCP:      LoadBalancerService (with External scope)   IBMCloud: LoadBalancerService (with External scope)   Libvirt:  HostNetwork
+ Any other platform types (including None) default to HostNetwork.
  endpointPublishingStrategy cannot be updated.
 
 | `httpEmptyRequestsPolicy`
 | `string`
-| httpEmptyRequestsPolicy describes how HTTP connections should be handled if the connection times out before a request is received. Allowed values for this field are "Respond" and "Ignore".  If the field is set to "Respond", the ingress controller sends an HTTP 400 or 408 response, logs the connection (if access logging is enabled), and counts the connection in the appropriate metrics.  If the field is set to "Ignore", the ingress controller closes the connection without sending a response, logging the connection, or incrementing metrics.  The default value is "Respond". 
+| httpEmptyRequestsPolicy describes how HTTP connections should be handled if the connection times out before a request is received. Allowed values for this field are "Respond" and "Ignore".  If the field is set to "Respond", the ingress controller sends an HTTP 400 or 408 response, logs the connection (if access logging is enabled), and counts the connection in the appropriate metrics.  If the field is set to "Ignore", the ingress controller closes the connection without sending a response, logging the connection, or incrementing metrics.  The default value is "Respond".
  Typically, these connections come from load balancers' health probes or Web browsers' speculative connections ("preconnect") and can be safely ignored.  However, these requests may also be caused by network errors, and so setting this field to "Ignore" may impede detection and diagnosis of problems.  In addition, these requests may be caused by port scans, in which case logging empty requests may aid in detecting intrusion attempts.
 
 | `httpErrorCodePages`
@@ -108,7 +108,7 @@ Type::
 
 | `httpHeaders`
 | `object`
-| httpHeaders defines policy for HTTP headers. 
+| httpHeaders defines policy for HTTP headers.
  If this field is empty, the default values are used.
 
 | `logging`
@@ -117,12 +117,12 @@ Type::
 
 | `namespaceSelector`
 | `object`
-| namespaceSelector is used to filter the set of namespaces serviced by the ingress controller. This is useful for implementing shards. 
+| namespaceSelector is used to filter the set of namespaces serviced by the ingress controller. This is useful for implementing shards.
  If unset, the default is no filtering.
 
 | `nodePlacement`
 | `object`
-| nodePlacement enables explicit control over the scheduling of the ingress controller. 
+| nodePlacement enables explicit control over the scheduling of the ingress controller.
  If unset, defaults are used. See NodePlacement for more details.
 
 | `replicas`
@@ -131,23 +131,23 @@ Type::
 
 | `routeAdmission`
 | `object`
-| routeAdmission defines a policy for handling new route claims (for example, to allow or deny claims across namespaces). 
+| routeAdmission defines a policy for handling new route claims (for example, to allow or deny claims across namespaces).
  If empty, defaults will be applied. See specific routeAdmission fields for details about their defaults.
 
 | `routeSelector`
 | `object`
-| routeSelector is used to filter the set of Routes serviced by the ingress controller. This is useful for implementing shards. 
+| routeSelector is used to filter the set of Routes serviced by the ingress controller. This is useful for implementing shards.
  If unset, the default is no filtering.
 
 | `tlsSecurityProfile`
 | `object`
-| tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers. 
- If unset, the default is based on the apiservers.config.openshift.io/cluster resource. 
+| tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers.
+ If unset, the default is based on the apiservers.config.openshift.io/cluster resource.
  Note that when using the Old, Intermediate, and Modern profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied to the ingress controller, resulting in a rollout.
 
 | `tuningOptions`
 | `object`
-| tuningOptions defines parameters for adjusting the performance of ingress controller pods. All fields are optional and will use their respective defaults if not set. See specific tuningOptions fields for more details. 
+| tuningOptions defines parameters for adjusting the performance of ingress controller pods. All fields are optional and will use their respective defaults if not set. See specific tuningOptions fields for more details.
  Setting fields within tuningOptions is generally not recommended. The default values are suitable for most configurations.
 
 | `unsupportedConfigOverrides`
@@ -185,7 +185,7 @@ Required::
 
 | `clientCertificatePolicy`
 | `string`
-| clientCertificatePolicy specifies whether the ingress controller requires clients to provide certificates.  This field accepts the values "Required" or "Optional". 
+| clientCertificatePolicy specifies whether the ingress controller requires clients to provide certificates.  This field accepts the values "Required" or "Optional".
  Note that the ingress controller only checks client certificates for edge-terminated and reencrypt TLS routes; it cannot check certificates for cleartext HTTP or passthrough TLS routes.
 
 |===
@@ -217,11 +217,11 @@ Required::
 Description::
 +
 --
-defaultCertificate is a reference to a secret containing the default certificate served by the ingress controller. When Routes don't specify their own certificate, defaultCertificate is used. 
- The secret must contain the following keys and data: 
-   tls.crt: certificate file contents   tls.key: key file contents 
- If unset, a wildcard certificate is automatically generated and used. The certificate is valid for the ingress controller domain (and subdomains) and the generated certificate's CA will be automatically integrated with the cluster's trust store. 
- If a wildcard certificate is used and shared by multiple HTTP/2 enabled routes (which implies ALPN) then clients (i.e., notably browsers) are at liberty to reuse open connections. This means a client can reuse a connection to another route and that is likely to fail. This behaviour is generally known as connection coalescing. 
+defaultCertificate is a reference to a secret containing the default certificate served by the ingress controller. When Routes don't specify their own certificate, defaultCertificate is used.
+ The secret must contain the following keys and data:
+   tls.crt: certificate file contents   tls.key: key file contents
+ If unset, a wildcard certificate is automatically generated and used. The certificate is valid for the ingress controller domain (and subdomains) and the generated certificate's CA will be automatically integrated with the cluster's trust store.
+ If a wildcard certificate is used and shared by multiple HTTP/2 enabled routes (which implies ALPN) then clients (i.e., notably browsers) are at liberty to reuse open connections. This means a client can reuse a connection to another route and that is likely to fail. This behaviour is generally known as connection coalescing.
  The in-use certificate (whether generated or user-specified) will be automatically integrated with OpenShift's built-in OAuth server.
 --
 
@@ -244,10 +244,10 @@ Type::
 Description::
 +
 --
-endpointPublishingStrategy is used to publish the ingress controller endpoints to other networks, enable load balancer integrations, etc. 
- If unset, the default is based on infrastructure.config.openshift.io/cluster .status.platform: 
-   AWS:      LoadBalancerService (with External scope)   Azure:    LoadBalancerService (with External scope)   GCP:      LoadBalancerService (with External scope)   IBMCloud: LoadBalancerService (with External scope)   Libvirt:  HostNetwork 
- Any other platform types (including None) default to HostNetwork. 
+endpointPublishingStrategy is used to publish the ingress controller endpoints to other networks, enable load balancer integrations, etc.
+ If unset, the default is based on infrastructure.config.openshift.io/cluster .status.platform:
+   AWS:      LoadBalancerService (with External scope)   Azure:    LoadBalancerService (with External scope)   GCP:      LoadBalancerService (with External scope)   IBMCloud: LoadBalancerService (with External scope)   Libvirt:  HostNetwork
+ Any other platform types (including None) default to HostNetwork.
  endpointPublishingStrategy cannot be updated.
 --
 
@@ -281,21 +281,21 @@ Required::
 
 | `type`
 | `string`
-| type is the publishing strategy to use. Valid values are: 
- * LoadBalancerService 
- Publishes the ingress controller using a Kubernetes LoadBalancer Service. 
- In this configuration, the ingress controller deployment uses container networking. A LoadBalancer Service is created to publish the deployment. 
- See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer 
- If domain is set, a wildcard DNS record will be managed to point at the LoadBalancer Service's external name. DNS records are managed only in DNS zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone. 
- Wildcard DNS management is currently supported only on the AWS, Azure, and GCP platforms. 
- * HostNetwork 
- Publishes the ingress controller on node ports where the ingress controller is deployed. 
- In this configuration, the ingress controller deployment uses host networking, bound to node ports 80 and 443. The user is responsible for configuring an external load balancer to publish the ingress controller via the node ports. 
- * Private 
- Does not publish the ingress controller. 
- In this configuration, the ingress controller deployment uses container networking, and is not explicitly published. The user must manually publish the ingress controller. 
- * NodePortService 
- Publishes the ingress controller using a Kubernetes NodePort Service. 
+| type is the publishing strategy to use. Valid values are:
+ * LoadBalancerService
+ Publishes the ingress controller using a Kubernetes LoadBalancer Service.
+ In this configuration, the ingress controller deployment uses container networking. A LoadBalancer Service is created to publish the deployment.
+ See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+ If domain is set, a wildcard DNS record will be managed to point at the LoadBalancer Service's external name. DNS records are managed only in DNS zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone.
+ Wildcard DNS management is currently supported only on the AWS, Azure, and GCP platforms.
+ * HostNetwork
+ Publishes the ingress controller on node ports where the ingress controller is deployed.
+ In this configuration, the ingress controller deployment uses host networking, bound to node ports 80 and 443. The user is responsible for configuring an external load balancer to publish the ingress controller via the node ports.
+ * Private
+ Does not publish the ingress controller.
+ In this configuration, the ingress controller deployment uses container networking, and is not explicitly published. The user must manually publish the ingress controller.
+ * NodePortService
+ Publishes the ingress controller using a Kubernetes NodePort Service.
  In this configuration, the ingress controller deployment uses container networking. A NodePort Service is created to publish the deployment. The specific node ports are dynamically allocated by OpenShift; however, to support static port allocations, user changes to the node port field of the managed NodePort Service will preserved.
 
 |===
@@ -318,10 +318,10 @@ Type::
 
 | `protocol`
 | `string`
-| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. 
- PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. 
- The following values are valid for this field: 
- * The empty string. * "TCP". * "PROXY". 
+| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol.
+ PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol.
+ The following values are valid for this field:
+ * The empty string. * "TCP". * "PROXY".
  The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.
 
 |===
@@ -346,7 +346,7 @@ Required::
 
 | `providerParameters`
 | `object`
-| providerParameters holds desired load balancer information specific to the underlying infrastructure provider. 
+| providerParameters holds desired load balancer information specific to the underlying infrastructure provider.
  If empty, defaults will be applied. See specific providerParameters fields for details about their defaults.
 
 | `scope`
@@ -358,7 +358,7 @@ Required::
 Description::
 +
 --
-providerParameters holds desired load balancer information specific to the underlying infrastructure provider. 
+providerParameters holds desired load balancer information specific to the underlying infrastructure provider.
  If empty, defaults will be applied. See specific providerParameters fields for details about their defaults.
 --
 
@@ -376,12 +376,12 @@ Required::
 
 | `aws`
 | `object`
-| aws provides configuration settings that are specific to AWS load balancers. 
+| aws provides configuration settings that are specific to AWS load balancers.
  If empty, defaults will be applied. See specific aws fields for details about their defaults.
 
 | `gcp`
 | `object`
-| gcp provides configuration settings that are specific to GCP load balancers. 
+| gcp provides configuration settings that are specific to GCP load balancers.
  If empty, defaults will be applied. See specific gcp fields for details about their defaults.
 
 | `type`
@@ -393,7 +393,7 @@ Required::
 Description::
 +
 --
-aws provides configuration settings that are specific to AWS load balancers. 
+aws provides configuration settings that are specific to AWS load balancers.
  If empty, defaults will be applied. See specific aws fields for details about their defaults.
 --
 
@@ -419,11 +419,11 @@ Required::
 
 | `type`
 | `string`
-| type is the type of AWS load balancer to instantiate for an ingresscontroller. 
- Valid values are: 
- * "Classic": A Classic Load Balancer that makes routing decisions at either   the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See   the following for additional details: 
-     https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb 
- * "NLB": A Network Load Balancer that makes routing decisions at the   transport layer (TCP/SSL). See the following for additional details: 
+| type is the type of AWS load balancer to instantiate for an ingresscontroller.
+ Valid values are:
+ * "Classic": A Classic Load Balancer that makes routing decisions at either   the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See   the following for additional details:
+     https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb
+ * "NLB": A Network Load Balancer that makes routing decisions at the   transport layer (TCP/SSL). See the following for additional details:
      https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb
 
 |===
@@ -457,7 +457,7 @@ Type::
 Description::
 +
 --
-gcp provides configuration settings that are specific to GCP load balancers. 
+gcp provides configuration settings that are specific to GCP load balancers.
  If empty, defaults will be applied. See specific gcp fields for details about their defaults.
 --
 
@@ -473,10 +473,10 @@ Type::
 
 | `clientAccess`
 | `string`
-| clientAccess describes how client access is restricted for internal load balancers. 
- Valid values are: * "Global": Specifying an internal load balancer with Global client access   allows clients from any region within the VPC to communicate with the load   balancer. 
-     https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#global_access 
- * "Local": Specifying an internal load balancer with Local client access   means only clients within the same region (and VPC) as the GCP load balancer   can communicate with the load balancer. Note that this is the default behavior. 
+| clientAccess describes how client access is restricted for internal load balancers.
+ Valid values are: * "Global": Specifying an internal load balancer with Global client access   allows clients from any region within the VPC to communicate with the load   balancer.
+     https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#global_access
+ * "Local": Specifying an internal load balancer with Local client access   means only clients within the same region (and VPC) as the GCP load balancer   can communicate with the load balancer. Note that this is the default behavior.
      https://cloud.google.com/load-balancing/docs/internal#client_access
 
 |===
@@ -499,10 +499,10 @@ Type::
 
 | `protocol`
 | `string`
-| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. 
- PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. 
- The following values are valid for this field: 
- * The empty string. * "TCP". * "PROXY". 
+| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol.
+ PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol.
+ The following values are valid for this field:
+ * The empty string. * "TCP". * "PROXY".
  The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.
 
 |===
@@ -547,7 +547,7 @@ Required::
 Description::
 +
 --
-httpHeaders defines policy for HTTP headers. 
+httpHeaders defines policy for HTTP headers.
  If this field is empty, the default values are used.
 --
 
@@ -563,23 +563,23 @@ Type::
 
 | `forwardedHeaderPolicy`
 | `string`
-| forwardedHeaderPolicy specifies when and how the IngressController sets the Forwarded, X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Proto, and X-Forwarded-Proto-Version HTTP headers.  The value may be one of the following: 
- * "Append", which specifies that the IngressController appends the   headers, preserving existing headers. 
- * "Replace", which specifies that the IngressController sets the   headers, replacing any existing Forwarded or X-Forwarded-* headers. 
- * "IfNone", which specifies that the IngressController sets the   headers if they are not already set. 
- * "Never", which specifies that the IngressController never sets the   headers, preserving any existing headers. 
+| forwardedHeaderPolicy specifies when and how the IngressController sets the Forwarded, X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Proto, and X-Forwarded-Proto-Version HTTP headers.  The value may be one of the following:
+ * "Append", which specifies that the IngressController appends the   headers, preserving existing headers.
+ * "Replace", which specifies that the IngressController sets the   headers, replacing any existing Forwarded or X-Forwarded-* headers.
+ * "IfNone", which specifies that the IngressController sets the   headers if they are not already set.
+ * "Never", which specifies that the IngressController never sets the   headers, preserving any existing headers.
  By default, the policy is "Append".
 
 | `headerNameCaseAdjustments`
 | ``
-| headerNameCaseAdjustments specifies case adjustments that can be applied to HTTP header names.  Each adjustment is specified as an HTTP header name with the desired capitalization.  For example, specifying "X-Forwarded-For" indicates that the "x-forwarded-for" HTTP header should be adjusted to have the specified capitalization. 
- These adjustments are only applied to cleartext, edge-terminated, and re-encrypt routes, and only when using HTTP/1. 
- For request headers, these adjustments are applied only for routes that have the haproxy.router.openshift.io/h1-adjust-case=true annotation.  For response headers, these adjustments are applied to all HTTP responses. 
+| headerNameCaseAdjustments specifies case adjustments that can be applied to HTTP header names.  Each adjustment is specified as an HTTP header name with the desired capitalization.  For example, specifying "X-Forwarded-For" indicates that the "x-forwarded-for" HTTP header should be adjusted to have the specified capitalization.
+ These adjustments are only applied to cleartext, edge-terminated, and re-encrypt routes, and only when using HTTP/1.
+ For request headers, these adjustments are applied only for routes that have the haproxy.router.openshift.io/h1-adjust-case=true annotation.  For response headers, these adjustments are applied to all HTTP responses.
  If this field is empty, no request headers are adjusted.
 
 | `uniqueId`
 | `object`
-| uniqueId describes configuration for a custom HTTP header that the ingress controller should inject into incoming HTTP requests. Typically, this header is configured to have a value that is unique to the HTTP request.  The header can be used by applications or included in access logs to facilitate tracing individual HTTP requests. 
+| uniqueId describes configuration for a custom HTTP header that the ingress controller should inject into incoming HTTP requests. Typically, this header is configured to have a value that is unique to the HTTP request.  The header can be used by applications or included in access logs to facilitate tracing individual HTTP requests.
  If this field is empty, no such header is injected into requests.
 
 |===
@@ -587,7 +587,7 @@ Type::
 Description::
 +
 --
-uniqueId describes configuration for a custom HTTP header that the ingress controller should inject into incoming HTTP requests. Typically, this header is configured to have a value that is unique to the HTTP request.  The header can be used by applications or included in access logs to facilitate tracing individual HTTP requests. 
+uniqueId describes configuration for a custom HTTP header that the ingress controller should inject into incoming HTTP requests. Typically, this header is configured to have a value that is unique to the HTTP request.  The header can be used by applications or included in access logs to facilitate tracing individual HTTP requests.
  If this field is empty, no such header is injected into requests.
 --
 
@@ -629,7 +629,7 @@ Type::
 
 | `access`
 | `object`
-| access describes how the client requests should be logged. 
+| access describes how the client requests should be logged.
  If this field is empty, access logging is disabled.
 
 |===
@@ -637,7 +637,7 @@ Type::
 Description::
 +
 --
-access describes how the client requests should be logged. 
+access describes how the client requests should be logged.
  If this field is empty, access logging is disabled.
 --
 
@@ -663,13 +663,13 @@ Required::
 
 | `httpCaptureHeaders`
 | `object`
-| httpCaptureHeaders defines HTTP headers that should be captured in access logs.  If this field is empty, no headers are captured. 
+| httpCaptureHeaders defines HTTP headers that should be captured in access logs.  If this field is empty, no headers are captured.
  Note that this option only applies to cleartext HTTP connections and to secure HTTP connections for which the ingress controller terminates encryption (that is, edge-terminated or reencrypt connections).  Headers cannot be captured for TLS passthrough connections.
 
 | `httpLogFormat`
 | `string`
-| httpLogFormat specifies the format of the log message for an HTTP request. 
- If this field is empty, log messages use the implementation's default HTTP log format.  For HAProxy's default HTTP log format, see the HAProxy documentation: http://cbonte.github.io/haproxy-dconv/2.0/configuration.html#8.2.3 
+| httpLogFormat specifies the format of the log message for an HTTP request.
+ If this field is empty, log messages use the implementation's default HTTP log format.  For HAProxy's default HTTP log format, see the HAProxy documentation: http://cbonte.github.io/haproxy-dconv/2.0/configuration.html#8.2.3
  Note that this format only applies to cleartext HTTP connections and to secure HTTP connections for which the ingress controller terminates encryption (that is, edge-terminated or reencrypt connections).  It does not affect the log format for TLS passthrough connections.
 
 | `logEmptyRequests`
@@ -706,10 +706,10 @@ Required::
 
 | `type`
 | `string`
-| type is the type of destination for logs.  It must be one of the following: 
- * Container 
- The ingress operator configures the sidecar container named "logs" on the ingress controller pod and configures the ingress controller to write logs to the sidecar.  The logs are then available as container logs.  The expectation is that the administrator configures a custom logging solution that reads logs from this sidecar.  Note that using container logs means that logs may be dropped if the rate of logs exceeds the container runtime's or the custom logging solution's capacity. 
- * Syslog 
+| type is the type of destination for logs.  It must be one of the following:
+ * Container
+ The ingress operator configures the sidecar container named "logs" on the ingress controller pod and configures the ingress controller to write logs to the sidecar.  The logs are then available as container logs.  The expectation is that the administrator configures a custom logging solution that reads logs from this sidecar.  Note that using container logs means that logs may be dropped if the rate of logs exceeds the container runtime's or the custom logging solution's capacity.
+ * Syslog
  Logs are sent to a syslog endpoint.  The administrator must specify an endpoint that can receive syslog messages.  The expectation is that the administrator has configured a custom syslog instance.
 
 |===
@@ -752,7 +752,7 @@ Required::
 
 | `facility`
 | `string`
-| facility specifies the syslog facility of log messages. 
+| facility specifies the syslog facility of log messages.
  If this field is empty, the facility is "local1".
 
 | `port`
@@ -764,7 +764,7 @@ Required::
 Description::
 +
 --
-httpCaptureHeaders defines HTTP headers that should be captured in access logs.  If this field is empty, no headers are captured. 
+httpCaptureHeaders defines HTTP headers that should be captured in access logs.  If this field is empty, no headers are captured.
  Note that this option only applies to cleartext HTTP connections and to secure HTTP connections for which the ingress controller terminates encryption (that is, edge-terminated or reencrypt connections).  Headers cannot be captured for TLS passthrough connections.
 --
 
@@ -780,12 +780,12 @@ Type::
 
 | `request`
 | ``
-| request specifies which HTTP request headers to capture. 
+| request specifies which HTTP request headers to capture.
  If this field is empty, no request headers are captured.
 
 | `response`
 | ``
-| response specifies which HTTP response headers to capture. 
+| response specifies which HTTP response headers to capture.
  If this field is empty, no response headers are captured.
 
 |===
@@ -793,7 +793,7 @@ Type::
 Description::
 +
 --
-namespaceSelector is used to filter the set of namespaces serviced by the ingress controller. This is useful for implementing shards. 
+namespaceSelector is used to filter the set of namespaces serviced by the ingress controller. This is useful for implementing shards.
  If unset, the default is no filtering.
 --
 
@@ -870,7 +870,7 @@ Required::
 Description::
 +
 --
-nodePlacement enables explicit control over the scheduling of the ingress controller. 
+nodePlacement enables explicit control over the scheduling of the ingress controller.
  If unset, defaults are used. See NodePlacement for more details.
 --
 
@@ -886,15 +886,15 @@ Type::
 
 | `nodeSelector`
 | `object`
-| nodeSelector is the node selector applied to ingress controller deployments. 
- If unset, the default is: 
-   kubernetes.io/os: linux   node-role.kubernetes.io/worker: '' 
+| nodeSelector is the node selector applied to ingress controller deployments.
+ If unset, the default is:
+   kubernetes.io/os: linux   node-role.kubernetes.io/worker: ''
  If set, the specified selector is used and replaces the default.
 
 | `tolerations`
 | `array`
-| tolerations is a list of tolerations applied to ingress controller deployments. 
- The default is an empty list. 
+| tolerations is a list of tolerations applied to ingress controller deployments.
+ The default is an empty list.
  See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 
 | `tolerations[]`
@@ -906,9 +906,9 @@ Type::
 Description::
 +
 --
-nodeSelector is the node selector applied to ingress controller deployments. 
- If unset, the default is: 
-   kubernetes.io/os: linux   node-role.kubernetes.io/worker: '' 
+nodeSelector is the node selector applied to ingress controller deployments.
+ If unset, the default is:
+   kubernetes.io/os: linux   node-role.kubernetes.io/worker: ''
  If set, the specified selector is used and replaces the default.
 --
 
@@ -985,8 +985,8 @@ Required::
 Description::
 +
 --
-tolerations is a list of tolerations applied to ingress controller deployments. 
- The default is an empty list. 
+tolerations is a list of tolerations applied to ingress controller deployments.
+ The default is an empty list.
  See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 --
 
@@ -1038,7 +1038,7 @@ Type::
 Description::
 +
 --
-routeAdmission defines a policy for handling new route claims (for example, to allow or deny claims across namespaces). 
+routeAdmission defines a policy for handling new route claims (for example, to allow or deny claims across namespaces).
  If empty, defaults will be applied. See specific routeAdmission fields for details about their defaults.
 --
 
@@ -1054,18 +1054,18 @@ Type::
 
 | `namespaceOwnership`
 | `string`
-| namespaceOwnership describes how host name claims across namespaces should be handled. 
- Value must be one of: 
- - Strict: Do not allow routes in different namespaces to claim the same host. 
- - InterNamespaceAllowed: Allow routes to claim different paths of the same   host name across namespaces. 
+| namespaceOwnership describes how host name claims across namespaces should be handled.
+ Value must be one of:
+ - Strict: Do not allow routes in different namespaces to claim the same host.
+ - InterNamespaceAllowed: Allow routes to claim different paths of the same   host name across namespaces.
  If empty, the default is Strict.
 
 | `wildcardPolicy`
 | `string`
-| wildcardPolicy describes how routes with wildcard policies should be handled for the ingress controller. WildcardPolicy controls use of routes [1] exposed by the ingress controller based on the route's wildcard policy. 
- [1] https://github.com/openshift/api/blob/master/route/v1/types.go 
- Note: Updating WildcardPolicy from WildcardsAllowed to WildcardsDisallowed will cause admitted routes with a wildcard policy of Subdomain to stop working. These routes must be updated to a wildcard policy of None to be readmitted by the ingress controller. 
- WildcardPolicy supports WildcardsAllowed and WildcardsDisallowed values. 
+| wildcardPolicy describes how routes with wildcard policies should be handled for the ingress controller. WildcardPolicy controls use of routes [1] exposed by the ingress controller based on the route's wildcard policy.
+ [1] https://github.com/openshift/api/blob/master/route/v1/types.go
+ Note: Updating WildcardPolicy from WildcardsAllowed to WildcardsDisallowed will cause admitted routes with a wildcard policy of Subdomain to stop working. These routes must be updated to a wildcard policy of None to be readmitted by the ingress controller.
+ WildcardPolicy supports WildcardsAllowed and WildcardsDisallowed values.
  If empty, defaults to "WildcardsDisallowed".
 
 |===
@@ -1073,7 +1073,7 @@ Type::
 Description::
 +
 --
-routeSelector is used to filter the set of Routes serviced by the ingress controller. This is useful for implementing shards. 
+routeSelector is used to filter the set of Routes serviced by the ingress controller. This is useful for implementing shards.
  If unset, the default is no filtering.
 --
 
@@ -1150,8 +1150,8 @@ Required::
 Description::
 +
 --
-tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers. 
- If unset, the default is based on the apiservers.config.openshift.io/cluster resource. 
+tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers.
+ If unset, the default is based on the apiservers.config.openshift.io/cluster resource.
  Note that when using the Old, Intermediate, and Modern profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied to the ingress controller, resulting in a rollout.
 --
 
@@ -1167,36 +1167,36 @@ Type::
 
 | `custom`
 | ``
-| custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this: 
+| custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this:
    ciphers:     - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305     - ECDHE-RSA-AES128-GCM-SHA256     - ECDHE-ECDSA-AES128-GCM-SHA256   minTLSVersion: TLSv1.1
 
 | `intermediate`
 | ``
-| intermediate is a TLS security profile based on: 
- https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29 
- and looks like this (yaml): 
+| intermediate is a TLS security profile based on:
+ https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+ and looks like this (yaml):
    ciphers:     - TLS_AES_128_GCM_SHA256     - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256     - ECDHE-ECDSA-AES128-GCM-SHA256     - ECDHE-RSA-AES128-GCM-SHA256     - ECDHE-ECDSA-AES256-GCM-SHA384     - ECDHE-RSA-AES256-GCM-SHA384     - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305     - DHE-RSA-AES128-GCM-SHA256     - DHE-RSA-AES256-GCM-SHA384   minTLSVersion: TLSv1.2
 
 | `modern`
 | ``
-| modern is a TLS security profile based on: 
- https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility 
- and looks like this (yaml): 
-   ciphers:     - TLS_AES_128_GCM_SHA256     - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256   minTLSVersion: TLSv1.3 
+| modern is a TLS security profile based on:
+ https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+ and looks like this (yaml):
+   ciphers:     - TLS_AES_128_GCM_SHA256     - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256   minTLSVersion: TLSv1.3
  NOTE: Currently unsupported.
 
 | `old`
 | ``
-| old is a TLS security profile based on: 
- https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility 
- and looks like this (yaml): 
+| old is a TLS security profile based on:
+ https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
+ and looks like this (yaml):
    ciphers:     - TLS_AES_128_GCM_SHA256     - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256     - ECDHE-ECDSA-AES128-GCM-SHA256     - ECDHE-RSA-AES128-GCM-SHA256     - ECDHE-ECDSA-AES256-GCM-SHA384     - ECDHE-RSA-AES256-GCM-SHA384     - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305     - DHE-RSA-AES128-GCM-SHA256     - DHE-RSA-AES256-GCM-SHA384     - DHE-RSA-CHACHA20-POLY1305     - ECDHE-ECDSA-AES128-SHA256     - ECDHE-RSA-AES128-SHA256     - ECDHE-ECDSA-AES128-SHA     - ECDHE-RSA-AES128-SHA     - ECDHE-ECDSA-AES256-SHA384     - ECDHE-RSA-AES256-SHA384     - ECDHE-ECDSA-AES256-SHA     - ECDHE-RSA-AES256-SHA     - DHE-RSA-AES128-SHA256     - DHE-RSA-AES256-SHA256     - AES128-GCM-SHA256     - AES256-GCM-SHA384     - AES128-SHA256     - AES256-SHA256     - AES128-SHA     - AES256-SHA     - DES-CBC3-SHA   minTLSVersion: TLSv1.0
 
 | `type`
 | `string`
-| type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on: 
- https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations 
- The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced. 
+| type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on:
+ https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
+ The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced.
  Note that the Modern profile is currently not supported because it is not yet well adopted by common software libraries.
 
 |===
@@ -1204,7 +1204,7 @@ Type::
 Description::
 +
 --
-tuningOptions defines parameters for adjusting the performance of ingress controller pods. All fields are optional and will use their respective defaults if not set. See specific tuningOptions fields for more details. 
+tuningOptions defines parameters for adjusting the performance of ingress controller pods. All fields are optional and will use their respective defaults if not set. See specific tuningOptions fields for more details.
  Setting fields within tuningOptions is generally not recommended. The default values are suitable for most configurations.
 --
 
@@ -1220,48 +1220,48 @@ Type::
 
 | `clientFinTimeout`
 | `string`
-| clientFinTimeout defines how long a connection will be held open while waiting for the client response to the server/backend closing the connection. 
+| clientFinTimeout defines how long a connection will be held open while waiting for the client response to the server/backend closing the connection.
  If unset, the default timeout is 1s
 
 | `clientTimeout`
 | `string`
-| clientTimeout defines how long a connection will be held open while waiting for a client response. 
+| clientTimeout defines how long a connection will be held open while waiting for a client response.
  If unset, the default timeout is 30s
 
 | `headerBufferBytes`
 | `integer`
-| headerBufferBytes describes how much memory should be reserved (in bytes) for IngressController connection sessions. Note that this value must be at least 16384 if HTTP/2 is enabled for the IngressController (https://tools.ietf.org/html/rfc7540). If this field is empty, the IngressController will use a default value of 32768 bytes. 
+| headerBufferBytes describes how much memory should be reserved (in bytes) for IngressController connection sessions. Note that this value must be at least 16384 if HTTP/2 is enabled for the IngressController (https://tools.ietf.org/html/rfc7540). If this field is empty, the IngressController will use a default value of 32768 bytes.
  Setting this field is generally not recommended as headerBufferBytes values that are too small may break the IngressController and headerBufferBytes values that are too large could cause the IngressController to use significantly more memory than necessary.
 
 | `headerBufferMaxRewriteBytes`
 | `integer`
-| headerBufferMaxRewriteBytes describes how much memory should be reserved (in bytes) from headerBufferBytes for HTTP header rewriting and appending for IngressController connection sessions. Note that incoming HTTP requests will be limited to (headerBufferBytes - headerBufferMaxRewriteBytes) bytes, meaning headerBufferBytes must be greater than headerBufferMaxRewriteBytes. If this field is empty, the IngressController will use a default value of 8192 bytes. 
+| headerBufferMaxRewriteBytes describes how much memory should be reserved (in bytes) from headerBufferBytes for HTTP header rewriting and appending for IngressController connection sessions. Note that incoming HTTP requests will be limited to (headerBufferBytes - headerBufferMaxRewriteBytes) bytes, meaning headerBufferBytes must be greater than headerBufferMaxRewriteBytes. If this field is empty, the IngressController will use a default value of 8192 bytes.
  Setting this field is generally not recommended as headerBufferMaxRewriteBytes values that are too small may break the IngressController and headerBufferMaxRewriteBytes values that are too large could cause the IngressController to use significantly more memory than necessary.
 
 | `serverFinTimeout`
 | `string`
-| serverFinTimeout defines how long a connection will be held open while waiting for the server/backend response to the client closing the connection. 
+| serverFinTimeout defines how long a connection will be held open while waiting for the server/backend response to the client closing the connection.
  If unset, the default timeout is 1s
 
 | `serverTimeout`
 | `string`
-| serverTimeout defines how long a connection will be held open while waiting for a server/backend response. 
+| serverTimeout defines how long a connection will be held open while waiting for a server/backend response.
  If unset, the default timeout is 30s
 
 | `threadCount`
 | `integer`
-| threadCount defines the number of threads created per HAProxy process. Creating more threads allows each ingress controller pod to handle more connections, at the cost of more system resources being used. HAProxy currently supports up to 64 threads. If this field is empty, the IngressController will use the default value.  The current default is 4 threads, but this may change in future releases. 
+| threadCount defines the number of threads created per HAProxy process. Creating more threads allows each ingress controller pod to handle more connections, at the cost of more system resources being used. HAProxy currently supports up to 64 threads. If this field is empty, the IngressController will use the default value.  The current default is 4 threads, but this may change in future releases.
  Setting this field is generally not recommended. Increasing the number of HAProxy threads allows ingress controller pods to utilize more CPU time under load, potentially starving other pods if set too high. Reducing the number of threads may cause the ingress controller to perform poorly.
 
 | `tlsInspectDelay`
 | `string`
-| tlsInspectDelay defines how long the router can hold data to find a matching route. 
- Setting this too short can cause the router to fall back to the default certificate for edge-terminated or reencrypt routes even when a better matching certificate could be used. 
+| tlsInspectDelay defines how long the router can hold data to find a matching route.
+ Setting this too short can cause the router to fall back to the default certificate for edge-terminated or reencrypt routes even when a better matching certificate could be used.
  If unset, the default inspect delay is 5s
 
 | `tunnelTimeout`
 | `string`
-| tunnelTimeout defines how long a tunnel connection (including websockets) will be held open while the tunnel is idle. 
+| tunnelTimeout defines how long a tunnel connection (including websockets) will be held open while the tunnel is idle.
  If unset, the default timeout is 1h
 
 |===
@@ -1288,12 +1288,12 @@ Type::
 
 | `conditions`
 | `array`
-| conditions is a list of conditions and their status. 
- Available means the ingress controller deployment is available and servicing route and ingress resources (i.e, .status.availableReplicas equals .spec.replicas) 
- There are additional conditions which indicate the status of other ingress controller features and capabilities. 
-   * LoadBalancerManaged   - True if the following conditions are met:     * The endpoint publishing strategy requires a service load balancer.   - False if any of those conditions are unsatisfied. 
-   * LoadBalancerReady   - True if the following conditions are met:     * A load balancer is managed.     * The load balancer is ready.   - False if any of those conditions are unsatisfied. 
-   * DNSManaged   - True if the following conditions are met:     * The endpoint publishing strategy and platform support DNS.     * The ingress controller domain is set.     * dns.config.openshift.io/cluster configures DNS zones.   - False if any of those conditions are unsatisfied. 
+| conditions is a list of conditions and their status.
+ Available means the ingress controller deployment is available and servicing route and ingress resources (i.e, .status.availableReplicas equals .spec.replicas)
+ There are additional conditions which indicate the status of other ingress controller features and capabilities.
+   * LoadBalancerManaged   - True if the following conditions are met:     * The endpoint publishing strategy requires a service load balancer.   - False if any of those conditions are unsatisfied.
+   * LoadBalancerReady   - True if the following conditions are met:     * A load balancer is managed.     * The load balancer is ready.   - False if any of those conditions are unsatisfied.
+   * DNSManaged   - True if the following conditions are met:     * The endpoint publishing strategy and platform support DNS.     * The ingress controller domain is set.     * dns.config.openshift.io/cluster configures DNS zones.   - False if any of those conditions are unsatisfied.
    * DNSReady   - True if the following conditions are met:     * DNS is managed.     * DNS records have been successfully created.   - False if any of those conditions are unsatisfied.
 
 | `conditions[]`
@@ -1325,12 +1325,12 @@ Type::
 Description::
 +
 --
-conditions is a list of conditions and their status. 
- Available means the ingress controller deployment is available and servicing route and ingress resources (i.e, .status.availableReplicas equals .spec.replicas) 
- There are additional conditions which indicate the status of other ingress controller features and capabilities. 
-   * LoadBalancerManaged   - True if the following conditions are met:     * The endpoint publishing strategy requires a service load balancer.   - False if any of those conditions are unsatisfied. 
-   * LoadBalancerReady   - True if the following conditions are met:     * A load balancer is managed.     * The load balancer is ready.   - False if any of those conditions are unsatisfied. 
-   * DNSManaged   - True if the following conditions are met:     * The endpoint publishing strategy and platform support DNS.     * The ingress controller domain is set.     * dns.config.openshift.io/cluster configures DNS zones.   - False if any of those conditions are unsatisfied. 
+conditions is a list of conditions and their status.
+ Available means the ingress controller deployment is available and servicing route and ingress resources (i.e, .status.availableReplicas equals .spec.replicas)
+ There are additional conditions which indicate the status of other ingress controller features and capabilities.
+   * LoadBalancerManaged   - True if the following conditions are met:     * The endpoint publishing strategy requires a service load balancer.   - False if any of those conditions are unsatisfied.
+   * LoadBalancerReady   - True if the following conditions are met:     * A load balancer is managed.     * The load balancer is ready.   - False if any of those conditions are unsatisfied.
+   * DNSManaged   - True if the following conditions are met:     * The endpoint publishing strategy and platform support DNS.     * The ingress controller domain is set.     * dns.config.openshift.io/cluster configures DNS zones.   - False if any of those conditions are unsatisfied.
    * DNSReady   - True if the following conditions are met:     * DNS is managed.     * DNS records have been successfully created.   - False if any of those conditions are unsatisfied.
 --
 
@@ -1359,23 +1359,23 @@ Type::
 
 | `lastTransitionTime`
 | `string`
-| 
+|
 
 | `message`
 | `string`
-| 
+|
 
 | `reason`
 | `string`
-| 
+|
 
 | `status`
 | `string`
-| 
+|
 
 | `type`
 | `string`
-| 
+|
 
 |===
 === .status.endpointPublishingStrategy
@@ -1415,21 +1415,21 @@ Required::
 
 | `type`
 | `string`
-| type is the publishing strategy to use. Valid values are: 
- * LoadBalancerService 
- Publishes the ingress controller using a Kubernetes LoadBalancer Service. 
- In this configuration, the ingress controller deployment uses container networking. A LoadBalancer Service is created to publish the deployment. 
- See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer 
- If domain is set, a wildcard DNS record will be managed to point at the LoadBalancer Service's external name. DNS records are managed only in DNS zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone. 
- Wildcard DNS management is currently supported only on the AWS, Azure, and GCP platforms. 
- * HostNetwork 
- Publishes the ingress controller on node ports where the ingress controller is deployed. 
- In this configuration, the ingress controller deployment uses host networking, bound to node ports 80 and 443. The user is responsible for configuring an external load balancer to publish the ingress controller via the node ports. 
- * Private 
- Does not publish the ingress controller. 
- In this configuration, the ingress controller deployment uses container networking, and is not explicitly published. The user must manually publish the ingress controller. 
- * NodePortService 
- Publishes the ingress controller using a Kubernetes NodePort Service. 
+| type is the publishing strategy to use. Valid values are:
+ * LoadBalancerService
+ Publishes the ingress controller using a Kubernetes LoadBalancer Service.
+ In this configuration, the ingress controller deployment uses container networking. A LoadBalancer Service is created to publish the deployment.
+ See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+ If domain is set, a wildcard DNS record will be managed to point at the LoadBalancer Service's external name. DNS records are managed only in DNS zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone.
+ Wildcard DNS management is currently supported only on the AWS, Azure, and GCP platforms.
+ * HostNetwork
+ Publishes the ingress controller on node ports where the ingress controller is deployed.
+ In this configuration, the ingress controller deployment uses host networking, bound to node ports 80 and 443. The user is responsible for configuring an external load balancer to publish the ingress controller via the node ports.
+ * Private
+ Does not publish the ingress controller.
+ In this configuration, the ingress controller deployment uses container networking, and is not explicitly published. The user must manually publish the ingress controller.
+ * NodePortService
+ Publishes the ingress controller using a Kubernetes NodePort Service.
  In this configuration, the ingress controller deployment uses container networking. A NodePort Service is created to publish the deployment. The specific node ports are dynamically allocated by OpenShift; however, to support static port allocations, user changes to the node port field of the managed NodePort Service will preserved.
 
 |===
@@ -1452,10 +1452,10 @@ Type::
 
 | `protocol`
 | `string`
-| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. 
- PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. 
- The following values are valid for this field: 
- * The empty string. * "TCP". * "PROXY". 
+| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol.
+ PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol.
+ The following values are valid for this field:
+ * The empty string. * "TCP". * "PROXY".
  The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.
 
 |===
@@ -1480,7 +1480,7 @@ Required::
 
 | `providerParameters`
 | `object`
-| providerParameters holds desired load balancer information specific to the underlying infrastructure provider. 
+| providerParameters holds desired load balancer information specific to the underlying infrastructure provider.
  If empty, defaults will be applied. See specific providerParameters fields for details about their defaults.
 
 | `scope`
@@ -1492,7 +1492,7 @@ Required::
 Description::
 +
 --
-providerParameters holds desired load balancer information specific to the underlying infrastructure provider. 
+providerParameters holds desired load balancer information specific to the underlying infrastructure provider.
  If empty, defaults will be applied. See specific providerParameters fields for details about their defaults.
 --
 
@@ -1510,12 +1510,12 @@ Required::
 
 | `aws`
 | `object`
-| aws provides configuration settings that are specific to AWS load balancers. 
+| aws provides configuration settings that are specific to AWS load balancers.
  If empty, defaults will be applied. See specific aws fields for details about their defaults.
 
 | `gcp`
 | `object`
-| gcp provides configuration settings that are specific to GCP load balancers. 
+| gcp provides configuration settings that are specific to GCP load balancers.
  If empty, defaults will be applied. See specific gcp fields for details about their defaults.
 
 | `type`
@@ -1527,7 +1527,7 @@ Required::
 Description::
 +
 --
-aws provides configuration settings that are specific to AWS load balancers. 
+aws provides configuration settings that are specific to AWS load balancers.
  If empty, defaults will be applied. See specific aws fields for details about their defaults.
 --
 
@@ -1553,11 +1553,11 @@ Required::
 
 | `type`
 | `string`
-| type is the type of AWS load balancer to instantiate for an ingresscontroller. 
- Valid values are: 
- * "Classic": A Classic Load Balancer that makes routing decisions at either   the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See   the following for additional details: 
-     https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb 
- * "NLB": A Network Load Balancer that makes routing decisions at the   transport layer (TCP/SSL). See the following for additional details: 
+| type is the type of AWS load balancer to instantiate for an ingresscontroller.
+ Valid values are:
+ * "Classic": A Classic Load Balancer that makes routing decisions at either   the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See   the following for additional details:
+     https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb
+ * "NLB": A Network Load Balancer that makes routing decisions at the   transport layer (TCP/SSL). See the following for additional details:
      https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb
 
 |===
@@ -1591,7 +1591,7 @@ Type::
 Description::
 +
 --
-gcp provides configuration settings that are specific to GCP load balancers. 
+gcp provides configuration settings that are specific to GCP load balancers.
  If empty, defaults will be applied. See specific gcp fields for details about their defaults.
 --
 
@@ -1607,10 +1607,10 @@ Type::
 
 | `clientAccess`
 | `string`
-| clientAccess describes how client access is restricted for internal load balancers. 
- Valid values are: * "Global": Specifying an internal load balancer with Global client access   allows clients from any region within the VPC to communicate with the load   balancer. 
-     https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#global_access 
- * "Local": Specifying an internal load balancer with Local client access   means only clients within the same region (and VPC) as the GCP load balancer   can communicate with the load balancer. Note that this is the default behavior. 
+| clientAccess describes how client access is restricted for internal load balancers.
+ Valid values are: * "Global": Specifying an internal load balancer with Global client access   allows clients from any region within the VPC to communicate with the load   balancer.
+     https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#global_access
+ * "Local": Specifying an internal load balancer with Local client access   means only clients within the same region (and VPC) as the GCP load balancer   can communicate with the load balancer. Note that this is the default behavior.
      https://cloud.google.com/load-balancing/docs/internal#client_access
 
 |===
@@ -1633,10 +1633,10 @@ Type::
 
 | `protocol`
 | `string`
-| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. 
- PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. 
- The following values are valid for this field: 
- * The empty string. * "TCP". * "PROXY". 
+| protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol.
+ PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol.
+ The following values are valid for this field:
+ * The empty string. * "TCP". * "PROXY".
  The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.
 
 |===
@@ -1672,13 +1672,13 @@ Type::
 
 | `ciphers`
 | `array (string)`
-| ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml): 
+| ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml):
    ciphers:     - DES-CBC3-SHA
 
 | `minTLSVersion`
 | `string`
-| minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml): 
-   minTLSVersion: TLSv1.1 
+| minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml):
+   minTLSVersion: TLSv1.1
  NOTE: currently the highest minTLSVersion allowed is VersionTLS12
 
 |===
@@ -1936,7 +1936,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../operator_apis/ingresscontroller-operator-openshift-io-v1.adoc#ingresscontroller-operator-openshift-io-v1[`IngressController`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2008,7 +2008,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions_v2[`DeleteOptions_v2`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2077,7 +2077,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2115,7 +2115,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../operator_apis/ingresscontroller-operator-openshift-io-v1.adoc#ingresscontroller-operator-openshift-io-v1[`IngressController`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2208,7 +2208,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2246,7 +2246,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.api.autoscaling.v1.Scale_v2[`Scale_v2`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2339,7 +2339,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2377,7 +2377,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../operator_apis/ingresscontroller-operator-openshift-io-v1.adoc#ingresscontroller-operator-openshift-io-v1[`IngressController`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -2391,5 +2391,3 @@ Description::
 | 401 - Unauthorized
 | Empty
 |===
-
-

--- a/rest_api/operator_apis/operator-apis-index.adoc
+++ b/rest_api/operator_apis/operator-apis-index.adoc
@@ -13,7 +13,7 @@ toc::[]
 Description::
 +
 --
-Authentication provides information to configure an operator to manage authentication. 
+Authentication provides information to configure an operator to manage authentication.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -36,7 +36,7 @@ Type::
 Description::
 +
 --
-ClusterCSIDriver object allows management and configuration of a CSI driver operator installed by default in OpenShift. Name of the object must be name of the CSI driver it operates. See CSIDriverName type for list of allowed values. 
+ClusterCSIDriver object allows management and configuration of a CSI driver operator installed by default in OpenShift. Name of the object must be name of the CSI driver it operates. See CSIDriverName type for list of allowed values.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -48,7 +48,7 @@ Type::
 Description::
 +
 --
-Console provides a means to configure an operator to manage the console. 
+Console provides a means to configure an operator to manage the console.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -60,7 +60,7 @@ Type::
 Description::
 +
 --
-Config provides information to configure the config operator. It handles installation, migration or synchronization of cloud based cluster configurations like AWS or Azure. 
+Config provides information to configure the config operator. It handles installation, migration or synchronization of cloud based cluster configurations like AWS or Azure.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -94,7 +94,7 @@ Type::
 Description::
 +
 --
-CSISnapshotController provides a means to configure an operator to manage the CSI snapshots. `cluster` is the canonical name. 
+CSISnapshotController provides a means to configure an operator to manage the CSI snapshots. `cluster` is the canonical name.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -106,8 +106,8 @@ Type::
 Description::
 +
 --
-DNS manages the CoreDNS component to provide a name resolution service for pods and services in the cluster. 
- This supports the DNS-based service discovery specification: https://github.com/kubernetes/dns/blob/master/docs/specification.md 
+DNS manages the CoreDNS component to provide a name resolution service for pods and services in the cluster.
+ This supports the DNS-based service discovery specification: https://github.com/kubernetes/dns/blob/master/docs/specification.md
  More details: https://kubernetes.io/docs/tasks/administer-cluster/coredns
 --
 
@@ -119,7 +119,7 @@ Type::
 Description::
 +
 --
-DNSRecord is a DNS record managed in the zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone. 
+DNSRecord is a DNS record managed in the zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone.
  Cluster admin manipulation of this resource is not supported. This resource is only for internal communication of OpenShift operators.
 --
 
@@ -131,7 +131,7 @@ Type::
 Description::
 +
 --
-Etcd provides information to configure an operator to manage etcd. 
+Etcd provides information to configure an operator to manage etcd.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -143,7 +143,7 @@ Type::
 Description::
 +
 --
-ImageContentSourcePolicy holds cluster-wide information about how to handle registry mirror rules. When multiple policies are defined, the outcome of the behavior is defined on each field. 
+ImageContentSourcePolicy holds cluster-wide information about how to handle registry mirror rules. When multiple policies are defined, the outcome of the behavior is defined on each field.
  Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
 --
 
@@ -166,9 +166,9 @@ Type::
 Description::
 +
 --
-IngressController describes a managed ingress controller for the cluster. The controller can service OpenShift Route and Kubernetes Ingress resources. 
- When an IngressController is created, a new ingress controller deployment is created to allow external traffic to reach the services that expose Ingress or Route resources. Updating this resource may lead to disruption for public facing network connections as a new ingress controller revision may be rolled out. 
- https://kubernetes.io/docs/concepts/services-networking/ingress-controllers 
+IngressController describes a managed ingress controller for the cluster. The controller can service OpenShift Route and Kubernetes Ingress resources.
+ When an IngressController is created, a new ingress controller deployment is created to allow external traffic to reach the services that expose Ingress or Route resources. Updating this resource may lead to disruption for public facing network connections as a new ingress controller revision may be rolled out.
+ https://kubernetes.io/docs/concepts/services-networking/ingress-controllers
  Whenever possible, sensible defaults for the platform are used. See each field for more details.
 --
 
@@ -180,7 +180,7 @@ Type::
 Description::
 +
 --
-KubeAPIServer provides information to configure an operator to manage kube-apiserver. 
+KubeAPIServer provides information to configure an operator to manage kube-apiserver.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -192,7 +192,7 @@ Type::
 Description::
 +
 --
-KubeControllerManager provides information to configure an operator to manage kube-controller-manager. 
+KubeControllerManager provides information to configure an operator to manage kube-controller-manager.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -204,7 +204,7 @@ Type::
 Description::
 +
 --
-KubeScheduler provides information to configure an operator to manage scheduler. 
+KubeScheduler provides information to configure an operator to manage scheduler.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -216,7 +216,7 @@ Type::
 Description::
 +
 --
-KubeStorageVersionMigrator provides information to configure an operator to manage kube-storage-version-migrator. 
+KubeStorageVersionMigrator provides information to configure an operator to manage kube-storage-version-migrator.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -228,7 +228,7 @@ Type::
 Description::
 +
 --
-Network describes the cluster's desired network configuration. It is consumed by the cluster-network-operator. 
+Network describes the cluster's desired network configuration. It is consumed by the cluster-network-operator.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -240,7 +240,7 @@ Type::
 Description::
 +
 --
-OpenShiftAPIServer provides information to configure an operator to manage openshift-apiserver. 
+OpenShiftAPIServer provides information to configure an operator to manage openshift-apiserver.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -252,7 +252,7 @@ Type::
 Description::
 +
 --
-OpenShiftControllerManager provides information to configure an operator to manage openshift-controller-manager. 
+OpenShiftControllerManager provides information to configure an operator to manage openshift-controller-manager.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -264,9 +264,9 @@ Type::
 Description::
 +
 --
-OperatorPKI is a simple certificate authority. It is not intended for external use - rather, it is internal to the network operator. The CNO creates a CA and a certificate signed by that CA. The certificate has both ClientAuth and ServerAuth extended usages enabled. 
-  More specifically, given an OperatorPKI with <name>, the CNO will manage: - A Secret called <name>-ca with two data keys:   - tls.key - the private key   - tls.crt - the CA certificate - A ConfigMap called <name>-ca with a single data key:   - cabundle.crt - the CA certificate(s) - A Secret called <name>-cert with two data keys:   - tls.key - the private key   - tls.crt - the certificate, signed by the CA 
- The CA certificate will have a validity of 10 years, rotated after 9. The target certificate will have a validity of 6 months, rotated after 3 
+OperatorPKI is a simple certificate authority. It is not intended for external use - rather, it is internal to the network operator. The CNO creates a CA and a certificate signed by that CA. The certificate has both ClientAuth and ServerAuth extended usages enabled.
+  More specifically, given an OperatorPKI with <name>, the CNO will manage: - A Secret called <name>-ca with two data keys:   - tls.key - the private key   - tls.crt - the CA certificate - A ConfigMap called <name>-ca with a single data key:   - cabundle.crt - the CA certificate(s) - A Secret called <name>-cert with two data keys:   - tls.key - the private key   - tls.crt - the certificate, signed by the CA
+ The CA certificate will have a validity of 10 years, rotated after 9. The target certificate will have a validity of 6 months, rotated after 3
  The CA certificate will have a CommonName of "<namespace>_<name>-ca@<timestamp>", where <timestamp> is the last rotation time.
 --
 
@@ -278,7 +278,7 @@ Type::
 Description::
 +
 --
-ServiceCA provides information to configure an operator to manage the service cert controllers 
+ServiceCA provides information to configure an operator to manage the service cert controllers
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -290,10 +290,9 @@ Type::
 Description::
 +
 --
-Storage provides a means to configure an operator to manage the cluster storage operator. `cluster` is the canonical name. 
+Storage provides a means to configure an operator to manage the cluster storage operator. `cluster` is the canonical name.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
 Type::
   `object`
-

--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -141,7 +141,7 @@ create microsegmentation between deployed application services on the cluster.
 
 You can also use the `Route` API objects that are found in {product-title},
 including its sophisticated integration with the HAproxy edge routing layer as an
-out of the box Kubernetes ingress controller.
+out of the box Kubernetes Ingress Controller.
 
 [[about_oke_core_user_experience]]
 === Core user experience
@@ -202,7 +202,7 @@ found in {product-title}. That ingress solution is supported in {oke}.
 {oke} users are supported for the Kubernetes ingress control object, which
 offers integrations with public cloud providers. Red Hat Service Mesh, which is
 derived from the istio.io open source project, is not supported in {oke}. Also,
-the Kourier ingress controller found in OpenShift Serverless is not supported
+the Kourier Ingress Controller found in OpenShift Serverless is not supported
 on {oke}.
 
 === Developer experience


### PR DESCRIPTION
- Applies to 4.10 and above versions.
- [OCP Glossary](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/term_glossary.adoc#ingress-controller) state that Ingress Controller, the first letters should be capitalized. Correct wrong instances. 
- [Preview](https://deploy-preview-43923--osdocs.netlify.app/openshift-enterprise/latest/welcome/index.html)
