### PR TITLE
ocprhv-417 updates to URLs for ansible playbook download

### DIFF
--- a/modules/installation-rhv-downloading-ansible-playbooks.adoc
+++ b/modules/installation-rhv-downloading-ansible-playbooks.adoc
@@ -25,21 +25,18 @@ $ cd playbooks
 [source,terminal,subs=attributes+]
 ----
 $  xargs -n 1 curl -O <<< '
-        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/bootstrap.yml
-        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/common-auth.yml
-        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/create-templates-and-vms.yml
-        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/inventory.yml
-        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/<release-version>s.yml
-        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/retire-bootstrap.yml
-        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/retire-<release-version>s.yml
-        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/retire-workers.yml
-        https://raw.githubusercontent.com/openshift/installer/<release-version>/upi/ovirt/workers.yml'
+        https://raw.githubusercontent.com/openshift/installer/release-{product-version}/upi/ovirt/bootstrap.yml
+        https://raw.githubusercontent.com/openshift/installer/release-{product-version}/upi/ovirt/common-auth.yml
+        https://raw.githubusercontent.com/openshift/installer/release-{product-version}/upi/ovirt/create-templates-and-vms.yml
+        https://raw.githubusercontent.com/openshift/installer/release-{product-version}/upi/ovirt/inventory.yml
+        https://raw.githubusercontent.com/openshift/installer/release-{product-version}/upi/ovirt/masters.yml
+        https://raw.githubusercontent.com/openshift/installer/release-{product-version}/upi/ovirt/retire-bootstrap.yml
+        https://raw.githubusercontent.com/openshift/installer/release-{product-version}/upi/ovirt/retire-masters.yml
+        https://raw.githubusercontent.com/openshift/installer/release-{product-version}/upi/ovirt/retire-workers.yml
+        https://raw.githubusercontent.com/openshift/installer/release-{product-version}/upi/ovirt/workers.yml'
 
 ----
-+
-where:
-+
-<release-version>:: Specifies the minor release version, such as `release-4.11`. See the branch drop-down list in the link:https://github.com/openshift/installer/tree/master/upi/ovirt[`openshift/installer` repository] for the available minor versions.
+
 
 .Next steps
 


### PR DESCRIPTION
Target - enterprise-4.11
https://issues.redhat.com/browse/OCPRHV-417
update GitHub resource URL and command for downloading installer Ansible playbooks

redoing to correct typos in the URLs and insert the correct attribute for the release version

Preview: https://deploy-preview-44233--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-user-infra.html#installation-rhv-downloading-ansible-playbooks_installing-rhv-user-infra