### PR TITLE
[RHACS] Improve docs for RHACS OpenShift OAuth provider

### DIFF
--- a/modules/configure-ocp-oauth-identity-provider.adoc
+++ b/modules/configure-ocp-oauth-identity-provider.adoc
@@ -10,7 +10,7 @@ To integrate the built-in {ocp} OAuth server as an identity provider for {produc
 
 .Prerequisites
 * You must have the `AuthProvider` permission to configure identity providers in {product-title-short}.
-* You must have already configured users and groups in {ocp} OAuth server.
+* You must have already configured users and groups in {ocp} OAuth server through an identity provider. For information on the identity provider requirements, see link:https://docs.openshift.com/container-platform/4.9/authentication/understanding-identity-provider.html[Understanding identity provider configuration].
 
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Access Control*.
@@ -22,5 +22,26 @@ To integrate the built-in {ocp} OAuth server as an identity provider for {produc
 ====
 For security, Red Hat recommends setting the *Minimum access role* to *None* while you complete setup. Later, you can return to the *Access Control* page to set up more tailored access rules based on user metadata from your identity provider.
 ====
-. To add access rules for users and groups accessing {product-title-short}, use the *Rules* section. For example, to give the *Admin* role to a user called `administrator`, select *User* as *Key*, *administrator* as *Value*, and *Admin* as the *Role*. Use *Add new rule* to add more rules.
+
+. To add access rules for users and groups accessing {product-title-short}, use the *Rules* section. For example:
+.. To give the *Admin* role to a user called `administrator`, you can use the following key-value pairs to create access rules:
++
+|===
+| *Key* | *Value*
+|Name
+|administrator
+|Role
+|Admin
+|===
+.. If you are using the link:https://docs.openshift.com/container-platform/4.9/authentication/understanding-identity-provider.html[HTPasswd Identity Provider] with the username `UserA` that is part of the group `GroupA`, you can use the following key-value pairs to create access rules:
++
+|===
+| *Key* | *Value*
+|Name
+|UserA
+|Group
+|GroupA
+|UserID
+|<UUID>
+|===
 . Click *Save*.

--- a/operating/manage-user-access/configure-ocp-oauth.adoc
+++ b/operating/manage-user-access/configure-ocp-oauth.adoc
@@ -20,6 +20,8 @@ include::modules/configure-ocp-oauth-identity-provider.adoc[leveloffset=+1]
 ----
 $ oc -n stackrox set env deploy/central ROX_ENABLE_OPENSHIFT_AUTH=true
 ----
+* For access rules, you should use the key `Name` to reference the user name that the {ocp} OAuth server returns.
+* For access rules, the {ocp} OAuth server does not return the key `Email`.
 ====
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s): 3.70.0

Link to docs preview: https://deploy-preview-45324--osdocs.netlify.app/openshift-acs/latest/operating/manage-user-access/configure-ocp-oauth

Additional information:
Feedback was received that setting up the OpenShift OAuth provider within ACS was not as intuitively as imagined.
The part of configuring the users within the OpenShift OAuth server itself was not as trivial, as well as confusion regarding the `Name` key within the access rules.
