### PR TITLE
[enterprise-4.7] GH#44121: OKD Documentation still mentions RedHat Enterprise Linux and Fedora 8

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -11,13 +11,17 @@
 :prewrap!:
 :op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
 :op-system: RHCOS
+:op-system-lowercase: rhcos
 :op-system-base: RHEL
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
+:op-system-version: 8.x
 ifdef::openshift-origin[]
 :op-system-first: Fedora CoreOS (FCOS)
 :op-system: FCOS
+:op-system-lowercase: fcos
 :op-system-base: Fedora
 :op-system-base-full: Fedora
+:op-system-version: 35
 endif::[]
 :tsb-name: Template Service Broker
 :kebab: image:kebab.png[title="Options menu"]

--- a/modules/configuring-huge-pages.adoc
+++ b/modules/configuring-huge-pages.adoc
@@ -93,10 +93,12 @@ $ oc get node <node_using_hugepages> -o jsonpath="{.status.allocatable.hugepages
 100Mi
 ----
 
+ifndef::openshift-origin[]
 [WARNING]
 ====
 This functionality is currently only supported on {op-system-first} 8.x worker nodes. On {op-system-base-full} 7.x worker nodes the Tuned `[bootloader]` plug-in is currently not supported.
 ====
+endif::openshift-origin[]
 
 ////
 For run-time allocation, kubelet changes are needed, see BZ1819719.

--- a/modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc
+++ b/modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc
@@ -3,6 +3,6 @@
 // * list of assemblies where this module is included
 // ipi-install-installation-workflow.adoc
 [id="installing-rhel-on-the-provisioner-node_{context}"]
-= Installing RHEL on the provisioner node
+= Installing {op-system-base} on the provisioner node
 
-With the networking configuration complete, the next step is to install {op-system-base} 8.x on the provisioner node. The installer uses the provisioner node as the orchestrator while installing the {product-title} cluster. For the purposes of this document, installing RHEL on the provisioner node is out of scope. However, options include but are not limited to using a RHEL Satellite server, PXE, or installation media.
+With the networking configuration complete, the next step is to install {op-system-base} {op-system-version} on the provisioner node. The installer uses the provisioner node as the orchestrator while installing the {product-title} cluster. For the purposes of this document, installing {op-system-base} on the provisioner node is out of scope. However, options include but are not limited to using a RHEL Satellite server, PXE, or installation media.

--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -37,6 +37,7 @@ Perform the following steps to prepare the environment.
 $
 ----
 
+ifndef::openshift-origin[]
 . Use Red Hat Subscription Manager to register the provisioner node:
 +
 [source,terminal]
@@ -49,6 +50,7 @@ $ sudo subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms --en
 ====
 For more information about Red Hat Subscription Manager, see link:https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html-single/rhsm/index[Using and Configuring Red Hat Subscription Manager].
 ====
+endif::openshift-origin[]
 
 . Install the following packages:
 +


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/44796