### PR TITLE
CNV-13656: Move HA content to new section

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -26,33 +26,6 @@ include::snippets/technology-preview.adoc[leveloffset=+2]
 endif::[]
 --
 
-
-* Additionally, there are three options to maintain high availability (HA) of virtual machines:
-
-** Use xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[installer-provisioned infrastructure] and xref:../../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[deploy machine health checks].
-+
-[NOTE]
-====
-In {VirtProductName} clusters installed using installer-provisioned infrastructure and with MachineHealthCheck properly configured, if a node fails the MachineHealthCheck and becomes unavailable to the cluster, it is recycled. What happens next with VMs that ran on the failed node depends on a series of conditions. See xref:../../virt/virtual_machines/virt-create-vms.adoc#virt-about-runstrategies-vms_virt-create-vms[About RunStrategies for virtual machines] for more detailed information about the potential outcomes and how RunStrategies affect those outcomes.
-====
-
-** If you are not using installer-provisioned infrastructure, use either a monitoring system or a qualified human to monitor node availability. When a node is lost, shut it down and run `oc delete node <lost_node>`.
-+
-[NOTE]
-====
-Without an external monitoring system or a qualified human monitoring node health, virtual machines lose high availability.
-====
-
-** Use the xref:../../nodes/nodes/eco-node-health-check-operator.adoc#node-health-check-operator[Node Health Check Operator] on any {product-title} cluster to deploy the `NodeHealthCheck` controller. The controller identifies unhealthy nodes and uses the Poison Pill Operator to remediate the unhealthy nodes.
-+
---
-ifdef::openshift-enterprise[]
-:FeatureName: Node Health Check Operator
-include::snippets/technology-preview.adoc[leveloffset=+2]
-:!FeatureName:
-endif::[]
---
-
 * Shared storage is required to enable live migration.
 
 * You must manage your Compute nodes according to the number and size of the virtual machines that you want to host in the cluster.
@@ -77,6 +50,36 @@ endif::[]
 ====
 To obtain an evaluation version of {product-title}, download a trial
 from the {product-title} home page.
+====
+
+[id="virt-maintain-high-availability_preparing-cluster-for-virt"]
+== How to maintain high availability of virtual machines
+
+There are three options to maintain high availability (HA) of virtual machines:
+
+* Automatic high availability for xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[installer-provisioned infrastructure] (IPI) is available by deploying xref:../../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[machine health checks].
++
+[NOTE]
+====
+In {VirtProductName} clusters installed using installer-provisioned infrastructure and with MachineHealthCheck properly configured, if a node fails the MachineHealthCheck and becomes unavailable to the cluster, it is recycled. What happens next with VMs that ran on the failed node depends on a series of conditions. See xref:../../virt/virtual_machines/virt-create-vms.adoc#virt-about-runstrategies-vms_virt-create-vms[About RunStrategies for virtual machines] for more detailed information about the potential outcomes and how RunStrategies affect those outcomes.
+====
+
+
+* Automatic high availability for both IPI and non-IPI is available by using the xref:../../nodes/nodes/eco-node-health-check-operator.adoc#node-health-check-operator[Node Health Check Operator] on any {product-title} cluster to deploy the `NodeHealthCheck` controller. The controller identifies unhealthy nodes and uses the Self Node Remediation Operator to remediate the unhealthy nodes.
++
+--
+ifdef::openshift-enterprise[]
+:FeatureName: Node Health Check Operator
+include::snippets/technology-preview.adoc[leveloffset=+2]
+:!FeatureName:
+endif::[]
+--
+
+* High availability for any platform is available by using either a monitoring system or a qualified human to monitor node availability. When a node is lost, shut it down and run `oc delete node <lost_node>`.
++
+[NOTE]
+====
+Without an external monitoring system or a qualified human monitoring node health, virtual machines lose high availability.
 ====
 
 include::modules/virt-single-node-cluster.adoc[leveloffset=+1]


### PR DESCRIPTION
Re: [CNV-13656](https://issues.redhat.com//browse/CNV-13656)
For 4.11 and later

Preview: https://deploy-preview-44553--osdocs.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html#virt-maintain-high-availability_preparing-cluster-for-virt