### PR TITLE
Change auto-number callouts to numbered in Operators guide

### DIFF
--- a/modules/olm-catalogsource.adoc
+++ b/modules/olm-catalogsource.adoc
@@ -30,50 +30,50 @@ The `spec` of a `CatalogSource` object indicates how to construct a pod or how t
 kind: CatalogSource
 metadata:
   generation: 1
-  name: example-catalog <.>
-  namespace: {global_ns} <.>
+  name: example-catalog <1>
+  namespace: {global_ns} <2>
   annotations:
-    olm.catalogImageTemplate: <.>
+    olm.catalogImageTemplate: <3>
       "quay.io/example-org/example-catalog:v{kube_major_version}.{kube_minor_version}.{kube_patch_version}"
 spec:
-  displayName: Example Catalog <.>
-  image: quay.io/example-org/example-catalog:v1 <.>
-  priority: -400 <.>
+  displayName: Example Catalog <4>
+  image: quay.io/example-org/example-catalog:v1 <5>
+  priority: -400 <6>
   publisher: Example Org
-  sourceType: grpc <.>
+  sourceType: grpc <7>
   updateStrategy:
-    registryPoll: <.>
+    registryPoll: <8>
       interval: 30m0s
 status:
   connectionState:
     address: example-catalog.{global_ns}.svc:50051
     lastConnect: 2021-08-26T18:14:31Z
-    lastObservedState: READY <.>
-  latestImageRegistryPoll: 2021-08-26T18:46:25Z <.>
-  registryService: <.>
+    lastObservedState: READY <9>
+  latestImageRegistryPoll: 2021-08-26T18:46:25Z <10>
+  registryService: <11>
     createdAt: 2021-08-26T16:16:37Z
     port: 50051
     protocol: grpc
     serviceName: example-catalog
     serviceNamespace: {global_ns}
 ----
-<.> Name for the `CatalogSource` object. This value is also used as part of the name for the related pod that is created in the requested namespace.
-<.> Namespace to create the catalog available. To make the catalog available cluster-wide in all namespaces, set this value to `{global_ns}`. The default Red Hat-provided catalog sources also use the `{global_ns}` namespace. Otherwise, set the value to a specific namespace to make the Operator only available in that namespace.
-<.> Optional: To avoid cluster upgrades potentially leaving Operator installations in an unsupported state or without a continued update path, you can enable automatically changing your Operator catalog's index image version as part of cluster upgrades.
+<1> Name for the `CatalogSource` object. This value is also used as part of the name for the related pod that is created in the requested namespace.
+<2> Namespace to create the catalog available. To make the catalog available cluster-wide in all namespaces, set this value to `{global_ns}`. The default Red Hat-provided catalog sources also use the `{global_ns}` namespace. Otherwise, set the value to a specific namespace to make the Operator only available in that namespace.
+<3> Optional: To avoid cluster upgrades potentially leaving Operator installations in an unsupported state or without a continued update path, you can enable automatically changing your Operator catalog's index image version as part of cluster upgrades.
 +
 Set the `olm.catalogImageTemplate` annotation to your index image name and use one or more of the Kubernetes cluster version variables as shown when constructing the template for the image tag. The annotation overwrites the `spec.image` field at run time. See the "Image template for custom catalog sources" section for more details.
-<.> Display name for the catalog in the web console and CLI.
-<.> Index image for the catalog. Optionally, can be omitted when using the `olm.catalogImageTemplate` annotation, which sets the pull spec at run time.
-<.> Weight for the catalog source. OLM uses the weight for prioritization during dependency resolution. A higher weight indicates the catalog is preferred over lower-weighted catalogs.
-<.> Source types include the following:
+<4> Display name for the catalog in the web console and CLI.
+<5> Index image for the catalog. Optionally, can be omitted when using the `olm.catalogImageTemplate` annotation, which sets the pull spec at run time.
+<6> Weight for the catalog source. OLM uses the weight for prioritization during dependency resolution. A higher weight indicates the catalog is preferred over lower-weighted catalogs.
+<7> Source types include the following:
 +
 --
 * `grpc` with an `image` reference: OLM pulls the image and runs the pod, which is expected to serve a compliant API.
 * `grpc` with an `address` field: OLM attempts to contact the gRPC API at the given address. This should not be used in most cases.
 * `configmap`: OLM parses config map data and runs a pod that can serve the gRPC API over it.
 --
