### PR TITLE
BZ 2004210: Removes ifeval with product-version variable. 

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
@@ -12,18 +12,10 @@ ifdef::openshift-origin[. One provisioner node with {op-system-first} installed.
 ifndef::openshift-origin[. One provisioner node with {op-system-base-full} 8.x installed. The provisioning node can be removed after installation.]
 . Three control plane nodes.
 . Baseboard Management Controller (BMC) access to each node.
-ifeval::[{product-version} > 4.5]
 . At least one network:
 .. One required routable network
 .. One optional network for provisioning nodes; and,
 .. One optional management network.
-endif::[]
-ifeval::[{product-version} < 4.6]
-. At least two networks:
-.. One required routable network
-.. One required network for provisioning nodes; and,
-.. One optional management network.
-endif::[]
 
 Before starting an installer-provisioned installation of {product-title}, ensure the hardware environment meets the following requirements.
 

--- a/modules/install-ibm-cloud-setting-up-ibm-cloud-infrastructure.adoc
+++ b/modules/install-ibm-cloud-setting-up-ibm-cloud-infrastructure.adoc
@@ -109,9 +109,6 @@ The following table provides an example of fully qualified domain names. The API
 | Usage | Host Name | IP
 | API | api.<cluster_name>.<domain> | <ip>
 | Ingress LB (apps) |  *.apps.<cluster_name>.<domain>  | <ip>
-ifeval::[{product-version} <= 4.5]
-| Nameserver | ns1.<cluster_name>.<domain> | <ip>
-endif::[]
 | Provisioner node | provisioner.<cluster_name>.<domain> | <ip>
 | Master-0 | openshift-master-0.<cluster_name>.<domain> | <ip>
 | Master-1 | openshift-master-1.<cluster_name>.<domain> | <ip>

--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -47,13 +47,7 @@ networking:
     - cidr:
 ----
 |
-|The public CIDR (Classless Inter-Domain Routing) of the external network. For example, `10.0.0.0/24`
-ifdef::upstream[]
-ifeval::[{product-version} >= 4.5]
-or `2620:52:0:1302::/64`
-endif::[]
-endif::[]
-.
+|The public CIDR (Classless Inter-Domain Routing) of the external network. For example, `10.0.0.0/24`.
 
 a|
 ----

--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -22,7 +22,7 @@ baseDomain: <domain>
 metadata:
   name: <cluster-name>
 networking:
-  machineNetwork: 
+  machineNetwork:
   - cidr: <public-cidr>
   networkType: OVNKubernetes
 compute:
@@ -110,7 +110,6 @@ $ cp install-config.yaml ~/clusterconfigs
 $ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
 ----
 
-ifeval::[{product-version} >= 4.6]
 . Remove old bootstrap resources if any are left over from a previous deployment attempt.
 +
 [source,terminal]
@@ -125,20 +124,3 @@ do
   sudo virsh pool-undefine $i;
 done
 ----
-
-endif::[]
-ifeval::[{product-version} < 4.6]
-. Remove old bootstrap resources if any are left over from a previous deployment attempt.
-+
-[source,terminal]
-----
-for i in $(sudo virsh list | tail -n +3 | grep bootstrap | awk {'print $2'});
-do
-  sudo virsh destroy $i;
-  sudo virsh undefine $i;
-  sudo virsh vol-delete $i --pool default;
-  sudo virsh vol-delete $i.ign --pool default;
-done
-----
-
-endif::[]

--- a/modules/ipi-install-creating-the-openshift-manifests.adoc
+++ b/modules/ipi-install-creating-the-openshift-manifests.adoc
@@ -18,12 +18,3 @@ INFO Consuming Install Config from target directory
 WARNING Making control-plane schedulable by setting MastersSchedulable to true for Scheduler cluster settings
 WARNING Discarding the OpenShift Manifest that was provided in the target directory because its dependencies are dirty and it needs to be regenerated
 ----
-
-ifeval::[{product-version} <= 4.3]
-. Copy the `metal3-config.yaml` file to the `clusterconfigs/openshift` directory.
-+
-[source,terminal]
-----
-$ cp ~/metal3-config.yaml clusterconfigs/openshift/99_metal3-config.yaml
-----
-endif::[]

--- a/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
+++ b/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
@@ -17,7 +17,6 @@ In the event of a previous failed deployment, remove the artifacts from the fail
 $ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
 ----
 
-ifeval::[{product-version} >= 4.6]
 . Remove all old bootstrap resources if any are left over from a previous deployment attempt:
 +
 [source,terminal]
@@ -32,22 +31,6 @@ do
   sudo virsh pool-undefine $i;
 done
 ----
-
-endif::[]
-ifeval::[{product-version} < 4.6]
-. Remove all old bootstrap resources if any are left over from a previous deployment attempt:
-+
-[source,terminal]
-----
-for i in $(sudo virsh list | tail -n +3 | grep bootstrap | awk {'print $2'});
-do
-  sudo virsh destroy $i;
-  sudo virsh undefine $i;
-  sudo virsh vol-delete $i --pool default;
-  sudo virsh vol-delete $i.ign --pool default;
-done
-----
-endif::[]
 
 . Remove the following from the `clusterconfigs` directory to prevent Terraform from failing:
 +


### PR DESCRIPTION
This PR removes the last of the ifeval tags that compare product-version variable in the IPI docs. Thus, the upstream and downstream IPI docs are now completely decoupled and should have no more preview issues related to conditional text that depends on a comparison of the product-version variable. It has no visible impact on the presentation to end users and does not change the documentation from the end user perspective.

Signed-off-by: John Wilkins <jowilkin@redhat.com>

Version: 4.10+