### PR TITLE
BZ2070775: Correcting Example VM Manifest for VM node placement with nodeSelector

### DIFF
--- a/modules/virt-example-vm-node-placement-node-selector.adoc
+++ b/modules/virt-example-vm-node-placement-node-selector.adoc
@@ -20,8 +20,10 @@ metadata:
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 spec:
-  nodeSelector:
-    example-key-1: example-value-1
-    example-key-2: example-value-2
+  template:
+    spec:
+      nodeSelector:
+        example-key-1: example-value-1
+        example-key-2: example-value-2
 ...
 ----


### PR DESCRIPTION
This PR addresses bug [BZ2070775](https://bugzilla.redhat.com/show_bug.cgi?id=2070775) and its associated JIRA story [CNV17333](https://issues.redhat.com/browse/CNV-17333).

The bug asks for a correction to the Example VM Manifest in the [Example: VM node placement with nodeSelector](https://docs.openshift.com/container-platform/4.10/virt/virtual_machines/advanced_vm_management/virt-specifying-nodes-for-vms.html#virt-example-vm-node-placement-node-selector_virt-specifying-nodes-for-vms) section of [Specifying nodes for virtual machines](https://docs.openshift.com/container-platform/4.10/virt/virtual_machines/advanced_vm_management/virt-specifying-nodes-for-vms.html).

CP: 4.8, 4.9, 4.10, 4.11

Preview: https://deploy-preview-44659--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-specifying-nodes-for-vms.html#virt-example-vm-node-placement-node-selector_virt-specifying-nodes-for-vms