### PR TITLE
BZ-2070861: Clarifying minor version update for CVO

### DIFF
--- a/modules/monitoring-unmanaged-monitoring-operators.adoc
+++ b/modules/monitoring-unmanaged-monitoring-operators.adoc
@@ -11,11 +11,11 @@ While overriding CVO control for an Operator can be helpful during debugging, th
 
 .Overriding the Cluster Version Operator
 
-The `spec.overrides` parameter can be added to the configuration for the CVO to allow administrators to provide a list of overrides to the behavior of the CVO for a component. Setting the `spec.overrides[].unmanaged` parameter to `true` for a component blocks cluster upgrades and alerts the administrator after a CVO override has been set:
+The `spec.overrides` parameter can be added to the configuration for the CVO to allow administrators to provide a list of overrides to the behavior of the CVO for a component. Setting the `spec.overrides[].unmanaged` parameter to `true` for a component blocks minor version updates and alerts the administrator after a CVO override has been set:
 
 [source,terminal]
 ----
-Disabling ownership via cluster version overrides prevents upgrades. Please remove overrides before continuing.
+Disabling ownership via cluster version overrides prevents minor version updates. Please remove overrides before continuing.
 ----
 
 [WARNING]

--- a/modules/unmanaged-operators.adoc
+++ b/modules/unmanaged-operators.adoc
@@ -42,12 +42,12 @@ component and functionality unsupported. Reported issues must be reproduced in
 The `spec.overrides` parameter can be added to the CVO's configuration to allow
 administrators to provide a list of overrides to the CVO's behavior for a
 component. Setting the `spec.overrides[].unmanaged` parameter to `true` for a
-component blocks cluster upgrades and alerts the administrator after a CVO
+component blocks minor version updates and alerts the administrator after a CVO
 override has been set:
 +
 [source,terminal]
 ----
-Disabling ownership via cluster version overrides prevents upgrades. Please remove overrides before continuing.
+Disabling ownership via cluster version overrides prevents minor version updates. Please remove overrides before continuing.
 ----
 +
 [WARNING]


### PR DESCRIPTION
Applies to 4.6+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=2070861
QE ack required.
Preview Links:

- [Support policy for monitoring Operators](https://deploy-preview-44187--osdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#unmanaged-monitoring-operators_configuring-the-monitoring-stack)
- [Support policy for unmanaged Operators](https://deploy-preview-44187--osdocs.netlify.app/openshift-enterprise/latest/architecture/architecture-installation.html#unmanaged-operators_architecture-installation)