### PR TITLE
RHDEVDOCS-3858 - update example code in Configuring cluster monitoring topic

### DIFF
--- a/modules/configuring-cluster-monitoring.adoc
+++ b/modules/configuring-cluster-monitoring.adoc
@@ -6,11 +6,14 @@
 [id="configuring-cluster-monitoring_{context}"]
 = Configuring cluster monitoring
 
+[role="_abstract"]
+You can increase the storage capacity for the Prometheus component in the cluster monitoring stack.
+
 .Procedure
 
 To increase the storage capacity for Prometheus:
 
-. Create a YAML configuration file, `cluster-monitoring-config.yml`. For example:
+. Create a YAML configuration file, `cluster-monitoring-config.yaml`. For example:
 +
 [source,yaml]
 ----
@@ -18,68 +21,46 @@ apiVersion: v1
 kind: ConfigMap
 data:
   config.yaml: |
-    prometheusOperator:
-      baseImage: quay.io/coreos/prometheus-operator
-      prometheusConfigReloaderBaseImage: quay.io/coreos/prometheus-config-reloader
-      configReloaderBaseImage: quay.io/coreos/configmap-reload
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
     prometheusK8s:
       retention: {{PROMETHEUS_RETENTION_PERIOD}} <1>
-      baseImage: openshift/prometheus
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       volumeClaimTemplate:
         spec:
-          storageClassName: gp2
+          storageClassName: {{STORAGE_CLASS}} <2>
           resources:
             requests:
-              storage: {{PROMETHEUS_STORAGE_SIZE}} <2>
+              storage: {{PROMETHEUS_STORAGE_SIZE}} <3>
     alertmanagerMain:
-      baseImage: openshift/prometheus-alertmanager
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       volumeClaimTemplate:
         spec:
-          storageClassName: gp2
+          storageClassName: {{STORAGE_CLASS}} <2>
           resources:
             requests:
-              storage: {{ALERTMANAGER_STORAGE_SIZE}} <3>
-    nodeExporter:
-      baseImage: openshift/prometheus-node-exporter
-    kubeRbacProxy:
-      baseImage: quay.io/coreos/kube-rbac-proxy
-    kubeStateMetrics:
-      baseImage: quay.io/coreos/kube-state-metrics
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
-    grafana:
-      baseImage: grafana/grafana
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
-    auth:
-      baseImage: openshift/oauth-proxy
-    k8sPrometheusAdapter:
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
+              storage: {{ALERTMANAGER_STORAGE_SIZE}} <4>
 metadata:
   name: cluster-monitoring-config
-namespace: openshift-monitoring
+  namespace: openshift-monitoring
 ----
 <1> A typical value is `PROMETHEUS_RETENTION_PERIOD=15d`. Units are measured in
 time using one of these suffixes: s, m, h, d.
-<2> A typical value is `PROMETHEUS_STORAGE_SIZE=2000Gi`. Storage values can be a
+<2> The storage class for your cluster.
+<3> A typical value is `PROMETHEUS_STORAGE_SIZE=2000Gi`. Storage values can be a
 plain integer or as a fixed-point integer using one of these suffixes: E, P, T,
 G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.
-<3> A typical value is `ALERTMANAGER_STORAGE_SIZE=20Gi`. Storage values can be a
+<4> A typical value is `ALERTMANAGER_STORAGE_SIZE=20Gi`. Storage values can be a
 plain integer or as a fixed-point integer using one of these suffixes: E, P, T,
 G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.
 
-. Set the values like the retention period and storage sizes.
+. Add values for the retention period, storage class, and storage sizes.
+
+. Save the file.
 
 . Apply the changes by running:
 +
 [source,terminal]
 ----
-$ oc create -f cluster-monitoring-config.yml
+$ oc create -f cluster-monitoring-config.yaml
 ----


### PR DESCRIPTION
Summary: This PR updates and fixes sample code in the "Configuring cluster monitoring" topic in the "Scaling the Cluster Monitoring Operator" section. Applies to OCP 4.6+

- Aligned team: DevTools
- For branches: 4.6+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3858
- Direct link to doc preview: https://deploy-preview-44107--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/scaling-cluster-monitoring-operator.html#configuring-cluster-monitoring_cluster-monitoring-operator
- SME review: n/a 
- QE review: @juzhao (approved)
- Peer review: @jc-berger (approved)
- <All reviews complete. Please merge now>