### PR TITLE
[enterprise-4.7] BZ2049266 Added note on configuring MTU during installation

### DIFF
--- a/modules/installation-aws-about-government-region.adoc
+++ b/modules/installation-aws-about-government-region.adoc
@@ -2,6 +2,10 @@
 //
 // * installing/installing_aws/installing-aws-government-region.adoc
 
+ifeval::["{context}" == "installing-aws-government-region"]
+:aws-government:
+endif::[]
+
 [id="installation-aws-about-government-region_{context}"]
 = AWS government and secret regions
 
@@ -22,6 +26,16 @@ The following AWS Secret Region partition is supported:
 
 * `us-iso-east-1`
 
+ifdef::aws-government[]
+[NOTE]
+====
+The maximum supported MTU in an AWS Top Secret Region is not the same as
+AWS commercial. For more information about configuring MTU during installation,
+see the _Cluster Network Operator configuration object_ section in _Installing
+a cluster on AWS with network customizations_
+====
+endif::aws-government[]
+
 The AWS government or secret region, and accompanying custom AMI, must be manually configured in the
 `install-config.yaml` file since {op-system} AMIs are not provided by Red Hat
 for those regions.
@@ -30,3 +44,7 @@ for those regions.
 ====
 If you are deploying to the C2S Secret Region, you must also define a custom CA certificate in the `additionalTrustBundle` field of the `install-config.yaml` file because the AWS API requires a custom CA trust bundle. To allow the installation program to access the AWS API, the CA certificates must also be defined on the machine that runs the installation program. You must add the CA bundle to the trust store on the machine, use the `AWS_CA_BUNDLE` environment variable, or define the CA bundle in the link:https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-ca_bundle.html[`ca_bundle`] field of the AWS config file.
 ====
+
+ifeval::["{context}" == "installing-aws-government-region"]
+:!aws-government:
+endif::[]


### PR DESCRIPTION
**This has the same work done for PR:** https://github.com/openshift/openshift-docs/pull/42239

Only for versions 4.7 and 4.8

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2049266#c4

Direct link to doc preview: https://deploy-preview-44066--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-government-region.html#installation-aws-about-government-region_installing-aws-government-region

QA: @yunjiang29