### PR TITLE
BZ2007783 - Updating ssh key in installer

### DIFF
--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -166,7 +166,7 @@ endif::openshift-origin[]
 ----
 $ ssh-keygen -t ed25519 -N '' -f <path>/<file_name> <1>
 ----
-<1> Specify the path and file name, such as `~/.ssh/id_rsa`, of the new SSH key. If you have an existing key pair, ensure your public key is in the your `~/.ssh` directory.
+<1> Specify the path and file name, such as `~/.ssh/id_ed25519`, of the new SSH key. If you have an existing key pair, ensure your public key is in the your `~/.ssh` directory.
 +
 [NOTE]
 ====
@@ -180,11 +180,11 @@ If you plan to install an {product-title} cluster that uses FIPS Validated / Mod
 $ cat <path>/<file_name>.pub
 ----
 +
-For example, run the following to view the `~/.ssh/id_rsa.pub` public key:
+For example, run the following to view the `~/.ssh/id_ed25519.pub` public key:
 +
 [source,termanal]
 ----
-$ cat ~/.ssh/id_rsa.pub
+$ cat ~/.ssh/id_ed25519.pub
 ----
 
 . Add the SSH private key identity to the SSH agent for your local user, if it has not already been added. SSH agent management of the key is required for password-less SSH authentication onto your cluster nodes, or if you want to use the `./openshift-install gather` command.
@@ -218,7 +218,7 @@ If your cluster is in FIPS mode, only use FIPS-compliant algorithms to generate 
 ----
 $ ssh-add <path>/<file_name> <1>
 ----
-<1> Specify the path and file name for your SSH private key, such as `~/.ssh/id_rsa`
+<1> Specify the path and file name for your SSH private key, such as `~/.ssh/id_ed25519`
 +
 .Example output
 [source,terminal]


### PR DESCRIPTION
For versions 4.8+
[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2007783)

Ready for QA

Preview: [Generating a key pair for cluster node SSH access](https://deploy-preview-45034--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.html#ssh-agent-using_installing-azure-stack-hub-user-infra)