### PR TITLE
[Enterprise-4.9] OSDOCS-3438: Updated the EOL dates for OSD and ROSA

### DIFF
--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -8,8 +8,8 @@
 [options="header"]
 |===
 |Version    |General availability   |End of life
-|4.9        |Oct 18, 2021           |Jul 18, 2022
-|4.8        |Jul 27, 2021           |May 27, 2022
+|4.9        |Oct 18, 2021           |Aug 18, 2022
+|4.8        |Jul 27, 2021           |Jul 27, 2022
 
 ifeval::["{product-title}" == "OpenShift Dedicated"]
 |4.7        |Feb 24, 2021           |Dec 17, 2021 footnote:[4.7 minor version follows previous Y-1 life cycle]


### PR DESCRIPTION
This is a manual cherrypick of #43996 for `enterprise-4.9` branch