### PR TITLE
OSDOCS-3436: Add STS info for AWS EFS CSI driver operator

### DIFF
--- a/modules/persistent-storage-csi-efs-sts.adoc
+++ b/modules/persistent-storage-csi-efs-sts.adoc
@@ -1,0 +1,101 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent-storage-csi-aws-efs.adoc
+
+:_content-type: PROCEDURE
+[id="efs-sts_{context}"]
+= Configuring AWS EFS CSI Driver Operator with Secure Token Service
+
+This procedure explains how to configure the AWS EFS CSI Driver Operator with {product-title} on AWS Secure Token Service (STS).
+
+Perform this procedure after installing the AWS EFS CSI Operator, but before installing the AWS EFS CSI driver as part of _Installing the AWS EFS CSI Driver Operator_ procedure. If you perform this procedure after installing the driver and creating volumes, your volumes will fail to mount into pods.
+
+.Prerequisites
+
+* AWS account credentials
+
+.Procedure
+
+To configure the AWS EFS CSI Driver Operator with STS:
+
+. Extract the CCO utility (`ccoctl`) binary from the {product-title} release image, which you used to install the cluster with STS. For more information, see "Configuring the Cloud Credential Operator utility".
+
+. Create and save an EFS `CredentialsRequest` YAML file, such as shown in the following example, and then place it in the `credrequests` directory:
++
+.Example
++
+[source, yaml]
+----
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-aws-efs-csi-driver
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - action:
+      - elasticfilesystem:*
+      effect: Allow
+      resource: '*'
+  secretRef:
+    name: aws-efs-cloud-credentials
+    namespace: openshift-cluster-csi-drivers
+  serviceAccountNames:
+  - aws-efs-csi-driver-operator
+  - aws-efs-csi-driver-controller-sa
+----
+
+. Run the `ccoctl` tool to generate a new IAM role in AWS, and create a YAML file for it in the local file system (`<path_to_ccoctl_output_dir>/manifests/openshift-cluster-csi-drivers-aws-efs-cloud-credentials-credentials.yaml`).
++
+[source, terminal]
+----
+$ ccoctl aws create-iam-roles --name=<name> --region=<aws_region> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests --identity-provider-arn=arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
+----
++
+* `name=<name>` is the name used to tag any cloud resources that are created for tracking.
+
+* `region=<aws_region>` is the AWS region where cloud resources are created.
+
+* `dir=<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the EFS CredentialsRequest file in previous step.
+
+* `<aws_account_id>`` is the AWS account ID.
++
+.Example
++
+[source, terminal]
+----
+$ ccoctl aws create-iam-roles --name my-aws-efs --credentials-requests-dir credrequests --identity-provider-arn arn:aws:iam::123456789012:oidc-provider/my-aws-efs-oidc.s3.us-east-2.amazonaws.com
+----
++
+.Example output
++
+[source, terminal]
+----
+2022/03/21 06:24:44 Role arn:aws:iam::123456789012:role/my-aws-efs -openshift-cluster-csi-drivers-aws-efs-cloud- created
+2022/03/21 06:24:44 Saved credentials configuration to: /manifests/openshift-cluster-csi-drivers-aws-efs-cloud-credentials-credentials.yaml
+2022/03/21 06:24:45 Updated Role policy for Role my-aws-efs-openshift-cluster-csi-drivers-aws-efs-cloud-
+----
+
+. Create the AWS EFS cloud credentials and secret:
++
+[source, terminal]
+----
+$ oc create -f <path_to_ccoctl_output_dir>/manifests/openshift-cluster-csi-drivers-aws-efs-cloud-credentials-credentials.yaml
+----
++
+.Example
++
+[source, terminal]
+----
+$ oc create -f /manifests/openshift-cluster-csi-drivers-aws-efs-cloud-credentials-credentials.yaml
+----
++
+.Example output
++
+[source, terminal]
+----
+secret/aws-efs-cloud-credentials created
+----

--- a/modules/persistent-storage-csi-olm-operator-install.adoc
+++ b/modules/persistent-storage-csi-olm-operator-install.adoc
@@ -6,6 +6,10 @@
 [id="persistent-storage-csi-olm-operator-install_{context}"]
 = Installing the {FeatureName} CSI Driver Operator
 
+ifeval::["{context}" == "persistent-storage-csi-aws-efs"]
+:AWS_EFS:
+endif::[]
+
 The {FeatureName} CSI Driver Operator is not installed in {product-title} by default. Use the following procedure to install and configure the {FeatureName} CSI Driver Operator in your cluster.
 
 .Prerequisites
@@ -39,6 +43,10 @@ Be sure to select the *AWS EFS CSI Driver Operator* and not the *AWS EFS Operato
 .. Click *Install*.
 +
 After the installation finishes, the {FeatureName} CSI Operator is listed in the *Installed Operators* section of the web console.
+
+ifdef::AWS_EFS[]
+. If you are using {FeatureName} with AWS Secure Token Service (STS), you must configure the {FeatureName} CSI Driver with STS. For more information, see "Configuring AWS EFS CSI Driver with STS".
+endif::AWS_EFS[]
 
 . Install the {FeatureName} CSI Driver:
 

--- a/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
@@ -17,7 +17,7 @@ After installing the AWS EFS CSI Driver Operator, {product-title} installs the A
 * The _AWS EFS CSI Driver Operator_, after being installed, does not create a storage class by default to use to create persistent volume claims (PVCs). However, you can manually create the AWS EFS `StorageClass`.
 The AWS EFS CSI Driver Operator supports dynamic volume provisioning by allowing storage volumes to be created on-demand, eliminating the need for cluster administrators to pre-provision storage.
 
-* The _AWS EFS CSI driver_ enables you to create and mount AWS EFS PVs. 
+* The _AWS EFS CSI driver_ enables you to create and mount AWS EFS PVs.
 
 [NOTE]
 ====
@@ -28,6 +28,15 @@ include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 
 :FeatureName: AWS EFS
 include::modules/persistent-storage-csi-olm-operator-install.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../storage/container_storage_interface//persistent-storage-csi-aws-efs.adoc#efs-sts_persistent-storage-csi-aws-efs[Configuring AWS EFS CSI Driver with STS]
+
+include::modules/persistent-storage-csi-efs-sts.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#persistent-storage-csi-olm-operator-install_persistent-storage-csi-aws-efs[Installing the AWS EFS CSI Driver Operator]
+* xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-configuring_cco-mode-sts[Configuring the Cloud Credential Operator utility]
 
 :StorageClass: AWS EFS
 :Provisioner: efs.csi.aws.com


### PR DESCRIPTION
4.10+

[OSDOCS-3436
](https://issues.redhat.com/browse/OSDOCS-3436)
**Preview**: 
Reference to STS procedure in install procedure: https://deploy-preview-44136--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-aws-efs.html#persistent-storage-csi-olm-operator-install_persistent-storage-csi-aws-efs

STS procedure: https://deploy-preview-44136--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-aws-efs.html#efs-sts_persistent-storage-csi-aws-efs


**PTAL**: @jsafrane , @duanwei33 