### PR TITLE
BZ:2069259 - Update correct port access for out-of-band management IP…

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -161,4 +161,4 @@ You can reconfigure the control plane nodes to act as NTP servers on disconnecte
 [id='network-requirements-out-of-band_{context}']
 == Port access for the out-of-band management IP address
 
-The out-of-band management IP address is on a separate network from the node. To ensure that the out-of-band management can communicate with the `baremetal` node during installation, the out-of-band management IP address must be granted access to port `6180`.
+The out-of-band management IP address is on a separate network from the node. To ensure that the out-of-band management can communicate with the provisioning node during installation, the out-of-band management IP address must be granted access to port `80` on the bootstrap host and port `6180` on the {product-title} control plane hosts.


### PR DESCRIPTION
Update to main, 4.9,  4.10, and 4.11 for [BZ-2069529](https://bugzilla.redhat.com/show_bug.cgi?id=2069259)

[Preview link](http://file.emea.redhat.com/miweiss/BZ-2069259/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-out-of-band_ipi-install-prerequisites)

@zaneb @cmyster please review/approve.