### PR TITLE
NE-888: Add binding options to release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -91,7 +91,7 @@ For more information, see xref:../getting_started/openshift-overview.adoc[Gettin
 With this update, `HostNetwork` has a `hostNetwork` field with the following default values for the optional binding ports: `httpPort: 80`, `httpsPort: 443`, and `statsPort: 1936`.
 With the binding ports, you can deploy multiple Ingress Controllers on the same node for the `HostNetwork` strategy.
 
-For more information, see
+For more information, see xref:../networking/ingress-operator.adoc#configuring-ingress[Ingress Controller configuration parameters].
 
 [id="ocp-4-11-hardware"]
 === Hardware

--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -88,6 +88,11 @@ For more information, see xref:../getting_started/openshift-overview.adoc[Gettin
 [id="ocp-4-11-networking"]
 === Networking
 
+With this update, `HostNetwork` has a `hostNetwork` field with the following default values for the optional binding ports: `httpPort: 80`, `httpsPort: 443`, and `statsPort: 1936`.
+With the binding ports, you can deploy multiple Ingress Controllers on the same node for the `HostNetwork` strategy.
+
+For more information, see
+
 [id="ocp-4-11-hardware"]
 === Hardware
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.11 only
Issue:
[Jira](https://issues.redhat.com/browse/NE-888)

Link to docs preview:
[Preview](https://deploy-preview-45064--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes)
@quarterpin ptal.
Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
