### PR TITLE
OSDOCS-3500: ROSA/OSD: Correct docs to say that customer KMS key only encrypts data volume

### DIFF
--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -151,7 +151,8 @@ endif::osd-on-aws[]
 ifdef::osd-on-gcp[]
 encryption keys through the Google Cloud Key Management Service.
 endif::osd-on-gcp[]
-The key is used for encryption of persistent volumes in your cluster.
+These keys are used for encrypting all control plane, infrastructure, and worker node root volumes.
+
 .. Click *Next*.
 
 . On the *Default machine pool* page, select a *Compute node instance type* and a *Compute node count*. The number and types of nodes that are available depend on your {product-title} subscription. If you are using multiple availability zones, the compute node count is per zone.

--- a/modules/policy-security-regulation-compliance.adoc
+++ b/modules/policy-security-regulation-compliance.adoc
@@ -14,9 +14,9 @@ Red Hat defines and follows a data classification standard to determine the sens
 
 [id="data-management_{context}"]
 == Data management
-{product-title} uses cloud provider services to help securely manage keys for encrypted data (AWS KMS and Google Cloud KMS). These keys are used for control plane data volumes which are encrypted by default. Persistent volumes for customer applications also use these cloud services for key management.
+{product-title} uses cloud provider services such as AWS Key Management Service (KMS) and Google Cloud KMS to help securely manage encryption keys for persistent data. These keys are used for encrypting all control plane, infrastructure, and worker node root volumes. Customers can specify their own KMS key for encrypting root volumes at installation time. Persistent volumes (PVs) also use KMS for key management. Customers can specify their own KMS key for encrypting PVs by creating a new `StorageClass` referencing the KMS key Amazon Resource Name (ARN) or ID.
 
-When a customer deletes their {product-title} cluster, all cluster data is permanently deleted, including control plane data volumes, customer application data volumes (PVs), and backup data.
+When a customer deletes their {product-title} cluster, all cluster data is permanently deleted, including control plane data volumes and customer application data volumes, such a persistent volumes (PV).
 
 [id="vulnerability-management_{context}"]
 == Vulnerability management

--- a/modules/rosa-policy-security-regulation-compliance.adoc
+++ b/modules/rosa-policy-security-regulation-compliance.adoc
@@ -15,9 +15,9 @@ Red Hat defines and follows a data classification standard to determine the sens
 
 [id="rosa-policy-data-management_{context}"]
 == Data management
-{product-title} (ROSA) uses AWS KMS to help securely manage keys for encrypted data. These keys are used for control plane data volumes that are encrypted by default. Persistent volumes (PVs) for customer applications also use AWS KMS for key management.
+{product-title} (ROSA) uses AWS Key Management Service (KMS) to help securely manage keys for encrypted data. These keys are used for control plane data volumes that are encrypted by default.
 
-When a customer deletes their ROSA cluster, all cluster data is permanently deleted, including control plane data volumes, customer application data volumes, such as PVs, and backup data.
+When a customer deletes their ROSA cluster, all cluster data is permanently deleted, including control plane data volumes and customer application data volumes, such as persistent volumes (PV).
 
 [id="rosa-policy-vulnerability-management_{context}"]
 == Vulnerability management

--- a/modules/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -49,7 +49,7 @@ $ rosa create account-roles --mode manual <1>
 +
 .. After review, run the `aws` commands manually to create the roles and policies. Alternatively, you can run the preceding command using `--mode auto` to run the `aws` commands immediately.
 
-. (Optional) If you are using your own AWS KMS key to encrypt the control plane data volumes and the persistent volumes (PVs) for your applications, add the ARN for the account-wide installer role to your KMS key policy.
+. Optional: If you are using your own AWS KMS key to encrypt the control plane, infrastructure, and worker node root volumes, add the ARN for the account-wide installer role to your KMS key policy.
 .. Save the key policy for your KMS key to a file on your local machine. The following example saves the output to `kms-key-policy.json` in the current working directory:
 +
 [source,terminal]
@@ -143,7 +143,7 @@ I: To watch your cluster installation logs, run 'rosa logs install -c <cluster_n
 <1> When creating the cluster, the listed `OpenShift version` options include the major, minor, and patch versions, for example `4.8.9`.
 <2> If more than one matching set of account-wide roles are available in your account for a cluster version, an interactive list of options is provided.
 <3> Multiple availability zones are recommended for production workloads. The default is a single availability zone.
-<4> Enable this option if you are using your own AWS KMS key to encrypt the control plane data volumes and the PVs for your applications. Specify the ARN for the KMS key that you added the account-wide role ARN to in the preceding step.
+<4> Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, and worker node root volumes. Specify the ARN for the KMS key that you added to the account-wide role ARN to in the preceding step.
 <5> Enable this option only if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted, but not the keys.
 +
 [IMPORTANT]

--- a/modules/rosa-sts-interactive-mode-reference.adoc
+++ b/modules/rosa-sts-interactive-mode-reference.adoc
@@ -42,7 +42,7 @@ You can create a {product-title} cluster with the AWS Security Token Service (ST
 |Install a cluster into an existing AWS VPC. To use this option, your VPC must have 2 subnets for each availability zone that you are installing the cluster into. The default is `No`.
 
 |`Enable customer managed key`
-|Enable this option to use the AWS Key Management Service (KMS) to help securely manage keys for encrypted data. The keys are used for control plane data volumes that are encrypted by default. Persistent volumes (PVs) for customer applications also use AWS KMS for key management. When enabled, the account KMS key for the region is used by default. The default is `No`.
+|Enable this option to use a specific AWS Key Management Service (KMS) key as the encryption key for persistent data. This key is used as the encryption key for control plane, infrastructure, and worker node root volumes. When disabled, the account KMS key for the specified region is used by default to ensure persistent data is always encrypted. The default is `No`.
 
 |`Compute nodes instance type`
 |Select a compute node instance type. The default is `m5.xlarge`.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3500

**Previews**
ROSA:
https://deploy-preview-44392--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations_rosa-sts-creating-a-cluster-with-customizations

https://deploy-preview-44392--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-sts-interactive-mode-reference.html#rosa-sts-understanding-interactive-mode-options_rosa-sts-interactive-mode-reference

https://deploy-preview-44392--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-policy-process-security.html#rosa-policy-data-management_rosa-policy-process-security

OSD:
https://deploy-preview-44392--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/policy-process-security.html#data-management_policy-process-security

https://deploy-preview-44392--osdocs.netlify.app/openshift-dedicated/latest/osd_cluster_create/creating-an-aws-cluster.html#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws

Urgent PR. No QE review required. 