### PR TITLE
BZ2073610 - Adding note for extra storage when installing single node

### DIFF
--- a/modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc
+++ b/modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc
@@ -49,3 +49,8 @@ All DNS records must be subdomains of this base domain and include the cluster n
 . Download the discovery ISO.
 
 . Make a note of the discovery ISO URL for installing with virtual media.
+
+[NOTE]
+=====
+If you enable {VirtProductName} during this process, you must have a second local storage device of at least 50GiB for your virtual machines.
+=====


### PR DESCRIPTION
For versions 4.10+
[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2073610)

Description: Adding clarification note for storage when applying OpenShift virtualization.

Ready for QE
SME: Acked

Preview: [Installing OpenShift on a single node -> Generating the discovery ISO with the Assisted Installer](https://deploy-preview-44551--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno#install-sno-generating-the-discovery-iso-with-the-assisted-installer_install-sno-installing-sno-with-the-assisted-installer)
