### PR TITLE
RHDEVDOCS-4015 - Corrected case of value 'SystemMaxUse=8g' to 'SystemMaxUse=8G'

### DIFF
--- a/modules/cluster-logging-systemd-scaling.adoc
+++ b/modules/cluster-logging-systemd-scaling.adoc
@@ -48,7 +48,7 @@ storage:
         RateLimitIntervalSec=30s
         Storage=persistent <6>
         SyncIntervalSec=1s <7>
-        SystemMaxUse=8g <8>
+        SystemMaxUse=8G <8>
         SystemKeepFree=20% <9>
         SystemMaxFileSize=10M <10>
 ----
@@ -71,7 +71,7 @@ include a unit: "year", "month", "week", "day", "h" or "m". Enter `0` to disable
 * `none` to not store logs. systemd drops all logs.
 <7> Specify the timeout before synchronizing journal files to disk for *ERR*, *WARNING*, *NOTICE*, *INFO*, and *DEBUG* logs.
 systemd immediately syncs after receiving a *CRIT*, *ALERT*, or *EMERG* log. The default is `1s`.
-<8> Specify the maximum size the journal can use. The default is `8g`.
+<8> Specify the maximum size the journal can use. The default is `8G`.
 <9> Specify how much disk space systemd must leave free. The default is `20%`.
 <10> Specify the maximum size for individual journal files stored persistently in `/var/log/journal`. The default is `10M`.
 +


### PR DESCRIPTION
Version(s): 4.11, 4.10, 4.9. 4.8
Issue:(https://issues.redhat.com/browse/RHDEVDOCS-4015)

This is a single character change of case to correct a case sensitive value within a config file example. 
Please merge.  

