### PR TITLE
BZ#2074819: Change the description of state migration in MTC documentation

### DIFF
--- a/migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc
@@ -16,7 +16,7 @@ You can use stage migration and cutover migration to migrate an application betw
 
 You can use state migration to migrate an application's state:
 
-* State migration copies selected persistent volume claims (PVCs) and Kubernetes resources.
+* State migration copies selected persistent volume claims (PVCs).
 * You can use state migration to migrate a namespace within the same cluster.
 
 Most cluster-scoped resources are not yet handled by {mtc-short}. If your applications require cluster-scoped resources, you might have to create them manually on the target cluster.

--- a/migration_toolkit_for_containers/about-mtc.adoc
+++ b/migration_toolkit_for_containers/about-mtc.adoc
@@ -13,7 +13,7 @@ The {mtc-full} ({mtc-short}) enables you to migrate stateful application workloa
 If you are migrating from {product-title} 3, see xref:../migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.adoc#about-migrating-from-3-to-4[About migrating from {product-title} 3 to 4] and xref:../migrating_from_ocp_3_to_4/installing-3-4.adoc#migration-installing-legacy-operator_installing-3-4[Installing the legacy {mtc-full} Operator on {product-title} 3].
 ====
 
-You can migrate applications within the same cluster by using state migration.
+You can migrate applications within the same cluster or between clusters by using state migration.
 
 {mtc-short} provides a web console and an API, based on Kubernetes custom resources, to help you control the migration and minimize application downtime.
 

--- a/migration_toolkit_for_containers/migrating-applications-with-mtc.adoc
+++ b/migration_toolkit_for_containers/migrating-applications-with-mtc.adoc
@@ -17,7 +17,7 @@ You can use stage migration and cutover migration to migrate an application betw
 
 You can use state migration to migrate an application's state:
 
-* State migration copies selected persistent volume claims (PVCs) and Kubernetes resources.
+* State migration copies selected persistent volume claims (PVCs).
 * You can use state migration to migrate a namespace within the same cluster.
 
 During migration, the {mtc-full} ({mtc-short}) preserves the following namespace annotations:

--- a/modules/migration-running-migration-plan-cam.adoc
+++ b/modules/migration-running-migration-plan-cam.adoc
@@ -35,7 +35,7 @@ The {mtc-short} web console must contain the following:
 +
 Optional: In the *Cutover migration* dialog, you can clear the *Halt transactions on the source cluster during migration* checkbox.
 
-* *State* copies selected persistent volume claims (PVCs) and Kubernetes resources that constitute an application's state. You can use state migration to migrate a namespace within the same cluster.
+* *State* copies selected persistent volume claims (PVCs).
 +
 [IMPORTANT]
 ====

--- a/modules/migration-terminology.adoc
+++ b/modules/migration-terminology.adoc
@@ -34,7 +34,7 @@ A remote cluster requires an exposed secure registry route for direct image migr
 
 Running a stage migration multiple times reduces the duration of the cutover migration.
 |Cutover migration |The application is stopped on the source cluster and its resources are migrated to the destination cluster.
-|State migration |Application state is migrated by copying specific persistent volume claims and Kubernetes objects to the destination cluster.
+|State migration |Application state is migrated by copying specific persistent volume claims to the destination cluster.
 |Rollback migration |Rollback migration rolls back a completed migration.
 |===
 ^1^  Called the _target_ cluster in the {mtc-short} web console.


### PR DESCRIPTION
MTC 1.7.1; OCP 4.6+

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2074819 -- Change the description of state migration in MTC documentation. 

Previews: 
1 https://deploy-preview-44543--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/migrating-applications-3-4.html [Removed reference to Kubernetes resources in the sentence that begins "State migration copies..." ]
2. https://deploy-preview-44543--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/about-mtc.html [Added reference to migration between clusters in the sentence after the note].
3. https://deploy-preview-44543--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/migrating-applications-3-4.html [Removed reference to Kubernetes resources in the bulleted item that begins "State migration copies..." ]
4. https://deploy-preview-44543--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/migrating-applications-with-mtc.html [Removed reference to Kubernetes resources in step 2 of the procedure at the very end of the section]
6.  https://deploy-preview-44543--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/about-mtc.html [Removed reference to Kubernetes objects in definition of "state migration" in the table.] 