### PR TITLE
Adds notes for 4.7.47 release that pushed to 11-04-2022

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -3165,3 +3165,19 @@ link:https://access.redhat.com/solutions/6844051[{product-title} 4.7.46 containe
 ==== Updating
 
 To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-7-47"]
+=== RHSA-2022:0492 - {product-title} 4.7.47 bug fix and security update
+
+Issued: 2022-04-11
+
+{product-title} release 4.7.47, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:1166[RHSA-2022:1166] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1165[RHBA-2022:1165] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6890031﻿[{product-title} 4.7.47 container image list]
+
+[id="ocp-4-7-47-updating"]
+==== Updating
+
+To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.7.47 that was pushed to 11-04-2022 

- Applies to `enterprise-4.7`
- [Preview link](https://deploy-preview-44280--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-47)