### PR TITLE
OSDOCS-3437: Installing to the AWS SC2S region

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -157,7 +157,7 @@ Topics:
     File: installing-aws-private
   - Name: Installing a cluster on AWS into a government region
     File: installing-aws-government-region
-  - Name: Installing a cluster on AWS into a Top Secret Region
+  - Name: Installing a cluster on AWS into a Secret or Top Secret Region
     File: installing-aws-secret-region
   - Name: Installing a cluster on AWS into a China region
     File: installing-aws-china

--- a/installing/installing_aws/installing-aws-secret-region.adoc
+++ b/installing/installing_aws/installing-aws-secret-region.adoc
@@ -1,12 +1,17 @@
 :_content-type: ASSEMBLY
 [id="installing-aws-secret-region"]
-= Installing a cluster on AWS into a Top Secret Region
+= Installing a cluster on AWS into a Secret or Top Secret Region
 include::_attributes/common-attributes.adoc[]
 :context: installing-aws-secret-region
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on Amazon Web Services (AWS) into a Commercial Cloud Services (C2S) Top Secret Region. To configure the region, modify parameters in the `install config.yaml` file before you install the cluster.
+In {product-title} version {product-version}, you can install a cluster on Amazon Web Services (AWS) into the following secret regions:
+
+* Secret Commercial Cloud Services (SC2S)
+* Commercial Cloud Services (C2S)
+
+To configure a cluster in either region, you change parameters in the `install config.yaml` file before you install the cluster.
 
 [id="prerequisites_installing-aws-secret-region"]
 == Prerequisites
@@ -56,20 +61,17 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_installing-aws-secret-region_console"]
 .Additional resources
-
-* See xref:../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
+* xref:../../web_console/web-console.adoc#web-console[Accessing the web console]
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_installing-aws-secret-region_telemetry"]
 .Additional resources
-
-* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 
 [id="next-steps_installing-aws-secret-region"]
 == Next steps
-
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/modules/installation-aws-about-government-region.adoc
+++ b/modules/installation-aws-about-government-region.adoc
@@ -15,21 +15,12 @@ ifdef::aws-gov[]
 = AWS government regions
 endif::aws-gov[]
 ifdef::aws-secret[]
-= AWS Top Secret Region
+= AWS secret regions
 endif::aws-secret[]
 
 ifdef::aws-gov[]
 {product-title} supports deploying a cluster to an link:https://aws.amazon.com/govcloud-us[AWS GovCloud (US)] region.
 endif::aws-gov[]
-
-ifdef::aws-secret[]
-{product-title} supports deploying a cluster to an link:https://aws.amazon.com/federal/us-intelligence-community/[AWS Commercial Cloud Services (C2S) Top Secret Region].
-endif::aws-secret[]
-
-ifdef::aws-secret[]
-The C2S Top Secret Region does not have a published {op-system-first} Amazon Machine Images (AMI) to select, so you
-must upload a custom AMI that belongs to that region.
-endif::aws-secret[]
 
 ifdef::aws-gov[]
 The following AWS GovCloud partitions are supported:
@@ -39,13 +30,14 @@ The following AWS GovCloud partitions are supported:
 endif::aws-gov[]
 
 ifdef::aws-secret[]
-The following AWS Top Secret Region partition is supported:
+The following AWS secret partitions are supported:
 
-* `us-iso-east-1`
+* `us-isob-east-1` (SC2S)
+* `us-iso-east-1` (C2S)
 
 [NOTE]
 ====
-The maximum supported MTU in an AWS Top Secret Region is not the same as
+The maximum supported MTU in an AWS SC2S and C2S Regions is not the same as
 AWS commercial. For more information about configuring MTU during installation,
 see the _Cluster Network Operator configuration object_ section in _Installing
 a cluster on AWS with network customizations_

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -373,10 +373,10 @@ endif::openshift-origin[]
 endif::private[]
 ifdef::secret[]
 ifndef::openshift-origin[]
