### PR TITLE
BZ2071475: fix typos and conditional

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -212,13 +212,13 @@ You can verify that the RAM users and policies are created by querying Alibaba C
 +
 [source,terminal]
 ----
-$ cp ./<path_to_ccoctl_output_dir>/manifests/*credentials.yaml ./<path_to_installation>dir>/manifests/
+$ cp ./<path_to_ccoctl_output_dir>/manifests/* ./<path_to_installation_dir>/manifests/
 ----
 +
 where:
 
 `<path_to_ccoctl_output_dir>`:: Specifies the directory created by the `ccoctl alibabacloud create-ram-users` command.
-`<path_to_installation>dir>`:: Specifies the directory in which the installation program creates files.
+`<path_to_installation_dir>`:: Specifies the directory in which the installation program creates files.
 endif::alibabacloud-default,alibabacloud-customizations[]
 
 ifdef::aws-sts,google-cloud-platform[]

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -198,6 +198,20 @@ spec:
 ----
 endif::google-cloud-platform[]
 
+. Copy the generated credential files to the target manifests directory:
++
+[source,terminal]
+----
+$ cp ./<path_to_ccoctl_output_dir>/manifests/* ./<path_to_installation_dir>/manifests/
+----
++
+where:
+
+ifdef::alibaba-default,alibaba-custom[]
+`<path_to_ccoctl_output_dir>`:: Specifies the directory created by the `ccoctl alibabacloud create-ram-users` command.
+endif::alibaba-default,alibaba-custom[]
+`<path_to_installation_dir>`:: Specifies the directory in which the installation program creates files.
+
 . Create YAML files for secrets in the `openshift-install` manifests directory that you generated previously. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object. The format for the secret data varies for each cloud provider.
 +
 [IMPORTANT]
@@ -207,9 +221,8 @@ The release image includes `CredentialsRequest` objects for Technology Preview f
 * If you are not using any of these features, do not create secrets for these objects. Creating secrets for Technology Preview features that you are not using can cause the installation to fail.
 
 * If you are using any of these features, you must create secrets for the corresponding objects.
-====
 
-** To find `CredentialsRequest` objects with the `TechPreviewNoUpgrade` annotation, run the following command:
+* To find `CredentialsRequest` objects with the `TechPreviewNoUpgrade` annotation, run the following command:
 +
 [source,terminal]
 ----
@@ -222,6 +235,56 @@ $ grep "release.openshift.io/feature-gate" *
 0000_30_capi-operator_00_credentials-request.yaml:  release.openshift.io/feature-gate: TechPreviewNoUpgrade
 ----
 // Right now, only the CAPI Operator is an issue, but it might make sense to update `0000_30_capi-operator_00_credentials-request.yaml` to `<tech_preview_credentials_request>.yaml` for the future.
+====
+
+.. Create an IAM user for each cluster component.
+.. Generate and attach a policy to the newly created IAM user with the permissions from the credentials request manifest generated in the previous step.
+.. Generate a secret access key for the newly created IAM user.
+.. Create a kubernetes secret YAML file with the secret access key and add it to the installer manifests directory:
++
+[source,yaml]
+ifdef::aws[]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: openshift-cloud-credential-operator <1>
+  name: cloud-credential-operator-iam-ro-creds <2>
+data:
+  aws_access_key_id: <base64_encode_access_key_ID>
+  aws_secret_access_key: <base64_encode_access_key>
+----
+endif::aws[]
+ifdef::azure,ash[]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: openshift-cloud-credential-operator <1>
+  name: installer-cloud-credentials <2>
+data:
+  azure_subscription_id: <base64_encode_subscription_ID>
+  azure_client_id: <base64_encode_client_ID>
+  azure_client_secret: <base64_encode_client_secret>
+  azure_tenant_id: <base64_encode_tenant_ID>
+  azure_resource_prefix: <base64_encode_resource_prefix>
+  azure_resourcegroup: <base64_encode_resource_group>
+  azure_region: <base64_encode_region>
+----
+endif::[]
+ifdef::google-cloud-platform[]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: openshift-image-registry <1>
+  name: installer-cloud-credentials <2>
+data:
+  service_account.json: <base64_encode_service_account>
+----
+endif::[]
+<1> The value for this field should be the same as the `credentialsrequest.spec.secretRef.namespace` value from the `CredentialsRequest` object.
+<2> The value for this field should be the same as the `credentialsrequest.spec.secretRef.name` value from the `CredentialsRequest` object.
 
 ifdef::cco-multi-mode[]
 . From the directory that contains the installation program, proceed with your cluster creation:


### PR DESCRIPTION
Fixes #44011. This PR fixes an issue where alibaba specific instructions were showing up in the AWS pages. I opted for wrapping that specific text with `ifdef` statements. Step 4 has also been moved to Step 6 of this procedure for clarity, and a few typos in paths were fixed.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2071475

OCP Version:

Current 4.10 docs: https://docs.openshift.com/container-platform/4.10/installing/installing_aws/manually-creating-iam.html#manually-create-iam_manually-creating-iam-aws

Direct doc preview link: https://deploy-preview-44248--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/manually-creating-iam.html#manually-create-iam_manually-creating-iam-aws