### PR TITLE
CCXDEV-5230 document how to get gatherers duration time info

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -39,6 +39,8 @@ endif::openshift-origin[]
 :cluster-manager: OpenShift Cluster Manager
 :cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager]
 :cluster-manager-url-pull: link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager]
+:insights-advisor-url: link:https://console.redhat.com/openshift/insights/advisor/[Insights Advisor]
+:hybrid-console: Red Hat Hybrid Cloud Console
 :rh-storage-first: Red Hat OpenShift Data Foundation
 :rh-storage: OpenShift Data Foundation
 :rh-rhacm-first: Red Hat Advanced Cluster Management (RHACM)

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -567,6 +567,8 @@ Topics:
     File: enabling-remote-health-reporting
   - Name: Using Insights to identify issues with your cluster
     File: using-insights-to-identify-issues-with-your-cluster
+  - Name: Using Insights Operator
+    File: using-insights-operator
   - Name: Using remote health reporting in a restricted network
     File: remote-health-reporting-from-restricted-network
   - Name: Importing simple content access certificates with Insights Operator

--- a/modules/insights-operator-about.adoc
+++ b/modules/insights-operator-about.adoc
@@ -8,12 +8,12 @@
 
 The Insights Operator periodically gathers configuration and component failure status and, by default, reports that data every two hours to Red Hat. This information enables Red Hat to assess configuration and deeper failure data than is reported through Telemetry.
 
-Users of {product-title} can display the report of each cluster in {cluster-manager-url}. If any issues have been identified, Insights provides further details and, if available, steps on how to solve a problem.
+Users of {product-title} can display the report of each cluster in the {insights-advisor-url} service on {hybrid-console}. If any issues have been identified, Insights provides further details and, if available, steps on how to solve a problem.
 
 The Insights Operator does not collect identifying information, such as user names, passwords, or certificates. See link:https://console.redhat.com/security/insights[Red Hat Insights Data & Application Security] for information about Red Hat Insights data collection and controls.
 
 Red Hat uses all connected cluster information to:
 
-* Proactively identify potential cluster issues and provide a solution and preventive actions in {cluster-manager-url}
+* Identify potential cluster issues and provide a solution and preventive actions in the {insights-advisor-url} service on {hybrid-console}
 * Improve {product-title} by providing aggregated and critical information to product and support teams
 * Make {product-title} more intuitive

--- a/modules/insights-operator-downloading-archive.adoc
+++ b/modules/insights-operator-downloading-archive.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-operator.adoc
+
+:_content-type: PROCEDURE
+[id="insights-operator-downloading-archive_{context}"]
+= Downloading your Insights Operator archive
+
+Insights Operator stores gathered data in an archive located in the `openshift-insights` namespace of your cluster. You can download and review the data that is gathered by the Insights Operator. 
+
+.Prerequisites
+
+* Access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Find the name of the running pod for the Insights Operator:
++
+[source,terminal]
+----
+$ oc get pods --namespace=openshift-insights -o custom-columns=:metadata.name --no-headers  --field-selector=status.phase=Running
+----
+
+. Copy the recent data archives collected by the Insights Operator:
++
+[source,terminal]
+----
+$ oc cp openshift-insights/<insights_operator_pod_name>:/var/lib/insights-operator ./insights-data <1>
+----
+<1> Replace `<insights_operator_pod_name>` with the pod name output from the preceding command.
+
+The recent Insights Operator archives are now available in the `insights-data` directory.

--- a/modules/insights-operator-gather-duration.adoc
+++ b/modules/insights-operator-gather-duration.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-operator.adoc
+
+:_content-type: PROCEDURE
+[id="insights-operator-gather-duration_{context}"]
+= Viewing Insights Operator gather durations
+
+You can view the time it takes for the Insights Operator to gather the information contained in the archive. This helps you to understand Insights Operator resource usage and issues with Insights Advisor.
+
+
+.Prerequisites 
+
+* A recent copy of your Insights Operator archive.
+
+.Procedure
+
+. From your archive, open `/insights-operator/gathers.json`.
++
+The file contains a list of Insights Operator gather operations: 
++
+[source,json]
+----
+    {
+      "name": "clusterconfig/authentication",
+      "duration_in_ms": 730, <1>
+      "records_count": 1,
+      "errors": null,
+      "panic": null
+    }
+----
++
+<1> `duration_in_ms` is the amount of time in milliseconds for each gather operation. 
+
+. Inspect each gather operation for abnormalities. 

--- a/support/remote_health_monitoring/using-insights-operator.adoc
+++ b/support/remote_health_monitoring/using-insights-operator.adoc
@@ -1,0 +1,22 @@
+:_content-type: ASSEMBLY
+[id="using-insights-operator"]
+= Using Insights Operator
+include::_attributes/common-attributes.adoc[]
+ifdef::openshift-dedicated[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+endif::[]
+:context: using-insights-operator
+
+toc::[]
+
+The Insights Operator periodically gathers configuration and component failure status and, by default, reports that data every two hours to Red Hat. This information enables Red Hat to assess configuration and deeper failure data than is reported through Telemetry. Users of {product-title} can display the report in the {insights-advisor-url} service on {hybrid-console}.
+
+[role="_additional-resources"]
+.Additional resources
+
+* The Insights Operator is installed and enabled by default. If you need to opt out of remote health reporting, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting[Opting out of remote health reporting].
+
+* For more information on using Insights Advisor to identify issues with your cluster, see xref:../../support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc#using-insights-to-identify-issues-with-your-cluster[Using Insights to identify issues with your cluster].
+
+include::modules/insights-operator-downloading-archive.adoc[leveloffset=+1]
+include::modules/insights-operator-gather-duration.adoc[leveloffset=+1]

--- a/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
+++ b/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
@@ -9,7 +9,7 @@ endif::[]
 
 toc::[]
 
-Insights repeatedly analyzes the data Insights Operator sends. Users of {product-title} can display the report in the *Insights* tab of each cluster on {cluster-manager-url}.
+Insights repeatedly analyzes the data Insights Operator sends. Users of {product-title} can display the report in the {insights-advisor-url} service on {hybrid-console}.
 
 include::modules/insights-operator-advisor-overview.adoc[leveloffset=+1]
 include::modules/insights-operator-advisor-recommendations.adoc[leveloffset=+1]


### PR DESCRIPTION
New doc on how to access gather time duration from the Insights Operator archive.  

Versions: `enterprise-4.6`, `enterprise-4.7`, `enterprise-4.8`, `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`


Jira: https://issues.redhat.com/browse/CCXDEV-5230 

Preview(VPN required): http://file.brq.redhat.com/junixon/insights-operator-using/support/remote_health_monitoring/using-insights-operator.html

SME: tremes
QE: JoaoFula