### PR TITLE
BZ-2049375:Adds command to Entitlement Build

### DIFF
--- a/modules/builds-source-secrets-entitlements.adoc
+++ b/modules/builds-source-secrets-entitlements.adoc
@@ -12,6 +12,17 @@ Builds that use Red Hat subscriptions to install content must include the entitl
 
 You must have access to Red Hat entitlements through your subscription, and the entitlements must have separate public and private key files.
 
+
+[TIP]
+====
+When you perform an Entitlement Build using {op-system-base-full} 7, you must have the following instructions in your Dockerfile before you run any `yum` commands:
+
+[source,terminal]
+----
+RUN rm /etc/rhsm-host
+----
+====
+
 .Procedure
 
 . Create a secret containing your entitlements, ensuring that there are separate files containing the public and private keys:


### PR DESCRIPTION
4.7+

[BZ 2049375](https://bugzilla.redhat.com/show_bug.cgi?id=2049375)

[Preview](https://deploy-preview-44472--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/running-entitled-builds.html)

Has QE in BZ.