### PR TITLE
Fixing typo from BZ1964063

### DIFF
--- a/modules/registry-configuring-storage-vsphere.adoc
+++ b/modules/registry-configuring-storage-vsphere.adoc
@@ -100,7 +100,7 @@ $ oc get clusteroperator image-registry
 [source,terminal]
 ----
 NAME             VERSION                              AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-image-registry   4.8                                  True        False         False      6h50m
+image-registry   4.7                                  True        False         False      6h50m
 ----
 
 //+


### PR DESCRIPTION
For versions 4.7+

Typo fix from pull #44241

Preview: [Installing a cluster on vSphere with customizations](https://deploy-preview-44856--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-registry-storage-config_installing-vsphere-installer-provisioned-customizations)