### PR TITLE
BZ2068245: Updating process for VLAN configuration using NADs and NNCPs

### DIFF
--- a/modules/virt-creating-bridge-nad-cli.adoc
+++ b/modules/virt-creating-bridge-nad-cli.adoc
@@ -41,7 +41,7 @@ spec:
 <4> The actual name of the Container Network Interface (CNI) plug-in that provides the network for this network attachment definition. Do not change this field unless you want to use a different CNI.
 <5> The name of the Linux bridge configured on the node.
 <6> Optional: Flag to enable MAC spoof check. When set to `true`, you cannot change the MAC address of the pod or guest interface. This attribute provides security against a MAC spoofing attack by allowing only a single MAC address to exit the pod.
-<7> Optional: The VLAN tag.
+<7> Optional: The VLAN tag. No additional VLAN configuration is required on the node network configuration policy.
 
 . Create the network attachment definition:
 +

--- a/modules/virt-creating-linux-bridge-nncp.adoc
+++ b/modules/virt-creating-linux-bridge-nncp.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
+
+:_content-type: PROCEDURE
+[id="virt-configuring-linux-bridge-nncp_{context}"]
+= Creating a Linux bridge using a node network configuration policy
+
+As a network administrator, you can create a Linux bridge interface on nodes in the cluster by applying a `NodeNetworkConfigurationPolicy` manifest to the cluster.
+
+.Procedure
+
+. Create the `NodeNetworkConfigurationPolicy` manifest. This YAML file is an example of a manifest for a Linux bridge interface.
+It includes samples values that you must replace with your own information.
+
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: br1-eth1-policy <1>
+spec:
+  desiredState:
+    interfaces:
+      - name: br1 <2>
+        description: Linux bridge with eth1 as a port <3>
+        type: linux-bridge <4>
+        state: up <5>
+        ipv4:
+          enabled: false <6>
+        bridge:
+          options:
+            stp:
+              enabled: false <7>
+          port:
+            - name: eth1 <8>
+----
+<1> Name of the policy.
+<2> Name of the interface.
+<3> Optional: Human-readable description of the interface.
+<4> The type of interface. This example creates a bridge.
+<5> The requested state for the interface after creation.
+<6> Disables ipv4 in this example.
+<7> Disables stp in this example.
+<8> The node NIC to which the bridge attaches.

--- a/modules/virt-networking-glossary.adoc
+++ b/modules/virt-networking-glossary.adoc
@@ -19,7 +19,10 @@ Multus:: a "meta" CNI plug-in that allows multiple CNIs to exist so that a pod o
 Custom resource definition (CRD):: a link:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[Kubernetes]
 API resource that allows you to define custom resources, or an object defined by using the CRD API resource.
 
-Network attachment definition:: a CRD introduced by the Multus project that allows you to attach pods, virtual machines, and virtual machine instances to one or more networks.
+Network attachment definition (NAD):: a CRD introduced by the Multus project that allows you to attach pods, virtual machines, and virtual machine instances to one or more networks.
+
+Node network configuration policy (NNCP):: a description of the requested network configuration on nodes.
+You update the node network configuration, including adding and removing interfaces, by applying a `NodeNetworkConfigurationPolicy` manifest to the cluster.
 
 Preboot eXecution Environment (PXE):: an interface that enables an administrator to boot a client machine from a server over the network.
 Network booting allows you to remotely load operating systems and other software onto the client.

--- a/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
+++ b/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
@@ -11,6 +11,7 @@ You can also import virtual machines with existing workloads that depend on acce
 
 To attach a virtual machine to an additional network:
 
+. Configure a Linux bridge.
 . Configure a bridge network attachment definition for a namespace in the web console or CLI.
 +
 [NOTE]
@@ -21,16 +22,25 @@ The network attachment definition must be in the same namespace as the pod or vi
 ** In the web console, create a NIC for a new or existing virtual machine.
 ** In the CLI, include the network information in the virtual machine configuration.
 
+[NOTE]
+====
+There are multiple methods for configuring a VLAN, including network attachment definition and node network configuration policy.
+However, a network attachment definition provides a more efficient and more manageable configuration.
+====
+
 include::modules/virt-networking-glossary.adoc[leveloffset=+1]
+
+[id="virt-creating-linux-bridge"]
+== Configuring a Linux bridge
+
+include::modules/virt-creating-linux-bridge-nncp.adoc[leveloffset=+2]
+
+For more information about scheduling, interface types, and other node networking activities,
+see the xref:../../../virt/node_network/virt-updating-node-network-config.adoc#virt-about-nmstate_virt-updating-node-network-config[node networking]
+section.
 
 [id="virt-creating-network-attachment-definition"]
 == Creating a network attachment definition
-
-[id="{context}_prerequisites"]
-=== Prerequisites
-
-* A Linux bridge must be configured and attached on every node.
-See the xref:../../../virt/node_network/virt-updating-node-network-config.adoc#virt-about-nmstate_virt-updating-node-network-config[node networking] section for more information.
 
 [WARNING]
 ====


### PR DESCRIPTION
This PR relates to [BZ2068245](https://bugzilla.redhat.com/show_bug.cgi?id=2068245).

The bugs asks to better explain the processes for configuring a VLAN using network attachment definitions and node network configuration policies when attaching a VM using a Linux bridge and subsequent procedures ([Accessing a virtual machine instance via SSH](https://docs.openshift.com/container-platform/4.10/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html)). 

CP: 4.10, 4.11

Preview: https://deploy-preview-43988--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html