### PR TITLE
Compliance Operator v0.1.49 release notes

### DIFF
--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -13,6 +13,39 @@ These release notes track the development of the Compliance Operator in the {pro
 
 For an overview of the Compliance Operator, see xref:../../security/compliance_operator/compliance-operator-understanding.adoc#understanding-compliance-operator[Understanding the Compliance Operator].
 
+[id="compliance-operator-release-notes-0-1-49"]
+== OpenShift Compliance Operator 0.1.49
+
+The following advisory is available for the OpenShift Compliance Operator 0.1.49:
+
+* link:https://access.redhat.com/errata/RHBA-2022:1148[RHBA-2022:1148 - OpenShift Compliance Operator bug fix and enhancement update]
+
+[id="compliance-operator-0-1-49-new-features-and-enhancements"]
+=== New features and enhancements
+
+* The Compliance Operator is now supported on the following architectures:
++
+** IBM Power
+** IBM Z
+** IBM LinuxONE
+
+[id="compliance-operator-0-1-49-bug-fixes"]
+=== Bug fixes
+
+* Previously, the `openshift-compliance` content did not include platform-specific checks for network types. As a result, OVN- and SDN-specific checks would show as `failed` instead of `not-applicable` based on the network configuration. Now, new rules contain platform checks for networking rules, resulting in a more accurate assessment of network-specific checks. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1994609[*BZ#1994609*])
+
+* Previously, the `ocp4-moderate-routes-protected-by-tls` rule incorrectly checked TLS settings that results in the rule failing the check, even if the connection secure SSL TLS protocol. Now, the check will properly evaluate TLS settings that are consistent with the networking guidance and profile recommendations. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2002695[*BZ#2002695*])
+
+* Previously, `ocp-cis-configure-network-policies-namespace` used pagination when requesting namespaces. This caused the rule to fail because the deployments truncated lists of more than 500 namespaces. Now, the entire namespace list is requested, and the rule for checking configured network policies will work for deployments with more than 500 namespaces. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2038909[*BZ#2038909*])
+
+* Previously, remediations using the `sshd jinja` macros were hard-coded to specific sshd configurations. As a result, the configurations were inconsistent with the content the rules were checking for and the check would fail. Now, the sshd configuration is parameterized and the rules apply successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049141[*BZ#2049141*])
+
+* Previously, the `ocp4-cluster-version-operator-verify-integrity` always checked the first entry in the Cluter Version Operator (CVO) history. As a result, the upgrade would fail in situations where subsequent versions of {product-name} would be verified. Now, the compliance check result for `ocp4-cluster-version-operator-verify-integrity` is able to detect verified versions and is accurate with the CVO history. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2053602[*BZ#2053602*])
+
+* Previously, the `ocp4-api-server-no-adm-ctrl-plugins-disabled` rule did not check for a list of empty admission controller plug-ins. As a result, the rule would always fail, even if all admission plug-ins were enabled. Now, more robust checking of the `ocp4-api-server-no-adm-ctrl-plugins-disabled` rule will accurately pass with all admission controller plug-ins enabled. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2058631[*BZ#2058631*])
+
+* Previously, scans did not contain platform checks for running against Linux worker nodes. As a result, running scans against worker nodes that were not Linux-based resulted in a never ending scan loop. Now, the scan will schedule appropriately based on platform type and labels and will completely successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2056911[*BZ#2056911*])
+
 [id="compliance-operator-release-notes-0-1-48"]
 == OpenShift Compliance Operator 0.1.48
 
@@ -21,7 +54,6 @@ The following advisory is available for the OpenShift Compliance Operator 0.1.48
 * link:https://access.redhat.com/errata/RHBA-2022:0416[RHBA-2022:0416 - OpenShift Compliance Operator bug fix and enhancement update]
 
 [id="openshift-compliance-operator-0-1-48-bug-fixes"]
-
 === Bug fixes
 
 * Previously, some rules associated with extended Open Vulnerability and Assessment Language (OVAL) definitions had a `checkType` of `None`. This was because the Compliance Operator was not processing extended OVAL definitions when parsing rules. With this update, content from extended OVAL definitions is parsed so that these rules now have a `checkType` of either `Node` or `Platform`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2040282[*BZ#2040282*])


### PR DESCRIPTION
Will need cherry-pick to 4.6+ after the errata goes live.
Preview: https://deploy-preview-44510--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-release-notes.html#compliance-operator-0-1-49-new-features-and-enhancements