### PR TITLE
OSDOCS-3253: add firewall prereqs to standard STS prereqs doc

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -1,14 +1,15 @@
 // Module included in the following assemblies:
 //
-// * rosa_getting_started/rosa-aws-prereqs.adoc
+// * rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
+// * rosa_planning/rosa-sts-aws-prereqs.adoc
 
 :_content-type: PROCEDURE
-[id="osd-aws-privatelink-firewall-prerequisites"]
+[id="osd-aws-privatelink-firewall-prerequisites_{context}"]
 = AWS firewall prerequisites
 
 [IMPORTANT]
 ====
-Only ROSA clusters deployed with PrivateLink may use a firewall to control egress traffic.
+Only ROSA clusters deployed with PrivateLink can use a firewall to control egress traffic.
 ====
 
 This section provides the necessary details that enable you to control egress traffic from your {product-title} cluster. If you are using a firewall to control egress traffic, you must configure your firewall to grant access to the domain and port combinations below. {product-title} requires this access to provide a fully managed OpenShift service.
@@ -54,7 +55,7 @@ This section provides the necessary details that enable you to control egress tr
 
 |`registry.access.redhat.com`
 |443
-|Provides access to the odo CLI tool that helps developers build on OpenShift and Kubernetes.
+|Provides access to the `odo` CLI tool that helps developers build on OpenShift and Kubernetes.
 
 |`console.redhat.com`
 |443, 80
@@ -72,11 +73,10 @@ This section provides the necessary details that enable you to control egress tr
 |443
 |Provides core container images as a fallback when quay.io is not available.
 |===
-+
-[NOTE]
-====
-Creating a firewall with a ROSA private cluster (non-PrivateLink) is not supported.
-====
+//[NOTE]
+//====
+//Creating a firewall with a ROSA private cluster (non-PrivateLink) is not supported.
+//====
 +
 When you add a site such as `quay.io` to your allowlist, do not add a wildcard entry such as `*.quay.io` to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a host name such as `cdn01.quay.io`.
 +
@@ -123,7 +123,7 @@ See link:https://docs.openshift.com/container-platform/4.9/support/remote_health
 |Required to access AWS services and resources.
 |===
 +
-Alternatively, if you wish to not use a wildcard for Amazon Web Services (AWS) APIs, you must allowlist the following URLs:
+Alternatively, if you choose to not use a wildcard for Amazon Web Services (AWS) APIs, you must allowlist the following URLs:
 +
 [cols="6,1,6",options="header"]
 |===
@@ -202,6 +202,8 @@ Alternatively, if you wish to not use a wildcard for Amazon Web Services (AWS) A
 |443
 |This alerting service is used by the in-cluster alertmanager to send alerts notifying Red Hat SRE of an event to take action on.
 
+ifdef::openshift-dedicated[]
+
 |`api.deadmanssnitch.com`
 |443
 |Alerting service used by OpenShift Dedicated to send periodic pings that indicate whether the cluster is available and running.
@@ -209,7 +211,7 @@ Alternatively, if you wish to not use a wildcard for Amazon Web Services (AWS) A
 |`nosnch.in`
 |443
 |Alerting service used by OpenShift Dedicated to send periodic pings that indicate whether the cluster is available and running.
-
+endif::[]
 |`*.osdsecuritylogs.splunkcloud.com`
 OR
 `inputs1.osdsecuritylogs.splunkcloud.com`
@@ -238,7 +240,7 @@ OR
 |The SFTP server used by `must-gather-operator` to upload diagnostic logs to help troubleshoot issues with the cluster.
 |===
 
-. If you did not allow a wildcard for Amazon Web Services (AWS) APIs, you will need to also allow the S3 bucket used for the internal OpenShift registry. To retrieve that endpoint, run the following command once the cluster has successfully been provisioned:
+. If you did not allow a wildcard for Amazon Web Services (AWS) APIs, you must also allow the S3 bucket used for the internal OpenShift registry. To retrieve that endpoint, run the following command after the cluster is successfully provisioned:
 +
 [source,terminal]
 ----

--- a/rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.adoc
+++ b/rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.adoc
@@ -19,7 +19,7 @@ xref:../rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.a
 [role="_additional-resources"]
 == Additional resources
 
-* xref:rosa_getting_started_iam/rosa-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites[AWS PrivateLink firewall prerequisites]
+* xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS PrivateLink firewall prerequisites]
 * xref:../rosa_getting_started/rosa-sts-getting-started-workflow.adoc#rosa-sts-overview-of-the-deployment-workflow[Overview of the ROSA with STS deployment workflow]
 * xref:../rosa_install_access_delete_clusters/rosa-sts-deleting-cluster.adoc#rosa-sts-deleting-cluster[Deleting a ROSA cluster]
 * xref:../rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc#rosa-architecture-models[ROSA architecture]

--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -25,6 +25,7 @@ include::modules/rosa-requirements-deploying-in-opt-in-regions.adoc[leveloffset=
 include::modules/rosa-setting-the-aws-security-token-version.adoc[leveloffset=+2]
 include::modules/rosa-sts-aws-iam.adoc[leveloffset=+1]
 include::modules/rosa-aws-provisioned.adoc[leveloffset=+1]
+include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+1]
 
 == Next steps
 xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-sts-required-aws-service-quotas[Review the required AWS service quotas]


### PR DESCRIPTION
Version(s):
4.10, 4.11

Issue:
(https://issues.redhat.com/browse/OSDOCS-3253)

Link to docs preview:
https://deploy-preview-45186--osdocs.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites

Additional information:
No QE review required. This PR is adding an existing module to an assembly, commenting out an admonition, and updating a few style issues. 


<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
