### PR TITLE
CNV-11176: Revising API name for HPP CR

### DIFF
--- a/modules/virt-creating-custom-resources-hpp.adoc
+++ b/modules/virt-creating-custom-resources-hpp.adoc
@@ -21,7 +21,7 @@ $ touch hostpathprovisioner_cr.yaml
 +
 [source,yaml]
 ----
-apiVersion: hostpathprovisioner.kubevirt.io/v1beta1
+apiVersion: hostpathprovisioner.kubevirt.io.v1beta1
 kind: HostPathProvisioner
 metadata:
  name: hostpath-provisioner


### PR DESCRIPTION
For 4.10 and 4.11 only.

Jira: https://issues.redhat.com/browse/CNV-11176

Direct doc preview link: https://deploy-preview-44159--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.html

This is a small revision to the API name for the HPP CR, as we don't want the user to use the old provisioner under any circumstances.

@awels and @jpeimer can you approve this? If so, I can merge this in and pick to 4.10 and 4.11 ASAP.

Thanks

Bob