### PR TITLE
Adding warning about auto defrag of etcd data causing harmless restart

### DIFF
--- a/modules/etcd-defrag.adoc
+++ b/modules/etcd-defrag.adoc
@@ -29,6 +29,11 @@ Verify that the defragmentation process is successful by viewing one of these lo
 * cluster-etcd-operator pod
 * operator status error log
 
+[WARNING]
+====
+Automatic defragmentation can cause leader election failure in various OpenShift core components, such as the Kubernetes controller manager, which triggers a restart of the failing component. The restart is harmless and either triggers failover to the next running instance or the component resumes work again after the restart.
+====
+
 .Example log output
 [source,terminal]
 ----


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2063184

Versions: 4.9+

Details: Automatic defragmentation of etcd data can causes OpenShift core components to restart. Customers were getting concerned that the restart was bad, so this warning is to make them aware that the auto defrag can cause restarts and it is harmless + component will resume work after restart. 

Preview: https://deploy-preview-44355--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#etcd-defrag_post-install-cluster-tasks