### PR TITLE
OSDOCS-3333: add supported AWS instance types

### DIFF
--- a/modules/rosa-sdpolicy-account-management.adoc
+++ b/modules/rosa-sdpolicy-account-management.adoc
@@ -64,36 +64,66 @@ For additional information, see the link:https://kubernetes.io/docs/tasks/admini
 .General purpose compute types
 [%collapsible]
 ====
-- M5.xlarge (4 vCPU, 16 GiB)
-- M5.2xlarge (8 vCPU, 32 GiB)
-- M5.4xlarge (16 vCPU, 64 GiB)
-- M5.8xlarge (32 vCPU, 128 GiB)
-- M5.12xlarge (48 vCPU, 192 GiB)
-- M5.16xlarge (64 vCPU, 256 GiB)
-- M5.24xlarge (96 vCPU, 384 GiB)
+- m5.xlarge (4 vCPU, 16 GiB)
+- m5.2xlarge (8 vCPU, 32 GiB)
+- m5.4xlarge (16 vCPU, 64 GiB)
+- m5.8xlarge (32 vCPU, 128 GiB)
+- m5.12xlarge (48 vCPU, 192 GiB)
+- m5.16xlarge (64 vCPU, 256 GiB)
+- m5.24xlarge (96 vCPU, 384 GiB)
 ====
 
 .Memory-optimized compute types
 [%collapsible]
 ====
-- R5.xlarge (4 vCPU, 32 GiB)
-- R5.2xlarge (8 vCPU, 64 GiB)
-- R5.4xlarge (16 vCPU, 128 GiB)
-- R5.8xlarge (32 vCPU, 256 GiB)
-- R5.12xlarge (48 vCPU, 384 GiB)
-- R5.16xlarge (64 vCPU, 512 GiB)
-- R5.24xlarge (96 vCPU, 768 GiB)
+- r5.xlarge (4 vCPU, 32 GiB)
+- r5.2xlarge (8 vCPU, 64 GiB)
+- r5.4xlarge (16 vCPU, 128 GiB)
+- r5.8xlarge (32 vCPU, 256 GiB)
+- r5.12xlarge (48 vCPU, 384 GiB)
+- r5.16xlarge (64 vCPU, 512 GiB)
+- r5.24xlarge (96 vCPU, 768 GiB)
+- r6i.xlarge (4 vCPU, 32 GiB)
+- r6i.2xlarge (8 vCPU, 64 GiB)
+- r6i.4xlarge (16 vCPU, 128 GiB)
+- r6i.8xlarge (32 vCPU, 256 GiB)
+- r6i.12xlarge (48 vCPU, 384 GiB)
+- r6i.16xlarge (64 vCPU, 512 GiB)
+- r6i.24xlarge (96 vCPU, 768 GiB)
+- r6i.32xlarge (128 vCPU, 1,024 GiB)
+- z1d.xlarge (4 vCPU, 32 GiB)
+- z1d.2xlarge (8 vCPU, 64 GiB)
+- z1d.3xlarge (12 vCPU, 96 GiB)
+- z1d.6xlarge (24 vCPU, 192 GiB)
+- z1d.12xlarge (48 vCPU, 384 GiB)
 ====
 
 .Compute-optimized compute types
 [%collapsible]
 ====
+- c5.xlarge (4 vCPU, 8 GiB)
 - C5.2xlarge (8 vCPU, 16 GiB)
 - C5.4xlarge (16 vCPU, 32 GiB)
 - C5.9xlarge (36 vCPU, 72 GiB)
 - C5.12xlarge (48 vCPU, 96 GiB)
 - C5.18xlarge (72 vCPU, 144 GiB)
 - C5.24xlarge (96 vCPU, 192 GiB)
