### PR TITLE
OSDOCS-3252: Clarify that etcd is not backed up for STS

### DIFF
--- a/modules/rosa-policy-incident.adoc
+++ b/modules/rosa-policy-incident.adoc
@@ -55,7 +55,7 @@ All {product-title} clusters are backed up using AWS snapshots. Notably, this do
 .2+|Full object store backup, all SRE-managed cluster PVs
 |Daily
 |7 days
-.2+|This is a full backup of all Kubernetes objects, such as etcd, and all SRE-managed PVs in the cluster.
+.2+|This is a full backup of all Kubernetes objects, such as etcd, and all SRE-managed PVs in the cluster. Etcd backup does not apply to STS clusters.
 
 |Weekly
 |30 days
@@ -64,7 +64,7 @@ All {product-title} clusters are backed up using AWS snapshots. Notably, this do
 |Full object store backup
 |Hourly
 |24-hour
-|This is a full backup of all Kubernetes objects, such as etcd. No PVs are backed up in this backup schedule.
+|This is a full backup of all Kubernetes objects, such as etcd. No PVs are backed up in this backup schedule. Etcd backup does not apply to STS clusters. 
 
 |Node root volume
 |Never


### PR DESCRIPTION
Fixes: https://github.com/openshift/openshift-docs/issues/41188
https://issues.redhat.com/browse/OSDOCS-3252

Preview: https://deploy-preview-43997--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-policy-process-security#rosa-policy-backup-recovery_rosa-policy-process-security