### PR TITLE
Typo fix in 4.9.5

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2299,7 +2299,7 @@ To upgrade an existing {product-title} 4.9 cluster to this latest release, see x
 
 Issued: 2021-11-01
 
-{product-title} release 4.9.5 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4005[RHBA-2021:4005] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:4004[RHSA-2021:4004] advisory.
+{product-title} release 4.9.5 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4005[RHBA-2021:4005] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4004[RHBA-2021:4004] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2480,7 +2480,7 @@ To upgrade an existing {product-title} 4.9 cluster to this latest release, see x
 
 Issued: 2022-01-17
 
-{product-title} release 4.9.15 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0110[RHBA-2022:0110] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0109[RHSA-2022:0109] advisory.
+{product-title} release 4.9.15 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0110[RHBA-2022:0110] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0109[RHBA-2022:0109] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 


### PR DESCRIPTION
Preview: https://deploy-preview-44269--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-5

Just a broken link fix. 