### PR TITLE
BZ-2060950 fixing incorrect apiVersion in HTTP2 code sample

### DIFF
--- a/modules/nw-http2-haproxy.adoc
+++ b/modules/nw-http2-haproxy.adoc
@@ -46,9 +46,10 @@ $ oc annotate ingresses.config/cluster ingress.operator.openshift.io/default-ena
 You can alternatively apply the following YAML to add the annotation:
 [source,yaml]
 ----
-apiVersion: operator.openshift.io/v1
-kind: IngressController
+apiVersion: config.openshift.io/v1
+kind: Ingress
 metadata:
+  name: cluster
   annotations:
     ingress.operator.openshift.io/default-enable-http2: "true"
 ----


### PR DESCRIPTION
[Bugzilla link](https://bugzilla.redhat.com/show_bug.cgi?id=2060950)
Applies to 4.8+ 
[Preview link](https://deploy-preview-43959--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-http2-haproxy_configuring-ingress)