### PR TITLE
GH#45150: scopes must be specified when running az ad sp create-for-rbac

### DIFF
--- a/modules/installation-azure-service-principal.adoc
+++ b/modules/installation-azure-service-principal.adoc
@@ -123,9 +123,10 @@ output. You need these values during {product-title} installation.
 +
 [source,terminal]
 ----
-$ az ad sp create-for-rbac --role Contributor --name <service_principal> <1>
+$ az ad sp create-for-rbac --role Contributor --name <service_principal> --scopes /subscription/<subscription_id> <1> <2>
 ----
 <1> Replace `<service_principal>` with the name to assign to the service principal.
+<2> Replace `<subscription_id>` with the `id` of the subscription that you want to use. This grants the service principal access to everything with the subscription. More specific scopes can be specified; consult https://docs.microsoft.com/en-us/cli/azure/ad/sp?view=azure-cli-latest#az-ad-sp-create-for-rbac[the documentation for `az ad sp create-for-rbac`] for details.
 +
 .Example output
 [source,terminal]


### PR DESCRIPTION
Closes #45150

Version(s):
All

Issue:
https://github.com/openshift/openshift-docs/issues/45150

Link to docs preview:
https://deploy-preview-45151--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account.html#installation-azure-service-principal_installing-azure-account

Additional information:
I guess the `az ad sp create-for-rbac` command used to default to the current subscription scope. This is no longer the case.