### PR TITLE
GitHub-43098: Removing duplicate step and other issues from an incorr…

### DIFF
--- a/modules/installation-adding-registry-pull-secret.adoc
+++ b/modules/installation-adding-registry-pull-secret.adoc
@@ -54,19 +54,7 @@ endif::restricted[]
 Complete the following steps on the installation host:
 
 ifndef::openshift-origin[]
-. Download your `registry.redhat.io` {cluster-manager-url-pull} and save it to a `.json` file.
-endif::[]
-
-. Generate the base64-encoded user name and password or token for your mirror
-registry:
-+
-[source,terminal]
-----
-$ echo -n '<user_name>:<password>' | base64 -w0 <1>
-BGVtbYk3ZHAtqXs=
-----
-<1> For `<user_name>` and `<password>`, specify the user name and password that
-you configured for your registry.
+. Download your `registry.redhat.io` {cluster-manager-url-pull}.
 
 . Make a copy of your pull secret in JSON format:
 +
@@ -106,6 +94,7 @@ The contents of the file resemble the following example:
   }
 }
 ----
+endif::[]
 
 . Generate the base64-encoded user name and password or token for your mirror registry:
 +
@@ -117,7 +106,7 @@ BGVtbYk3ZHAtqXs=
 <1> For `<user_name>` and `<password>`, specify the user name and password that you configured for your registry.
 
 ifndef::openshift-origin[]
-. Edit the new
+. Edit the JSON
 endif::[]
 ifdef::openshift-origin[]
 . Create a `.json`


### PR DESCRIPTION
…ect merge conflict resolution

To address #43098

Preview:

* OCP: https://deploy-preview-44019--osdocs.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected.html#installation-adding-registry-pull-secret_installing-mirroring-disconnected
* OKD: http://file.rdu.redhat.com/~ahoffer/2022/github-43098/installing/disconnected_install/installing-mirroring-disconnected.html#installation-adding-registry-pull-secret_installing-mirroring-disconnected

Also the other section that uses this module:
* OCP: https://deploy-preview-44019--osdocs.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-installation-images.html#installation-adding-registry-pull-secret_installing-mirroring-installation-images
* OKD: http://file.rdu.redhat.com/~ahoffer/2022/github-43098/installing/disconnected_install/installing-mirroring-installation-images.html#installation-adding-registry-pull-secret_installing-mirroring-installation-images