### PR TITLE
Restoring lost TOC formatting.

### DIFF
--- a/service_mesh/v2x/ossm-create-mesh.adoc
+++ b/service_mesh/v2x/ossm-create-mesh.adoc
@@ -4,6 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: ossm-create-mesh
 
+toc::[]
+
 After installing the Operators and `ServiceMeshControlPlane` resource, add applications, workloads, or services to your mesh by creating a `ServiceMeshMemberRoll` resource and specifying the namespaces where your content is located. If you already have an application, workload, or service to add to a `ServiceMeshMemberRoll` resource, use the following steps. Or, to install a sample application called Bookinfo and add it to a  `ServiceMeshMemberRoll` resource, skip to the tutorial for installing the xref:../../service_mesh/v2x/ossm-create-mesh.adoc#ossm-tutorial-bookinfo-overview_ossm-create-mesh[Bookinfo example application] to see how an application works in {SMProductName}.
 
 The items listed in the `ServiceMeshMemberRoll` resource are the applications and workflows that are managed by the `ServiceMeshControlPlane` resource. The control plane, which includes the {SMProductShortName} Operators, Istiod, and `ServiceMeshControlPlane`, and the data plane, which includes applications and Envoy proxy, must be in separate namespaces.

--- a/service_mesh/v2x/ossm-create-smcp.adoc
+++ b/service_mesh/v2x/ossm-create-smcp.adoc
@@ -4,6 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: ossm-create-smcp
 
+toc::[]
+
 You can deploy a basic installation of the `ServiceMeshControlPlane` by using either the {product-title} web console or from the command line using the `oc` client tool.
 
 [NOTE]

--- a/service_mesh/v2x/ossm-deployment-models.adoc
+++ b/service_mesh/v2x/ossm-deployment-models.adoc
@@ -4,6 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: ossm-deployment-models
 
+toc::[]
+
 {SMProductName} supports several different deployment models that can be combined in different ways to best suit your business requirements.
 
 include::modules/ossm-deploy-single-mesh.adoc[leveloffset=+1]

--- a/service_mesh/v2x/ossm-reference-smcp.adoc
+++ b/service_mesh/v2x/ossm-reference-smcp.adoc
@@ -4,6 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: ossm-reference
 
+toc::[]
+
 You can customize your {SMProductName} by modifying the default `ServiceMeshControlPlane` (SMCP) resource or by creating a completely custom SMCP resource. This reference section documents the configuration options available for the SMCP resource.
 
 include::modules/ossm-cr-example.adoc[leveloffset=+1]

--- a/service_mesh/v2x/ossm-security.adoc
+++ b/service_mesh/v2x/ossm-security.adoc
@@ -6,7 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-
 If your service mesh application is constructed with a complex array of microservices, you can use {SMProductName} to customize the security of the communication between those services. The infrastructure of {product-title} along with the traffic management features of {SMProductShortName} help you manage the complexity of your applications and secure microservices.
 
 .Before you begin

--- a/service_mesh/v2x/prepare-to-deploy-applications-ossm.adoc
+++ b/service_mesh/v2x/prepare-to-deploy-applications-ossm.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-After adding your services to a mesh, enable automatic sidecar injection in the deployment resource for your application. You must enable automatic sidecar injection for each deployment. 
+After adding your services to a mesh, enable automatic sidecar injection in the deployment resource for your application. You must enable automatic sidecar injection for each deployment.
 
 If you have installed the Bookinfo sample application, the application was deployed and the sidecars were injected. If you are using your own project and service, deploy your applications on {product-title}. For more information, see xref:../../applications/deployments/what-deployments-are.html[Understanding Deployment and DeploymentConfig objects].
 


### PR DESCRIPTION
Restoring the `toc::[]` formatting that disappeared (probably during the attributes files merges).

Preview links:
https://deploy-preview-44175--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-deployment-models.html 
https://deploy-preview-44175--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-create-smcp.html
https://deploy-preview-44175--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-create-mesh.html
https://deploy-preview-44175--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-reference-smcp.html 


Peer review - stevsmit