### PR TITLE
RNs-4.9.28 Added with Bug Fixes 

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2733,3 +2733,26 @@ link:https://access.redhat.com/solutions/6885691[{product-title} 4.9.27 containe
 ==== Updating
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-9-28"]
+=== RHBA-2022:1245 - {product-title} 4.9.28 bug fix update
+
+Issued: 2022-04-13
+
+{product-title} OpenShift Container Platform release 4.9.28 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1245[RHBA-2022:1245] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6906441[{product-title} 4.9.28 container image list]
+
+[id="ocp-4-9-28-known-issues"]
+==== Known issues
+
+* When updating to {product-title} 4.9.28, the etcd pod fails to start and the etcd Operator falls into a `degraded` state. A future version of {product-title} will resolve this issue. For more information, see the following Knowledgebase solutions:
+** link:https://access.redhat.com/solutions/6907321[etcd pod is failing to start after updating {product-title} 4.9.28 or 4.10.9]
+** link:https://access.redhat.com/solutions/6849521[Potential etcd data inconsistency issue in OCP 4.9 and 4.10]
+
+[id="ocp-4-9-28-updating"]
+==== Updating
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
To be merged on **04-13**

Jira: https://issues.redhat.com/browse/OCPPLAN-8792

OCP version: Applicable only to **enterprise-4.9**

Direct Doc Preview Link: https://deploy-preview-44508--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-28