### PR TITLE
Removes an unsupported Podman section and adds a link to OMR

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -59,6 +59,17 @@ include::modules/ipi-install-configuring-bios-for-worker-node.adoc[leveloffset=+
 include::modules/ipi-install-configuring-raid-for-worker-node.adoc[leveloffset=+2]
 
 include::modules/ipi-install-creating-a-disconnected-registry.adoc[leveloffset=+1]
+include::modules/ipi-mirroring-a-disconnected-registry.adoc[leveloffset=+2]
+include::modules/ipi-modify-a-disconnected-registry-config-yaml.adoc[leveloffset=+2]
+
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/disconnected_install/index.adoc#installing-mirroring-disconnected-about[About disconnected installation mirroring]
+xref:../../installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-flags_installing-mirroring-creating-registry[Mirror registry for Red Hat OpenShift flags]
+* xref:../../installing/disconnected_install/installing-mirroring-creating-registry.adoc#installing-mirroring-creating-registry[Creating a mirror registry]
+* xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in]
 
 include::modules/ipi-install-deploying-routers-on-worker-nodes.adoc[leveloffset=+1]
 

--- a/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -5,254 +5,72 @@
 
 :_content-type: PROCEDURE
 [id="ipi-install-creating-a-disconnected-registry_{context}"]
-= (Optional) Creating a disconnected registry
+= Creating a disconnected registry on a registry node
 
-In some cases, you might want to install an {product-title} cluster using a local copy of the installation registry. This could be for enhancing network efficiency because the cluster nodes are on a network that does not have access to the internet.
-
-A local, or mirrored, copy of the registry requires the following:
-
-* A certificate for the registry node. This can be a self-signed certificate.
-* A web server that a container on a system will serve.
-* An updated pull secret that contains the certificate and local repository information.
+In some cases, you might want to install an {product-title} cluster using a local copy of the installation registry. This might be for enhancing network efficiency because the cluster nodes are on a network that does not have access to the internet.
 
 [NOTE]
 ====
-Creating a disconnected registry on a registry node is optional. The subsequent sections indicate that they are optional since they are steps you need to execute only when creating a disconnected registry on a registry node. You should execute all of the subsequent sub-sections labeled "(optional)" when creating a disconnected registry on a registry node.
+If you cannot connect to your registry, or you do not have a registry, within your isolated network. Red Hat recommends that you mirror {product-title} content to the _mirror registry for Red Hat OpenShift_ as the disconnected registry for your cluster. For more information, see "About disconnected installation mirroring".
+
+The subsequent sections indicate that they are optional because they are steps that you must run only when you create a disconnected registry. To create a _mirror registry for Red Hat OpenShift_ to host a disconnected registry on a registry node, you must complete all of the subsequent sub-sections that are labeled "(optional)".
 ====
 
-== Preparing the registry node to host the mirrored registry (optional)
+== Install the _mirror registry for Red Hat OpenShift_ on a local host (optional)
 
-Make the following changes to the registry node.
+This procedure explains how to install the _mirror registry for Red Hat OpenShift_ on a local host using the `mirror-registry` installer tool. By doing so, users can create a local host registry running on port 443 for the purpose of storing a mirror of {product-title} images.
 
-.Procedure
+[NOTE]
+====
+Installing the _mirror registry for Red Hat OpenShift_ using the `mirror-registry` CLI tool makes several changes to your machine. After installation, a `/etc/quay-install` directory is created, which has installation files, local storage, and the configuration bundle. Trusted SSH keys are generated in case the deployment target is the local host, and systemd files on the host machine are set up to ensure that container runtimes are persistent. Additionally, an initial user named `init` is created with an automatically generated password. All access credentials are printed at the end of the install routine.
+====
 
-. Open the firewall port on the registry node.
-+
-[source,terminal]
-----
-$ sudo firewall-cmd --add-port=5000/tcp --zone=libvirt  --permanent
-$ sudo firewall-cmd --add-port=5000/tcp --zone=public   --permanent
-$ sudo firewall-cmd --reload
-----
+.Prerequisites
 
