### PR TITLE
[WIP] OSDOCS-3272: Bump to RHEL 8.6

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -70,6 +70,11 @@ For more information, see xref:../getting_started/openshift-overview.adoc[Gettin
 
 {product-title} 4.11 introduces the `nvme-cli` package that provides an interface for communicating with NVMe disks using host software capabilities.
 
+[id="ocp-4-11-rhcos-rhel-8-6-packages"]
+==== {op-system} now uses {op-system-base} 8.6
+
+{op-system} now uses {op-system-base-full} 8.6 packages in {product-title} 4.11 and above. This enables you to have the latest fixes, features, and enhancements, as well as the latest hardware support and driver updates.
+
 [id="ocp-4-11-installation-and-upgrade"]
 === Installation and upgrade
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3272
Mention in 4.11 RNs that RHCOS is now integrated with RHEL 8.6 content.

**Preview link**: https://deploy-preview-43942--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-rhcos-rhel-8-6-packages