### PR TITLE
RNs-4.9.27 Added with Bug Fixes & Security Updates

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2712,3 +2712,24 @@ link:https://access.redhat.com/solutions/6843421[{product-title} 4.9.26 containe
 ==== Updating
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-9-27"]
+=== RHSA-2022:1158 - {product-title} 4.9.27 bug fix and security update
+
+Issued: 2022-04-07
+
+{product-title} release 4.9.27, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:1158[RHSA-2022:1158] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1157[RHBA-2022:1157] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6885691[{product-title} 4.9.27 container image list]
+
+[id="ocp-4-9-27-bug-fixes"]
+==== Bug fixes
+
+* Before this update, a bug in Cisco's ACI resulted in an error when running new virtual machines (VMs) in {rh-openstack-first}. With this update, extra filters were added in the {rh-openstack} cluster-API-provider. Virtual machines now run properly with Cisco's ACI. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2064633[*BZ#2064633*])
+
+[id="ocp-4-9-27-updating"]
+==== Updating
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
To be merged on **04-06**

Jira: https://issues.redhat.com/browse/OCPPLAN-8738

OCP version: Applicable only to **enterprise-4.9**

Direct Doc Preview Link: https://deploy-preview-44282--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-27