### PR TITLE
RHDEVDOCS-3974 Create a ":builds-v1shortname: OpenShift Builds" attri…

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -50,6 +50,11 @@ endif::[]
 :mtc-version: 1.7
 :mtc-legacy-version: 1.5
 :mtc-legacy-version-z: 1.5.3
+// builds
+:builds-v1shortname: OpenShift Builds
+ifdef::openshift-origin[]
+:builds-v1shortname: Builds
+endif::[]
 //gitops
 :gitops-title: Red Hat OpenShift GitOps
 :gitops-shortname: GitOps


### PR DESCRIPTION
Purpose: Create a ":builds-v1shortname: OpenShift Builds" attribute for 4.10 and earlier

Aligned team: Dev Tools
- For branches: 
  - **NOT** main and enterprise-4.11
  - Yes for enterprise-4.10
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3974
- Direct link to doc preview: 
- SME review: @adambkaplan 
- QE review: @jitendar-singh 
- Peer review: @JStickler 
- <All reviews complete. Please merge now>