### PR TITLE
[OSDOCS-3585]: Add field in GCP machine set YAML

### DIFF
--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -80,6 +80,14 @@ endif::infra[]
             labels: null
             sizeGb: 128
             type: pd-ssd
+ifndef::infra[]
+          gcpMetadata: <4>
+endif::infra[]
+ifdef::infra[]
+          gcpMetadata: <5>
+endif::infra[]
+          - key: <custom_metadata_key>
+            value: <custom_metadata_value>
           kind: GCPMachineProviderSpec
           machineType: n1-standard-4
           metadata:
@@ -88,18 +96,18 @@ endif::infra[]
           - network: <infrastructure_id>-network <1>
             subnetwork: <infrastructure_id>-worker-subnet <1>
 ifndef::infra[]
-          projectID: <project_name> <4>
+          projectID: <project_name> <5>
 endif::infra[]
 ifdef::infra[]
-          projectID: <project_name> <5>
+          projectID: <project_name> <6>
 endif::infra[]
           region: us-central1
           serviceAccounts:
 ifndef::infra[]
-          - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com <1> <4>
+          - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com <1> <5>
 endif::infra[]
 ifdef::infra[]
-          - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com <1> <5>
+          - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com <1> <6>
 endif::infra[]
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
@@ -125,7 +133,8 @@ $ oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.disks[0].image}{"\n"}' \
     get machineset/<infrastructure_id>-worker-a
 ----
-<4> Specify the name of the GCP project that you use for your cluster.
+<4> Optional: Specify custom metadata in the form of a `key:value` pair. For example use cases, see the GCP documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
+<5> Specify the name of the GCP project that you use for your cluster.
 endif::infra[]
 ifdef::infra[]
 <2> Specify the `<infra>` node label.
@@ -138,7 +147,8 @@ $ oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.disks[0].image}{"\n"}' \
     get machineset/<infrastructure_id>-worker-a
 ----
-<5> Specify the name of the GCP project that you use for your cluster.
+<5> Optional: Specify custom metadata in the form of a `key:value` pair. For example use cases, see the GCP documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
+<6> Specify the name of the GCP project that you use for your cluster.
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]


### PR DESCRIPTION
Version(s):
4.6+

Issue:
[OSDOCS-3585](https://issues.redhat.com//browse/OSDOCS-3585)

Link to docs preview:
- [Sample YAML for a machine set custom resource on GCP](https://deploy-preview-45120--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-yaml-gcp_creating-machineset-gcp)
- [Infrastructure machine set version of same](https://deploy-preview-45120--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-gcp_creating-infrastructure-machinesets)

Additional information:
Required an annotation number bump, as well as defining the new entry twice to hit both regular and infra conditions.