### PR TITLE
editing github PR template to separate a note block

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,9 +14,11 @@ Link to docs preview:
   - Review the preview build to make sure your changes are rendering properly. --->
 
 Additional information:
-<!--- Optional: Include additional context or expand the description here.
+<!--- Optional: Include additional context or expand the description here.--->
 
-Next steps after opening your PR:
+
+
+<!--- Next steps after opening your PR:
 
 * Ask for peer review from the OpenShift docs team:
   - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:


### PR DESCRIPTION
If you delete line 17 to add more info, you uncomment the entire next steps block and openshift/team-documentation gets an email.

No issue
Main only
No preview
