### PR TITLE
[virt] adding back erroneously removed RN

### DIFF
--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -171,6 +171,9 @@ To use the HPP to provide storage for virtual machine disks, configure it with d
 [id="virt-4-10-known-issues"]
 == Known issues
 
+* If a single node contains more than 50 images, pod scheduling might be imbalanced across nodes. This is because the list of images on a node is shortened to 50 by default. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1984442[*BZ#1984442*])
+** As a workaround, you can disable the image limit by xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing[editing the `KubeletConfig` object] and setting the value of `nodeStatusMaxImages` to `-1`.
+
 * If you deploy the xref:../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-configuring-local-storage-for-vms[hostpath provisioner] on a cluster where any node has a fully qualified domain name (FQDN) that exceeds 42 characters, the provisioner fails to bind PVCs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057157[*BZ#2057157*])
 +
 --


### PR DESCRIPTION
- This RN was erroneously removed in the final RN sweep, so I am adding it back.
- [CNV-13681](https://issues.redhat.com/browse/CNV-13681) is the original Jira
- https://github.com/openshift/openshift-docs/pull/41303 is the original PR
- @sabrinajess and @mgarrellRH FYI

Preview build: https://deploy-preview-44677--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-10-release-notes.html#virt-4-10-known-issues