### PR TITLE
OSDOCS-3438: Updated the EOL dates for OSD and ROSA

### DIFF
--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -9,8 +9,8 @@
 |===
 |Version    |General availability   |End of life
 |4.10       |Mar 10, 2022           |Dec 10, 2022
-|4.9        |Oct 18, 2021           |Jul 18, 2022
-|4.8        |Jul 27, 2021           |May 27, 2022
+|4.9        |Oct 18, 2021           |Aug 18, 2022
+|4.8        |Jul 27, 2021           |Jul 27, 2022
 
 ifeval::["{product-title}" == "OpenShift Dedicated"]
 |4.7        |Feb 24, 2021           |Dec 17, 2021 footnote:[4.7 minor version follows previous Y-1 life cycle]


### PR DESCRIPTION
Updated the end-of-life dates for OSD and ROSA.

JIRA: https://issues.redhat.com/browse/OSDOCS-3438#rosa-life-cycle-dates_osd-life-cycle

PREVIEW: 

* **ROSA** https://deploy-preview-43996--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-life-cycle.html#rosa-life-cycle-dates_rosa-life-cycle
* **OSD** https://deploy-preview-43996--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/osd-life-cycle.html#rosa-life-cycle-dates_osd-life-cycle