### PR TITLE
BZ2003499: Updated apiVersion for ingressController

### DIFF
--- a/modules/tls-profiles-ingress-configuring.adoc
+++ b/modules/tls-profiles-ingress-configuring.adoc
@@ -11,7 +11,7 @@ To configure a TLS security profile for an Ingress Controller, edit the `Ingress
 .Sample `IngressController` CR that configures the `Old` TLS security profile
 [source,yaml]
 ----
-apiVersion: config.openshift.io/v1
+apiVersion: operator.openshift.io/v1
 kind: IngressController
  ...
 spec:


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2003499

OCP version: 4.9+

Direct Doc Preview Link: https://deploy-preview-44729--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#tls-profiles-ingress-configuring_configuring-ingress

@cchen666 Please review and let me know your feedback. FYI, this PR is applicable to 4.9+. For versions below 4.9, I will create another PR and link it here.