### PR TITLE
RHDEVDOCS-4033 - Added 1.4.6 release notes

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -25,6 +25,8 @@ include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 // Modules included, most to least recent
 include::modules/gitops-release-notes-1-5-0.adoc[leveloffset=+1]
 
+include::modules/gitops-release-notes-1-4-6.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-4-5.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-4-3.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-4-6.adoc
+++ b/modules/gitops-release-notes-1-4-6.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-4-6_{context}"]
+= Release notes for {gitops-title} 1.4.6
+
+[role="_abstract"]
+{gitops-title} 1.4.6 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-4-6_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* The base images are updated to the latest version to avoid OpenSSL flaw link: https://access.redhat.com/security/cve/CVE-2022-0778[(CVE-2022-0778)].
+
+[NOTE]
+====
+To install the current release of {gitops-title} 1.4 and receive further updates during its product life cycle, switch to the **GitOps-1.4** channel.  
+====


### PR DESCRIPTION
OCP version for cherry-picking: enterprise- 4.10, 4.11
JIRA issues: https://issues.redhat.com/browse/RHDEVDOCS-4033

Preview pages: https://deploy-preview-45069--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes#gitops-release-notes-1-4-6_gitops-release-notes

SME+QE review:
Peer-review: 