### PR TITLE
Bug 2079334, corrected and hardcoded version number

### DIFF
--- a/modules/cnf-cpu-infra-container.adoc
+++ b/modules/cnf-cpu-infra-container.adoc
@@ -21,7 +21,7 @@ Generic housekeeping and workload tasks use CPUs in a way that may impact latenc
 |Runs on any CPU except where low latency workload is running
 
 |Interrupts
-|Redirects to reserved CPUs (optional in {product-title} {product-version} and later)
+|Redirects to reserved CPUs (optional in {product-title} 4.7 and later)
 
 |Kernel processes
 |Pins to reserved CPUs


### PR DESCRIPTION
Version(s):
4.7+

Addresses: 
https://bugzilla.redhat.com/show_bug.cgi?id=2079334

Preview build: https://deploy-preview-45036--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#cnf-cpu-infra-container_cnf-master



