### PR TITLE
SRVKS-912: Fix OSSM attribute usage in Serverless docs

### DIFF
--- a/serverless/admin_guide/serverless-ossm-setup.adoc
+++ b/serverless/admin_guide/serverless-ossm-setup.adoc
@@ -1,14 +1,14 @@
 :_content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="serverless-ossm-setup"]
-= Integrating {ProductShortName} with {ServerlessProductName}
+= Integrating {SMProductShortName} with {ServerlessProductName}
 :context: serverless-ossm-setup
 
 toc::[]
 
-Using {ProductShortName} with {ServerlessProductName} enables developers to configure additional networking and routing options.
+Using {SMProductShortName} with {ServerlessProductName} enables developers to configure additional networking and routing options.
 
-The {ServerlessOperatorName} provides Kourier as the default ingress for Knative. However, you can use {ProductShortName} with {ServerlessProductName} whether Kourier is enabled or not. Integrating with Kourier disabled allows you to configure additional networking and routing options that the Kourier ingress does not support.
+The {ServerlessOperatorName} provides Kourier as the default ingress for Knative. However, you can use {SMProductShortName} with {ServerlessProductName} whether Kourier is enabled or not. Integrating with Kourier disabled allows you to configure additional networking and routing options that the Kourier ingress does not support.
 
 [IMPORTANT]
 ====
@@ -17,9 +17,9 @@ The {ServerlessOperatorName} provides Kourier as the default ingress for Knative
 
 // without kourier
 [id="serverless-ossm-setup-native"]
-== Integrating {ProductShortName} with {ServerlessProductName} natively
+== Integrating {SMProductShortName} with {ServerlessProductName} natively
 
-Integrating {ProductShortName} with {ServerlessProductName} natively, without Kourier, allows you to use additional networking and routing options that are not supported by the default Kourier ingress, such as mTLS functionality.
+Integrating {SMProductShortName} with {ServerlessProductName} natively, without Kourier, allows you to use additional networking and routing options that are not supported by the default Kourier ingress, such as mTLS functionality.
 
 The examples in the following procedures use the domain `example.com`. The example certificate for this domain is used as a certificate authority (CA) that signs the subdomain certificate.
 

--- a/serverless/security/serverless-ossm-with-kourier-jwt.adoc
+++ b/serverless/security/serverless-ossm-with-kourier-jwt.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-After the {ProductShortName} integration with {ServerlessProductName} and Kourier has been configured on your cluster, you can enable JSON Web Token (JWT) authentication for your Knative services.
+After the {SMProductShortName} integration with {ServerlessProductName} and Kourier has been configured on your cluster, you can enable JSON Web Token (JWT) authentication for your Knative services.
 
 include::modules/serverless-ossm-enable-sidecar-injection-with-kourier.adoc[leveloffset=+1]
 include::modules/serverless-ossm-v2x-jwt.adoc[leveloffset=+1]


### PR DESCRIPTION
For versions 4.6+

https://issues.redhat.com/browse/SRVKS-912

Preview:
https://deploy-preview-44442--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-ossm-setup.html
https://deploy-preview-44442--osdocs.netlify.app/openshift-enterprise/latest/serverless/security/serverless-ossm-with-kourier-jwt.html