### PR TITLE
JIRA-OSDOCS3173: Updated AWS firewall allowlist

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="osd-aws-privatelink-firewall-prerequisites"]
-= Firewall prerequisites
+= AWS firewall prerequisites
 
 [IMPORTANT]
 ====
@@ -72,6 +72,11 @@ This section provides the necessary details that enable you to control egress tr
 |443
 |Provides core container images as a fallback when quay.io is not available.
 |===
++
+[NOTE]
+====
+Creating a firewall with a ROSA private cluster (non-PrivateLink) is not supported.
+====
 +
 When you add a site such as `quay.io` to your allowlist, do not add a wildcard entry such as `*.quay.io` to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a host name such as `cdn01.quay.io`.
 +
@@ -154,6 +159,14 @@ Alternatively, if you wish to not use a wildcard for Amazon Web Services (AWS) A
 |`elasticloadbalancing.<aws_region>.amazonaws.com`
 |443
 |Used to install and manage clusters in an AWS environment.
+
+|`servicequotas.<aws region>.amazonaws.com`
+|443, 80
+|Required. Used to confirm quotas for deploying the service.
+
+|`tagging.<region>.amazonaws.com`
+|443, 80
+|Allows the assignment of metadata about AWS resources in the form of tags.
 |===
 
 . Allowlist the following OpenShift URLs:


### PR DESCRIPTION
**This PR is to address the JIRA issue**: https://issues.redhat.com/browse/OSDOCS-3173

**Updated topic**:
https://deploy-preview-44546--osdocs.netlify.app/openshift-rosa/latest/rosa_planning/rosa-aws-prereqs#osd-aws-privatelink-firewall-prerequisites

**Following are the updates**:

1. Added a row to the second table in step 3 at the [AWS PrivateLink firewall prerequisites](https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites) containing:
URL: servicequotas.<aws region>.amazonaws.com 
Function: Required. Used to confirm quotas for deploying the service.
Port: 443, 80

2. Added another row to the same table containing:
URL: tagging.<region>.amazonaws.com
Function: Allows the assignment of metadata about AWS resources in the form of tags.
Port: 443, 80

3. Renamed the title here from "AWS PrivateLink firewall prerequisites" to "AWS firewall prerequisites".

4. Added a note stating that the table in step 1 on that page stating that "Creating a firewall with a ROSA private cluster (non-PrivateLink) is not supported."

**Repo**: Request cherrypick to enterprise-4.10 and enterprise-4.11