### PR TITLE
[SRVKS-887] Add Knative services PersistentVolumeClaim ConfigMap

### DIFF
--- a/modules/serverless-enabling-pvc-support.adoc
+++ b/modules/serverless-enabling-pvc-support.adoc
@@ -1,0 +1,86 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-enabling-pvc-support_{context}"]
+= Enabling PVC support
+
+Some serverless applications need permanent data storage. To achieve this, you can configure persistent volume claims (PVCs) for your Knative services.
+
+.Procedure
+
+. To enable Knative Serving to use PVCs and write to them, modify the `KnativeServing` custom resource (CR) to include the following YAML:
++
+.Enabling PVCs with write access
+[source,yaml]
+----
+...
+spec:
+  config:
+    features:
+      "kubernetes.podspec-persistent-volume-claim": enabled
+      "kubernetes.podspec-persistent-volume-write": enabled
+...
+----
++
+* The `kubernetes.podspec-persistent-volume-claim` extension controls whether persistent volumes (PVs) can be used with Knative Serving.
+* The `kubernetes.podspec-persistent-volume-write` extension controls whether PVs are available to Knative Serving with the write access.
+
+. To claim a PV, modify your service to include the PV configuration. For example, you might have a persistent volume claim with the following configuration:
++
+[NOTE]
+====
+Use the storage class that supports the access mode that you are requesting. For example, you can the `ocs-storagecluster-cephfs` class for the `ReadWriteMany` access mode.
+====
++
+.PersistentVolumeClaim configuration
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: example-pv-claim
+  namespace: my-ns
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ocs-storagecluster-cephfs
+  resources:
+    requests:
+      storage: 1Gi
+----
++
+In this case, to claim a PV with write access, modify your service as follows:
++
+.Knative service PVC configuration
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  namespace: my-ns
+...
+spec:
+ template:
+   spec:
+     containers:
+         ...
+         volumeMounts: <1>
+           - mountPath: /data
+             name: mydata
+             readOnly: false
+     volumes:
+       - name: mydata
+         persistentVolumeClaim: <2>
+           claimName: example-pv-claim
+           readOnly: false <3>
+----
+<1> Volume mount specification.
+<2> Persistent volume claim specification.
+<3> Flag that enables read-only access.
++
+[NOTE]
+====
+To successfully use persistent storage in Knative services, you need additional configuration, such as the user permissions for the Knative container user.
+====

--- a/serverless/admin_guide/serverless-configuration.adoc
+++ b/serverless/admin_guide/serverless-configuration.adoc
@@ -24,10 +24,13 @@ include::modules/serverless-https-redirect-global.adoc[leveloffset=+1]
 include::modules/serverless-url-scheme-external-routes.adoc[leveloffset=+1]
 // Kourier Gateway service type
 include::modules/serverless-kourier-gateway-service-type.adoc[leveloffset=+1]
+// Enabling PVC for Serving
+include::modules/serverless-enabling-pvc-support.adoc[leveloffset=+1]
 
 ifdef::openshift-enterprise[]
 [id="additional-resources_knative-serving-CR-config"]
 [role="_additional-resources"]
 == Additional resources
 * xref:../../operators/understanding/crds/crd-managing-resources-from-crds.adoc[Managing resources from custom resource definitions]
+* xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage]
 endif::[]


### PR DESCRIPTION
Version(s): 4.6+

Issue: https://issues.redhat.com/browse/SRVKS-887

Link to docs preview: https://deploy-preview-45083--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-configuration.html#serverless-enabling-pvc-support_serverless-configuration