### PR TITLE
CNV-13468: Updated HCO version variable for 2.6.10

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -58,7 +58,7 @@ endif::[]
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 2.6
 :KubeVirtVersion: v0.36.5
-:HCOVersion: 2.6.9
+:HCOVersion: 2.6.10
 :delete: image:delete.png[title="Delete"]
 ifdef::openshift-origin[]
 :VirtProductName: OKD Virtualization


### PR DESCRIPTION
[CNV-13468](https://issues.redhat.com//browse/CNV-13468)

Updated the HCO version variable for the 2.6.10 z-stream release