### PR TITLE
[OSDOCS-3566]: Add admonition about lack of machine set support for control planes

### DIFF
--- a/modules/machine-api-overview.adoc
+++ b/modules/machine-api-overview.adoc
@@ -23,6 +23,11 @@ The two primary resources are:
 Machines:: A fundamental unit that describes the host for a node. A machine has a `providerSpec` specification, which describes the types of compute nodes that are offered for different cloud platforms. For example, a machine type for a worker node on Amazon Web Services (AWS) might define a specific machine type and required metadata.
 
 Machine sets:: `MachineSet` resources are groups of machines. Machine sets are to machines as replica sets are to pods. If you need more machines or must scale them down, you change the *replicas* field on the machine set to meet your compute need.
++
+[WARNING]
+====
+Control plane machines cannot be managed by machine sets.
+====
 
 The following custom resources add more capabilities to your cluster:
 


### PR DESCRIPTION
Version(s):
4.6+

Issue:
[OSDOCS-3566](https://issues.redhat.com//browse/OSDOCS-3566)

Link to docs preview:
[Machine API overview](https://deploy-preview-45035--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws) (AWS)

Additional information:
This appears in every platform's creating machine sets assembly, so I linked AWS as a representative sample. I have a backlog item to move all this into the book intro, so longer-term it will end up there. Given that, do we need to mention it closer to the actual procedure as a reminder?