### PR TITLE
RHDEVDOCS-3917 - document new authentication methods for remote_write in monitoring

### DIFF
--- a/modules/monitoring-configuring-remote-write-storage.adoc
+++ b/modules/monitoring-configuring-remote-write-storage.adoc
@@ -21,14 +21,24 @@ Doing so has no impact on how or for how long Prometheus stores metrics.
 * You have installed the OpenShift CLI (`oc`).
 * You have set up a remote write compatible endpoint (such as Thanos) and know the endpoint URL.
 See the link:https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage[Prometheus remote endpoints and storage documentation] for information about endpoints that are compatible with the remote write feature.
-* You have set up authentication credentials for the remote write endpoint. 
+* You have set up authentication credentials in a `Secret` object for the remote write endpoint.
+You must create the secret in the same namespace as the Prometheus object for which you configure remote write:  the `openshift-monitoring` namespace for default platform monitoring or the `openshift-user-workload-monitoring` namespace for user workload monitoring.
+ 
 +
 [CAUTION]
 ====
-To reduce security risks, avoid sending metrics to an endpoint via unencrypted HTTP or without using authentication.
+To reduce security risks, use HTTPS and authentication to send metrics to an endpoint.
 ====
 
 .Procedure
+
+Follow these steps to configure remote write for default platform monitoring in the `cluster-monitoring-config` config map in the `openshift-monitoring` namespace.
+
+[NOTE]
+====
+If you configure remote write for the Prometheus instance that monitors user-defined projects, make similar edits to the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace. 
+Note that the Prometheus config map component is called `prometheus` in the `user-workload-monitoring-config` `ConfigMap` object and not `prometheusK8s`, as it is in the `cluster-monitoring-config` `ConfigMap` object. 
+====
 
 . Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
 +
@@ -52,89 +62,14 @@ data:
   config.yaml: |
     prometheusK8s:
       remoteWrite:
-      - url: "https://remote-write.endpoint"
-        <endpoint_authentication_credentials>
+      - url: "https://remote-write-endpoint.example.com" <1>
+        <endpoint_authentication_credentials> <2>
 ----
 +
-For `endpoint_authentication_credentials` substitute the credentials for the endpoint.
-Currently supported authentication methods are basic authentication (`basicAuth`) and client TLS (`tlsConfig`) authentication.
-+
-* The following example configures basic authentication:
-+
-[source,yaml]
-----
-basicAuth:
-  username:
-    <usernameSecret>
-  password:
-    <passwordSecret>
-----
-Substitute `<usernameSecret>` and `<passwordSecret>` accordingly. 
-+
-The following sample shows basic authentication configured with `remoteWriteAuth` for the `name` values and `user` and `password` for the `key` values. These values contain the endpoint authentication credentials:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
-data:
-  config.yaml: |
-    prometheusK8s:
-      remoteWrite:
-      - url: "https://remote-write.endpoint"
-        basicAuth:
-          username:
-            name: remoteWriteAuth
-            key: user
-          password:
-            name: remoteWriteAuth
-            key: password
-----
-+
-* The following example configures client TLS authentication:
-+
-[source,yaml]
-----
-tlsConfig:
-  ca:
-    <caSecret>
-  cert:
-    <certSecret>
-  keySecret:
-    <keySecret>
-----
-Substitute `<caSecret>`, `<certSecret>`, and `<keySecret>` accordingly. 
-+
-The following sample shows a TLS authentication configuration using `selfsigned-mtls-bundle` for the `name` values and `ca.crt` for the `ca` `key` value, `client.crt` for the `cert` `key` value, and `client.key` for the `keySecret` `key` value:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
-data:
-  config.yaml: |
-    prometheusK8s:
-      remoteWrite:
-      - url: "https://remote-write.endpoint"
-        tlsConfig:
-          ca:
-            secret:
-              name: selfsigned-mtls-bundle
-              key: ca.crt
-          cert:
-            secret:
-              name: selfsigned-mtls-bundle
-              key: client.crt
-          keySecret:
-            name: selfsigned-mtls-bundle
-            key: client.key
-----
+<1> The URL of the remote write endpoint.
+<2> The authentication method and credentials for the endpoint.
+Currently supported authentication methods are AWS Signature Version 4, authentication using HTTP an `Authorization` request header, basic authentication, OAuth 2.0, and TLS client. 
+See _Supported remote write authentication settings_ below for sample configurations of supported authentication methods.
 
 . Add write relabel configuration values after the authentication credentials:
 +
