### PR TITLE
BZ2072425: oc binary is not sending authentication headers when using  a http proxy

### DIFF
--- a/modules/cli-logging-in.adoc
+++ b/modules/cli-logging-in.adoc
@@ -17,6 +17,8 @@ You can log in to the OpenShift CLI (`oc`) to access and manage your cluster.
 ====
 To access a cluster that is accessible only over an HTTP proxy server, you can set the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` variables.
 These environment variables are respected by the `oc` CLI so that all communication with the cluster goes through the HTTP proxy.
+
+Authentication headers are sent only when using HTTPS transport.
 ====
 
 .Procedure


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2072425

Describe the issue: 
the written [NOTE on utilising a Proxy to access the cluster](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/cli_tools/openshift-cli-oc#cli-logging-in_cli-developer-commands) should be extended with an additional statement to avoid confusion and authentication errors.
