### PR TITLE
Windows Server 2022 support in WINC 5.1.0

### DIFF
--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -19,12 +19,7 @@ You must use link:https://docs.microsoft.com/en-us/powershell/scripting/install/
 
 .Procedure
 
-. Create a new VM in the vSphere client using the Windows Server 2022 Long-Term Servicing Channel ISO image that includes the link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[Microsoft patch KB5012637]. For example, you can use the following PowerShell command to download and install the patch:
-+
-[source,posh]
-----
-PS C:\> Get-WindowsUpdate -Install -KBArticleId 'KB5012637'
----- 
+. Create a new VM in the vSphere client using the Windows Server 2022 Long-Term Servicing Channel ISO image that includes the link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[Microsoft patch KB5012637]. 
 +
 [IMPORTANT]
 ====
@@ -70,24 +65,6 @@ The public key used in the instructions must correspond to the private key you c
 ====
 
 . Install the `docker` container runtime on your Windows VM following the link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server[Microsoft documentation].
-
-. Install Microsoft container networking patch KB5012637 
-
-.. Download the patch files from the link:https://www.catalog.update.microsoft.com/Search.aspx?q=KB5012637[Microsoft Update Catalog].
-+
-For example, you can use the following PowerShell command to download the file:
-+
-[source,posh]
-----
-PS C:\> Invoke-WebRequest -Uri https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2022/04/windows10.0-kb5012637-x64_6a7459b60e226b0ad0d30b34a4be069bee4d2867.msu -OutFile windows10.0-kb5012637-x64.msu
-----
-
-.. Install the patch and reboot the machine to apply the update to the operating system:
-+
-[source,posh]
-----
-PS C:\> `wusa.exe C:\PATH-TO-UPDATE\windows10.0-kb5012637-x64.msu /quiet /forcerestart`
-----
 
 . You must create a new firewall rule in the Windows VM that allows incoming connections for container logs. Run the following PowerShell command to create the firewall rule on TCP port 10250:
 +

--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -19,7 +19,12 @@ You must use link:https://docs.microsoft.com/en-us/powershell/scripting/install/
 
 .Procedure
 
-. Create a new VM in the vSphere client using the Windows Server 2022 Long-Term Servicing Channel ISO image that includes the link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[Microsoft patch KB5012637].
+. Create a new VM in the vSphere client using the Windows Server 2022 Long-Term Servicing Channel ISO image that includes the link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[Microsoft patch KB5012637].For example, you can use the following PowerShell command to download and install the patch:
++
+[source,posh]
+----
+PS C:\> Get-WindowsUpdate -Install -KBArticleId 'KB5012637'
+---- 
 +
 [IMPORTANT]
 ====
@@ -72,14 +77,14 @@ The public key used in the instructions must correspond to the private key you c
 +
 For example, you can use the following PowerShell command to download the file:
 +
-[source,terminal]
+[source,posh]
 ----
 PS C:\> Invoke-WebRequest -Uri https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2022/04/windows10.0-kb5012637-x64_6a7459b60e226b0ad0d30b34a4be069bee4d2867.msu -OutFile windows10.0-kb5012637-x64.msu
 ----
 
 .. Install the patch and reboot the machine to apply the update to the operating system:
 +
-[source,terminal]
+[source,posh]
 ----
 PS C:\> `wusa.exe C:\PATH-TO-UPDATE\windows10.0-kb5012637-x64.msu /quiet /forcerestart`
 ----

--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -19,7 +19,7 @@ You must use link:https://docs.microsoft.com/en-us/powershell/scripting/install/
 
 .Procedure
 
