### PR TITLE
RHDEVDOCS-3930 - Added 1.4.5 release notes

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,6 +23,8 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-4-5.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-4-3.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-4-2.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-4-5.adoc
+++ b/modules/gitops-release-notes-1-4-5.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-4-5_{context}"]
+= Release notes for {gitops-title} 1.4.5
+
+[role="_abstract"]
+{gitops-title} 1.4.5 is now available on {product-title} 4.7, 4.8, 4.9 and 4.10.
+
+[id="fixed-issues-1-4-5_{context}"]
+== Fixed issues
+
+[WARNING]
+====
+You should directly upgrade to {gitops-title} v1.4.5 from {gitops-title} v1.4.3. Do not use {gitops-title} v1.4.4 in a production environment. Major issues that affected {gitops-title} v1.4.4 are fixed in {gitops-title} 1.4.5. 
+====
+
+The following issue has been resolved in the current release:
+
+* Before this update, Argo CD pods were stuck in the `ErrImagePullBackOff` state. The following error message was shown:
+[source,yaml]
+----
+reason: ErrImagePull
+          message: >-
+            rpc error: code = Unknown desc = reading manifest
+            sha256:ff4ad30752cf0d321cd6c2c6fd4490b716607ea2960558347440f2f370a586a8
+            in registry.redhat.io/openshift-gitops-1/argocd-rhel8: StatusCode:
+            404, <HTML><HEAD><TITLE>Error</TITLE></HEAD><BODY> 
+----
+This issue is now fixed. link:https://issues.redhat.com/browse/GITOPS-1848[GITOPS-1848]

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -16,7 +16,7 @@ In the table, features are marked with the following statuses:
 
 |*Version*|*kam*    |*Helm*  |*Kustomize*|*Argo CD*|*ApplicationSet*|*Dex*     |*RH SSO* |
 |1.4.0    |0.0.41 TP|3.7.1 GA|4.2.0 GA   |2.2.2 GA |0.2.0 TP        |2.30.0 GA |7.4.0 GA |4.7-4.9
-|1.3.0    |0.0.40 TP|3.6.0 GA|4.2.0 GA   |2.1.2 GA |0.2.0 TP        |2.28.0 GA |7.4.0 GA |4.6-4.9
+|1.3.0    |0.0.40 TP|3.6.0 GA|4.2.0 GA   |2.1.2 GA |0.2.0 TP        |2.28.0 GA |7.4.0 GA |4.7-4.9
 |1.2.0    |0.0.38 TP|3.5.0 GA|3.9.4 GA   |2.0.5 GA |0.1.0 TP        |N/A  |7.4.0 GA |4.8
 |1.1.0    |0.0.32 TP|3.5.0 GA|3.9.4 GA   |2.0.0 GA |N/A             |N/A      |N/A      |4.7
 |===


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.9, 4.10, 4.11
JIRA issues: https://issues.redhat.com/browse/RHDEVDOCS-3930

Preview pages: https://deploy-preview-44078--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes#gitops-release-notes-1-4-5_gitops-release-notes

SME+QE review:@iam-veeramalla, @wtam2018 

Peer-review:@bburt-rh