### PR TITLE
TELCODOCS 546: Adds "Known Issues" into the release notes.

### DIFF
--- a/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -10,6 +10,10 @@ During installation, you can set the `networkConfig` configuration setting in th
 [IMPORTANT]
 ====
 Before configuring host network interfaces, review the OpenShift Container Platform 4.10 release notes.
+
+link:https://bugzilla.redhat.com/show_bug.cgi?id=2048600[*BZ#2048600*] is a known issue where the bootstrap VM does not receive an IP address in the absence of a DHCP server. To assign an IP address to the bootstrap VM, see link:https://access.redhat.com/articles/6850661[Assigning a bootstrap VM an IP address on the baremetal network without a DHCP server].
+
+link:https://bugzilla.redhat.com/show_bug.cgi?id=2036677[*BZ#2036677*] is a known issue where the configured IP addresses get reset by the DHCP server, if present. To prevent DHCP from assigning an IP address to a node on reboot, see link:https://access.redhat.com/articles/6865841[Preventing DHCP from assigning an IP address on node reboot].
 ====
 
 See link:https://nmstate.io/examples.html#interfaces-ethernet[NMState] for additional examples of the NMState syntax.

--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2547,8 +2547,11 @@ Workaround: Use OpenShift OAuth for authentication. (link:https://bugzilla.redha
 and recreate it without a BFD profile. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2050824[*BZ#2050824*])
 
 * For clusters that run on {rh-openstack} and use Mellanox NICs as part of a single-root I/O virtualization configuration (SR-IOV), you may not be able to create a pod after you start one, restart the SR-IOV device plugin, and then stop the pod. No workaround is available for this issue.
-
 // TODO: ^^^ Add BZ when created.
+
+* {product-title} supports deploying an installer-provisioned cluster without a DHCP server. However, without a DHCP server, the bootstrap VM does not receive an external IP address for the `baremetal` network. To assign an IP address to the bootstrap VM, see link:https://access.redhat.com/articles/6850661[Assigning a bootstrap VM an IP address on the baremetal network without a DHCP server]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2048600[*BZ#2048600*])
+
+* {product-title} supports deploying an installer-provisioned cluster with static IP addresses on the `baremetal` network for environments without a DHCP server. If a DHCP server is present, nodes might retrieve an IP address from the DHCP server on reboot. To prevent DHCP from assigning an IP address to a node on reboot, see link:https://access.redhat.com/articles/6865841[Preventing DHCP from assigning an IP address on node reboot]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2036677[*BZ#2036677*])
 
 [id="ocp-4-10-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
This PR adds two "known issues" entries related to static IP addresses and networking. 

Fixes: [TELCODOCS-546](https://issues.redhat.com/browse/TELCODOCS-546)

See https://issues.redhat.com/browse/TELCODOCS-546

For release: 4.10

Preview URL: https://deploy-preview-43999--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-asynchronous-errata-updates  <-- Scroll up to the two previous bullet points. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>