### PR TITLE
OSDOCS-3421: Added a collapsible list to the ROSA documentation.

### DIFF
--- a/modules/rosa-sdpolicy-account-management.adoc
+++ b/modules/rosa-sdpolicy-account-management.adoc
@@ -61,8 +61,9 @@ For additional information, see the link:https://kubernetes.io/docs/tasks/admini
 
 {product-title} offers the following worker node types and sizes:
 
-General purpose
-
+.General purpose compute types
+[%collapsible]
+====
 - M5.xlarge (4 vCPU, 16 GiB)
 - M5.2xlarge (8 vCPU, 32 GiB)
 - M5.4xlarge (16 vCPU, 64 GiB)
@@ -70,9 +71,11 @@ General purpose
 - M5.12xlarge (48 vCPU, 192 GiB)
 - M5.16xlarge (64 vCPU, 256 GiB)
 - M5.24xlarge (96 vCPU, 384 GiB)
+====
 
-Memory-optimized
-
+.Memory-optimized compute types
+[%collapsible]
+====
 - R5.xlarge (4 vCPU, 32 GiB)
 - R5.2xlarge (8 vCPU, 64 GiB)
 - R5.4xlarge (16 vCPU, 128 GiB)
@@ -80,16 +83,18 @@ Memory-optimized
 - R5.12xlarge (48 vCPU, 384 GiB)
 - R5.16xlarge (64 vCPU, 512 GiB)
 - R5.24xlarge (96 vCPU, 768 GiB)
+====
 
-Compute-optimized
-
+.Compute-optimized compute types
+[%collapsible]
+====
 - C5.2xlarge (8 vCPU, 16 GiB)
 - C5.4xlarge (16 vCPU, 32 GiB)
 - C5.9xlarge (36 vCPU, 72 GiB)
 - C5.12xlarge (48 vCPU, 96 GiB)
 - C5.18xlarge (72 vCPU, 144 GiB)
 - C5.24xlarge (96 vCPU, 192 GiB)
-
+====
 
 [id="rosa-sdpolicy-regions-az_{context}"]
 == Regions and availability zones


### PR DESCRIPTION
This PR modifies an existing list to be collapsible. This change was made due to the size of the list increasing in a subsequent update.

JIRA: https://issues.redhat.com/browse/OSDOCS-3421

PREVIEW: https://deploy-preview-43995--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-service-definition#rosa-sdpolicy-aws-compute-types_rosa-service-definition
