### PR TITLE
BUILD-433: Unprivileged Builds

### DIFF
--- a/cicd/builds/advanced-build-operations.adoc
+++ b/cicd/builds/advanced-build-operations.adoc
@@ -21,3 +21,5 @@ include::modules/builds-chaining-builds.adoc[leveloffset=+1]
 include::modules/builds-build-pruning.adoc[leveloffset=+1]
 
 include::modules/builds-build-run-policy.adoc[leveloffset=+1]
+
+include::modules/builds-build-unprivileged.adoc[leveloffset=+1]

--- a/modules/builds-build-unprivileged.adoc
+++ b/modules/builds-build-unprivileged.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * builds/advanced-build-operations.adoc
+
+:_content-type: PROCEDURE
+[id="builds-build-unprivileged_{context}"]
+= Unprivileged Builds (Developer Preview)
+
+Builds can be configured to run as an unprivileged user, with the minimal set of capabilities to build a container image.
+
+[IMPORTANT]
+====
+[subs="attributes+"]
+Unprivileged {product-title} Builds is a Developer Preview feature, intended to provide early access to new capabilities. This feature is not recommended for production or business-critical environments.
+====
+
+.Procedure
+
+* To run builds as an unprivileged user, pass the `BUILD_PRIVILEGED` environment variable as part of the `sourceStrategy`
+ifndef::openshift-online[]
+or `dockerStrategy`
+endif::[]
+in a `BuildConfig`, with the value `"false"`:
++
+[source,yaml]
+----
+sourceStrategy:
+...
+  env:
+    - name: "BUILD_PRIVILEGED"
+      value: "false" <1>
+----
+<1> To run builds as an unprivileged user, set this value to `"false"` in quotation marks.


### PR DESCRIPTION
Document how to enable unprivileged OpenShift Builds in a BuildConfig.
This is a Developer Preview feature that is not intended to be used in
production environments.