### PR TITLE
CNV14987: Adding information on support for vTPM

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1609,7 +1609,7 @@ Topics:
   - Name: Deploying a Spring Boot application with Argo CD
     File: deploying-a-spring-boot-application-with-argo-cd
   - Name: Argo CD custom resource properties
-    File: argo-cd-custom-resource-properties  
+    File: argo-cd-custom-resource-properties
   - Name: Monitoring application health status
     File: health-information-for-resources-deployment
   - Name: Configuring SSO for Argo CD using Dex
@@ -3110,6 +3110,8 @@ Topics:
     File: virt-installing-virtio-drivers-on-existing-windows-vm
   - Name: Installing VirtIO driver on a new Windows virtual machine
     File: virt-installing-virtio-drivers-on-new-windows-vm
+  - Name: Using virtual Trusted Platform Module devices
+    File: virt-using-vtpm-devices
   - Name: Advanced virtual machine management
     Dir: advanced_vm_management
     Topics:

--- a/modules/virt-about-vtpm-devices.adoc
+++ b/modules/virt-about-vtpm-devices.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virt-using-vtpm-devices.adoc
+
+:_content-type: CONCEPT
+[id="virt-about-vtpm-devices_{context}"]
+= About vTPM devices
+
+A virtual Trusted Platform Module (vTPM) device functions like a
+physical Trusted Platform Module (TPM) hardware chip.
+
+You can use a vTPM device with any operating system, but Windows 11 requires
+the presence of a TPM chip to install or boot. A vTPM device allows VMs created
+from a Windows 11 image to function without a physical TPM chip.
+
+If you do not enable vTPM, then the VM does not recognize a TPM device, even if
+the node has one.
+
+vTPM devices also protect virtual machines by temporarily storing secrets
+without physical hardware. However, using vTPM for persistent secret storage is
+not currently supported. vTPM discards stored secrets after a VM shuts down.

--- a/modules/virt-adding-vtpm-to-vm.adoc
+++ b/modules/virt-adding-vtpm-to-vm.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virt-using-vtpm-devices.adoc
+
+:_content-type: PROCEDURE
+[id="virt-adding-vtpm-to-vm_{context}"]
+= Adding a vTPM device to a virtual machine
+
+Adding a virtual Trusted Platform Module (vTPM) device to a virtual machine
+(VM) allows you to run a VM created from a Windows 11 image without a physical
+TPM device. A vTPM device also temporarily stores secrets for that VM.
+
+.Procedure
+
+. Run the following command to update the VM configuration:
++
+[source,terminal]
+----
+$ oc edit vm <vm_name>
+----
+
+. Edit the VM `spec` so that it includes the `tpm: {}` line. For example:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+    name: example-vm
+spec:
+  template:
+    spec:
+      domain:
+        devices:
+          tpm: {} <1>
+...
+----
+<1> Adds the TPM device to the VM.
+
+. To apply your changes, save and exit the editor.
+
+. Optional: If you edited a running virtual machine, you must restart it for
+the changes to take effect.

--- a/virt/virtual_machines/virt-using-vtpm-devices.adoc
+++ b/virt/virtual_machines/virt-using-vtpm-devices.adoc
@@ -1,0 +1,14 @@
+:_content-type: ASSEMBLY
+[id="virt-using-vtpm-devices"]
+= Using virtual Trusted Platform Module devices
+include::_attributes/common-attributes.adoc[]
+:context: virt-using-vtpm-devices
+
+toc::[]
+
+Add a virtual Trusted Platform Module (vTPM) device to a new or existing virtual
+machine by editing the `VirtualMachine` (VM) or `VirtualMachineInstance` (VMI)
+manifest.
+
+include::modules/virt-about-vtpm-devices.adoc[leveloffset=+1]
+include::modules/virt-adding-vtpm-to-vm.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR addresses JIRA story [CNV-14987](https://issues.redhat.com/browse/CNV-14987).

The story asks to add documentation on support for virtual Trusted Platform Module (vTPM) devices.

CP: 4.11

Preview: https://deploy-preview-44827--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-using-vtpm-devices.html