### PR TITLE
[RHACS] Fixed vulneribility naming in 3.69.1 release notes

### DIFF
--- a/release_notes/369-release-notes.adoc
+++ b/release_notes/369-release-notes.adoc
@@ -25,7 +25,7 @@ If you are using {ocp} and not using the {product-title}, Red Hat advises you to
 
 [id="spring-security-vulnerabilities"]
 ==== Improved detection of Spring vulnerabilities
-{product-title-short} 3.69.1 includes enhancements in Scanner to identify vulnerabilities in packages that follow the Spring naming conventions. Scanner now detects Spring packages impacted by the newly discovered critical Spring4Shell vulnerabilities link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-22963[CVE-2022-22963] and link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-22965[CVE-2022-22965].
+{product-title-short} 3.69.1 includes enhancements in Scanner to identify vulnerabilities in packages that follow the Spring naming conventions. Scanner now detects Spring packages impacted by the newly discovered critical vulnerabilities link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-22963[CVE-2022-22963] and link:https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-22965[CVE-2022-22965] (Spring4Shell).
 
 [id="released-in-version-3690"]
 === Released in version 3.69.0


### PR DESCRIPTION
Only applies to RHACS 3.69