### PR TITLE
CNV16355: Adding new and non-critical CNV alerts for 4.11

### DIFF
--- a/modules/virt-cnv-hco-alerts.adoc
+++ b/modules/virt-cnv-hco-alerts.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-events.html/virt-virtualization-alerts.adoc
+:_content-type: REFERENCE
+
+[id="virt-cnv-hco-alerts_{context}"]
+= HCO Alerts
+
+HCO alerts provide information about problems for the {VirtProductName} Hyperconverged Cluster Operator.
+
+//KubevirtHyperconvergedClusterOperatorCRModification Alert
+[id="KubevirtHyperconvergedClusterOperatorCRModification_{context}"]
+== KubevirtHyperconvergedClusterOperatorCRModification
+
+.Description
+
+The Hyperconverged Cluster Operator (HCO) configures kubevirt and its supporting Operators and overwrites its operands if unexpected changes occur.
+
+.Reason
+
+Manually changing the operands can result in cluster configuration problems and instabilities.
+
+.Troubleshoot
+
+. Check the alert details. The `component_name` attribute is the overwritten operand and uses a `<kind-of-operand>`/`<name-of-operand>`. For example:
++
+[source,terminal]
+----
+Labels
+
+alertname=KubevirtHyperconvergedClusterOperatorCRModification
+component_name=kubevirt/kubevirt-kubevirt-hyperconverged
+severity=warning
+----
+In this example, the kind of operand is `kubevirt` and the operand's name is `kubevirt-kubevirt-hyperconverged`.
+
+.Resolution
+
+Use HyperConverged objects to configure the cluster. The alert resolves in 10 min. To avoid this problem in the future, do not manually edit the operands.
+
+//KubevirtHyperconvergedClusterOperatorUSModification Alert
+[id="KubevirtHyperconvergedClusterOperatorUSModification_{context}"]
+== KubevirtHyperconvergedClusterOperatorUSModification alert
+
+.Description
+
+The Hyperconverged Cluster Operator (HCO) configures kubevirt and its supporting Operators and overwrites its operands if unexpected changes occur.
+
+.Reason
+
+Manually changing the operands can result in cluster configuration problems and instabilities. If the HCO API requires an unsupported change, then you can use special annotations to force HCO to set the required changes in the required Operator.
+
+[NOTE]
+====
+Using special annotations is risky and unsafe. This alert occurs as a result of using an unsafe annotation.
+====
+
+.Troubleshoot
+
+. Check the alert details. `annotation_name` refers to the specific unsafe jsonpatch annotation in the HyperConverged resource.
++
+[source,terminal]
+----
+Labels
+
+alertname=KubevirtHyperconvergedClusterOperatorUSModification
+annotation_name=kubevirt.kubevirt.io/jsonpatch
+severity=info
+----
+In this example, the specific jsonpatch annotation is `kubevirt.kubevirt.io/jsonpatch`.
+
+.Resolution
+
+Verify that you need to use an unsafe change in the jsonpatch annotation and that using the jsonpatch annotation is the only way to make this change. If the HyperConverged API supports this modification, then modify the HyperConverged resource.
+
+If this jsonpatch annotation is generic and can benefit others, then open a support issue. Otherwise, consider this alert as information only.

--- a/modules/virt-cnv-network-alerts.adoc
+++ b/modules/virt-cnv-network-alerts.adoc
@@ -7,6 +7,50 @@
 
 Network alerts provide information about problems for the {VirtProductName} Network Operator.
 
+//CnaoDown Alert
+[id="CnaoDown_{context}"]
+== CnaoDown alert
+
+.Description
+
+The cluster-network-addons-operator (CNAO) deploys additional networking components on top of the cluster. This alert occurs when the CNAO Operator is down.
+
+.Reason
+
+If the CNAO is down, then reconciliation of changes in the CNV components and deployment of those components fails.
+
+.Troubleshoot
+
+. Check the CNAO’s operator pod namespace.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get deployment -A | grep cluster-network-addons-operator | awk '{print $1}')"
+----
+
+. Determine if the CNAO’s operator pod is down.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get pods -l name=cluster-network-addons-operator
+----
+
+. Check CNAO’s operator pod description and logs.
++
+[source,terminal]
+----
+$ oc -n NAMESPACE describe pods -l name=cluster-network-addons-operator
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE logs -l name=cluster-network-addons-operator
+----
+
+.Troubleshoot
+
+Open a support issue and provide the information gathered in the troubleshooting process.
+
 //KubeMacPoolDown Alert
 [id="KubeMacPoolDown_{context}"]
 == KubeMacPoolDown alert
@@ -46,5 +90,118 @@ $ oc logs -n $KMP_NAMESPACE $KMP_NAME
 ----
 
 .Resolution
+
+Open a support issue and provide the information gathered in the troubleshooting process.
+
+//KubeMacPoolDuplicateMacsFound Alert
+[id="KubeMacPoolDuplicateMacsFound_{context}"]
+== KubeMacPoolDuplicateMacsFound alert
+
+.Description
+
+The KubeMacPool allocates MAC Addresses and prevents MAC Address conflicts. After opening the KubeMacPool, a scan of the cluster for MAC Addresses in virtual machines set on the managed namespaces occurs. This alert occurs if duplicate MAC addresses are found in the scan.
+
+.Reason
+
+Duplicate MAC Addresses on the same LAN causes unexpected and various connection issues in the network.
+
+.Troubleshoot
+
+. Determine the `kubemacpool-mac-controller` pod namespace and name.
++
+[source,terminal]
+----
+$ oc get pod -A -l control-plane=mac-controller-manager --no-headers -o custom-columns=":metadata.namespace,:metadata.name"
+----
+
+. Extract the conflicting Mac Addresses from the kubemacpool-mac-controller pod.
++
+[source,terminal]
+----
+$ oc logs -n <kubemacpool-namespace> <kubemacpool-mac-controller-pod-name> | grep "already allocated"
+----
++
+The extracted output contains the necessary information:
++
+* The Mac Address with the conflict
+* The current entry in the database (VM namespace, name, and interface)
+* The rejected entry with the conflict (VM namespace, name, and interface)
++
+An example of a log line is:
++
+[source,terminal]
+----
+"mac address 02:00:ff:ff:ff:ff already allocated to vm/kubemacpool-test/testvm, br1, conflict with: vm/kubemacpool-test/testvm2, br1"
+----
+
+. Check the Kubemacpool-manager pod's pod description and logs.
++
+[source,terminal]
+----
+$ oc describe pod -n $KMP_NAMESPACE $KMP_NAME
+----
++
+[source,terminal]
+----
+$ oc logs -n $KMP_NAMESPACE $KMP_NAME
+----
+
+.Resolution
+
+. Inspect the duplicates.
+. Update the VMs to remove the duplicate MAC Addresses.
+. Once resolution of all the conflicts occurs, restart the `kubemacpool-mac-controller` pod.
++
+[source,terminal]
+----
+$ oc delete pod -n <kubemacpool-namespace> <kubemacpool-mac-controller-pod-name>
+----
+
+//NetworkAddonsConfigNotReady Alert
+[id="NetworkAddonsConfigNotReady_{context}"]
+== NetworkAddonsConfigNotReady alert
+
+.Description
+
+The cluster-network-addons-operator (CNAO) deploys additional networking components on top of the cluster. This alert occurs when the CNAO custom resource (CR) NetworkAddonsConfig is not ready, indicating one of the deployed components is not ready.
+
+.Reason
+
+If CNAO component deployment fails, then some kubevirt networking scenarios also fail.
+
+.Troubleshoot
+
+. Check for messages on the `networkaddonsconfig` CR status.
++
+[source,terminal]
+----
+$ oc get networkaddonsconfig -o custom-columns="":.status.conditions[*].message
+----
+
+. Identify which component is not ready and gather more information from it.
+.. Extract the component deployment or daemonSet and namespace from the message.
++
+For example, if the message is `DaemonSet "cluster-network-addons/kube-cni-linux-bridge-plugin" update is being processed...`, then the namespace is `cluster-network-addons` and DaemonSet name is `kube-cni-linux-bridge-plugin`.
+
+.. Check the components’s pod YAML.
++
+[source,terminal]
+----
+$ oc -n <component-namespace> get daemonset <daemonset-name> -o yaml
+----
+
+.. Check the component's pod description and logs.
++
+[source,terminal]
+----
+$ oc -n <component-namespace> logs <pod-name>
+----
++
+[source,terminal]
+----
+$ oc -n <component-namespace> describe pod <pod-name>
+----
+
+.Troubleshoot
 
 Open a support issue and provide the information gathered in the troubleshooting process.

