### PR TITLE
BZ1723494: Add procedure to remove OLM via playbooks

### DIFF
--- a/install_config/uninstall-olm-using-ansible.adoc
+++ b/install_config/uninstall-olm-using-ansible.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: ASSEMBLY
 [id="uninstall-olm-using-ansible"]
-= Uninstalling Operator Lifecycle Manager using Ansible
+= Uninstalling Operator Lifecycle Manager 
 :context: uninstall-olm-using-ansible
 
 toc::[]

--- a/modules/uninstalling-olm-using-ansible.adoc
+++ b/modules/uninstalling-olm-using-ansible.adoc
@@ -5,19 +5,16 @@
 [id="uninstalling-olm-using-ansible_{context}"]
 = Uninstalling Operator Lifecycle Manager using Ansible
 
-After installing your cluster, you can uninstall the Technology Preview Operator Framework by using he {product-title} `openshift-ansible` installer.
+After installing your cluster, you can use this procedure with the {product-title} `openshift-ansible` installer to uninstall the Technology Preview Operator Framework.
 
-.Prerequisites
+You must check the following prerequisites before uninstalling the Technology Preview Operator Framework:
 
 - An existing {product-title} 3.11 cluster
 - Access to the cluster using an account with `cluster-admin` permissions
 - Ansible playbooks provided by the latest `openshift-ansible` installer
 
-.Procedure
-
 . Add the following variables to your `config.yml` playbook:
 +
-[source,yaml]
 ----
 operator_lifecycle_manager_install=false
 operator_lifecycle_manager_remove=true


### PR DESCRIPTION
Adds a procedure to remove OLM via Ansible playbooks
OCP version: 3.11
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1723494)
[Preview](https://deploy-preview-44170--osdocs.netlify.app/openshift-enterprise/latest/install_config/uninstall-olm-using-ansible.html)