@@ -149,10 +84,11 @@ data:
   config.yaml: |
     prometheusK8s:
       remoteWrite:
-      - url: "https://remote-write.endpoint"
+      - url: "https://remote-write-endpoint.example.com"
         <endpoint_authentication_credentials>
-        <write_relabel_configs>
+        <write_relabel_configs> <1>
 ----
+<1> The write relabel configuration settings.
 +
 For `<write_relabel_configs>` substitute a list of write relabel configurations for metrics that you want to send to the remote endpoint.
 +
@@ -169,7 +105,7 @@ data:
   config.yaml: |
     prometheusK8s:
       remoteWrite:
-      - url: "https://remote-write.endpoint"
+      - url: "https://remote-write-endpoint.example.com"
         writeRelabelConfigs:
         - sourceLabels: [__name__]
           regex: 'my_metric'
@@ -178,29 +114,6 @@ data:
 ----
 +
 See the link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[Prometheus relabel_config documentation] for information about write relabel configuration options.
-
-. If required, configure remote write for the Prometheus instance that monitors user-defined projects by changing the `name` and `namespace` `metadata` values as follows:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    prometheus:
-      remoteWrite:
-      - url: "https://remote-write.endpoint"
-        <endpoint_authentication_credentials>
-        <write_relabel_configs>
-----
-+
-[NOTE]
-====
-The Prometheus config map component is called `prometheusK8s` in the `cluster-monitoring-config` `ConfigMap` object and `prometheus` in the `user-workload-monitoring-config` `ConfigMap` object.
-====
 
 . Save the file to apply the changes to the `ConfigMap` object.
 The pods affected by the new configuration restart automatically.
@@ -214,4 +127,3 @@ Configurations applied to the `user-workload-monitoring-config` `ConfigMap` obje
 ====
 Saving changes to a monitoring `ConfigMap` object might redeploy the pods and other resources in the related project. Saving changes might also restart the running monitoring processes in that project.
 ====
-

