### PR TITLE
OSDOCS-3596: Release note for MS HyperVGeneration version 2 support

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -75,9 +75,13 @@ For more information, see xref:../getting_started/openshift-overview.adoc[Gettin
 
 [id="ocp-4-11-aws-serial-console-logs"]
 ==== Troubleshooting bootstrap failures during installation on AWS
-The installer now gathers serial console logs from the bootstrap and control plane hosts on AWS. This log data is added to the standard bootstrap log bundle. 
+The installer now gathers serial console logs from the bootstrap and control plane hosts on AWS. This log data is added to the standard bootstrap log bundle.
 
 For more information, see xref:../installing/installing-troubleshooting.adoc#installation-bootstrap-gather_installing-troubleshooting[Troubleshooting installation issues].
+
+[id="ocp-4-11-installation-and-upgrade-hyperv"]
+==== Support for Microsoft Hyper-V generation version 2
+By default, the installation program now deploys a Microsoft Azure cluster using Hyper-V generation version 2 virtual machines (VMs). If the installation program detects that the instance type selected for the VMs does not support version 2, it uses version 1 for the deployment.
 
 [id="ocp-4-11-web-console"]
 === Web console


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR addresses [CORS-1916](https://issues.redhat.com/browse/CORS-1916)/[OSDOCS-3596](https://issues.redhat.com/browse/OSDOCS-3596)

Link to docs preview:
[Support for Microsoft HyperVGeneration version 2 images](https://deploy-preview-45295--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#support-for-microsoft-hypervgeneration-2-images)