### PR TITLE
RNs-4.10.8:Adds notes for 4.10.8 release

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2640,7 +2640,35 @@ This update contains changes from Kubernetes 1.23.3 up to 1.23.5. More informati
 
 * Previously, the sink for event sources in the `Trigger/Subscription` modal in the *Topology* UI showed all resources, irrespective of whether they were created as a standalone or an underlying resource included with back KSVC, Broker, or KameletBinding. Consequently, users could sink to the underlying addressable resources as they showed up in the sink drop-down menu. With this update, a resource filter has been added to show only standalone resource sink events. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2059807[*BZ#2059807*])
 
-[id="ocp-4-10-6-updating"]
+[id="ocp-4-10-8"]
+
+=== RHBA-2022:1161 - {product-title} 4.10.8 bug fix and security update
+
+Issued: 2022-04-7
+
+{product-title} release 4.10.8, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1161[RHBA-2022:1161] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:1162[RHSA-2022:1162] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6877401[{product-title} 4.10.8 container image list]
+
+[id="ocp-4-10-8-known-issues"]
+==== Known issues
+
+* Currently, the web console does not display virtual machine templates that are deployed to a custom `namespace`. Only templates deployed to the default `namespace` will display in the web console. As a workaround, avoid deploying templates to a custom `namespace`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054650[*BZ#2054650*])
+
+[id="ocp-4-10-8-bug-fixes"]
+==== Bug fixes
+* Previously, the Infrastructure Operator could not provision X11 and X12 based systems due to validation errors created by the bare metal controller (BMC) when special characters such as question marks or equals signs were used in `filename` parameters of URLs. With this update, the `filename` parameter is removed from the URL if the virtual media image is backed by a local file. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2011626[*BZ#2011626*])
+
+* Previously, when cloning a Virtual Machine from a template, changes the Operator made would revert after dismissing the dialog box if the boot disk is edited and the storage class is changed. With this update, changes made to storage class remain set after closing the dialogue box. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049762[*BZ#2049762*])
+
+* Previously, the `startupProbe` field was added to container’s definition. As a result, `startupProbe` causes problems when creating a debug pod. With this update, `startupProbe` is removed by default from the debug pod by `Expose --keep-startup flag` which is now false by default.(link:https://bugzilla.redhat.com/show_bug.cgi?id=2068474[*BZ#2068474*])
+
+* Before this update, the Local Storage Operator (LSO) added an `OwnerReference` to the persistent volumes (PV) it created, which sometimes causes an issue where a delete request for a PV could leave the PV in the `terminating` state while still attached to the pod. With this update, the LSO no longer creates `OwnerReference` so cluster administrators will now be able to manually delete any unused PVs after a node is removed from the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2065714[*BZ#2065714*])
+
+
+[id="ocp-4-10-8-updating"]
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Adds RNs for 4.10.8

Hold merge till asked for on 4.7.22. 

Applies to enterprise 4.10

[Preview](https://deploy-preview-44202--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-8)