### PR TITLE
RHDEVDOCS-4016 Pipelines 1.7 RN revisions

### DIFF
--- a/modules/op-installing-pipelines-operator-in-web-console.adoc
+++ b/modules/op-installing-pipelines-operator-in-web-console.adoc
@@ -41,8 +41,13 @@ The supported profiles are:
 
 .. Select an *Update Channel*.
 
-*** The *stable* channel enables installation of the latest stable and supported release of the {pipelines-title} Operator.
-*** The *preview* channel enables installation of the latest preview version of the {pipelines-title} Operator, which may contain features that are not yet available from the *stable* channel and is not supported.
+*** The `pipelines-<version>` channel is the default channel to install the {pipelines-title} Operator. For example, the default channel to install the {pipelines-title} Operator version `1.7` is `pipelines-1.7`.
+*** The `latest` channel enables installation of the most recent stable version of the {pipelines-title} Operator. 
++
+[NOTE]
+====
+The `preview` and `stable` channels will be deprecated and removed in a future release.
+====  
 
 . Click *Install*. You will see the Operator listed on the *Installed Operators* page.
 +

--- a/modules/op-installing-pipelines-operator-using-the-cli.adoc
+++ b/modules/op-installing-pipelines-operator-using-the-cli.adoc
@@ -28,7 +28,7 @@ spec:
   source: redhat-operators <3>
   sourceNamespace: openshift-marketplace <4>
 ----
-<1> Specify the channel name from where you want to subscribe the Operator
+<1> The channel name of the Operator. The `pipelines-<version>` channel is the default channel. For example, the default channel for {pipelines-title} Operator version `1.7` is `pipelines-1.7`. The `latest` channel enables installation of the most recent stable version of the {pipelines-title} Operator.
 <2> Name of the Operator to subscribe to.
 <3> Name of the CatalogSource that provides the Operator.
 <4> Namespace of the CatalogSource. Use `openshift-marketplace` for the default OperatorHub CatalogSources.

--- a/modules/op-release-notes-1-7.adoc
+++ b/modules/op-release-notes-1-7.adoc
@@ -15,6 +15,18 @@ In addition to the fixes and stability improvements, the following sections high
 [id="pipelines-new-features-1-7_{context}"]
 === Pipelines
 
+* With this update, `pipelines-<version>` is the default channel to install the {pipelines-title} Operator. For example, the default channel to install the {pipelines-shortname} Operator version `1.7` is `pipelines-1.7`. Cluster administrators can also use the `latest` channel to install the most recent stable version of the Operator. 
++
+[NOTE]
+====
+The `preview` and `stable` channels will be deprecated and removed in a future release.
+====  
+
+* When you run a command in a user namespace, your container runs as `root` (user id `0`) but has user privileges on the host. With this update, to run pods in the user namespace, you must pass the annotations that link:https://cri-o.io/[CRI-O] expects.
+** To add these annotations for all users, run the `oc edit clustertask buildah` command and edit the `buildah` cluster task. 
+** To add the annotations to a specific namespace, export the cluster task as a task to that namespace.
+// https://issues.redhat.com/browse/SRVKP-1514
+
 * With this update, the `when` expressions in a `Task` object are scoped to guard the tasks by default. To continue guarding the `Task` object and its dependent tasks, set the `scope-when-expressions-to-task` flag to `true`. 
 +
 [NOTE]
@@ -254,6 +266,31 @@ Pipelines as Code supports the following features:
 [id="known-issues-1-7_{context}"]
 == Known issues
 
+* When you run Maven and Jib-Maven cluster tasks, the default container image is supported only on Intel (x86) architecture. Therefore, tasks will fail on IBM Power Systems (ppc64le), IBM Z, and LinuxONE (s390x) clusters. As a workaround, you can specify a custom image by setting the `MAVEN_IMAGE` parameter value to `maven:3.6.3-adoptopenjdk-11`.
+// issue # is unknown.
++
+[TIP]
+====
+Before you install tasks based on the Tekton Catalog on IBM Power Systems (ppc64le), IBM Z, and LinuxONE (s390x) using `tkn hub`, verify if the task can be executed on these platforms. To check if `ppc64le` and `s390x` are listed in the "Platforms" section of the task information, you can run the following command: `tkn hub info task <name>`
+// issue # is unknown.
+====
+
+* On IBM Power Systems, IBM Z, and LinuxONE, the `s2i-dotnet` cluster task is unsupported.
+// issue # is unknown.
+
+* You cannot use the `nodejs:14-ubi8-minimal` image stream because doing so generates the following errors:
++
+[source,terminal]
+----
+STEP 7: RUN /usr/libexec/s2i/assemble
+/bin/sh: /usr/libexec/s2i/assemble: No such file or directory
+subprocess exited with status 127
+subprocess exited with status 127
+error building at STEP "RUN /usr/libexec/s2i/assemble": exit status 127
+time="2021-11-04T13:05:26Z" level=error msg="exit status 127"
+----
+// https://issues.redhat.com/browse/SRVKP-1782
+
 // Pipelines
 * Implicit parameter mapping incorrectly passes parameters from the top-level `Pipeline` or `PipelineRun` definitions to the `taskRef` tasks. Mapping should only occur from a top-level resource to tasks with in-line `taskSpec` specifications. This issue only affects users who have set the `enable-api-fields` feature flag to `alpha`.
 
@@ -262,8 +299,8 @@ Pipelines as Code supports the following features:
 == Fixed issues
 
 // Pipelines
-* With this update, metadata such as `labels` and `annotations` from task and pipeline definitions does not propagate to task runs and pipeline runs.
-// https://github.com/tektoncd/pipeline/pull/4478
+* With this update, if metadata such as `labels` and `annotations` are present in both `Pipeline` and `PipelineRun` object definitions, the values in the `PipelineRun` type takes precedence. You can observe similar behavior for `Task` and `TaskRun` objects. 
+// https://github.com/tektoncd/pipeline/pull/4638
 
 * With this update, if the `timeouts.tasks` field or the `timeouts.finally` field is set to `0`, then the `timeouts.pipeline` is also set to `0`. 
 // https://github.com/tektoncd/pipeline/pull/4539


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.10`, `enterprise-4.11`
- **JIRA issues**: [RHDEVDOCS-4016 Revisions to Pipelines 1.7 RN](https://issues.redhat.com/browse/RHDEVDOCS-4016)
- **Preview pages**: 
  - [Installing OpenShift Pipelines](https://deploy-preview-45012--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/installing-pipelines.html) for the changes in installation channels.
  - [Release notes for Red Hat OpenShift Pipelines General Availability 1.7](https://deploy-preview-45012--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#op-release-notes-1-7_op-release-notes)
- **SME review**: TBD       
- **Peer-review**: TBD   