### PR TITLE
MULTIARCH-1430 Add IBM z16 as supported model

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -111,3 +111,5 @@ endif::[]
 :SMProductVersion1x: 1.1.18
 //Windows containers
 :productwinc: Red Hat OpenShift support for Windows Containers
+// IBM zSystems
+:ibmzProductName: IBM Z

--- a/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
+++ b/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
@@ -50,9 +50,9 @@ See link:https://access.redhat.com/articles/rhel-limits[Red Hat Enterprise Linux
 The {product-title} installer creates the Ignition files, which are necessary for all the {op-system-first} virtual machines. The automated installation of {product-title} is performed by the bootstrap machine. It starts the installation of {product-title} on each node, starts the Kubernetes cluster, and then finishes. During this bootstrap, the virtual machine must have an established network connection either through a Dynamic Host Configuration Protocol (DHCP) server or static IP address.
 
 [id="ibm-z-network-connectivity_{context}"]
-== IBM Z network connectivity requirements
+== {ibmzProductName} network connectivity requirements
 
-To install on IBM Z under {op-system-base} KVM, you need:
+To install on {ibmzProductName} under {op-system-base} KVM, you need:
 
 *   A {op-system-base} KVM host configured with an OSA or RoCE network adapter.
 *   Either a {op-system-base} KVM host that is configured to use bridged networking in libvirt or MacVTap to connect the network to the guests.
@@ -65,21 +65,21 @@ The {op-system-base} KVM host in your environment must meet the following requir
 
 You can install {product-title} version {product-version} on the following IBM hardware:
 
-* IBM z15 (all models), IBM z14 (all models), IBM z13, and IBM z13s
+* IBM z16 (all models), IBM z15 (all models), IBM z14 (all models), IBM z13, and IBM z13s
 * LinuxONE, any version
 
 [id="minimum-ibm-z-system-requirements_{context}"]
-== Minimum IBM Z system environment
+== Minimum {ibmzProductName} system environment
 
 [discrete]
 === Hardware requirements
 
-* The equivalent of six IFLs, which are SMT2 enabled, for each cluster.
+* The equivalent of six Integrated Facilities for Linux (IFL), which are SMT2 enabled, for each cluster.
 * At least one network connection to both connect to the `LoadBalancer` service and to serve data for traffic outside the cluster.
 
 [NOTE]
 ====
-You can use dedicated or shared IFLs to assign sufficient compute resources. Resource sharing is one of the key strengths of IBM Z. However, you must adjust capacity correctly on each hypervisor layer and ensure sufficient resources for every {product-title} cluster.
+You can use dedicated or shared IFLs to assign sufficient compute resources. Resource sharing is one of the key strengths of {ibmzProductName}. However, you must adjust capacity correctly on each hypervisor layer and ensure sufficient resources for every {product-title} cluster.
 ====
 
 [IMPORTANT]
@@ -140,7 +140,7 @@ Each cluster virtual machine must meet the following minimum requirements:
 --
 
 [id="preferred-ibm-z-system-requirements_{context}"]
-== Preferred IBM Z system environment
+== Preferred {ibmzProductName} system environment
 
 [discrete]
 === Hardware requirements

--- a/modules/minimum-ibm-z-system-requirements.adoc
+++ b/modules/minimum-ibm-z-system-requirements.adoc
@@ -5,22 +5,22 @@
 
 :_content-type: CONCEPT
 [id="minimum-ibm-z-system-requirements_{context}"]
-= Minimum IBM Z system environment
+= Minimum {ibmzProductName} system environment
 
 You can install {product-title} version {product-version} on the following IBM hardware:
 
-* IBM z15 (all models), IBM z14 (all models), IBM z13, and IBM z13s
+* IBM z16 (all models), IBM z15 (all models), IBM z14 (all models), IBM z13, and IBM z13s
 * LinuxONE, any version
 
 [discrete]
 == Hardware requirements
 
-* The equivalent of 6 IFLs, which are SMT2 enabled, for each cluster.
+* The equivalent of six Integrated Facilities for Linux (IFL), which are SMT2 enabled, for each cluster.
 * At least one network connection to both connect to the `LoadBalancer` service and to serve data for traffic outside the cluster.
 
 [NOTE]
 ====
-You can use dedicated or shared IFLs to assign sufficient compute resources. Resource sharing is one of the key strengths of IBM Z. However, you must adjust capacity correctly on each hypervisor layer and ensure sufficient resources for every {product-title} cluster.
+You can use dedicated or shared IFLs to assign sufficient compute resources. Resource sharing is one of the key strengths of {ibmzProductName}. However, you must adjust capacity correctly on each hypervisor layer and ensure sufficient resources for every {product-title} cluster.
 ====
 
 [IMPORTANT]
@@ -35,14 +35,14 @@ Since the overall performance of the cluster can be impacted, the LPARs that are
 
 On your z/VM instance, set up:
 
-* 3 guest virtual machines for {product-title} control plane machines
-* 2 guest virtual machines for {product-title} compute machines
-* 1 guest virtual machine for the temporary {product-title} bootstrap machine
+* Three guest virtual machines for {product-title} control plane machines
+* Two guest virtual machines for {product-title} compute machines
+* One guest virtual machine for the temporary {product-title} bootstrap machine
 
 [discrete]
-== IBM Z network connectivity requirements
+== {ibmzProductName} network connectivity requirements
 
-To install on IBM Z under z/VM, you require a single z/VM virtual NIC in layer 2 mode. You also need:
+To install on {ibmzProductName} under z/VM, you require a single z/VM virtual NIC in layer 2 mode. You also need:
 
 *   A direct-attached OSA or RoCE network adapter
 *   A z/VM VSwitch set up. For a preferred setup, use OSA link aggregation.


### PR DESCRIPTION
- OCP version for cherry-picking: enterprise-4.10 and later

- Jira: https://issues.redhat.com/browse/MULTIARCH-1430
- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2075143

Also added IBM Z to common attributes, because there might be a brand name change coming up. 
 


- Preview
   - [Installing a cluster with z/VM on IBM Z and LinuxONE](https://deploy-preview-44567--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#minimum-ibm-z-system-requirements_installing-ibm-z)
   - [Installing a cluster with z/VM on IBM Z and LinuxONE in a restricted network](https://deploy-preview-44567--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z.html#minimum-ibm-z-system-requirements_installing-restricted-networks-ibm-z)
   - [Installing a cluster with RHEL KVM on IBM Z and LinuxONE](https://deploy-preview-44567--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html#host-machine-resource-requirements_installing-ibm-z-kvm)
   - [Installing a cluster with RHEL KVM on IBM Z and LinuxONE in a restricted network](https://deploy-preview-44567--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.html#host-machine-resource-requirements_installing-restricted-networks-ibm-z-kvm)

- QE review: Holger Wolf






