### PR TITLE
SPLAT-527: add external load balancer details for vSphere IPI installs

### DIFF
--- a/installing/installing_vmc/installing-restricted-networks-vmc.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc.adoc
@@ -88,6 +88,8 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
 [id="next-steps_installing-restricted-networks-vmc"]
 == Next steps
 

--- a/installing/installing_vmc/installing-vmc-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-customizations.adoc
@@ -85,6 +85,8 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
 == Next steps
 
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].

--- a/installing/installing_vmc/installing-vmc-network-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-network-customizations.adoc
@@ -90,6 +90,8 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
 == Next steps
 
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].

--- a/installing/installing_vmc/installing-vmc.adoc
+++ b/installing/installing_vmc/installing-vmc.adoc
@@ -74,6 +74,8 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
 == Next steps
 
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].

--- a/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -85,6 +85,8 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
 [id="next-steps_installing-restricted-networks-installer-provisioned-vsphere"]
 == Next steps
 

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -80,6 +80,8 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
 == Next steps
 
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -89,6 +89,8 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
 == Next steps
 
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
@@ -73,6 +73,8 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
 == Next steps
 
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].


### PR DESCRIPTION
The intention of this PR is to add details to on configuring an external load balancer in the vSphere IPI install modules.

Version(s):
OpenShift 4.11

Issue:
https://issues.redhat.com/browse/SPLAT-409



