### PR TITLE
bz2067990 Removed metadata.selfLink references

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -328,18 +328,6 @@ metadata:
   ...
 ----
 
-... Update the `metadata.selfLink` field to use the new machine name from the previous step:
-+
-[source,terminal]
-----
-apiVersion: machine.openshift.io/v1beta1
-kind: Machine
-metadata:
-  ...
-  selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machines/clustername-8qw5l-master-3
-  ...
-----
-
 ... Remove the `spec.providerID` field:
 +
 [source,terminal]

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -234,18 +234,6 @@ metadata:
   ...
 ----
 
-... Update the `metadata.selfLink` field to use the new machine name from the previous step.
-+
-[source,yaml]
-----
-apiVersion: machine.openshift.io/v1beta1
-kind: Machine
-metadata:
-  ...
-  selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machines/clustername-8qw5l-master-3
-  ...
-----
-
 ... Remove the `spec.providerID` field:
 +
 [source,yaml]


### PR DESCRIPTION
[bz2067990](https://bugzilla.redhat.com/show_bug.cgi?id=2067990)
Per [bz1919699](https://bugzilla.redhat.com/show_bug.cgi?id=1919699) comment 2, `metadata.selfLink` was a planned deprecation in Kubernetes 1.20 (OCP 4.7+). 