-. Create a new VM in the vSphere client using the Windows Server Semi-Annual Channel (SAC): Windows Server 20H2 ISO image that includes the link:https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351[Microsoft patch KB4565351]. This patch is required to set the VXLAN UDP port, which is required for clusters installed on vSphere. See the link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.hostclient.doc/GUID-77AB6625-F968-4983-A230-A020C0A70326.html[VMware documentation] for more information.
+. Create a new VM in the vSphere client using the Windows Server Semi-Annual Channel (SAC): Windows Server 2022 ISO image that includes the link:https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351[Microsoft patch KB4565351]. This patch is required to set the VXLAN UDP port, which is required for clusters installed on vSphere. See the link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.hostclient.doc/GUID-77AB6625-F968-4983-A230-A020C0A70326.html[VMware documentation] for more information.
 +
 [IMPORTANT]
 ====

--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -19,7 +19,7 @@ You must use link:https://docs.microsoft.com/en-us/powershell/scripting/install/
 
 .Procedure
 
-. Create a new VM in the vSphere client using the Windows Server 2022 Long-Term Servicing Channel ISO image that includes the link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[Microsoft patch KB5012637].For example, you can use the following PowerShell command to download and install the patch:
+. Create a new VM in the vSphere client using the Windows Server 2022 Long-Term Servicing Channel ISO image that includes the link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[Microsoft patch KB5012637]. For example, you can use the following PowerShell command to download and install the patch:
 +
 [source,posh]
 ----
@@ -102,7 +102,7 @@ PS C:\> New-NetFirewallRule -DisplayName "ContainerLogsPort" -LocalPort 10250 -E
 +
 [source,terminal]
 ----
-PS C:\> C:\Windows\System32\Sysprep\sysprep.exe /generalize /oobe /shutdown /unattend:<path_to_unattend.xml> <1>
+C:\> C:\Windows\System32\Sysprep\sysprep.exe /generalize /oobe /shutdown /unattend:<path_to_unattend.xml> <1>
 ----
 <1> Specify the path to your `unattend.xml` file.
 +

--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -19,7 +19,7 @@ You must use link:https://docs.microsoft.com/en-us/powershell/scripting/install/
 
 .Procedure
 
-. Create a new VM in the vSphere client using the Windows Server Semi-Annual Channel (SAC): Windows Server 2022 ISO image that includes the link:https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351[Microsoft patch KB4565351]. This patch is required to set the VXLAN UDP port, which is required for clusters installed on vSphere. See the link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.hostclient.doc/GUID-77AB6625-F968-4983-A230-A020C0A70326.html[VMware documentation] for more information.
+. Create a new VM in the vSphere client using the Windows Server 2022 Long-Term Servicing Channel ISO image that includes the link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[Microsoft patch KB5012637].
 +
 [IMPORTANT]
 ====
@@ -65,6 +65,24 @@ The public key used in the instructions must correspond to the private key you c
 ====
 
 . Install the `docker` container runtime on your Windows VM following the link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server[Microsoft documentation].
+
+. Install Microsoft container networking patch KB5012637 
+
+.. Download the patch files from the link:https://www.catalog.update.microsoft.com/Search.aspx?q=KB5012637[Microsoft Update Catalog].
+
+.. Install the patch:
++
+[source,terminal]
+====
+C:\> `wusa.exe C:\PATH-TO-UPDATE\windows10.0-kb5012637-x64.msu /quiet`
+====
+
+.. Reboot the machine to apply the update to the operating system:
++
+[source,terminal]
+====
+C:\> `shutdown /r`
+====
 
 . You must create a new firewall rule in the Windows VM that allows incoming connections for container logs. Run the following PowerShell command to create the firewall rule on TCP port 10250:
 +

--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -19,7 +19,7 @@ You must use link:https://docs.microsoft.com/en-us/powershell/scripting/install/
 
 .Procedure
 
-. Create a new VM in the vSphere client using the Windows Server 2022 Long-Term Servicing Channel ISO image that includes the link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[Microsoft patch KB5012637]. 
+. Create a new VM in the vSphere client using the Windows Server 2022 image that includes the link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[Microsoft patch KB5012637]. 
 +
 [IMPORTANT]
 ====

--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -69,20 +69,20 @@ The public key used in the instructions must correspond to the private key you c
 . Install Microsoft container networking patch KB5012637 
 
 .. Download the patch files from the link:https://www.catalog.update.microsoft.com/Search.aspx?q=KB5012637[Microsoft Update Catalog].
