### PR TITLE
RHDEVDOCS-3963 Note only for 4.11+

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -50,7 +50,7 @@ endif::[]
 :mtc-version: 1.7
 :mtc-legacy-version: 1.5
 :mtc-legacy-version-z: 1.5.3
-// builds
+// builds (Valid only in 4.11 and later)
 :builds-v2title: Builds for Red Hat OpenShift
 :builds-v2shortname: OpenShift Builds v2
 :builds-v1shortname: OpenShift Builds v1


### PR DESCRIPTION
Purpose: Add a note to the comment line that these attributes are valid only for 4.11 and later 
 Aligned team: Dev Tools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3963
- Direct link to doc preview: NA
- All reviews completed in https://github.com/openshift/openshift-docs/pull/44433. Ready for merge.