--- a/modules/virt-cnv-ssp-alerts.adoc
+++ b/modules/virt-cnv-ssp-alerts.adoc
@@ -7,6 +7,44 @@
 
 SSP alerts provide information about problems for the {VirtProductName} SSP Operator.
 
+//SSPCommonTemplatesModificationReverted Alert
+[id="SSPCommonTemplatesModificationReverted_{context}"]
+== SSPCommonTemplatesModificationReverted alert
+
+.Description
+
+The SSP Operator's reconciliation procedure changes one or more of the common templates. If you or a script make any changes to a common template, then the Operator reverts the changes.
+
+.Reason
+
+Losing manual changes to the templates occurs.
+
+.Troubleshoot
+
+Do not manually modify common templates.
+
+* Check the logs of the SSP Operator pods.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get deployment -A | grep ssp-operator | awk '{print $1}')"
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE logs --tail=-1 -l control-plane=ssp-operator
+----
+Look for lines to find the names of the restored Common Templates. For example:
++
+[source,terminal]
+----
+Changes reverted in common template: <template name>
+----
+
+.Resolution
+
+Open a support issue and provide the information gathered in the troubleshooting process.
+
 //SSPFailingToReconcile Alert
 [id="SSPFailingToReconcile_{context}"]
 == SSPFailingToReconcile alert
@@ -58,6 +96,43 @@ $ oc -n $NAMESPACE describe pods -l name=virt-template-validator
 [source,terminal]
 ----
 $ oc -n $NAMESPACE logs --tail=-1 -l name=virt-template-validator
+----
+
+.Resolution
+
+Open a support issue and provide the information gathered in the troubleshooting process.
+
+//SSPHighRateRejectedVms Alert
+[id="SSPHighRateRejectedVms_{context}"]
+== SSPHighRateRejectedVms alert
+
+.Description
+You or a script is continuously trying to create invalid virtual machines, causing VM creation or modification failures.
+
+.Reason
+
+There is no immediate effect. However, a large number of invalid virtual machines indicates a problem. For example, a script consistently fails to create or modify VMs.
+
+.Troubleshoot
+
+The template validator validates and rejects the virtual machines. Find more information in the virtual machine pods' logs.
+
+* Check the logs of the template validator pods:
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get deployment -A | grep ssp-operator | awk '{print $1}')"
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE logs --tail=-1 -l name=virt-template-validator
+----
+Look for lines that contain clues to the source of the invalid VMs. For example:
++
+[source,terminal]
+----
+{"component":"kubevirt-template-validator","level":"info","msg":"evalution summary for ubuntu-3166wmdbbfkroku0:\nminimal-required-memory applied: FAIL, value 1073741824 is lower than minimum [2147483648]\n\nsucceeded=false","pos":"admission.go:25","timestamp":"2021-09-28T17:59:10.934470Z"}
 ----
 
 .Resolution