--- a/modules/monitoring-supported-remote-write-authentication-settings.adoc
+++ b/modules/monitoring-supported-remote-write-authentication-settings.adoc
@@ -1,0 +1,314 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+:_content-type: REFERENCE
+[id="supported_remote_write_authentication_settings_{context}"]
+= Supported remote write authentication settings
+
+You can use different methods to authenticate with a remote write endpoint.
+Currently supported authentication methods are AWS Signature Version 4, basic authentication, authorization, OAuth 2.0, and TLS client.
+The following table provides details about supported authentication methods for use with remote write.
+
+[options="header"]
+|===
+
+|Authentication method|Config map field|Description
+
+|AWS Signature Version 4|`sigv4`|This method uses AWS Signature Version 4 authentication to sign requests.
+You cannot use this method simultaneously with authorization, OAuth 2.0, or basic authentication.
+
+|basic authentication|`basicAuth`|Basic authentication sets the authorization header on every remote write request with the configured username and password.
+
+|authorization|`authorization`|Authorization sets the `Authorization` header on every remote write request using the configured token.
+
+|OAuth 2.0|`oauth2`|An OAuth 2.0 configuration uses the client credentials grant type. 
+Prometheus fetches an access token from `tokenUrl` with the specified client ID and client secret to access the remote write endpoint.
+You cannot use this method simultaneously with authorization, AWS Signature Version 4, or basic authentication.
+
+|TLS client|`tlsConfig`|A TLS client configuration specifies the CA certificate, the client certificate, and the client key file information used to authenticate with the remote write endpoint server using TLS.
+The sample configuration assumes that you have already created a CA certificate file, a client certificate file, and a client key file.
+
+|===
+
+== Config map location for authentication settings
+The following shows the location of the authentication configuration in the `ConfigMap` object for default platform monitoring.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      remoteWrite:
+      - url: "https://remote-write-endpoint.example.com" <1>
+        <endpoint_authentication_details> <2>
+----
+<1> The URL of the remote write endpoint.
+<2> The required configuration details for the authentication method for the endpoint.
+Currently supported authentication methods are Amazon Web Services (AWS) Signature Version 4, authorization, basic authentication, OAuth 2.0, and TLS client. 
+
+[NOTE]
+====
+If you configure remote write for the Prometheus instance that monitors user-defined projects, edit the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace.
+Note that the Prometheus config map component is called `prometheus` in the `user-workload-monitoring-config` `ConfigMap` object and not `prometheusK8s`, as it is in the `cluster-monitoring-config` `ConfigMap` object. 
+====
+
+== Example remote write authentication settings
+
+The following samples show different authentication settings you can use to connect to a remote write endpoint.
+Each sample also shows how to configure a corresponding `Secret` object that contains authentication credentials and other relevant settings.
+Each sample configures authentication for use with default platform monitoring in the `openshift-monitoring` namespace.
+
+.Sample YAML for AWS Signature Version 4 authentication
+
+The following shows the settings for a `sigv4` secret named `sigv4-credentials` in the `openshift-monitoring` namespace.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sigv4-credentials
+  namespace: openshift-monitoring
+stringData:
+  accessKey: <AWS_access_key> <1>
+  secretKey: <AWS_secret_key> <2>
+type: Opaque
+----
+<1> The AWS API access key.
+<2> The AWS API secret key.
+
+The following shows sample AWS Signature Version 4 remote write authentication settings that use a `Secret` object named `sigv4-credentials` in the `openshift-monitoring` namespace:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      remoteWrite:
+      - url: "https://authorization.example.com/api/write"
+        sigv4:
+          region: <AWS_region> <1>
+          accessKey:
+            name: sigv4-credentials <2>
+            key: accessKey <3>
+          secretKey:
+            name: sigv4-credentials <2>
+            key: secretKey <4>
+          profile: <AWS_profile_name> <5>
+          roleArn: <AWS_role_arn> <6>
+----
+<1> The AWS region.
+<2> The name of the `Secret` object containing the AWS API access credentials.
+<3> The key that contains the AWS API access key in the specified `Secret` object.
+<4> The key that contains teh AWS API secret key in the specified `Secret` object.
+<5> The name of the AWS profile that is being used to authenticate.
+<6> The unique identifier for the Amazon Resource Name (ARN) assigned to your role.
+
+.Sample YAML for basic authentication
+
+The following shows sample basic authentication settings for a `Secret` object named `rw-basic-auth` in the `openshift-monitoring` namespace: 
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rw-basic-auth
+  namespace: openshift-monitoring
+stringData:
+  user: <basic_username> <1>
+  password: <basic_password> <2>
+type: Opaque
+----
+<1> The username.
+<2> The password.
+
+The following sample shows a `basicAuth` remote write configuration that uses a `Secret` object named `rw-basic-auth` in the `openshift-monitoring` namespace.
+It assumes that you have already set up authentication credentials for the endpoint. 
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      remoteWrite:
+      - url: "https://basicauth.example.com/api/write"
+        basicAuth:
+          username:
+            name: rw-basic-auth <1>
+            key: user <2>
+          password:
+            name: rw-basic-auth <1>
+            key: password <3>
+----
+<1> The name of the `Secret` object that contains the authentication credentials.
+<2> The key that contains the username  in the specified `Secret` object.
+<3> The key that contains the password in the specified `Secret` object.
+
+.Sample YAML for authentication with a bearer token using a `Secret` Object
+
+The following shows bearer token settings for a `Secret` object named `rw-bearer-auth` in the `openshift-monitoring` namespace:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rw-bearer-auth
+  namespace: openshift-monitoring
+stringData:
+  token: <authentication_token> <1>
+type: Opaque
+----
+<1> The authentication token.
+
+The following shows sample bearer token config map settings that use a `Secret` object named `rw-bearer-auth` in the `openshift-monitoring` namespace:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+    prometheusK8s:
+      remoteWrite:
+      - url: "https://authorization.example.com/api/write"
+        authorization:
+          type: Bearer <1>
+          credentials:
+            name: rw-bearer-auth <2>
+            key: token <3>
+----
+<1> The authentication type of the request. The default value is `Bearer`.
+<2> The name of the `Secret` object that contains the authentication credentials.
+<3> The key that contains the authentication token in the specified `Secret` object.
+
+.Sample YAML for OAuth 2.0 authentication
+
+The following shows sample OAuth 2.0 settings for a `Secret` object named `oauth2-credentials` in the `openshift-monitoring` namespace:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oauth2-credentials
+  namespace: openshift-monitoring
+stringData:
+  id: <oauth2_id> <1>
+  secret: <oauth2_secret> <2>
+  token: <oauth2_authentication_token> <3>
+type: Opaque
+----
+<1> The Oauth 2.0 ID.
+<2> The OAuth 2.0 secret.
+<3> The OAuth 2.0 token.
+
+The following shows an `oauth2` remote write authentication sample configuration that uses a `Secret` object named `oauth2-credentials` in the `openshift-monitoring` namespace:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      remoteWrite:
+      - url: "https://test.example.com/api/write"
+        oauth2:
+          clientId:
+            secret:
+              name: oauth2-credentials <1>
+              key: id <2>
+          clientSecret:
+            name: oauth2-credentials <1>
+            key: secret <2>
+          tokenUrl: https://example.com/oauth2/token <3>
+          scopes: <4>
+          - <scope_1>
+          - <scope_2>
+          endpointParams: <5>
+            param1: <parameter_1>
+            param2: <parameter_2>
+----
+<1> The name of the corresponding `Secret` object. Note that `ClientId` can alternatively refer to a `ConfigMap` object, although `clientSecret` must refer to a `Secret` object.
+<2> The key that contains the OAuth 2.0 credentials in the specified `Secret` object.
+<3> The URL used to fetch a token with the specified `clientId` and `clientSecret`.
+<4> The OAuth 2.0 scopes for the authorization request. These scopes limit what data the tokens can access.
+<5> The OAuth 2.0 authorization request parameters required for the authorization server.
+
+.Sample YAML for TLS client authentication
+
+The following shows sample TLS client settings for a `tls` `Secret` object named `mtls-bundle` in the `openshift-monitoring` namespace.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mtls-bundle
+  namespace: openshift-monitoring
+data:
+  ca.crt: <ca_cert> <1>
+  client.crt: <client_cert> <2>
+  client.key: <client_key> <3>
+type: tls
+----
+<1> The CA certificate in the Prometheus container with which to validate the server certificate. 
+<2> The client certificate for authentication with the server.
+<3> The client key.
+
+The following sample shows a `tlsConfig` remote write authentication configuration that uses a TLS `Secret` object named `mtls-bundle`.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      remoteWrite:
+      - url: "https://remote-write-endpoint.example.com"
+        tlsConfig:
+          ca:
+            secret:
+              name: mtls-bundle <1>
+              key: ca.crt <2>
+          cert:
+            secret:
+              name: mtls-bundle <1>
+              key: client.crt <3>
+          keySecret:
+            name: mtls-bundle <1>
+            key: client.key <4>
+----
+<1> The name of the corresponding `Secret` object that contains the TLS authentication credentials. Note that `ca` and `cert` can alternatively refer to a `ConfigMap` object, though `keySecret` must refer to a `Secret` object.
+<2> The key in the specified `Secret` object that contains the CA certificate for the endpoint.
+<3> The key in the specified `Secret` object that contains the client certificate for the endpoint.
+<4> The key in the specified `Secret` object that contains the client key secret.

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -108,13 +108,16 @@ include::modules/monitoring-modifying-retention-time-for-prometheus-metrics-data
 
 // Configuring remote write storage for Prometheus
 include::modules/monitoring-configuring-remote-write-storage.adoc[leveloffset=+1]