-. Install the required packages for the registry node.
-+
-[source,terminal]
-----
-$ sudo yum -y install python3 podman httpd httpd-tools jq
-----
+Creating a local, or mirrored, copy of the registry by using the _mirror registry for Red Hat OpenShift_ requires the following components:
 
-. Create the directory structure where the repository information will be held.
-+
-[source,terminal]
-----
-$ sudo mkdir -p /opt/registry/{auth,certs,data}
-----
-
-== Generating the self-signed certificate (optional)
-
-Generate a self-signed certificate for the registry node and put it in the `/opt/registry/certs` directory.
+* An {product-title} subscription.
+* {op-system-base-full} 8 with Podman 3.3 and OpenSSL installed.
+* A fully qualified domain name for the Red Hat Quay service, which must resolve through a DNS server.
+* Passwordless `sudo` access on the target host.
+* Key-based SSH connectivity on the target host. SSH keys are automatically generated for local installations. For remote hosts, you must generate your own SSH keys.
+* 2 or more vCPUs.
+* 8 GB of RAM.
+* About 12 GB for {product-title} {product-version} release images, or about 358 GB for {product-title} {product-version} release images and {product-title} {product-version} Red Hat Operator images. Up to 1 TB per stream or more is suggested.
 
 .Procedure
 
-. Adjust the certificate information as appropriate.
+. Download the `mirror-registry.tar.gz` package for the latest version of the _mirror registry for Red Hat OpenShift_ found on the link:https://console.redhat.com/openshift/downloads#tool-mirror-registry[OpenShift console *Downloads*] page.
+
+. Install the _mirror registry for Red Hat OpenShift_ on your local host with your current user account by using the `mirror-registry` tool. For a full list of available flags, see "mirror registry for Red Hat OpenShift flags".
 +
 [source,terminal]
 ----
-$ host_fqdn=$( hostname --long )
-$ cert_c="<Country Name>"   # Country Name (C, 2 letter code)
-$ cert_s="<State>"          # Certificate State (S)
-$ cert_l="<Locality>"       # Certificate Locality (L)
-$ cert_o="<Organization>"   # Certificate Organization (O)
-$ cert_ou="<Org Unit>"      # Certificate Organizational Unit (OU)
-$ cert_cn="${host_fqdn}"    # Certificate Common Name (CN)
-
-$ openssl req \
-    -newkey rsa:4096 \
-    -nodes \
-    -sha256 \
-    -keyout /opt/registry/certs/domain.key \
-    -x509 \
-    -days 365 \
-    -out /opt/registry/certs/domain.crt \
-    -addext "subjectAltName = DNS:${host_fqdn}" \
-    -subj "/C=${cert_c}/ST=${cert_s}/L=${cert_l}/O=${cert_o}/OU=${cert_ou}/CN=${cert_cn}"
+$ sudo ./mirror-registry install \
+  --quayHostname <host_example_com> \
+  --quayRoot <example_directory_name>
 ----
-+
-NOTE: When replacing `<Country Name>`, ensure that it only contains two letters. For example, `US`.
 
-. Update the registry node's `ca-trust` with the new certificate.
+. Use the user name and password that was generated during installation to log into the registry by running the following command:
 +
 [source,terminal]
 ----
-$ sudo cp /opt/registry/certs/domain.crt /etc/pki/ca-trust/source/anchors/
-$ sudo update-ca-trust extract
+$ podman login --authfile pull-secret.txt \
+  -u init \
+  -p <password> \
+  <host_example_com>:8443> \
+  --tls-verify=false <1>
 ----
-
-== Creating the registry podman container (optional)
-
-The registry container uses the `/opt/registry` directory for certificates, authentication files, and to store its data files.
-
-The registry container uses `httpd` and needs an `htpasswd` file for authentication.
-
-.Procedure
-
-. Create an `htpasswd` file in `/opt/registry/auth` for the container to use.
+<1> You can avoid running `--tls-verify=false` by configuring your system to trust the generated rootCA certificates. See "Using SSL to protect connections to Red Hat Quay" and "Configuring the system to trust the certificate authority" for more information.
 +
