### PR TITLE
[WIP] OSDODCS-3230: OSDK CIT: Add supported images to upstream OSDK

### DIFF
--- a/modules/osdk-prepare-supported-images.adoc
+++ b/modules/osdk-prepare-supported-images.adoc
@@ -1,0 +1,105 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/golang/osdk-golang-tutorial.adoc
+// * operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+// * operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+
+ifeval::["{context}" == "osdk-golang-tutorial"]
+:golang:
+:type: Go
+endif::[]
+ifeval::["{context}" == "osdk-ansible-tutorial"]
+:ansible:
+:type: Ansible
+:type_lc: ansible
+endif::[]
+ifeval::["{context}" == "osdk-helm-tutorial"]
+:helm:
+:type: Helm
+:type_lc: helm
+endif::[]
+
+:_content-type: PROCEDURE
+[id="osdk-prepare-supported-images_{context}"]
+= Preparing your Operator to use supported images
+
+[IMPORTANT]
+====
+If you are using the Red Hat supported, or downstream, release of the Operator SDK, you do not need to update your project to use supported images as shown in the following procedure. The downstream release of the Operator SDK uses universal base images (UBIs) by default.
+====
+
+Before running your {type}-based Operator on {product-title} Container Platform, update your project to use supported images.
+
+.Prerequisite
+
+* A {type}-based Operator project that uses a community-provided image.
+
+.Procedure
+
+ifdef::golang[]
+. Update the project root-level Dockerfile to use supported images. Change the runner image reference from:
++
+[source,terminal]
+----
+FROM gcr.io/distroless/static:nonroot
+----
++
+to:
++
+[source,terminal]
+----
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+----
+
+. Depending on the Go project version, your Dockerfile might contain a `USER 65532:65532` or `USER nonroot:nonroot` directive. In either case, remove the line, as it is not required by the supported runner image.
+endif::[]
+
+ifdef::ansible,helm[]
+. Update the project root-level Dockerfile to use supported images. Change the builder image reference from:
++
+[source,terminal,subs="attributes+"]
+----
+FROM quay.io/operator-framework/{type_lc}-operator:<operator_sdk_version>
+----
++
+to:
++
+[source,terminal,subs="attributes+"]
+----
+FROM registry.redhat.io/openshift4/ose-{type_lc}-operator:v{product-version}
+----
++
+[IMPORTANT]
+====
+Use the builder image version that matches your Operator SDK version. Failure to do so can result in problems due to project layout, or _scaffolding_, differences, particularly when mixing newer upstream versions of the Operator SDK with downstream {product-title} builder images.
+====
+endif::[]
+
+. In the `config/default/manager_auth_proxy_patch.yaml` file, change the `image` value from:
++
+[source,terminal]
+----
+gcr.io/kubebuilder/kube-rbac-proxy:<tag>
+----
++
+to use the supported image:
++
+[source,terminal,subs="attributes+"]
+----
+registry.redhat.io/openshift4/ose-kube-rbac-proxy:v{product-version}
+----
+
+ifeval::["{context}" == "osdk-golang-tutorial"]
+:!golang:
+:!type:
+endif::[]
+ifeval::["{context}" == "osdk-ansible-tutorial"]
+:!ansible:
+:!type:
+:!type_lc:
+endif::[]
+ifeval::["{context}" == "osdk-helm-tutorial"]
+:!helm:
+:!type:
+:!type_lc:
+endif::[]

--- a/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
@@ -34,6 +34,7 @@ include::modules/osdk-ansible-modify-manager.adoc[leveloffset=+1]
 include::modules/osdk-run-proxy.adoc[leveloffset=+1]
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
+include::modules/osdk-prepare-supported-images.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
 
 [id="osdk-bundle-deploy-olm_{context}"]

--- a/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
@@ -43,6 +43,7 @@ include::modules/osdk-golang-controller-rbac-markers.adoc[leveloffset=+2]
 include::modules/osdk-run-proxy.adoc[leveloffset=+1]
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
+include::modules/osdk-prepare-supported-images.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
 
 [id="osdk-bundle-deploy-olm_{context}"]

--- a/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
@@ -36,6 +36,7 @@ include::modules/osdk-helm-modify-cr.adoc[leveloffset=+2]
 include::modules/osdk-run-proxy.adoc[leveloffset=+1]
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
+include::modules/osdk-prepare-supported-images.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
 
 [id="osdk-bundle-deploy-olm_{context}"]


### PR DESCRIPTION
Version(s): 4.8+

Issue: [OSDOCS-3230](https://issues.redhat.com//browse/OSDOCS-3230)

Link to docs preview (requires VPN access to view):
- [Go](http://file.rdu.redhat.com/mipeter/osdocs-3230-osdk-upstream-supported-images/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-prepare-supported-images_osdk-golang-tutorial)
- [Ansible](http://file.rdu.redhat.com/mipeter/osdocs-3230-osdk-upstream-supported-images/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-prepare-supported-images_osdk-ansible-tutorial)
- [Helm](http://file.rdu.redhat.com/mipeter/osdocs-3230-osdk-upstream-supported-images/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-prepare-supported-images_osdk-helm-tutorial)

Additional information:
When the downstream version of Operator SDK was released in OCP 4.8, the docs removed the procedure to manaully update images to Operators. 