### PR TITLE
[enterprise-4.6] BZ2064162 - Adding missing disktype in azure parameters

### DIFF
--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -43,6 +43,7 @@ controlPlane: <2>
     azure:
       osDisk:
         diskSizeGB: 1024 <5>
+        diskType: Premium_LRS
       type: Standard_D8s_v3
   replicas: 3
 compute: <2>
@@ -53,6 +54,7 @@ compute: <2>
       type: Standard_D2s_v3
       osDisk:
         diskSizeGB: 512 <5>
+        diskType: Standard_LRS
       zones: <6>
       - "1"
       - "2"

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -661,9 +661,21 @@ Additional Azure configuration parameters are described in the following table:
 |====
 |Parameter|Description|Values
 
+|`compute.platform.azure.osDisk.diskSizeGB`
+|The Azure disk size for the VM.
+|Integer that represents the size of the disk in GB. The default is `128`.
+
+|`compute.platform.azure.osDisk.diskType`
+|Defines the type of disk.
+|`standard_LRS`, `premium_LRS`, or `standardSSD_LRS`. The default is `premium_LRS`.
+
 |`controlPlane.platform.azure.osDisk.diskSizeGB`
 |The Azure disk size for the VM.
-|Integer that represents the size of the disk in GB. The minimum supported disk size is `1024`.
+|Integer that represents the size of the disk in GB. The default is `1024`.
+
+|`controlPlane.platform.azure.osDisk.diskType`
+|Defines the type of disk.
+|`premium_LRS` or `standardSSD_LRS`. The default is `premium_LRS`.
 
 |`platform.azure.baseDomainResourceGroupName`
 |The name of the resource group that contains the DNS zone for your base domain.


### PR DESCRIPTION
Conflicts: 
modules/installation-azure-config-yaml.adoc
modules/installation-configuration-parameters.adoc

Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/44058