--- a/modules/virt-cnv-storage-alerts.adoc
+++ b/modules/virt-cnv-storage-alerts.adoc
@@ -1,0 +1,478 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-events.html/virt-virtualization-alerts.adoc
+:_content-type: REFERENCE
+
+[id="virt-cnv-storage-alerts_{context}"]
+= Storage Alerts
+
+Storage alerts provide information about problems for the {VirtProductName} Containerized Data Importer (CDI) Operator and the Host Path Provisioner (HPP) Operator.
+
+//CDIDataImportCronOutdated Alert
+[id="CDIDataImportCronOutdated_{context}"]
+== CDIDataImportCronOutdated alert
+
+.Description
+
+DataImportCron polls the latest versions of disk images such as persistent volume claims (PVCs), most commonly into a golden image namespace.
+
+The `latest` version always updates in the PVCs, serving as a trustworthy clone source for a virtual machine (VM) created from the latest image of an operating system.
+
+This alert occurs when a DataImportCron fails to create a corresponding PVC or keep its corresponding PVC updated because it already has the `latest` version.
+
+[NOTE]
+====
+If you use a golden image, then `latest` is the latest operating system version of the distribution.
+If you do not use a golden image, then `latest` is the latest hash of the image that is available.
+====
+
+.Reason
+
+Using outdated disk images or VMs creates VMs that fail to start because there is no source PVC from which to clone.
+
+.Troubleshoot
+
+*Distinguish between golden images and regular crons*
+
+Golden images often use DataImportCrons and serve as a common source to create VM disks.
+
+. Find the erroneous DataImportCron’s namespace & name.
++
+[source,terminal]
+----
+$ oc get dataimportcron -A -o json | jq -r '.items[] | select(.status.conditions[] | select(.type == "UpToDate" and .status == "False")) | .metadata.namespace + "/" + .metadata.name'
+----
+
+The output appears as `namespace/name - golden image crons` residing in the `openshift-virtualization-os-images` namespace.
+
+. With golden image crons, verify configuration of a default storage class.
++
+[source,terminal]
+----
+$ oc get sc
+----
+
+Do not mark a single storage class with (default) next to its name.
+
+*Troubleshoot artifacts*
+
+. Replace `<cron_namespace>` and `<cron_name>` to find the DataImportCron’s corresponding DataVolume that resides in same namespace as cron.
++
+[source,terminal]
+----
+$ oc -n <cron_namespace> get dataimportcron <cron_name> -o json | jq .status.lastImportedPVC.name
+----
+
+. Replace `<dv_name>` with the previous output to check for error messages using this command:
++
+[source,terminal]
+----
+$ oc -n <cron_namespace> get dv <dv_name> -o yaml
+----
+
+. Find the cdi-operator’s pod namespace.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get deployment -A | grep cdi-operator | awk '{print $1}')"
+----
+
+. Check the cdi controller logs for error messages.
++
+[source,terminal]
+----
+$ oc logs -n $NAMESPACE deployment/cdi-deployment
+----
+
+.Resolution
+
+There are two primary causes for this alert:
+
+* You do not have a default storage class defined.
+* Your cluster is in a disconnected environment.
+
+*No storage class defined*
+
+A common issue when opting into golden images auto-polling is not having a default storage class set.
+
+Ensure you have a default storage class set in the cluster. However, if you’re using a custom DataImportCron, then verify that there is an explicit storage class set in the DataImportCron definition.
+[source,yaml]
+----
+$ oc get dataimportcron cron-test -o yaml | grep -B 5 storageClassName
+          url: docker://.../cdi-func-test-tinycore
+      storage:
+        resources:
+          requests:
+            storage: 5Gi
+        storageClassName: rook-ceph-block
+----
+
+If there is no defined storage class, then the DataVolume controller fails to create PVCs and triggers an event:
+[source,terminal]
+----
+DataVolume.storage spec is missing accessMode and no storageClass to choose profile
+----
+
+Once you define a storage class, updated versions of CDI resolve this issue automatically. If the alert does not resolve within a few seconds:
+
+. Find all of the affected DataImportCrons
+. Determine the DV associated with each DataImportCron
+. Make sure each DV has an empty status which is an indicator of the issue
+. Delete each of these DVs
+
+CDI then recreates the DVs with proper reference to the default storage class.
+
+*Disconnected Environment*
+
+If your cluster is in a restricted network, then the default golden images are out of reach, causing this alert to occur.
+
+Disable the feature gate `enableCommonBootImageImport` to opt-out from automatic updates of the common data import cron templates and to prevent this alert using this command:
+[source,terminal]
+----
+$ oc patch hco kubevirt-hyperconverged -n $CDI_NAMESPACE --type json -p '[{"op": "replace", "path": "/spec/featureGates/enableCommonBootImageImport", "value": false}]'
+----
+
+Otherwise, open a support issue and provide the information gathered in the troubleshooting process.
+
+//CDIDataVolumeUnusualRestartCount Alert
+[id="CDIDataVolumeUnusualRestartCount_{context}"]
+== CDIDataVolumeUnusualRestartCount alert
+
+.Description
+
+A DataVolume's (DV) `.RestartCount` field shows the number of times that a CDI ephemeral workload pod restarts.
+
+For example, when an HTTP import occurs, the `.RestartCount` field indicates the amount of times the CDI importer pod restarts.
+
+This alert occurs if any DV's restart count is greater than three.
+
+.Reason
+
+If the restart count is greater than three, the DataVolume fails to create a VM on a PVC.
+
+.Troubleshoot
+
+. Find the erroneous DV's name and namespace.
++
+[source,terminal]
+----
+$ oc get dv -A -o json | jq -r '.items[] | select(.status.restartCount>3)' | jq '.metadata.name, .metadata.namespace'
+----
+
+. Change the `<dv_name>` and `<dv_namespace>` fields based on the erroneous DV's name and namespace to find the corresponding worker pod.
++
+[source,terminal]
+----
+$ oc get pods -n <dv_namespace> -o json | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name=="<dv_name>")).metadata.name'
+----
+
+. Change the `<worker_pod>` field that corresponds to the erroneous DV's namespace to check the failing deployments’ corresponding description and logs.
++
+[source,terminal]
+----
+$ oc -n <dv_namespace> describe pods <worker_pod>
+----
++
+[source,terminal]
+----
+$ oc -n <dv_namespace> logs <worker_pod>
+----
+
+.Resolution
+
+In some cases, the error is an incorrect URL, indicated by a 404 error when troubleshooting the problem. If an incorrect URL is the cause, then you can restart by deleting the DV, correcting the URL in the DV manifest, and recreating the DV.
+
+Open a support issue and provide the information gathered in the troubleshooting process.
+
+//CDINotReady Alert
+[id="CDINotReady_{context}"]
+== CDINotReady alert
+
+.Description
+
+If a CDI installation is in a degraded state, then the installation is not progressing or is unavailable to use.
+
+.Reason
+
+If the CDI is unusable, then you cannot build virtual machine disks on PVCs using CDI’s DataVolumes (DVs). Additionally, components are not ready and stop progressing toward a ready state.
+
+.Troubleshoot
+
+. Check the cdi-operator’s pod namespace.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get deployment -A | grep cdi-operator | awk '{print $1}')"
+----
+In this example, the kind of operand is `kubevirt` and the operand's name is `kubevirt-kubevirt-hyperconverged`.
+
+. Verify if any of the CDI components are currently not ready.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get deploy -l cdi.kubevirt.io
+----
+
+. Check the failing deployments’ corresponding pod logs and description.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE describe pods <corresponding_pod_name>
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE logs <corresponding_pod_name>
+----
+
+.Resolution
+
+Open a support issue and provide the information gathered in the troubleshooting process.
+
+//CDIOperatorDown Alert
+[id="CDIOperatorDown_{context}"]
+== CDIOperatorDown alert
+
+.Description
+
+The CDI Operator deploys and manages the CDI infrastructure components such as the DataVolume or PVC controllers that help you build virtual machine disks on PVCs.
+
+This alert fires when the CDI Operator is down.
+
+.Reason
+
+If the CDI Operators is down, then the dependent infrastructure components do not deploy at all or fail to stay in a required state. As a result, the CDI installation is not fully operational in the cluster.
+
+.Troubleshoot
+
+. Check the cdi-operator’s pod namespace.
++
+[source,terminal]
+----
+export NAMESPACE="$(oc get deployment -A | grep cdi-operator | awk '{print $1}')"
+----
+
+. Verify the cdi-operator’s pod is currently down.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get pods -l name=cdi-operator
+----
+
+. Check the cdi-operator’s pod description and logs.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE describe pods -l name=cdi-operator
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE logs -l name=cdi-operator
+----
+
+.Resolution
+
+Open a support issue and provide the information gathered in the troubleshooting process.
+
+//CDIStorageProfilesIncomplete Alert
+[id="CDIStorageProfilesIncomplete_{context}"]
+== CDIStorageProfilesIncomplete alert
+
+.Description
+
+An incomplete StorageProfile indicates the CDI cannot automatically obtain persistent volume claim (PVC) fields such as volumeMode or accessMode for your disk request.
+
+.Reason
+
+The DataVolume fails to create a VM on a PVC.
+
+.Troubleshoot
+
+. Find the storage profile that cannot be fully populated by CDI using the name of your desired storage class from the DataVolume.
++
+[source,terminal]
+----
+$ oc get storageprofile <your_storage_class_name>
+----
+
+.Resolution
+
+Open a support issue and provide the needed information in the StorageProfile spec section. For example:
+
+*Before*
+
+[source,terminal]
+----
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: local
+spec: {}
+status:
+  provisioner: kubernetes.io/no-provisioner
+  storageClass: local
+----
+
+*Addition*
+
+[source,terminal]
+----
+$ oc patch storageprofile local --type=merge -p '{"spec": {"claimPropertySets": [{"accessModes": ["ReadWriteOnce"], "volumeMode": "Filesystem"}]}}'
+----
+
+*After*
+
+[source,terminal]
+----
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: local
+spec:
+  claimPropertySets:
+  - accessModes:
+    - ReadWriteOnce
+    volumeMode: Filesystem
+status:
+  claimPropertySets:
+  - accessModes:
+    - ReadWriteOnce
+    volumeMode: Filesystem
+  provisioner: kubernetes.io/no-provisioner
+  storageClass: local
+----
+
+//HPPNotReady Alert
+[id="HPPNotReady_{context}"]
+== HPPNotReady alert
+
+.Description
+
+The hostpath-provisioner (HPP) dynamically provisions hostPath volumes to provide storage for PVCs.
+
+.Reason
+
+If an HPP installation is in a degraded state, then the installation is not progressing or unavailable to use.
+
+.Troubleshoot
+
+. Check the hostpath-provisioner-operator’s pod namespace.
++
+[source,terminal]
+----
+$ export HPP_NAMESPACE="$(oc get deployment -A | grep hostpath-provisioner-operator | awk '{print $1}')"
+----
+
+. Verify if any of the HPP components are currently not ready.
++
+[source,terminal]
+----
+$ oc -n $HPP_NAMESPACE get all -l k8s-app=hostpath-provisioner
+----
+
+. Check the failing corresponding pod description and logs.
++
+[source,terminal]
+----
+$ oc -n $HPP_NAMESPACE describe pods <corresponding_pod_name>
+----
++
+[source,terminal]
+----
+$ oc -n $HPP_NAMESPACE logs <corresponding_pod_name>
+----
+
+.Resolution
+
+Open a support issue and provide the information gathered in the troubleshooting process.
+
+//HPPOperatorDown Alert
+[id="HPPOperatorDown_{context}"]
+== HPPOperatorDown alert
+
+.Description
+
+The Host Path Provider (HPP) Operator deploys and manages the HPP infrastructure components, such as the DaemonSet in charge of provisioning hostPath volumes.
+
+.Reason
+
+If the HPP Operator is down, then the dependent infrastructure components do not deploy at all or fail to stay in a required state. As a result, the HPP installation is not fully operational in the cluster.
+
+.Troubleshoot
+
+. Check the hostpath-provisioner-operator’s pod namespace.
++
+[source,terminal]
+----
+$ export HPP_NAMESPACE="$(oc get deployment -A | grep hostpath-provisioner-operator | awk '{print $1}')"
+----
+
+. Verify the hostpath-provisioner-operator’s pod is currently down.
++
+[source,terminal]
+----
+$ oc -n $HPP_NAMESPACE get pods -l name=hostpath-provisioner-operator
+----
+
+. Check the hostpath-provisioner-operator’s pod description and logs.
++
+[source,terminal]
+----
+$ oc -n $HPP_NAMESPACE describe pods -l name=hostpath-provisioner-operator
+----
++
+[source,terminal]
+----
+$ oc -n $HPP_NAMESPACE logs -l name=hostpath-provisioner-operator
+----
+
+.Resolution
+
+Open a support issue and provide the information gathered in the troubleshooting process.
+
+//HPPSharingPoolPathWithOS Alert
+[id="HPPSharingPoolPathWithOS_{context}"]
+== HPPSharingPoolPathWithOS alert
+
+.Description
+
+The hostpath-provisioner dynamically provisions hostPath volumes to provide storage for PVCs.
+
+.Reason
+
+If HPP is sharing a filesystem with other critical components such as an operating system (OS), then HPP PVs may cause node disk pressure.
+
+.Troubleshoot
+
+. Examine the DaemonSet logs to determine which HPP pool shares with an OS.
++
+[source,terminal]
+----
+$ export HPP_NAMESPACE="$(kubectl get deployment -A | grep hostpath-provisioner-operator | awk '{print $1}')"
+----
+
+. Find the CSI DaemonSet pods.
++
+[source,terminal]
+----
+$ oc -n $HPP_NAMESPACE get pods | grep hostpath-provisioner-csi
+----
+
+. Check the CSI pod logs to determine which pool and path share with an OS.
++
+[source,terminal]
+----
+$ oc -n $HPP_NAMESPACE logs <csi_daemonset_pod> -c hostpath-provisioner
+----
++
+The relevant log lines are similar to this example:
++
+[source,terminal]
+----
+I0208 15:21:03.769731 1 utils.go:221] pool (legacy, csi-data-dir/csi) shares path with OS which can lead to node disk pressure
+----
+
+.Resolution
+
+Open a support issue and provide the information gathered in the troubleshooting process.

