### PR TITLE
CNV-16657: Clarify namespace must gather information

### DIFF
--- a/modules/virt-must-gather-usage-targeted-vm-data.adoc
+++ b/modules/virt-must-gather-usage-targeted-vm-data.adoc
@@ -13,7 +13,7 @@ When you use the `must-gather` CLI tool to collect {VirtProductName} data, the v
 
 .Environment variables
 
-`NS=<namespace_name>`:: Gather virtual machine details from the namespace that you specify.
+`NS=<namespace_name>`:: Gather virtual machine information, including `virt-launcher` pod details, from the namespace that you specify. The `VirtualMachine` and `VirtualMachineInstance` CR data is collected for all namespaces.
 
 `VM=<vm_name>`:: Gather details about a particular virtual machine. To use this option, you must also specify a namespace by using the `NS` environment variable.
 


### PR DESCRIPTION
Re: [CNV-16657](https://issues.redhat.com/browse/CNV-16657)
For 4.9 and later
Preview:  https://deploy-preview-44032--osdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-collecting-virt-data#virt-must-gather-usage-targeted-vm-data_virt-collecting-virt-data