### PR TITLE
[BZ1649480]: Add a note in Image Pull Policy section

### DIFF
--- a/modules/images-image-pull-policy-overview.adoc
+++ b/modules/images-image-pull-policy-overview.adoc
@@ -22,6 +22,10 @@ When {product-title} creates containers, it uses the container `imagePullPolicy`
 |Never pull the image.
 |===
 
+[NOTE]
+====
+Parameters such as `DisableScheduledImport`, `MaxImagesBulkImportedPerRepository`, `MaxScheduledImportsPerMinute`, `ScheduledImageImportMinimumIntervalSeconds`, `InternalRegistryHostname` are not configurable.
+====
 
 If a container `imagePullPolicy` parameter is not specified, {product-title} sets it based on the image tag:
 


### PR DESCRIPTION
OCP version: 4.6+
[Preview](https://deploy-preview-44320--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/managing_images/image-pull-policy.html#images-image-pull-policy-overview_image-pull-policy)
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1649480)
QE contact: @xiuwang 