### PR TITLE
BZ-1892592: adds specifying oc command to Ingress controller policy

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -56,6 +56,16 @@ spec:
   policyTypes:
   - Ingress
 ----
++
+[IMPORTANT]
+====
+When using the {product-title} Ingress Controller, you must apply the following policy to your project to ensure that outside traffic reaches the endpoint pod:
+
+[source,terminal]
+----
+$ oc label namespace default 'network.openshift.io/policy-group=ingress'
+----
+====
 
 * Only accept connections from pods within a project:
 +


### PR DESCRIPTION
4.6+

[BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1892592)

[Preview](https://deploy-preview-44562--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/about-network-policy.html)

Adds oc command to Ingress Controller policy to ensure outside traffic hits the endpoint pod.

@zhaozhanqi PTAL.