### PR TITLE
Adds 4.10.11 release notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2793,3 +2793,23 @@ link:https://access.redhat.com/solutions/6932751[{product-title} 4.10.10 contain
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-11"]
+=== RHBA-2022:1431 - {product-title} 4.10.11 bug fix update
+
+Issued: 2022-04-25
+
+{product-title} release 4.10.11 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1431[RHBA-2022:1431] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6954628[{product-title} 4.10.11 container image list]
+
+[id="ocp-4-10-11-bug-fixes"]
+==== Bug fixes
+* Previously, when cloning a virtual machine from a template, Operator-made changes reverted after dismissing the dialog box if the boot disk was edited and the storage class was changed. With this update, changes made to storage class remain set after closing the dialogue box. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049762[*BZ#2049762*])
+
+[id="ocp-4-10-11-updating"]
+==== Updating
+
+To upgrade an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
Applies to enterprise-4.10

Issue:
No BZ

To be merged on 04-25. I will send reminder when the Erratas are shipped live.

Link to docs preview:
https://deploy-preview-44924--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-11


