### PR TITLE
add a note about azure file csi operator missing snapshot support

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-azure-file.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-azure-file.adoc
@@ -20,6 +20,11 @@ To create CSI-provisioned PVs that mount to Azure File storage assets with this 
 
 * The _Azure File CSI driver_ enables you to create and mount Azure File PVs.
 
+[IMPORTANT]
+====
+_Azure File CSI Driver Operator_ currently does not support snapshots.
+====
+
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 
 :FeatureName: Azure File


### PR DESCRIPTION
Due to a known [limitation](https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/136) of Azure File SDK snapshots can not be restored at this moment.

To prevent users from creating snapshots they can not later recover in OCP we have decided to disable snapshots altogether in [Azure File CSI Operator](https://github.com/openshift/azure-file-csi-driver-operator/pull/26).

Currently we don't know if or when the support will be added.