### PR TITLE
BZ2071970 - Updating OCS registry link to ODF

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -43,7 +43,7 @@ ifdef::openshift-dedicated[]
 |Data collection for migration-related information.
 endif::openshift-dedicated[]
 
-|`registry.redhat.io/ocs4/ocs-must-gather-rhel8:v4.9`
+|`registry.redhat.io/odf4/ocs-must-gather-rhel8:v4.9`
 |Data collection for {rh-storage-first}.
 
 |`registry.redhat.io/openshift-logging/cluster-logging-rhel8-operator`


### PR DESCRIPTION
For versions 4.9+
[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2071970)

Ready for QE

Preview: [Gathering data about your cluster](https://deploy-preview-44325--osdocs.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data#gathering-data-specific-features_gathering-cluster-data)