### PR TITLE
CNV-13360: Use RHEL image for liveness and readiness probes doc

### DIFF
--- a/modules/virt-template-vm-probe-config.adoc
+++ b/modules/virt-template-vm-probe-config.adoc
@@ -11,13 +11,13 @@ apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   labels:
-    special: vm-fedora
-  name: vm-fedora
+    special: vm-rhel
+  name: vm-rhel
 spec:
   template:
     metadata:
       labels:
-        special: vm-fedora
+        special: vm-rhel
     spec:
       domain:
         devices:
@@ -43,12 +43,10 @@ spec:
       volumes:
       - name: containerdisk
         containerDisk:
-          image: kubevirt/fedora-cloud-registry-disk-demo
+          image: registry.redhat.io/rhel8/rhel-guest-image
       - cloudInitNoCloud:
           userData: |-
             #cloud-config
-            password: fedora
-            chpasswd: { expire: False }
             bootcmd:
               - setenforce 0
               - dnf install -y nmap-ncat


### PR DESCRIPTION
Re: [CNV-13360](https://issues.redhat.com//browse/CNV-13360)
For 4.11 and later

Preview: https://deploy-preview-44502--osdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-monitoring-vm-health.html#virt-template-vm-probe-config_virt-monitoring-vm-health