### PR TITLE
BZ-1961399: Adding clarification around required GCP permissions

### DIFF
--- a/modules/installation-gcp-permissions.adoc
+++ b/modules/installation-gcp-permissions.adoc
@@ -45,7 +45,7 @@ the following role:
 * Service Account Key Admin
 
 The roles are applied to the service accounts that the control plane and compute
-machines use:
+machines use. The roles are required for configuring a GCP project to host the {product-title}.
 
 .GCP service account permissions
 [cols="2a,2a",options="header"]


### PR DESCRIPTION
Applies to 4.6+ 
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1961399
QE ack required.
**Preview Link: ** Added a sentence before Table 3 in the [Required GCP permissions](https://deploy-preview-44356--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-permissions_installing-gcp-account) section.