### PR TITLE
OKD Documentation still mentions RedHat Enterprise Linux and Fedora 8

### DIFF
--- a/modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc
+++ b/modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc
@@ -3,6 +3,6 @@
 // * list of assemblies where this module is included
 // ipi-install-installation-workflow.adoc
 [id="installing-rhel-on-the-provisioner-node_{context}"]
-= Installing RHEL on the provisioner node
+= Installing {op-system-base} on the provisioner node
 
-With the networking configuration complete, the next step is to install {op-system-base} 8.x on the provisioner node. The installer uses the provisioner node as the orchestrator while installing the {product-title} cluster. For the purposes of this document, installing RHEL on the provisioner node is out of scope. However, options include but are not limited to using a RHEL Satellite server, PXE, or installation media.
+With the networking configuration complete, the next step is to install {op-system-base-full} on the provisioner node. The installer uses the provisioner node as the orchestrator while installing the {product-title} cluster. For the purposes of this document, installing {op-system-base} on the provisioner node is out of scope. However, options include but are not limited to using a {op-system-base} Satellite server, PXE, or installation media.


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/44121

This section mentions two things wrong. RHEL should be Fedora

Previews:
[OCP](https://deploy-preview-44230--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html)
[OKD](http://file.rdu.redhat.com/~mburke/GH44121-fix-rhel-in-okd/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html)