### PR TITLE
ROX-10632 Correct cut and paste error in documentation

### DIFF
--- a/modules/webhook-configuring-acs.adoc
+++ b/modules/webhook-configuring-acs.adoc
@@ -10,29 +10,29 @@ Create a new integration in {product-title} by using the webhook URL.
 
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
-. Scroll down to the *Notifier Integrations* section and select *PagerDuty*.
-. Click *New Integration* (*`add`* icon).
-. Enter a name for *Integration Name*.
+. Scroll down to the *Notifier Integrations* section and select *Generic Webhook*.
+. Click *New integration*.
+. Enter a name for *Integration name*.
 . Enter the webhook URL in the *Endpoint* field.
-. If your webhook receiver uses an untrusted certificate, enter a CA certificate in the *CA Cert* field; otherwise leave it blank.
+. If your webhook receiver uses an untrusted certificate, enter a CA certificate in the *CA certificate* field. Otherwise, leave it blank.
 +
 [NOTE]
 ====
 The server certificate used by the webhook receiver must be valid for the endpoint DNS name.
-You can turn on the *Skip TLS Verify* toggle to ignore this validation.
-Red Hat does not recommend turning off TLS verification.
+You can click *Skip TLS verification* to ignore this validation.
+Red Hat does not suggest turning off TLS verification. Without TLS verification, data could be intercepted by an unintended recipient.
 ====
-. Optional: Turn on the *Enable Audit Logging* toggle, to receive alerts about all the changes made in {product-title}.
+. Optional: Click *Enable audit logging* to receive alerts about all the changes made in {product-title}.
 //See link:/docs/integrate-with-other-tools/enable-audit-logging/[Audit Logging] for more information.
 +
 [NOTE]
 ====
-Red Hat recommends using separate webhooks for alerts and audit logs to handle these messages differently.
+Red Hat suggests using separate webhooks for alerts and audit logs to handle these messages differently.
 ====
 . To authenticate with the webhook receiver, enter details for one of the following:
 ** *Username* and *Password* for basic HTTP authentication
 ** Custom *Header*, for example: `Authorization: Bearer <access_token>`
 . Use *Extra fields* to include additional key-value pairs in the JSON object that {product-title} sends.
-For example, if your webhook receiver accepts objects from multiple sources, you can add `"source": "rhacs"` as an extra field and then filter on this value to identify all alerts from {product-title}.
-. Select *Test* (*`checkmark`* icon) to send a test message to verify that the integration with your generic webhook is working.
-. Select *Create* (*`save`* icon) to create the configuration.
+For example, if your webhook receiver accepts objects from multiple sources, you can add `"source": "rhacs"` as an extra field and filter on this value to identify all alerts from {product-title}.
+. Select *Test* to send a test message to verify that the integration with your generic webhook is working.
+. Select *Save* to create the configuration.


### PR DESCRIPTION
- Version(s): rhacs-docs, rhacs-docs-3.69, rhacs-docs-3.68, rhacs-docs-3.67
- Labels: **rhacs**
- Issue: [ROX-10632](https://issues.redhat.com/browse/ROX-10632)
- [Docs preview](https://deploy-preview-45086--osdocs.netlify.app/openshift-acs/latest/integration/integrate-using-generic-webhooks)

Changes:
- Corrected cut & paste error
- changed some words to match what is actually displayed on screen
- changed language to comply with style ("click" rather than "turn on toggle")
