### PR TITLE
[enterprise-4.7] BZ2078474:ContainerRuntimeConfig default overlaySize value not applied

### DIFF
--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -8,13 +8,12 @@
 
 The `ContainerRuntimeConfig` custom resource definition (CRD) provides a structured way of changing settings associated with the {product-title} CRI-O runtime. Using a `ContainerRuntimeConfig` custom resource (CR), you select the configuration values you want and the MCO handles rebuilding the `crio.conf` and `storage.conf` configuration files.
 
-Parameters you can set in a `ContainerRuntimeConfig` CR include:
+You can modify the following settings by using a `ContainerRuntimeConfig` CR:
 
-* **PIDs limit**: Sets the maximum number of processes allowed in a container. By default, the limit is set to 1024 (`pids_limit = 1024`).
-* **Log level**: Sets the level of verbosity for log messages. The default is `info` (`log_level = info`). Other options include `fatal`, `panic`, `error`, `warn`, `debug`, and `trace`.
-* **Overlay size**: Sets the maxim size of a container image. The default is 10 GB.
-* **Maximum log size**: Sets the maximum size allowed for the container log file. The default maximum log size is unlimited (`log_size_max = -1`). If it is set to a positive number, it must be at least 8192 to not be smaller than  the `conmon` read buffer. Conmon is a program that
-monitors communications between a container manager (such as Podman or CRI-O) and the OCI runtime (such as runc or crun) for a single container.
+* **PIDs limit**: The `pidsLimit` parameter sets the CRI-O `pids_limit` parameter, which is maximum number of processes allowed in a container. The default is 1024 (`pids_limit = 1024`).
+* **Log level**: The `logLevel` parameter sets the CRI-O `log_level` parameter, which is the level of verbosity for log messages. The default is `info` (`log_level = info`). Other options include `fatal`, `panic`, `error`, `warn`, `debug`, and `trace`.
+* **Overlay size**: The `overlaySize` parameter sets the CRI-O Overlay storage driver `size` parameter, which is the maximum size of a container image.
+* **Maximum log size**: The `logSizeMax` parameter sets the CRI-O `log_size_max` parameter, which is the maximum size allowed for the container log file. The default is unlimited (`log_size_max = -1`). If set to a positive number, it must be at least 8192 to not be smaller than  the ConMon read buffer. ConMon is a program that monitors communications between a container manager (such as Podman or CRI-O) and the OCI runtime (such as runc or crun) for a single container.
 
 The following procedure describes how to change CRI-O settings using the `ContainerRuntimeConfig` CR.
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/45194