### PR TITLE
OSDOCS-2929: Added the maximum number of worker nodes to the Compute Nodes row

### DIFF
--- a/modules/rosa-sts-interactive-mode-reference.adoc
+++ b/modules/rosa-sts-interactive-mode-reference.adoc
@@ -51,7 +51,7 @@ You can create a {product-title} cluster with the AWS Security Token Service (ST
 |Enable compute node autoscaling. The autoscaler adjusts the size of the cluster to meet your deployment demands. The default is `No`.
 
 |`Compute nodes`
-|Specify the number of compute nodes to provision into each availability zone. Clusters deployed in a single availability zone require at least 2 nodes. Clusters deployed in multiple zones must have at least 3 nodes. The default is `2`.
+|Specify the number of compute nodes to provision into each availability zone. Clusters deployed in a single availability zone require at least 2 nodes. Clusters deployed in multiple zones must have at least 3 nodes. The maximum number of worker nodes is 180 nodes. The default value is `2`.
 
 |`Machine CIDR`
 |Specify the IP address range for machines (cluster nodes), which must encompass all CIDR address ranges for your VPC subnets. Subnets must be contiguous. A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones. The default is `10.0.0.0/16`. This range must not conflict with any connected networks.


### PR DESCRIPTION
This PR notes the maximum number of worker nodes (`180`) for compute nodes.

JIRA: https://issues.redhat.com/browse/OSDOCS-2929

PREVIEW: https://deploy-preview-44563--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-sts-interactive-mode-reference