### PR TITLE
BZ2075801 - Fixing arm machine type table

### DIFF
--- a/modules/installation-supported-aws-machine-types.adoc
+++ b/modules/installation-supported-aws-machine-types.adoc
@@ -462,11 +462,11 @@ ifndef::aws-restricted-upi,aws-govcloud,aws-secret,aws-china[]
 |`c6g.large`
 |x
 |
-|x
+|
 
 |`c6g.xlarge`
 |
-|x
+|
 |x
 
 |`c6g.2xlarge`


### PR DESCRIPTION
For versions 4.10+
[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2075801)

Description: Fixing error in arm64 machine types table 

Ready for QE: @lwan-wanglin 

Preview: [Installing a cluster on AWS with customizations -> Supported AWS machine types
](https://deploy-preview-44668--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-supported-aws-machine-types_installing-aws-customizations)