-
-.. Install the patch:
++
+For example, you can use the following PowerShell command to download the file:
 +
 [source,terminal]
-====
-C:\> `wusa.exe C:\PATH-TO-UPDATE\windows10.0-kb5012637-x64.msu /quiet`
-====
+----
+PS C:\> Invoke-WebRequest -Uri https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2022/04/windows10.0-kb5012637-x64_6a7459b60e226b0ad0d30b34a4be069bee4d2867.msu -OutFile windows10.0-kb5012637-x64.msu
+----
 
-.. Reboot the machine to apply the update to the operating system:
+.. Install the patch and reboot the machine to apply the update to the operating system:
 +
 [source,terminal]
-====
-C:\> `shutdown /r`
-====
+----
+PS C:\> `wusa.exe C:\PATH-TO-UPDATE\windows10.0-kb5012637-x64.msu /quiet /forcerestart`
+----
 
 . You must create a new firewall rule in the Windows VM that allows incoming connections for container logs. Run the following PowerShell command to create the firewall rule on TCP port 10250:
 +
@@ -97,7 +97,7 @@ PS C:\> New-NetFirewallRule -DisplayName "ContainerLogsPort" -LocalPort 10250 -E
 +
 [source,terminal]
 ----
-C:\> C:\Windows\System32\Sysprep\sysprep.exe /generalize /oobe /shutdown /unattend:<path_to_unattend.xml> <1>
+PS C:\> C:\Windows\System32\Sysprep\sysprep.exe /generalize /oobe /shutdown /unattend:<path_to_unattend.xml> <1>
 ----
 <1> Specify the path to your `unattend.xml` file.
 +

--- a/modules/windows-machineset-aws.adoc
+++ b/modules/windows-machineset-aws.adoc
@@ -80,7 +80,7 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 <2> Specify the infrastructure ID, worker label, and zone.
 <3> Configure the machine set as a Windows machine.
 <4> Configure the Windows node as a compute machine.
-<5> Specify the AMI ID of a Windows image with a container runtime installed. You must use Windows Server 2019 or 2022.
+<5> Specify the AMI ID of a Windows image with a container runtime installed. You must use Windows Server 2019.
 <6> Specify the AWS zone, like `us-east-1a`.
 <7> Specify the AWS region, like `us-east-1`.
 <8> Created by the WMCO when it is configuring the first Windows machine. After that, the `windows-user-data` is available for all subsequent machine sets to consume.

--- a/modules/windows-machineset-aws.adoc
+++ b/modules/windows-machineset-aws.adoc
@@ -80,7 +80,7 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 <2> Specify the infrastructure ID, worker label, and zone.
 <3> Configure the machine set as a Windows machine.
 <4> Configure the Windows node as a compute machine.
-<5> Specify the AMI ID of a Windows image with a container runtime installed. You must use Windows Server 2019.
+<5> Specify the AMI ID of a Windows image with a container runtime installed. You must use Windows Server 2019 or 2022.
 <6> Specify the AWS zone, like `us-east-1a`.
 <7> Specify the AWS region, like `us-east-1`.
 <8> Created by the WMCO when it is configuring the first Windows machine. After that, the `windows-user-data` is available for all subsequent machine sets to consume.

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -66,4 +66,5 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 
 |Custom VXLAN port
 a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.
-* Windows Server 20H2 |===
+* Windows Server 20H2 
+|===

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -62,7 +62,7 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Supported Windows Server version
 
 |Default VXLAN port
-Windows Server 2019 (version 1809)
+|Windows Server 2019 (version 1809)
 
 |Custom VXLAN port
 a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -18,10 +18,10 @@ The following table lists the link:https://docs.microsoft.com/en-us/windows/rele
 |Supported Windows Server version
 
 |Amazon Web Services (AWS)
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+|Windows Server 2019 (version 1809)
 
 |Microsoft Azure
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+|Windows Server 2019 (version 1809)
 
 |VMware vSphere
 a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.