+====
+
+.Storage-optimized compute types
+[%collapsible]
+====
+- i3.xlarge	(4 vCPU, 30.5 GiB)
+- i3.2xlarge (8 vCPU, 61 GiB)
+- i3.4xlarge (16 vCPU, 122 GiB)
+- i3.8xlarge (32 vCPU, 244 GiB)
+- i3.16xlarge (64 vCPU, 488 GiB)
+- i3en.xlarge (4 vCPU, 32 GiB)
+- i3en.2xlarge (8 vCPU, 64 GiB)
+- i3en.3xlarge (12 vCPU, 96 GiB)
+- i3en.6xlarge (24 vCPU, 192 GiB)
+- i3en.12xlarge (48 vCPU, 384 GiB)
+- i3en.24xlarge (96 vCPU, 768 GiB)
 ====
 
 [id="rosa-sdpolicy-regions-az_{context}"]

--- a/modules/sdpolicy-account-management.adoc
+++ b/modules/sdpolicy-account-management.adoc
@@ -65,32 +65,32 @@ Approximately 1 vCPU core and 1 GiB of memory are reserved on each worker node a
 
 .General purpose
 
-* M5.xlarge (4 vCPU, 16 GiB)
-* M5.2xlarge (8 vCPU, 32 GiB)
-* M5.4xlarge (16 vCPU, 64 GiB)
-* M5.8xlarge (32 vCPU, 128 GiB)
-* M5.12xlarge (48 vCPU, 192 GiB)
-* M5.16xlarge (64 vCPU, 256 GiB)
-* M5.24xlarge (96 vCPU, 384 GiB)
+* m5.xlarge (4 vCPU, 16 GiB)
+* m5.2xlarge (8 vCPU, 32 GiB)
+* m5.4xlarge (16 vCPU, 64 GiB)
+* m5.8xlarge (32 vCPU, 128 GiB)
+* m5.12xlarge (48 vCPU, 192 GiB)
+* m5.16xlarge (64 vCPU, 256 GiB)
+* m5.24xlarge (96 vCPU, 384 GiB)
 
 .Memory-optimized
 
-* R5.xlarge (4 vCPU, 32 GiB)
-* R5.2xlarge (8 vCPU, 64 GiB)
-* R5.4xlarge (16 vCPU, 128 GiB)
-* R5.8xlarge (32 vCPU, 256 GiB)
-* R5.12xlarge (48 vCPU, 384 GiB)
-* R5.16xlarge (64 vCPU, 512 GiB)
-* R5.24xlarge (96 vCPU, 768 GiB)
+* r5.xlarge (4 vCPU, 32 GiB)
+* r5.2xlarge (8 vCPU, 64 GiB)
+* r5.4xlarge (16 vCPU, 128 GiB)
+* r5.8xlarge (32 vCPU, 256 GiB)
+* r5.12xlarge (48 vCPU, 384 GiB)
+* r5.16xlarge (64 vCPU, 512 GiB)
+* r5.24xlarge (96 vCPU, 768 GiB)
 
 .Compute-optimized
 
-* C5.2xlarge (8 vCPU, 16 GiB)
-* C5.4xlarge (16 vCPU, 32 GiB)
-* C5.9xlarge (36 vCPU, 72 GiB)
-* C5.12xlarge (48 vCPU, 96 GiB)
-* C5.18xlarge (72 vCPU, 144 GiB)
-* C5.24xlarge (96 vCPU, 192 GiB)
+* c5.2xlarge (8 vCPU, 16 GiB)
+* c5.4xlarge (16 vCPU, 32 GiB)
+* c5.9xlarge (36 vCPU, 72 GiB)
+* c5.12xlarge (48 vCPU, 96 GiB)
+* c5.18xlarge (72 vCPU, 144 GiB)
+* c5.24xlarge (96 vCPU, 192 GiB)
 
 [id="gcp-compute-types_{context}"]
 == Google Cloud compute types


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3333

**Previews**
ROSA (new content): https://deploy-preview-44154--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-service-definition#rosa-sdpolicy-aws-compute-types_rosa-service-definition
Dedicated(updated formatting): https://deploy-preview-44154--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/osd-service-definition.html#aws-compute-types_osd-service-definition

OSD-specific PR: https://github.com/openshift/openshift-docs/pull/44281/