### PR TITLE
Fixing aws installer modules for non arm specific sections

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -56,11 +56,13 @@ endif::[]
 ifeval::["{context}" == "installing-aws-customizations"]
 :aws:
 endif::[]
+//Starting in 4.10, aws on arm64 is only supported for installation on custom, network custom, private clusters and VPC . This attribute excludes arm64 content from installing on gov regions. When government regions are supported on arm64, change `aws-govcloud` to `aws`.
 ifeval::["{context}" == "installing-aws-government-region"]
-:aws:
+:aws-govcloud:
 endif::[]
+//Starting in 4.10, aws on arm64 is only supported for installation on custom, network custom, private clusters and VPC. This attribute excludes arm64 content from installing on secret regions. When secret regions are supported on arm64, change `aws-secret` to `aws`.
 ifeval::["{context}" == "installing-aws-secret-region"]
-:aws:
+:aws-secret:
 endif::[]
 ifeval::["{context}" == "installing-aws-network-customizations"]
 :aws:
@@ -71,8 +73,9 @@ endif::[]
 ifeval::["{context}" == "installing-aws-vpc"]
 :aws:
 endif::[]
+//Starting in 4.10, aws on arm64 is only supported for installation on custom, network custom, private clusters and VPC. This attribute excludes arm64 content from installing in restricted networks upi. When restricted networks upi is supported on arm64, change `aws-restricted` to `aws`.
 ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
-:aws:
+:aws-restricted:
 endif::[]
 ifeval::["{context}" == "installing-azure-customizations"]
 :azure:
@@ -629,10 +632,10 @@ endif::openshift-origin[]
 |`publish`
 |How to publish or expose the user-facing endpoints of your cluster, such as the Kubernetes API, OpenShift routes.
 |
-ifdef::aws,azure,gcp[]
+ifdef::aws,aws-govcloud,aws-secret,aws-restricted,azure,gcp[]
 `Internal` or `External`. To deploy a private cluster, which cannot be accessed from the internet, set `publish` to `Internal`. The default value is `External`.
 endif::[]
-ifndef::aws,azure,gcp[]
+ifndef::aws,aws-govcloud,aws-secret,aws-restricted,azure,gcp[]
 `Internal` or `External`. The default value is `External`.
 
 Setting this field to `Internal` is not supported on non-cloud platforms and IBM Cloud.
@@ -654,7 +657,7 @@ a|For example, `sshKey: ssh-ed25519 AAAA..`.
 
 |====
 
-ifdef::aws[]
+ifdef::aws,aws-govcloud,aws-secret,aws-restricted[]
 [id="installation-configuration-parameters-optional-aws_{context}"]
 == Optional AWS configuration parameters
 
@@ -757,7 +760,7 @@ host must trust the certificate.
 |Valid subnet IDs.
 
 |====
-endif::aws[]
+endif::aws,aws-govcloud,aws-secret,aws-restricted[]
 
 ifdef::osp[]
 [id="installation-configuration-parameters-additional-osp_{context}"]
@@ -1494,10 +1497,10 @@ ifeval::["{context}" == "installing-aws-customizations"]
 :!aws:
 endif::[]
 ifeval::["{context}" == "installing-aws-government-region"]
-:!aws:
+:!aws-govcloud:
 endif::[]
 ifeval::["{context}" == "installing-aws-secret-region"]
-:!aws:
+:!aws-secret:
 endif::[]
 ifeval::["{context}" == "installing-aws-network-customizations"]
 :!aws:
@@ -1509,7 +1512,7 @@ ifeval::["{context}" == "installing-aws-vpc"]
 :!aws:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
-:!aws:
+:!aws-restricted:
 endif::[]
 ifeval::["{context}" == "installing-azure-customizations"]
 :!azure:

--- a/modules/installation-supported-aws-machine-types.adoc
+++ b/modules/installation-supported-aws-machine-types.adoc
@@ -8,6 +8,25 @@
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc
 // * installing/installing_aws/installing-aws-private.adoc
+// * installing/installing_aws/installing-aws-china.adoc
+
+//Starting in 4.10, aws on arm64 is only supported for installation on custom, network custom, private clusters and VPC. This attribute excludes arm64 content from installing in restricted networks upi. When restricted networks upi is supported on arm64, remove this ifdevel.
+ifeval::["{context}" == "installing-restricted-networks-aws"]
+:aws-restricted-upi:
+endif::[]
+//Starting in 4.10, aws on arm64 is only supported for installation on custom, network custom, private clusters and VPC. This attribute excludes arm64 content from installing on gov regions. When government regions are supported on arm64, remove this ifdevel.
+ifeval::["{context}" == "installing-aws-government-region"]
+:aws-govcloud:
+endif::[]
+//Starting in 4.10, aws on arm64 is only supported for installation on custom, network custom, private clusters and VPC. This attribute excludes arm64 content from installing on secret regions. When secret regions are supported on arm64, remove this ifdevel.
+ifeval::["{context}" == "installing-aws-secret-region"]
+:aws-secret:
+endif::[]
+//Starting in 4.10, aws on arm64 is only supported for installation on custom, network custom, private clusters and VPC. This attribute excludes arm64 content from installing in china regions. When china regions are supported on arm64, remove this ifdevel.
+ifeval::["{context}" == "installing-aws-china-region"]
+:aws-china:
+endif::[]
+
 
 [id="installation-supported-aws-machine-types_{context}"]
 = Supported AWS machine types
@@ -383,6 +402,7 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 |===
 ====
 
+ifndef::aws-restricted-upi,aws-govcloud,aws-secret,aws-china[]
 .Machine types based on arm64 architecture
 [%collapsible]
 ====
@@ -466,3 +486,17 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 
 |===
 ====
+endif::[]
+
+ifeval::["{context}" == "installing-restricted-networks-aws"]
+:!aws-restricted-upi:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:!aws-govcloud:
+endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:!aws-secret:
+endif::[]
+ifeval::["{context}" == "installing-aws-china-region"]
+:!aws-china:
+endif::[]


### PR DESCRIPTION
For versions 4.10+

Description: ARM in not supported yet on AWS UPI, Restricted networks, government regions, secret regions and china. Removing arm instances in these sections of the docs. 

Previews: 

- These sections will have `amd64` and `arm64` in `controlPlane.architecture`/ `compute.architecture`. Also includes `Machine types for arm64 architectures`
1. [Installing a cluster on AWS with customizations](https://deploy-preview-43933--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-supported-aws-machine-types_installing-aws-customizations) 
2. [Installing a cluster on AWS with network customizations](https://deploy-preview-43933--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html#installation-supported-aws-machine-types_installing-aws-network-customizations)
3. [Installing a cluster on AWS into an existing VPC](https://deploy-preview-43933--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-vpc.html)
4. [Installing a private cluster on AWS](https://deploy-preview-43933--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-private.html)

-  These sections will only have `amd64` for `controlPlane.architecture`/ `compute.architecture`  and `Machine types for x86_64 architectures` only

1.  [Installing a cluster on AWS in a restricted network with user-provisioned infrastructure](https://deploy-preview-43933--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws.html#installation-supported-aws-machine-types_installing-restricted-networks-aws) 
2. [Installing a cluster on AWS into a government region](https://deploy-preview-43933--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-government-region.html)
3. [Installing a cluster on AWS into a Top Secret Region](https://deploy-preview-43933--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-secret-region.html#installation-supported-aws-machine-types_installing-aws-secret-region)
4. [Installing a cluster on AWS China](https://deploy-preview-43933--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-china.html#installation-supported-aws-machine-types_installing-aws-china-region)
