### PR TITLE
JIRA-OSDOCS3265: Updated the release management content for ROSA

### DIFF
--- a/modules/rosa-policy-change-management.adoc
+++ b/modules/rosa-policy-change-management.adoc
@@ -62,6 +62,11 @@ OpenShift Container Platform software and the underlying immutable Red Hat CoreO
 [id="rosa-policy-release-management_{context}"]
 == Release management
 
-ROSA clusters can be configured for automatic upgrades on a schedule. Alternatively, you can perform manual upgrades using the `rosa` CLI. For more details, see the link:https://access.redhat.com/support/policy/updates/openshift/dedicated[Life Cycle policy].
+Red Hat does not automatically upgrade your clusters. You can schedule to upgrade the clusters at regular intervals (recurring upgrade) or just once (individual upgrade) using the {cluster-manager} web console. Red Hat might forcefully upgrade a cluster to a new z-stream version only if the cluster is affected by a critical impact CVE.
 
-Customers can review the history of all cluster upgrade events in their {cluster-manager} web console on the Events tab.
+[NOTE]
+====
+ROSA clusters that use the AWS Security Token Service (STS) need an interruption between upgrades to ensure that the STS roles and policies are updated. Therefore, you cannot schedule recurring upgrades on ROSA clusters with STS.
+====
+
+You can review the history of all cluster upgrade events in the {cluster-manager} web console. For more information about releases, see the link:https://access.redhat.com/support/policy/updates/openshift/dedicated[Life Cycle policy].


### PR DESCRIPTION
This PR is to address the JIRA issue: https://issues.redhat.com/browse/OSDOCS-3265

Following is the change:
Updated the 'Release Management' section in OSD docs.

The change is seen in the following topic:
https://deploy-preview-44691--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security#rosa-policy-release-management_rosa-policy-process-security

Repo: Request cherrypick to enterprise-4.10 and enterprise-4.11