### PR TITLE
Adds notes for 4.10.10 release and Telco RAN GA

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2699,7 +2699,6 @@ link:https://access.redhat.com/solutions/6849321[{product-title} 4.10.6 containe
 ==== Updates from Kubernetes 1.23.5
 This update contains changes from Kubernetes 1.23.3 up to 1.23.5. More information can be found in the following changelogs: link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#v1234[1.23.4] and link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#v1235[1.23.5]
 
-
 [id="ocp-4-10-6-bug-fixes"]
 ==== Bug fixes
 * Previously, the query for subnets in Cisco ACI's neutron implementation, which is avaiable in {rh-openstack-first}-16, returned unexpected results for a given network. Consequently, the {rh-openstack} `cluster-api-provider` could potentially try to provision instances with duplicated ports on the same subnet, which caused failed provision. With this update, an additional filter is added in the {rh-openstack} `cluster-api-provider` to ensure there is only one port per subnet. As a result, it is now possible to deploy {product-title} on {rh-openstack}-16 with Cisco ACI. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2050064[*BZ#2050064*])
@@ -2770,6 +2769,27 @@ link:https://access.redhat.com/solutions/6902561[{product-title} 4.10.9 containe
 * When updating to {product-title} 4.10.9, the etcd pod fails to start and the etcd Operator falls into a `degraded` state. A future version of {product-title} will resolve this issue. For more information, see link:https://access.redhat.com/solutions/6907321[etcd pod is failing to start after updating {product-title} 4.9.28 or 4.10.9] and link:https://access.redhat.com/solutions/6849521[Potential etcd data inconsistency issue in OCP 4.9 and 4.10].
 
 [id="ocp-4-10-9-updating"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-10"]
+=== RHSA-2022:1357 - {product-title} 4.10.10 bug fix and security update
+
+Issued: 2022-04-20
+
+{product-title} release 4.10.10 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:1357[RHSA-2022:1357] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1355[RHBA-2022:1355] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6932751[{product-title} 4.10.10 container image list]
+
+[id="ocp-4-10-10-bug-fixes"]
+==== Bug fixes
+
+* Previously, the cluster storage Operator credentials request for Amazon Web Services (AWS) did not include KMS statements. Consequently, persistent volumes (PVs) failed to deploy due to the inability to provide a key. With this update, the default credentials request for AWS now allows the mounting of encrypted volumes using customer-managed keys from KMS. Administrators who create credentials requests in manual mode with Cloud Credential Operator (CCO) must apply those changes manually. Other administrators should not be impacted by this change. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2072191[*BZ#2072191*])
+
+[id="ocp-4-10-10-updating"]
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 20-04-2022 4.10.10 release. Also includes notes for Telco RAN GA.

- Applies to `enterprise-4.10` only
- [4.10.10 notes preview link](https://deploy-preview-44654--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-10)

Telco RAN release:
- [Tech preview table preview link](url) not included yet
- [Notes added to enhancement section](url) not included yet