### PR TITLE
Drop ifeval for configuring bios module

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -54,9 +54,7 @@ include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leve
 
 include::modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc[leveloffset=+2]
 
-ifeval::[{product-version} > 4.8]
 include::modules/ipi-install-configuring-bios-for-worker-node.adoc[leveloffset=+2]
-endif::[]
 
 include::modules/ipi-install-configuring-raid-for-worker-node.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Apply to 4.9+

According to [guidelines](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#conditional-content), it is not recommended to use `ifeval` to vary content based on product version. The `ifeval` here is redundant and buggy.

Fix #44541

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>