### PR TITLE
[OSDOCS-3445] Amends GCP Workload Identity docs in 4.10 branch

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
@@ -81,6 +81,11 @@ data:
 <3> The resource URL of the service account that can be impersonated with these credentials.
 <4> The path to the service account token inside the pod. By convention, this is `/var/run/secrets/openshift/serviceaccount/token` for {product-title} components.
 
+[IMPORTANT]
+====
+In {product-title} 4.10.8, image registry support for using GCP Workload Identity was removed due to the discovery of link:https://bugzilla.redhat.com/show_bug.cgi?id=2069807[an adverse impact to the image registry]. To use the image registry on an {product-title} 4.10.8 cluster that uses Workload Identity, you must configure the image registry to use long-lived credentials instead. This mitigation is planned to last until Workload Identity support for the image registry is restored in a later release.
+====
+
 //Supertask: Installing an OCP cluster configured for manual mode with GCP Workload Identity
 [id="gcp-workload-identity-mode-installing"]
 == Installing an {product-title} cluster configured for manual mode with GCP Workload Identity
@@ -105,6 +110,9 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
 
 //Task part 2: Creating the required GCP resources all at once
 include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+2]
+
+//Task part 2a: Configuring the image registry
+include::modules/cco-ccoctl-gcp-image-registry.adoc[leveloffset=+3]
 
 //Task part 3: Run the OCP installer
 include::modules/sts-mode-installing-manual-run-installer.adoc[leveloffset=+2]

--- a/modules/cco-ccoctl-gcp-image-registry.adoc
+++ b/modules/cco-ccoctl-gcp-image-registry.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
+
+:_content-type: PROCEDURE
+[id="cco-ccoctl-gcp-image-registry_{context}"]
+= Configuring the image registry to use long-lived credentials
+
+In {product-title} 4.10.8, image registry support for using GCP Workload Identity was removed due to the discovery of link:https://bugzilla.redhat.com/show_bug.cgi?id=2069807[an adverse impact to the image registry]. To use the image registry on an {product-title} 4.10.8 cluster that uses Workload Identity, you must configure the image registry to use long-lived credentials instead. This mitigation is planned to last until Workload Identity support for the image registry is restored in a later release.
+
+.Prerequisites
+
+* You have created GCP resources with the Cloud Credential Operator utility (`ccoctl`).
+
+* You have obtained and initialized the link:https://cloud.google.com/sdk/docs/initializing[gcloud CLI].
+
+.Procedure
+
+. Obtain the email address of the IAM service account that the `ccoctl` created for the {product-title} image registry by running the following command:
++
+[source,terminal]
+----
+$ gcloud iam service-accounts list --filter="displayName=<name>-openshift-image-registry-gcs"
+----
++
+where `<name>` is the user-defined name for all `ccoctl`-created GCP resources used for tracking.
+
+. Create a long-lived credentials key file for the {product-title} image registry by running the following command:
++
+[source,terminal]
+----
+$ gcloud iam service-accounts keys create <path_to_image_registry_service_account_keyfile> --iam-account=<image_registry_service_account_email>
+----
++
+where:
++
+* `<path_to_image_registry_service_account_key_file>` is the path to a location you choose in which to store the key file for the image registry's IAM service account.
+* `<image_registry_service_account_email>` is the email address of the IAM service account that the `ccoctl` created for the {product-title} image registry.
+
+. Generate a Base64-encoded string for the image registry key file by running the following command:
++
+[source,terminal]
+----
+$ cat <path_to_image_registry_service_account_keyfile> | base64 -w 0
+----
+
+. In the `<path_to_ccoctl_output_dir>/manifests` directory, locate the {product-title} image registry secret manifest YAML file, `openshift-image-registry-installer-cloud-credentials-credentials.yaml`. In this file, replace the contents of the `data.service_account.json` field with the Base64-encoded key file.

--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1208,7 +1208,14 @@ Users also have the option to use the `REGISTRY_AUTH_FILE` environment variable,
 
 You can now use the Cloud Credential Operator (CCO) utility `ccoctl` to configure the CCO to use the Google Cloud Platform Workload Identity. When the CCO is configured to use GCP Workload Identity, the in-cluster components can impersonate IAM service accounts using short-term, limited-privilege security credentials to components.
 
