### PR TITLE
OSDOCS-3434: Adding permission requirement for installation directory

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -207,15 +207,10 @@ $ ./openshift-install create install-config --dir <installation_directory> <1>
 <1> For `<installation_directory>`, specify the directory name to store the
 files that the installation program creates.
 +
-[IMPORTANT]
-====
-Specify an empty directory. Some installation assets, like bootstrap X.509
-certificates have short expiration intervals, so you must not reuse an
-installation directory. If you want to reuse individual files from another
-cluster installation, you can copy them into your directory. However, the file
-names for the installation assets might change between releases. Use caution
-when copying installation files from an earlier {product-title} version.
-====
+When specifying the directory:
+* Verify that the directory has the `execute` permission. This permission is required to run Terraform binaries under the installation directory.
+* Use an empty directory. Some installation assets, such as bootstrap X.509 certificates, have short expiration intervals, therefore you must not reuse an installation directory. If you want to reuse individual files from another cluster installation, you can copy them into your directory. However, the file names for the installation assets might change between releases. Use caution when copying installation files from an earlier {product-title} version.
+
 ifndef::rhv[]
 .. At the prompts, provide the configuration details for your cloud:
 ... Optional: Select an SSH key to use to access your cluster machines.
@@ -684,4 +679,3 @@ ifeval::["{context}" == "installing-restricted-networks-vmc"]
 :!vsphere:
 :!restricted:
 endif::[]
-

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -207,7 +207,12 @@ environment variables
 ** The `gcloud cli` default credentials
 endif::gcp[]
 
+ifdef::no-config[]
 . Change to the directory that contains the installation program and initialize the cluster deployment:
+endif::no-config[]
+ifdef::custom-config[]
+* Change to the directory that contains the installation program and initialize the cluster deployment:
+endif::custom-config[]
 +
 [source,terminal]
 ----
@@ -225,19 +230,12 @@ endif::no-config[]
 `error` instead of `info`.
 ifdef::no-config[]
 +
-[IMPORTANT]
-====
-Specify an empty directory. Some installation assets, like bootstrap X.509
-certificates have short expiration intervals, so you must not reuse an
-installation directory. If you want to reuse individual files from another
-cluster installation, you can copy them into your directory. However, the file
-names for the installation assets might change between releases. Use caution
-when copying installation files from an earlier {product-title} version.
-====
-+
---
+When specifying the directory:
+* Verify that the directory has the `execute` permission. This permission is required to run Terraform binaries under the installation directory.
+* Use an empty directory. Some installation assets, such as bootstrap X.509 certificates, have short expiration intervals, therefore you must not reuse an installation directory. If you want to reuse individual files from another cluster installation, you can copy them into your directory. However, the file names for the installation assets might change between releases. Use caution when copying installation files from an earlier {product-title} version.
+
 ifndef::rhv[]
-Provide values at the prompts:
+. Provide values at the prompts:
 
 .. Optional: Select an SSH key to use to access your cluster machines.
 +
@@ -341,7 +339,7 @@ ifdef::openshift-origin[]
 endif::openshift-origin[]
 endif::rhv[]
 ifdef::rhv[]
-Respond to the installation program prompts.
+. Respond to the installation program prompts.
 
 .. Optional: For `SSH Public Key`, select a password-less public key, such as `~/.ssh/id_rsa.pub`. This key authenticates connections with the new {product-title} cluster.
 +
@@ -389,7 +387,7 @@ endif::openshift-origin[]
 .. For `Cluster Name`, enter the name of the cluster. For example, `my-cluster`. Use cluster name from the externally registered/resolvable DNS entries you created for the {product-title} REST API and apps domain names. The installation program also gives this name to the cluster in the {rh-virtualization} environment.
 .. For `Pull Secret`, copy the pull secret from the `pull-secret.txt` file you downloaded earlier and paste it here. You can also get a copy of the same {cluster-manager-url-pull}.
 endif::rhv[]
---
+
 endif::no-config[]
 ifdef::vmc[]
 +
@@ -407,39 +405,6 @@ permissions to deploy the cluster, the installation process stops, and the
 missing permissions are displayed.
 ====
 endif::vsphere[]
