### PR TITLE
[enterprise-4.7] [BZ2035368]: Explain non-STS clusters cannot switch to STS

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
@@ -11,6 +11,11 @@ Manual mode with STS is available as a link:https://access.redhat.com/support/of
 :FeatureName: Support for AWS Secure Token Service (STS)
 include::snippets/technology-preview.adoc[leveloffset=+0]
 
+[NOTE]
+====
+This credentials strategy is supported for only new {product-title} clusters and must be configured during installation. You cannot reconfigure an existing cluster that uses a different credentials strategy to use this feature.
+====
+
 In manual mode with STS, the individual {product-title} cluster components use AWS Secure Token Service (STS) to assign components IAM roles that provide short-term, limited-privilege security credentials. These credentials are associated with IAM roles that are specific to each component that makes AWS API calls.
 
 Requests for new and refreshed credentials are automated by using an appropriately configured AWS IAM OpenID Connect (OIDC) identity provider, combined with AWS IAM roles. {product-title} signs service account tokens that are trusted by AWS IAM, and can be projected into a pod and used for authentication. Tokens are refreshed after one hour.


### PR DESCRIPTION
Cherry Picked from 7dbb2729a26c545ce8fe5d32ed25bb4cb96a56d8 xref: #44944