### PR TITLE
BZ#2071560: Adding link to openjdk documentation for Java S2I reference in OCP docs

### DIFF
--- a/openshift_images/using_images/using-s21-images.adoc
+++ b/openshift_images/using_images/using-s21-images.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use the link:https://access.redhat.com/documentation/en-us/red_hat_software_collections/3/html-single/using_red_hat_software_collections_container_images/index[Red Hat Software Collections] images as a foundation for applications that rely on specific runtime environments such as Node.js, Perl, or Python. Special versions of some of these runtime base images are referred to as Source-to-Image (S2I) images. With S2I images, you can insert your code into a base image environment that is ready to run that code.
+You can use the link:https://access.redhat.com/documentation/en-us/red_hat_software_collections/3/html-single/using_red_hat_software_collections_container_images/index[Red Hat Software Collections] images as a foundation for applications that rely on specific runtime environments such as Node.js, Perl, or Python. You can use the link:https://access.redhat.com/documentation/en-us/openjdk/11/html/using_openjdk_11_source-to-image_for_openshift/index[Red Hat Java Source-to-Image for OpenShift] documentation as a reference for runtime environments that use Java. Special versions of some of these runtime base images are referred to as Source-to-Image (S2I) images. With S2I images, you can insert your code into a base image environment that is ready to run that code.
 
 S2I images include:
 


### PR DESCRIPTION
Version(s):
4.6+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2071560

Link to docs preview:
https://deploy-preview-44950--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/using_images/using-s21-images.html
