### PR TITLE
WINC fix product naming

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -99,3 +99,5 @@ endif::[]
 :MaistraVersion: 2.1
 //Service Mesh v1
 :SMProductVersion1x: 1.1.17
+//Windows containers
+:productwinc: Red Hat OpenShift support for Windows Containers

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1994,9 +1994,9 @@ Name: Windows Container Support for OpenShift
 Dir: windows_containers
 Distros: openshift-origin,openshift-enterprise
 Topics:
-- Name: Windows Container Support for Openshift overview
+- Name: Red Hat OpenShift support for Windows Containers overview
   File: index
-- Name: Windows Container Support for OpenShift release notes
+- Name: Red Hat OpenShift support for Windows Containers release notes
   File: windows-containers-release-notes-5-x
 - Name: Understanding Windows container workloads
   File: understanding-windows-container-workloads

--- a/modules/rosa-sdpolicy-platform.adoc
+++ b/modules/rosa-sdpolicy-platform.adoc
@@ -3,8 +3,10 @@
 //
 // * assemblies/rosa-service-definition.adoc
 
+:_content-type: ASSEMBLY
 [id="rosa-sdpolicy-platform_{context}"]
 = Platform
+:productwinc: Red Hat OpenShift support for Windows Containers
 
 This section provides information about the service definition for the {product-title} (ROSA) platform.
 
@@ -84,7 +86,7 @@ See the link:https://docs.openshift.com/rosa/rosa_policy/rosa-life-cycle.html[{p
 
 [id="rosa-sdpolicy-window-containers_{context}"]
 == Windows Containers
-Windows Containers are not available on {product-title} at this time.
+{productwinc} is not available on {product-title} at this time.
 
 [id="rosa-sdpolicy-container-engine_{context}"]
 == Container engine

--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -111,7 +111,7 @@ vulnerabilities and errors protection as {product-title}. {oke} includes a
 allows you to use an integrated Linux operating system with container runtime
 from the same technology provider.
 
-{oke} is subscription compatible with Windows Containers from Microsoft.
+The {oke} subscription is compatible with the {productwinc} subscription.
 
 [[about_oke_enterprise_ready_configurations]]
 === Enterprise-ready configurations

--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -1,12 +1,12 @@
 :_content-type: ASSEMBLY
 [id="windows-container-overview"]
-= Windows Container Support for OpenShift overview
+= {productwinc} overview
 include::_attributes/common-attributes.adoc[]
 :context: windows-container-overview
 
 toc::[]
 
-Windows Container Support for OpenShift is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. For more information, see the xref:../windows_containers/windows-containers-release-notes-5-x.adoc#windows-containers-release-notes-5-x[release notes].
+{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. For more information, see the xref:../windows_containers/windows-containers-release-notes-5-x.adoc#windows-containers-release-notes-5-x[release notes].
 
 For workloads including both Linux and Windows, {product-title} allows you to deploy Windows workloads running on Windows Server containers while also providing traditional Linux workloads hosted on {op-system-first} or {op-system-base-full}. For more information, see xref:../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[getting started with Windows container workloads].
 

--- a/windows_containers/understanding-windows-container-workloads.adoc
+++ b/windows_containers/understanding-windows-container-workloads.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Windows Container Support for Red Hat OpenShift provides built-in support for running Microsoft Windows Server containers on {product-title}. For those that administer heterogeneous environments with a mix of Linux and Windows workloads, {product-title} allows you to deploy Windows workloads running on Windows Server containers while also providing traditional Linux workloads hosted on {op-system-first} or {op-system-base-full}.
+{productwinc} provides built-in support for running Microsoft Windows Server containers on {product-title}. For those that administer heterogeneous environments with a mix of Linux and Windows workloads, {product-title} allows you to deploy Windows workloads running on Windows Server containers while also providing traditional Linux workloads hosted on {op-system-first} or {op-system-base-full}.
 
 [NOTE]
 ====

--- a/windows_containers/windows-containers-release-notes-5-x.adoc
+++ b/windows_containers/windows-containers-release-notes-5-x.adoc
@@ -23,7 +23,7 @@ Windows Container Support for Red Hat OpenShift is provided and available as an 
 
 You must have this separate subscription to receive support for Windows Container Support for Red Hat OpenShift. Without this additional Red Hat subscription, deploying Windows container workloads in production clusters is not supported. You can request support through the link:http://access.redhat.com/[Red Hat Customer Portal]. 
 
-For more information, see the Red Hat OpenShift Container Platform Life Cycle Policy document for link:https://access.redhat.com/support/policy/updates/openshift#windows[Red Hat OpenShift support for Windows Containers].
+For more information, see the Red Hat OpenShift Container Platform Life Cycle Policy document for link:https://access.redhat.com/support/policy/updates/openshift#windows[{productwinc}].
 
 If you do not have this additional Red Hat subscription, you can use the Community Windows Machine Config Operator, a distribution that lacks official support. 
 endif::openshift-origin[]


### PR DESCRIPTION
Per [Slack conversation](https://coreos.slack.com/archives/CM4ERHBJS/p1649088568811029?thread_ts=1648789414.418059&cid=CM4ERHBJS):

Windows Container Support for Red Hat OpenShift is the official product name

This PR cleans up a few places where the name was incorrect.

Previews:
[Overview](https://deploy-preview-44135--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/index.html)
[Release notes](https://deploy-preview-44135--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-4-x.html)
[Understanding](https://deploy-preview-44135--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/understanding-windows-container-workloads.html)
[OKE - Core Kubernetes and container orchestration](s)
[ROSA service definition - windows containers](https://deploy-preview-44135--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-service-definition.html#rosa-sdpolicy-window-containers_rosa-service-definition)