--- a/modules/virt-cnv-virt-alerts.adoc
+++ b/modules/virt-cnv-virt-alerts.adoc
@@ -7,6 +7,524 @@
 
 Virt alerts provide information about problems for the {VirtProductName} Virt Operator.
 
+//KubeVirtComponentExceedsRequestedCPU Alert
+[id="KubeVirtComponentExceedsRequestedCPU_{context}"]
+== KubeVirtComponentExceedsRequestedCPU alert
+
+.Description
+
+This alert occurs when a container uses more CPU than it requested.
+
+.Reason
+
+If this alert consistently occurs, then the usage of the node’s CPU resources is not optimal, resulting in potential overload.
+
+.Troubleshoot
+
+. Set the environment variable `NAMESPACE`.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+----
+
+. Check to see what the CPU resource limit is.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get deployment <name-of-resource-firing-alert> -o yaml | grep requests: -A 2
+----
+
+. Check actual resource usage using promQL.
++
+[source,terminal]
+----
+node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace="$NAMESPACE",container="<name-of-resource-firing-alert>"}
+----
+
+.Resolution
+
+After checking the actual resource usage, determine what a better resource request is for the resource and update it using the `customizeComponents` option on the custom resource (CR).
+[source,yaml]
+----
+  spec:
+  customizeComponents:
+    patches:
+    - type:
+      resourceName: <name-of-resource-firing-alert>
+      resourceType: <Deployment|DaemonSet>
+      type: strategic
+      patch: '{"spec":{"template":{"spec":{"containers":[{"name":"< name-of-resource-firing-alert >","resources":{"requests":{"cpu":" < new-CPU-request > "}}}]}}}}'
+----
+
+//KubeVirtComponentExceedsRequestedMemory Alert
+[id="KubeVirtComponentExceedsRequestedMemory_{context}"]
+== KubeVirtComponentExceedsRequestedMemory alert
+
+.Description
+
+This alert occurs when a container uses more memory than it requested.
+
+.Reason
+
+If this alert consistently occurs, the usage of the node’s memory resources is not optimal, resulting in potential overload.
+
+.Troubleshoot
+
+. Set the environment variable `NAMESPACE`.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+----
+
+. Check to see what the CPU resource limit is.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get deployment <name-of-resource-firing-alert> -o yaml | grep requests: -A 2
+----
+
+. Check actual resource usage using promQL.
++
+[source,terminal]
+----
+container_memory_usage_bytes{namespace="$NAMESPACE",container="<name-of-resource-firing-alert>"}
+----
+
+.Resolution
+
+After checking the actual resource usage, determine what a better resource request is for the resource and update it using the `customizeComponents` option on the CR.
+[source,yaml]
+----
+  spec:
+  customizeComponents:
+    patches:
+    - type:
+      resourceName: < name-of-resource-firing-alert >
+      resourceType: < Deployment|DaemonSet >
+      type: strategic
+      patch: '{"spec":{"template":{"spec":{"containers":[{"name":"< name-of-resource-firing-alert >","resources":{"requests":{"memory":" < new-memory-request > "}}}]}}}}'
+----
+
+//KubevirtVmHighMemoryUsageBasedOnRequests
+[id="KubevirtVmHighMemoryUsageBasedOnRequests_{context}"]
+== KubevirtVmHighMemoryUsageBasedOnRequests alert
+
+.Description
+
+The container hosting a virtual machine has less than 20 MB free memory and is close to its requested memory.
+
+.Reason
+
+The scheduler considers the memory request when scheduling a container to a node. Then, the schedules allocates the requested memory on the chosen node for use by the container.
+
+If exhaustion of a node’s memory occurs, then the system prioritizes evicting containers whose memory usage most exceeds their memory request. In serious cases of memory exhaustion, the node Out of Memory (OOM) killer selects and stops the virtual machine in the container, based on a similar metric.
+
+.Troubleshoot
+
+. Check the `compute` container memory resource request and limit.
++
+[source,terminal]
+----
+$ oc get pod <virt launcher pod name> -o yaml
+----
+Look for the container name `compute`.
+
+. Identify processes with high memory usage.
++
+[source,terminal]
+----
+$ oc exec -it <virt launcher pod name> -c compute -- top
+----
+
+.Resolution
+
+Consider changing the container memory limit.
+
+Memory resource requests and limits are set in the virtual machine's manifest. For example:
+
+[source,yaml]
+----
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-name
+    spec:
+      domain:
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            memory: 128Mi
+...
+----
+
+//KubevirtVmHighMemoryUsage Alert
+[id="KubevirtVmHighMemoryUsage_{context}"]
+== KubevirtVmHighMemoryUsage alert
+
+.Description
+
+The container hosting a virtual machine has less than 20 MB of free memory and is close to its memory limit.
+
+.Reason
+
+When the container memory usage exceeds the memory limit, the runtime stops the virtual machine.
+
+.Troubleshoot
+
+. Check the `compute` container memory resource request and limit.
++
+[source,terminal]
+----
+$ oc get pod <virt launcher pod name> -o yaml
+----
+Look for the container name `compute`.
+
+. Identify processes with high memory usage.
++
+[source,terminal]
+----
+$ oc exec -it <virt launcher pod name> -c compute -- top
+----
+
+.Resolution
+
+Consider changing container memory limit.
+
+Memory resource requests and limits are set in the virtual machine's manifest. For example:
+
+[source,yaml]
+----
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-name
+    spec:
+      domain:
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            memory: 128Mi
+...
+----
+
+//LowKVMNodesCount Alert
+[id="LowKVMNodesCount_{context}"]
+== LowKVMNodesCount alert
+
+.Description
+
+Virtual machine migration requires at least two nodes with a Kernel-based virtual machine (KVM) resource. This alert occurs if there are less than two nodes with a KVM resource available.
+
+.Reason
+
+You cannot schedule and run a VM if there are no nodes with a KVM resource available.
+
+You cannot migrate a VM if less than two nodes in the cluster have a KVM resource available.
+
+.Troubleshoot
+
+. Verify that nodes have a KVM resource available.
++
+[source,terminal]
+----
+$ oc get nodes -o jsonpath='{.items[*].status.allocatable}' | grep devices.kubevirt.io/kvm
+----
+
+.Resolution
+
+. Validate hardware virtualization support using `virt-host-validate` to ensure that your hosts are capable of running virtualization workloads:
++
+[source,terminal]
+----
+virt-host-validate qemu
+----
+
+//LowReadyVirtControllersCount Alert
+[id="LowReadyVirtControllersCount_{context}"]
+== LowReadyVirtControllersCount alert
+
+.Description
+
+Virt-controller is responsible for monitoring virtual machine instances (VMIs) and managing the associated pods by creating and managing the lifecycle of the pods associated with the VMI objects.
+
+A VMI object is always associated with a pod during its lifetime. However, the pod instance might change over time because of VMI migration.
+
+.Reason
+
+If some virt-controllers are running but not ready in the past five minutes, then the virt-controller becomes a single point of failure.
+
+.Troubleshoot
+
+. Modify the environment variable `NAMESPACE`.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+----
+
+. Run this command:
++
+[source,terminal]
+----
+$ oc get deployment -n $NAMESPACE virt-controller -o jsonpath='{.status.readyReplicas}'
+----
+
+. Check the status of the virt-controller deployment to find out more information.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get deploy virt-controller -o yaml
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE describe deploy virt-controller
+----
+
+. Check if there are issues with the nodes, such as if the nodes are in a `NotReady` state.
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
+.Resolution
+
+Open a support issue and provide the information gathered in the troubleshooting process.
+
+//LowReadyVirtOperatorsCount Alert
+[id="LowReadyVirtOperatorsCount_{context}"]
+== LowReadyVirtOperatorsCount alert
+
+.Description
+
+Some virt Operators are running but not in the `Ready` state in the past 10 minutes. The virt-operator deployment has a default replica of two pods.
+
+.Reason
+
+The virt-operator is the first Kubernetes Operator active in an OpenShift cluster. Its primary responsibilities are:
+
+* Installation
+* Live-update
+* Live-upgrade of a cluster
+* Monitoring the lifecycle of top-level controllers such as virt-controller, virt-handler, and virt-launcher
+* Managing the reconciliation of top-level controllers
+
+In addition, the virt-operator is responsible for cluster-wide tasks such as certificate rotation and some infrastructure management.
+
+[NOTE]
+====
+Virt-operator is not directly responsible for virtual machines in the cluster. Virt-operator's unavailability does not affect the custom workloads.
+====
+
+If this alert occurs and the NoReadyVirtOperator alert does not occur, then the virt-operator becomes a single point of failure.
+
+.Troubleshoot
+
+. Check the status of the virt-operator deployment to learn more information. These commands provide the associated events and show if there are any specific issues:
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get deploy virt-operator -o yaml
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE describe deploy virt-operator
+----
+
+. Check if there are issues with the nodes for control-plane and masters such as if they are in a `NotReady` state.
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
+.Resolution
+
+There are several reasons for a low number of virt-operator pods in a `Ready` state. Identify the root cause and take appropriate action.
+
+Otherwise, open a support issue and provide the information gathered in the troubleshooting process.
+
+//LowVirtAPICount Alert
+[id="LowVirtAPICount_{context}"]
+== LowVirtAPICount alert
+
+.Description
+
+This alert occurs if only one virt-api pod is available in a 60 minute period, despite at least two worker nodes available for scheduling.
+
+.Reason
+
+The virt-api pod becomes a single point of failure that can lead to an API calls outage if the pod fails.
+
+.Troubleshoot
+
+. Modify the environment variable `NAMESPACE`.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+----
+
+. Run this command:
++
+[source,terminal]
+----
+$ oc get deployment -n $NAMESPACE virt-api -o jsonpath='{.status.readyReplicas}'
+----
+
+. Check the status of the virt-api deployment. Use these commands to learn about related events and show if there are any issues with pulling an image, crashing pod, or other similar problems.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get deploy virt-api -o yaml
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE describe deploy virt-api
+----
+
+. Check if there are issues with the nodes, such as if the nodes are in a `NotReady` state.
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
+.Resolution
+
+Open a support issue and provide the information gathered in the troubleshooting process.
+
+//LowVirtControllersCount Alert
+[id="LowVirtControllersCount_{context}"]
+== LowVirtControllersCount alert
+
+.Description
+
+More than one virt-controller pod must be ready to ensure high availability. The current default number of replicas is two.
+
+.Reason
+
+If the virt-controller fails, then VM lifecycle management, such as launching a new VM instance or shutting down an existing VM instance, completely fails.
+
+.Troubleshoot
+
+. Modify the environment variable `NAMESPACE`.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+----
+
+. Check the status of the virt-controller deployment.
++
+[source,terminal]
+----
+# oc get deployment -n $NAMESPACE virt-controller -o yaml
+----
+
+. Check if there are any running virt-controller pods.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get pods -l kubevirt.io=virt-controller
+----
+
+. Check the virt-controller pods that are not ready or crashing.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE logs virt-launcher-<unique id>
+----
++
+[source,terminal]
+----
+oc -n $NAMESPACE describe pod/virt-launcher-<unique id>
+----
+
+.Resolution
+
+There are several reasons for a low number of virt-controller pods. Identify the root cause and take appropriate action.
+
+* Not enough memory on the cluster
+* Nodes are down
+* The API server overloads, such as when the scheduler is not 100% available
+* Networking issues
+
+Otherwise, open a support issue and provide the information gathered in the troubleshooting process.
+
+//LowVirtOperatorCount Alert
+[id="LowVirtOperatorCount_{context}"]
+== LowVirtOperatorCount alert
+
+.Description
+
+There is only one virt-operator pod running in `Ready` state in the past 60 minutes.
+
+.Reason
+
+The virt-operator is the first Kubernetes Operator active in an OpenShift cluster. Its primary responsibilities are:
+
+* Installation
+* Live-update
+* Live-upgrade of a cluster
+* Monitoring the lifecycle of top-level controllers such as virt-controller, virt-handler, and virt-launcher
+* Managing the reconciliation of top-level controllers
+
+In addition, the virt-operator is responsible for cluster-wide tasks such as certificate rotation and some infrastructure management.
+
+[NOTE]
+====
+Virt-operator is not directly responsible for virtual machines in the cluster. Virt-operator's unavailability does not affect the custom workloads.
+====
+
+.Troubleshoot
+
+. Check the states of virt-operator pods.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get pods -l kubevirt.io=virt-operator
+----
+
+. Check in-depth virt-operator pods that are in trouble.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE logs <pod-name>
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE describe pod <pod-name>
+----
+
+.Resolution
+
+There can be several reasons for a low virt-operator count. Identify the root cause and take appropriate action.
+
+Otherwise, open a support issue and provide the information gathered in the troubleshooting process.
+
 //NoLeadingVirtOperator Alert
 [id="NoLeadingVirtOperator_{context}"]
 == NoLeadingVirtOperator alert
