### PR TITLE
Resolves AttributeError issues to prepare for makeBuild.py transform

### DIFF
--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -606,7 +606,10 @@ def _fix_links(content, book_dir, src_file, info, tag=None, cwd=None):
 
                 # We are dealing with a cross reference to another book here
                 external_link = EXTERNAL_LINK_RE.search(link_file)
-                book_dir_name = external_link.group(1)
+                try:
+                    book_dir_name = external_link.group(1)
+                except AttributeError as error:
+                    print(f"Error ({src_file}): {link.group()} appears to be an invalid cross-reference")
 
                 # Find the book name
                 book_name = book_dir_name


### PR DESCRIPTION
Follows the findings and proposed solution from @pneedle-rh to add error handling in the `build_for_portal.py` script so that the wider Customer Portal book sync issue could potentially be averted when the `AttributeError` is seen. This fix allows the book processing to complete successfully prior to the transformation that happens in the `makeBuild.py` script.