### PR TITLE
NE-709, update router default to random balancing algorithm

### DIFF
--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -19,7 +19,7 @@ To create a whitelist with multiple source IPs or subnets, use a space-delimited
 [cols="3*", options="header"]
 |===
 |Variable | Description | Environment variable used as default
-|`haproxy.router.openshift.io/balance`| Sets the load-balancing algorithm. Available options are `random`, `source`, `roundrobin`, and `leastconn`.  The default value is `leastconn`.| `ROUTER_TCP_BALANCE_SCHEME` for passthrough routes. Otherwise, use `ROUTER_LOAD_BALANCE_ALGORITHM`.
+|`haproxy.router.openshift.io/balance`| Sets the load-balancing algorithm. Available options are `random`, `source`, `roundrobin`, and `leastconn`.  The default value is `random`.| `ROUTER_TCP_BALANCE_SCHEME` for passthrough routes. Otherwise, use `ROUTER_LOAD_BALANCE_ALGORITHM`.
 |`haproxy.router.openshift.io/disable_cookies`| Disables the use of cookies to track related connections. If set to `'true'` or `'TRUE'`, the balance algorithm is used to choose which back-end serves connections for each incoming HTTP request. |
 |`router.openshift.io/cookie_name`| Specifies an optional cookie to use for
 this route. The name must consist of any combination of upper and lower case letters, digits, "_",


### PR DESCRIPTION
Version(s): 4.11

Addresses https://issues.redhat.com/browse/NE-709 / https://issues.redhat.com/browse/NE-825

https://issues.redhat.com/browse/OSDOCS-3619

Preview build: https://deploy-preview-44889--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-route-specific-annotations_route-configuration


