### PR TITLE
Issue 45300, fixed typos in the command

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
+++ b/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
@@ -577,7 +577,7 @@ To perform the `hwlatdetect`, run the following command:
 
 [source, terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=worker-cnf -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20  registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh -ginko.focus=”hwladetect”
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=worker-cnf -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20  registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh -ginkgo.focus="hwladetect"
 ----
 
 The above command runs the `hwlatdetect` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs), and the command line displays `SUCCESS!`.


### PR DESCRIPTION
This addresses https://github.com/openshift/openshift-docs/issues/45300

This error is found in version 4.9 only.

Preview build: https://deploy-preview-45314--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes#cnf-performing-end-to-end-tests-running-hwlatdetect