### PR TITLE
OSDOCS-3509: OSDK bug fix for Helm restricted env procedure

### DIFF
--- a/modules/olm-enabling-operator-restricted-network.adoc
+++ b/modules/olm-enabling-operator-restricted-network.adoc
@@ -108,23 +108,53 @@ spec:
 <.> Use the `lookup` function to call the `<related_image_environment_variable>`.
 ====
 
-* For Helm-based Operator projects, add the environment variable to the `helm-charts/memchached/values.yaml` file as shown in the following example:
+* For Helm-based Operator projects, add the `overrideValues` field to the `watches.yaml` file as shown in the following example:
 +
-.`helm-charts/memchached/values.yaml` diff
+.Example `watches.yaml` file
 [%collapsible]
 ====
-[source,diff]
+[source,yaml]
 ----
-  ## Memcached image and tag
-  ## ref: https://hub.docker.com/r/library/memcached/tags/
-  ##
-- image: memcached:1.5.20 <.>
-+ image: "{{ lookup('env', '<related_image_environment_variable>') }}" <.>
-
 ...
+- group: demo.example.com
+  version: v1alpha1
+  kind: Memcached
+  chart: helm-charts/memcached
+  overrideValues: <.>
+    relatedImage: ${<related_image_environment_variable>} <.>
 ----
-<.> Delete the image reference and tag.
-<.> Use the `lookup` function to call the `<related_image_environment_variable>`.
+<.> Add the `overrideValues` field.
+<.> Define the `overrideValues` field by using the `<related_image_environment_variable>`, such as `RELATED_IMAGE_MEMCACHED`.
+====
+
+.. Add the value of the `overrideValues` field to the `helm-charts/memchached/values.yaml` file as shown in the following example:
++
+.Example `helm-charts/memchached/values.yaml` file
+[source,yaml]
+----
+...
+relatedImage: ""
+----
+
+.. Edit the chart template in the `helm-charts/memcached/templates/deployment.yaml` file as shown in the following example:
++
+.Example `helm-charts/memcached/templates/deployment.yaml` file
+[%collapsible]
+====
+[source,yaml]
+----
+containers:
+  - name: {{ .Chart.Name }}
+    securityContext:
+      - toYaml {{ .Values.securityContext | nindent 12 }}
+    image: "{{ .Values.image.pullPolicy }}
+    env: <.>
+      - name: related_image <.>
+        value: "{{ .Values.relatedImage }}" <.>
+----
+<.> Add the `env` field.
+<.> Name the environment variable.
+<.> Define the value of the environment variable.
 ====
 
 . Add the `BUNDLE_GEN_FLAGS` variable definition to your `Makefile` with the following changes:


### PR DESCRIPTION
Version(s): 4.10+
Issue: [OSDOCS-3509](https://issues.redhat.com//browse/OSDOCS-3509)
Direct link to docs preview: https://deploy-preview-44509--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs

Helm does not use the `lookup` function, so the procedure for Helm-based Operator projects needs to be fixed.