@@ -117,7 +635,7 @@ $ oc -n $NAMESPACE get deployment virt-controller -o yaml
 +
 [source,terminal]
 ----
-get pods -n $NAMESPACE |grep virt-controller
+$ get pods -n $NAMESPACE |grep virt-controller
 ----
 
 . Check the virt-controller pods' events.
@@ -209,6 +727,232 @@ $ oc get nodes
 There are several reasons for no virt-operator pods being in a `Ready` state. Identify the root cause and take appropriate action.
 
 Otherwise, open a support issue and provide the information gathered in the troubleshooting process.
+
+//OrphanedVirtualMachineInstances Alert
+[id="OrphanedVirtualMachineInstances_{context}"]
+== OrphanedVirtualMachineInstances alert
+
+.Description
+
+A virtual machine instance (VMI) such as a `virt-launcher` pod is running on a node that does not have a running `virt-handler` pod.
+
+.Reason
+
+If a node does not have a running `virt-handler`, then any VMI running on that node is an orphan and no longer manageable.
+
+.Troubleshoot
+
+. Confirm the alert by finding which nodes your virt-handler pods are running on using this command:
++
+[source,terminal]
+----
+$ oc get pods --all-namespaces -o wide -l kubevirt.io=virt-handler
+----
++
+Output:
++
+[source,terminal]
+----
+NAME                 READY   STATUS    RESTARTS   AGE  IP               NODE     NOMINATED NODE   READINESS GATES
+virt-handler-vhqsp   1/1     Running   0          4h   10.244.140.80    node02   <none>           <none>
+virt-handler-xd8jc   1/1     Running   0          4h   10.244.196.168   node01   <none>           <none>
+----
+
+. Check to see on which nodes the VMIs are running. Any VMI running on a node that a `virt-handler` pod does not exist on is an orphan. Use this command:
++
+[source,terminal]
+----
+$ oc get vmis --all-namespaces
+----
++
+Output:
++
+[source,terminal]
+----
+NAMESPACE   NAME            AGE   PHASE       IP    NODENAME
+default     vmi-ephemeral   4s    Scheduled         node02
+----
+
+. Check to see if the DaemonSet that controls the `virt-handler` pods is healthy using this command:
++
+[source,terminal]
+----
+$ oc get daemonset virt-handler --all-namespaces
+----
++
+Output:
++
+[source,terminal]
+----
+NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
+virt-handler            2         2         2       2            2           kubernetes.io/os=linux   4h
+----
+
+The DaemonSet is healthy if the Desired, Ready and Available columns contain the same number.
+
+*Unhealthy virt-handler DaemonSet*
+
+. Check the DaemonSet's status to determine what issues occur when deploying the pods.
++
+[source,terminal]
+----
+$ oc describe daemonset virt-handler --all-namespaces
+----
++
+. Check the status by determining the object and reading through its status object.
++
+[source,terminal]
+----
+$ oc get daemonset virt-handler --all-namespaces -o yaml | jq .status
+----
++
+. Check the health of the cluster nodes.
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
+*Healthy virt-handler DaemonSet*
+
+. Verify if there is a `workloads` placement policy on the resource in the `spec.workloads` field.
++
+[source,terminal]
+----
+$ oc get kubevirt kubevirt --all-namespaces -o yaml
+----
+
+.Resolution
+
+If there is a placement policy, then you can make adjustments so that the node that is running the VMI is included in the placement policy.
+
+There may also be a change to a node’s taints and tolerations or a pod’s scheduling rules.
+
+//OutdatedVirtualMachineInstanceWorkloads Alert
+[id="OutdatedVirtualMachineInstanceWorkloads_{context}"]
+== OutdatedVirtualMachineInstanceWorkloads alert
+
+.Description
+
+There are VMIs running in outdated virt-launcher pods 24 hours after the OpenShift control plane update finishes.
+
+.Reason
+
+Non-updated VMIs trying to run in the most recent virt-launcher pod do not have access to new features and do not have any security fixes associated with the virt-launcher pod update.
+
+.Troubleshoot
+
+You can identify the outdated VMIs by using the `kubevirt.io/outdatedLauncherImage` label as a label selector when listing VMIs. An example of a command that lists all out-of-date VMIs across all namespaces within the cluster is:
+[source,terminal]
+----
+$ oc get vmi -l kubevirt.io/outdatedLauncherImage --all-namespaces
+----
+
+.Resolution
+
+*Check for enabling automatic workload updates*
+
+Check the CR used to install KubeVirt to see if the configuration of the CR spec's `workloadUpdateStrategy` attribute is correct.
+
+If you use automatic workload updates, then workloads that are able to be live migrated can always migrate. If workloads are not able to be live migrated, eviction of those workloads occurs, causing a restart when using `RunStrategy: Always` on the corresponding VM definition. An example is:
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  imagePullPolicy: IfNotPresent
+  workloadUpdateStrategy:
+    workloadUpdateMethods:
+      - LiveMigrate
+      - Evict
+    batchEvictSize: 10
+    batchEvictInterval: "1m"
+----
+
+If you do not enable automatic workload updates, consider enabling them. Enabling automatic workload updates causes the OpenShift control plane to automatically update the VMI workloads using the methods defined in the `workloadUpdateMethods` field.
+
+*Enabled automatic workload updates, but VMIs are still out-of-date*
+
+Identify the VMIs that are out of date. Check each affected VMI to see if the VMIs are able to be live migrated or not by looking for the `LiveMigratable` condition within the VMI’s status.
+
+If a VMI is not able to be live migrated and the eviction method is not chosen as a `workloadUpdateMethods` value on the CR, then you must stop the VMI. If a corresponding VM controls the VMI with `RunStrategy: Always` set, then a new VMI immediately starts in an updated virt-launcher pod to replace the stopped VMI.
+
+If the VMI is able to be live migrated and the migration fails, then you can still stop the VMI. However, the failure interrupts the workload.
+
+To stop a VM named `my-vm` in namespace `my-namespace` using `virtctl`, use this command:
+[source,terminal]
+----
+$ virtctl stop --namespace my-namespace my-vm
+----
+
+*Manually updating VMIs*
+
+To manually update VMIs, either manually create migration objects for VMIs (non-destructive) that can be live migrated or manually stop VMIs (destructive) that cannot be live migrated.
+
+With live migration, the VMIs migrate into an updated virt-launcher container.
+
+If you stop (and potentially restart when a VM controls the VMI), any replacement VMIs start in updated virt-launcher containers.
+
+You can manually execute a live migration by posting a `VirtualMachineInstanceMigration` object to the cluster that targets a specific running VM. For example, you can create a VM called `my-vm` that runs in the namespace `my-namespace`.
+[source,yaml]
+----
+cat << EOF > migration.yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstanceMigration
+metadata:
+  name: my-vm-migration-job
+  namespace: my-namespace
+spec:
+  vmiName: my-vm
+EOF
+
+$ oc create -f migration.yaml
+----
+
+//VMCannotBeEvicted Alert
+[id="VMCannotBeEvicted_{context}"]
+== VMCannotBeEvicted alert
+
+.Description
+
+This alert occurs when a VM's eviction strategy is set to `LiveMigration` but the VM cannot be live migrated.
+
+.Reason
+
+VMs that cannot be live migrated block node eviction and affect operations such as node drain and updates.
+
+.Troubleshoot
+
+. Check the eviction strategy and the `Migratable` status of the VMI.
+
+. Use the `oc get vmis -o yaml` command. Search for the `evictionStrategy` field. For example, `evictionStrategy: LiveMigrate`.
+
+. Use the `oc get vmis -o wide` command. Examine the `LIVE-MIGRATABLE` column of the output. In case the status is `False`, you can inspect the VMI to understand why you cannot migrate the VM.
++
+. Use the `oc get vmis -o yaml` command. Inspect the conditions section under the VMI status. For example:
++
+[source,yaml]
+----
+  status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: null
+    message: cannot migrate VMI which does not use masquerade to connect to the pod network
+    reason: InterfaceNotLiveMigratable
+    status: "False"
+    type: LiveMigratable
+----
+
+.Resolution
+
+To resolve this alert, you can either:
+
+. Set the `evictionStrategy` to Shutdown.
+
+. Determine why a VM cannot be live migrated and if changing disk type or network configuration alters the migration status.
 
 //VirtAPIDown Alert
 [id="VirtAPIDown_{context}"]
