### PR TITLE
[SRVCOM-1730] Add Serverless 1.22.0 release notes

### DIFF
--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -13,20 +13,22 @@ For the most recent list of major functionality deprecated and removed within {S
 // OCP table
 ifdef::openshift-enterprise[]
 .Deprecated and removed features tracker
-[cols="3,1,1,1,1",options="header"]
+[cols="3,1,1,1,1,1",options="header"]
 |====
-|Feature |1.18|1.19|1.20|1.21
+|Feature |1.18|1.19|1.20|1.21|1.22
 
 |`KafkaBinding` API
 |GA
 |Deprecated
 |Deprecated
 |Deprecated
+|Removed
 
 |`kn func emit` (`kn func invoke` in 1.21+)
 |TP
 |TP
 |Deprecated
+|Removed
 |Removed
 
 |====

--- a/modules/serverless-rn-1-20-0.adoc
+++ b/modules/serverless-rn-1-20-0.adoc
@@ -27,6 +27,8 @@ The Kafka broker, which is currently in Technology Preview, is not supported on 
 
 * The `kn event` plug-in is now available as a Technology Preview.
 
+* The `--min-scale` and `--max-scale` flags for the `kn service create` command have been deprecated. Use the `--scale-min` and `--scale-max` flags instead.
+
 [id="known-issues-1-20-0_{context}"]
 == Known issues
 

--- a/modules/serverless-rn-1-22-0.adoc
+++ b/modules/serverless-rn-1-22-0.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-22-0_{context}"]
+= Release notes for Red Hat {ServerlessProductName} 1.22.0
+
+{ServerlessProductName} 1.22.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+[id="new-features-1-22-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.1.
+* {ServerlessProductName} now uses Knative Eventing 1.1.
+* {ServerlessProductName} now uses Kourier 1.1.
+* {ServerlessProductName} now uses Knative `kn` CLI 1.1.
+* {ServerlessProductName} now uses Knative Kafka 1.1.
+* The `kn func` CLI plug-in now uses `func` 0.23.
+* Knative service specifications now support init containers.
+* The persistent volume claim (PVC) support for Knative services is now available as a Technology Preview.
+* The `knative-serving`, `knative-serving-ingress`, `knative-eventing` and `knative-kafka` system namespaces now have the `knative.openshift.io/part-of: "openshift-serverless"` label by default.
+* The *Knative Eventing - Kafka Broker/Trigger* dashboard has been added, which allows visualizing Kafka broker and trigger metrics in the web console.
+* The *Knative Eventing - KafkaSink* dashboard has been added, which allows visualizing KafkaSink metrics in the web console.
+* The *Knative Eventing - Broker/Trigger* dashboard is now called *Knative Eventing - Channel-based Broker/Trigger*.
+* The `knative.openshift.io/part-of: "openshift-serverless"` label has substituted the `knative.openshift.io/system-namespace` label.
+* Naming style in Knative Serving YAML configuration files changed from camel case (`ExampleName`) to hyphen style (`example-name`). Beginning with this release, use the hyphen style notation when creating or editing Knative Serving YAML configuration files.
+
+[id="known-issues-1-22-0_{context}"]
+== Known issues
+
+* The Federal Information Processing Standards (FIPS) mode is disabled for Kafka broker, Kafka source, and Kafka sink.

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -23,6 +23,7 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD
+include::modules/serverless-rn-1-22-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-21-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-20-0.adoc[leveloffset=+1]
 


### PR DESCRIPTION
4.6+

Issue: https://issues.redhat.com/browse/SRVCOM-1730

Link to docs preview: https://deploy-preview-45026--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-rn-1-22-0_serverless-release-notes