### PR TITLE
Revert "Merge pull request #44797 from adellape/fix_dotcallout"

### DIFF
--- a/modules/olm-catalogsource.adoc
+++ b/modules/olm-catalogsource.adoc
@@ -22,6 +22,8 @@ Cluster administrators can view the full list of Operators provided by an enable
 The `spec` of a `CatalogSource` object indicates how to construct a pod or how to communicate with a service that serves the Operator Registry gRPC API.
 
 .Example `CatalogSource` object
+[%collapsible]
+====
 [source,yaml,subs="attributes+"]
 ----
 ﻿apiVersion: operators.coreos.com/v1alpha1
@@ -82,6 +84,7 @@ Set the `olm.catalogImageTemplate` annotation to your index image name and use o
 See link:https://grpc.github.io/grpc/core/md_doc_connectivity-semantics-and-api.html[States of Connectivity] in the gRPC documentation for more details.
 <.> Latest time the container registry storing the catalog image was polled to ensure the image is up-to-date.
 <.> Status information for the catalog's Operator Registry service.
+====
 
 Referencing the `name` of a `CatalogSource` object in a subscription instructs OLM where to search to find a requested Operator:
 

--- a/modules/olm-creating-fb-catalog-image.adoc
+++ b/modules/olm-creating-fb-catalog-image.adoc
@@ -67,11 +67,11 @@ The Dockerfile must be in the same parent directory as the catalog directory tha
 +
 [source,terminal]
 ----
-$ opm init <operator_name> \// <.>
-    --default-channel=preview \// <.>
-    --description=./README.md \// <.>
-    --icon=./operator-icon.svg \// <.>
-    --output yaml \// <.>
+$ opm init <operator_name> \ <.>
+    --default-channel=preview \ <.>
+    --description=./README.md \ <.>
+    --icon=./operator-icon.svg \ <.>
+    --output yaml \ <.>
     > <operator_name>-index/index.yaml <.>
 ----
 <.> Operator, or package, name.
@@ -87,7 +87,7 @@ This command generates an `olm.package` declarative config blob in the specified
 +
 [source,terminal]
 ----
-$ opm render <registry>/<namespace>/<bundle_image_name>:<tag> \// <.>
+$ opm render <registry>/<namespace>/<bundle_image_name>:<tag> \ <.>
     --output=yaml \
     >> <operator_name>-index/index.yaml <.>
 ----

--- a/modules/olm-mirroring-catalog-airgapped.adoc
+++ b/modules/olm-mirroring-catalog-airgapped.adoc
@@ -22,10 +22,10 @@ If your mirror registry is on a completely disconnected, or airgapped, host, tak
 [source,terminal]
 ----
 $ oc adm catalog mirror \
-    <index_image> \// <.>
-    file:///local/index \// <.>
-    -a ${REG_CREDS} \// <.>
-    --insecure \// <.>
+    <index_image> \ <.>
+    file:///local/index \ <.>
+    -a ${REG_CREDS} \ <.>
+    --insecure \ <.>
     --index-filter-by-os='<platform>/<arch>' <.>
 ----
 <.> Specify the index image for the catalog that you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
@@ -66,10 +66,10 @@ $ podman login <mirror_registry>
 [source,terminal]
 ----
 $ oc adm catalog mirror \
-    file://local/index/<repo>/<index_image>:<tag> \// <.>
-    <mirror_registry>:<port>/<namespace> \// <.>
-    -a ${REG_CREDS} \// <.>
-    --insecure \// <.>
+    file://local/index/<repo>/<index_image>:<tag> \ <.>
+    <mirror_registry>:<port>/<namespace> \ <.>
+    -a ${REG_CREDS} \ <.>
+    --insecure \ <.>
     --index-filter-by-os='<platform>/<arch>' <.>
 ----
 <.> Specify the `file://` path from the previous command output.

--- a/modules/olm-mirroring-catalog-colocated.adoc
+++ b/modules/olm-mirroring-catalog-colocated.adoc
@@ -31,11 +31,11 @@ $ podman login <mirror_registry>
 [source,terminal]
 ----
 $ oc adm catalog mirror \
-    <index_image> \// <.>
-    <mirror_registry>:<port>/<namespace> \// <.>
-    [-a ${REG_CREDS}] \// <.>
-    [--insecure] \// <.>
-    [--index-filter-by-os='<platform>/<arch>'] \// <.>
+    <index_image> \ <.>
+    <mirror_registry>:<port>/<namespace> \ <.>
+    [-a ${REG_CREDS}] \ <.>
+    [--insecure] \ <.>
+    [--index-filter-by-os='<platform>/<arch>'] \ <.>
     [--manifests-only] <.>
 ----
 <1> Specify the index image for the catalog that you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.


### PR DESCRIPTION
This reverts commit 13adda3790fc0870fe22a40300d8cf0414a529cf, reversing changes made to 22cf0b84c365177a314f0d6324d78978c1d9b136.

The change in https://github.com/openshift/openshift-docs/pull/44797 didn't actually fix the callouts issue on the Customer Portal, so reverting this and will follow-up with another PR that switches the `<.>` to numbered (e.g., `<1>`).

Example spot: https://deploy-preview-44897--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-creating-fb-catalog-image_olm-managing-custom-catalogs