### PR TITLE
[RHACS] Added a rewrite rule for ACS release notes

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -139,6 +139,8 @@ AddType text/vtt                            vtt
     # it should probably be best to combine the next few lines in one reg exp but for clarity keeping them separate
     # the first one redirects
     RewriteRule ^acs/?$ /acs/3.69/welcome/index.html [R=301]
+    # redirect to the latest release notes
+    RewriteRule ^acs/release_notes/?$ /acs/3.69/release_notes/369-release-notes.html [R=302,NE]
     RewriteRule ^acs/(\D.*)$ /acs/3.69/$1 [NE,R=301]
     RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68|3\.69)/?$ /acs/$1/welcome/index.html [L,R=301]
 


### PR DESCRIPTION
Creates a redirect rule to always point the URL https://docs.openshift.com/acs/release_notes to the latest release notes version
PS: https://github.com/stackrox/stackrox_community/pull/13#issuecomment-1107046313

