### PR TITLE
Adds 4.8.36 release notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -3235,3 +3235,27 @@ link:https://access.redhat.com/solutions/6834631[{product-title} 4.8.35 containe
 ==== Updating
 
 To update an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[[ocp-4-8-36]]
+=== RHSA-2022:1154 - {product-title} 4.8.36 bug fix and security update
+
+Issued: 2022-04-11
+
+{product-title} release 4.8.36, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:1154[RHSA-2022:1154] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:1153[RHSA-2022:1153] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6904371[{product-title} 4.8.36 container image list]
+
+[id="ocp-4-8-36-bug-fixes"]
+==== Bug fixes
+* Previously, the Ingress Operator performed health checks against the Ingress canary route. When the health check completed, the Ingress Operator did not close the TCP connection to the `LoadBalancer` service because `keepalive` packets were enabled on the connection. While performing the next health check, a new connection was established to the `LoadBalancer` service instead of using the existing connection. Consequently, this caused connections to accumulate on the `LoadBalancer` service. Over time, this exhausted the number of connections on the `LoadBalancer` service. With this update, Keepalive is disabled when connecting to the Ingress canary route. As a result, a new connection is made and closed each time the canary probe is run. While Keepalive is disabled, there is no longer an accumulation of established connections.(link:https://bugzilla.redhat.com/show_bug.cgi?id=2066302[*BZ#2066302*])
+
+* Previously, the query for subnets in the Cisco ACI Neutron implementation, which is avaiable in {rh-openstack-first}-16, returned unexpected results for a given network. Consequently, the {rh-openstack} `cluster-api-provider` could potentially try to provision instances with duplicated ports on the same subnet, which caused a provisioning failure. With this update, an additional filter is added in the {rh-openstack} `cluster-api-provider` to ensure there is only one port per subnet. As a result, it is now possible to deploy {product-title} on {rh-openstack}-16 with Cisco ACI. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2064634[*BZ#2064634*])
+
+* Previously, the `oc debug node` command did not have timeout specified on idle. Consequently, the users were never logged out of the cluster. With this update, a `TMOUT` environment variable for debug pods has been added to counter inactivity timeout. As a result, the session will be automatically terminated after `TMOUT` inactivity. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2066760[*BZ#2066760*])
+
+[id="ocp-4-8-36-updating"]
+==== Updating
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

OCP version: **Applicable to enterprise 4.8**

To be merged on 04-11. I will send a reminder when the Erratas are shipped live today.

Direct Doc preview Link: https://deploy-preview-44430--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-36
