### PR TITLE
WINC clarify Getting Support wording

### DIFF
--- a/windows_containers/windows-containers-release-notes-5-x.adoc
+++ b/windows_containers/windows-containers-release-notes-5-x.adoc
@@ -13,10 +13,20 @@ Windows Container Support for Red Hat OpenShift enables running Windows compute 
 
 The release notes for Red Hat OpenShift for Windows Containers tracks the development of the WMCO, which provides all Windows container workload capabilities in {product-title}.
 
+ifndef::openshift-origin[]
 [id="getting-support"]
 == Getting support
 
-You must have a subscription to receive support for the Red Hat WMCO. Deploying Windows container workloads in production clusters is not supported without a subscription. If you do not have a subscription, you can use the community WMCO, a distribution that lacks official support. Request support through the link:http://access.redhat.com/[Red Hat Customer Portal].
+// wording taken and modified from https://access.redhat.com/support/policy/updates/openshift#windows
+
+Windows Container Support for Red Hat OpenShift is provided and available as an optional, installable component. Windows Container Support for Red Hat OpenShift is not part of the {product-title} subscription. It requires an additional Red Hat subscription and is supported according to the link:https://access.redhat.com/support/offerings/production/soc/[Scope of coverage] and link:https://access.redhat.com/support/offerings/production/sla[Service level agreements].
+
+You must have this separate subscription to receive support for Windows Container Support for Red Hat OpenShift. Without this additional Red Hat subscription, deploying Windows container workloads in production clusters is not supported. You can request support through the link:http://access.redhat.com/[Red Hat Customer Portal]. 
+
+For more information, see the Red Hat OpenShift Container Platform Life Cycle Policy document for link:https://access.redhat.com/support/policy/updates/openshift#windows[Red Hat OpenShift support for Windows Containers].
+
+If you do not have this additional Red Hat subscription, you can use the Community Windows Machine Config Operator, a distribution that lacks official support. 
+endif::openshift-origin[]
 
 [id="wmco-5-0-0"]
 == Release notes for Red Hat Windows Machine Config Operator 5.0.0


### PR DESCRIPTION
Per [Slack conversation](https://coreos.slack.com/archives/CM4ERHBJS/p1648832040363479?thread_ts=1648789414.418059&cid=CM4ERHBJS)"
"https://docs.openshift.com/container-platform/4.9/windows_containers/windows-containers-release-notes-4-x.html#getting-support is confusing,...  I thus recommend fixing docs and pointing to https://access.redhat.com/support/policy/updates/openshift#windows" 
 
The wording in the PR is  wording taken and modified from https://access.redhat.com/support/policy/updates/openshift#windows

 Previews: 
[Getting support](https://deploy-preview-44201--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-5-x.html#getting-support)
[OKD without the Getting support section](https://deploy-preview-44201--osdocs.netlify.app/openshift-origin/latest/windows_containers/windows-containers-release-notes-5-x).
 
 Changing 4.6 to 4.9 in separate PRs, as this section is in the release notes and only in that branch.