### PR TITLE
OSDOCS-3271: RN to include nvme-cli

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -65,6 +65,11 @@ For more information, see xref:../getting_started/openshift-overview.adoc[Gettin
 [id="ocp-4-11-rhcos"]
 === {op-system-first}
 
+[id="ocp-4-11-nvme-cli"]
+==== Support for NVMe over Fabrics
+
+{product-title} 4.11 introduces the `nvme-cli` package that provides an interface for communicating with NVMe disks using host software capabilities.
+
 [id="ocp-4-11-installation-and-upgrade"]
 === Installation and upgrade
 


### PR DESCRIPTION
4.11 release note for inclusion of `nvme-cli`

JIRA: https://issues.redhat.com/browse/OSDOCS-3271

OCP Version: 4.11

Direct doc preview link: https://deploy-preview-44357--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-nvme-cli