### PR TITLE
Adding ROSA restructure phase 2 redirects

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -170,39 +170,61 @@ AddType text/vtt                            vtt
     # OSD redirects for new content
     RewriteRule dedicated/4/cloud_infrastructure_access/dedicated-aws-vpn.html dedicated/osd_private_connections/aws-private-connections.html [NE,R=302]
 
-    # Redirects for the ROSA restructure that was applied in https://github.com/openshift/openshift-docs/pull/41923
-    RewriteRule rosa/rosa_policy/?(.*)$ rosa/rosa_architecture/$1 [NE,R=301]
-    RewriteRule rosa/rosa_support/rosa-getting-support.html rosa/rosa_architecture/rosa-getting-support.html [NE,R=301]
+    # Redirects for the ROSA restructure applied in https://github.com/openshift/openshift-docs/pull/41923 and https://github.com/openshift/openshift-docs/pull/43807
+    RewriteRule rosa/rosa_policy/?(.*)$ rosa/rosa_architecture/rosa_policy_service_definition/$1 [NE,R=302]
 
-    RewriteRule rosa/rosa_getting_started_sts/rosa-sts-getting-started-workflow.html rosa/rosa_architecture/rosa-sts-getting-started-workflow.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started_sts/rosa-sts-aws-prereqs.html rosa/rosa_planning/rosa-sts-aws-prereqs.html [NE,R=301]
+    RewriteRule rosa/rosa_architecture/rosa-basic-architecture-concepts.html rosa/rosa_architecture/rosa_architecture_sub/rosa-basic-architecture-concepts.html [NE,R=302]
+    RewriteRule rosa/rosa_architecture/rosa-architecture-models.html rosa/rosa_architecture/rosa_architecture_sub/rosa-architecture-models.html [NE,R=302]
+    RewriteRule rosa/rosa_architecture/rosa-policy-?(.*)$ rosa/rosa_architecture/rosa_policy_service_definition/rosa-policy-$1 [NE,R=302]
+    RewriteRule rosa/rosa_architecture/rosa-service-definition.html rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html [NE,R=302]
+    RewriteRule rosa/rosa_architecture/rosa-life-cycle.html rosa/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html [NE,R=302]
+    RewriteRule rosa/rosa_architecture/rosa-sts-getting-started-workflow.html rosa/rosa_getting_started/rosa-sts-getting-started-workflow.html [NE,R=302]
 
-    RewriteRule rosa/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/?(.*)$ rosa/rosa_getting_started/$1 [NE,R=301]
+    RewriteRule rosa/rosa_planning/rosa-aws-prereqs.html rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html [NE,R=302]
 
-    RewriteRule rosa/rosa_getting_started_sts/?(.*)$ rosa/rosa_getting_started/$1 [NE,R=301]
+    RewriteRule rosa/rosa_support/rosa-getting-support.html rosa/rosa_architecture/rosa-getting-support.html [NE,R=302]
 
-    RewriteRule rosa/rosa_getting_started/rosa-aws-prereqs.html rosa/rosa_planning/rosa-aws-prereqs.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started/rosa-getting-started-workflow.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-getting-started-workflow.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started/rosa-required-aws-service-quotas.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-required-aws-service-quotas.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started/rosa-config-aws-account.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-config-aws-account.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started/rosa-installing-rosa.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-installing-rosa.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started/rosa-creating-cluster.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-creating-cluster.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started/rosa-aws-privatelink-creating-cluster.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-aws-privatelink-creating-cluster.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started/rosa-accessing-cluster.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-accessing-cluster.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started/rosa-config-identity-providers.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-config-identity-providers.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started/rosa-deleting-access-cluster.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-deleting-access-cluster.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started/rosa-deleting-cluster.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-deleting-cluster.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started/rosa-quickstart.html rosa/rosa_getting_started/rosa_getting_started_iam/rosa-quickstart.html [NE,R=301]
+    RewriteRule rosa/rosa_getting_started_sts/rosa-sts-getting-started-workflow.html rosa/rosa_getting_started/rosa-sts-getting-started-workflow.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started_sts/rosa-sts-aws-prereqs.html rosa/rosa_planning/rosa-sts-aws-prereqs.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-about-iam-resources.html rosa/rosa_architecture/rosa-sts-about-iam-resources.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/?(.*)$ rosa/rosa_install_access_delete_clusters/$1 [NE,R=302]
+    RewriteRule rosa/rosa_getting_started_sts/rosa-sts-setting-up-environment.html rosa/rosa_planning/rosa-sts-setting-up-environment.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started_sts/rosa-sts-required-aws-service-quotas.html rosa/rosa_planning/rosa-sts-required-aws-service-quotas.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started_sts/?(.*)$ rosa/rosa_install_access_delete_clusters/$1 [NE,R=302]
 
