### PR TITLE
[BZ2028487]: Fix incorrect list namespace command

### DIFF
--- a/modules/manually-rotating-cloud-creds.adoc
+++ b/modules/manually-rotating-cloud-creds.adoc
@@ -66,7 +66,7 @@ You can also use the command line interface to complete all parts of this proced
 +
 [source,terminal]
 ----
-$ oc -n openshift-cloud-credential-operator get CredentialsRequest -o json | jq -r '.items[] | select (.spec[].kind=="<provider_spec>") | .spec.secretRef'
+$ oc -n openshift-cloud-credential-operator get CredentialsRequest -o json | jq -r '.items[] | select (.spec.providerSpec.kind=="<provider_spec>") | .spec.secretRef'
 ----
 +
 Where `<provider_spec>` is the corresponding value for your cloud provider: `AWSProviderSpec` for AWS, `AzureProviderSpec` for Azure, or `GCPProviderSpec` for GCP.


### PR DESCRIPTION
Version(s):
4.6+

Issue:
[BZ2028487](https://bugzilla.redhat.com/show_bug.cgi?id=2028487)

Link to docs preview:
[Rotating cloud provider credentials manually](https://deploy-preview-44947--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#manually-rotating-cloud-creds_post-install-cluster-tasks) (step 6b)

Additional information:
BZ is filed against 4.8, and reporter has verified the same applies to 4.9&4.10. The same command exists in in all published versions (4.6+), so I think this needs to be verified against all supported versions of OCP.