-//For more information, see xr/ef:../authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc#cco-mode-gcp-workload-identity[Using manual mode with GCP Workload Identity].
+For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc#cco-mode-gcp-workload-identity[Using manual mode with GCP Workload Identity].
+
+[IMPORTANT]
+====
+In {product-title} 4.10.8, image registry support for using GCP Workload Identity was removed due to the discovery of link:https://bugzilla.redhat.com/show_bug.cgi?id=2069807[an adverse impact to the image registry]. To use the image registry on an {product-title} 4.10.8 cluster that uses Workload Identity, you must configure the image registry to use long-lived credentials instead. This mitigation is planned to last until Workload Identity support for the image registry is restored in a later release.
+
+For more information, see xref:../release_notes/ocp-4-10-release-notes.adoc#ocp-4-10-removed-feature-auth-gcp-workload-identity[Image registry support for Google Cloud Platform Workload Identity removed].
+====
 
 [id="ocp-4-10-notable-technical-changes"]
 == Notable technical changes
@@ -1395,6 +1402,11 @@ In the table, features are marked with the following statuses:
 |
 |DEP
 
+|Support for Google Cloud Platform Workload Identity
+|-
+|-
+|xref:../release_notes/ocp-4-10-release-notes.adoc#ocp-4-10-removed-feature-auth-gcp-workload-identity[REM]
+
 |====
 
 [id="ocp-4-10-deprecated-features"]
@@ -1525,6 +1537,58 @@ $ az ad app delete --id 038c2538-7c40-49f5-abe5-f59c59c29244
 ====
 After cleaning up resources manually, the `OrphanedCloudResource` condition persists because the CCO cannot verify that the resources were cleaned up.
 ====
+
+[id="ocp-4-10-removed-feature-auth-gcp-workload-identity"]
+==== Image registry support for Google Cloud Platform Workload Identity removed
+
+{product-title} 4.10.3 introduced the ability to configure the Cloud Credential Operator (CCO) to use Google Cloud Platform (GCP) Workload Identity by using the CCO utility `ccoctl`.
+
+In {product-title} 4.10.8, image registry support for using GCP Workload Identity is removed due to the discovery of link:https://bugzilla.redhat.com/show_bug.cgi?id=2069807[an adverse impact to the image registry]. To use the image registry on an {product-title} 4.10.8 cluster that uses Workload Identity, you must configure the image registry to use long-lived credentials instead. This mitigation is planned to last until Workload Identity support for the image registry is restored in a later release.
+
+.Prerequisites
+
+* You have installed an {product-title} cluster that uses manual mode with GCP Workload Identity.
+
+* You have obtained and initialized the link:https://cloud.google.com/sdk/docs/initializing[gcloud CLI].
+
+.Procedure
+
+. Obtain the email address of the IAM service account that the `ccoctl` created for the {product-title} image registry by running the following command:
++
+[source,terminal]
+----
+$ gcloud iam service-accounts list --filter="displayName=<name>-openshift-image-registry-gcs"
+----
++
+where `<name>` is the user-defined name for all `ccoctl`-created GCP resources used for tracking.
+
+. Create a long-lived credentials key file for the {product-title} image registry by running the following command:
++
+[source,terminal]
+----
+$ gcloud iam service-accounts keys create <path_to_image_registry_service_account_keyfile> --iam-account=<image_registry_service_account_email>
+----
++
+where:
++
+* `<path_to_image_registry_service_account_key_file>` is the path to a location you choose in which to store the key file for the image registry's IAM service account.
+* `<image_registry_service_account_email>` is the email address of the IAM service account that the `ccoctl` created for the {product-title} image registry.
+
+. Generate a Base64-encoded string for the image registry key file by running the following command:
++
+[source,terminal]
+----
+$ cat <path_to_image_registry_service_account_keyfile> | base64 -w 0
+----
+
+. In the `installer-cloud-credentials` secret in the `openshift-image-registry` namespace, replace the contents of the `data.service_account.json` field with the Base64-encoded key file by running the following command:
++
+[source,terminal]
+----
+$ oc patch secret installer-cloud-credentials -n openshift-image-registry --patch '{"data":{"service_account.json":"<base64_encoded_credentials_key>"}}'
+----
+
+. Continue the upgrade process.
 
 [id="ocp-4-10-bug-fixes"]
 == Bug fixes
