### PR TITLE
BZ2079224 - Adding  to required SCC api parameters

### DIFF
--- a/rest_api/security_apis/securitycontextconstraints-security-openshift-io-v1.adoc
+++ b/rest_api/security_apis/securitycontextconstraints-security-openshift-io-v1.adoc
@@ -12,7 +12,7 @@ toc::[]
 Description::
 +
 --
-SecurityContextConstraints governs the ability to make requests that affect the SecurityContext that will be applied to a container. For historical reasons SCC was exposed under the core Kubernetes API group. That exposure is deprecated and will be removed in a future release - users should instead use the security.openshift.io group to manage SecurityContextConstraints. 
+SecurityContextConstraints governs the ability to make requests that affect the SecurityContext that will be applied to a container. For historical reasons SCC was exposed under the core Kubernetes API group. That exposure is deprecated and will be removed in a future release - users should instead use the security.openshift.io group to manage SecurityContextConstraints.
  Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
@@ -27,6 +27,7 @@ Required::
   - `allowHostPorts`
   - `allowPrivilegedContainer`
   - `readOnlyRootFilesystem`
+  - `volumes`
 
 
 == Specification
@@ -73,7 +74,7 @@ Required::
 
 | `allowedUnsafeSysctls`
 | ``
-| AllowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection. 
+| AllowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
  Examples: e.g. "foo/*" allows "foo/bar", "foo/baz", etc. e.g. "foo.*" allows "foo.bar", "foo.baz", etc.
 
 | `apiVersion`
@@ -90,7 +91,7 @@ Required::
 
 | `forbiddenSysctls`
 | ``
-| ForbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden. 
+| ForbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden.
  Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
 
 | `fsGroup`
@@ -321,7 +322,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../security_apis/securitycontextconstraints-security-openshift-io-v1.adoc#securitycontextconstraints-security-openshift-io-v1[`SecurityContextConstraints`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -455,7 +456,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions_v2[`DeleteOptions_v2`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -524,7 +525,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -562,7 +563,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../security_apis/securitycontextconstraints-security-openshift-io-v1.adoc#securitycontextconstraints-security-openshift-io-v1[`SecurityContextConstraints`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -649,5 +650,3 @@ Description::
 | 401 - Unauthorized
 | Empty
 |===
-
-


### PR DESCRIPTION
For Versions: 4.6+
[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2079224)
Ready for QE: 
Preview: [API reference -> Security APIs -> SecurityContextConstraints [security.openshift.io/v1]](https://deploy-preview-45182--osdocs.netlify.app/openshift-enterprise/latest/rest_api/security_apis/securitycontextconstraints-security-openshift-io-v1.html)