@@ -326,6 +1070,61 @@ There are several reasons for a high rate of failed REST calls. Identify the roo
 
 Otherwise, open a support issue and provide the information gathered in the troubleshooting process.
 
+//VirtApiRESTErrorsHigh Alert
+[id="VirtApiRESTErrorsHigh_{context}"]
+== VirtApiRESTErrorsHigh alert
+
+.Description
+
+More than 5% of the REST calls failed in virt-api for the last 60 minutes.
+
+.Reason
+
+A high rate of failed REST calls to virt-api causes slow response and slow execution of API calls.
+
+.Troubleshoot
+
+. Modify the environment variable `NAMESPACE`.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+----
+
+. Check to see how many running virt-api pods exist.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get pods -l kubevirt.io=virt-api
+----
+
+. View the pods' logs using `oc logs` and pod status using `oc describe`.
+
+. Check the status of the virt-api deployment to find out more information. These commands provide the associated events and show if there are any issues with pulling an image or a crashing pod.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get deploy virt-api -o yaml
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE describe deploy virt-api
+----
+
+. Check if there are issues with the nodes, such as if the nodes are in a `NotReady` state.
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
+.Resolution
+
+Virt-api pods fail for several reasons. Identify the root cause and take appropriate action.
+
+Otherwise, open a support issue and provide the information gathered in the troubleshooting process.
+
 //VirtControllerDown Alert
 [id="VirtControllerDown_{context}"]
 == VirtControllerDown alert