-<15> The custom CA certificate. This is required when deploying to the AWS C2S Top Secret Region because the AWS API requires a custom CA trust bundle.
+<15> The custom CA certificate. This is required when deploying to the SC2S or C2S Regions because the AWS API requires a custom CA trust bundle.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<14> The custom CA certificate. This is required when deploying to the AWS C2S Top Secret Region because the AWS API requires a custom CA trust bundle.
+<14> The custom CA certificate. This is required when deploying to the SC2S or C2S Regions because the AWS API requires a custom CA trust bundle.
 endif::openshift-origin[]
 endif::secret[]
 ifdef::restricted[]

--- a/modules/installation-aws-regions-with-no-ami.adoc
+++ b/modules/installation-aws-regions-with-no-ami.adoc
@@ -43,7 +43,7 @@ endif::aws-china,aws-secret[]
 
 ifdef::aws-china,aws-secret[]
 ifdef::aws-china[Red Hat does not publish a {op-system-first} Amazon Machine Image (AMI) for the AWS China regions.]
-ifdef::aws-secret[Red Hat does not publish a {op-system-first} Amzaon Machine Image for the AWS Top Secret Region.]
+ifdef::aws-secret[Red Hat does not publish a {op-system-first} Amzaon Machine Image for the AWS Secret and Top Secret Regions.]
 
 Before you can install the cluster, you must:
 

--- a/modules/installation-aws-regions.adoc
+++ b/modules/installation-aws-regions.adoc
@@ -48,9 +48,12 @@ The following AWS GovCloud regions are supported:
 * `us-gov-east-1`
 
 [id="installation-aws-c2s_{context}"]
-== AWS C2S Secret region
+== AWS SC2S and C2S secret regions
 
-The `us-iso-east-1` region is supported.
+The following AWS secret regions are supported:
+
+* `us-isob-east-1` Secret Commercial Cloud Services (SC2S)
+* `us-iso-east-1` Commercial Cloud Services (C2S)
 
 [id="installation-aws-china_{context}"]
 == AWS China regions

--- a/modules/installation-custom-aws-vpc.adoc
+++ b/modules/installation-custom-aws-vpc.adoc
@@ -82,7 +82,13 @@ If you are working in a disconnected environment, you are unable to reach the pu
 endif::aws-china[]
 
 ifdef::aws-secret[]
-* A cluster in a Top Secret Region is unable to reach the public IP addresses for the EC2 and ELB endpoints. You must create a VPC endpoint and attach it to the subnet that the clusters are using. Name the endpoints as follows:
+* A cluster in an SC2S or C2S Region is unable to reach the public IP addresses for the EC2 and ELB endpoints. You must create a VPC endpoint and attach it to the subnet that the clusters are using. Name the endpoints as follows:
++
+SC2S::
+** `elasticloadbalancing.<region>.sc2s.sgov.gov`
+** `ec2.<region>.sc2s.sgov.gov`
+** `s3.<region>.sc2s.sgov.gov`
+C2S::
 ** `elasticloadbalancing.<region>.c2s.ic.gov`
 ** `ec2.<region>.c2s.ic.gov`
 ** `s3.<region>.c2s.ic.gov`


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR documents [CORS-1951](https://issues.redhat.com/browse/CORS-1951)/[OSDOCS-3437](https://issues.redhat.com/browse/OSDOCS-3437) (Installer support for AWS Secret Region).

Link to docs preview:

- [AWS SC2S and C2S secret regions](http://file.rdu.redhat.com/mpytlak/osdocs-3437/installing/installing_aws/installing-aws-account.html#installation-aws-c2s_installing-aws-account)
- [Installing a cluster on AWS into a Secret or Top Secret Region](http://file.rdu.redhat.com/mpytlak/osdocs-3437/installing/installing_aws/installing-aws-secret-region.html)
- [AWS secret regions](http://file.rdu.redhat.com/mpytlak/osdocs-3437/installing/installing_aws/installing-aws-secret-region.html)
- [Installation requirements](http://file.rdu.redhat.com/mpytlak/osdocs-3437/installing/installing_aws/installing-aws-secret-region.html#installation-aws-regions-with-no-ami_installing-aws-secret-region)
-  [Requirements for using your VPC](http://file.rdu.redhat.com/mpytlak/osdocs-3437/installing/installing_aws/installing-aws-secret-region.html#installation-custom-aws-vpc-requirements_installing-aws-secret-region)