### PR TITLE
BZ2068283 - Adding clarification for IPsec

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -209,7 +209,7 @@ the Cluster Version Operator on port `9099`.
 |`10256`
 |openshift-sdn
 
-.3+|UDP
+.5+|UDP
 |`4789`
 |VXLAN
 
@@ -219,9 +219,19 @@ the Cluster Version Operator on port `9099`.
 |`9000`-`9999`
 |Host level services, including the node exporter on ports `9100`-`9101`.
 
+|`500`
+|IPsec IKE packets
+
+|`4500`
+|IPsec NAT-T packets
+
 |TCP/UDP
 |`30000`-`32767`
 |Kubernetes node port
+
+|ESP
+|N/A
+|IPsec Encapsulating Security Payload (ESP)
 
 |===
 

--- a/modules/nw-ovn-ipsec-traffic.adoc
+++ b/modules/nw-ovn-ipsec-traffic.adoc
@@ -19,3 +19,30 @@ The following traffic flows are not encrypted:
 The encrypted and unencrypted flows are illustrated in the following diagram:
 
 image::nw-ipsec-encryption.png[IPsec encrypted and unencrypted traffic flows]
+
+== Network connectivity requirements when IPsec is enabled
+
+You must configure the network connectivity between machines to allow {product-title} cluster
+components to communicate. Each machine must be able to resolve the hostnames
+of all other machines in the cluster.
+
+.Ports used for all-machine to all-machine communications
+[cols="2a,2a,5a",options="header"]
+|===
+
+|Protocol
+|Port
+|Description
+
+.2+|UDP
+|`500`
+|IPsec IKE packets
+
+|`4500`
+|IPsec NAT-T packets
+
+|ESP
+|N/A
+|IPsec Encapsulating Security Payload (ESP)
+
+|===


### PR DESCRIPTION
For Versons 4.8+
[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2068283)

Preview:

- [Installing a cluster on vSphere with user-provisioned infrastructure](https://deploy-preview-44577--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-network-user-infra_installing-vsphere)
- [Installing a cluster on any platform](https://deploy-preview-44577--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-network-user-infra_installing-platform-agnostic)
- [IPsec encryption configuration](https://deploy-preview-44577--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ipsec-ovn.html#network-connectivity-requirements-when-ipsec-is-enabled)

