### PR TITLE
Adds a prerequisite step to SRIOV config

### DIFF
--- a/modules/nw-sriov-configuring-device.adoc
+++ b/modules/nw-sriov-configuring-device.adoc
@@ -87,6 +87,8 @@ A device can be used in either mode.
 ====
 endif::virt-sriov[]
 
+. Optional: Label the SR-IOV capable cluster nodes with `SriovNetworkNodePolicy.Spec.NodeSelector` if they are not already labeled. For more information about labeling nodes, see "Understanding how to update labels on nodes".
+
 [start=2]
 . Create the `SriovNetworkNodePolicy` object:
 +

--- a/networking/hardware_networks/configuring-sriov-device.adoc
+++ b/networking/hardware_networks/configuring-sriov-device.adoc
@@ -15,6 +15,11 @@ include::modules/nw-sriov-nic-partitioning.adoc[leveloffset=+2]
 
 include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes].
+
 include::modules/nw-sriov-troubleshooting.adoc[leveloffset=+1]
 
 include::modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc[leveloffset=+1]


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1956454

Preview: https://deploy-preview-44476--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device.html#nw-sriov-configuring-device_configuring-sriov-device

QE needed. 
