### PR TITLE
BZ2058143: Changing .md5sum ext to sha256sum in Creating an RHCOS image cache

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -161,7 +161,7 @@ $ export BOOTSTRAP_OS_IMAGE="http://${BAREMETAL_IP}:8080/${RHCOS_QEMU_URI}?sha25
 +
 [source,terminal]
 ----
-$ echo "${RHCOS_OPENSTACK_SHA256}  ${RHCOS_OPENSTACK_URI}" > /home/kni/rhcos_image_cache/rhcos-ootpa-latest.qcow2.md5sum
+$ echo "${RHCOS_OPENSTACK_SHA256}  ${RHCOS_OPENSTACK_URI}" > /home/kni/rhcos_image_cache/rhcos-ootpa-latest.qcow2.sha256sum
 ----
 +
 [source,terminal]


### PR DESCRIPTION
Version(s): 4.8

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2058143

Link to docs preview:
https://deploy-preview-45014--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow#ipi-install-creating-an-rhcos-images-cache_ipi-install-installation-workflow

PR for 4.9: https://github.com/openshift/openshift-docs/pull/45013