### PR TITLE
BZ2079176 - Fixing tag in updating clusters overview

### DIFF
--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -12,7 +12,7 @@ You can update a {product-title} cluster with a single operation by using the we
 == Understanding OpenShift Container Platform updates
 xref:../updating/understanding-openshift-updates.adoc#understanding-openshift-updates[About the OpenShift Update Service]: For clusters with internet accessibility, Red{nbsp}Hat provides over-the-air updates through an {product-title} update service as a hosted service located behind public APIs.
 
-["updating-clusters-overview-upgrade-channels-and-releases"]
+[id="updating-clusters-overview-upgrade-channels-and-releases"]
 == Understanding upgrade channels and releases
 xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Upgrade channels and releases]: Upgrade channels allow you to choose an upgrade strategy. Upgrade channels are connected to a minor version of {product-title}. Upgrade channels control only release selection and do not impact the version of the cluster that you install; the openshift-install binary file for a specific version of {product-title} always installs that version. For more information, see the following:
 
@@ -22,13 +22,13 @@ xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgra
 * xref:../updating/understanding-upgrade-channels-release.adoc#switching-between-channels_understanding-upgrade-channels-releases[Switching between channels]
 * xref:../updating/understanding-upgrade-channels-release.adoc#conditional-updates-overview_understanding-upgrade-channels-releases[Understanding conditional updates]
 
-["updating-clusters-overview-prepare-eus-to-eus-update"]
+[id="updating-clusters-overview-prepare-eus-to-eus-update"]
 == Preparing to perform an EUS-to-EUS update
 xref:../updating/preparing-eus-eus-upgrade.adoc#preparing-eus-eus-upgrade[Preparing to perform an EUS-to-EUS update]: Due to fundamental Kubernetes design, all {product-title} updates between minor versions must be serialized. You must update from {product-title} 4.8 to 4.9, and then to 4.10. You cannot update from {product-title} 4.8 to 4.10 directly. However, if you want to update between two Extended Update Support (EUS) versions, you can do so by incurring only a single reboot of non-master hosts. For more information, see the following item:
 
 * xref:../updating/preparing-eus-eus-upgrade.adoc#updating-eus-to-eus-upgrade_eus-to-eus-upgrade[Updating EUS-to-EUS]
 
-["updating-clusters-overview-update-cluster-using-web-console"]
+[id="updating-clusters-overview-update-cluster-using-web-console"]
 == Updating a cluster using the web console
 xref:../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[Updating a cluster within a minor version using the web console]: You can update an {product-title} cluster by using the web console. You can the update a cluster between minor versions. For more information, see the following items:
 
@@ -38,7 +38,7 @@ xref:../updating/updating-cluster-within-minor.adoc#updating-cluster-within-mino
 * xref:../updating/updating-cluster-within-minor.adoc#update-upgrading-web_updating-cluster-within-minor[Updating a cluster by using the web console]
 * xref:../updating/updating-cluster-within-minor.adoc#update-changing-update-server-web_updating-cluster-within-minor[Changing the update server by using the web console]
 
-["updating-clusters-overview-update-cluster-using-cli"]
+[id="updating-clusters-overview-update-cluster-using-cli"]
 == Updating a cluster within a minor version using the command-line interface (CLI)
 xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version using the CLI]: You can update an {product-title} cluster by using the `oc`. You can the update a cluster between minor versions. For more information, see the following actions:
 
@@ -47,7 +47,7 @@ xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a clust
 * xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI]
 * xref:../updating/updating-cluster-cli.adoc#update-changing-update-server-cli_updating-cluster-cli[Changing the update server by using the CLI]
 
