### PR TITLE
Adds notes for 4.6.57 and backport of rem feature

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -1429,6 +1429,10 @@ In the table, features are marked with the following statuses:
 |REM
 |REM
 
+|Minting credentials for Microsoft Azure clusters
+|GA
+|GA
+|xref:../release_notes/ocp-4-6-release-notes.adoc#ocp-4-6-57-removed-feature-azure-mint-mode[REM]
 |====
 
 [id="ocp-4-6-deprecated-features"]
@@ -1465,6 +1469,54 @@ The Amazon Web Services (AWS) Elastic File System (EFS) Technology Preview featu
 ==== TLS verification falling back to the Common Name field
 
 The behavior of falling back to the *Common Name* field on X.509 certificates as a host name when no Subject Alternative Names (SANs) are present is removed. Certificates must properly set the *Subject Alternative Names* field.
+
+[id="ocp-4-6-removed-feature-azure-mint-mode"]
+==== Support for minting credentials for Microsoft Azure removed
+
+Starting with {product-title} 4.6.57, support for using the Cloud Credential Operator (CCO) in mint mode on Microsoft Azure clusters has been removed from {product-title} 4.6. This change is due to the planned link:https://azure.microsoft.com/en-us/updates/update-your-apps-to-use-microsoft-graph-before-30-june-2022/[retirement of the Azure AD Graph API by Microsoft on 30 June 2022] and is being backported to all supported versions of {product-title} in z-stream updates.
+
+For previously installed Azure clusters that use mint mode, the CCO attempts to update existing secrets. If a secret contains the credentials of previously minted app registration service principals, it is updated with the contents of the secret in `kube-system/azure-credentials`. This behavior is similar to passthrough mode.
+
+For clusters with the credentials mode set to its default value of `""`, the updated CCO automatically changes from operating in mint mode to operating in passthrough mode. If your cluster has the credentials mode explicitly set to mint mode (`"Mint"`), you must change the value to `""` or `"Passthrough"`.
+
+[NOTE]
+====
+In addition to the `Contributor` role that is required by mint mode, the modified app registration service principals now require the `User Access Administrator` role that is used for passthrough mode.
+====
+
+While the Azure AD Graph API is still available, the CCO in upgraded versions of {product-title} attempts to clean up previously minted app registration service principals. Upgrading your cluster before the Azure AD Graph API is retired might avoid the need to clean up resources manually.
+
+If the cluster is upgraded to a version of {product-title} that no longer supports mint mode after the Azure AD Graph API is retired, the CCO sets an `OrphanedCloudResource` condition on the associated `CredentialsRequest` but does not treat the error as fatal. The condition includes a message similar to `unable to clean up App Registration / Service Principal: <app_registration_name>`. Cleanup after the Azure AD Graph API is retired requires manual intervention using the Azure CLI tool or the Azure web console to remove any remaining app registration service principals.
+
+To clean up resources manually, you must find and delete the affected resources.
+
+. Using the Azure CLI tool, filter the app registration service principals that use the `<app_registration_name>` from an `OrphanedCloudResource` condition message by running the following command:
++
+[source,terminal]
+----
+$ az ad app list --filter "displayname eq '<app_registration_name>'" --query '[].objectId'
+----
++
+.Example output
++
+[source,terminal]
+----
+[
+  "038c2538-7c40-49f5-abe5-f59c59c29244"
+]
+----
+
+. Delete the app registration service principal by running the following command:
++
+[source,terminal]
+----
+$ az ad app delete --id 038c2538-7c40-49f5-abe5-f59c59c29244
+----
+
+[NOTE]
+====
+After cleaning up resources manually, the `OrphanedCloudResource` condition persists because the CCO cannot verify that the resources were cleaned up.
+====
 
 [id="ocp-4-6-bug-fixes"]
 == Bug fixes
@@ -3505,6 +3557,27 @@ link:https://access.redhat.com/solutions/6833311[{product-title} 4.6.56 containe
  * Previously, an error between {rh-openstack-first} credentials secret creation and `kube-controller-manager` startup prevented {rh-openstack} credentials from configuring properly. Consequently, `LoadBalancer` services were not created in {rh-openstack}. This updates fetches the {rh-openstack} credentials when `kube-controller-manager` starts. As a result, {rh-openstack} secret credentials now initialize properly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2059677[*BZ#2059677*])
 
 [id="ocp-4-6-56-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-6-57"]
+=== RHBA-2022:1621 - {product-title} 4.6.57 bug fix and security update
+
+Issued: 2022-05-04
+
+{product-title} release 4.6.57, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1621[RHBA-2022:1621] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:1620[RHSA-2022:1620] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6956136[{product-title} 4.6.57 container image list]
+
+[id="ocp-4-6-57-removed-feature-azure-mint-mode"]
+==== Removed features
+
+Starting with {product-title} 4.6.57, support for using the Cloud Credential Operator (CCO) in mint mode on Microsoft Azure clusters has been removed from {product-title} 4.6. This change is due to the planned link:https://azure.microsoft.com/en-us/updates/update-your-apps-to-use-microsoft-graph-before-30-june-2022[retirement of the Azure AD Graph API by Microsoft on 30 June 2022] and is being backported to all supported versions of {product-title} in z-stream updates. For more information, see xref:../release_notes/ocp-4-6-release-notes.adoc#ocp-4-6-removed-feature-azure-mint-mode[Support for minting credentials for Microsoft Azure removed].
+
+[id="ocp-4-6-57-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.6.57 release and includes a backported removed feature. See Change management acks on https://github.com/openshift/openshift-docs/pull/43289

Version(s):
Applies to `enterpirse-4.6` only


Link to docs preview:
[Preview link to 4.6.57 notes](https://deploy-preview-45282--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-57)
[Preview link to removal table](https://deploy-preview-45282--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-deprecated-removed-features)
[Preview link to removal notes](https://deploy-preview-45282--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-removed-feature-azure-mint-mode)




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
