### PR TITLE
BZ 2058050: document manual migration to new customDeploy install method

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
@@ -14,4 +14,4 @@ include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leve
 
 include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
 
-include:: modules/ipi-manual-migration-to-customdeploy.adoc[leveloffset=+1]
+include::modules/ipi-manual-migration-to-customdeploy.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
@@ -19,4 +19,4 @@ include::modules/ipi-manual-migration-to-customdeploy.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_ipi-install-post-installation-configuration"]
 == Additional resources
-For more information about modifying machine sets, see xref:../machine_management/modifying-machineset.adoc#modifying-machineset[Modifying a machine set].
+For more information about modifying machine sets, see xref:../../machine_management/modifying-machineset.adoc#modifying-machineset[Modifying a machine set].

--- a/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
@@ -13,3 +13,5 @@ include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leve
 include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]
 
 include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
+include:: modules/ipi-manual-migration-to-customdeploy.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
@@ -15,3 +15,8 @@ include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leve
 include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
 
 include::modules/ipi-manual-migration-to-customdeploy.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_ipi-install-post-installation-configuration"]
+== Additional resources
+For more information about modifying machine sets, see xref:../machine_management/modifying-machineset.adoc#modifying-machineset[Modifying a machine set].

--- a/modules/ipi-manual-migration-to-customdeploy.adoc
+++ b/modules/ipi-manual-migration-to-customdeploy.adoc
@@ -7,24 +7,39 @@
 
 = Manual migration to new customDeploy install method
 
-A new deployment method, which allows for some new capabilities and related APIs (and in particular added some BaremetalHost APIs that allow for deploy/scale-out time network customization)
+A new deployment method introduced in 4.10 allows you to customize the network configuration (`networkConfig`) in the `install-config.yaml` file by host during the install and provisioning process. You can also set static IPs per host and additional advanced network configurations.
 
-.Prerequisites
+When you upgrade to {product-title} 4.10, the new deployment method is not automatically upgraded and therefore you need to perform the following manual steps.
 
-*
-*
-*
-*
 
 .Procedure
 
-.
+. Log in to `oc` as a user with `cluster-admin` permission.
 
-.
-
-.
+. Find out what machineSets exists:
 +
 [source,terminal]
 ----
-$ oc get provisioning -o yaml > enable-provisioning-nw.yaml
+$ oc get machinesets -A
+----
+
+. Edit each machineSet:
++
+[source,terminal]
+----
+$ oc edit machineset <machineset> -n openshift-machine-api
+----
+
+.. Amend to include the following:
++
+[source,yaml]
+----
+    spec:
+      providerSpec:
+        value:
+          customDeploy:
+            method: install_coreos
+          image:
+            checksum: ""
+            url: "
 ----

--- a/modules/ipi-manual-migration-to-customdeploy.adoc
+++ b/modules/ipi-manual-migration-to-customdeploy.adoc
@@ -5,27 +5,26 @@
 :_content-type: PROCEDURE
 [id="manual-migration-to-new-customdeploy-install-method_{context}"]
 
-= Manual migration to new customDeploy install method 
+= Manual migration to new customDeploy install method
 
 A new deployment method, which allows for some new capabilities and related APIs (and in particular added some BaremetalHost APIs that allow for deploy/scale-out time network customization)
 
 .Prerequisites
 
-* 
-* 
-* 
-* 
+*
+*
+*
+*
 
 .Procedure
 
-. 
+.
 
-. 
+.
 
-. 
+.
 +
 [source,terminal]
 ----
 $ oc get provisioning -o yaml > enable-provisioning-nw.yaml
 ----
-

--- a/modules/ipi-manual-migration-to-customdeploy.adoc
+++ b/modules/ipi-manual-migration-to-customdeploy.adoc
@@ -1,0 +1,31 @@
+// This is included in the following assemblies:
+//
+// ipi-install-post-installation-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="manual-migration-to-new-customdeploy-install-method_{context}"]
+
+= Manual migration to new customDeploy install method 
+
+A new deployment method, which allows for some new capabilities and related APIs (and in particular added some BaremetalHost APIs that allow for deploy/scale-out time network customization)
+
+.Prerequisites
+
+* 
+* 
+* 
+* 
+
+.Procedure
+
+. 
+
+. 
+
+. 
++
+[source,terminal]
+----
+$ oc get provisioning -o yaml > enable-provisioning-nw.yaml
+----
+


### PR DESCRIPTION
[BZ#2058050]:  [IPI baremetal ] document manual migration to new customDeploy install method

Version(s):


Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2058050

Link to docs preview: https://deploy-preview-45170--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.html#manual-migration-to-new-customdeploy-install-method_ipi-install-post-installation-configuration

Already merged in https://github.com/openshift/openshift-docs/pull/45864 so this can be deleted.