### PR TITLE
RHDEVDOCS-3545 - Removed integrating with disconnected cluster module

### DIFF
--- a/cicd/gitops/configuring-sso-for-argo-cd-using-keycloak.adoc
+++ b/cicd/gitops/configuring-sso-for-argo-cd-using-keycloak.adoc
@@ -16,8 +16,6 @@ include::modules/gitops-creating-a-new-client-using-keycloak.adoc[leveloffset=+1
 
 include::modules/gitops-logging-into-keycloak.adoc[leveloffset=+1]
 
-include::modules/gitops-additional-steps-for-disconnected-clusters.adoc[leveloffset=+1]
-
 include::modules/gitops-uninstall-keycloak.adoc[leveloffset=+1]
 
 ////


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.9, 4.10, 4.11
JIRA issues: https://issues.redhat.com/browse/RHDEVDOCS-3545

Preview pages: https://deploy-preview-44123--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring-sso-for-argo-cd-using-keycloak

SME+QE review:

Peer-review: