### PR TITLE
Windows Containers: containerd Rel Note

### DIFF
--- a/windows_containers/windows-containers-release-notes-6-x.adoc
+++ b/windows_containers/windows-containers-release-notes-6-x.adoc
@@ -33,6 +33,16 @@ endif::openshift-origin[]
 
 This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 6.0.0 were released in 
 
+[id="wmco-6-0-0-new-features"]
+=== New features
+
+[id="wmco-6-0-0-containerd"]
+==== Containerd is the default container runtime
+
+Because the Docker runtime is deprecated in Kubernetes 1.24, containerD is now the default runtime for WMCO-supported Windows nodes. Upon the installation of or an upgrade to WMCO 6.0.0, containerd is installed as a Windows service. The kubelet now uses containerd for image pulls instead of the Docker runtime. Users no longer need to enable the Docker-formatted container runtime or install the Docker container runtime on Bring-Your-Own-Host (BYOH) instances. You can continue to use nodes based on VM images that use Docker. containerd can run along with the Docker service.
+
+The WMCO supports a Windows golden image with or without Docker for vSphere and Bring-Your-Own-Host (BYOH) Windows instances. 
+
 include::modules/wmco-prerequisites.adoc[leveloffset=+1]
 
 [IMPORTANT]


### PR DESCRIPTION
Release note for [Windows Containers: containerd](https://github.com/openshift/openshift-docs/pull/45117)

Preview: [Containerd is the default container runtime](http://file.rdu.redhat.com/mburke/OSDOCS-2524-winc-containerd-RN/windows-containers-release-notes-6-x.html#wmco-6-0-0-containerd) (single file)