### PR TITLE
[BZ2075081]:  Add x86 only support

### DIFF
--- a/machine_management/adding-rhel-compute.adoc
+++ b/machine_management/adding-rhel-compute.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title}, you can add Red Hat Enterprise Linux (RHEL) compute, or worker, machines to a user-provisioned infrastructure cluster or a installation-provisioned infrastructure cluster. You can use RHEL as the operating system on only compute machines.
+In {product-title}, you can add {op-system-base-full} compute machines to a user-provisioned infrastructure cluster or an installation-provisioned infrastructure cluster on the `x86_64` architecture. You can use {op-system-base} as the operating system only on compute machines.
 
 include::modules/rhel-compute-overview.adoc[leveloffset=+1]
 

--- a/modules/rhel-compute-overview.adoc
+++ b/modules/rhel-compute-overview.adoc
@@ -8,18 +8,15 @@
 [id="rhel-compute-overview_{context}"]
 = About adding RHEL compute nodes to a cluster
 
-In {product-title} {product-version}, you have the option of using Red Hat Enterprise Linux (RHEL) machines as compute machines, which are also known as worker machines, in your cluster if you use a user-provisioned infrastructure installation. You must use {op-system-first} machines for the control plane, or master, machines in your cluster.
+In {product-title} {product-version}, you have the option of using {op-system-base-full} machines as compute machines in your cluster if you use a user-provisioned infrastructure installation on the `x86_64` architecture. You must use {op-system-first} machines for the control plane machines in your cluster.
 
-As with all installations that use user-provisioned infrastructure, if you choose to use RHEL compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks.
-
-[IMPORTANT]
-====
-Because removing {product-title} from a machine in the cluster requires destroying the operating system, you must use dedicated hardware for any RHEL machines that you add to the cluster.
-====
+If you choose to use {op-system-base} compute machines in your cluster, you are responsible for all operating system life cycle management and maintenance. You must perform system updates, apply patches, and complete all other required tasks.
 
 [IMPORTANT]
 ====
-Swap memory is disabled on all RHEL machines that you add to your {product-title} cluster. You cannot enable swap memory on these machines.
+* Because removing {product-title} from a machine in the cluster requires destroying the operating system, you must use dedicated hardware for any {op-system-base} machines that you add to the cluster.
+
+* Swap memory is disabled on all {op-system-base} machines that you add to your {product-title} cluster. You cannot enable swap memory on these machines.
 ====
 
-You must add any RHEL compute machines to the cluster after you initialize the control plane.
+You must add any {op-system-base} compute machines to the cluster after you initialize the control plane.

--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -8,7 +8,7 @@
 [id="rhel-compute-requirements_{context}"]
 = System requirements for {op-system-base} compute nodes
 
-The {op-system-base-full} compute, or worker, machine hosts in your {product-title} environment must meet the following minimum hardware specifications and system-level requirements:
+The {op-system-base-full} compute machine hosts in your {product-title} environment must meet the following minimum hardware specifications and system-level requirements:
 
 * You must have an active {product-title} subscription on your Red Hat account. If you do not, contact your sales representative for more information.
 


### PR DESCRIPTION

Version(s): enterprise-4.10 and later
<!--- Specify the version or versions of OpenShift your PR applies to.
If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2075081

Link to docs preview:
https://deploy-preview-45228--osdocs.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html

Additional information:
Ack from Duncan Hardie that only x86 is supported in this thread: https://coreos.slack.com/archives/CFFJUNP6C/p1651233635363859?thread_ts=1651233197.479949&cid=CFFJUNP6C



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