-    RewriteRule rosa/logging/?(.*)$ rosa/rosa_cluster_admin/rosa_logging/$1 [NE,R=301]
+    RewriteRule rosa/rosa_getting_started/rosa-aws-prereqs.html rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa_getting_started_iam/rosa-aws-privatelink-creating-cluster.html rosa/rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-getting-started-workflow.html rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-getting-started-workflow.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-required-aws-service-quotas.html rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-required-aws-service-quotas.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-config-aws-account.html rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-config-aws-account.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-installing-rosa.html rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-installing-rosa.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-creating-cluster.html rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-creating-cluster.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-accessing-cluster.html rosa/rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa_getting_started_iam/rosa-accessing-cluster.html rosa/rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-config-identity-providers.html rosa/rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa_getting_started_iam/rosa-config-identity-providers.html rosa/rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-deleting-access-cluster.html rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-deleting-access-cluster.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-deleting-cluster.html rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-deleting-cluster.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-quickstart.html rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-quickstart.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa_getting_started_iam/?(.*)$ rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/$1 [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-sts-about-iam-resources.html rosa/rosa_architecture/rosa-sts-about-iam-resources.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-sts-required-aws-service-quotas.html rosa/rosa_planning/rosa-sts-required-aws-service-quotas.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/rosa-sts-setting-up-environment.html rosa/rosa_planning/rosa-sts-setting-up-environment.html [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/(rosa-getting-started|rosa-sts-getting-started-workflow).html - [L]
+    RewriteRule rosa/rosa_getting_started/?(.*)$ rosa/rosa_install_access_delete_clusters/$1 [NE,R=302]
 
-    RewriteRule rosa/monitoring/osd?(.*)$ rosa/rosa_cluster_admin/rosa_monitoring/rosa$1 [NE,R=301]
+    RewriteRule rosa/logging/?(.*)$ rosa/rosa_cluster_admin/rosa_logging/$1 [NE,R=302]
 
-    RewriteRule rosa/cloud_infrastructure_access/?(.*)$ rosa/rosa_cluster_admin/cloud_infrastructure_access/$1 [NE,R=301]
+    RewriteRule rosa/monitoring/osd?(.*)$ rosa/rosa_cluster_admin/rosa_monitoring/rosa$1 [NE,R=302]
 
-    RewriteRule rosa/nodes/nodes-machinepools-about.html rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.html [NE,R=301]
-    RewriteRule rosa/nodes/rosa-managing-worker-nodes.html rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html [NE,R=301]
-    RewriteRule rosa/nodes/nodes-about-autoscaling-nodes.html rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.html [NE,R=301]
+    RewriteRule rosa/cloud_infrastructure_access/?(.*)$ rosa/rosa_cluster_admin/cloud_infrastructure_access/$1 [NE,R=302]
+
+    RewriteRule rosa/nodes/nodes-machinepools-about.html rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.html [NE,R=302]
+    RewriteRule rosa/nodes/rosa-managing-worker-nodes.html rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html [NE,R=302]
+    RewriteRule rosa/nodes/nodes-about-autoscaling-nodes.html rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.html [NE,R=302]
+
+    # ROSA UI short-term redirect https://issues.redhat.com/browse/OSDOCS-3511
+    RewriteRule rosa/post_installation_configuration/machine-configuration-tasks.html rosa/rosa_getting_started/rosa-getting-started.html#rosa-getting-started-configure-an-idp-and-grant-access_rosa-getting-started [NE,R=302]
 
     # ACS welcome page redirect to StackRox docs
     # RewriteRule ^acs/?(.*)$ https://help.stackrox.com/ [NE,R=301]


### PR DESCRIPTION
This applies to `main` only.

This relates to https://github.com/openshift/openshift-docs/pull/43807. The pull request applies redirects that relate to the restructuring changes in PR 43807, as well as the previous changes made through the phase 1 restructuring PR https://github.com/openshift/openshift-docs/pull/41923.

The PR also adds a short term redirect for https://issues.redhat.com/browse/OSDOCS-3511.