### PR TITLE
Remove Alibaba step in ASH install docs

### DIFF
--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -1,18 +1,10 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_alibaba/installing-alibaba-default.adoc
-// * installing/installing_alibaba/installing-alibaba-customizations.adoc
 // * installing/installing_aws/manually-creating-iam.adoc
 // * installing/installing_azure/manually-creating-iam-azure.adoc
 // * installing/installing_gcp/manually-creating-iam-gcp.adoc
 // * installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc
 
-ifeval::["{context}" == "installing-alibaba-default"]
-:alibaba-default:
-endif::[]
-ifeval::["{context}" == "installing-alibaba-customizations"]
-:alibaba-custom:
-endif::[]
 ifeval::["{context}" == "manually-creating-iam-aws"]
 :aws:
 :cco-multi-mode:
@@ -45,15 +37,8 @@ endif::cco-multi-mode[]
 
 //For providers who only support manual mode
 ifdef::cco-manual-mode[]
-[id="manually-create-iam_{context}"]
 = Manually manage cloud credentials
 endif::cco-manual-mode[]
-
-//For providers that support multiple modes of operation
-ifdef::alibaba-default,alibaba-custom[]
-[id="manually-create-manifests_{context}"]
-= Generating the required installation manifests
-endif::alibaba-default,alibaba-custom[]
 
 //For providers that support multiple modes of operation
 ifdef::cco-multi-mode[]
@@ -67,10 +52,6 @@ endif::cco-multi-mode[]
 ifdef::cco-manual-mode[]
 The Cloud Credential Operator (CCO) only supports your cloud provider in manual mode. As a result, you must specify the identity and access management (IAM) secrets for your cloud provider.
 endif::cco-manual-mode[]
-
-ifdef::alibaba-default,alibaba-custom[]
-You must generate the Kubernetes manifest and Ignition config files that the cluster needs to configure the machines.
-endif::alibaba-default,alibaba-custom[]
 
 .Procedure
 
@@ -111,19 +92,6 @@ where:
 
 `<installation_directory>`:: Specifies the directory in which the installation program creates files.
 
-. Copy the generated credential files to the target manifests directory:
-+
-[source,terminal]
-----
-$ cp ./<path_to_ccoctl_output_dir>/manifests/*credentials.yaml ./<path_to_installation>dir>/manifests/
-----
-+
-where:
-
-`<path_to_ccoctl_output_dir>`:: Specifies the directory created by the `ccoctl alibabacloud create-ram-users` command.
-`<path_to_installation>dir>`:: Specifies the directory in which the installation program creates files.
-
-ifndef::alibaba-default,alibaba-custom[]
 . From the directory that contains the installation program, obtain details of the {product-title} release image that your `openshift-install` binary is built to use:
 +
 [source,terminal]
@@ -140,11 +108,6 @@ release image quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64
 . Locate all `CredentialsRequest` objects in this release image that target the cloud you are deploying on:
 +
 [source,terminal]
-ifdef::custom[]
-----
-$ oc adm release extract quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64 --credentials-requests --cloud=alibaba
-----
-endif::custom[]
 ifdef::aws[]
 ----
 $ oc adm release extract quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64 --credentials-requests --cloud=aws
@@ -163,39 +126,6 @@ endif::google-cloud-platform[]
 +
 This command creates a YAML file for each `CredentialsRequest` object.
 +
-ifdef::custom[]
-.Sample `CredentialsRequest` object
-[source,yaml]
-----
-apiVersion: cloudcredential.openshift.io/v1
-kind: CredentialsRequest
-metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: openshift-image-registry-alibaba
-  namespace: openshift-cloud-credential-operator
-  annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-spec:
-  secretRef:
-    name: installer-cloud-credentials
-    namespace: openshift-image-registry
-  providerSpec:
-    apiVersion: cloudcredential.openshift.io/v1
-    kind: AlibabaCloudProviderSpec
-    statementEntries:
-    - effect: Allow
-      action:
-      - oss:PutBucket
- ...
-      resource: "*"
-  serviceAccountNames:
-  - cluster-image-registry-operator
-  - registry
-----
-endif::custom[]
 ifdef::aws[]
 .Sample `CredentialsRequest` object
 [source,yaml]
@@ -307,14 +237,6 @@ endif::cco-multi-mode[]
 Before upgrading a cluster that uses manually maintained credentials, you must ensure that the CCO is in an upgradeable state.
 ====
 
-endif::alibaba-default,alibaba-custom[]
-
-ifeval::["{context}" == "manually-creating-alibaba-default"]
-:!alibaba-default:
-endif::[]
-ifeval::["{context}" == "installing-alibaba-customizations"]
-:!alibaba-custom:
-endif::[]
 ifeval::["{context}" == "manually-creating-iam-aws"]
 :!aws:
 :!cco-multi-mode:


### PR DESCRIPTION
Per @mjpytlak in Slack

Removed all Alibaba artifacts from `manually-create-identity-access-management.adoc` that were added via https://github.com/openshift/openshift-docs/pull/41083/files#diff-aba65666970ec0397d998aa5b6083c7ea6e71a39ec5b3a3de7e2192bdccf2f26.

The info was added to Alibaba install via https://github.com/openshift/openshift-docs/pull/41083/files#diff-c6f98021c4bef2d720b6a7f7c7dba39d2805e68ba95191c08ebb4ab31e3d9fbf

Preview: [ASH Manually manage cloud credentials](https://deploy-preview-44564--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.html#manually-create-iam_installing-azure-stack-hub-default)
[Alibaba Generating the required installation manifests](https://deploy-preview-44564--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-customizations.html#manually-creating-alibaba-manifests_installing-alibaba-customizations)
