### PR TITLE
Added an explanation to use the images from openshift-install command

### DIFF
--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -67,17 +67,39 @@ $ curl -k http://<HTTP_server>/bootstrap.ign <1>
 ----
 +
 Replace `bootstrap.ign` with `master.ign` or `worker.ign` in the command to validate that the Ignition config files for the control plane and compute nodes are also available.
-
-ifndef::openshift-origin[]
-. Obtain the {op-system} images that are required for your preferred method of installing operating system instances for your target cluster architecture from the
-ifndef::ibm-power[]
-link:https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.10/[{op-system} (x86_64) image mirror] or
-link:https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/[{op-system} (aarch64) image mirror] pages.
-endif::ibm-power[]
++
+. Although it is possible to obtain the {op-system} images that are required for your preferred method of installing operating system instances from the
+ifdef::openshift-enterprise[]
+link:https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/[{op-system} image mirror]
+endif::openshift-enterprise[]
+ifdef::openshift-origin[]
+link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system}]
+endif::openshift-origin[]
 ifdef::ibm-power[]
-link:https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/[{op-system} image mirror] page.
+link:https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/[{op-system} image mirror]
 endif::ibm-power[]
-
+page, the recommended way to obtain the correct version of your {op-system} images are from the output of `openshift-install` command:
++
+[source,terminal]
+----
+$ openshift-install coreos print-stream-json | grep '\.iso[^.]'
+----
++
+.Example output
+[source,terminal]
+ifndef::openshift-origin[]
+----
+"location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202110080947-0/aarch64/rhcos-49.84.202110080947-0-live.aarch64.iso",
+"location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202110081256-0/ppc64le/rhcos-49.84.202110081256-0-live.ppc64le.iso",
+"location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202110081202-0/s390x/rhcos-49.84.202110081202-0-live.s390x.iso",
+"location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202110081407-0/x86_64/rhcos-49.84.202110081407-0-live.x86_64.iso",
+----
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+----
+"location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live.x86_64.iso",
+----
+endif::openshift-origin[]
 +
 [IMPORTANT]
 ====
@@ -86,11 +108,11 @@ The {op-system} images might not change with every release of {product-title}. Y
 +
 ISO file names resemble the following example:
 +
+ifndef::openshift-origin[]
 `rhcos-<version>-live.<architecture>.iso`
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-. Obtain the {op-system} images from the
-link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system} Downloads] page
+`fedora-coreos-<version>-live.<architecture>.iso`
 endif::openshift-origin[]
 
 . Use the ISO to start the {op-system} installation. Use one of the following installation options:

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -73,34 +73,76 @@ $ curl -k http://<HTTP_server>/bootstrap.ign <1>
   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0{"ignition":{"version":"3.2.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["ssh-rsa...
 ----
 +
-Replace `bootstrap.ign` with `master.ign` or `worker.ign` in the command to validate that the Ignition config files for the control plane and compute nodes are also available.
+Replace `bootstrap.ign` with `master.ign` or `worker.ign` in the command to validate 
+that the Ignition config files for the control plane and compute nodes are also available.
 
+. Although it is possible to obtain the {op-system} `kernel`, `initramfs` and `rootfs`
+files that are required for your preferred method of installing operating system instances from the
+ifdef::openshift-enterprise[]
+link:https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/[{op-system} image mirror]
+endif::openshift-enterprise[]
+ifdef::openshift-origin[]
+link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system}]
+endif::openshift-origin[]
+ifdef::ibm-power[]
+link:https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/[{op-system} image mirror]
+endif::ibm-power[] 
+page, the recommended way to obtain the correct version of your {op-system} files are
+from the output of `openshift-install` command:
++
+[source,terminal]
+----
+$ openshift-install coreos print-stream-json | grep -Eo '"https.*(kernel-|initramfs.|rootfs.)\w+(\.img)?"'
+----
++
+.Example output
+[source,terminal]
 ifndef::openshift-origin[]
-. Obtain the {op-system} `kernel`,
-`initramfs` and `rootfs` files from the
-link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/[{op-system} image mirror]
-page.
+----
+"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202110080947-0/aarch64/rhcos-49.84.202110080947-0-live-kernel-aarch64"
+"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202110080947-0/aarch64/rhcos-49.84.202110080947-0-live-initramfs.aarch64.img"
+"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202110080947-0/aarch64/rhcos-49.84.202110080947-0-live-rootfs.aarch64.img"
+"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202110081256-0/ppc64le/rhcos-49.84.202110081256-0-live-kernel-ppc64le"
+"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202110081256-0/ppc64le/rhcos-49.84.202110081256-0-live-initramfs.ppc64le.img"
+"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202110081256-0/ppc64le/rhcos-49.84.202110081256-0-live-rootfs.ppc64le.img"
+"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202110081202-0/s390x/rhcos-49.84.202110081202-0-live-kernel-s390x"
+"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202110081202-0/s390x/rhcos-49.84.202110081202-0-live-initramfs.s390x.img"
+"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202110081202-0/s390x/rhcos-49.84.202110081202-0-live-rootfs.s390x.img"
+"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202110081407-0/x86_64/rhcos-49.84.202110081407-0-live-kernel-x86_64"
+"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202110081407-0/x86_64/rhcos-49.84.202110081407-0-live-initramfs.x86_64.img"
+"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202110081407-0/x86_64/rhcos-49.84.202110081407-0-live-rootfs.x86_64.img"
+----
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+----
+"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-kernel-x86_64"
+"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-initramfs.x86_64.img"
+"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-rootfs.x86_64.img"
+----
+endif::openshift-origin[]
 +
 [IMPORTANT]
 ====
 The {op-system} artifacts might not change with every release of {product-title}.
-You must download artifacts with the highest version that is less than or equal
+You must download images with the highest version that is less than or equal
 to the {product-title} version that you install. Only use
 the appropriate `kernel`, `initramfs`, and `rootfs` artifacts described below
 for this procedure.
-{op-system} QCOW2 images are not supported for this installation type.
+{op-system} QCOW2 images are not supported for this installation type. 
 ====
 +
 The file names contain the {product-title} version number.
 They resemble the following examples:
-
++
+ifndef::openshift-origin[]
 ** `kernel`: `rhcos-<version>-live-kernel-<architecture>`
 ** `initramfs`: `rhcos-<version>-live-initramfs.<architecture>.img`
 ** `rootfs`: `rhcos-<version>-live-rootfs.<architecture>.img`
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-. Obtain the {op-system}  `kernel`, `initramfs` and `rootfs` files from the
-link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system} Downloads] page
+** `kernel`: `fedora-coreos-<version>-live-kernel-<architecture>`
+** `initramfs`: `fedora-coreos-<version>-live-initramfs.<architecture>.img`
+** `rootfs`: `fedora-coreos-<version>-live-rootfs.<architecture>.img`
 endif::openshift-origin[]
 
 . Upload the `rootfs`, `kernel`, and `initramfs` files


### PR DESCRIPTION
This steps shows how to use the correct image versions for bare metal installation, because some users think that using the latest stable version would work.