### PR TITLE
RHDEVDOCS-4032 - Added release notes for 1.3.7

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -35,6 +35,10 @@ include::modules/gitops-release-notes-1-4-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-4-0.adoc[leveloffset=+1]
 
+include::modules/gitops-release-notes-1-3-7.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-3-6.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-3-3.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-2.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-3-6.adoc
+++ b/modules/gitops-release-notes-1-3-6.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-3-6_{context}"]
+= Release notes for {gitops-title} 1.3.6
+
+{gitops-title} 1.3.6 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-3-6_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* In {gitops-title}, improper access control allows admin privilege escalation link:https://access.redhat.com/security/cve/CVE-2022-1025[(CVE-2022-1025)]. This update fixes the issue.
+
+* A path traversal flaw allows leaking of out-of-bound files link:https://access.redhat.com/security/cve/CVE-2022-24731[(CVE-2022-24731)]. This update fixes the issue.
+
+* A path traversal flaw and improper access control allows leaking of out-of-bound files link:https://access.redhat.com/security/cve/CVE-2022-24730[(CVE-2022-24730)]. This update fixes the issue.
+

--- a/modules/gitops-release-notes-1-3-7.adoc
+++ b/modules/gitops-release-notes-1-3-7.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-3-7_{context}"]
+= Release notes for {gitops-title} 1.3.7
+
+{gitops-title} 1.3.7 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-3-7_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* Before this update, a flaw was found in OpenSSL. This update fixes the issue by updating the base images to the latest version to avoid the OpenSSL flaw. link:https://access.redhat.com/security/cve/CVE-2022-0778[(CVE-2022-0778)].
+
+[NOTE]
+====
+To install the current release of {gitops-title} 1.3 and receive further updates during its product life cycle, switch to the **GitOps-1.3** channel.
+====


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.9, 4.10
JIRA issues: https://issues.redhat.com/browse/RHDEVDOCS-4032

Preview pages: https://deploy-preview-45076--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes

SME+QE review:
Peer-review: