### PR TITLE
BZ-2074511: Can not enable image signature verification on rhel7 worker node

### DIFF
--- a/modules/containers-signature-verify-enable.adoc
+++ b/modules/containers-signature-verify-enable.adoc
@@ -5,9 +5,10 @@
 :_content-type: PROCEDURE
 [id="containers-signature-verify-enable_{context}"]
 = Enabling signature verification for Red Hat Container Registries
-Enabling container signature validation for Red Hat Container Registries requires writing a signature verification policy file specifying the keys to verify images from these registries. The registries are already defined in `/etc/containers/registries.d` by default.
+Enabling container signature validation for Red Hat Container Registries requires writing a signature verification policy file specifying the keys to verify images from these registries. For RHEL8 nodes, the registries are already defined in `/etc/containers/registries.d` by default.
 
 .Procedure
+
 . Create a Butane config file, `51-worker-rh-registry-trust.bu`, containing the necessary configuration for the worker nodes.
 +
 [NOTE]
@@ -78,19 +79,90 @@ $ butane 51-worker-rh-registry-trust.bu -o 51-worker-rh-registry-trust.yaml
 $ oc apply -f 51-worker-rh-registry-trust.yaml
 ----
 
-. Create a Butane config and corresponding machine config which writes the configuration to disk on the control plane nodes:
+. Check that the worker machine config pool has rolled out with the new machine config:
+
+.. Check that the new machine config was created:
 +
 [source,terminal]
 ----
-$ sed -e 's,\(machineconfiguration.openshift.io/role: \)worker,\1master,' \
-    -e 's,\(name: 51-\)worker,\1master,' 51-worker-rh-registry-trust.bu \
-    > 51-master-rh-registry-trust.bu
-$ butane 51-master-rh-registry-trust.bu -o 51-master-rh-registry-trust.yaml
+$ oc get mc
+----
++
+.Sample output
+[source,terminal] 
+----
+NAME                                               GENERATEDBYCONTROLLER                      IGNITIONVERSION   AGE
+00-master                                          a2178ad522c49ee330b0033bb5cb5ea132060b0a   3.2.0             25m
+00-worker                                          a2178ad522c49ee330b0033bb5cb5ea132060b0a   3.2.0             25m
+01-master-container-runtime                        a2178ad522c49ee330b0033bb5cb5ea132060b0a   3.2.0             25m
+01-master-kubelet                                  a2178ad522c49ee330b0033bb5cb5ea132060b0a   3.2.0             25m
+01-worker-container-runtime                        a2178ad522c49ee330b0033bb5cb5ea132060b0a   3.2.0             25m
+01-worker-kubelet                                  a2178ad522c49ee330b0033bb5cb5ea132060b0a   3.2.0             25m
+51-master-rh-registry-trust                                                                   3.2.0             13s
+51-worker-rh-registry-trust                                                                   3.2.0             53s <1>
+99-master-generated-crio-seccomp-use-default                                                  3.2.0             25m
+99-master-generated-registries                     a2178ad522c49ee330b0033bb5cb5ea132060b0a   3.2.0             25m
+99-master-ssh                                                                                 3.2.0             28m
+99-worker-generated-crio-seccomp-use-default                                                  3.2.0             25m
+99-worker-generated-registries                     a2178ad522c49ee330b0033bb5cb5ea132060b0a   3.2.0             25m
+99-worker-ssh                                                                                 3.2.0             28m
+rendered-master-af1e7ff78da0a9c851bab4be2777773b   a2178ad522c49ee330b0033bb5cb5ea132060b0a   3.2.0             8s  
+rendered-master-cd51fd0c47e91812bfef2765c52ec7e6   a2178ad522c49ee330b0033bb5cb5ea132060b0a   3.2.0             24m
+rendered-worker-2b52f75684fbc711bd1652dd86fd0b82   a2178ad522c49ee330b0033bb5cb5ea132060b0a   3.2.0             24m
+rendered-worker-be3b3bce4f4aa52a62902304bac9da3c   a2178ad522c49ee330b0033bb5cb5ea132060b0a   3.2.0             48s <2>
+----
+<1> New machine config
+<2> New rendered machine config 
+
+.. Check that the machine config pool worker is updating with the new machine config:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+.Sample output
+[source,terminal] 
+----
+NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+master   rendered-master-af1e7ff78da0a9c851bab4be2777773b   True      False      False      3              3                   3                     0                      30m
+worker   rendered-worker-be3b3bce4f4aa52a62902304bac9da3c   False     True       False      3              0                   0                     0                      30m <1>
+----
+<1> When the `UPDATING` field is `True`, the machine config pool is updating with the new machine config. When the field becomes `False`, the worker machine config pool has rolled out to the new machine config.
+
+. If your cluster uses any RHEL7 worker nodes, when the worker machine config pool is updated, create YAML files on those nodes in the `/etc/containers/registries.d` directory, which specify the location of the detached signatures for a given registry server. The following example works only for images hosted in `registry.access.redhat.com` and `registry.redhat.io`.
+
+.. Start a debug session to each RHEL7 worker node:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
 ----
 
-. Apply the control plane machine config to the cluster:
+.. Change your root directory to the host:
 +
 [source,terminal]
 ----
-$ oc apply -f 51-master-rh-registry-trust.yaml
+sh-4.2# chroot /host
 ----
+
+.. Create a `/etc/containers/registries.d/registry.redhat.io.yaml` file that contains the following:   
++
+[source,terminal]
+----
+docker:
+     registry.redhat.io:
+         sigstore: https://registry.redhat.io/containers/sigstore
+----
+
+.. Create a `/etc/containers/registries.d/registry.access.redhat.com.yaml` file that contains the following:   
++
+[source,terminal]
+----
+docker:
+     registry.access.redhat.com:
+         sigstore: https://access.redhat.com/webassets/docker/content/sigstore
+----
+
+.. Exit the debug session.
+


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2074511

...add file `registry.redhat.io.yaml` and `registry.access.redhat.com.yaml` in directory `/etc/containers/registries.d/`. So I think it's a doc bug.

Preview: [Enabling signature verification for Red Hat Container Registries](https://deploy-preview-45006--osdocs.netlify.app/openshift-enterprise/latest/security/container_security/security-container-signature.html#containers-signature-verify-enable_security-container-signature)
