### PR TITLE
BZ2017465: Adding prerequisite for assembly

### DIFF
--- a/virt/virtual_machines/vm_networking/virt-viewing-ip-of-vm-nic.adoc
+++ b/virt/virtual_machines/vm_networking/virt-viewing-ip-of-vm-nic.adoc
@@ -8,5 +8,9 @@ toc::[]
 
 You can view the IP address for a network interface controller (NIC) by using the web console or the `oc` client. The xref:../../../virt/virtual_machines/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent[QEMU guest agent] displays additional information about the virtual machine's secondary networks.
 
+[id="prerequisites_virt-viewing-ip-of-vm-vnic"]
+== Prerequisites
+* Install the QEMU guest agent on the virtual machine.
+
 include::modules/virt-viewing-vmi-ip-cli.adoc[leveloffset=+1]
 include::modules/virt-viewing-vmi-ip-web.adoc[leveloffset=+1]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2017465

Added new prerequisite to the "Viewing the IP address of NICs on a virtual machine" assembly.

Applies to 4.9, 4.10, 4.11

Preview: https://deploy-preview-44041--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-viewing-ip-of-vm-nic.html