### PR TITLE
OSDOCS-3533: Adding ADFS to list of supported OIDC providers

### DIFF
--- a/modules/identity-provider-oidc-supported.adoc
+++ b/modules/identity-provider-oidc-supported.adoc
@@ -7,6 +7,12 @@
 
 The following OpenID Connect (OIDC) providers are tested and supported with {product-title}:
 
+* Active Directory Federation Services
++
+[NOTE]
+====
+Currently, it is not supported to use Active Directory Federation Services with {product-title} when custom claims are used.
+====
 * GitLab
 * Google
 * Keycloak


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3533

Link to docs preview:
https://deploy-preview-45263--osdocs.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-oidc-identity-provider#identity-provider-oidc-supported_configuring-oidc-identity-provider

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
