### PR TITLE
OSDOCS3023: Change "config" to "configuration"

### DIFF
--- a/modules/update-using-custom-machine-config-pools-mcp-remove.adoc
+++ b/modules/update-using-custom-machine-config-pools-mcp-remove.adoc
@@ -3,9 +3,9 @@
 // * updating/update-using-custom-machine-config-pools.adoc
 
 [id="update-using-custom-machine-config-pools-mcp-remove_{context}"]
-= Moving a node to the original machine config pool
+= Moving a node to the original machine configuration pool
 
-In this canary rollout update process, after you have unpaused a custom machine config pool (MCP) and verified that the applications on the nodes associated with that MCP are working as expected, you should move the node back to its original MCP by removing the custom label you added to the node.
+In this canary rollout update process, after you have unpaused a custom machine configuration pool (MCP) and verified that the applications on the nodes associated with that MCP are working as expected, you should move the node back to its original MCP by removing the custom label you added to the node.
 
 [IMPORTANT]
 ====
@@ -29,10 +29,10 @@ $ oc label node ci-ln-0qv1yp2-f76d1-kl2tq-worker-a-j2ssz node-role.kubernetes.io
 error: 'node-role.kubernetes.io/worker' already has a value (), and --overwrite is false
 ----
 +
-If the node does not have a `worker` label or a label from an updated MCP, add the label. 
+If the node does not have a `worker` label or a label from an updated MCP, add the label.
 ////
 
-. Remove the custom label from the node. 
+. Remove the custom label from the node.
 +
 [source,terminal]
 ----
@@ -78,4 +78,3 @@ The node is removed from the custom MCP and moved back to the original MCP. It c
 ----
 $ oc delete mcp <mcp_name>
 ----
-

--- a/modules/update-using-custom-machine-config-pools-mcp.adoc
+++ b/modules/update-using-custom-machine-config-pools-mcp.adoc
@@ -3,9 +3,9 @@
 // * updating/update-using-custom-machine-config-pools.adoc
 
 [id="update-using-custom-machine-config-pools-mcp_{context}"]
-= Creating machine config pools to perform a canary rollout update
+= Creating machine configuration pools to perform a canary rollout update
 
-The first task in performing this canary rollout update is to create one or more machine config pools (MCP). 
+The first task in performing this canary rollout update is to create one or more machine configuration pools (MCP).
 
 . Create an MCP from a worker node.
 
@@ -61,7 +61,7 @@ spec:
          key: machineconfiguration.openshift.io/role,
          operator: In,
          values: [worker,workerpool-canary]
-        } 
+        }
   nodeSelector:
     matchLabels:
       node-role.kubernetes.io/workerpool-canary: "" <3>
@@ -98,6 +98,4 @@ workerpool-canary rendered-workerpool-canary-87ba3dec1ad78cb6aecebf7fbb476a36   
 worker            rendered-worker-87ba3dec1ad78cb6aecebf7fbb476a36              True      False      False      2              2                   2                     0                      97m
 ----
 +
-The new machine config pool, `workerpool-canary`, is created and the number of nodes to which you added the custom label are shown in the machine counts. The worker MCP machine counts are reduced by the same number. It can take several minutes to update the machine counts. In this example, one node was moved from the `worker` MCP to the `workerpool-canary` MCP.
-
-
+The new machine configuration pool, `workerpool-canary`, is created and the number of nodes to which you added the custom label are shown in the machine counts. The worker MCP machine counts are reduced by the same number. It can take several minutes to update the machine counts. In this example, one node was moved from the `worker` MCP to the `workerpool-canary` MCP.

--- a/modules/update-using-custom-machine-config-pools-pause.adoc
+++ b/modules/update-using-custom-machine-config-pools-pause.adoc
@@ -3,9 +3,9 @@
 // * updating/update-using-custom-machine-config-pools.adoc
 
 [id="update-using-custom-machine-config-pools-pause_{context}"]
-= Pausing the machine config pools
+= Pausing the machine configuration pools
 
-In this canary rollout update process, after you label the nodes that you do not want to update with the rest of your {product-title} cluster and create the machine config pools (MCPs), you pause those MCPs. Pausing an MCP prevents the Machine Config Operator (MCO) from updating the nodes associated with that MCP.
+In this canary rollout update process, after you label the nodes that you do not want to update with the rest of your {product-title} cluster and create the machine configuration pools (MCPs), you pause those MCPs. Pausing an MCP prevents the Machine Config Operator (MCO) from updating the nodes associated with that MCP.
 
 [NOTE]
 ====
@@ -33,4 +33,3 @@ $  oc patch mcp/workerpool-canary --patch '{"spec":{"paused":true}}' --type=merg
 ----
 machineconfigpool.machineconfiguration.openshift.io/workerpool-canary patched
 ----
-

--- a/modules/update-using-custom-machine-config-pools-unpause.adoc
+++ b/modules/update-using-custom-machine-config-pools-unpause.adoc
@@ -3,9 +3,9 @@
 // * updating/update-using-custom-machine-config-pools.adoc
 
 [id="update-using-custom-machine-config-pools-unpause_{context}"]
-= Unpausing the machine config pools
+= Unpausing the machine configuration pools
 
-In this canary rollout update process, after the {product-title} update is complete, unpause your custom MCPs one-by-one. Unpausing an MCP allows the Machine Config Operator (MCO) to update the nodes associated with that MCP.
+In this canary rollout update process, after the {product-title} update is complete, unpause your custom MCPs one-by-one. Unpausing an MCP allows the Machine Configuration Operator (MCO) to update the nodes associated with that MCP.
 
 To unpause an MCP:
 
@@ -40,4 +40,3 @@ You can check the progress of the update by using the `oc get machineconfigpools
 == In case of application failure
 
 In case of a failure, such as your applications not working on the updated nodes, you can cordon and drain the nodes in the pool, which moves the application pods to other nodes to help maintain the quality-of-service for the applications. This first MCP should be no larger than the excess capacity.
-


### PR DESCRIPTION
This change is a part of OSDOCS3023. 
This PR changes the word `config` to `configuration`
OCP version: 4.7+
QE contact: @jiajliu 
[Jira](https://issues.redhat.com/browse/OSDOCS-3023)
Previews:
[Creating machine configuration pools to perform a canary rollout update](https://deploy-preview-44734--osdocs.netlify.app/openshift-enterprise/latest/updating/update-using-custom-machine-config-pools.html#update-using-custom-machine-config-pools-mcp_update-using-custom-machine-config-pools)
[Pausing the machine configuration pools](https://deploy-preview-44734--osdocs.netlify.app/openshift-enterprise/latest/updating/update-using-custom-machine-config-pools.html#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools)
[Unpausing the machine configuration pools](https://deploy-preview-44734--osdocs.netlify.app/openshift-enterprise/latest/updating/update-using-custom-machine-config-pools.html#update-using-custom-machine-config-pools-unpause_update-using-custom-machine-config-pools)
[Moving a node to the original machine configuration pool](https://deploy-preview-44734--osdocs.netlify.app/openshift-enterprise/latest/updating/update-using-custom-machine-config-pools.html#update-using-custom-machine-config-pools-mcp-remove_update-using-custom-machine-config-pools)