### PR TITLE
OSDOCS-3427: Removed the explicit ROSA version

### DIFF
--- a/modules/rosa-sts-setting-up-environment.adoc
+++ b/modules/rosa-sts-setting-up-environment.adoc
@@ -49,7 +49,7 @@ The ROSA service evaluates regions in the following priority order:
 $ aws sts get-caller-identity
 ----
 +
-. Install `rosa`, the {product-title} command-line interface (CLI) version 1.0.8 or greater.
+. Install the latest version of `rosa`, the {product-title} command-line interface (CLI).
 .. Download the link:https://access.redhat.com/products/red-hat-openshift-service-aws/[latest release] of the `rosa` CLI for your operating system.
 .. Optional: Rename the file you downloaded to `rosa` and make the file executable. This documentation uses `rosa` to refer to the executable file.
 +


### PR DESCRIPTION
Version(s):
Enterprise-4.9+

Issue:
[OSDOCS-3427](https://issues.redhat.com/browse/OSDOCS-3427)

Link to docs preview:

Step 4 of the second **Setting up the environment for STS**
https://deploy-preview-44895--osdocs.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-setting-up-environment

Additional information:
This PR removes the explicitly stated version for `rosa` CLI since this changes often.