### PR TITLE
[OSDOCS-3346]: Add AWS ccoctl permissions reqs

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="cco-mode-sts"]
-= Using manual mode with STS
+= Using manual mode with Amazon Web Services Secure Token Service
 include::_attributes/common-attributes.adoc[]
 :context: cco-mode-sts
 
@@ -12,6 +12,9 @@ Manual mode with STS is supported for Amazon Web Services (AWS).
 ====
 This credentials strategy is supported for only new {product-title} clusters and must be configured during installation. You cannot reconfigure an existing cluster that uses a different credentials strategy to use this feature.
 ====
+
+[id="sts-mode-about"]
+== About manual mode with AWS Secure Token Service
 
 In manual mode with STS, the individual {product-title} cluster components use AWS Secure Token Service (STS) to assign components IAM roles that provide short-term, limited-privilege security credentials. These credentials are associated with IAM roles that are specific to each component that makes AWS API calls.
 

--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -37,6 +37,48 @@ endif::alibabacloud[]
 The `ccoctl` is a Linux binary that must run in a Linux environment.
 ====
 
+ifdef::aws-sts[]
+.Prerequisites
+
+* You have created an AWS account for the `ccoctl` to use with the following permissions:
++
+.Required AWS permissions
+[cols="a,a"]
+|====
+|`iam` permissions |`s3` permissions
+
+|* `iam:CreateOpenIDConnectProvider`
+* `iam:CreateRole`
+* `iam:DeleteOpenIDConnectProvider`
+* `iam:DeleteRole`
+* `iam:DeleteRolePolicy`
+* `iam:GetOpenIDConnectProvider`
+* `iam:GetRole`
+* `iam:GetUser`
+* `iam:ListOpenIDConnectProviders`
+* `iam:ListRolePolicies`
+* `iam:ListRoles`
+* `iam:PutRolePolicy`
+* `iam:TagOpenIDConnectProvider`
+* `iam:TagRole`
+|* `s3:CreateBucket`
+* `s3:DeleteBucket`
+* `s3:DeleteObject`
+* `s3:GetBucketAcl`
+* `s3:GetBucketTagging`
+* `s3:GetObject`
+* `s3:GetObjectAcl`
+* `s3:GetObjectTagging`
+* `s3:ListBucket`
+* `s3:PutBucketAcl`
+* `s3:PutBucketTagging`
+* `s3:PutObject`
+* `s3:PutObjectAcl`
+* `s3:PutObjectTagging`
+
+|====
+endif::aws-sts[]
+
 .Procedure
 
 . Obtain the {product-title} release image:


### PR DESCRIPTION
Version(s):
~4.7+~
Actually 4.8+, forgot `ccoctl` was added in 4.8 and the 4.7 config is a different process.

Issue:
[OSDOCS-3346](https://issues.redhat.com//browse/OSDOCS-3346)

Link to docs preview:
- [Configuring the Cloud Credential Operator utility](https://deploy-preview-44837--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-configuring_cco-mode-sts)
- Also changed title of the [assembly](https://deploy-preview-44837--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html) and added an "About" heading for the intro content

Additional information: