### PR TITLE
BZ1709936: Information bubble contains contradictory statement on feature availability

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -1348,9 +1348,7 @@ network isolation and do not support Kubernetes `NetworkPolicy`. However,
 
 [NOTE]
 ====
-The `v1` NetworkPolicy features are available only in {product-title}. This
-means that egress policy types, IPBlock, and combining `podSelector` and
-`namespaceSelector` are not available in {product-title}.
+The `Egress` policy type, the `ipBlock` parameter, and the ability to combine the `podSelector` and `namespaceSelector` parameters are not available in {product-title}.
 ====
 
 [NOTE]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1709936

Preview: [First note under Enabling Network Policy](http://file.rdu.redhat.com/~mburke/BZ1709936-fix-network-v1-note/admin_guide/managing_networking.html#admin-guide-networking-networkpolicy).