### PR TITLE
CFE-10/374: binding options

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -36,11 +36,35 @@ If empty, the default value is `ingress.config.openshift.io/cluster` `.spec.doma
 
 If not set, the default value is based on `infrastructure.config.openshift.io/cluster` `.status.platform`:
 
-* AWS: `LoadBalancerService` (with External scope)
+* Amazon Web Services (AWS): `LoadBalancerService` (with External scope)
 * Azure: `LoadBalancerService` (with External scope)
-* GCP: `LoadBalancerService` (with External scope)
+* Google Cloud Platform (GCP): `LoadBalancerService` (with External scope)
 * Bare metal: `NodePortService`
 * Other: `HostNetwork`
++
+[NOTE]
+====
+`HostNetwork` has a `hostNetwork` field with the following default values for the optional binding ports: `httpPort: 80`, `httpsPort: 443`, and `statsPort: 1936`.
+With the binding ports, you can deploy multiple Ingress Controllers on the same node for the `HostNetwork` strategy.
+
+.Example
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: internal
+  namespace: openshift-ingress-operator
+spec:
+  domain: example.com
+  endpointPublishingStrategy:
+    type: HostNetwork
+    hostNetwork:
+      httpPort: 80
+      httpsPort: 443
+      statsPort: 1936
+----
+====
 
 For most platforms, the `endpointPublishingStrategy` value can be updated. On GCP, you can configure the following `endpointPublishingStrategy` fields:
 


### PR DESCRIPTION
- Applies to 4.11 only
- [Preview](https://deploy-preview-43576--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress)
- [Jira ](https://issues.redhat.com/browse/CFE-374) 
- Was previously [CFE-10](https://issues.redhat.com/browse/CFE-10)

**NOTE**
This PR is duplicated from https://github.com/openshift/openshift-docs/pull/43576  but covers only the first file (modules/nw-ingress-controller-configuration-parameters.adoc)  . Incorporated SME/peer review feedback.

@sherine-k  @quarterpin 

**UPDATE**
The rest_api.adoc file will be updated nearing the time of 4.11 release, as it's going to be built , based on the OpenAPI spec, which OpenShift derives from the **openshift/api** repository contents. 
