### PR TITLE
Updating versions to 4.10 instead of 4.9

### DIFF
--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -89,15 +89,15 @@ $ openshift-install coreos print-stream-json | grep '\.iso[^.]'
 [source,terminal]
 ifndef::openshift-origin[]
 ----
-"location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202110080947-0/aarch64/rhcos-49.84.202110080947-0-live.aarch64.iso",
-"location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202110081256-0/ppc64le/rhcos-49.84.202110081256-0-live.ppc64le.iso",
-"location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202110081202-0/s390x/rhcos-49.84.202110081202-0-live.s390x.iso",
-"location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202110081407-0/x86_64/rhcos-49.84.202110081407-0-live.x86_64.iso",
+"location": "<url>/art/storage/releases/rhcos-4.10-aarch64/<release>/aarch64/rhcos-<release>-live.aarch64.iso",
+"location": "<url>/art/storage/releases/rhcos-4.10-ppc64le/<release>/ppc64le/rhcos-<release>-live.ppc64le.iso",
+"location": "<url>/art/storage/releases/rhcos-4.10-s390x/<release>/s390x/rhcos-<release>-live.s390x.iso",
+"location": "<url>/art/storage/releases/rhcos-4.10/<release>/x86_64/rhcos-<release>-live.x86_64.iso",
 ----
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 ----
-"location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live.x86_64.iso",
+"location": "<url>/prod/streams/stable/builds/<release>/x86_64/fedora-coreos-<release>-live.x86_64.iso",
 ----
 endif::openshift-origin[]
 +

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -73,7 +73,7 @@ $ curl -k http://<HTTP_server>/bootstrap.ign <1>
   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0{"ignition":{"version":"3.2.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["ssh-rsa...
 ----
 +
-Replace `bootstrap.ign` with `master.ign` or `worker.ign` in the command to validate 
+Replace `bootstrap.ign` with `master.ign` or `worker.ign` in the command to validate
 that the Ignition config files for the control plane and compute nodes are also available.
 
 . Although it is possible to obtain the {op-system} `kernel`, `initramfs` and `rootfs`
@@ -86,7 +86,7 @@ link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stabl
 endif::openshift-origin[]
 ifdef::ibm-power[]
 link:https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/[{op-system} image mirror]
-endif::ibm-power[] 
+endif::ibm-power[]
 page, the recommended way to obtain the correct version of your {op-system} files are
 from the output of `openshift-install` command:
 +
@@ -99,25 +99,25 @@ $ openshift-install coreos print-stream-json | grep -Eo '"https.*(kernel-|initra
 [source,terminal]
 ifndef::openshift-origin[]
 ----
-"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202110080947-0/aarch64/rhcos-49.84.202110080947-0-live-kernel-aarch64"
-"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202110080947-0/aarch64/rhcos-49.84.202110080947-0-live-initramfs.aarch64.img"
-"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202110080947-0/aarch64/rhcos-49.84.202110080947-0-live-rootfs.aarch64.img"
-"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202110081256-0/ppc64le/rhcos-49.84.202110081256-0-live-kernel-ppc64le"
-"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202110081256-0/ppc64le/rhcos-49.84.202110081256-0-live-initramfs.ppc64le.img"
-"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202110081256-0/ppc64le/rhcos-49.84.202110081256-0-live-rootfs.ppc64le.img"
-"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202110081202-0/s390x/rhcos-49.84.202110081202-0-live-kernel-s390x"
-"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202110081202-0/s390x/rhcos-49.84.202110081202-0-live-initramfs.s390x.img"
-"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202110081202-0/s390x/rhcos-49.84.202110081202-0-live-rootfs.s390x.img"
-"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202110081407-0/x86_64/rhcos-49.84.202110081407-0-live-kernel-x86_64"
-"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202110081407-0/x86_64/rhcos-49.84.202110081407-0-live-initramfs.x86_64.img"
-"https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202110081407-0/x86_64/rhcos-49.84.202110081407-0-live-rootfs.x86_64.img"
+"<url>/art/storage/releases/rhcos-4.10-aarch64/<release>/aarch64/rhcos-<release>-live-kernel-aarch64"
+"<url>/art/storage/releases/rhcos-4.10-aarch64/<release>/aarch64/rhcos-<release>-live-initramfs.aarch64.img"
+"<url>/art/storage/releases/rhcos-4.10-aarch64/<release>/aarch64/rhcos-<release>-live-rootfs.aarch64.img"
+"<url>/art/storage/releases/rhcos-4.10-ppc64le/49.84.202110081256-0/ppc64le/rhcos-<release>-live-kernel-ppc64le"
+"<url>/art/storage/releases/rhcos-4.10-ppc64le/<release>/ppc64le/rhcos-<release>-live-initramfs.ppc64le.img"
+"<url>/art/storage/releases/rhcos-4.10-ppc64le/<release>/ppc64le/rhcos-<release>-live-rootfs.ppc64le.img"
+"<url>/art/storage/releases/rhcos-4.10-s390x/<release>/s390x/rhcos-<release>-live-kernel-s390x"
+"<url>/art/storage/releases/rhcos-4.10-s390x/<release>/s390x/rhcos-<release>-live-initramfs.s390x.img"
+"<url>/art/storage/releases/rhcos-4.10-s390x/<release>/s390x/rhcos-<release>-live-rootfs.s390x.img"
+"<url>/art/storage/releases/rhcos-4.10/<release>/x86_64/rhcos-<release>-live-kernel-x86_64"
+"<url>/art/storage/releases/rhcos-4.10/<release>/x86_64/rhcos-<release>-live-initramfs.x86_64.img"
+"<url>/art/storage/releases/rhcos-4.10/<release>/x86_64/rhcos-<release>-live-rootfs.x86_64.img"
 ----
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 ----
-"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-kernel-x86_64"
-"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-initramfs.x86_64.img"
-"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-rootfs.x86_64.img"
+"<url>/prod/streams/stable/builds/<release>/x86_64/fedora-coreos-<release>-live-kernel-x86_64"
+"<url>/prod/streams/stable/builds/<release>/x86_64/fedora-coreos-<release>-live-initramfs.x86_64.img"
+"<url>/prod/streams/stable/builds/<release>/x86_64/fedora-coreos-<release>-live-rootfs.x86_64.img"
 ----
 endif::openshift-origin[]
 +
@@ -128,7 +128,7 @@ You must download images with the highest version that is less than or equal
 to the {product-title} version that you install. Only use
 the appropriate `kernel`, `initramfs`, and `rootfs` artifacts described below
 for this procedure.
-{op-system} QCOW2 images are not supported for this installation type. 
+{op-system} QCOW2 images are not supported for this installation type.
 ====
 +
 The file names contain the {product-title} version number.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Followup to #44319, to fix 4.9 versions to 4.10.

Version(s):
4.9, 4.10, 4.11

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://deploy-preview-45260--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-user-infra-machines-iso_installing-platform-agnostic

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
