### PR TITLE
Change in must-gather image

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 :namespace: openshift-adp
 :local-product: OADP
 :velero-domain: velero.io
-:must-gather: registry.access.redhat.com/oadp-operator/oadp-must-gather-rhel8:v1.0
+:must-gather: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.0
 
 toc::[]
 


### PR DESCRIPTION
OADP 1.0.2 

Resolves: https://issues.redhat.com/browse/OADP-439

Corrects the OADP must-gather image in the documentation. 

Preview: https://deploy-preview-44764--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html  [Scroll down to "using the must-gather tool"] 