-<.> Automatically check for new versions at a given interval to stay up-to-date.
-<.> Last observed state of the catalog connection. For example:
+<8> Automatically check for new versions at a given interval to stay up-to-date.
+<9> Last observed state of the catalog connection. For example:
 +
 --
 * `READY`: A connection is successfully established.
@@ -82,8 +82,8 @@ Set the `olm.catalogImageTemplate` annotation to your index image name and use o
 --
 +
 See link:https://grpc.github.io/grpc/core/md_doc_connectivity-semantics-and-api.html[States of Connectivity] in the gRPC documentation for more details.
-<.> Latest time the container registry storing the catalog image was polled to ensure the image is up-to-date.
-<.> Status information for the catalog's Operator Registry service.
+<10> Latest time the container registry storing the catalog image was polled to ensure the image is up-to-date.
+<11> Status information for the catalog's Operator Registry service.
 ====
 
 Referencing the `name` of a `CatalogSource` object in a subscription instructs OLM where to search to find a requested Operator:

--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -40,47 +40,55 @@ endif::[]
 
 .. Modify the following to your specifications and save it as a `catalogSource.yaml` file:
 +
+ifdef::olm-restricted-networks[]
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-ifdef::olm-restricted-networks[]
-  name: my-operator-catalog <.>
-endif::[]
-ifndef::olm-restricted-networks[]
-  name: my-operator-catalog
-endif::[]
-  namespace: {namespace} <.>
-ifndef::olm-restricted-networks[]
-  annotations:
-    olm.catalogImageTemplate: <.>
-      "<registry>/<namespace>/<index_image_name>:v{kube_major_version}.{kube_minor_version}.{kube_patch_version}"
-endif::[]
+  name: my-operator-catalog <1>
+  namespace: {namespace} <2>
 spec:
   sourceType: grpc
-ifdef::olm-restricted-networks[]
-  image: <registry>/<namespace>/{index-image}:{tag} <.>
-endif::[]
-ifndef::olm-restricted-networks[]
-  image: <registry>/<namespace>/<index_image_name>:<tag> <.>
-endif::[]
+  image: <registry>/<namespace>/{index-image}:{tag} <3>
   displayName: My Operator Catalog
-  publisher: <publisher_name> <.>
+  publisher: <publisher_name> <4>
   updateStrategy:
-    registryPoll: <.>
+    registryPoll: <5>
       interval: 30m
 ----
-<.> If you want the catalog source to be available globally to users in all namespaces, specify the `{namespace}` namespace. Otherwise, you can specify a different namespace for the catalog to be scoped and available only for that namespace.
+<1> If you mirrored content to local files before uploading to a registry, remove any backslash (`/`) characters from the `metadata.name` field to avoid an "invalid resource name" error when you create the object.
+<2> If you want the catalog source to be available globally to users in all namespaces, specify the `{namespace}` namespace. Otherwise, you can specify a different namespace for the catalog to be scoped and available only for that namespace.
+<3> Specify your index image.
+<4> Specify your name or an organization name publishing the catalog.
+<5> Catalog sources can automatically check for new versions to keep up to date.
+endif::[]
 ifndef::olm-restricted-networks[]
-<.> Optional: Set the `olm.catalogImageTemplate` annotation to your index image name and use one or more of the Kubernetes cluster version variables as shown when constructing the template for the image tag.
+[source,yaml,subs="attributes+"]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: my-operator-catalog
+  namespace: {namespace} <1>
+  annotations:
+    olm.catalogImageTemplate: <2>
+      "<registry>/<namespace>/<index_image_name>:v{kube_major_version}.{kube_minor_version}.{kube_patch_version}"
+spec:
+  sourceType: grpc
+  image: <registry>/<namespace>/<index_image_name>:<tag> <3>
+  displayName: My Operator Catalog
+  publisher: <publisher_name> <4>
+  updateStrategy:
+    registryPoll: <5>
+      interval: 30m
+----
+<1> If you want the catalog source to be available globally to users in all namespaces, specify the `{namespace}` namespace. Otherwise, you can specify a different namespace for the catalog to be scoped and available only for that namespace.
+<2> Optional: Set the `olm.catalogImageTemplate` annotation to your index image name and use one or more of the Kubernetes cluster version variables as shown when constructing the template for the image tag.
+<3> Specify your index image.
+<4> Specify your name or an organization name publishing the catalog.
+<5> Catalog sources can automatically check for new versions to keep up to date.
 endif::[]
