### PR TITLE
RHDEVDOCS-3878-H1 correction

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -12,7 +12,7 @@ include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 include::modules/cluster-logging-release-notes-5.4.0.adoc[leveloffset=+1]
 
 [id="cluster-logging-technology-previews-5.4"]
-= Technology Previews
+== Technology Previews
 
 include::modules/cluster-logging-vector-tech-preview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
DevTools
Version(s):main, 4.11, 4.10

Issue: [RHDEVDOCS-3878](https://issues.redhat.com//browse/RHDEVDOCS-3878)

Link to docs preview: https://deploy-preview-45167--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html 

