### PR TITLE
OSDOCS-3568: Adding RN about future Kubernetes API removals

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -505,6 +505,15 @@ Support for deploying custom schedulers manually has been removed with this rele
 
 Support for deploying {sno} clusters with OpenShiftSDN has been removed with this release. OVN-Kubernetes is the default networking solution for {sno} deployments.
 
+[id="ocp-4-11-future-removals"]
+=== Future Kubernetes API removals
+
+The next minor release of {product-title} is expected to use Kubernetes 1.25. Currently, Kubernetes 1.25 is scheduled to remove several deprecated `v1beta1` and `v2beta1` APIs.
+
+See the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25[Deprecated API Migration Guide] in the upstream Kubernetes documentation for the list of planned Kubernetes API removals.
+
+See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API deprecations and removals] for information on how to check your cluster for Kubernetes APIs that are planned for removal.
+
 [id="ocp-4-11-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3572

Link to docs preview:
http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3568/release_notes/ocp-4-11-release-notes.html#ocp-4-11-future-removals
