### PR TITLE
Fixes BZ links and typo in 4.8.25 release

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -3013,9 +3013,9 @@ link:https://access.redhat.com/solutions/6620441[{product-title} 4.8.25 containe
 [id="ocp-4-8-25-bug-fixes"]
 ==== Bug fixes
 
-* Previously, `ovnkube-node` and `ovnkube-master` pods failed to start when the config file had an unknown field or section. Consequently, OVN-Kubernetes would not update. With this update, OVN-Kubernetes no longer exits if unknown fields are found in the config file. Instead, a warning is logged. As a result, OVN-Kubernetes updates no longer fail if the config file contains an unknown field or section. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2022171[*BZ#2022171*])
+* Previously, `ovnkube-node` and `ovnkube-master` pods failed to start when the config file had an unknown field or section. Consequently, OVN-Kubernetes would not update. With this update, OVN-Kubernetes no longer exits if unknown fields are found in the config file. Instead, a warning is logged. As a result, OVN-Kubernetes updates no longer fail if the config file contains an unknown field or section. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2030465[*BZ#2030465*])
 
-* Previously, a vCentre hostname that began with a numeric character was unable to run the `openshift-install` command. Consequently, the installer labeled it as `invalid`. This update adds validation for numeric characters. As a result, it is possible to create a vCenter host with a numeric character. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2030465[*BZ#2030465*])
+* Previously, a vCenter hostname that began with a numeric character was unable to run the `openshift-install` command. Consequently, the installer labeled it as `invalid`. This update adds validation for numeric characters. As a result, it is possible to create a vCenter host with a numeric character. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2022171[*BZ#2022171*])
 
 * Previously, 'curl' in the {rh-openstack-first} downloader container did not recognize network CIDRs in the 'noProxy' value of the `install-config.yaml` file. Instead, it only recognized the list of IP addresses separated by commas. With this update, users can include network CIDRs in the 'noProxy' value. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2005805[*BZ#2005805*])
 


### PR DESCRIPTION
Fixes #40661

The BZ links for Bug 2030465 and Bug 2022171 were assigned to the wrong doc text. There was also a typo on vcenter. This assigns the correct link to the correct doc text and fixes the typo.

- applies to `enterprise-4.8` only
- [Preview links](https://deploy-preview-44354--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-25)