### PR TITLE
OSDOCS-2524: Windows Containers: containerd

### DIFF
--- a/modules/byoh-configuring.adoc
+++ b/modules/byoh-configuring.adoc
@@ -11,7 +11,6 @@ Creating a BYOH Windows instance requires creating a config map in the WMCO name
 .Prerequisites
 Any Windows instances that are to be attached to the cluster as a node must fulfill the following requirements:
 
-* The Docker container runtime must be installed on the instance.
 * The instance must be on the same network as the Linux worker nodes in the cluster.
 * Port 22 must be open and running an SSH server.
 * The default shell for the SSH server must be the link:https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration#configuring-the-default-shell-for-openssh-in-windows[Windows Command shell], or `cmd.exe`.

--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -64,8 +64,6 @@ PS C:\> Get-Service -Name VMTools | Select Status, StartType
 The public key used in the instructions must correspond to the private key you create later in the WMCO namespace that holds your secret. See the "Configuring a secret for the Windows Machine Config Operator" section for more details.
 ====
 
-. Install the `docker` container runtime on your Windows VM following the link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server[Microsoft documentation].
-
 . You must create a new firewall rule in the Windows VM that allows incoming connections for container logs. Run the following PowerShell command to create the firewall rule on TCP port 10250:
 +
 [source,posh]

--- a/modules/windows-workload-management.adoc
+++ b/modules/windows-workload-management.adoc
@@ -10,11 +10,11 @@ To run Windows workloads in your cluster, you must first install the Windows Mac
 .WMCO design
 image::wmco-design.png[WMCO workflow]
 
-Before deploying Windows workloads, you must create a Windows compute node and have it join the cluster. The Windows node hosts the Windows workloads in a cluster, and can run alongside other Linux-based compute nodes. You can create a Windows compute node by creating a Windows machine set to host Windows Server compute machines. You must apply a Windows-specific label to the machine set that specifies a Windows OS image that has the Docker-formatted container runtime add-on enabled.
+Before deploying Windows workloads, you must create a Windows compute node and have it join the cluster. The Windows node hosts the Windows workloads in a cluster, and can run alongside other Linux-based compute nodes. You can create a Windows compute node by creating a Windows machine set to host Windows Server compute machines. You must apply a Windows-specific label to the machine set that specifies a Windows OS image.
 
 [IMPORTANT]
 ====
-Currently, the Docker-formatted container runtime is used in Windows nodes. Kubernetes is deprecating Docker as a container runtime; you can reference the Kubernetes documentation for more information in link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Docker deprecation]. Containerd will be the new supported container runtime for Windows nodes in a future release of Kubernetes.
+Previously, the Docker-formatted container runtime is used in Windows nodes. Kubernetes is deprecating Docker as a container runtime; you can reference the Kubernetes documentation for more information in link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Docker deprecation]. Containerd is the new supported container runtime for Windows nodes.
 ====
 
 The WMCO watches for machines with the Windows label. After a Windows machine set is detected and its respective machines are provisioned, the WMCO configures the underlying Windows virtual machine (VM) so that it can join the cluster as a compute node.

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
@@ -12,12 +12,6 @@ You can create a Windows `MachineSet` object to serve a specific purpose in your
 == Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
-* You are using a supported Windows Server as the operating system image with the Docker-formatted container runtime add-on enabled.
-
-[IMPORTANT]
-====
-Currently, the Docker-formatted container runtime is used in Windows nodes. Kubernetes is deprecating Docker as a container runtime; you can reference the Kubernetes documentation for more information in link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Docker deprecation]. Containerd will be the new supported container runtime for Windows nodes in a future release of Kubernetes.
-====
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 include::modules/windows-machineset-aws.adoc[leveloffset=+1]

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
@@ -12,12 +12,6 @@ You can create a Windows `MachineSet` object to serve a specific purpose in your
 == Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
-* You are using a supported Windows Server as the operating system image with the Docker-formatted container runtime add-on enabled.
-
-[IMPORTANT]
-====
-Currently, the Docker-formatted container runtime is used in Windows nodes. Kubernetes is deprecating Docker as a container runtime; you can reference the Kubernetes documentation for more information in link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Docker deprecation]. Containerd will be the new supported container runtime for Windows nodes in a future release of Kubernetes.
-====
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 include::modules/windows-machineset-azure.adoc[leveloffset=+1]

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
@@ -12,12 +12,6 @@ You can create a Windows `MachineSet` object to serve a specific purpose in your
 == Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
-* You are using a supported Windows Server as the operating system image with the Docker-formatted container runtime add-on enabled.
-
-[IMPORTANT]
-====
-Currently, the Docker-formatted container runtime is used in Windows nodes. Kubernetes is deprecating Docker as a container runtime; you can reference the Kubernetes documentation for more information on link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Docker deprecation]. Containerd will be the new supported container runtime for Windows nodes in a future release of Kubernetes.
-====
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 

--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. For more information, see the xref:../windows_containers/windows-containers-release-notes-5-x.adoc#windows-containers-release-notes-5-x[release notes].
+{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances brought up with WMCO are set up with the containerd container runtime. For more information, see the xref:../windows_containers/windows-containers-release-notes-5-x.adoc#windows-containers-release-notes-5-x[release notes].
 
 For workloads including both Linux and Windows, {product-title} allows you to deploy Windows workloads running on Windows Server containers while also providing traditional Linux workloads hosted on {op-system-first} or {op-system-base-full}. For more information, see xref:../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[getting started with Windows container workloads].
 

--- a/windows_containers/scheduling-windows-workloads.adoc
+++ b/windows_containers/scheduling-windows-workloads.adoc
@@ -12,13 +12,8 @@ You can schedule Windows workloads to Windows compute nodes.
 == Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
-* You are using a Windows container as the OS image with the Docker-formatted container runtime add-on enabled.
+* You are using a Windows container as the OS image.
 * You have created a Windows machine set.
-
-[IMPORTANT]
-====
-Currently, the Docker-formatted container runtime is used in Windows nodes. Kubernetes is deprecating Docker as a container runtime; you can reference the Kubernetes documentation for more information in link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Docker deprecation]. Containerd will be the new supported container runtime for Windows nodes in a future release of Kubernetes.
-====
 
 include::modules/windows-pod-placement.adoc[leveloffset=+1]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2524

WINC 6.0.0.

Move from Windows Server with Docker runtime to Windows Server with containerd runtime.

- [ ] Include Update on containerd pre requisites  