### PR TITLE
Renaming overview to fix broken breadcrumb link

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2238,8 +2238,8 @@ Name: Backup and restore
 Dir: backup_and_restore
 Distros: openshift-origin,openshift-enterprise
 Topics:
-- Name: Overview of backup and restore operations
-  File: index
+- Name: Backup and restore operations
+  File: backup-restore-overview
 - Name: Shutting down a cluster gracefully
   File: graceful-cluster-shutdown
 - Name: Restarting a cluster gracefully

--- a/backup_and_restore/backup-restore-overview.adoc
+++ b/backup_and_restore/backup-restore-overview.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
-[id="backup-restore-overview"]
-= Backup and restore
 include::_attributes/common-attributes.adoc[]
+[id="backup-restore-overview"]
+= Backup and restore operations
 :context: backup-restore-overview
 :backup-restore-overview:
 :velero-domain: velero.io

--- a/virt/backup_restore/virt-backup-restore-overview.adoc
+++ b/virt/backup_restore/virt-backup-restore-overview.adoc
@@ -18,6 +18,6 @@ You restore the `Backup` CR by creating a `Restore` CR.
 [id="additional-resources_{context}"]
 == Additional resources
 
-* xref:../../backup_and_restore/index.adoc#application-backup-restore-operations-overview_backup-restore-overview[OADP overview]
+* xref:../../backup_and_restore/backup-restore-overview.adoc#application-backup-restore-operations-overview_backup-restore-overview[OADP overview]
 * xref:../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-features-plugins[OADP features and plugins]
 * xref:../../backup_and_restore/application_backup_and_restore/troubleshooting.adoc#troubleshooting[Troubleshooting]

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -28,7 +28,7 @@ Use the following sections to find content to help you learn about and use {prod
 | link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[{product-title} life cycle]
 
 |
-| xref:../backup_and_restore/index.adoc#backup-restore-overview[Backup and restore]
+| xref:../backup_and_restore/backup-restore-overview.adoc#backup-restore-overview[Backup and restore]
 |
 
 |
@@ -64,7 +64,7 @@ Use the following sections to find content to help you learn about and use {prod
 |
 
 |
-| xref:../backup_and_restore/index.adoc#backup-restore-overview[Backup and restore]
+| xref:../backup_and_restore/backup-restore-overview.adoc#backup-restore-overview[Backup and restore]
 |
 |
 


### PR DESCRIPTION
Renaming backup restore overview file to fix broken breadcrumb link (Backup and restore)

Preview: https://deploy-preview-44569--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/backup-restore-overview.html