### PR TITLE
Updating the operator role examples

### DIFF
--- a/modules/rosa-sts-operator-role-commands.adoc
+++ b/modules/rosa-sts-operator-role-commands.adoc
@@ -21,48 +21,48 @@ When using `manual` mode, the `aws` commands are printed to the terminal for you
 [source,terminal]
 ----
 aws iam create-role \
-	--role-name <cluster_name>-xxxx-openshift-cluster-csi-drivers-ebs-cloud-credent \
+	--role-name <cluster_name>-<hash>-openshift-cluster-csi-drivers-ebs-cloud-credent \
 	--assume-role-policy-document file://operator_cluster_csi_drivers_ebs_cloud_credentials_policy.json \
 	--tags Key=rosa_cluster_id,Value=<id> Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value= Key=operator_namespace,Value=openshift-cluster-csi-drivers Key=operator_name,Value=ebs-cloud-credentials
 
 aws iam attach-role-policy \
-	--role-name <cluster_name>-xxxx-openshift-cluster-csi-drivers-ebs-cloud-credent \
+	--role-name <cluster_name>-<hash>-openshift-cluster-csi-drivers-ebs-cloud-credent \
 	--policy-arn arn:aws:iam::<aws_account_id>:policy/ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credent
 
 aws iam create-role \
-	--role-name <cluster_name>-xxxx-openshift-machine-api-aws-cloud-credentials \
+	--role-name <cluster_name>-<hash>-openshift-machine-api-aws-cloud-credentials \
 	--assume-role-policy-document file://operator_machine_api_aws_cloud_credentials_policy.json \
 	--tags Key=rosa_cluster_id,Value=<id> Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value= Key=operator_namespace,Value=openshift-machine-api Key=operator_name,Value=aws-cloud-credentials
 
 aws iam attach-role-policy \
-	--role-name <cluster_name>-xxxx-openshift-machine-api-aws-cloud-credentials \
+	--role-name <cluster_name>-<hash>-openshift-machine-api-aws-cloud-credentials \
 	--policy-arn arn:aws:iam::<aws_account_id>:policy/ManagedOpenShift-openshift-machine-api-aws-cloud-credentials
 
 aws iam create-role \
-	--role-name <cluster_name>-xxxx-openshift-cloud-credential-operator-cloud-crede \
+	--role-name <cluster_name>-<hash>-openshift-cloud-credential-operator-cloud-crede \
 	--assume-role-policy-document file://operator_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy.json \
 	--tags Key=rosa_cluster_id,Value=<id> Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value= Key=operator_namespace,Value=openshift-cloud-credential-operator Key=operator_name,Value=cloud-credential-operator-iam-ro-creds
 
 aws iam attach-role-policy \
-	--role-name <cluster_name>-xxxx-openshift-cloud-credential-operator-cloud-crede \
+	--role-name <cluster_name>-<hash>-openshift-cloud-credential-operator-cloud-crede \
 	--policy-arn arn:aws:iam::<aws_account_id>:policy/ManagedOpenShift-openshift-cloud-credential-operator-cloud-crede
 
 aws iam create-role \
-	--role-name <cluster_name>-xxxx-openshift-image-registry-installer-cloud-creden \
+	--role-name <cluster_name>-<hash>-openshift-image-registry-installer-cloud-creden \
 	--assume-role-policy-document file://operator_image_registry_installer_cloud_credentials_policy.json \
 	--tags Key=rosa_cluster_id,Value=<id> Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value= Key=operator_namespace,Value=openshift-image-registry Key=operator_name,Value=installer-cloud-credentials
 
 aws iam attach-role-policy \
-	--role-name <cluster_name>-xxxx-openshift-image-registry-installer-cloud-creden \
+	--role-name <cluster_name>-<hash>-openshift-image-registry-installer-cloud-creden \
 	--policy-arn arn:aws:iam::<aws_account_id>:policy/ManagedOpenShift-openshift-image-registry-installer-cloud-creden
 
 aws iam create-role \
-	--role-name <cluster_name>-xxxx-openshift-ingress-operator-cloud-credentials \
+	--role-name <cluster_name>-<hash>-openshift-ingress-operator-cloud-credentials \
 	--assume-role-policy-document file://operator_ingress_operator_cloud_credentials_policy.json \
 	--tags Key=rosa_cluster_id,Value=<id> Key=rosa_openshift_version,Value=4.8 Key=rosa_role_prefix,Value= Key=operator_namespace,Value=openshift-ingress-operator Key=operator_name,Value=cloud-credentials
 
 aws iam attach-role-policy \
-	--role-name <cluster_name>-xxxx-openshift-ingress-operator-cloud-credentials \
+	--role-name <cluster_name>-<hash>-openshift-ingress-operator-cloud-credentials \
 	--policy-arn arn:aws:iam::<aws_account_id>:policy/ManagedOpenShift-openshift-ingress-operator-cloud-credentials
 ----
 

--- a/modules/rosa-sts-operator-roles.adoc
+++ b/modules/rosa-sts-operator-roles.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-about-iam-resources.adoc
+// * rosa_getting_started/rosa-sts-about-iam-resources.adoc
 
 [id="rosa-sts-operator-roles_{context}"]
 = Cluster-specific Operator IAM role reference
@@ -20,19 +20,19 @@ If more than one matching policy is available in your account for an Operator ro
 
 |Resource|Description
 
-|`ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials`
+|`<cluster_name>-<hash>-openshift-cluster-csi-drivers-ebs-cloud-credentials`
 |An IAM role required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
 
-|`ManagedOpenShift-openshift-machine-api-aws-cloud-credentials`
+|`<cluster_name>-<hash>-openshift-machine-api-aws-cloud-credentials`
 |An IAM role required by the ROSA Machine Config Operator to perform core cluster functionality.
 
-|`ManagedOpenShift-openshift-cloud-credential-operator-cloud-credentials`
+|`<cluster_name>-<hash>-openshift-cloud-credential-operator-cloud-credentials`
 |An IAM role required by the ROSA Cloud Credential Operator to cloud provider credentials.
 
-|`ManagedOpenShift-openshift-image-registry-installer-cloud-credentials`
+|`<cluster_name>-<hash>-openshift-image-registry-installer-cloud-credentials`
 |An IAM role required by the ROSA Image Registry Operator to manage the internal registry storage in AWS S3 for a cluster.
 
-|`ManagedOpenShift-openshift-ingress-operator-cloud-credentials`
+|`<cluster_name>-<hash>-openshift-ingress-operator-cloud-credentials`
 |An IAM role required by the ROSA Ingress Operator to manage external access to a cluster.
 
 |===


### PR DESCRIPTION
This applies to `main`, `enterprise-4.11` and `enterprise-4.10`.

This pull request updates the operator role name examples in the [Cluster-specific Operator IAM role reference](https://docs.openshift.com/rosa/rosa_getting_started/rosa-sts-about-iam-resources.html#rosa-sts-operator-roles_rosa-sts-about-iam-resources) section to use the correct syntax. Unless a custom prefix is applied, the operator roles are prefixed with the cluster name and a 4-digit hash, not the `ManagedOpenShift` default prefix.

The preview is [here](https://deploy-preview-44467--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-operator-roles_rosa-sts-about-iam-resources).