### PR TITLE
RHDEVDOCS-3483 - fix for remote_write feature incorrectly listed as experimental

### DIFF
--- a/rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.adoc
+++ b/rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.adoc
@@ -282,7 +282,7 @@ Type::
 
 | `remoteWrite`
 | `array`
-| If specified, the remote_write spec. This is an experimental feature, it may change in any upcoming release in a breaking way.
+| If specified, the remote_write spec.
 
 | `remoteWrite[]`
 | `object`
@@ -6895,7 +6895,7 @@ Required::
 Description::
 +
 --
-If specified, the remote_write spec. This is an experimental feature, it may change in any upcoming release in a breaking way.
+If specified, the remote_write spec.
 --
 
 Type::


### PR DESCRIPTION
Summary: This PR fixes an issue with the monitoring API docs in which the remote_write feature was incorrectly listed as experimental.

- Aligned team: DevTools
- For branches: 4.9 AND 4.10
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3483
- Direct link to doc preview: https://deploy-preview-44603--osdocs.netlify.app/openshift-enterprise/latest/rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.html#spec-remotewrite
- SME review: @
- QE review: @ tbd
- Peer review: @ tbd