### PR TITLE
RHDEVDOCS-3875-setting-alertmanager-log-level

### DIFF
--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -6,9 +6,9 @@
 [id="setting-log-levels-for-monitoring-components_{context}"]
 = Setting log levels for monitoring components
 
-You can configure the log level for Prometheus Operator, Prometheus, Thanos Querier, and Thanos Ruler.
+You can configure the log level for Alertmanager, Prometheus Operator, Prometheus, Thanos Querier, and Thanos Ruler.
 
-The following log levels can be applied to each of those components in the `cluster-monitoring-config` and `user-workload-monitoring-config` `ConfigMap` objects:
+The following log levels can be applied to the relevant component in the `cluster-monitoring-config` and `user-workload-monitoring-config` `ConfigMap` objects:
 
 * `debug`. Log debug, informational, warning, and error messages.
 * `info`. Log informational, warning, and error messages.
@@ -19,7 +19,7 @@ The default log level is `info`.
 
 .Prerequisites
 
-* *If you are setting a log level for Prometheus Operator, Prometheus, or Thanos Querier in the `openshift-monitoring` project*:
+* *If you are setting a log level for Alertmanager, Prometheus Operator, Prometheus, or Thanos Querier in the `openshift-monitoring` project*:
 ** You have access to the cluster as a user with the `cluster-admin` role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are setting a log level for Prometheus Operator, Prometheus, or Thanos Ruler in the `openshift-user-workload-monitoring` project*:


### PR DESCRIPTION
Summary: This PR documents that log levels can now be set for the Alertmanager component in OCP 4.9+.

- Aligned team: DevTools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3875
- Direct link to doc preview: https://deploy-preview-44487--osdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#setting-log-levels-for-monitoring-components_configuring-the-monitoring-stack
- SME review: n/a
- QE review: @juzhao 
- Peer review: @rolfedh 