### PR TITLE
Fixes broken link in 4.10.5 release notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2584,11 +2584,11 @@ link:https://access.redhat.com/solutions/6815061[{product-title} 4.10.4 containe
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-5"]
-=== RHBA-2022:0982 - {product-title} 4.10.5 bug fix and security update
+=== RHBA-2022:0928 - {product-title} 4.10.5 bug fix and security update
 
 Issued: 2022-03-21
 
-{product-title} release 4.10.5, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0982[RHBA-2022:0982] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0927[RHSA-2022:0927] advisory.
+{product-title} release 4.10.5, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0928[RHBA-2022:0928] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0927[RHSA-2022:0927] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 


### PR DESCRIPTION
 https://access.redhat.com/errata/RHBA-2022:0982 showing a 404 message. 

This updates to the correct link: https://access.redhat.com/errata/RHBA-2022:0928

[Preview link](https://deploy-preview-44259--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-5)