### PR TITLE
BZ 2070016: Adds an "Increase network MTU" section.

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -9,6 +9,12 @@ Installer-provisioned installation of {product-title} involves several network r
 
 image::210_OpenShift_Baremetal_IPI_Deployment_updates_0122_2.png[Installer-provisioned networking]
 
+
+[id="network-requirements-increase-mtu_{context}"]
+== Increase the network MTU
+
+Before deploying {product-title}, increase the network maximum transmission unit (MTU) to 1500 or more. If the MTU is lower than 1500, the Ironic image that is used to boot the node might fail to communicate with the Ironic inspector pod, and inspection will fail. If this occurs, installation stops because the nodes are not available for installation. 
+
 [id='network-requirements-config-nics_{context}']
 == Configuring NICs
 


### PR DESCRIPTION
Adds an "Increase network MTU" section to increase MTU to 1500 or more.

Issue: 2070016

Signed-off-by: John Wilkins <jowilkin@redhat.com>

Versions: 4.9, 4.10, 4.11

Preview: https://deploy-preview-44847--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-increase-mtu_ipi-install-prerequisites