### PR TITLE
[enterprise-4.9] [BZ2035368]: Explain non-STS clusters cannot switch to STS

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 Manual mode with STS is supported for Amazon Web Services (AWS).
 
+[NOTE]
+====
+This credentials strategy is supported for only new {product-title} clusters and must be configured during installation. You cannot reconfigure an existing cluster that uses a different credentials strategy to use this feature.
+====
+
 In manual mode with STS, the individual {product-title} cluster components use AWS Secure Token Service (STS) to assign components IAM roles that provide short-term, limited-privilege security credentials. These credentials are associated with IAM roles that are specific to each component that makes AWS API calls.
 
 Requests for new and refreshed credentials are automated by using an appropriately configured AWS IAM OpenID Connect (OIDC) identity provider, combined with AWS IAM roles. {product-title} signs service account tokens that are trusted by AWS IAM, and can be projected into a pod and used for authentication. Tokens are refreshed after one hour.

--- a/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
+++ b/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
@@ -28,6 +28,11 @@ ifdef::aws[]
 * *Use the Amazon Web Services Security Token Service*:
 +
 You can use the CCO utility (`ccoctl`) to configure the cluster to use the Amazon Web Services Security Token Service (AWS STS). When the CCO utility is used to configure the cluster for STS, it assigns IAM roles that provide short-term, limited-privilege security credentials to components.
++
+[NOTE]
+====
+This credentials strategy is supported for only new {product-title} clusters and must be configured during installation. You cannot reconfigure an existing cluster that uses a different credentials strategy to use this feature.
+====
 
 endif::aws[]
 


### PR DESCRIPTION
Cherry Picked from 7dbb2729a26c545ce8fe5d32ed25bb4cb96a56d8 xref: #44944