### PR TITLE
Adds a step to get the OCP release image

### DIFF
--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -13,11 +13,14 @@ To create and manage cloud credentials from outside of the cluster when the Clou
 The `ccoctl` is a Linux binary that must run in a Linux environment.
 ====
 
-.Prerequisites
-
-* Obtain the {product-title} release image.
-
 .Procedure
+
+. Obtain the {product-title} release image.
++
+[source,terminal]
+----
+$ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
+----
 
 . Get the CCO container image from the {product-title} release image:
 +


### PR DESCRIPTION
GH issue: https://github.com/openshift/openshift-docs/issues/41515

Preview: https://deploy-preview-44157--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts#cco-ccoctl-configuring_cco-mode-sts

Adds a step to collect the OCP release image instead of having it as a prereq. 