### PR TITLE
OADP 1.0.2 release notes

### DIFF
--- a/modules/oadp-release-notes-102.adoc
+++ b/modules/oadp-release-notes-102.adoc
@@ -1,0 +1,28 @@
+:_content-type: CONCEPT
+[id="oadp-release-notes-102_{context}"]
+
+= Release notes for OADP 1.0.2
+
+= OADP release notes
+
+The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, and known issues for each new release.
+
+New features::
+
+This release adds improvements related to the following components and concepts:
+
+.The `kubevirt` Velero plugin is now a default installation option for the OADP operator
+
+You can now choose the `kubert` Velero plugin as an option when you install the OADP operator.
+
+.New Operator update channel lets you pin to a specific 1.0 release
+
+When you install the OADP Operator, you can now choose `stable-1.0` as your *Update channel* in order to pin your Operator to a specific 1.0 release, for example, 1.0.1 or 1.0.2.
+
+Known issues::
+
+Restore operations using `restic` get stuck with `InProgress` status when an app is deployed with `DeploymentConfig`.
+
+Resolved issues::
+
+Previous `restic` backups sometimes failed if a previous backup did not use `restic`. With this update, the problem has been resolved.


### PR DESCRIPTION
OADP 1.0.2 

Resolves https://issues.redhat.com/browse/OADP-365

Adds release notes for OADP version 1.0.2 

Preview: https://deploy-preview-44299--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-features-plugins.html