@@ -2644,6 +2708,42 @@ This update contains changes from Kubernetes 1.23.3 up to 1.23.5. More informati
 * Previously, the sink for event sources in the `Trigger/Subscription` modal in the *Topology* UI showed all resources, irrespective of whether they were created as a standalone or an underlying resource included with back KSVC, Broker, or KameletBinding. Consequently, users could sink to the underlying addressable resources as they showed up in the sink drop-down menu. With this update, a resource filter has been added to show only standalone resource sink events. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2059807[*BZ#2059807*])
 
 [id="ocp-4-10-6-updating"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-8"]
+=== RHSA-2022:1162 - {product-title} 4.10.8 bug fix and security update
+
+Issued: 2022-04-07
+
+{product-title} release 4.10.8, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:1162[RHSA-2022:1162] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1161[RHBA-2022:1161] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6877401[{product-title} 4.10.8 container image list]
+
+[id="ocp-4-10-8-removed-feature-azure-mint-mode"]
+==== Removed features
+
+Starting with {product-title} 4.10.8, support for Google Cloud Platform Workload Identity has been removed from {product-title} 4.10 for the image registry. This change is due to the discovery of link:https://bugzilla.redhat.com/show_bug.cgi?id=2069807[an adverse impact to the image registry]. For more information, see xref:../release_notes/ocp-4-10-release-notes.adoc#ocp-4-10-removed-feature-auth-gcp-workload-identity[Image registry support for Google Cloud Platform Workload Identity removed].
+
+[id="ocp-4-10-8-known-issues"]
+==== Known issues
+
+* Currently, the web console does not display virtual machine templates that are deployed to a custom namespace. Only templates deployed to the default namespace are displayed in the web console. As a workaround, avoid deploying templates to a custom namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054650[*BZ#2054650*])
+
+[id="ocp-4-10-8-bug-fixes"]
+==== Bug fixes
+* Previously, the Infrastructure Operator could not provision X11- and X12-based systems due to validation errors created by the bare metal controller (BMC) when special characters such as question marks or equal signs were used in the `filename` parameters of URLs. With this update, the `filename` parameter is removed from the URL if the virtual media image is backed by a local file. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2011626[*BZ#2011626*])
+
+* Previously, when cloning a virtual machine from a template, Operator-made changes reverted after dismissing the dialog box if the boot disk was edited and the storage class was changed. With this update, changes made to storage class remain set after closing the dialogue box. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049762[*BZ#2049762*])
+
+* Previously, the `startupProbe` field was added to a container’s definition. As a result, `startupProbe` causes problems when creating a debug pod. With this update, `startupProbe` is removed by default from the debug pod by the `Expose --keep-startup flag` parameter, which is now set to false by default. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2068474[*BZ#2068474*])
+
+* Previously, the Local Storage Operator (LSO) added an `OwnerReference` object to the persistent volumes (PV) it created, which sometimes caused an issue where a delete request for a PV could leave the PV in the `terminating` state while still attached to the pod. With this update, the LSO no longer creates an `OwnerReference` object and cluster administrators are now able to manually delete any unused PVs after a node is removed from the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2065714[*BZ#2065714*])
+
+[id="ocp-4-10-8-updating"]
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
For [OSDOCS-3445](https://issues.redhat.com/browse/OSDOCS-3445)

**Previews:**
- Added **IMPORTANT** admonition to [Using manual mode with GCP Workload Identity](https://deploy-preview-44062--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.html)
- Added new procedure [Configuring the image registry to use long-lived credentials](https://deploy-preview-44062--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.html#cco-ccoctl-gcp-image-registry_cco-mode-gcp-workload-identity)
- Added **IMPORTANT** admonition to [Support for Google Cloud Platform Workload Identity](https://deploy-preview-44062--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-auth-gcp-workload-identity) 4.10 announcement
- Added _**Support for Google Cloud Platform Workload Identity**_ to [Deprecated and removed features tracker](https://deploy-preview-44062--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-deprecated-removed-features) with link to explanation
- Added [Image registry support for Google Cloud Platform Workload Identity removed](https://deploy-preview-44062--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-removed-feature-auth-gcp-workload-identity) to **_Removed features_** section
- Added [short version of removal notice](https://deploy-preview-44062--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-8-removed-feature-azure-mint-mode) to the 4.10.8 Rel Notes section