@@ -421,6 +1220,73 @@ The issue normally relates to DNS or CNI issues outside of the scope of this ale
 
 Otherwise, open a support issue and provide the information gathered in the troubleshooting process.
 
+//VirtControllerRESTErrorsHigh Alert
+[id="VirtControllerRESTErrorsHigh_{context}"]
+== VirtControllerRESTErrorsHigh alert
+
+.Description
+
+More than 5% of the REST calls failed in virt-controller for the last 60 minutes.
+
+.Reason
+
+Virt-controller partially loses the connection to the API server. Delay of cluster-level related actions such as starting, migrating, and scheduling VMs occurs. This delay does not affect running workloads, but delay of reporting the workloads' current status occurs.
+
+.Troubleshoot
+
+There are two common error types associated with virt-controller REST call failure:
+
+* The API server overloads, causing timeouts. Check the API server metrics and details like response times and overall calls.
+
+* The virt-controller pod cannot reach the API server. Common causes are:
+** DNS issues on the node
+** Networking connectivity issues
+
+.Resolution
+
+Check the virt-controller logs to determine if it cannot connect to the API server at all. If so, delete the pod to force a restart. The issue normally relates to DNS or CNI issues outside of the scope of this alert.
+
+Otherwise, open a support issue and provide the information gathered in the troubleshooting process.
+
+//VirtHandlerDaemonSetRolloutFailing Alert
+[id="VirtHandlerDaemonSetRolloutFailing_{context}"]
+== VirtHandlerDaemonSetRolloutFailing alert
+
+.Description
+
+Some virt-handler DaemonSets fail to roll out after 15 minutes. This alert suggests that, in the cluster, at least one worker node does not have the virt-handler DaemonSet pod successfully rolls out in the given time.
+
+.Reason
+
+This alert does not indicate the failure of rollouts of all virt-handler DaemonSet. The normal VM lifecycle has no problems if no overload of the cluster.
+
+.Troubleshoot
+
+You can identify the nodes associated with the failed rollouts to show that at least one worker node does not have a virt-handler pod running:
+
+. List all the pods in the virt-handler DaemonSet.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+----
++
+[source,terminal]
+----
+$ oc get pods -n $NAMESPACE -l=kubevirt.io=virt-handler
+----
+
+. Determine the name of the worker node that the pod deploys on for each virt-handler pod.
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get pod <virt-handler-pod-name> -o jsonpath='{.spec.nodeName}'
+----
+
+.Resolution
+
+A common reason for this alert is that the nodes associated with the failed rollouts run out of resources. For example, you can delete some non-DaemonSet pods from the affected nodes.
+
 //VirtHandlerRESTErrorsBurst Alert
 [id="VirtHandlerRESTErrorsBurst_{context}"]
 == VirtHandlerRESTErrorsBurst alert
