### PR TITLE
[BZ1723494]: Uninstalling OLM using Ansible

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -534,8 +534,8 @@ Topics:
 - Name: Installing the Operator Framework (Technology Preview)
   File: installing-operator-framework
   Distros: openshift-origin,openshift-enterprise
-- Name: Uninstalling Operator Lifecycle Manager 
-  File: uninstall-olm-using-ansible
+- Name: Uninstalling Operator Lifecycle Manager
+  File: uninstall-olm-ansible
   Distros: openshift-origin,openshift-enterprise
 ---
 Name: Day Two Operations Guide

--- a/install_config/uninstall-olm-ansible.adoc
+++ b/install_config/uninstall-olm-ansible.adoc
@@ -1,0 +1,14 @@
+// This assembly is included in the following assemblies:
+//
+// * n/a
+
+:_content-type: ASSEMBLY
+[id="uninstall-olm-using-ansible"]
+= Uninstalling Operator Lifecycle Manager 
+:context: uninstall-olm-using-ansible
+
+toc::[]
+
+After installing your cluster, you can uninstall the Operator Lifecycle Manager by using the {product-title} `openshift-ansible` installer.
+
+include::modules/uninstalling-olm-ansible.adoc[leveloffset=+1]

--- a/modules/uninstalling-olm-ansible.adoc
+++ b/modules/uninstalling-olm-ansible.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * install_config/uninstall-olm-ansible.adoc
+
+[id="uninstalling-olm-using-ansible_{context}"]
+= Uninstalling Operator Lifecycle Manager using Ansible
+
+After installing your cluster, you can use this procedure with the {product-title} `openshift-ansible` installer to uninstall the Technology Preview Operator Framework.
+
+- You must have an existing {product-title} 3.11 cluster
+- You must have access to the cluster using an account with `cluster-admin` permissions
+- You must have Ansible playbooks provided by the latest `openshift-ansible` installer
+
+. Add the following variables to your `config.yml` playbook:
++
+----
+operator_lifecycle_manager_install=false
+operator_lifecycle_manager_remove=true
+----
+
+. Change to the playbook directory:
++
+----
+$ cd /usr/share/ansible/openshift-ansible
+----
+
+. Run the OLM installation playbook to uninstall OLM using your inventory file:
++
+----
+$ ansible-playbook -i <inventory_file> playbooks/olm/config.yml
+----


### PR DESCRIPTION
Adds a procedure to remove OLM via Ansible playbooks
OCP version: 3.11
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1723494)
[Preview](https://deploy-preview-44161--osdocs.netlify.app/openshift-enterprise/latest/install_config/uninstall-olm-ansible.html)
 QE contact @jianzhangbj-LGTMed