### PR TITLE
Fixes the .z in 3.11.685 release

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -5772,14 +5772,14 @@ openshift3/ose-template-service-broker:v3.11.664-1.g48523b6
 
 To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.
 
-[[ocp-3-11-665]]
-=== RHSA-2022:1420 - {product-title} 3.11.665 bug fix and security update
+[[ocp-3-11-685]]
+=== RHSA-2022:1420 - {product-title} 3.11.685 bug fix and security update
 
 Issued: 2022-04-27
 
-{product-title} release 3.11.665 is now available. The list of packages and bug fixes included in the update are documented in the link:https://access.redhat.com/errata/RHSA-2022:1420[RHSA-2022:1420] advisory. The container images included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1421[RHBA-2021:1421] advisory.
+{product-title} release 3.11.685 is now available. The list of packages and bug fixes included in the update are documented in the link:https://access.redhat.com/errata/RHSA-2022:1420[RHSA-2022:1420] advisory. The container images included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1421[RHBA-2021:1421] advisory.
 
-[[ocp-3-11-665-images]]
+[[ocp-3-11-685-images]]
 ==== Images
 
 This release updates the Red Hat Container Registry (`registry.redhat.io`) with the following images:
@@ -5862,7 +5862,7 @@ openshift3/snapshot-provisioner:v3.11.685-1
 openshift3/ose-template-service-broker:v3.11.685-1.g7faaeaa
 ----
 
-[[ocp-3-11-665-upgrading]]
+[[ocp-3-11-685-upgrading]]
 ==== Upgrading
 
 To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.


### PR DESCRIPTION
There was a typo in the advisory/PR for 3.11.685. It was published as 3.11.665, but 3.11.685 is the correct version numbers.

Version(s):
Applies to `enterprise-3.11` only

Link to docs preview: [Preview link](https://deploy-preview-45037--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp_3_11_release_notes#ocp-3-11-685)

Additional information:
I have spoken with the engineers working on this, they have updated the metadata in the advisories. Once the pages update, we can merge!



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
