### PR TITLE
WIP [OSDOCS-3347]: Add GCP ccoctl permissions reqs

### DIFF
--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -37,6 +37,15 @@ endif::alibabacloud[]
 The `ccoctl` is a Linux binary that must run in a Linux environment.
 ====
 
+.Prerequisites
+
+ifdef::google-cloud-platform[]
+* You have created a GCP account for the `ccoctl` to use with the following permissions:
+
+// Permissions TBD
+
+endif::google-cloud-platform[]
+
 .Procedure
 
 . Obtain the {product-title} release image:


### PR DESCRIPTION
Version(s):
4.10+

Issue:
[OSDOCS-3347](https://issues.redhat.com//browse/OSDOCS-3347)

Link to docs preview:
- [Configuring the Cloud Credential Operator utility](https://deploy-preview-44887--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.html#cco-ccoctl-configuring_cco-mode-gcp-workload-identity)

Additional information:
Setting this PR up for later. Need permissions list from dev.