### PR TITLE
BZ-1636292: Adding a note about pod priority

### DIFF
--- a/admin_guide/topics/pod-priority-about.adoc
+++ b/admin_guide/topics/pod-priority-about.adoc
@@ -11,6 +11,11 @@ Module included in the following assemblies:
 
 When the Pod Priority and Preemption feature is enabled, the scheduler orders pending pods by their priority, and a pending pod is placed ahead of other pending pods with lower priority in the scheduling queue. As a result, the higher priority pod might be scheduled sooner than pods with lower priority if its scheduling requirements are met. If a pod cannot be scheduled, scheduler continues to schedule other lower priority pods.
 
+[NOTE]
+====
+Priority pods can only run in reserved namespaces, such as `kube-system`.
+====
+
 [[admin-guide-priority-preemption-priority-class]]
 == Pod priority classes
 
@@ -24,7 +29,7 @@ A priority class object can take any 32-bit integer value smaller than or equal 
 
 [NOTE]
 ====
-If you upgrade your existing cluster, the priority of your existing pods is effectively zero. However, existing pods with 
+If you upgrade your existing cluster, the priority of your existing pods is effectively zero. However, existing pods with
 the `scheduler.alpha.kubernetes.io/critical-pod` annotation are automatically converted to `system-cluster-critical` class.
 ====
 


### PR DESCRIPTION
Applies to 3.11 only.
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1636292
**Preview Link**: Added a note to [About pod priority](https://deploy-preview-44350--osdocs.netlify.app/openshift-enterprise/latest/admin_guide/scheduling/priority_preemption.html#priority-priority-about_priority-preemption) section. 
QE ack needed.