### PR TITLE
RHDEVDOCS-3932 Release Notes for Build and Jenkins in 4.11

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -17,7 +17,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} (link:https://access.redhat.com/errata/RHSA-2022:TODO[RHSA-2022:TODO]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md[Kubernetes 1.24] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 //Red Hat did not publicly release {product-title} 4.10.0 as the GA version and, instead, is releasing {product-title} 4.10.3 as the GA version.
 
-{product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title} users can you to deploy OpenShift clusters to either on-premise or cloud environments.
+{product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title}, you can deploy OpenShift clusters to either on-premises or cloud environments.
 
 // Double check OP system versions
 {product-title} {product-version} is supported on {op-system-base-full} 8.4 and 8.5, as well as on {op-system-first} 4.11.
@@ -94,7 +94,7 @@ The following Operators are supported for {product-title} on ARM:
 
 [id="ocp-4-11-aws-serial-console-logs"]
 ==== Troubleshooting bootstrap failures during installation on AWS
-The installer now gathers serial console logs from the bootstrap and control plane hosts on AWS. This log data is added to the standard bootstrap log bundle.
+The installation program now gathers serial console logs from the bootstrap and control plane hosts on AWS. This log data is added to the standard bootstrap log bundle.
 
 For more information, see xref:../installing/installing-troubleshooting.adoc#installation-bootstrap-gather_installing-troubleshooting[Troubleshooting installation issues].
 
@@ -616,6 +616,8 @@ For more information, see xref:../operators/operator_sdk/osdk-bundle-validate.ad
 [id="ocp-4-11-jenkins"]
 === Jenkins
 
+* This enhancement adds a new Jenkins environment variable, `JAVA_FIPS_OPTIONS`, that controls how the JVM operates when running on a FIPS node. For more information, see link:https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk[OpenJDK support article] (link:https://bugzilla.redhat.com/show_bug.cgi?id=2066019[BZ#2066019])
+
 [id="ocp-4-11-machine-api"]
 === Machine API
 
@@ -1059,6 +1061,11 @@ In the table, features are marked with the following statuses:
 |GA
 |REM
 
+|Removal of Jenkins images from install payload
+|GA
+|GA
+|REM
+
 |====
 
 [id="ocp-4-11-deprecated-features"]
@@ -1114,6 +1121,16 @@ Support for deploying custom schedulers manually has been removed with this rele
 
 Support for deploying {sno} clusters with OpenShiftSDN has been removed with this release. OVN-Kubernetes is the default networking solution for {sno} deployments.
 
+==== Removal of Jenkins images from install payload
+
+* {product-title} 4.11 moves the "OpenShift Jenkins" and "OpenShift Agent Base" images to the `ocp-tools-4` repository at `registry.redhat.io` so that Red Hat can produce and update the images outside the {product-title} lifecycle. Previously, these images were in the {product-title} install payload and the `openshift4` repository at `registry.redhat.io`. For more information, see xref:../cicd/jenkins/openshift-jenkins.adoc#openshift-jenkins[OpenShift Jenkins].
+
+* {product-title} 4.11 removes "OpenShift Jenkins Maven" and "NodeJS Agent" images from its payload. Previously, {product-title} 4.10 deprecated these images. Red Hat no longer produces these images, and they are not available from the `ocp-tools-4` repository at `registry.redhat.io`.
++
+However, upgrading to {product-title} 4.11 does not remove "OpenShift Jenkins Maven" and "NodeJS Agent" images from 4.10 and earlier releases. And Red Hat provides bug fixes and support for these images through the end of the 4.10 release lifecycle, in accordance with the link:https://access.redhat.com/support/policy/updates/openshift[{product-title} lifecycle policy].
++
+For more information, see xref:../cicd/jenkins/openshift-jenkins.adoc#openshift-jenkins[OpenShift Jenkins].
+
 [id="ocp-4-11-future-removals"]
 === Future Kubernetes API removals
 
@@ -1144,9 +1161,17 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 
 * Previously, Shared Resource CSI Driver metrics were not exported to the Telemetry service. As a result, usage metrics for the Shared Resource CSI Driver could not be analyzed. With this fix, Shared Resource CSI Driver metrics are exposed to the Telemetry service. As a result, usage metrics for the Shared Resource CSI Driver can be collected and analyzed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2058225[*BZ#2058225*])
 
-[discrete]
-[id="ocp-4-11-jenkins-bug-fixes"]
-==== Jenkins
+
+* By default, Buildah prints steps to the log file, including the contents of environment variables, which might include xref:../cicd/builds/creating-build-inputs.adoc#builds-input-secrets-configmaps_creating-build-inputs[build input secrets]. Although you can use the `--quiet` build argument to suppress printing of those environment variables, this argument isn't available if you use the source-to-image (S2I) build strategy. The current release fixes this issue. To suppress printing of environment variables, set the `BUILDAH_QUIET` environment variable in your build configuration:
++
+[source,yaml]
+----
+sourceStrategy:
+...
+  env:
+    - name: "BUILDAH_QUIET"
+      value: "true"
+----
 
 [discrete]
 [id="ocp-4-11-cloud-compute-bug-fixes"]
@@ -1475,10 +1500,10 @@ In the table below, features are marked with the following statuses:
 |GA
 |GA
 
-|CSI Volumes in OpenShift Builds
+|Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds
 |-
 |TP
-|
+|TP
 
 |Service Binding
 |TP


### PR DESCRIPTION
 Aligned team: Dev Tools
- For branches: 4.11 only (release notes)
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3932
- Direct link to doc preview: 
  - https://rolfedh.github.io/previews/RHDEVDOCS-3932/release_notes/ocp-4-11-release-notes.html#ocp-4-11-builds-bug-fixes
  - https://rolfedh.github.io/previews/RHDEVDOCS-3932/release_notes/ocp-4-11-release-notes.html#ocp-4-11-jenkins
  - https://rolfedh.github.io/previews/RHDEVDOCS-3932/release_notes/ocp-4-11-release-notes.html#removal-of-jenkins-images-from-install-payload
- SME review: @coreydaley @akram 
- QE review: @jitendar-singh 
- Peer review: @jc-berger 
- All reviews complete. Please merge now.