### PR TITLE
BZ#2077375 Random string is present under Installing MTC section

### DIFF
--- a/modules/migration-configuring-mcg.adoc
+++ b/modules/migration-configuring-mcg.adoc
@@ -14,8 +14,8 @@ ifdef::installing-3-4,installing-mtc[]
 You must retrieve the Multicloud Object Gateway (MCG) credentials and S3 endpoint in order to configure MCG as a replication repository for the {mtc-full} ({mtc-short}).
 endif::[]
 You must retrieve the Multicloud Object Gateway (MCG) credentials in order to create a `Secret` custom resource (CR) for the OpenShift API for Data Protection (OADP).
-////ifdef::installing-oadp-mcg[]
-////endif::[]
+//ifdef::installing-oadp-mcg[]
+//endif::[]
 
 MCG is a component of {rh-storage}.
 


### PR DESCRIPTION
MTC 1.7.0

CP: OCP: 4.6+

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2077375

Removes "random string" from _Installing MTC_ section. The "string" is actually a repeated _comment out_ command in the .adoc file. 

Preview: In https://deploy-preview-45220--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc.html  verify that " ////ifdef::installing-oadp-mcg[] ////endif::[] " does not appear before "MCG is a component of OpenShift Data Foundation." [or anywhere else] 