### PR TITLE
RHDEVDOCS-3954 Add "Non-sidecar pod templates for Jenkins" to depreca…

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1395,6 +1395,11 @@ In the table, features are marked with the following statuses:
 |
 |DEP
 
+|Non-sidecar pod templates for Jenkins
+|
+|
+|DEP
+
 |====
 
 [id="ocp-4-10-deprecated-features"]
@@ -1422,7 +1427,7 @@ Support for empty files using the `--registry-config` and `--to` flags in `oc re
 [id="ocp-4-10-jenkins-non-sidecar-podtemplates-deprecation"]
 ==== Non-sidecar pod templates for Jenkins deprecation
 
-* In {product-title} 4.10, the non-sidecar `maven` and `nodejs` pod templates for Jenkins are deprecated. These pod templates are planned for removal in a future release. Bug fixes and support are provided through the end of that future life cycle, after which no new feature enhancements are made. Instead, with this update, you can run Jenkins agents as sidecar containers. (link:https://issues.redhat.com/browse/JKNS-257[JKNS-257])
+In {product-title} 4.10, the non-sidecar `maven` and `nodejs` pod templates for Jenkins are deprecated. These pod templates are planned for removal in a future release. Bug fixes and support are provided through the end of that future life cycle, after which no new feature enhancements are made. Instead, with this update, you can run Jenkins agents as sidecar containers. (link:https://issues.redhat.com/browse/JKNS-257[JKNS-257])
 
 [id="ocp-4-10-third-party-monitoring-components-uis-deprecation"]
 ==== Third-party monitoring components user interface deprecation


### PR DESCRIPTION
…tion table in 4.10 release notes.

Purpose: 
- Add a missing entry to the last row of "Table 1. Deprecated and removed features tracker"


 Aligned team: Dev Tools
- For branches: 4.10 release notes only
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3954
- Direct link to doc preview: https://deploy-preview-44243--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-deprecated-removed-features
- SME reviewed by: @gabemontero 
- QE review: Not needed - Minor fix - This PR doesn't introduce new information.
- Peer review: Not needed - Minor fix - This PR doesn't introduce new information.
- Sufficiently reviewed. Please merge now.