### PR TITLE
OSDOCS-3201: Detailed various ocm roles

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -96,6 +96,8 @@ Distros: openshift-rosa
 Topics:
 - Name: AWS prerequisites for ROSA with STS
   File: rosa-sts-aws-prereqs
+- Name: OpenShift Cluster Manager roles and permissions
+  File: rosa-sts-ocm-roles-and-permissions
 - Name: Limits and scalability
   File: rosa-limits-scalability
 - Name: Planning your environment

--- a/rosa_planning/rosa-sts-ocm-roles-and-permissions.adoc
+++ b/rosa_planning/rosa-sts-ocm-roles-and-permissions.adoc
@@ -1,0 +1,61 @@
+:_content-type: ASSEMBLY
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-sts-ocm-roles-and-permissions
+[id="rosa-sts-ocm-roles-and-permissions_{context}"]
+= {cluster-manager} roles and permissions
+
+When creating clusters, you need to have at least three roles created to create and use the clusters. These roles are:
+
+* A user role
+* A basic `ocm-role`
+* An admin `ocm-role`
+
+[id="rosa-sts-ocm-roles-and-permissions-iam-user-role_{context}"]
+== User role
+
+The user role has no additional permissions. {cluster-manager} identifies this user role and creates trust between this role, the Red Hat account, and the two `ocm-role` resources that you create.
+
+//Used to identify the user by creating a trust between it, Red Hat account and the ocm role.
+
+[id="rosa-sts-ocm-roles-and-permissions-iam-basic-role_{context}"]
+== Creating basic {cluster-manager} permissions
+
+You create a basic `ocm-role` by using the following command:
+
+[source,terminal]
+----
+rosa create ocm-role
+----
+
+This command creates the role, prompting you for specifications for the role. The basic `ocm-role` contains the following permissions:
+
+* iam:GetOpenIDConnectProvider
+* iam:GetRole
+* iam:ListRoles
+* iam:ListRoleTags
+* ec2:DescribeRegions
+* ec2:DescribeRouteTables
+* ec2:DescribeSubnets
+* ec2:DescribeVpcs
+* sts:AssumeRole
+* sts:AssumeRoleWithWebIdentity
+
+[id="rosa-sts-ocm-roles-and-permissions-iam-admin-role__{context}"]
+== Creating admin {cluster-manager} permissions
+
+You create an administrator `ocm-role` by using the following command:
+
+[source,terminal]
+----
+rosa create ocm-role --admin
+----
+
+This command creates the role, prompting you for specifications for the role. The admin `ocm-role` contains all of the permissions of the basic `ocm` role as well as
+
+* iam:AttachRolePolicy
+* iam:CreateOpenIDConnectProvider
+* iam:CreateRole
+* iam:ListPolicies
+* iam:ListPolicyTags
+* iam:PutRolePermissionsBoundary
+* iam:TagRole


### PR DESCRIPTION
This PR adds descriptions of the roles required for ROSA cluster creation.

JIRA: https://issues.redhat.com/browse/OSDOCS-3201

PREVIEW: https://deploy-preview-44707--osdocs.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-ocm-roles-and-permissions.html