### PR TITLE
OCDOCS-3446: Recommend support of alternative VPA recommender to the community

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-about.adoc
@@ -8,9 +8,11 @@
 
 The Vertical Pod Autoscaler Operator (VPA) is implemented as an API resource and a custom resource (CR). The CR determines the actions the Vertical Pod Autoscaler Operator should take with the pods associated with a specific workload object, such as a daemon set, replication controller, and so forth, in a project.
 
-The VPA automatically computes historic and current CPU and memory usage for the containers in those pods and uses this data to determine optimized resource limits and requests to ensure that these pods are operating efficiently at all times. For example, the VPA reduces resources for pods that are requesting more resources than they are using and increases resources for pods that are not requesting enough.
+You can use the default recommender or use your own alternative recommender to autoscale based on your own algorithms.
 
-The VPA automatically deletes any pods that are out of alignment with its recommendations one at a time, so that your applications can continue to serve requests with no downtime. The workload objects then re-deploy the pods with the original resource limits and requests. The VPA uses a mutating admission webhook to update the pods with optimized resource limits and requests before the pods are admitted to a node. If you do not want the VPA to delete pods, you can view the VPA resource limits and requests and manually update the pods as needed.
+The default recommender automatically computes historic and current CPU and memory usage for the containers in those pods and uses this data to determine optimized resource limits and requests to ensure that these pods are operating efficiently at all times. For example, the default recommender suggests reduced resources for pods that are requesting more resources than they are using and increased resources for pods that are not requesting enough.
+
+The VPA then automatically deletes any pods that are out of alignment with these recommendations one at a time, so that your applications can continue to serve requests with no downtime. The workload objects then re-deploy the pods with the original resource limits and requests. The VPA uses a mutating admission webhook to update the pods with optimized resource limits and requests before the pods are admitted to a node. If you do not want the VPA to delete pods, you can view the VPA resource limits and requests and manually update the pods as needed.
 
 [NOTE]
 ====

--- a/modules/nodes-pods-vertical-autoscaler-configuring.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-configuring.adoc
@@ -8,6 +8,12 @@
 
 You can use the Vertical Pod Autoscaler Operator (VPA) by creating a VPA custom resource (CR). The CR indicates which pods it should analyze and determines the actions the VPA should take with those pods. 
 
+.Prerequisites
+
+* The workload object that you want to autoscale must exist.
+
+* If you want to use an alternative recommender, a deployment including that recommender must exist.
+
 .Procedure
 
 To create a VPA CR for a specific workload object:
@@ -33,6 +39,8 @@ spec:
     containerPolicies:
     - containerName: my-opt-sidecar
       mode: "Off"
+  recommenders: <5>
+    - name: my-recommender
 ----
 <1> Specify the type of workload object you want this VPA to manage: `Deployment`, `StatefulSet`, `Job`, `DaemonSet`, `ReplicaSet`, or `ReplicationController`.
 <2> Specify the name of an existing workload object you want this VPA to manage.
@@ -42,7 +50,7 @@ spec:
 * `initial` to automatically apply the recommended resources when pods associated with the workload object are created. The VPA does not update the pods as it learns new resource recommendations.
 * `off` to only generate resource recommendations for the pods associated with the workload object. The VPA does not update the pods as it learns new resource recommendations and does not apply the recommendations to new pods. 
 <4> Optional. Specify the containers you want to opt-out and set the mode to `Off`.
-
+<5> Optional. Specify an alternative recommender.
 
 .. Create the VPA CR:
 +

