### PR TITLE
BZ:2068127 - Updating kata config YAML files to include kataMonitorIm…

### DIFF
--- a/modules/sandboxed-containers-create-kata-config-resource-cli.adoc
+++ b/modules/sandboxed-containers-create-kata-config-resource-cli.adoc
@@ -34,6 +34,8 @@ apiVersion: kataconfiguration.openshift.io/v1
 kind: KataConfig
 metadata:
   name: cluster-kataconfig
+spec:
+  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:1.2.0
 ----
 
 . (Optional) If you want to install `kata` as a `RuntimeClass` only on selected nodes, create a YAML file that includes the label in the manifest:
@@ -45,9 +47,10 @@ kind: KataConfig
 metadata:
   name: cluster-kataconfig
 spec:
+  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:1.2.0
   kataConfigPoolSelector:
     matchLabels:
-    <label_key>: '<label_value>'
+      <label_key>: '<label_value>'
 ----
 
 . Create the `KataConfig` resource:

--- a/modules/sandboxed-containers-create-kataconfig-resource-web-console.adoc
+++ b/modules/sandboxed-containers-create-kataconfig-resource-web-console.adoc
@@ -38,6 +38,8 @@ apiVersion: kataconfiguration.openshift.io/v1
 kind: KataConfig
 metadata:
   name: cluster-kataconfig
+spec:
+  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:1.2.0
 ----
 +
 If you want to install `kata` as a `RuntimeClass` only on selected nodes, include the label in the manifest:
@@ -45,14 +47,15 @@ If you want to install `kata` as a `RuntimeClass` only on selected nodes, includ
 +
 [source,yaml]
 ----
- apiVersion: kataconfiguration.openshift.io/v1
- kind: KataConfig
- metadata:
-   name: cluster-kataconfig
- spec:
-   kataConfigPoolSelector:
-     matchLabels:
-     <label_key>: '<label_value>'
+apiVersion: kataconfiguration.openshift.io/v1
+kind: KataConfig
+metadata:
+  name: cluster-kataconfig
+spec:
+  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:1.2.0
+  kataConfigPoolSelector:
+    matchLabels:
+      <label_key>: '<label_value>'
 ----
 
 . Click *Create*.


### PR DESCRIPTION
Update to main and 4.10 for [BZ-2068127](https://bugzilla.redhat.com/show_bug.cgi?id=2068127)

[Preview link for web console procedure update](https://deploy-preview-44001--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads#sandboxed-containers-create-kataconfig-resource-web-console_deploying-sandboxed-containers)
 
[Preview link for CLI procedure update](https://deploy-preview-44001--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads#sandboxed-containers-create-kataconfig-rsource-cli_deploying-sandboxed-containers) 

Acked by SME and QE.