-["updating-clusters-overview-perform-canary-rollout-update"]
+[id="updating-clusters-overview-perform-canary-rollout-update"]
 == Performing a canary rollout update
 xref:../updating/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools[Performing a canary rollout update]: By controlling rollout of an update to the worker nodes, you can ensure that mission-critical applications stay available during the whole update, even if the update process causes your applications to fail. Depending on your organizational needs, you might want to update a small subset of worker nodes, evaluate cluster and workload health over a period of time, and then update the remaining nodes. This is referred to as a _canary_ update. Alternatively, you might also want to fit worker node updates, which often requires a host reboot, into smaller defined maintenance windows when it is not possible to take a large maintenance window to update the entire cluster at one time. You can perform the following actions:
 
@@ -57,7 +57,7 @@ xref:../updating/update-using-custom-machine-config-pools.adoc#update-using-cust
 * xref:../updating/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-unpause_update-using-custom-machine-config-pools[Unpausing the machine configuration pools]
 * xref:../updating/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-mcp-remove_update-using-custom-machine-config-pools[Moving a node to the original machine configuration pool]
 
-["updating-clusters-overview-update-cluster-with-rhel-compute-machines"]
+[id="updating-clusters-overview-update-cluster-with-rhel-compute-machines"]
 == Updating a cluster that includes {op-system-base} compute machines
 xref:../updating/updating-cluster-rhel-compute.adoc#updating-cluster-rhel-compute[Updating a cluster that includes {op-system-base} compute machines]:  You can update an {product-title} cluster. If your cluster contains {op-system-base-full} machines, you must update those machines. You can perform the following actions:
 
@@ -65,7 +65,7 @@ xref:../updating/updating-cluster-rhel-compute.adoc#updating-cluster-rhel-comput
 * xref:../updating/updating-cluster-rhel-compute.adoc#updating-cluster-rhel-compute-hooks[Optional: Adding hooks to perform Ansible tasks on {op-system-base} machines]
 * xref:../updating/updating-cluster-rhel-compute.adoc#rhel-compute-updating-minor_updating-cluster-rhel-compute[Updating {op-system-base} compute machines in your cluster]
 
-["updating-clusters-overview-update-restricted-network-cluster"]
+[id="updating-clusters-overview-update-restricted-network-cluster"]
 == Updating a restricted network cluster
 xref:../updating/updating-restricted-network-cluster.adoc#updating-restricted-network-cluster[Updating a restricted network cluster]: A restricted network environment is one in which your cluster nodes cannot access the internet. You can update a restricted network {product-title} cluster by using the `oc`. You can also update a restricted network {product-title} cluster by using the OpenShift Update Service. For more information, see the following items:
 
@@ -80,7 +80,7 @@ xref:../updating/updating-restricted-network-cluster.adoc#updating-restricted-ne
 * xref:../updating/updating-restricted-network-cluster.adoc#update-service-delete-service[Deleting an OpenShift Update Service application]
 * xref:../updating/updating-restricted-network-cluster.adoc#update-service-uninstall[Uninstalling the OpenShift Update Service Operator]
 
-["updating-clusters-overview-vsphere-updating-hardware"]
+[id="updating-clusters-overview-vsphere-updating-hardware"]
 == Updating hardware on nodes running on vSphere
 
 xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on vSphere]: You must ensure that your nodes running in vSphere are running on the hardware version supported by OpenShift Container Platform. Currently, hardware version 13 or later is supported for vSphere virtual machines in a cluster. For more information, see the following information:


### PR DESCRIPTION
For versions 4.7+
[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2079176)

**Description:**  There were missing `id` in some of the headings in this assembly, the current customer portal is showing the html tags due to this issue. Adding `id` to the headings that are missing them. 
_Live docs - Updating clusters overview_

- (Renders normal) [docs.openshift.com](https://docs.openshift.com/container-platform/4.10/updating/index.html)
- (Renders with HTML tags) [access.redhat.com](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html-single/updating_clusters/index#updating-clusters-overview)

**No QE required:** Asciidoc format fix 
**Preview:** [Updating clusters overview](https://deploy-preview-45245--osdocs.netlify.app/openshift-enterprise/latest/updating/index.html)

**NOTE** 
I will follow up after this PR is merged and verify that the render in the customer portal is fixed 