### PR TITLE
bz2066992 updated installation with custom SCC

### DIFF
--- a/modules/compliance-custom-scc.adoc
+++ b/modules/compliance-custom-scc.adoc
@@ -1,0 +1,88 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/compliance-operator-advanced.adoc
+
+:_content-type: PROCEDURE
+[id="compliance-custom-scc_{context}"]
+= Creating a custom SCC for the Compliance Operator
+
+In some environments, you must create a custom Security Context Constraints (SCC) file to ensure the correct permissions are available to the Compliance Operator `api-resource-collector`. 
+
+.Prerequisites
+
+* You must have `admin` privileges.
+
+.Procedure
+. Define the SCC in a YAML file named `restricted-adjusted-compliance.yaml`:
++
+.`SecurityContextConstraints` object definition
+[source,yaml]
+----
+  allowHostDirVolumePlugin: false
+  allowHostIPC: false
+  allowHostNetwork: false
+  allowHostPID: false
+  allowHostPorts: false
+  allowPrivilegeEscalation: true
+  allowPrivilegedContainer: false
+  allowedCapabilities: null
+  apiVersion: security.openshift.io/v1
+  defaultAddCapabilities: null
+  fsGroup:
+    type: MustRunAs
+  kind: SecurityContextConstraints
+  metadata:
+    name: restricted-adjusted-compliance
+  priority: 30 <1>
+  readOnlyRootFilesystem: false
+  requiredDropCapabilities:
+  - KILL
+  - SETUID
+  - SETGID
+  - MKNOD
+  runAsUser:
+    type: MustRunAsRange
+  seLinuxContext:
+    type: MustRunAs
+  supplementalGroups:
+    type: RunAsAny
+  users:
+  - system:serviceaccount:openshift-compliance:api-resource-collector <2>
+  volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+----
+<1> The priority of this SCC must be higher than any other SCC that applies to the `system:authenticated` group.
+<2> Service Account used by Compliance Operator Scanner pod.
+
+. Create the SCC:
++
+[source,terminal]
+----
+$ oc create -f restricted-adjusted-compliance.yaml
+----
++
+.Example output
+[source,terminal]
+----
+securitycontextconstraints.security.openshift.io/restricted-adjusted-compliance created
+----
+
+.Verification
+. Verify the SCC was created:
++
+[source,terminal]
+----
+$ oc get scc restricted-adjusted-compliance
+----
++
+.Example output
+[source,terminal]
+----
+NAME                             PRIV    CAPS         SELINUX     RUNASUSER        FSGROUP     SUPGROUP   PRIORITY   READONLYROOTFS   VOLUMES
+restricted-adjusted-compliance   false   <no value>   MustRunAs   MustRunAsRange   MustRunAs   RunAsAny   30         false            ["configMap","downwardAPI","emptyDir","persistentVolumeClaim","projected","secret"]
+----

--- a/modules/security-context-constraints-example.adoc
+++ b/modules/security-context-constraints-example.adoc
@@ -8,7 +8,7 @@
 The following examples show the security context constraints (SCC) format and
 annotations:
 
-.Annotated `priviledged` SCC
+.Annotated `privileged` SCC
 [source,yaml]
 ----
 allowHostDirVolumePlugin: true

--- a/security/compliance_operator/compliance-operator-advanced.adoc
+++ b/security/compliance_operator/compliance-operator-advanced.adoc
@@ -19,3 +19,10 @@ include::modules/compliance-custom-storage.adoc[leveloffset=+1]
 include::modules/compliance-apply-remediations-from-scans.adoc[leveloffset=+1]
 
 include::modules/compliance-auto-update-remediations.adoc[leveloffset=+1]
+
+include::modules/compliance-custom-scc.adoc[leveloffset=+1]
+
+[id="additional-resources_compliance-operator-advanced"]
+[role="_additional-resources"]
+== Additional resources
+* xref:../../authentication/managing-security-context-constraints.adoc[Managing security context constraints]

--- a/security/compliance_operator/compliance-operator-installation.adoc
+++ b/security/compliance_operator/compliance-operator-installation.adoc
@@ -10,7 +10,21 @@ Before you can use the Compliance Operator, you must ensure it is deployed in th
 
 include::modules/compliance-operator-console-installation.adoc[leveloffset=+1]
 
+[IMPORTANT]
+====
+If the `restricted` Security Context Constraints (SCC) have been modified to contain the `system:authenticated` group or has added `requiredDropCapabilities`, the Compliance Operator may not function properly due to permissions issues.
+
+You can create a custom SCC for the Compliance Operator scanner pod service account. For more information, see xref:../../security/compliance_operator/compliance-operator-advanced.adoc#compliance-custom-scc_compliance-advanced[Creating a custom SCC for the Compliance Operator].
+====
+
 include::modules/compliance-operator-cli-installation.adoc[leveloffset=+1]
+
+[IMPORTANT]
+====
+If the `restricted` Security Context Constraints (SCC) have been modified to contain the `system:authenticated` group or has added `requiredDropCapabilities`, the Compliance Operator may not function properly due to permissions issues.
+
+You can create a custom SCC for the Compliance Operator scanner pod service account. For more information, see xref:../../security/compliance_operator/compliance-operator-advanced.adoc#compliance-custom-scc_compliance-advanced[Creating a custom SCC for the Compliance Operator].
+====
 
 [id="additional-resources-installing-the-compliance-operator"]
 [role="_additional-resources"]


### PR DESCRIPTION
CP to 4.7+
I put an IMPORTANT note at the bottom of each type of installation method:
[deploy-preview-44210--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-installation.html](https://deploy-preview-44210--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-installation.html)

In the note, I linked to the custom SCC procedure, which I placed in the advanced CO tasks section:
[deploy-preview-44210--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-advanced.html#compliance-custom-scc_compliance-advanced](https://deploy-preview-44210--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-advanced.html#compliance-custom-scc_compliance-advanced)

Per [bz2066992](https://bugzilla.redhat.com/show_bug.cgi?id=2066992):

* Added statements in the install sections that included custom SCC creation
* Added a procedure module to the Advanced Compliance Operator section, personally tested validation in cluster-bot; added additional resources for more info on SCCs
* Fixed a typo I found in another file while researching SCCs