-[source,terminal]
-----
-$ htpasswd -bBc /opt/registry/auth/htpasswd <user> <passwd>
-----
+[NOTE]
+====
+You can also log in by accessing the UI at `\https://<host.example.com>:8443` after installation.
+====
+
+. You can mirror {product-title} images after logging in. Depending on your requirements, see either the "Mirroring the {product-title} image repository" or the "Mirroring Operator catalogs for use with disconnected clusters" sections that follow.
 +
-Replace `<user>` with the user name and `<passwd>` with the password.
-
-. Create and start the registry container.
-+
-[source,terminal]
-----
-$ podman create \
-  --name ocpdiscon-registry \
-  -p 5000:5000 \
-  -e "REGISTRY_AUTH=htpasswd" \
-  -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry" \
-  -e "REGISTRY_HTTP_SECRET=ALongRandomSecretForRegistry" \
-  -e "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd" \
-  -e "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt" \
-  -e "REGISTRY_HTTP_TLS_KEY=/certs/domain.key" \
-  -e "REGISTRY_COMPATIBILITY_SCHEMA1_ENABLED=true" \
-  -v /opt/registry/data:/var/lib/registry:z \
-  -v /opt/registry/auth:/auth:z \
-  -v /opt/registry/certs:/certs:z \
-  docker.io/library/registry:2
-----
-+
-[source,terminal]
-----
-$ podman start ocpdiscon-registry
-----
-
-== Copy and update the pull-secret (optional)
-
-Copy the pull secret file from the provisioner node to the registry node and modify it to include the authentication information for the new registry node.
-
-.Procedure
-
-. Copy the `pull-secret.txt` file.
-+
-[source,terminal]
-----
-$ scp kni@provisioner:/home/kni/pull-secret.txt pull-secret.txt
-----
-
-. Update the `host_fqdn` environment variable with the fully qualified domain name of the registry node.
-+
-[source,terminal]
-----
-$ host_fqdn=$( hostname --long )
-----
-
-. Update the `b64auth` environment variable with the base64 encoding of the `http` credentials used to create the `htpasswd` file.
-+
-[source,terminal]
-----
-$ b64auth=$( echo -n '<username>:<passwd>' | openssl base64 )
-----
-+
-Replace `<username>` with the user name and `<passwd>` with the password.
-
-. Set the `AUTHSTRING` environment variable to use the `base64` authorization string. The `$USER` variable is an environment variable containing the name of the current user.
-+
-[source,terminal]
-----
-$ AUTHSTRING="{\"$host_fqdn:5000\": {\"auth\": \"$b64auth\",\"email\": \"$USER@redhat.com\"}}"
-----
-
-. Update the `pull-secret.txt` file.
-+
-[source,terminal]
-----
-$ jq ".auths += $AUTHSTRING" < pull-secret.txt > pull-secret-update.txt
-----
-
-== Mirroring the repository (optional)
-
-.Procedure
-
-. Copy the `oc` binary from the provisioner node to the registry node.
-+
-[source,terminal]
-----
-$ sudo scp kni@provisioner:/usr/local/bin/oc /usr/local/bin
-----
-
-. Set the required environment variables.
-
-.. Set the release version:
-+
-[source,terminal]
-----
-$ VERSION=<release_version>
-----
-+
-For `<release_version>`, specify the tag that corresponds to the version of {product-title} to install, such as `{product-version}`.
-
-.. Set the local registry name and host port:
-+
-[source,terminal]
-----
-$ LOCAL_REG='<local_registry_host_name>:<local_registry_host_port>'
-----
-+
-For `<local_registry_host_name>`, specify the registry domain name for your mirror
-repository, and for `<local_registry_host_port>`, specify the port that it
-serves content on.
-
-.. Set the local repository name:
-+
-[source,terminal]
-----
-$ LOCAL_REPO='<local_repository_name>'
-----
-+
-For `<local_repository_name>`, specify the name of the repository to create in your
-registry, such as `ocp4/openshift4`.
-
-. Mirror the remote install images to the local repository.
-+
-[source,terminal]
-----
-$ /usr/local/bin/oc adm release mirror \
-  -a pull-secret-update.txt \
-  --from=$UPSTREAM_REPO \
-  --to-release-image=$LOCAL_REG/$LOCAL_REPO:${VERSION} \
-  --to=$LOCAL_REG/$LOCAL_REPO
-----
-
-== Modify the `install-config.yaml` file to use the disconnected registry (optional)
-
-On the provisioner node, the `install-config.yaml` file should use the newly created pull-secret from the `pull-secret-update.txt` file. The `install-config.yaml` file must also contain the disconnected registry node's certificate and registry information.
-
-.Procedure
-
-. Add the disconnected registry node's certificate to the `install-config.yaml` file. The certificate should follow the `"additionalTrustBundle: |"` line and be properly indented, usually by two spaces.
-+
-[source,terminal]
-----
-$ echo "additionalTrustBundle: |" >> install-config.yaml
-$ sed -e 's/^/  /' /opt/registry/certs/domain.crt >> install-config.yaml
-----
-
-. Add the mirror information for the registry to the `install-config.yaml` file.
-+
-[source,terminal]
-----
-$ echo "imageContentSources:" >> install-config.yaml
-$ echo "- mirrors:" >> install-config.yaml
-$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
-$ echo "  source: quay.io/openshift-release-dev/ocp-release" >> install-config.yaml
-$ echo "- mirrors:" >> install-config.yaml
-$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
-$ echo "  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev" >> install-config.yaml
-----
-+
-NOTE: Replace `registry.example.com` with the registry's fully qualified domain name.
+[NOTE]
+====
+If you experience issues with images stored by the _mirror registry for Red Hat OpenShift_ due to storage layer problems, you can re-mirror the {product-title} images or reinstall mirror registry on more stable storage.
+====