-+
-When the cluster deployment completes, directions for accessing your cluster,
-including a link to its web console and credentials for the `kubeadmin` user,
-display in your terminal.
-+
-.Example output
-[source,terminal]
-----
-...
-INFO Install complete!
-INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/myuser/install_dir/auth/kubeconfig'
-INFO Access the OpenShift web-console here: https://console-openshift-console.apps.mycluster.example.com
-INFO Login to the console with user: "kubeadmin", and password: "4vYBz-Ee6gm-ymBZj-Wt5AL"
-INFO Time elapsed: 36m22s
-----
-+
-[NOTE]
-====
-The cluster access and credential information also outputs to `<installation_directory>/.openshift_install.log` when an installation succeeds.
-====
-+
-[IMPORTANT]
-====
-* The Ignition config files that the installation program generates contain certificates that expire after 24 hours, which are then renewed at that time. If the cluster is shut down before renewing the certificates and the cluster is later restarted after the 24 hours have elapsed, the cluster automatically recovers the expired certificates. The exception is that you must manually approve the pending `node-bootstrapper` certificate signing requests (CSRs) to recover kubelet certificates. See the documentation for _Recovering from expired control plane certificates_ for more information.
-
-* It is recommended that you use Ignition config files within 12 hours after they are generated because the 24-hour certificate rotates from 16 to 22 hours after the cluster is installed. By using the Ignition config files within 12 hours, you can avoid installation failure if the certificate update runs during installation.
-====
-+
-[IMPORTANT]
-====
-You must not delete the installation program or the files that the installation
-program creates. Both are required to delete the cluster.
-====
 
 ifdef::aws[]
 . Optional: Remove or disable the `AdministratorAccess` policy from the IAM
@@ -457,6 +422,35 @@ ifdef::gcp[]
 ** If you included the `Service Account Key Admin` role,
 you can remove it.
 endif::gcp[]
+
+.Verification
+When the cluster deployment completes successfully:
+
+* The terminal displays directions for accessing your cluster, including a link to the web console and credentials for the `kubeadmin` user.
+* Credential information also outputs to `<installation_directory>/.openshift_install.log`.
+
+[IMPORTANT]
+====
+Do not delete the installation program or the files that the installation program creates. Both are required to delete the cluster.
+====
+
+.Example output
+[source,terminal]
+----
+...
+INFO Install complete!
+INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/myuser/install_dir/auth/kubeconfig'
+INFO Access the OpenShift web-console here: https://console-openshift-console.apps.mycluster.example.com
+INFO Login to the console with user: "kubeadmin", and password: "4vYBz-Ee6gm-ymBZj-Wt5AL"
+INFO Time elapsed: 36m22s
+----
+
+[IMPORTANT]
+====
+* The Ignition config files that the installation program generates contain certificates that expire after 24 hours, which are then renewed at that time. If the cluster is shut down before renewing the certificates and the cluster is later restarted after the 24 hours have elapsed, the cluster automatically recovers the expired certificates. The exception is that you must manually approve the pending `node-bootstrapper` certificate signing requests (CSRs) to recover kubelet certificates. See the documentation for _Recovering from expired control plane certificates_ for more information.
+
+* It is recommended that you use Ignition config files within 12 hours after they are generated because the 24-hour certificate rotates from 16 to 22 hours after the cluster is installed. By using the Ignition config files within 12 hours, you can avoid installation failure if the certificate update runs during installation.
+====
 
 ifeval::["{context}" == "installing-alibaba-customizations"]
 :!custom-config:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
CP to 4.11

Issue:
This PR addresses [OSDOC-3434](https://issues.redhat.com/browse/OSDOCS-3434)/ [CORS-1880](https://issues.redhat.com/browse/CORS-1880).

Link to docs preview:

- [Creating the installation configuration file](https://deploy-preview-45195--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-initializing_installing-aws-customizations)
- [Deploying the cluster](https://deploy-preview-45195--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-default.html#installation-launching-installer_installing-aws-default)

Additional information:

- In each procedure, as part of the annotation in step 1, stated that the installation directory requires the `execute` permission. While the preview doc links point to AWS examples, it is worth noting that the updates apply to ~30 installation topics. (assemblies).
- It is also worth noting that while the only technical change to this content was to reference the required permission on the installation directory, I took this as an opportunity to refactor "Deploying the cluster" to better meet CCS module standards.