### PR TITLE
[SRVKS-888]: Change the label used by Serverless

### DIFF
--- a/modules/serverless-ossm-setup-with-kourier.adoc
+++ b/modules/serverless-ossm-setup-with-kourier.adoc
@@ -46,18 +46,6 @@ $ oc apply -f <filename>
 ----
 
 . Create a network policy that permits traffic flow from Knative system pods to Knative services:
-.. Add the `serving.knative.openshift.io/system-namespace=true` label to the `knative-serving` namespace:
-+
-[source,terminal]
-----
-$ oc label namespace knative-serving serving.knative.openshift.io/system-namespace=true
-----
-.. Add the `serving.knative.openshift.io/system-namespace=true` label to the `knative-serving-ingress` namespace:
-+
-[source,terminal]
-----
-$ oc label namespace knative-serving-ingress serving.knative.openshift.io/system-namespace=true
-----
 .. For each namespace that you want to integrate with {SMProductShortName}, create a `NetworkPolicy` resource:
 +
 [source,yaml]
@@ -72,13 +60,32 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          serving.knative.openshift.io/system-namespace: "true"
+          knative.openshift.io/part-of: "openshift-serverless"
   podSelector: {}
   policyTypes:
   - Ingress
 ...
 ----
 <1> Add the namespace that you want to integrate with {SMProductShortName}.
++
+[NOTE]
+====
+The `knative.openshift.io/part-of: "openshift-serverless"` label was added in {ServerlessProductName} 1.22.0. If you are using {ServerlessProductName} 1.21.1 or earlier, add the `knative.openshift.io/part-of` label to the `knative-serving` and `knative-serving-ingress` namespaces.
+
+Add the label to the `knative-serving` namespace:
+
+[source,terminal]
+----
+$ oc label namespace knative-serving knative.openshift.io/part-of=openshift-serverless
+----
+
+Add the label to the `knative-serving-ingress` namespace:
+
+[source,terminal]
+----
+$ oc label namespace knative-serving-ingress knative.openshift.io/part-of=openshift-serverless
+----
+====
 .. Apply the `NetworkPolicy` resource:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s): 4.6+

Issue: https://issues.redhat.com/browse/SRVKS-888

Link to docs preview: https://deploy-preview-44824--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-ossm-setup.html#serverless-ossm-setup-with-kourier_serverless-ossm-setup