### PR TITLE
OADP-470_Fix indent in DPA yaml

### DIFF
--- a/modules/oadp-installing-dpa.adoc
+++ b/modules/oadp-installing-dpa.adoc
@@ -238,8 +238,6 @@ spec:
         - gcp <.>
         - csi <.>
         - openshift <.>
-     featureFlags:
-     - EnableCSI <.>
     restic:
       enable: true <.>
   backupLocations:
@@ -256,7 +254,6 @@ spec:
 <.> Specify the default plug-in for the backup provider, for example, `gcp`, if appropriate.
 <.> Specify the `csi` default plug-in if you use CSI snapshots to back up PVs. The `csi` plug-in uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
 <.> The `openshift` plug-in is mandatory.
-<.> The `EnableCSI` flag is mandatory for CSI.
 <.> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
 <.> Specify the backup provider.
 <.> If you use a default plug-in for the backup provider, you must specify the correct default name for the `Secret`, for example, `cloud-credentials-gcp`. If you specify a custom name, the custom name is used for the backup location. If you do not specify a `Secret` name, the default name is used.

--- a/modules/oadp-installing-dpa.adoc
+++ b/modules/oadp-installing-dpa.adoc
@@ -238,8 +238,8 @@ spec:
         - gcp <.>
         - csi <.>
         - openshift <.>
-    featureFlags:
-    - EnableCSI <.>
+     featureFlags:
+     - EnableCSI <.>
     restic:
       enable: true <.>
   backupLocations:


### PR DESCRIPTION
[OADP-470](https://issues.redhat.com//browse/OADP-470): Fix indent in DPA yaml (changed to remove two lines from a YAML)

Resolves: https://issues.redhat.com/browse/OADP-470 by removing two lines and the comment attached to them from the specified YAML file 

Version(s): Current OADP; OCP 4.6+

Link to docs preview:
https://deploy-preview-45009--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html -- See the manifest in Step 3 of Installing the Data Protection Application. 
