### PR TITLE
Add prereqs to WINC release notes

### DIFF
--- a/windows_containers/windows-containers-release-notes-5-x.adoc
+++ b/windows_containers/windows-containers-release-notes-5-x.adoc
@@ -1,13 +1,13 @@
 :_content-type: ASSEMBLY
 [id="windows-containers-release-notes-5-x"]
-= Windows Container Support for Red Hat OpenShift release notes
+= {productwinc} release notes
 include::_attributes/common-attributes.adoc[]
 :context: windows-containers-release-notes
 
 toc::[]
 
 [id="about-windows-containers"]
-== About Windows Container Support for Red Hat OpenShift
+== About {productwinc}
 
 {productwinc} enables running Windows compute nodes in an {product-title} cluster. Running Windows workloads is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With Windows nodes available, you can run Windows container workloads in {product-title}.
 
@@ -42,4 +42,13 @@ This release of the WMCO provides bug fixes for running Windows compute nodes in
 * Previously, if the `windows-exporter` metrics endpoint object contained a reference to a deleted machine, the WMCO ignored `Deleting` phase notification event for  those machines. This fix removes the validation of the machine object from event filtering. As a result, the `windows-exporter` metrics endpoint object is correctly updated even when the machine is still deleting. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2008601[**BZ#2008601**])
 
 * Previously, if an entity other than the WMCO modified the certificate signing request (CSR) associated with a BYOH node, the WMCO would have a stale reference to the CSR and would be unable to approve it. With this fix, if an update conflict is detected, the WMCO retries the CSR approval until a specified timeout. As a result, the CSR processing completes as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2032048[**BZ#2032048**])
+
+include::modules/wmco-prerequisites.adoc[leveloffset=+1]
+
+[IMPORTANT]
+====
+Running Windows container workloads is not supported for clusters in a restricted network or disconnected environment.
+====
+
+Version 5.x of the WMCO is only compatible with {product-title} 4.10.
 


### PR DESCRIPTION
I neglected to add the WINC Prerequisite module to the WINC Release Notes.

Preview: [Prerequisites](https://deploy-preview-44365--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-5-x.html#wmco-prerequisites_windows-containers-release-notes) 