### PR TITLE
[GH44741] Correct supported ShiftStack versions 

### DIFF
--- a/modules/supported-platforms-for-openshift-clusters.adoc
+++ b/modules/supported-platforms-for-openshift-clusters.adoc
@@ -13,7 +13,7 @@ In {product-title} {product-version}, you can install a cluster that uses instal
 * Google Cloud Platform (GCP)
 * Microsoft Azure
 * Microsoft Azure Stack Hub
-* {rh-openstack-first} version 13 and 16
+* {rh-openstack-first} versions 16.1 and 16.2 
 ** The latest {product-title} release supports both the latest {rh-openstack} long-life release and intermediate release. For complete {rh-openstack} release compatibility, see the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 * IBM Cloud
 * {rh-virtualization-first}
@@ -38,7 +38,7 @@ In {product-title} {product-version}, you can install a cluster that uses user-p
 * Azure
 * Azure Stack Hub
 * GCP
-* {rh-openstack}
+* {rh-openstack} versions 16.1 and 16.2
 * {rh-virtualization}
 * VMware vSphere
 * VMware Cloud on AWS


### PR DESCRIPTION
FYI @EricArrakis 

Fixes #44741

Preview: https://deploy-preview-44750--osdocs.netlify.app/openshift-enterprise/latest/architecture/architecture-installation.html#supported-platforms-for-openshift-clusters_architecture-installation

QE ack: https://github.com/openshift/openshift-docs/pull/44750#issuecomment-1106473823