### PR TITLE
OSDOCS-3600: Added Sao Paulo to Supported IBM Cloud regions

### DIFF
--- a/modules/installation-ibm-cloud-regions.adoc
+++ b/modules/installation-ibm-cloud-regions.adoc
@@ -11,6 +11,7 @@ You can deploy an {product-title} cluster to the following regions:
 //Not listed for openshift-install: br-sao, in-che, kr-seo
 
 * `au-syd` (Sydney, Australia)
+* `br-sao` (Sao Paulo, Brazil)
 * `ca-tor` (Toronto, Canada)
 * `eu-de` (Frankfurt, Germany)
 * `eu-gb` (London, United Kingdom)


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This issue addresses [BZ 2061891](https://bugzilla.redhat.com/show_bug.cgi?id=2061891)/[OSDOCS-3600](https://issues.redhat.com/browse/OSDOCS-3600).

Added `br-sao (Sao Paulo, Brazil)` to list of supported regions.

Link to docs preview:

[Supported IBM Cloud regions](https://deploy-preview-45272--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.html#installation-ibm-cloud-regions_installing-ibm-cloud-account)