### PR TITLE
4.10 RN update for CentOS 8 Stream

### DIFF
--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -113,7 +113,12 @@ Removed features are not supported in the current release.
 
 * The VM Import Operator has been removed from {VirtProductName} with this release. It is replaced by the link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.2[Migration Toolkit for Virtualization].
 
-* This release removes the template for CentOS Linux 8. CentOS Linux 8 is no longer supported as of December 31, 2021.
+* This release removes the template for CentOS Linux 8, which reached link:https://www.centos.org/centos-linux-eol/[End of Life (EOL)] on December 31, 2021. However, {product-title} now includes templates for CentOS Stream 8 and CentOS Stream 9.
++
+[NOTE]
+====
+All CentOS distributions are community-supported.
+====
 
 // NOTE: no notable technical changes in 4.9, commenting out to retain
 //[id="virt-4-10-changes"]


### PR DESCRIPTION
For 4.10 only.

Jira: https://issues.redhat.com/browse/CNV-15707

Direct doc preview link: https://deploy-preview-44176--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-10-release-notes.html

This is a minor update to the Removed section of the 4.10 release notes.

@ctomasko - This is the positive addition about CentOS 8 in the removed features section that @dankenigsberg wanted us to add. 

Dan and Dominick, if you have recommendations for the wording, just tell me. I was not sure if I should specifically state "out-of-the-box".

cc: @dominikholler 

Thanks
Bob

