### PR TITLE
RHDEVDOCS-3386 - How to configure Prometheus Adapter audit log levels

### DIFF
--- a/modules/monitoring-setting-audit-log-levels-for-the-prometheus-adapter.adoc
+++ b/modules/monitoring-setting-audit-log-levels-for-the-prometheus-adapter.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+:_content-type: PROCEDURE
+[id="setting-audit-log-levels-for-the-prometheus-adapter_{context}"]
+= Setting audit log levels for the Prometheus Adapter
+
+[role=_abstract]
+In default platform monitoring, you can configure the audit log level for the Prometheus Adapter.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+
+.Procedure
+
+You can set an audit log level for the Prometheus Adapter in the default `openshift-monitoring` project:
+
+. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+----
+
+. Add `profile:` in the `k8sPrometheusAdapter/audit` section under `data/config.yaml`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    k8sPrometheusAdapter:
+      audit:
+        profile: <audit_log_level> <1>
+----
+<1> The audit log level to apply to the Prometheus Adapter. 
+
+. Set the audit log level by using one of the following values for the `profile:` parameter:
++
+* `None`: Do not log events.
+* `Metadata`: Log only the metadata for the request, such as user, timestamp, and so forth. Do not log the request text and the response text. `Metadata` is the default audit log level.
+* `Request`: Log only the metadata and the request text but not the response text. This option does not apply for non-resource requests.
+* `RequestResponse`: Log event metadata, request text, and response text. This option does not apply for non-resource requests.
+
+. Save the file to apply the changes. The pods for the Prometheus Adapter restart automatically when you apply the change.
++
+[WARNING]
+====
+When changes are saved to a monitoring config map, the pods and other resources in the related project might be redeployed. The running monitoring processes in that project might also be restarted.
+====
+
+.Verification
+
+. In the config map, under `k8sPrometheusAdapter/audit/profile`, set the log level to `Request` and save the file.
+
+. Confirm that the pods for the Prometheus Adapter are running. The following example lists the status of pods in the `openshift-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring get pods
+----
+
+. Confirm that the audit log level and audit log file path are correctly configured:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring get deploy prometheus-adapter -o yaml
+----
++
+.Example output
+[source,terminal]
+----
+...
+  - --audit-policy-file=/etc/audit/request-profile.yaml
+  - --audit-log-path=/var/log/adapter/audit.log
+----
+
+. Confirm that the correct log level has been applied in the `prometheus-adapter` deployment in the `openshift-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring exec deploy/prometheus-adapter -c prometheus-adapter -- cat /etc/audit/request-profile.yaml
+----
++
+.Example output
+[source,terminal]
+----
+"apiVersion": "audit.k8s.io/v1"
+"kind": "Policy"
+"metadata":
+  "name": "Request"
+"omitStages":
+- "RequestReceived"
+"rules":
+- "level": "Request"
+----
++
+[NOTE]
+====
+If you enter an unrecognized `profile` value for the Prometheus Adapter in the `ConfigMap` object, no changes are made to the Prometheus Adapter, and an error is logged by the Cluster Monitoring Operator.
+====
+
+. Review the audit log for the Prometheus Adapter:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring exec -c <prometheus_adapter_pod_name> -- cat /var/log/adapter/audit.log
+----
+

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -101,7 +101,7 @@ include::modules/monitoring-modifying-retention-time-for-prometheus-metrics-data
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps
+* See xref:../monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps.
 * xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
 * xref:../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage]
 * xref:../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
@@ -126,7 +126,7 @@ include::modules/monitoring-creating-scrape-sample-alerts.adoc[leveloffset=+2]
 
 * xref:../monitoring/configuring-the-monitoring-stack.adoc#creating-user-defined-workload-monitoring-configmap_configuring-the-monitoring-stack[Creating a user-defined workload monitoring config map]
 * xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
-* See xref:../monitoring/troubleshooting-monitoring-issues.html#determining-why-prometheus-is-consuming-disk-space_troubleshooting-monitoring-issues[Determining why Prometheus is consuming a lot of disk space] for steps to query which metrics have the highest number of scrape samples
+* See xref:../monitoring/troubleshooting-monitoring-issues.html#determining-why-prometheus-is-consuming-disk-space_troubleshooting-monitoring-issues[Determining why Prometheus is consuming a lot of disk space] for steps to query which metrics have the highest number of scrape samples.
 
 //Configuring external alertmanagers
 include::modules/monitoring-configuring-external-alertmanagers.adoc[leveloffset=1]
@@ -137,7 +137,7 @@ include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps
+* See xref:../monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps.
 * xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
 
 // Setting log levels for monitoring components
@@ -155,6 +155,17 @@ include::modules/monitoring-setting-query-log-file-for-prometheus.adoc[leveloffs
 // Enabling query logging for Thanos Querier
 include::modules/monitoring-enabling-query-logging-for-thanos-querier.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* See xref:../monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps.
+
+// Setting audit log levels for the Prometheus Adapter
+include::modules/monitoring-setting-audit-log-levels-for-the-prometheus-adapter.adoc[leveloffset=1]
+
+[role="_additional-resources"]
+.Additional resources
+
 * See xref:../monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps.
 
 // Disabling the default Grafana deployment
@@ -163,7 +174,7 @@ include::modules/monitoring-disabling-grafana.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps
+* See xref:../monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps.
 
 // Disabling the local Alertmanager
 include::modules/monitoring-disabling-the-local-alertmanager.adoc[leveloffset=+1]
@@ -176,4 +187,4 @@ include::modules/monitoring-disabling-the-local-alertmanager.adoc[leveloffset=+1
 == Next steps
 
 * xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
-* Learn about xref:../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[remote health reporting] and, if necessary, opt out of it
+* Learn about xref:../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[remote health reporting] and, if necessary, opt out of it.


### PR DESCRIPTION
Summary: This PR documents how to configure audit log levels for the Prometheus adapter.

- Aligned team: DevTools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3386
- Direct link to doc preview: https://deploy-preview-44229--osdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#setting-audit-log-levels-for-the-prometheus-adapter_configuring-the-monitoring-stack
- SME review: @sthaha 
- QE review: @juzhao 
- Peer review: @rolfedh 
- <All reviews complete. Please merge now>