### PR TITLE
RHDEVDOCS-3431 -- removed  #32M from configuring-logging-collector

### DIFF
--- a/modules/cluster-logging-collector-tuning.adoc
+++ b/modules/cluster-logging-collector-tuning.adoc
@@ -151,20 +151,19 @@ $ oc extract configmap/fluentd --confirm
 .Example fluentd.conf
 [source,terminal]
 ----
-       <buffer>
-        @type file
-        path '/var/lib/fluentd/default'
-        flush_mode interval
-        flush_interval 5s
-        flush_thread_count 3
-        flush_at_shutdown true
-        retry_type periodic
-        retry_wait 1s
-        retry_max_interval 300s
-        retry_forever true
-        queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
-        total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #32M
-        chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
-        overflow_action throw_exception
-      </buffer>
+<buffer>
+ @type file
+ path '/var/lib/fluentd/default'
+ flush_mode interval
+ flush_interval 5s
+ flush_thread_count 3
+ retry_type periodic
+ retry_wait 1s
+ retry_max_interval 300s
+ retry_timeout 60m
+ queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+ total_limit_size 32m
+ chunk_limit_size 8m
+ overflow_action throw_exception
+</buffer>
 ----


### PR DESCRIPTION
DevTools
Version(s): main, 4.11, 4.10, 4.9, 4.8, 4.7, 4.6
Issue: https://issues.redhat.com/browse/RHDEVDOCS-3431
Link to docs preview: https://deploy-preview-45166--osdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-collector.html#cluster-logging-collector-tuning_cluster-logging-collector
Reviewers: 
Peer: @rolfedh 
SME: [kabirbhartiRH](https://github.com/kabirbhartiRH) 
QE: [anpingli](https://github.com/anpingli)
