### PR TITLE
Replaces Pull Request 43203 - Restructuring Install Requirements

### DIFF
--- a/modules/virt-overhead-considerations.adoc
+++ b/modules/virt-overhead-considerations.adoc
@@ -2,9 +2,9 @@
 //
 // * virt/install/preparing-cluster-for-virt.adoc
 
-[id="virt-cluster-resource-requirements_{context}"]
-= Additional hardware requirements for {VirtProductName}
-
+:_content-type: CONCEPT
+[id="virt-overhead-considerations_{context}"]
+= Overhead considerations
 
 {VirtProductName} is an add-on to {product-title} and imposes additional overhead that you must account for when planning a cluster. Each cluster machine must accommodate the following overhead requirements in addition to the {product-title} requirements. Oversubscribing the physical resources in a cluster can affect performance.
 

--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -1,12 +1,19 @@
 :_content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="preparing-cluster-for-virt"]
-= Configuring your cluster for {VirtProductName}
+= Preparing your cluster for {VirtProductName}
 :context: preparing-cluster-for-virt
 
 toc::[]
 
 Before you install {VirtProductName}, ensure that your {product-title} cluster meets the following requirements:
+
+[id="infrastructure-requirements_preparing-cluster-for-virt"]
+== Infrastructure requirements
+
+{VirtProductName} works with {product-title} by default, but the following installation configurations are required:
+
+* Configure xref:../../monitoring/monitoring-overview.adoc#monitoring-overview[monitoring] in the cluster.
 
 * Your cluster must be installed on
 xref:../../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#installing-bare-metal[on-premise bare metal] infrastructure with {op-system-first} workers. You can use any installation method including user-provisioned, installer-provisioned, or assisted installer to deploy your cluster.
@@ -26,17 +33,23 @@ include::snippets/technology-preview.adoc[leveloffset=+2]
 endif::[]
 --
 
+[id="ha-requirements_preparing-cluster-for-virt"]
+== High Availability (HA) requirements for virtual machines
 
-* Additionally, there are three options to maintain high availability (HA) of virtual machines:
+Manage your compute nodes according to the number and size of the virtual machines that you want to host in the cluster.
 
-** Use xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[installer-provisioned infrastructure] and xref:../../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[deploy machine health checks].
+There are three options to maintain high availability (HA) of virtual machines:
+
+* Use xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[installer-provisioned infrastructure] and xref:../../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[deploy machine health checks].
 +
 [NOTE]
 ====
 In {VirtProductName} clusters installed using installer-provisioned infrastructure and with MachineHealthCheck properly configured, if a node fails the MachineHealthCheck and becomes unavailable to the cluster, it is recycled. What happens next with VMs that ran on the failed node depends on a series of conditions. See xref:../../virt/virtual_machines/virt-create-vms.adoc#virt-about-runstrategies-vms_virt-create-vms[About RunStrategies for virtual machines] for more detailed information about the potential outcomes and how RunStrategies affect those outcomes.
 ====
 
-** If you are not using installer-provisioned infrastructure, use either a monitoring system or a qualified human to monitor node availability. When a node is lost, shut it down and run `oc delete node <lost_node>`.
+* Use xref:../../nodes/nodes/eco-node-health-check-operator.adoc#eco-node-health-check-operator[Node Health Check] for user-provisioned deployments and IPI deployments.
+
+* If you are not using any of the mechanisms above, use a monitoring system or monitor node availability. When a node is lost, shut it down and run `oc delete node <lost_node>`.
 +
 [NOTE]
 ====
@@ -53,27 +66,43 @@ include::snippets/technology-preview.adoc[leveloffset=+2]
 endif::[]
 --
 
-* Shared storage is required to enable live migration.
+[id="storage-requirements_preparing-cluster-for-virt"]
+== Storage requirements
 
