### PR TITLE
Adds notes for 4.7.48 release

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -3239,3 +3239,19 @@ Starting with {product-title} 4.7.47, support for using the Cloud Credential Ope
 ==== Updating
 
 To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-7-48"]
+=== RHBA-2022:1249 - {product-title} 4.7.48 bug fix and security update
+
+Issued: 2022-04-13
+
+{product-title} release 4.7.48, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1249[RHBA-2022:1249] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:1248[RHSA-2022:1248] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6903381[{product-title} 4.7.48 container image list]
+
+[id="ocp-4-7-48-updating"]
+==== Updating
+
+To update an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.7.48 release today.

- applies to `enterprise-4.7` only
- [preview link](https://deploy-preview-44549--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-48)