@@ -446,6 +1312,34 @@ There are two common error types associated with virt-operator REST call failure
 .Resolution
 
 If the virt-handler cannot connect to the API server, delete the pod to force a restart. The issue normally relates to DNS or CNI issues outside of the scope of this alert. Identify the root cause and take appropriate action.
+
+Otherwise, open a support issue and provide the information gathered in the troubleshooting process.
+
+//VirtOperatorRESTErrorsHigh Alert
+[id="VirtHandlerRESTErrorsHigh_{context}"]
+== VirtHandlerRESTErrorsHigh alert
+
+.Description
+
+More than 5% of the REST calls failed in virt-handler for the last 60 minutes.
+
+.Reason
+
+Virt-handler has partially lost the connection to the API server. Delay of node-related actions such as starting and migrating workloads occurs. This delay does not affect running workloads, but delay of reporting the workloads' current status occurs.
+
+.Troubleshoot
+
+There are two common error types associated with virt-handler REST call failure:
+
+* The API server overloads, causing timeouts. Check the API server metrics and details like response times and overall calls. If you do not have cluster privileges, then you can fetch OpenShift API server pod logs with the `oc logs` command.
+
+* The virt-handler pod cannot reach the API server. Common causes are:
+** DNS issues on the node
+** Networking connectivity issues
+
+.Resolution
+
+If there is an indication that the virt-operator cannot connect to the API server, delete the pod to force a restart. The issue normally relates to DNS or CNI issues outside of the scope of this alert.
 
 Otherwise, open a support issue and provide the information gathered in the troubleshooting process.
 
@@ -570,5 +1464,51 @@ $ oc -n $NAMESPACE describe pod <pod-name>
 .Resolution
 
 If the virt-operator cannot connect to the API server, delete the pod to force a restart. The issue normally relates to DNS or CNI issues outside of the scope of this alert. Identify the root cause and take appropriate action.
+
+Otherwise, open a support issue and provide the information gathered in the troubleshooting process.
+
+//VirtOperatorRESTErrorsHigh Alert
+[id="VirtOperatorRESTErrorsHigh_{context}"]
+== VirtOperatorRESTErrorsHigh alert
+
+.Description
+
+More than 5% of the REST calls failed in virt-operator for the last 60 minutes.
+
+.Reason
+
+Virt-operator has partially lost the connection to the API server. Delay of cluster-level actions such as upgrading and controller reconciliation occurs. There is no effect to customer workloads such as VMs and VMIs.
+
+.Troubleshoot
+
+There are two common error types associated with virt-operator REST call failure:
+
+* The API server overloads, causing timeouts. Check the API server metrics and details like response times and overall calls. If you do not have cluster privileges, then you can fetch OpenShift API server pod logs with the `oc logs` command.
+
+* The virt-operator pod cannot reach the API server. A common cause is a network connectivity problem such as DNS issues on the node. Check virt-operator logs to verify whether it can connect to the API server at all.
++
+[source,terminal]
+----
+$ export NAMESPACE="$(oc get kubevirt -A -o custom-columns="":.metadata.namespace)"
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE get pods -l kubevirt.io=virt-operator
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE logs <pod-name>
+----
++
+[source,terminal]
+----
+$ oc -n $NAMESPACE describe pod <pod-name>
+----
+
+.Resolution
+
+If there is an indication that the virt-operator cannot connect to the API server, delete the pod to force a restart. The issue normally relates to DNS or CNI issues outside of the scope of this alert.
 
 Otherwise, open a support issue and provide the information gathered in the troubleshooting process.

--- a/virt/logging_events_monitoring/virt-virtualization-alerts.adoc
+++ b/virt/logging_events_monitoring/virt-virtualization-alerts.adoc
@@ -1,21 +1,23 @@
 :_content-type: ASSEMBLY
 [id="virt-virtualization-alerts"]
-= {VirtProductName} critical alerts
+= {VirtProductName} alerts
 include::_attributes/common-attributes.adoc[]
 :context: virt-virtualization-alerts
 
 toc::[]
 
-:FeatureName: {VirtProductName} critical alerts
-include::snippets/technology-preview.adoc[]
+:FeatureName: {VirtProductName} alerts
+//include::snippets/technology-preview.adoc[]
 
-{VirtProductName} has alerts that inform you when a problem occurs. Critical alerts require immediate attention.
+{VirtProductName} has alerts that inform you when a problem occurs.
 
 Each alert has a corresponding description of the problem, a reason for why the alert is occurring, a troubleshooting process to diagnose the source of the problem, and steps for resolving the alert.
 
 include::modules/virt-cnv-network-alerts.adoc[leveloffset=+1]
 include::modules/virt-cnv-ssp-alerts.adoc[leveloffset=+1]
 include::modules/virt-cnv-virt-alerts.adoc[leveloffset=+1]
+include::modules/virt-cnv-storage-alerts.adoc[leveloffset=+1]
+include::modules/virt-cnv-hco-alerts.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_virt-virtualization-alerts"]


### PR DESCRIPTION
This PR addresses JIRA story [CNV-16355](https://issues.redhat.com/browse/CNV-16355) which is part of epic [CNV-16350](https://issues.redhat.com/browse/CNV-16350).

The epic asks to document new and non-critical level CNV alerts.

CP: 4.11

Preview: https://deploy-preview-44448--osdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-virtualization-alerts.html