-* You must manage your Compute nodes according to the number and size of the virtual machines that you want to host in the cluster.
+{VirtProductName} works with any CSI compliant storage provider. Shared storage is required to enable live migration.
+
+The storage modes that your CSI provider supports can impact the availability of some {VirtProductName} features. See xref:../../virt/virtual_machines/virtual_disks/virt-features-for-storage.adoc#virt-features-for-storage[Storage features] for more information.
+
+[id="computing-requirements_preparing-cluster-for-virt"]
+== Computing requirements
+
+All CPUs must be supported by Red Hat Enterprise Linux 8 and meet the following requirements:
+
+* Intel 64 or AMD64 CPU extensions are supported
+* Intel VT or AMD-V hardware virtualization extensions are enabled
+* The no-execute (NX) flag is enabled
+
+If your cluster uses worker nodes with different CPUs, live migration failures can occur because different CPUs have different capacities. To avoid these failures, use CPUs with appropriate capacity for each node and set node affinity on your virtual machines to ensure successful migration. See xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity-configuring-required_nodes-scheduler-node-affinity[Configuring a required node affinity rule] for more information.
+
+[id="scaling-requirements_preparing-cluster-for-virt"]
+== Scaling requirements
+
+You must manage Compute nodes according to the number and size of the virtual machines that you want to host in the cluster.
+
+See xref:../../virt/install/virt-planning-environment-object-maximums.adoc#virt-planning-environment-object-maximums[Planning your environment according to {VirtProductName} object maximums] for more information.
+
+== Requirements for deploying {VirtProductName} in disconnected environments
 
 * To deploy {VirtProductName} in a disconnected environment, you must xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[configure Operator Lifecycle Manager on restricted networks].
 
-* When using a disconnected cluster on a restricted network, you must xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[configure proxy support in Operator Lifecycle Manager] to access the Red Hat-provided OperatorHub. Using a proxy allows the cluster to fetch the {VirtProductName} Operator.
+* With limited internet connectivity, you can xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[configure proxy support in Operator Lifecycle Manager] to access the Red Hat-provided OperatorHub. If you are using a restricted network with no internet connectivity, you must xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Configure Operator Lifecycle Manager for restricted networks].
 
 * If your cluster uses worker nodes with different CPUs, live migration failures can occur because different CPUs have different capacities. To avoid such failures, use CPUs with appropriate capacity for each node and set node affinity on your virtual machines to ensure successful migration. See xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity-configuring-required_nodes-scheduler-node-affinity[Configuring a required node affinity rule] for more information.
 
-* All CPUs must be supported by Red Hat Enterprise Linux 8 and meet the following requirements:
-
-** Intel 64 or AMD64 CPU extensions are supported
-** Intel VT or AMD-V hardware virtualization extensions are enabled
-** The no-execute (NX) flag is enabled
+[id="additional-requirements_preparing-cluster-for-virt"]
+== Additional requirements
 
 * If FIPS mode is xref:../../installing/installing-fips.adoc#installing-fips[enabled for your cluster], no additional setup is needed for {VirtProductName}. Support for FIPS cryptography must be enabled before the operating system that your cluster uses boots for the first time.
-
-{VirtProductName} works with {product-title} by default, but the following installation configurations are recommended:
-
-* Configure xref:../../monitoring/monitoring-overview.adoc#monitoring-overview[monitoring] in the cluster.
 
 [NOTE]
 ====
@@ -87,4 +116,4 @@ include::modules/virt-single-node-cluster.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../operators/operator_sdk/osdk-ha-sno.adoc#osdk-ha-sno[High-availability or single node cluster detection and support]
 
-include::modules/virt-cluster-resource-requirements.adoc[leveloffset=+1]
+include::modules/virt-overhead-considerations.adoc[leveloffset=+1]

--- a/virt/install/virt-planning-environment-object-maximums.adoc
+++ b/virt/install/virt-planning-environment-object-maximums.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
-[id="virt-planning-environment-object-maximums"]
 include::_attributes/common-attributes.adoc[]
+[id="virt-planning-environment-object-maximums"]
 = Planning your environment according to {VirtProductName} object maximums
 :context: virt-planning-environment-object-maximums
 


### PR DESCRIPTION
For 4.6, 4.7, 4.8, 4.9, 4.10, and 4.11

No Jira or BZ. This PR replaces @fabiand's PR https://github.com/openshift/openshift-docs/pull/43203

@fabiand - Due to the extensive nature of this restructuring (badly needed, in my opinion, as we have had multiple complaints about the disorganization from field engineers and developers) I would recommend meeting 1/1 to go over the content in detail.

What is an ideal time/day for you to do this?

Thanks, I do appreciate this as this page badly needs the kind of structure you are introducing.

Direct doc preview link: https://deploy-preview-44140--osdocs.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html

Bob

Copying @apinnick as this restructuring was noted (by me) in our doc improvements project GoogleDoc. Your comments are obviously greatly welcomed as our Content Strategist!

NOTE: Please close https://github.com/openshift/openshift-docs/pull/43203 as soon as possible reference this PR as it's replacement.