### PR TITLE
CNV16208d: Adding dummy file for 4.11 release notes

### DIFF
--- a/virt/virt-4-11-release-notes.adoc
+++ b/virt/virt-4-11-release-notes.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="virt-4-11-release-notes"]
+= {VirtProductName} release notes
+include::_attributes/common-attributes.adoc[]
+:context: virt-4-11-release-notes
+toc::[]
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+This file is here to allow builds to work.


### PR DESCRIPTION
PR to add a dummy virt-4-11-release-notes.adoc file to main