### PR TITLE
Rel Notes doc text for 4.7.47 release

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1103,6 +1103,11 @@ In the table, features are marked with the following statuses:
 |GA
 |DEP
 
+|Minting credentials for Microsoft Azure clusters
+|GA
+|GA
+|xref:../release_notes/ocp-4-7-release-notes.adoc#ocp-4-7-47-removed-feature-azure-mint-mode[REM]
+
 |====
 
 [id="ocp-4-7-deprecated-features"]
@@ -1200,6 +1205,54 @@ If you are using the option `--keep-manifest-list=true`, the only valid value fo
 [id="ocp-4-7-aws-efs-tp_removed-2nd"]
 ==== External provisioner for AWS EFS (Technology Preview) feature has been removed
 The Amazon Web Services (AWS) Elastic File System (EFS) Technology Preview feature has been removed and is no longer supported.
+
+[id="ocp-4-7-removed-feature-azure-mint-mode"]
+==== Support for minting credentials for Microsoft Azure removed
+
+Starting with {product-title} 4.7.47, support for using the Cloud Credential Operator (CCO) in mint mode on Microsoft Azure clusters has been removed from {product-title} 4.7. This change is due to the planned link:https://azure.microsoft.com/en-us/updates/update-your-apps-to-use-microsoft-graph-before-30-june-2022/[retirement of the Azure AD Graph API by Microsoft on 30 June 2022] and is being backported to all supported versions of {product-title} in z-stream updates.
+
+For previously installed Azure clusters that use mint mode, the CCO attempts to update existing secrets. If a secret contains the credentials of previously minted app registration service principals, it is updated with the contents of the secret in `kube-system/azure-credentials`. This behavior is similar to passthrough mode.
+
+For clusters with the credentials mode set to its default value of `""`, the updated CCO automatically changes from operating in mint mode to operating in passthrough mode. If your cluster has the credentials mode explicitly set to mint mode (`"Mint"`), you must change the value to `""` or `"Passthrough"`.
+
+[NOTE]
+====
+In addition to the `Contributor` role that is required by mint mode, the modified app registration service principals now require the `User Access Administrator` role that is used for passthrough mode.
+====
+
+While the Azure AD Graph API is still available, the CCO in upgraded versions of {product-title} attempts to clean up previously minted app registration service principals. Upgrading your cluster before the Azure AD Graph API is retired might avoid the need to clean up resources manually.
+
+If the cluster is upgraded to a version of {product-title} that no longer supports mint mode after the Azure AD Graph API is retired, the CCO sets an `OrphanedCloudResource` condition on the associated `CredentialsRequest` but does not treat the error as fatal. The condition includes a message similar to `unable to clean up App Registration / Service Principal: <app_registration_name>`. Cleanup after the Azure AD Graph API is retired requires manual intervention using the Azure CLI tool or the Azure web console to remove any remaining app registration service principals.
+
+To clean up resources manually, you must find and delete the affected resources.
+
+. Using the Azure CLI tool, filter the app registration service principals that use the `<app_registration_name>` from an `OrphanedCloudResource` condition message by running the following command:
++
+[source,terminal]
+----
+$ az ad app list --filter "displayname eq '<app_registration_name>'" --query '[].objectId'
+----
++
+.Example output
++
+[source,terminal]
+----
+[
+  "038c2538-7c40-49f5-abe5-f59c59c29244"
+]
+----
+
+. Delete the app registration service principal by running the following command:
++
+[source,terminal]
+----
+$ az ad app delete --id 038c2538-7c40-49f5-abe5-f59c59c29244
+----
+
+[NOTE]
+====
+After cleaning up resources manually, the `OrphanedCloudResource` condition persists because the CCO cannot verify that the resources were cleaned up.
+====
 
 [id="ocp-4-7-bug-fixes"]
 == Bug fixes
@@ -3165,3 +3218,24 @@ link:https://access.redhat.com/solutions/6844051[{product-title} 4.7.46 containe
 ==== Updating
 
 To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-7-47"]
+=== RHSA-2022:0492 - {product-title} 4.7.47 bug fix and security update
+
+Issued: 2022-04-11
+
+{product-title} release 4.7.47, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:1166[RHSA-2022:1166] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1165[RHBA-2022:1165] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6890031﻿[{product-title} 4.7.47 container image list]
+
+[id="ocp-4-7-47-removed-feature-azure-mint-mode"]
+==== Removed features
+
+Starting with {product-title} 4.7.47, support for using the Cloud Credential Operator (CCO) in mint mode on Microsoft Azure clusters has been removed from {product-title} 4.7. This change is due to the planned link:https://azure.microsoft.com/en-us/updates/update-your-apps-to-use-microsoft-graph-before-30-june-2022[retirement of the Azure AD Graph API by Microsoft on 30 June 2022] and is being backported to all supported versions of {product-title} in z-stream updates. For more information, see xref:../release_notes/ocp-4-7-release-notes.adoc#ocp-4-7-removed-feature-azure-mint-mode[Support for minting credentials for Microsoft Azure removed].
+
+[id="ocp-4-7-47-updating"]
+==== Updating
+
+To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
For OpenShift 4.7.47 release. Replacing #44280 because this release also includes the Azure AD Graph removal update for 4.7.

Change management acks are on #43289

Previews:
- [Dep/rem table](https://deploy-preview-44460--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-deprecated-removed-features)
- [Removed feature info](https://deploy-preview-44460--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-removed-feature-azure-mint-mode)
- [Rel notes](https://deploy-preview-44460--osdocs.netlify.app/openshift-enterprise/latest/rlease_notes/ocp-4-7-release-notes.html#ocp-4-7-47-removed-feature-azure-mint-mode)