### PR TITLE
fix build errors for incorrect includes

### DIFF
--- a/networking/hardware_networks/uninstalling-sriov-operator.adoc
+++ b/networking/hardware_networks/uninstalling-sriov-operator.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 [id="uninstalling-sriov-operator"]
 = Uninstalling the SR-IOV Network Operator
-include::modules/common-attributes.adoc[]
+include::_attributes/common-attributes.adoc[]
 :context: uninstalling-sr-iov-operator
 
 toc::[]

--- a/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.adoc
+++ b/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 [id="sno-du-enabling-workload-partitioning-on-single-node-openshift"]
 = Workload partitioning on single node OpenShift
-include::modules/common-attributes.adoc[]
+include::_attributes/common-attributes.adoc[]
 :context: sno-du-enabling-workload-partitioning-on-single-node-openshift
 
 toc::[]


### PR DESCRIPTION
This PR fixes build errors in the following files: 
* networking/hardware_networks/uninstalling-sriov-operator.adoc
* scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.adoc

Above files updated with `include::_attributes/common-attributes.adoc[]`

Merge to main, enterprise-4.10, enterprise-4.11
