### PR TITLE
Clarify architecture changes for patch release

### DIFF
--- a/modules/acs-architecture-external-components.adoc
+++ b/modules/acs-architecture-external-components.adoc
@@ -6,7 +6,10 @@
 = External components
 In addition to the primary services, {product-title} also interacts with other entities to provide enhanced security for your clusters.
 
-Figure 3 depicts the {product-title-short} architecture for {ocp}. In other Kubernetes based environments, Scanner services are only installed once with the centralized  service.
+Figure 3 depicts the {product-title-short} architecture for {ocp}, but you should note the following exceptions:
+
+- In {product-title-short} version 3.69 and older, Scanner services are only installed once with the centralized service.
+- In other Kubernetes based environments, Scanner services are only installed once with the centralized service.
 
 .External components
 image::acs-architecture-external-components.png[External components]

--- a/modules/acs-architecture-overview.adoc
+++ b/modules/acs-architecture-overview.adoc
@@ -7,13 +7,20 @@
 
 {product-title}({product-title-short}) uses a distributed architecture that supports high scale deployments and is optimized to minimize the impact on the underlying {ocp} or Kubernetes nodes. You install {product-title-short} as a set of containers in your {ocp} or Kubernetes cluster. {product-title-short} includes services that you install on each cluster secured by {product-title-short} and centralized services you install on one cluster.
 
+[discrete]
+== {product-title} version 3.69.1 and newer
+
 .High level {product-title} architecture for {ocp}
-image::acs-architecture-ocp.png[High-level {product-title} architecture for {ocp}]
+image::acs-architecture-ocp.png[High-level {product-title} for {ocp}]
+
+[discrete]
+== {product-title} version 3.69 and older
+
+For {product-title} versions 3.69 and older, Scanner is installed only on the cluster where Central is installed.
 
 [discrete]
 == Centralized services
 You install Centralized services on a single cluster (*Cluster 1* in Figure 1 and 2). These services includes two main components, Central and Scanner.
-However, when you install {product-title} on {ocp}, you also install a lightweight version of Scanner on each secured cluster (Figure 1) to enable scanning of images in the integrated OpenShift Container Registry (OCR).
 
 * *Central*:
 Central is the {product-title-short} application management interface and services.
@@ -23,6 +30,10 @@ You can use the same Central instance to secure multiple {ocp} or Kubernetes clu
 Scanner is a Red Hat-developed and certified vulnerability scanner for scanning container images and their associated databases.
 It analyzes all image layers to check known vulnerabilities from the Common Vulnerabilities and Exposures (CVEs) list.
 Scanner also identifies vulnerabilities in packages installed by package managers and in dependencies for multiple programming languages.
+
+[discrete]
+=== Scanner Architecture in {product-title} version 3.69.1 and newer
+When you install {product-title} version 3.69.1 and newer on {ocp}, you also install a lightweight version of Scanner on each secured cluster (Figure 1) to enable scanning of images in the integrated OpenShift Container Registry (OCR).
 
 [discrete]
 == Secured cluster services
@@ -39,7 +50,7 @@ The admission controller prevents users from creating workloads that violate sec
 Collector analyzes and monitors container activity on cluster nodes.
 It collects information about container runtime and network activity and sends the collected data to Sensor.
 
-* *Scanner* (only on {ocp}):
+* *Scanner* (only on {ocp} version 3.69.1 and newer):
 On {ocp}, {product-title-short} installs a lightweight version of Scanner on each secured cluster (Figure 1) to enable scanning of images in the integrated OCR.
 
 Figure 2 depicts the architecture in a Kubernetes environment, where you install only the Scanner centrally.

--- a/release_notes/369-release-notes.adoc
+++ b/release_notes/369-release-notes.adoc
@@ -19,9 +19,7 @@ Release date: April 6, 2022
 
 [id="openshift-container-registry"]
 ==== Scanning of the integrated OpenShift Container Registry
-{product-title} 3.69.1 includes a lightweight version of Scanner as part of the secured cluster services on {ocp} by default to more effectively scan the OpenShift Container Registry.
-For other Kubernetes based environments, this Scanner is optional.
-If you are using {ocp} and not using the {product-title}, Red Hat advises you to update your Helm charts to take advantage of these new capabilities.
+{product-title} 3.69.1 includes a lightweight version of Scanner delivered as part of the secured cluster services on {ocp} to more effectively scan the OpenShift Container Registry. For {ocp} users who do not use the {product-title} Operator, Red Hat advises you to update your Helm charts to take advantage of these new capabilities.
 
 [id="spring-security-vulnerabilities"]
 ==== Improved detection of Spring vulnerabilities


### PR DESCRIPTION
This change is for RHACS version 3.69 and 3.69.1 to clarify architecture changes that happened in release 3.69.1, per request from the RHACS Product Manager & team.

Also minor changes to 3.69 release notes per request from RHACS PM.

[Preview of changes](https://deploy-preview-44473--osdocs.netlify.app/openshift-acs/latest/architecture/acs-architecture.html)