@@ -62,7 +62,7 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Supported Windows Server version
 
 |Default VXLAN port
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+Windows Server 2019 (version 1809)
 
 |Custom VXLAN port
 a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -18,10 +18,10 @@ The following table lists the link:https://docs.microsoft.com/en-us/windows/rele
 |Supported Windows Server version
 
 |Amazon Web Services (AWS)
-|Windows Server 2019
+|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
 
 |Microsoft Azure
-|Windows Server 2019
+|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
 
 |VMware vSphere
 a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.
@@ -62,7 +62,7 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Supported Windows Server version
 
 |Default VXLAN port
-|Windows Server 2019
+|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
 
 |Custom VXLAN port
 a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -24,10 +24,12 @@ The following table lists the link:https://docs.microsoft.com/en-us/windows/rele
 |Windows Server 2019
 
 |VMware vSphere
-|Windows Server 20H2 
+a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.
+* Windows Server 20H2 
 
 |Bare metal or provider agnostic
-|Windows Server 2019
+a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.
+* Windows Server 20H2 
 |===
 
 == Supported networking
@@ -49,7 +51,7 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |VMware vSphere
 |Hybrid networking with OVN-Kubernetes with a custom VXLAN port
 
-|bare metal
+|Bare metal or provider agnostic
 |Hybrid networking with OVN-Kubernetes
 |===
 
@@ -60,8 +62,8 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Supported Windows Server version
 
 |Default VXLAN port
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+|Windows Server 2019
 
 |Custom VXLAN port
-|Windows Server Semi-Annual Channel (SAC): Windows Server 20H2
-|===
+a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.
+* Windows Server 20H2 |===

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -32,12 +32,6 @@ a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-u
 * Windows Server 20H2 
 |===
 
-[NOTE]
-====
-For VMware vSphere, Windows Server 2019 is not supported, because the link:https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351[KB4565351] patch
-is not included. This patch is required for hybrid OVN-Kubernetes networking with a custom VXLAN port.
-====
-
 == Supported networking
 
 Hybrid networking with OVN-Kubernetes is the only supported networking configuration. See the additional resources below for more information on this functionality. The following tables outline the type of networking configuration and Windows Server versions to use based on your platform. You must specify the network configuration when you install the cluster. Be aware that OpenShift SDN networking is the default network for {product-title} clusters. However, OpenShift SDN is not supported by WMCO.

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -32,6 +32,12 @@ a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-u
 * Windows Server 20H2 
 |===
 
+[NOTE]
+====
+For VMware vSphere, Windows Server 2019 is not supported, because the link:https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351[KB4565351] patch
+is not included. This patch is required for hybrid OVN-Kubernetes networking with a custom VXLAN port.
+====
+
 == Supported networking
 
 Hybrid networking with OVN-Kubernetes is the only supported networking configuration. See the additional resources below for more information on this functionality. The following tables outline the type of networking configuration and Windows Server versions to use based on your platform. You must specify the network configuration when you install the cluster. Be aware that OpenShift SDN networking is the default network for {product-title} clusters. However, OpenShift SDN is not supported by WMCO.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3575
For 5.1.0:
2022 support for vSphere, and 20H2 still supported
no changes to other platforms

Preview:
WINC prereqs: 
[Supported Windows Server version](http://file.rdu.redhat.com/~mburke/OSDOCS-3575-windows-2022-winc-51/windows_containers/windows-containers-release-notes-5-x.html#wmco-prerequisites-supported-5.0.0_windows-containers-release-notes)
[Supported networking](http://file.rdu.redhat.com/~mburke/OSDOCS-3575-windows-2022-winc-51/windows_containers/windows-containers-release-notes-5-x.html#supported-networking)
[Creating the vSphere Windows VM golden image](http://file.rdu.redhat.com/~mburke/OSDOCS-3575-windows-2022-winc-51/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html#creating-the-vsphere-windows-vm-golden-image_creating-windows-machineset-vsphere). Updated Step 1