### PR TITLE
BZ19677592: Removes the appsDomain parameter from the table

### DIFF
--- a/modules/nw-ingress-configuring-application-domain.adoc
+++ b/modules/nw-ingress-configuring-application-domain.adoc
@@ -5,7 +5,7 @@
 
 :_content-type: PROCEDURE
 [id="nw-ingress-configuring-application-domain_{context}"]
-= Configuring application domain for the Ingress Controller Operator
+= Specifying an alternative cluster domain using the appsDomain option
 
 //OpenShift Dedicated or Amazon RH OpenShift cluster administrator
 
@@ -23,7 +23,7 @@ For example, you can use the DNS domain for your company as the default domain f
 
 . Configure the `appsDomain` field by specifying an alternative default domain for user-created routes.
 +
-.. Edit the Ingress Controller Operator:
+.. Edit the ingress `cluster` resource:
 +
 [source,terminal]
 ----

--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -25,9 +25,6 @@ The `domain` value must be unique among all Ingress Controllers and cannot be up
 
 If empty, the default value is `ingress.config.openshift.io/cluster` `.spec.domain`.
 
-|`appsDomain`
-|`appsDomain` is an optional domain for {product-title} to use instead of the one specified in the `domain` field when a Route is created without specifying an explicit host. If a value is entered for `appsDomain`, this value is used to generate default host values for the Route. Unlike `domain`, `appsDomain` can be modified after installation. You can use this parameter only if you set up a new Ingress Controller that uses a wildcard certificate.
-
 |`replicas`
 |`replicas` is the desired number of Ingress Controller replicas. If not set, the default value is `2`.
 


### PR DESCRIPTION
This PR removes the `appsDomain` parameter from the `Ingress controller configuration parameters` table
OCP version: 4.7+
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1967592)
[Preview](https://deploy-preview-44699--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress)
QE contact @zhaozhanqi 