### PR TITLE
OSDOCS-3419: healthCheckInterval Parameter documentation

### DIFF
--- a/modules/nw-ingress-controller-config-tuningoptions-healthcheckinterval.adoc
+++ b/modules/nw-ingress-controller-config-tuningoptions-healthcheckinterval.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-operator.adoc
+
+:_content-type: PROCEDURE
+[id="nw-ingress-controller-config-tuningoptions-healthcheckinterval_{context}"]
+= Setting the Ingress Controller health check interval
+A cluster administrator can set the health check interval to define how long the router waits between two consecutive health checks. This value is applied globally as a default for all routes. The default value is 5 seconds.
+
+.Prerequisites
+* The following assumes that you already created an Ingress Controller.
+
+.Procedure
+* Update the Ingress Controller to change the interval between back end health checks:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontroller/default --type=merge -p '{"spec":{"tuningOptions": {"healthCheckInterval": "8s"}}}'
+----
++
+[NOTE]
+====
+To override the `healthCheckInterval` for a single route, use the route annotation `router.openshift.io/haproxy.health.check.interval`
+====

--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -197,24 +197,26 @@ For request headers, these adjustments are applied only for routes that have the
 |`tuningOptions`
 |`tuningOptions` specifies options for tuning the performance of Ingress Controller pods.
 
+* `clientFinTimeout` specifies how long a connection is held open while waiting for the client response to the server closing the connection. The default timeout is `1s`.
+
+* `clientTimeout` specifies how long a connection is held open while waiting for a client response. The default timeout is `30s`.
+
 * `headerBufferBytes` specifies how much memory is reserved, in bytes, for Ingress Controller connection sessions. This value must be at least `16384` if HTTP/2 is enabled for the Ingress Controller. If not set, the default value is `32768` bytes. Setting this field not recommended because `headerBufferBytes` values that are too small can break the Ingress Controller, and `headerBufferBytes` values that are too large could cause the Ingress Controller to use significantly more memory than necessary.
 
 * `headerBufferMaxRewriteBytes` specifies how much memory should be reserved, in bytes, from `headerBufferBytes` for HTTP header rewriting and appending for Ingress Controller connection sessions. The minimum value for `headerBufferMaxRewriteBytes` is `4096`. `headerBufferBytes` must be greater than `headerBufferMaxRewriteBytes` for incoming HTTP requests. If not set, the default value is `8192` bytes. Setting this field not recommended because `headerBufferMaxRewriteBytes` values that are too small can break the Ingress Controller and `headerBufferMaxRewriteBytes` values that are too large could cause the Ingress Controller to use significantly more memory than necessary.
 
+* `healthCheckInterval` specifies how long the router waits between health checks. The default is `5s`.
+
+* `serverFinTimeout` specifies how long a connection is held open while waiting for the server response to the client that is closing the connection. The default timeout is `1s`.
+
+* `serverTimeout` specifies how long a connection is held open while waiting for a server response. The default timeout is `30s`.
+
 * `threadCount` specifies the number of threads to create per HAProxy process. Creating more threads allows each Ingress Controller pod to handle more connections, at the cost of more system resources being used. HAProxy
 supports up to `64` threads. If this field is empty, the Ingress Controller uses the default value of `4` threads. The default value can change in future releases. Setting this field is not recommended because increasing the number of HAProxy threads allows Ingress Controller pods to use more CPU time under load, and prevent other pods from receiving the CPU resources they need to perform. Reducing the number of threads can cause the Ingress Controller to perform poorly.
 
-* `clientTimeout` specifies how long a connection is held open while waiting for a client response. If unset, the default timeout is `30s`.
+* `tlsInspectDelay` specifies how long the router can hold data to find a matching route. Setting this value too short can cause the router to fall back to the default certificate for edge-terminated, reencrypted, or passthrough routes, even when using a better matched certificate. The default inspect delay is `5s`.
 
-* `serverFinTimeout` specifies how long a connection is held open while waiting for the server response to the client that is closing the connection. If unset, the default timeout is `1s`.
-
-* `serverTimeout` specifies how long a connection is held open while waiting for a server response. If unset, the default timeout is `30s`.
-
-* `clientFinTimeout` specifies how long a connection is held open while waiting for the client response to the server closing the connection. If unset, the default timeout is `1s`.
-
-* `tlsInspectDelay` specifies how long the router can hold data to find a matching route. Setting this value too short can cause the router to fall back to the default certificate for edge-terminated, reencrypted, or passthrough routes, even when using a better matched certificate. If unset, the default inspect delay is `5s`.
-
-* `tunnelTimeout` specifies how long a tunnel connection, including websockets, remains open while the tunnel is idle. If unset, the default timeout is `1h`.
+* `tunnelTimeout` specifies how long a tunnel connection, including websockets, remains open while the tunnel is idle. The default timeout is `1h`.
 
 * `maxConnections` specifies the maximum number of simultaneous connections that can be established per HAProxy process. Increasing this value allows each ingress controller pod handle more connections at the cost of additional system resources. Permitted values are `0`, `-1`, any value within the range `2000` and `2000000`, or the field can be left empty. 
 

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -55,6 +55,8 @@ include::modules/nw-ingress-setting-internal-lb.adoc[leveloffset=+2]
 
 include::modules/nw-ingress-controller-configuration-gcp-global-access.adoc[leveloffset=+2]
 
+include::modules/nw-ingress-controller-config-tuningoptions-healthcheckinterval.adoc[leveloffset=+2]
+
 include::modules/nw-ingress-default-internal.adoc[leveloffset=+2]
 
 include::modules/nw-route-admission-policy.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to.
If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->4.11 (will need confirmation)

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->https://issues.redhat.com/browse/OSDOCS-3419

Link to docs preview: https://deploy-preview-44848--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
  - The preview will be generated after you open the PR.
  - You will need to edit the comment to add the link after the preview builds.
  - Review the preview build to make sure your changes are rendering properly. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.

Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
