### PR TITLE
GH#44121: OKD Documentation still mentions RedHat Enterprise Linux and Fedora 8

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -11,13 +11,17 @@
 :prewrap!:
 :op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
 :op-system: RHCOS
+:op-system-lowercase: rhcos
 :op-system-base: RHEL
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
+:op-system-version: 8.x
 ifdef::openshift-origin[]
 :op-system-first: Fedora CoreOS (FCOS)
 :op-system: FCOS
+:op-system-lowercase: fcos
 :op-system-base: Fedora
 :op-system-base-full: Fedora
+:op-system-version: 35
 endif::[]
 :tsb-name: Template Service Broker
 :kebab: image:kebab.png[title="Options menu"]

--- a/modules/configuring-huge-pages.adoc
+++ b/modules/configuring-huge-pages.adoc
@@ -93,10 +93,12 @@ $ oc get node <node_using_hugepages> -o jsonpath="{.status.allocatable.hugepages
 100Mi
 ----
 
+ifndef::openshift-origin[]
 [WARNING]
 ====
 This functionality is currently only supported on {op-system-first} 8.x worker nodes. On {op-system-base-full} 7.x worker nodes the TuneD `[bootloader]` plug-in is currently not supported.
 ====
+endif::openshift-origin[]
 
 ////
 For run-time allocation, kubelet changes are needed, see BZ1819719.

--- a/modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc
+++ b/modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc
@@ -3,6 +3,6 @@
 // * list of assemblies where this module is included
 // ipi-install-installation-workflow.adoc
 [id="installing-rhel-on-the-provisioner-node_{context}"]
-= Installing RHEL on the provisioner node
+= Installing {op-system-base} on the provisioner node
 
-With the networking configuration complete, the next step is to install {op-system-base} 8.x on the provisioner node. The installer uses the provisioner node as the orchestrator while installing the {product-title} cluster. For the purposes of this document, installing RHEL on the provisioner node is out of scope. However, options include but are not limited to using a RHEL Satellite server, PXE, or installation media.
+With the networking configuration complete, the next step is to install {op-system-base} {op-system-version} on the provisioner node. The installer uses the provisioner node as the orchestrator while installing the {product-title} cluster. For the purposes of this document, installing {op-system-base} on the provisioner node is out of scope. However, options include but are not limited to using a RHEL Satellite server, PXE, or installation media.

--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -37,6 +37,7 @@ Perform the following steps to prepare the environment.
 $
 ----
 
+ifndef::openshift-origin[]
 . Use Red Hat Subscription Manager to register the provisioner node:
 +
 [source,terminal]
@@ -49,6 +50,7 @@ $ sudo subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms --en
 ====
 For more information about Red Hat Subscription Manager, see link:https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html-single/rhsm/index[Using and Configuring Red Hat Subscription Manager].
 ====
+endif::openshift-origin[]
 
 . Install the following packages:
 +

--- a/modules/nw-enabling-a-provisioning-network-after-installation.adoc
+++ b/modules/nw-enabling-a-provisioning-network-after-installation.adoc
@@ -60,7 +60,7 @@ items:
 +
 <1> The `provisioningNetwork` is one of `Managed`, `Unmanaged`, or `Disabled`. When set to `Managed`, Metal3 manages the provisioning network and the CBO deploys the Metal3 pod with a configured DHCP server. When set to `Unmanaged`, the system administrator configures the DHCP server manually.
 +
-<2> The `provisioningOSDownloadURL` is a valid HTTPS URL with a valid sha256 checksum that enables the Metal3 pod to download a qcow2 operating system image ending in `.qcow2.gz` or `.qcow2.xz`. This field is required whether the provisioning network is `Managed`, `Unmanaged`, or `Disabled`. For example: `\http://192.168.0.1/images/rhcos-_<version>_.x86_64.qcow2.gz?sha256=_<sha>_`.
+<2> The `provisioningOSDownloadURL` is a valid HTTPS URL with a valid sha256 checksum that enables the Metal3 pod to download a qcow2 operating system image ending in `.qcow2.gz` or `.qcow2.xz`. This field is required whether the provisioning network is `Managed`, `Unmanaged`, or `Disabled`. For example: `\http://192.168.0.1/images/{op-system-lowercase}-_<version>_.x86_64.qcow2.gz?sha256=_<sha>_`.
 +
 <3> The `provisioningIP` is the static IP address that the DHCP server and ironic use to provision the network. This static IP address must be within the `provisioning` subnet, and outside of the DHCP range. If you configure this setting, it must have a valid IP address even if the `provisioning` network is `Disabled`. The static IP address is bound to the metal3 pod. If the metal3 pod fails and moves to another server, the static IP address also moves to the new server.
 +


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/44121

Previews: 
OKD 
[Installing Fedora on the provisioner node](http://file.rdu.redhat.com/~mburke/okd-swap-rhel-fcos/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#installing-rhel-on-the-provisioner-node_ipi-install-installation-workflow). Heading has Fedora, not RHEL.
[Preparing the provisioner node for OKD installation](http://file.rdu.redhat.com/~mburke/okd-swap-rhel-fcos/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#preparing-the-provisioner-node-for-openshift-install_ipi-install-installation-workflow). Subscription step 5 hidden.
[Configuring huge pages](http://file.rdu.redhat.com/~mburke/okd-swap-rhel-fcos/post_installation_configuration/node-tasks.html#configuring-huge-pages_post-install-node-tasks). Note after _oc get node <node_using_hugepages>_ is hidden
[Enabling a provisioning network after installation](http://file.rdu.redhat.com/~mburke/okd-swap-rhel-fcos/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.html#enabling-a-provisioning-network-after-installation_ipi-install-post-installation-configuration), Step 4, callout 2 uses fcos.

OCP
[Installing Fedora on the provisioner node](https://deploy-preview-44796--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#installing-rhel-on-the-provisioner-node_ipi-install-installation-workflow). Heading has RHEL not Fedora.
[Preparing the provisioner node for OKD installation](https://deploy-preview-44796--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#preparing-the-provisioner-node-for-openshift-install_ipi-install-installation-workflow). Subscription step 5 shown.
[Configuring huge pages](https://deploy-preview-44796--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html#configuring-huge-pages_post-install-node-tasks). Note after oc get node <node_using_hugepages> is shown
[Enabling a provisioning network after installation](https://deploy-preview-44796--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.html#enabling-a-provisioning-network-after-installation_ipi-install-post-installation-configuration), Step 4, callout 2 uses rcos.