### PR TITLE
RHDEVDOCS-3995 Remove `[role="_abstract"]` and other cruft

### DIFF
--- a/modules/builds-adding-input-secrets-configmaps.adoc
+++ b/modules/builds-adding-input-secrets-configmaps.adoc
@@ -1,15 +1,7 @@
-// Module included in the following assemblies:
-//
-// * cicd/builds/creating-build-inputs.adoc
-// * cicd/builds/builds-using-build-volumes.adoc
-
-:_module-type: PROCEDURE
-
 :_content-type: PROCEDURE
 [id="builds-adding-input-secrets-configmaps_{context}"]
 = Adding input secrets and config maps
 
-[role="_abstract"]
 To provide credentials and other configuration data to a build without placing them in source control, you can define input secrets and input config maps.
 
 In some scenarios, build operations require credentials or other configuration data to access dependent resources. To make that information available without placing it in source control, you can define input secrets and input config maps.

--- a/modules/builds-running-entitled-builds-with-sharedsecret-objects.adoc
+++ b/modules/builds-running-entitled-builds-with-sharedsecret-objects.adoc
@@ -1,9 +1,7 @@
-// Used in cicd/builds/running-entitled-builds.adoc
-
+:_content-type: PROCEDURE
 [id="builds-running-entitled-builds-with-sharedsecret-objects_{context}"]
 = Running entitled builds using SharedSecret objects
 
-[role="_abstract"]
 You can configure and perform a build in one namespace that securely uses RHEL entitlements from a `Secret` object in another namespace.
 
 You can still access RHEL entitlements from OpenShift Builds by creating a `Secret` object with your subscription credentials in the same namespace as your `Build` object. However, now, in {product-title} 4.10 and later, you can access your credentials and certificates from a `Secret` object in one of the {product-title} system namespaces. You run entitled builds with a CSI volume mount of a `SharedSecret` custom resource (CR) instance that references the `Secret` object.

--- a/modules/builds-using-build-volumes.adoc
+++ b/modules/builds-using-build-volumes.adoc
@@ -1,5 +1,3 @@
-:_module-type: PROCEDURE
-
 ifeval::["{context}" == "build-strategies-docker"]
 :dockerstrategy:
 endif::[]
@@ -7,12 +5,10 @@ ifeval::["{context}" == "build-strategies-s2i"]
 :sourcestrategy:
 endif::[]
 
-
 :_content-type: PROCEDURE
 [id="builds-using-build-volumes_{context}"]
 = Using build volumes
 
-[role="_abstract"]
 You can mount build volumes to give running builds access to information that you don't want to persist in the output container image.
 
 Build volumes provide sensitive information, such as repository credentials, that the build environment or configuration only needs at build time. Build volumes are different from xref:../../cicd/builds/creating-build-inputs.adoc#builds-define-build-inputs_creating-build-inputs[build inputs], whose data can persist in the output container image.


### PR DESCRIPTION
 Aligned team: Dev Tools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3995
- Direct link to doc preview: NA - These changes do not affect the content. 
- SME review: NA
- QE review: NA
- Peer review: @Srivaralakshmi 
- Ready for merge.