### PR TITLE
[BZ2035368]: Explain non-STS clusters cannot switch to STS

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 Manual mode with GCP Workload Identity is supported for Google Cloud Platform (GCP).
 
+[NOTE]
+====
+This credentials strategy is supported for only new {product-title} clusters and must be configured during installation. You cannot reconfigure an existing cluster that uses a different credentials strategy to use this feature.
+====
+
 In manual mode with GCP Workload Identity, the individual {product-title} cluster components can impersonate IAM service accounts using short-term, limited-privilege credentials.
 
 Requests for new and refreshed credentials are automated by using an appropriately configured OpenID Connect (OIDC) identity provider, combined with IAM service accounts. {product-title} signs service account tokens that are trusted by GCP, and can be projected into a pod and used for authentication. Tokens are refreshed after one hour by default.

--- a/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 Manual mode with STS is supported for Amazon Web Services (AWS).
 
+[NOTE]
+====
+This credentials strategy is supported for only new {product-title} clusters and must be configured during installation. You cannot reconfigure an existing cluster that uses a different credentials strategy to use this feature.
+====
+
 In manual mode with STS, the individual {product-title} cluster components use AWS Secure Token Service (STS) to assign components IAM roles that provide short-term, limited-privilege security credentials. These credentials are associated with IAM roles that are specific to each component that makes AWS API calls.
 
 Requests for new and refreshed credentials are automated by using an appropriately configured AWS IAM OpenID Connect (OIDC) identity provider, combined with AWS IAM roles. {product-title} signs service account tokens that are trusted by AWS IAM, and can be projected into a pod and used for authentication. Tokens are refreshed after one hour.

--- a/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
+++ b/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
@@ -32,6 +32,11 @@ ifdef::aws[]
 * *Use the Amazon Web Services Security Token Service*:
 +
 You can use the CCO utility (`ccoctl`) to configure the cluster to use the Amazon Web Services Security Token Service (AWS STS). When the CCO utility is used to configure the cluster for STS, it assigns IAM roles that provide short-term, limited-privilege security credentials to components.
++
+[NOTE]
+====
+This credentials strategy is supported for only new {product-title} clusters and must be configured during installation. You cannot reconfigure an existing cluster that uses a different credentials strategy to use this feature.
+====
 
 endif::aws[]
 
@@ -39,6 +44,11 @@ ifdef::google-cloud-platform[]
 * *Use manual mode with GCP Workload Identity*:
 +
 You can use the CCO utility (`ccoctl`) to configure the cluster to use manual mode with GCP Workload Identity. When the CCO utility is used to configure the cluster for GCP Workload Identity, it signs service account tokens that provide short-term, limited-privilege security credentials to components.
++
+[NOTE]
+====
+This credentials strategy is supported for only new {product-title} clusters and must be configured during installation. You cannot reconfigure an existing cluster that uses a different credentials strategy to use this feature.
+====
 
 endif::google-cloud-platform[]
 


### PR DESCRIPTION
Version(s):
4.7+

Issue:
[BZ2035368](https://bugzilla.redhat.com/show_bug.cgi?id=2035368)

Link to docs preview:
- [Using manual mode with STS](https://deploy-preview-44944--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-mode-sts)
- [Using manual mode with GCP Workload Identity](https://deploy-preview-44944--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.html#cco-mode-gcp-workload-identity)
- [Alternatives to storing administrator-level secrets in the kube-system project (AWS)](https://deploy-preview-44944--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/manually-creating-iam.html#alternatives-to-storing-admin-secrets-in-kube-system_manually-creating-iam-aws)
- [Alternatives to storing administrator-level secrets in the kube-system project (GCP)](https://deploy-preview-44944--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/manually-creating-iam-gcp.html#alternatives-to-storing-admin-secrets-in-kube-system_manually-creating-iam-gcp)

Additional information:
Adds note that existing clusters cannot be reconfigured to use either of the short-term, limited-privilege credentials strategies (AWS STS or GCP Workload Identity). This will require manual cherrypicks because the supported status of these features is not consistent across 4.7+