### PR TITLE
BZ-2070861: Clarifying TechPreviewNoUpgrade feature

### DIFF
--- a/modules/builds-running-entitled-builds-with-sharedsecret-objects.adoc
+++ b/modules/builds-running-entitled-builds-with-sharedsecret-objects.adoc
@@ -18,7 +18,7 @@ The Shared Resources CSI Driver and The Build CSI Volumes are both Technology Pr
 For more information about the support scope of Red Hat Technology Preview
 features, see https://access.redhat.com/support/offerings/techpreview/.
 
-The Shared Resources CSI Driver and the Build CSI Volumes features also belong to the `TechPreviewNoUpgrade` feature set, which is a subset of the current Technology Preview features. You can enable the `TechPreviewNoUpgrade` feature set on test clusters, where you can fully test them while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents updates. This feature set is not recommended on production clusters. See "Enabling Technology Preview features using feature gates" in the following "Additional resources" section.
+The Shared Resources CSI Driver and the Build CSI Volumes features also belong to the `TechPreviewNoUpgrade` feature set, which is a subset of the current Technology Preview features. You can enable the `TechPreviewNoUpgrade` feature set on test clusters, where you can fully test them while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents minor version updates. This feature set is not recommended on production clusters. See "Enabling Technology Preview features using feature gates" in the following "Additional resources" section.
 ====
 
 .Prerequisites

--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -10,7 +10,7 @@ You can use the `FeatureGate` custom resource (CR) to enable specific feature se
 
 You can activate the following feature set by using the `FeatureGate` CR:
 
-* `TechPreviewNoUpgrade`. This feature set is a subset of the current Technology Preview features. This feature set allows you to enable these tech preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents updates. This feature set is not recommended on production clusters.
+* `TechPreviewNoUpgrade`. This feature set is a subset of the current Technology Preview features. This feature set allows you to enable these tech preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents minor version updates. This feature set is not recommended on production clusters.
 +
 The following Technology Preview features are enabled by this feature set:
 +

--- a/modules/nodes-cluster-enabling-features-cli.adoc
+++ b/modules/nodes-cluster-enabling-features-cli.adoc
@@ -44,12 +44,12 @@ After you save the changes, new machine configs are created, the machine config 
 +
 [NOTE]
 ====
-Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents upgrades. These feature sets are not recommended on production clusters.
+Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
 ====
 
 .Verification
 
-You can verify that the feature gates are enabled by looking at the `kubelet.conf` file on a node after the nodes return to the ready state. 
+You can verify that the feature gates are enabled by looking at the `kubelet.conf` file on a node after the nodes return to the ready state.
 
 . Start a debug session for a node:
 +
@@ -69,7 +69,7 @@ sh-4.2# chroot /host
 +
 [source,terminal]
 ----
-sh-4.2# cat /etc/kubernetes/kubelet.conf 
+sh-4.2# cat /etc/kubernetes/kubelet.conf
 ----
 +
 .Sample output
@@ -88,5 +88,4 @@ The features that are listed as `true` are enabled on your cluster.
 [NOTE]
 ====
 The features listed vary depending upon the {product-title} version.
-==== 
-
+====

--- a/modules/nodes-cluster-enabling-features-console.adoc
+++ b/modules/nodes-cluster-enabling-features-console.adoc
@@ -45,12 +45,12 @@ After you save the changes, new machine configs are created, the machine config 
 +
 [NOTE]
 ====
-Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents upgrades. These feature sets are not recommended on production clusters. 
+Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters. 
 ====
 
 .Verification
 
-You can verify that the feature gates are enabled by looking at the `kubelet.conf` file on a node after the nodes return to the ready state. 
+You can verify that the feature gates are enabled by looking at the `kubelet.conf` file on a node after the nodes return to the ready state.
 
 . From the *Administrator* perspective in the web console, navigate to *Compute* -> *Nodes*.
 
@@ -69,7 +69,7 @@ sh-4.2# chroot /host
 +
 [source,terminal]
 ----
-sh-4.2# cat /etc/kubernetes/kubelet.conf 
+sh-4.2# cat /etc/kubernetes/kubelet.conf
 ----
 +
 .Sample output
@@ -88,4 +88,4 @@ The features that are listed as `true` are enabled on your cluster.
 [NOTE]
 ====
 The features listed vary depending upon the {product-title} version.
-==== 
+====

--- a/modules/nodes-nodes-swap-memory.adoc
+++ b/modules/nodes-nodes-swap-memory.adoc
@@ -6,7 +6,7 @@
 :FeatureName: Enabling swap memory use on nodes
 include::snippets/technology-preview.adoc[]
 
-You can enable swap memory use for {product-title} workloads on a per-node basis. 
+You can enable swap memory use for {product-title} workloads on a per-node basis.
 
 [WARNING]
 ====
@@ -33,7 +33,7 @@ Because the kubelet will not start in the presence of swap memory without this c
 +
 [NOTE]
 ====
-Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents upgrades. These feature sets are not recommended on production clusters.
+Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
 ====
 
 * If cgroups v2 is enabled on a node, you must enable swap accounting on the node, by setting the `swapaccount=1` kernel argument.
@@ -64,8 +64,7 @@ spec:
     memorySwap:
       swapBehavior: LimitedSwap <2>
 ----
-<1> Set to `false` to enable swap memory use on the associated nodes. Set to `true` to disable swap memory use. 
+<1> Set to `false` to enable swap memory use on the associated nodes. Set to `true` to disable swap memory use.
 <2> Specify the swap memory behavior. If unspecified, the default is `LimitedSwap`.
 
-. Enable swap memory on the machines. 
-
+. Enable swap memory on the machines.


### PR DESCRIPTION
Applies to 4.8+ 
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=2070861
QE ack required.
Preview Links:

- [Understanding feature gates](https://deploy-preview-44180--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)
- [Enabling feature sets using the web console](https://deploy-preview-44180--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-console_nodes-cluster-enabling) See the Note. 
- [Enabling feature sets using the CLI](https://deploy-preview-44180--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-cli_nodes-cluster-enabling) See the Note. 
- [Running entitled builds using SharedSecret objects](https://deploy-preview-44180--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/running-entitled-builds.html#builds-running-entitled-builds-with-sharedsecret-objects_running-entitled-builds) See the Important note.
- [Enabling swap memory use on nodes](https://deploy-preview-44180--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-working.html#nodes-nodes-swap-memory_nodes-nodes-working) See note in prerequisites.
