### PR TITLE
RHDEVDOCS 4015 - CP to 4.7 - Corrected case of value 'SystemMaxUse=8g' to 'SystemMaxUse=8G'

### DIFF
--- a/modules/cluster-logging-systemd-scaling.adoc
+++ b/modules/cluster-logging-systemd-scaling.adoc
@@ -30,7 +30,7 @@ RateLimitBurst=10000 <4>
 RateLimitIntervalSec=30s
 Storage=persistent <5>
 SyncIntervalSec=1s <6>
-SystemMaxUse=8g <7>
+SystemMaxUse=8G <7>
 SystemKeepFree=20% <8>
 SystemMaxFileSize=10M <9>
 ----
@@ -53,7 +53,7 @@ are received, all further messages within the interval are dropped until the int
 * `none` to not store logs. systemd drops all logs.
 <6> Specify the timeout before synchronizing journal files to disk for *ERR*, *WARNING*, *NOTICE*, *INFO*, and *DEBUG* logs.
 systemd immediately syncs after receiving a *CRIT*, *ALERT*, or *EMERG* log. The default is `1s`.
-<7> Specify the maximum size the journal can use. The default is `8g`.
+<7> Specify the maximum size the journal can use. The default is `8G`.
 <8> Specify how much disk space systemd must leave free. The default is `20%`.
 <9> Specify the maximum size for individual journal files stored persistently in `/var/log/journal`. The default is `10M`.
 +


### PR DESCRIPTION
Manual CP of https://github.com/openshift/openshift-docs/pull/44984 

Branches: 4.7