### PR TITLE
[RHACS] Update to match approved changes in Google docs

### DIFF
--- a/release_notes/369-release-notes.adoc
+++ b/release_notes/369-release-notes.adoc
@@ -100,7 +100,7 @@ Red Hat is deprecating some of the features in {product-title} 3.69. Red Hat wil
 ** {product-title} will not allow deleting default policies. So rhather than deleting, you can disable default policies that you do not need.
 ** The `/v1/policies` API endpoint response will not return the *field* response body parameter.
 
-* In {product-title-short} 3.70, Red Hat will remove the support for security policies that do not have a `policyVersion`. Therefore, if you have some externally stored older policies, you must convert them to use `policyVersion` 1.1 before upgrading to {product-title-short} 3.70. To do this, import the old policies into {product-title-short} and then export them again. You can check the `policyVersion` field for your stored policies to identify if they need conversion.
+* In {product-title-short} 3.70, Red Hat will remove the support for security policies that do not have a `policyVersion`. Therefore, if you have externally stored older policies (without `policyVersion` or version prior to 1.1), you must convert them to use `policyVersion` 1.1. To do this, import the old policies into {product-title-short} and then export them again. You can check the `policyVersion` field for your stored policies to identify if they need conversion.
 
 For any questions, please contact the Red Hat support team at support@redhat.com.
 


### PR DESCRIPTION
> In RHACS 3.70, Red Hat will remove the support for security policies that do not have a `policyVersion`. Therefore, if you have externally stored older policies (without `policyVersion` or version prior to 1.1), you must convert them to use `policyVersion` 1.1. To do this, import the old policies into RHACS and then export them again. You can check the `policyVersion` field for your stored policies to identify if they need conversion.


We need this exact change https://srox.slack.com/archives/CMH5M8MHN/p1649337582602999