### PR TITLE
RHDEVDOCS-3946 Pipelines 1.7 Tutorial + RHDEVDOCS-3977 Delete optional CRs before uninstalling Operator

### DIFF
--- a/cicd/pipelines/uninstalling-pipelines.adoc
+++ b/cicd/pipelines/uninstalling-pipelines.adoc
@@ -6,9 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Uninstalling the {pipelines-title} Operator is a two-step process:
+Cluster administrators can uninstall the {pipelines-title} Operator by performing the following steps:
 
 . Delete the Custom Resources (CRs) that were added by default when you installed the {pipelines-title} Operator.
+. Delete the CRs of the optional components, such as {tekton-chains}, that are dependent on the Operator.
++
+[CAUTION]
+====
+If you uninstall the Operator without removing the CRs of optional components, you cannot remove them later.
+====
 . Uninstall the {pipelines-title} Operator.
 
 Uninstalling only the Operator will not remove the {pipelines-title} components created by default when the Operator is installed.

--- a/modules/op-adding-triggers.adoc
+++ b/modules/op-adding-triggers.adoc
@@ -77,7 +77,7 @@ spec:
       - name: git-revision
         value: $(tt.params.git-revision)
       - name: IMAGE
-        value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/$(tt.params.git-repo-name)
+        value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(tt.params.git-repo-name)
       workspaces:
       - name: shared-workspace
         volumeClaimTemplate:

--- a/modules/op-deleting-the-pipelines-component-and-custom-resources.adoc
+++ b/modules/op-deleting-the-pipelines-component-and-custom-resources.adoc
@@ -25,3 +25,8 @@ Deleting the CRs will delete the {pipelines-title} components, and all the Tasks
 ====
 
 . Click *Delete* to confirm the deletion of the CRs.
+
+[IMPORTANT]
+====
+Repeat the procedure to find and remove CRs of optional components such as {tekton-chains}, before uninstalling the Operator. If you uninstall the Operator without removing the CRs of optional components, you cannot remove them later.
+====

--- a/modules/op-running-a-pipeline.adoc
+++ b/modules/op-running-a-pipeline.adoc
@@ -19,7 +19,7 @@ $ tkn pipeline start build-and-deploy \
     -w name=shared-workspace,volumeClaimTemplateFile=https://raw.githubusercontent.com/openshift/pipelines-tutorial/{pipelines-ver}/01_pipeline/03_persistent_volume_claim.yaml \
     -p deployment-name=pipelines-vote-api \
     -p git-url=https://github.com/openshift/pipelines-vote-api.git \
-    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/pipelines-vote-api \
+    -p IMAGE=image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/pipelines-vote-api \
     --use-param-defaults
 ----
 +
@@ -42,7 +42,7 @@ $ tkn pipeline start build-and-deploy \
     -w name=shared-workspace,volumeClaimTemplateFile=https://raw.githubusercontent.com/openshift/pipelines-tutorial/{pipelines-ver}/01_pipeline/03_persistent_volume_claim.yaml \
     -p deployment-name=pipelines-vote-ui \
     -p git-url=https://github.com/openshift/pipelines-vote-ui.git \
-    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/pipelines-vote-ui \
+    -p IMAGE=image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/pipelines-vote-ui \
     --use-param-defaults
 ----
 


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.10`, `enterprise-4.11`
- **JIRA issues**: 
  - [RHDEVDOCS-3946 Pipelines 1.7 Tutorial](https://issues.redhat.com/browse/RHDEVDOCS-3946)
  - [RHDEVDOCS-3977 Delete optional CRs before uninstalling Operator](https://issues.redhat.com/browse/RHDEVDOCS-3977)
- **Preview pages**:
  - [Creating CI/CD solutions for applications using OpenShift Pipelines](https://deploy-preview-44804--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/creating-applications-with-cicd-pipelines.html)
  - [Uninstalling OpenShift Pipelines](https://deploy-preview-44804--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/uninstalling-pipelines.html)
- **SME review**: @savitaashture @ppitonak @nikhil-thomas       
- **Peer-review**: @Srivaralakshmi    