### PR TITLE
TELCODOCS-489: D/S Docs & RN: METAL-175 Add bootstrap external IP field to install-config API for bare metal 

### DIFF
--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -23,6 +23,14 @@ and the `bmc` parameter for the `install-config.yaml` file.
 | `UEFI`
 | The boot mode for a node. Options are `legacy`, `UEFI`, and `UEFISecureBoot`. If `bootMode` is not set, Ironic sets it while inspecting the node.
 
+| `bootstrapExternalStaticIP`
+|
+| The static IP address for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the `baremetal` network.
+
+| `bootstrapExternalStaticGateway`
+|
+| The static IP address of the gateway for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the `baremetal` network.
+
 | `sshKey`
 |
 | The `sshKey` configuration setting contains the key in the `~/.ssh/id_rsa.pub` file required to access the control plane nodes and worker nodes. Typically, this key is from the `provisioner` node.

--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -14,17 +14,17 @@ Most of the information teaches the installation program and the resulting clust
 The installation program no longer needs the `clusterOSImage` {op-system} image because the correct image is in the release payload.
 ====
 
-. Configure `install-config.yaml`. Change the appropriate variables to match the environment, including `pullSecret` and `sshKey`.
+. Configure `install-config.yaml`. Change the appropriate variables to match the environment, including `pullSecret` and `sshKey`:
 +
 [source,yaml]
 ----
 apiVersion: v1
 baseDomain: <domain>
 metadata:
-  name: <cluster-name>
+  name: <cluster_name>
 networking:
   machineNetwork:
-  - cidr: <public-cidr>
+  - cidr: <public_cidr>
   networkType: OVNKubernetes
 compute:
 - name: worker
@@ -36,51 +36,53 @@ controlPlane:
     baremetal: {}
 platform:
   baremetal:
-    apiVIP: <api-ip>
-    ingressVIP: <wildcard-ip>
+    apiVIP: <api_ip>
+    ingressVIP: <wildcard_ip>
     provisioningNetworkCIDR: <CIDR>
+    bootstrapExternalStaticIP: <bootstrap_static_ip_address> <2>
+    bootstrapExternalStaticGateway: <bootstrap_static_gateway> <3>
     hosts:
       - name: openshift-master-0
         role: master
         bmc:
-          address: ipmi://<out-of-band-ip> <2>
+          address: ipmi://<out_of_band_ip> <4>
           username: <user>
           password: <password>
-        bootMACAddress: <NIC1-mac-address>
+        bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
          deviceName: "/dev/sda"
-      - name: <openshift-master-1>
+      - name: <openshift_master_1>
         role: master
         bmc:
-          address: ipmi://<out-of-band-ip> <2>
+          address: ipmi://<out_of_band_ip> <4>
           username: <user>
           password: <password>
-        bootMACAddress: <NIC1-mac-address>
+        bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
          deviceName: "/dev/sda"
-      - name: <openshift-master-2>
+      - name: <openshift_master_2>
         role: master
         bmc:
-          address: ipmi://<out-of-band-ip> <2>
+          address: ipmi://<out_of_band_ip> <4>
           username: <user>
           password: <password>
-        bootMACAddress: <NIC1-mac-address>
+        bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
          deviceName: "/dev/sda"
-      - name: <openshift-worker-0>
+      - name: <openshift_worker_0>
         role: worker
         bmc:
-          address: ipmi://<out-of-band-ip> <2>
+          address: ipmi://<out_of_band_ip> <4>
           username: <user>
           password: <password>
-        bootMACAddress: <NIC1-mac-address>
-      - name: <openshift-worker-1>
+        bootMACAddress: <NIC1_mac_address>
+      - name: <openshift_worker_1>
         role: worker
         bmc:
-          address: ipmi://<out-of-band-ip>
+          address: ipmi://<out_of_band_ip>
           username: <user>
           password: <password>
-        bootMACAddress: <NIC1-mac-address>
+        bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
          deviceName: "/dev/sda"
 pullSecret: '<pull_secret>'
@@ -88,15 +90,11 @@ sshKey: '<ssh_pub_key>'
 ----
 +
 <1> Scale the worker machines based on the number of worker nodes that are part of the {product-title} cluster. Valid options for the `replicas` value are `0` and integers greater than or equal to `2`. Set the number of replicas to `0` to deploy a three-node cluster, which contains only three control plane machines. A three-node cluster is a smaller, more resource-efficient cluster that can be used for testing, development, and production. You cannot install the cluster with only one worker.
-ifdef::upstream[]
-<2> See the xref:bmc-addressing_{context}[BMC addressing] sections for more options.
-endif::[]
-ifndef::upstream[]
-<2> See the BMC addressing sections for more options.
-endif::[]
+<2> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticIP` configuration setting to specify the static IP address of the bootstrap VM when there is no DHCP server on the `baremetal` network.
+<3> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticGateway` configuration setting to specify the gateway IP address for the bootstrap VM when there is no DHCP server on the `baremetal` network.
+<4> See the BMC addressing sections for more options.
 
-
-. Create a directory to store cluster configs:
+. Create a directory to store the cluster configuration:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Added bootstrapExternalStaticIP and bootstrapExternalStaticGateway configuration settings.

Fixes: [TELCODOCS-489](https://issues.redhat.com//browse/TELCODOCS-489)

See https://issues.redhat.com/browse/TELCODOCS-489 for additional details.

Preview URL: https://deploy-preview-45104--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-the-install-config-file_ipi-install-installation-workflow  and  https://deploy-preview-45104--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#additional-install-config-parameters_ipi-install-installation-workflow

For release(s): 4.11
Signed-off-by: John Wilkins <jowilkin@redhat.com>
