### PR TITLE
Adds 4.9.29 release notes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2756,3 +2756,27 @@ link:https://access.redhat.com/solutions/6906441[{product-title} 4.9.28 containe
 ==== Updating
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[[ocp-4-9-29]]
+=== RHSA-2022:1363 - {product-title} 4.9.29 bug fix and security update
+
+Issued: 2022-04-20
+
+{product-title} release 4.9.29, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:1363[RHSA-2022:1363] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1362[RHBA-2022:1362] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6934361[{product-title} 4.9.29 container image list]
+
+[id="ocp-4-9-29-bug-fixes"]
+==== Bug fixes
+* Previously, the Local Storage Operator (LSO) added an `OwnerReference` object to the persistent volumes (PV) it created, which sometimes caused an issue where a delete request for a PV could leave the PV in the `terminating` state while still attached to the pod. With this update, the LSO no longer creates an `OwnerReference` object, and cluster administrators can delete unused PVs after a node is removed from the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2070617[*BZ#2070617*])
+
+* Previously, `oc adm must gather` fell back to the `oc adm inspect` command when the specified image could not run. Consequently, it was difficult to understand information from the logs when the fallback happened. With this update, the logs are improved to make it explicit when a fallback inspection is performed. As a result, the output of `oc adm must gather` is easier to understand. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2051944[*BZ#2051944*])
+
+* Previously, hard-coded BusyBox image from the Docker was used for the scorecard. Consequently, the Docker's new rate limit caused periodic failures when running the scorecard. This fix recommends to use the Universal Base Image (UBI) `registry.access.redhat.com/ubi8/ubi:8.4` for the scorecard, resulting no failures due to rate limiting. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2064408[*BZ#2064408*])
+
+[id="ocp-4-9-29-updating"]
+==== Updating
+
+To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

To be merged on 04-20. I will send a reminder today when the erratas are shipped live.

OCP version: **only Enterprise-4.9**

Direct Doc Preview Link: https://deploy-preview-44728--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-29