### PR TITLE
fixes invalid YAML example by changing capitalization

### DIFF
--- a/modules/machineset-yaml-rhv.adoc
+++ b/modules/machineset-yaml-rhv.adoc
@@ -23,7 +23,7 @@ metadata:
   namespace: openshift-machine-api
 spec:
   replicas: <number_of_replicas> <4>
-  Selector: <5>
+  selector: <5>
     matchLabels:
       machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <3>


### PR DESCRIPTION
The word `selector` should be lowercase in order for the example YAML to
be valid. The example YAML for other providers has the correct lowercase
word.

fixes #44753