### PR TITLE
CNV-14440: HCO bump 4.8.5

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -62,7 +62,7 @@ endif::[]
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 4.8
 :KubeVirtVersion: v0.41.0
-:HCOVersion: 4.8.4
+:HCOVersion: 4.8.5
 :delete: image:delete.png[title="Delete"]
 ifdef::openshift-origin[]
 :VirtProductName: OKD Virtualization


### PR DESCRIPTION
- [CNV-14440](https://issues.redhat.com//browse/CNV-14440)
- Changing the HCO value to 4.8.5 for the z-stream release.
- No CP.
- attn @tiraboschi 