### PR TITLE
BZ2003499-enterprise-4.8: Updates apiVersion for IngressController

### DIFF
--- a/modules/tls-profiles-ingress-configuring.adoc
+++ b/modules/tls-profiles-ingress-configuring.adoc
@@ -11,7 +11,7 @@ To configure a TLS security profile for an Ingress Controller, edit the `Ingress
 .Sample `IngressController` CR that configures the `Old` TLS security profile
 [source,yaml]
 ----
-apiVersion: config.openshift.io/v1
+apiVersion: operator.openshift.io/v1
 kind: IngressController
  ...
 spec:


### PR DESCRIPTION
This PR is related to #44729

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2003499

OCP version: **4.8, 4.7, and 4.6**
@peer-review-sqaud - Please backport this PR to 4.7 and 4.6 as well. Don't merge to main.

Direct Doc Preview Link: https://deploy-preview-44730--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#tls-profiles-ingress-configuring_configuring-ingress