### PR TITLE
TELCODOCS-324 Fix Typo for v4.8-4.11

### DIFF
--- a/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
+++ b/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
@@ -14,7 +14,7 @@ In the event of a previous failed deployment, remove the artifacts from the fail
 +
 [source,terminal]
 ----
-$ ipmitool -I lanplus -U _<user>_ -P _<password>_ -H _<management-server-ip>_ power off
+$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
 ----
 
 ifeval::[{product-version} >= 4.6]


### PR DESCRIPTION
Fixes: [issues.redhat.com/browse/TELCODOCS-324](https://issues.redhat.com/browse/TELCODOCS-324)

For: Version 4.8-4.11

[NOTE] This is a typo fix for: https://github.com/openshift/openshift-docs/pull/42991

Doc Preview: [deploy-preview-44666--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-the-bare-metal-node_ipi-install-expanding](https://deploy-preview-42991--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.html#ipi-install-troubleshooting-cleaning-up-previous-installations_ipi-install-troubleshooting)

Signed-off-by: Katie Tothill [ktothill@redhat.com](mailto:ktothill@redhat.com)