### PR TITLE
WINC Fix Supported Platform tables

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -21,19 +21,19 @@ The following information details the supported platform versions, Windows Serve
 |4.6+
 |WMCO 1.0+
 |GA
-|GA
+|
 
 |Microsoft Azure
 |4.6+
 |WMCO 1.0+
 |GA
-|GA
+|
 
 |VMware vSphere
 |4.7+
 |WMCO 2.0+
 |GA
-|GA
+|
 |===
 
 == Supported platforms for Bring-Your-Own-Host (BYOH) instances based on {product-title} and WMCO versions
@@ -50,21 +50,21 @@ The following information details the supported platform versions, Windows Serve
 |4.8+
 |WMCO 3.1+
 |GA
-|GA
+|
 
 |Microsoft Azure
 |4.8+
 |WMCO 3.1+
 |GA
-|GA
+|
 
 |VMware vSphere
 |4.8+
 |WMCO 3.1+
 |GA
-|GA
+|
 
-|bare metal
+|Provider agnostic (Platform: none)
 |4.8+
 |WMCO 3.1+
 |


### PR DESCRIPTION
From [forum-winc Slack](https://coreos.slack.com/archives/CM4ERHBJS/p1648737021325039)

For [this table](https://docs.openshift.com/container-platform/4.9/windows_containers/understanding-windows-container-workloads.html#supported-platforms-based-on-openshift-container-platform-and-wmco-versions) and the following table, the GA values for user-provisioned infrastructure support should be removed from everything except for the bare metal row.
Additionally the bare metal provider name should be changed to: `Provider Agnostic (Platform: none)`

Previews
[Supported platforms based on OpenShift Container Platform and WMCO versions
](https://deploy-preview-44052--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-4-x.html#supported-platforms-based-on-openshift-container-platform-and-wmco-versions)
[Supported platforms for Bring-Your-Own-Host (BYOH) instances based on OpenShift Container Platform and WMCO versions](https://deploy-preview-44052--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-4-x.html#supported-platforms-for-bring-your-own-host-byoh-instances-based-on-openshift-container-platform-and-wmco-versions)