--- a/modules/nodes-pods-vertical-autoscaler-custom.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-custom.adoc
@@ -1,0 +1,165 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-vertical-autoscaler.adoc
+
+:_content-type: PROCEDURE
+[id="nodes-pods-vertical-autoscaler-custom_{context}"]
+= Using an alternative recommender 
+
+You can use your own recommender to autoscale based on your own algorithms. If you do not specify an alternative recommender, {product-title} uses the default recommender, which suggests CPU and memory requests based on historical usage. Because there is no universal recommendation policy that applies to all types of workloads, you might want to create and deploy different recommenders for specific workloads. 
+
+For example, the default recommender might not accurately predict future resource usage when containers exhibit certain resource behaviors, such as cyclical patterns that alternate between usage spikes and idling as used by monitoring applications, or recurring and repeating patterns used with deep learning applications. Using the default recommender with these usage behaviors might result in significant over-provisioning and Out of Memory (OOM) kills for your applications. 
+
+// intro paragraph based on https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/enhancements/3919-customized-recommender-vpa
+
+[NOTE]
+====
+Instructions for how to create a recommender are beyond the scope of this documentation,
+====
+
+.Procedure
+
+To use an alternative recommender for your pods: 
+
+. Create a service account for the alternative recommender and bind that service account to the required cluster role:
++
+[source,yaml]
+----
+apiVersion: v1 <1>
+kind: ServiceAccount
+metadata:
+  name: alt-vpa-recommender-sa
+  namespace: <namespace_name>
+---
+apiVersion: rbac.authorization.k8s.io/v1 <2>
+kind: ClusterRoleBinding
+metadata:
+  name: system:example-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: alt-vpa-recommender-sa
+  namespace: <namespace_name>
+---
+apiVersion: rbac.authorization.k8s.io/v1 <3>
+kind: ClusterRoleBinding
+metadata:
+  name: system:example-vpa-actor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-actor
+subjects:
+- kind: ServiceAccount
+  name: alt-vpa-recommender-sa
+  namespace: <namespace_name>
+---
+apiVersion: rbac.authorization.k8s.io/v1 <4>
+kind: ClusterRoleBinding
+metadata:
+  name: system:example-vpa-target-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-target-reader
+subjects:
+- kind: ServiceAccount
+  name: alt-vpa-recommender-sa
+  namespace: <namespace_name>
+----
+<1> Creates a service accocunt for the recommender in the namespace where the recommender is deployed. 
+<2> Binds the recommender service account to the `metrics-reader` role. Specify the namespace where the recommender is to be deployed. 
+<3> Binds the recommender service account to the `vpa-actor` role. Specify the namespace where the recommender is to be deployed.
+<4> Binds the recommender service account to the `vpa-target-reader` role. Specify the namespace where the recommender is to be deployed.
+
+. To add the alternative recommender to the cluster, create a Deployment object similar to the following:
++
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alt-vpa-recommender
+  namespace: <namespace_name>
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alt-vpa-recommender
+  template:
+    metadata:
+      labels:
+        app: alt-vpa-recommender
+    spec:
+      containers: <1>
+      - name: recommender
+        image: quay.io/example/alt-recommender:latest <2>
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1000Mi
+          requests:
+            cpu: 50m
+            memory: 500Mi
+        ports:
+        - name: prometheus
+          containerPort: 8942
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+      serviceAccountName: alt-vpa-recommender-sa <3>
+      securityContext:
+        runAsNonRoot: true
+----
++
+--
+<1> Creates a container for your alternative recommender.
+<2> Specifies your recommender image. 
+<3> Associates the service account that you created for the recommender.
+--
++
+A new pod is created for the alternative recommender in the same namespace.
++
+[source,terminal]
+----
+$ oc get pods 
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                        READY   STATUS    RESTARTS   AGE
+frontend-845d5478d-558zf                    1/1     Running   0          4m25s
+frontend-845d5478d-7z9gx                    1/1     Running   0          4m25s
+frontend-845d5478d-b7l4j                    1/1     Running   0          4m25s
+vpa-alt-recommender-55878867f9-6tp5v        1/1     Running   0          9s
+----
+
+. Configure a VPA CR that includes the name of the alternative recommender `Deployment` object.
++
+.Example VPA CR to include the alternative recommender
+[source,yml]
+----
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: vpa-recommender
+  namespace: <namespace_name>
+spec:
+  recommenders:
+    - name: alt-vpa-recommender <1>
+  targetRef:
+    apiVersion: "apps/v1"
+    kind:       Deployment <2>
+    name:       frontend 
+----
+<1> Specifies the name of the alternative recommender deployment.
+<2> Specifies the name of an existing workload object you want this VPA to manage.

--- a/nodes/pods/nodes-pods-vertical-autoscaler.adoc
+++ b/nodes/pods/nodes-pods-vertical-autoscaler.adoc
@@ -24,6 +24,8 @@ include::modules/nodes-pods-vertical-autoscaler-install.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-vertical-autoscaler-using-about.adoc[leveloffset=+1]
 
+include::modules/nodes-pods-vertical-autoscaler-custom.adoc[leveloffset=+2]
+
 include::modules/nodes-pods-vertical-autoscaler-configuring.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-vertical-autoscaler-uninstall.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3446

Preview: 
[About the Vertical Pod Autoscaler Operator](http://file.rdu.redhat.com/~mburke/OSDOCS-3446-custom-autoscaler/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-about_nodes-pods-vertical-autoscaler). Added second paragraph and _default_ recommender wording.
[Using an alternative recommender](http://file.rdu.redhat.com/~mburke/OSDOCS-3446-custom-autoscaler/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-custom_nodes-pods-vertical-autoscaler). New module.
[Using the Vertical Pod Autoscaler Operator](http://file.rdu.redhat.com/~mburke/OSDOCS-3446-custom-autoscaler/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-configuring_nodes-pods-vertical-autoscaler). Added prerequisites and call-out 5