+// Configuring remote write authentication methods for Prometheus
+include::modules/monitoring-supported-remote-write-authentication-settings.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
 * See link:https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage[Setting up remote write compatible endpoints] for steps to create a remote write compatible endpoint (such as Thanos).
 * See link:https://prometheus.io/docs/practices/remote_write/#remote-write-tuning[Tuning remote write settings] for information about how to optimize remote write settings for different use cases.
-* For information about additional optional fields, please refer to the API documentation.
+* See xref:../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets-about_nodes-pods-secrets[Understanding secrets] for steps to create and configure `Secret` objects in {product-title}.
+* See the xref:../rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.adoc#spec-remotewrite-2[Prometheus REST API reference for remote write] for information about additional optional fields.
 
 // Managing scrape sample limits for user-defined projects
 include::modules/monitoring-limiting-scrape-samples-in-user-defined-projects.adoc[leveloffset=+1]


### PR DESCRIPTION
Summary: This PR documents additional endpoint authentication methods for the remote_write feature in OCP monitoriing.

- Aligned team: DevTools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3917
- Direct link to doc preview: https://deploy-preview-44713--osdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#configuring_remote_write_storage_configuring-the-monitoring-stack
- SME review: @raptorsun @JoaoBraveCoding @simonpasquier 
- QE review: @juzhao @lihongyan1 
- Peer review: @rolfedh 