### PR TITLE
Add E810-2CQDA2 to SR-IOV supported devices

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -39,17 +39,22 @@
 
 |Intel
 |E810-CQDA2
-|8088
+|8086
+|1592
+
+|Intel
+|E810-2CQDA2
+|8086
 |1592
 
 |Intel
 |E810-XXVDA2
-|8088
+|8086
 |159b
 
 |Intel
 |E810-XXVDA4
-|8088
+|8086
 |1593
 
 |Mellanox
@@ -82,3 +87,8 @@
 |15b3
 |101f
 |===
+
+[NOTE]
+====
+For the most up-to-date list of supported cards and compatible {product-title} versions available, see link:https://access.redhat.com/articles/6954499[Openshift Single Root I/O Virtualization (SR-IOV) and PTP hardware networks Support Matrix].
+====


### PR DESCRIPTION
This was originally included, but did not get re-added after
E810 was pulled temporarily from the release.

- https://github.com/openshift/openshift-docs/pull/31415
- https://github.com/openshift/openshift-docs/pull/43206

Preview: https://deploy-preview-44945--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov