### PR TITLE
JIRA-OSDOCS3264: Updated the patch and release management content for OSD

### DIFF
--- a/modules/policy-change-management.adoc
+++ b/modules/policy-change-management.adoc
@@ -55,17 +55,11 @@ An authorized SRE reviewer must approve advancement to each step. The reviewer m
 [id="patch-management_{context}"]
 == Patch management
 
-OpenShift Container Platform software and the underlying immutable Red Hat Enterprise Linux CoreOS (RHCOS) operating system image are patched for bugs and vulnerabilities as a side effect of regular z-stream upgrades. Read more about link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/architecture/architecture-rhcos[RHCOS architecture] in the OpenShift Container Platform documentation.
+OpenShift Container Platform software and the underlying immutable Red Hat Enterprise Linux CoreOS (RHCOS) operating system image are patched for bugs and vulnerabilities in regular z-stream upgrades. Read more about link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/architecture/architecture-rhcos[RHCOS architecture] in the OpenShift Container Platform documentation.
 
 // TODO: checking whether the OCP reference above should be dedicated? Either way, the attribute version should probably be used throughout the above paragraph
 
 [id="release-management_{context}"]
 == Release management
 
-{product-title} clusters are upgraded as frequently as weekly to ensure that the latest security patches and bug fixes are applied to {product-title} clusters.
-
-Patch-level upgrades, also referred to as z-stream upgrades (for example, 4.3.18 to 4.3.19), are automatically deployed on Tuesdays. New z-stream releases are tested nightly with automated {product-title} integration testing and released only once validated in the OSD environment.
-
-Minor version upgrades, also referred to as y-stream upgrades (for example, 4.3 to 4.4), are coordinated with customers by email notification.
-
-Customers can review the history of all cluster upgrade events in their {cluster-manager} web console.
+Red Hat does not automatically upgrade your clusters. You can schedule to upgrade the clusters at regular intervals (recurring upgrade) or just once (individual upgrade) using the {cluster-manager} web console. Red Hat might forcefully upgrade a cluster to a new z-stream version only if the cluster is affected by a critical impact CVE. You can review the history of all cluster upgrade events in the {cluster-manager} web console. For more information about releases, see the link:https://docs.openshift.com/dedicated/osd_policy/osd-life-cycle.html[Life Cycle policy].


### PR DESCRIPTION
This PR is to address the JIRA issue: https://issues.redhat.com/browse/OSDOCS-3264

Following is the change:
Updated the 'Patch Management' and 'Release Management' sections in OSD docs.

The change is seen in the following topic:
https://deploy-preview-44690--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/policy-process-security#patch-management_policy-process-security

Repo: Request cherrypick to enterprise-4.10 and enterprise-4.11