### PR TITLE
Fixing broken ROSA cross-reference

### DIFF
--- a/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-installing-rosa.adoc
+++ b/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-installing-rosa.adoc
@@ -13,7 +13,7 @@ include::modules/rosa-installing.adoc[leveloffset=+1]
 [id="next-steps_rosa-installing-rosa"]
 == Next steps
 
-* xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-creating-cluster.adoc#rosa-creating-cluster[Create a ROSA cluster] or xref:../rosa-aws-privatelink-creating-cluster.adoc#rosa-aws-privatelink-creating-cluster[Create an AWS PrivateLink cluster on ROSA].
+* xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-creating-cluster.adoc#rosa-creating-cluster[Create a ROSA cluster] or xref:../../rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.adoc#rosa-aws-privatelink-creating-cluster[Create an AWS PrivateLink cluster on ROSA].
 
 [id="additional-resources_rosa-installing-rosa"]
 [role="_additional-resources"]


### PR DESCRIPTION
This applies to `main`, `enterprise-4.11` and `enterprise.4.10`.

This pull request resolves a broken cross reference in the ROSA library. The broken cross reference is causing a ROSA sync script issue.

The preview is [here](https://deploy-preview-44602--osdocs.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-installing-rosa.html).