--- a/modules/ipi-mirroring-a-disconnected-registry.adoc
+++ b/modules/ipi-mirroring-a-disconnected-registry.adoc
@@ -1,0 +1,246 @@
+// Module included in the following assemblies:
+//
+// * list of assemblies where this module is included
+// install/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+
+:_content-type: PROCEDURE
+[id="ipi-mirroring-a-disconnected-registry_{context}"]
+
+= Mirroring the repository (optional)
+
+This procedure explains how mirror the repository to a local host.
+
+.Prerequisites
+
+* You have installed OpenShift CLI (`oc`).
+* You have a designated mirror registry.
+* (Optional) You have installed the `oc-mirror-plugin` tool.
+
+.Procedure
+
+Complete the following steps on the mirror host:
+
+. Review the
+link:https://access.redhat.com/downloads/content/290/[{product-title} downloads page]
+to determine the version of {product-title} that you want to install and determine the corresponding tag on the link:https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags[Repository Tags] page.
+
+. Set the required environment variables:
+.. Export the release version:
++
+[source,terminal]
+----
+$ OCP_RELEASE=<release_version>
+----
++
+For `<release_version>`, specify the tag that corresponds to the version of {product-title} to
+install, such as `4.5.4`.
+
+.. Export the local registry name and host port:
++
+[source,terminal]
+----
+$ LOCAL_REGISTRY='<local_registry_host_name>:<local_registry_host_port>'
+----
++
+For `<local_registry_host_name>`, specify the registry domain name for your mirror
+repository, and for `<local_registry_host_port>`, specify the port that it
+serves content on.
+
+.. Export the local repository name:
++
+[source,terminal]
+----
+$ LOCAL_REPOSITORY='<local_repository_name>'
+----
++
+For `<local_repository_name>`, specify the name of the repository to create in your
+registry, such as `ocp4/openshift4`.
+
+.. Export the name of the repository to mirror:
++
+ifndef::openshift-origin[]
+[source,terminal]
+----
+$ PRODUCT_REPO='openshift-release-dev'
+----
++
+For a production release, you must specify `openshift-release-dev`.
+endif::[]
+ifdef::openshift-origin[]
+[source,terminal]
+----
+$ PRODUCT_REPO='openshift'
+----
+endif::[]
+
+.. Export the path to your registry pull secret:
++
+[source,terminal]
+----
+$ LOCAL_SECRET_JSON='<path_to_pull_secret>'
+----
++
+For `<path_to_pull_secret>`, specify the absolute path to and file name of the pull secret for your mirror registry that you created.
+
+.. Export the release mirror:
++
+ifndef::openshift-origin[]
+[source,terminal]
+----
+$ RELEASE_NAME="ocp-release"
+----
++
+For a production release, you must specify `ocp-release`.
+endif::[]
+ifdef::openshift-origin[]
+[source,terminal]
+----
+$ RELEASE_NAME="okd"
+----
+endif::[]
+
+ifndef::openshift-origin[]
+.. Export the type of architecture for your server, such as `x86_64`:
++
+[source,terminal]
+----
+$ ARCHITECTURE=<server_architecture>
+----
+endif::[]
+
+.. Export the path to the directory to host the mirrored images:
++
+[source,terminal]
+----
+$ REMOVABLE_MEDIA_PATH=<path> <1>
+----
+<1> Specify the full path, including the initial forward slash (/) character.
+
+. Mirror the version images to the mirror registry:
+** If your mirror host does not have internet access, take the following actions:
+... Connect the removable media to a system that is connected to the internet.
+... Review the images and configuration manifests to mirror:
++
+ifdef::openshift-origin[]
+[source,terminal]
+----
+$ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
+     --from=quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE} \
+     --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} \
+     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE} --dry-run
+----
+endif::[]
+ifndef::openshift-origin[]
+[source,terminal]
+----
+$ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
+     --from=quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE}-${ARCHITECTURE} \
+     --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} \
+     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE} --dry-run
+----
+endif::[]
+
+... Record the entire `imageContentSources` section from the output of the previous
+command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageContentSources` section to the `install-config.yaml` file during installation.
+... Mirror the images to a directory on the removable media:
++
+ifdef::openshift-origin[]
+[source,terminal]
+----
+$ oc adm release mirror -a ${LOCAL_SECRET_JSON} --to-dir=${REMOVABLE_MEDIA_PATH}/mirror quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE}
+----
+endif::[]
+ifndef::openshift-origin[]
+[source,terminal]
+----
+$ oc adm release mirror -a ${LOCAL_SECRET_JSON} --to-dir=${REMOVABLE_MEDIA_PATH}/mirror quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE}-${ARCHITECTURE}
+----
+endif::[]
+
+... Take the media to the restricted network environment and upload the images to the local container registry.
++
+[source,terminal]
+----
+$ oc image mirror -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mirror "file://openshift/release:${OCP_RELEASE}*" ${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} <1>
+----
++
+<1> For `REMOVABLE_MEDIA_PATH`, you must use the same path that you specified when you mirrored the images.
+
+** If the local container registry is connected to the mirror host, take the following actions:
+... Directly push the release images to the local registry by using following command:
++
+ifdef::openshift-origin[]
+[source,terminal]
+----
+$ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
+     --from=quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE} \
+     --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} \
+     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}
+----
+endif::[]
+ifndef::openshift-origin[]
+[source,terminal]
+----
+$ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
+     --from=quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE}-${ARCHITECTURE} \
+     --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} \
+     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}
+----
+endif::[]
++
+This command pulls the release information as a digest, and its output includes
+the `imageContentSources` data that you require when you install your cluster.
+
+... Record the entire `imageContentSources` section from the output of the previous
+command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageContentSources` section to the `install-config.yaml` file during installation.
++
+[NOTE]
+====
+The image name gets patched to Quay.io during the mirroring process, and the podman images will show Quay.io in the registry on the bootstrap virtual machine.
+====
+
+. To create the installation program that is based on the content that you
+mirrored, extract it and pin it to the release:
+** If your mirror host does not have internet access, run the following command:
++
+[source,terminal]
+----
+$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}"
+----
+** If the local container registry is connected to the mirror host, run the following command:
++
+ifdef::openshift-origin[]
+[source,terminal]
+----
+$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}"
+----
+endif::[]
+ifndef::openshift-origin[]
+[source,terminal]
+----
+$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}"
+----
+endif::[]
++
+[IMPORTANT]
+====
+To ensure that you use the correct images for the version of {product-title}
+that you selected, you must extract the installation program from the mirrored
+content.
+
+You must perform this step on a machine with an active internet connection.
+
+If you are in a disconnected environment, use the `--image` flag as part of must-gather and point to the payload image.
+====
++
+. For clusters using installer-provisioned infrastructure, run the following command:
++
+[source,terminal]
+----
+$ openshift-install
+----
+
+[NOTE]
+====
+If required, you can mirror additional content using the `oc-mirror-plug-in` tool. For more information, see "Mirroring images for a disconnected installation using the oc-mirror plug-in".
+====

