### PR TITLE
BZ-1641584: Fixing incorrect values for certfile and cafile

### DIFF
--- a/install_config/certificate_customization.adoc
+++ b/install_config/certificate_customization.adoc
@@ -61,7 +61,7 @@ openshift_hosted_router_certificate={"certfile": "/path/on/host/to/app-crt-file"
 Example parameters for a master API certificate:
 ----
 openshift_master_overwrite_named_certificates=true
-openshift_master_named_certificates=[{"names": ["master.148.251.233.173.nip.io"], "certfile": "/home/cloud-user/master-bundle.cert.pem", "keyfile": "/home/cloud-user/master.148.251.233.173.nip.io.key.pem", "cafile": "/home/cloud-user/master.148.251.233.173.nip.io.key.pem"}]
+openshift_master_named_certificates=[{"names": ["master.148.251.233.173.nip.io"], "certfile": "/home/cloud-user/master.148.251.233.173.nip.io.cert.pem", "keyfile": "/home/cloud-user/master.148.251.233.173.nip.io.key.pem", "cafile": "/home/cloud-user/master-bundle.cert.pem"}]
 ----
 
 


### PR DESCRIPTION
Applies to 3.11 only
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1641584
Preview Link: https://docs.openshift.com/container-platform/3.11/install_config/certificate_customization.html#ansible-configuring-custom-certificates
QE ack required: @wangke19 