### PR TITLE
BZ2065539 - Fixing RHCOS command in sno installer

### DIFF
--- a/modules/install-sno-generating-the-discovery-iso-manually.adoc
+++ b/modules/install-sno-generating-the-discovery-iso-manually.adoc
@@ -64,7 +64,7 @@ $ ISO_URL=$(./openshift-install coreos print-stream-json | grep location | grep 
 +
 [source,terminal]
 ----
-$ curl $ISO_URL > rhcos-live.x86_64.iso
+$ curl -L $ISO_URL > rhcos-live.x86_64.iso
 ----
 
 . Prepare the `install-config.yaml` file:
@@ -138,7 +138,7 @@ $ ./openshift-install --dir=ocp create single-node-ignition-config
 +
 [source,terminal]
 ----
-$ alias coreos-installer='podman run --privileged --rm \
+$ alias coreos-installer='podman run --privileged --pull always --rm \
         -v /dev:/dev -v /run/udev:/run/udev -v $PWD:/data \
         -w /data quay.io/coreos/coreos-installer:release'
 ----


### PR DESCRIPTION
For Versions 4.9+
[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2065539)

Ready for QE: @jinyunma 

Preview: [Installing OpenShift on a single node -> Generating the discovery ISO manually](https://deploy-preview-45155--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html#generating-the-discovery-iso-manually_install-sno-installing-sno-with-the-assisted-installer) 