### PR TITLE
RHDEVDOCS-3878 - deprecation notice for Elasticsearch Operator

### DIFF
--- a/modules/cluster-logging-release-notes-5.4.0.adoc
+++ b/modules/cluster-logging-release-notes-5.4.0.adoc
@@ -40,7 +40,7 @@ link:https://access.redhat.com/errata/RHSA-2022:1461[{logging-title-uc} Release 
 
 * Before this update, clusters with a large number of namespaces caused Elasticsearch to stop serving requests because the list of namespaces reached the maximum header size limit. With this update, headers only include a list of namespace names, resolving the issue.	(link:https://issues.redhat.com/browse/LOG-1899[LOG-1899])
 
-* Before this update, the OpenShift Logging dashboard showed the number of shards 'x' times bigger than actual value when Elasticsearch has 'x' nodes. This was because it was printing all primary shards for each ES pod and processing sum on it, while the output is always for the whole ES cluster. With this update, the calculation has been corrected.	(link:https://issues.redhat.com/browse/LOG-2156[LOG-2156])	
+* Before this update, the OpenShift Logging dashboard showed the number of shards 'x' times bigger than actual value when Elasticsearch has 'x' nodes. This was because it was printing all primary shards for each ES pod and processing sum on it, while the output is always for the whole ES cluster. With this update, the calculation has been corrected.	(link:https://issues.redhat.com/browse/LOG-2156[LOG-2156])
 
 * Before this update, the secrets "kibana" and "kibana-proxy" were not recreated if they were deleted manually. With this update, the `elasticsearch-operator` will watch the resources and automatically recreate them if deleted.	(link:https://issues.redhat.com/browse/LOG-2250[LOG-2250])
 
@@ -49,6 +49,9 @@ link:https://access.redhat.com/errata/RHSA-2022:1461[{logging-title-uc} Release 
 * Before this update, the logging console link in OpenShift WebConsole was not removed with the ClusterLogging CR. With this update, deleting the CR or uninstalling the Cluster Logging Operator removes the link. (link:https://issues.redhat.com/browse/LOG-2373[LOG-2373])
 
 * Before this update, a change to the container logs path caused this metric to always be zero with older releases configured with the original path. With this update, the plugin which exposes metrics about collected logs supports reading from either path to resolve the issue. (link:https://issues.redhat.com/browse/LOG-2462[LOG-2462])
+
+== Elasticsearch Operator deprecation notice
+In {logging} 5.4, the Elasticsearch Operator is deprecated and is expected to be removed for the next EUS release of {product-title}.  Red Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. As an alternative to using the Elasticsearch Operator to manage the default log storage, you can use the Loki Operator.
 
 == CVEs
 [id="openshift-logging-5-4-0-CVEs"]


### PR DESCRIPTION
Dev Tools

Addition of deprecation notice for Elasticsearch Operator to logging 5.4 release notes. 

Version(s): main, 4.11, 4.10, 4.9, 4.8

Issue: [RHDEVDOCS-3878](https://issues.redhat.com//browse/RHDEVDOCS-3878) 

Preview: https://deploy-preview-45184--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#elasticsearch-operator-deprecation-notice

Reviewers: 
Peer: @rolfedh 
SME:@jcantrill
QE: N/A