### PR TITLE
Github-43873: Fixes small typo in 4.9.15 RN link

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2480,7 +2480,7 @@ To upgrade an existing {product-title} 4.9 cluster to this latest release, see x
 
 Issued: 2022-01-17
 
-{product-title} release 4.9.15 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0110[RHBA-2022:0110] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0109[RHSA-2022:0109] advisory.
+{product-title} release 4.9.15 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0110[RHBA-2022:0110] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0109[RHSA-2022:0109] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 


### PR DESCRIPTION
Fixes #43873

[Preview](https://deploy-preview-43928--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-15)

Fixes a typo in the RN for 4.9.15. 