-ifdef::olm-restricted-networks[]
-<.> If you mirrored content to local files before uploading to a registry, remove any backslash (`/`) characters from the `metadata.name` field to avoid an "invalid resource name" error when you create the object.
-endif::[]
-<.> Specify your index image.
-<.> Specify your name or an organization name publishing the catalog.
-<.> Catalog sources can automatically check for new versions to keep up to date.
 
 .. Use the file to create the `CatalogSource` object:
 +

--- a/modules/olm-creating-fb-catalog-image.adoc
+++ b/modules/olm-creating-fb-catalog-image.adoc
@@ -67,19 +67,19 @@ The Dockerfile must be in the same parent directory as the catalog directory tha
 +
 [source,terminal]
 ----
-$ opm init <operator_name> \ <.>
-    --default-channel=preview \ <.>
-    --description=./README.md \ <.>
-    --icon=./operator-icon.svg \ <.>
-    --output yaml \ <.>
-    > <operator_name>-index/index.yaml <.>
+$ opm init <operator_name> \ <1>
+    --default-channel=preview \ <2>
+    --description=./README.md \ <3>
+    --icon=./operator-icon.svg \ <4>
+    --output yaml \ <5>
+    > <operator_name>-index/index.yaml <6>
 ----
-<.> Operator, or package, name.
-<.> Channel that subscription will default to if unspecified.
-<.> Path to the Operator's `README.md` or other documentation.
-<.> Path to the Operator's icon.
-<.> Output format: JSON or YAML.
-<.> Path for creating the catalog configuration file.
+<1> Operator, or package, name.
+<2> Channel that subscription will default to if unspecified.
+<3> Path to the Operator's `README.md` or other documentation.
+<4> Path to the Operator's icon.
+<5> Output format: JSON or YAML.
+<6> Path for creating the catalog configuration file.
 +
 This command generates an `olm.package` declarative config blob in the specified catalog configuration file.
 
@@ -87,12 +87,12 @@ This command generates an `olm.package` declarative config blob in the specified
 +
 [source,terminal]
 ----
-$ opm render <registry>/<namespace>/<bundle_image_name>:<tag> \ <.>
+$ opm render <registry>/<namespace>/<bundle_image_name>:<tag> \ <1>
     --output=yaml \
-    >> <operator_name>-index/index.yaml <.>
+    >> <operator_name>-index/index.yaml <2>
 ----
-<.> Pull spec for the bundle image.
-<.> Path to the catalog configuration file.
+<1> Pull spec for the bundle image.
+<2> Path to the catalog configuration file.
 +
 The `opm render` command generates a declarative config blob from the provided catalog images and bundle images.
 +
@@ -111,9 +111,9 @@ schema: olm.channel
 package: <operator_name>
 name: preview
 entries:
-  - name: <operator_name>.v0.1.0 <.>
+  - name: <operator_name>.v0.1.0 <1>
 ----
-<.> Ensure that you include the period (`.`) after `<operator_name>` but before the `v` in the version. Otherwise, the entry will fail to pass the `opm validate` command.
+<1> Ensure that you include the period (`.`) after `<operator_name>` but before the `v` in the version. Otherwise, the entry will fail to pass the `opm validate` command.
 
 . Validate the file-based catalog:
 

--- a/modules/olm-enabling-operator-restricted-network.adoc
+++ b/modules/olm-enabling-operator-restricted-network.adoc
@@ -42,11 +42,11 @@ spec:
         - /manager
         ...
         env:
-        - name: <related_image_environment_variable> <.>
-          value: "<related_image_reference_with_tag>" <.>
+        - name: <related_image_environment_variable> <1>
+          value: "<related_image_reference_with_tag>" <2>
 ----