--- a/modules/ipi-modify-a-disconnected-registry-config-yaml.adoc
+++ b/modules/ipi-modify-a-disconnected-registry-config-yaml.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * list of assemblies where this module is included
+// install/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+
+:_content-type: PROCEDURE
+[id="ipi-modify-a-disconnected-registry-config-yaml_{context}"]
+
+= Modify the `install-config.yaml` file to use the disconnected registry (optional)
+
+On the provisioner node, the `install-config.yaml` file should use the newly created pull secret from the `pull-secret-update.txt` file. The `install-config.yaml` file must also contain the disconnected registry node's certificate and registry information.
+
+.Procedure
+
+. Add the disconnected registry node's certificate to the `install-config.yaml` file. The certificate should follow the `"additionalTrustBundle: |"` line and be properly indented, usually by two spaces:
++
+[source,terminal]
+----
+$ echo "additionalTrustBundle: |" >> install-config.yaml
+$ sed -e 's/^/  /' /opt/registry/certs/domain.crt >> install-config.yaml
+----
+
+. Edit the `install-config.yaml` file to provide the mirror information for the registry:
+.. Update the `pullSecret` value to contain the authentication information from your registry:
++
+[source,terminal]
+----
+$ pullSecret: '{"auths":{"<mirror_host_name>:5000": {"auth": "<credentials>","email": "you@example.com"}}}'----
+----
++
+For `<mirror_host_name>`, specify the registry domain name that you specified in the certificate for your mirror registry, and for `<credentials>``, specify the base64-encoded user name and password for your mirror registry.
+
+.. Add the `additionalTrustBundle` parameter and value:
++
+[source,yaml]
+----
+additionalTrustBundle: |
+  -----BEGIN CERTIFICATE-----
+  ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+  -----END CERTIFICATE-----
+----
++
+The value must be the contents of the certificate file that you used for your mirror registry, which can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.
+
+.. Define the subnets for the VPC to install the cluster in:
++
+[source,yaml]
+----
+subnets:
+- subnet-1
+- subnet-2
+- subnet-3
+----
+
+.. Add the image content resources, which look like this excerpt:
++
+[source,yaml]
+----
+imageContentSources:
+- mirrors:
+  - <mirror_host_name>:5000/<repo_name>/release
+  source: quay.example.com/openshift-release-dev/ocp-release
+- mirrors:
+  - <mirror_host_name>:5000/<repo_name>/release
+  source: registry.example.com/ocp/release
+----
++
+To complete these values, use the `imageContentSources` that you recorded during mirror registry creation.
+
+. Make any other modifications to the `install-config.yaml` file that you require. You can find more information about the available parameters in the *Installation configuration parameters* section.

--- a/updating/understanding-upgrade-channels-release.adoc
+++ b/updating/understanding-upgrade-channels-release.adoc
@@ -1,7 +1,5 @@
-:_content-type: ASSEMBLY
 [id="understanding-upgrade-channels-releases"]
 = Understanding upgrade channels and releases
-include::_attributes/common-attributes.adoc[]
 :context: understanding-upgrade-channels-releases
 
 toc::[]


### PR DESCRIPTION
Based on several conversations with Alex D, Stephanie Stout, John Wilkins, etc.

BZ: https://bugzilla.redhat.com/buglist.cgi?f1=assigned_to&list_id=12577133&o1=equals&resolution=---&v1=%25user%25

Preview: https://deploy-preview-44040--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-creating-a-disconnected-registry_ipi-install-installation-workflow

QE needed. SME approved. 