### PR TITLE
BZ-2070420 Moved diskType parameter to correct table

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1317,7 +1317,7 @@ in vSphere.
 |String
 
 |`platform.vsphere.folder`
-|_Optional_. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the datacenter virtual machine folder.
+|Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the datacenter virtual machine folder.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
 |`platform.vsphere.network`
@@ -1335,6 +1335,10 @@ in vSphere.
 |`platform.vsphere.ingressVIP`
 |The virtual IP (VIP) address that you configured for cluster ingress.
 |An IP address, for example `128.0.0.1`.
+
+|`platform.vsphere.diskType`
+|Optional. The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
+|Valid values are `thin`, `thick`, or `eagerZeroedThick`.
 |====
 
 [id="installation-configuration-parameters-optional-vsphere_{context}"]
@@ -1366,10 +1370,6 @@ Optional VMware vSphere machine pool configuration parameters are described in t
 |`platform.vsphere.memoryMB`
 |The size of a virtual machine's memory in megabytes.
 |Integer
-
-|`platform.vsphere.diskType`
-|The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
-|Valid values are `thin`, `thick`, or `eagerZeroedThick`.
 |====
 
 endif::vsphere,vmc[]


### PR DESCRIPTION
[Bugzilla link](https://bugzilla.redhat.com/show_bug.cgi?id=2070420)

[Doc preview](https://deploy-preview-44021--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#installation-configuration-parameters-additional-vsphere_installing-vsphere-installer-provisioned-network-customizations)

Moved `diskType` from table 8 to table 7.

CP to 4.10 and 4.11