### PR TITLE
OSDOCS-3451: Sort Node Updates by Zone and Age

### DIFF
--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -18,6 +18,8 @@ The Machine Config Operator (MCO) manages updates to systemd, CRI-O and Kubelet,
 A node can have multiple labels applied that indicate its type, such as `master` or `worker`, however it can be a member of only a *single* machine config pool.
 ====
 
+* After a machine config change, the MCO updates the affected nodes alphabetically by zone, based on the `topology.kubernetes.io/zone` label. If a zone has more than one node, the oldest nodes are updated first. For nodes that do not use zones, such as in bare metal deployments, the nodes are upgraded by age, with the oldest nodes updated first. The MCO updates the number of nodes as specified by the `maxUnavailable` field on the machine configuration pool at a time. 
+
 * Some machine configuration must be in place before {product-title} is installed to disk. In most cases, this can be accomplished by creating
 a machine config that is injected directly into the {product-title} installer process, instead of running as a post-installation machine config. In other cases, you might need to do bare metal installation where you pass kernel arguments at {product-title} installer startup, to do such things as setting per-node individual IP addresses or advanced disk partitioning.
 

--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -37,7 +37,7 @@ Two controllers run during continuous update mode. The first controller continuo
 Only upgrading to a newer version is supported. Reverting or rolling back your cluster to a previous version is not supported. If your update fails, contact Red Hat support.
 ====
 
-During the update process, the Machine Config Operator (MCO) applies the new configuration to your cluster machines. The MCO cordons the number of nodes as specified by the `maxUnavailable` field on the machine configuration pool and marks them as unavailable. By default, this value is set to `1`. The MCO then applies the new configuration and reboots the machine.
+During the update process, the Machine Config Operator (MCO) applies the new configuration to your cluster machines. The MCO cordons the number of nodes as specified by the `maxUnavailable` field on the machine configuration pool and marks them as unavailable. By default, this value is set to `1`. The MCO updates the affected nodes alphabetically by zone, based on the `topology.kubernetes.io/zone` label. If a zone has more than one node, the oldest nodes are updated first. For nodes that do not use zones, such as in bare metal deployments, the nodes are upgraded by age, with the oldest nodes updated first. The MCO updates the number of nodes as specified by the `maxUnavailable` field on the machine configuration pool at a time. The MCO then applies the new configuration and reboots the machine.
 
 If you use {op-system-base-full} machines as workers, the MCO does not update the kubelet because you must update the OpenShift API on the machines first.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3451

MCO to upgrade nodes per [topology.kubernetes.io/zone](http://topology.kubernetes.io/zone) and then by node age (oldest first).

Preview: 
[Machine config overview](https://deploy-preview-45261--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks), bullet 3
[About the OpenShift Update Service](https://deploy-preview-45261--osdocs.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#update-service-overview_control-plane), paragraph 5
