### PR TITLE
RNs-4.9.31 Added with Bug Fix Update

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2757,7 +2757,7 @@ link:https://access.redhat.com/solutions/6906441[{product-title} 4.9.28 containe
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
 
-[[ocp-4-9-29]]
+[id="ocp-4-9-29"]
 === RHSA-2022:1363 - {product-title} 4.9.29 bug fix and security update
 
 Issued: 2022-04-20
@@ -2777,6 +2777,33 @@ link:https://access.redhat.com/solutions/6934361[{product-title} 4.9.29 containe
 * Previously, hard-coded BusyBox image from the Docker was used for the scorecard. Consequently, the Docker's new rate limit caused periodic failures when running the scorecard. This fix recommends to use the Universal Base Image (UBI) `registry.access.redhat.com/ubi8/ubi:8.4` for the scorecard, resulting no failures due to rate limiting. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2064408[*BZ#2064408*])
 
 [id="ocp-4-9-29-updating"]
+==== Updating
+
+To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-9-31"]
+=== RHBA-2022:1605 - {product-title} 4.9.31 bug fix update
+
+Issued: 2022-05-03
+
+{product-title} release 4.9.31, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1605[RHBA-2022:1605] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1604[RHBA-2022:1604] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6955866[{product-title} 4.9.31 container image list]
+
+[id="ocp-kubernetes-1-22-8-updates"]
+==== Updates from Kubernetes 1.22.8
+
+This update contains changes from Kubernetes 1.22.6 up to 1.22.8. More information can be found in the following changelogs: link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#v1226[1.22.6], link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#v1227[1.22.7], and link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#v1228[1.22.8].
+
+[id="ocp-4-9-31-bug-fixes"]
+==== Bug fixes
+* Previously, the Kubernetes API server did not warn users about upcoming changes to the API for dual-stack services in {product-title} 4.10. This fix alerts users to specify either `ipFamilyPolicy: PreferDualStack` or `ipFamilyPolicy: RequireDualStack` for dual-stack services to be valid in {product-title} 4.10. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2050632#[*BZ#2050632*])
+
+* Previously, the *Git import* page failed to load due to performance improvement releases. With this fix, the *Git import* page no longer fails to load and now runs as intended. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2069621#[*BZ#2069621*])
+
+[id="ocp-4-9-31-updating"]
 ==== Updating
 
 To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
**RNs-4.9.31** 
 Added with bux fix update.

**Version(s):**
enterprise-4.9 only

**Issue:**
https://issues.redhat.com/browse/OCPPLAN-8989

**Link to docs preview:**
https://deploy-preview-45254--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-31

**Additional information:**
This RN contains updates from Kubernetes 1.22.6 to 1.22.8.



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