-<.> Define the environment variable, such as `RELATED_IMAGE_MEMCACHED`.
-<.> Set the related image reference and tag, such as `docker.io/memcached:1.4.36-alpine`.
+<1> Define the environment variable, such as `RELATED_IMAGE_MEMCACHED`.
+<2> Set the related image reference and tag, such as `docker.io/memcached:1.4.36-alpine`.
 ====
 
 . Replace hard-coded image references with environment variables in the relevant file for your Operator project type:
@@ -64,16 +64,16 @@ spec:
 
 	Spec: corev1.PodSpec{
         	Containers: []corev1.Container{{
--			Image:   "memcached:1.4.36-alpine", <.>
-+			Image:   os.Getenv("<related_image_environment_variable>"), <.>
+-			Image:   "memcached:1.4.36-alpine", <1>
++			Image:   os.Getenv("<related_image_environment_variable>"), <2>
 			Name:    "memcached",
 			Command: []string{"memcached", "-m=64", "-o", "modern", "-v"},
 			Ports: []corev1.ContainerPort{{
 
 ...
 ----
-<.> Delete the image reference and tag.
-<.> Use the `os.Getenv` function to call the `<related_image_environment_variable>`.
+<1> Delete the image reference and tag.
+<2> Use the `os.Getenv` function to call the `<related_image_environment_variable>`.
 
 [NOTE]
 =====
@@ -97,15 +97,15 @@ spec:
     - -o
     - modern
     - -v
--   image: "docker.io/memcached:1.4.36-alpine" <.>
-+   image: "{{ lookup('env', '<related_image_environment_variable>') }}" <.>
+-   image: "docker.io/memcached:1.4.36-alpine" <1>
++   image: "{{ lookup('env', '<related_image_environment_variable>') }}" <2>
     ports:
       - containerPort: 11211
 
 ...
 ----
-<.> Delete the image reference and tag.
-<.> Use the `lookup` function to call the `<related_image_environment_variable>`.
+<1> Delete the image reference and tag.
+<2> Use the `lookup` function to call the `<related_image_environment_variable>`.
 ====
 
 * For Helm-based Operator projects, add the `overrideValues` field to the `watches.yaml` file as shown in the following example:
@@ -120,11 +120,11 @@ spec:
   version: v1alpha1
   kind: Memcached
   chart: helm-charts/memcached
-  overrideValues: <.>
-    relatedImage: ${<related_image_environment_variable>} <.>
+  overrideValues: <1>
+    relatedImage: ${<related_image_environment_variable>} <2>
 ----
-<.> Add the `overrideValues` field.
-<.> Define the `overrideValues` field by using the `<related_image_environment_variable>`, such as `RELATED_IMAGE_MEMCACHED`.
+<1> Add the `overrideValues` field.
+<2> Define the `overrideValues` field by using the `<related_image_environment_variable>`, such as `RELATED_IMAGE_MEMCACHED`.
 ====
 
 .. Add the value of the `overrideValues` field to the `helm-charts/memchached/values.yaml` file as shown in the following example:
@@ -148,13 +148,13 @@ containers:
     securityContext:
       - toYaml {{ .Values.securityContext | nindent 12 }}
     image: "{{ .Values.image.pullPolicy }}
-    env: <.>
-      - name: related_image <.>
-        value: "{{ .Values.relatedImage }}" <.>
+    env: <1>
+      - name: related_image <2>
+        value: "{{ .Values.relatedImage }}" <3>
 ----
-<.> Add the `env` field.
-<.> Name the environment variable.
-<.> Define the value of the environment variable.
+<1> Add the `env` field.
+<2> Name the environment variable.
+<3> Define the value of the environment variable.
 ====
 
 . Add the `BUNDLE_GEN_FLAGS` variable definition to your `Makefile` with the following changes:
@@ -174,13 +174,13 @@ containers:
 
 ...
 
--  $(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS) <.>
-+  $(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS) <.>
+-  $(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS) <1>
++  $(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS) <2>
 
 ...
 ----
-<.> Delete this line in the `Makefile`.
-<.> Replace the line above with this line.
+<1> Delete this line in the `Makefile`.
+<2> Replace the line above with this line.
 
 . To update your Operator image to use a digest (SHA) and not a tag, run the `make bundle` command and set `USE_IMAGE_DIGESTS` to `true` :
 +

--- a/modules/olm-mirroring-catalog-airgapped.adoc
+++ b/modules/olm-mirroring-catalog-airgapped.adoc
@@ -22,17 +22,17 @@ If your mirror registry is on a completely disconnected, or airgapped, host, tak
 [source,terminal]
 ----
 $ oc adm catalog mirror \
-    <index_image> \ <.>
-    file:///local/index \ <.>
-    -a ${REG_CREDS} \ <.>
-    --insecure \ <.>
-    --index-filter-by-os='<platform>/<arch>' <.>
+    <index_image> \ <1>
+    file:///local/index \ <2>
+    -a ${REG_CREDS} \ <3>
+    --insecure \ <4>
+    --index-filter-by-os='<platform>/<arch>' <5>
 ----
-<.> Specify the index image for the catalog that you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
-<.> Specify the content to mirror to local files in your current directory.
-<.> Optional: If required, specify the location of your registry credentials file.
-<.> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<.> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are specified as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, and `.*`
+<1> Specify the index image for the catalog that you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
+<2> Specify the content to mirror to local files in your current directory.
+<3> Optional: If required, specify the location of your registry credentials file.
+<4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are specified as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, and `.*`
 +
 .Example output
 [source,terminal]
@@ -66,17 +66,17 @@ $ podman login <mirror_registry>
 [source,terminal]
 ----
 $ oc adm catalog mirror \
-    file://local/index/<repo>/<index_image>:<tag> \ <.>
-    <mirror_registry>:<port>/<namespace> \ <.>
-    -a ${REG_CREDS} \ <.>
-    --insecure \ <.>
-    --index-filter-by-os='<platform>/<arch>' <.>
+    file://local/index/<repo>/<index_image>:<tag> \ <1>
+    <mirror_registry>:<port>/<namespace> \ <2>
+    -a ${REG_CREDS} \ <3>
+    --insecure \ <4>
+    --index-filter-by-os='<platform>/<arch>' <5>
 ----
-<.> Specify the `file://` path from the previous command output.
-<.> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator contents to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
-<.> Optional: If required, specify the location of your registry credentials file.
-<.> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<.> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are specified as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, and `.*`
+<1> Specify the `file://` path from the previous command output.
+<2> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator contents to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
+<3> Optional: If required, specify the location of your registry credentials file.
+<4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are specified as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, and `.*`
 +
 [NOTE]
 ====

--- a/modules/olm-mirroring-catalog-colocated.adoc
+++ b/modules/olm-mirroring-catalog-colocated.adoc
@@ -31,12 +31,12 @@ $ podman login <mirror_registry>
 [source,terminal]
 ----
 $ oc adm catalog mirror \
-    <index_image> \ <.>
-    <mirror_registry>:<port>/<namespace> \ <.>
-    [-a ${REG_CREDS}] \ <.>
-    [--insecure] \ <.>
-    [--index-filter-by-os='<platform>/<arch>'] \ <.>
-    [--manifests-only] <.>
+    <index_image> \ <1>
+    <mirror_registry>:<port>/<namespace> \ <2>
+    [-a ${REG_CREDS}] \ <3>
+    [--insecure] \ <4>
+    [--index-filter-by-os='<platform>/<arch>'] \ <5>
+    [--manifests-only] <6>
 ----
 <1> Specify the index image for the catalog that you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
 <2> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator contents to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.


### PR DESCRIPTION
Auto-numbered callouts (`<.>`) are not rendering correctly on the Customer Portal versions of the OCP documentation:
![image](https://user-images.githubusercontent.com/3442316/165855389-d804d85a-f50e-48ef-9de2-a12b4df75e0a.png)

This PR changes them all to hardcoded numbers (e.g., `<1>`) in the Operators guide.

Some example spots to show this change; this is for the code block that was previously a single block with ifdef/ifndef conditionals, now broken apart into 2 separate blocks (since removing the auto-numbering made it too convoluted to try to maintain as one block):

One variant: https://deploy-preview-45140--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-creating-catalog-from-index_olm-managing-custom-catalogs
The other: https://deploy-preview-45140--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html#olm-creating-catalog-from-index_olm-restricted-networks