### PR TITLE
MULTIARCH-1458, 1457:  IBM Z & Power: Compliance Operator, ODF changes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -292,6 +292,7 @@ The following new features are supported on IBM Z and LinuxONE with {product-tit
 ** IPAM
 ** IPVLAN
 
+* Compliance Operator 0.1.49
 * NMState Operator
 * OVN-Kubernetes IPsec encryption
 * Vertical Pod Autoscaler Operator
@@ -303,6 +304,7 @@ The following features are also supported on IBM Z and LinuxONE:
 
 * Currently, the following Operators are supported:
 ** Cluster Logging Operator
+** Compliance Operator 0.1.49
 ** Local Storage Operator
 ** NFD Operator
 ** NMState Operator
@@ -349,7 +351,7 @@ The following restrictions impact {product-title} on IBM Z and LinuxONE:
 ** Tang mode disk encryption during {product-title} deployment
 
 * Worker nodes must run {op-system-first}
-* Persistent shared storage must be provisioned by using either NFS or other supported storage protocols
+* Persistent shared storage must be provisioned by using either {rh-storage} or other supported storage protocols
 * Persistent non-shared storage must be provisioned using local storage, like iSCSI, FC, or using LSO with DASD, FCP, or EDEV/FBA
 
 [id="ocp-4-10-ibm-power"]
@@ -372,6 +374,7 @@ The following new features are supported on IBM Power with {product-title} {prod
 ** IPAM
 ** IPVLAN
 
+* Compliance Operator 0.1.49
 * NMState Operator
 * OVN-Kubernetes IPsec encryption
 * Vertical Pod Autoscaler Operator
@@ -383,6 +386,7 @@ The following features are also supported on IBM Power:
 
 * Currently, the following Operators are supported:
 ** Cluster Logging Operator
+** Compliance Operator 0.1.49
 ** Local Storage Operator
 ** NFD Operator
 ** NMState Operator
@@ -425,7 +429,7 @@ The following restrictions impact {product-title} on IBM Power:
 ** Tang mode disk encryption during {product-title} deployment
 
 * Worker nodes must run {op-system-first}
-* Persistent storage must be of the Filesystem type that uses local volumes, Network File System (NFS), or Container Storage Interface (CSI)
+* Persistent storage must be of the Filesystem type that uses local volumes, {rh-storage}, Network File System (NFS), or Container Storage Interface (CSI)
 
 // Remove after 4.10
 


### PR DESCRIPTION
This PR adds Compliance Operator support for IBM Z and IBM Power and changes rec. persistent storage to ODF in the OCP 4.10 Release Notes. 

https://issues.redhat.com/browse/MULTIARCH-1458
https://issues.redhat.com/browse/MULTIARCH-1457

PR for Compliance Operator RNs (merged 4/18): 
https://issues.redhat.com/browse/OSDOCS-3210

BZ to change persistent storage from NFS to ODF:  https://bugzilla.redhat.com/show_bug.cgi?id=2066332
 - The ODF change has already been acked in a mail thread with etamir@redhat.com, dhardie@redhat.com, gcharot@redhat.com, stev.glodowski@de.ibm.com; Holger.Wolf@de.ibm.com; cbryan@us.ibm.com

Preview: 
- [IBM Z](https://deploy-preview-44692--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-ibm-z)
- [IBM Power](https://deploy-preview-44692--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-ibm-power)

QE Review: 
- IBM Z - Holger Wolf
- IBM Power - Manoj Kumar