### PR TITLE
BZ2017421: Adding more info about the IPv6 address and gateway IP

### DIFF
--- a/modules/virt-configuring-masquerade-mode-dual-stack.adoc
+++ b/modules/virt-configuring-masquerade-mode-dual-stack.adoc
@@ -6,9 +6,9 @@
 [id="virt-configuring-masquerade-mode-dual-stack_{context}"]
 = Configuring masquerade mode with dual-stack (IPv4 and IPv6)
 
-You can configure a new virtual machine to use both IPv6 and IPv4 on the default pod network by using cloud-init.
+You can configure a new virtual machine (VM) to use both IPv6 and IPv4 on the default pod network by using cloud-init.
 
-The IPv6 network address must be statically set to `fd10:0:2::2/120` with a default gateway of `fd10:0:2::1` in the virtual machine configuration. These are used by the virt-launcher pod to route IPv6 traffic to the virtual machine and are not used externally.
+The `Network.pod.vmIPv6NetworkCIDR` field in the virtual machine instance configuration determines the static IPv6 address of the VM and the gateway IP address. These are used by the virt-launcher pod to route IPv6 traffic to the virtual machine and are not used externally. The `Network.pod.vmIPv6NetworkCIDR` field specifies an IPv6 address block in Classless Inter-Domain Routing (CIDR) notation. The default value is `fd10:0:2::2/120`. You can edit this value based on your network requirements.
 
 When the virtual machine is running, incoming and outgoing traffic for the virtual machine is routed to both the IPv4 address and the unique IPv6 address of the virt-launcher pod. The virt-launcher pod then routes the IPv4 traffic to the DHCP address of the virtual machine, and the IPv6 traffic to the statically set IPv6 address of the virtual machine.
 
@@ -47,8 +47,8 @@ metadata:
 ----
 <1> Connect using masquerade mode.
 <2> Allows incoming traffic on port 80 to the virtual machine.
-<3> You must use the IPv6 address `fd10:0:2::2/120`.
-<4> You must use the gateway `fd10:0:2::1`.
+<3> The static IPv6 address as determined by the `Network.pod.vmIPv6NetworkCIDR` field in the virtual machine instance configuration. The default value is `fd10:0:2::2/120`.
+<4> The gateway IP address as determined by the `Network.pod.vmIPv6NetworkCIDR` field in the virtual machine instance configuration. The default value is `fd10:0:2::1`.
 
 . Create the virtual machine in the namespace:
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2017421

Updated the “Configuring masquerade mode with dual stack” module to include information about how to configure the VM IPv6 address and gateway IP.

Applies to 4.9, 4.10, 4.11

Preview: https://deploy-preview-44548--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html#virt-configuring-masquerade-mode-dual-stack_virt-using-the-default-pod-network-with-virt