### PR TITLE
OSSMDOC-571: PoC for using snippet to create out of support banner.

### DIFF
--- a/service_mesh/v1x/installing-ossm.adoc
+++ b/service_mesh/v1x/installing-ossm.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 Installing the {SMProductShortName} involves installing the OpenShift Elasticsearch, Jaeger, Kiali and {SMProductShortName} Operators, creating and managing a `ServiceMeshControlPlane` resource to deploy the control plane, and creating a `ServiceMeshMemberRoll` resource to specify the namespaces associated with the {SMProductShortName}.
 
 [NOTE]

--- a/service_mesh/v1x/ossm-architecture.adoc
+++ b/service_mesh/v1x/ossm-architecture.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 {SMProductName} provides a platform for behavioral insight and operational control over your networked microservices in a service mesh. With {SMProductName}, you can connect, secure, and monitor microservices in your {product-title} environment.
 
 include::modules/ossm-understanding-service-mesh.adoc[leveloffset=+1]

--- a/service_mesh/v1x/ossm-config.adoc
+++ b/service_mesh/v1x/ossm-config.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 After you create a `ServiceMeshControlPlane` resource, configure the resource to suit your environment and requirements.
 
 This guide references the Bookinfo sample application to provide examples of security in an example application. Install the xref:../../service_mesh/v2x/prepare-to-deploy-applications-ossm.adoc#ossm-tutorial-bookinfo-overview_deploying-applications-ossm[Bookinfo application] to learn how these routing examples work.

--- a/service_mesh/v1x/ossm-custom-resources.adoc
+++ b/service_mesh/v1x/ossm-custom-resources.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 You can customize your {SMProductName} by modifying the default {SMProductShortName} custom resource or by creating a new custom resource.
 
 == Prerequisites

--- a/service_mesh/v1x/ossm-observability.adoc
+++ b/service_mesh/v1x/ossm-observability.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 You can view your application's topology, health and metrics in the Kiali console. If your service is having issues, the Kiali console offers ways to visualize the data flow through your service. You can view insights about the mesh components at different levels, including abstract applications, services, and workloads. It also provides an interactive graph view of your namespace in real time.
 
 .Before you begin

--- a/service_mesh/v1x/ossm-security.adoc
+++ b/service_mesh/v1x/ossm-security.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 If your service mesh application is constructed with a complex array of microservices, you can use {SMProductName} to customize the security of the communication between those services. The infrastructure of {product-title} along with the traffic management features of {SMProductShortName} can help you manage the complexity of your applications and provide service and identity security for microservices.
 
 include::modules/ossm-security-mtls-1x.adoc[leveloffset=+1]

--- a/service_mesh/v1x/ossm-traffic-manage.adoc
+++ b/service_mesh/v1x/ossm-traffic-manage.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 You can control the flow of traffic and API calls between services in  {SMProductName}. For example, some services in your service mesh may need to communicate within the mesh and others may need to be hidden. Manage the traffic to hide specific backend services, expose services, create testing or versioning deployments, or add a security layer on a set of services.
 
 This guide references the Bookinfo sample application to provide examples of routing in an example application. Install the xref:../../service_mesh/v1x/prepare-to-deploy-applications-ossm.adoc#ossm-tutorial-bookinfo-overview_deploying-applications-ossm-v1x[Bookinfo application] to learn how these routing examples work.
@@ -20,6 +22,6 @@ include::modules/ossm-routing-ingress.adoc[leveloffset=+1]
 
 include::modules/ossm-auto-route-1x.adoc[leveloffset=+1]
 
-== Links 
+== Links
 
 For more information about configuring an {product-title} wildcard policy, see xref:../../networking/ingress-operator.adoc#using-wildcard-routes_configuring-ingress[Using wildcard routes].

--- a/service_mesh/v1x/ossm-vs-community.adoc
+++ b/service_mesh/v1x/ossm-vs-community.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 An installation of {SMProductName} differs from upstream Istio community installations in multiple ways. The modifications to {SMProductName} are sometimes necessary to resolve issues, provide additional features, or to handle differences when deploying on {product-title}.
 
 The current release of {SMProductName} differs from the current upstream Istio community release in the following ways:

--- a/service_mesh/v1x/prepare-to-deploy-applications-ossm.adoc
+++ b/service_mesh/v1x/prepare-to-deploy-applications-ossm.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 When you deploy an application into the {SMProductShortName}, there are several differences between the behavior of applications in the upstream community version of Istio and the behavior of applications within a {SMProductName} installation.
 
 == Prerequisites

--- a/service_mesh/v1x/preparing-ossm-installation.adoc
+++ b/service_mesh/v1x/preparing-ossm-installation.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 Before you can install {SMProductName}, review the installation activities, ensure that you meet the prerequisites:
 
 == Prerequisites

--- a/service_mesh/v1x/removing-ossm.adoc
+++ b/service_mesh/v1x/removing-ossm.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 To remove {SMProductName} from an existing {product-title} instance, remove the control plane before removing the operators.
 
 include::modules/ossm-control-plane-remove.adoc[leveloffset=+1]

--- a/service_mesh/v1x/servicemesh-release-notes.adoc
+++ b/service_mesh/v1x/servicemesh-release-notes.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 == Making open source more inclusive
 
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].

--- a/service_mesh/v1x/threescale-adapter.adoc
+++ b/service_mesh/v1x/threescale-adapter.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/ossm-out-of-support.adoc[]
+
 The 3scale Istio Adapter is an optional adapter that allows you to label a service running within the {SMProductName} and integrate that service with the 3scale API Management solution.
 It is not required for {SMProductName}.
 

--- a/snippets/ossm-out-of-support.adoc
+++ b/snippets/ossm-out-of-support.adoc
@@ -1,0 +1,14 @@
+// Text snippet included in all Service Mesh v1 assemblies.
+// NOTE: The OpenShift docs standards state that snippets should NOT contain xrefs.   https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#writing-text-snippets
+//Because this snippet contains two xrefs it should ONLY be used in the v1 assemblies and never in a module.
+
+:_content-type: SNIPPET
+
+[WARNING]
+====
+*You are viewing documentation for a {SMProductName} release that is no longer supported.*
+
+Service Mesh version 1.0 and 1.1 control planes are no longer supported. For information about upgrading your service mesh control plane, see xref:../../service_mesh/v2x/upgrading-ossm.adoc#ossm-versions_ossm-upgrade[Upgrading Service Mesh].
+
+For information about the support status of a particular {SMProductName} release, see the https://access.redhat.com/support/policy/updates/openshift#ossm[Product lifecycle page].
+====


### PR DESCRIPTION
Version(s): 4.6 - 4.11

Issue: [OSSMDOC-571](https://issues.redhat.com/browse/OSSMDOC-571)

Warning was chosen over Note format, because it is highlighted in color in both stylesheets (for the Customer Portal and docs.openshift).

Link to docs preview:  (Snippet added to all V1 assemblies, I'm just linking to three)
http://file.bos.redhat.com/jstickle/OSSMDOC-571/service_mesh/v1x/servicemesh-release-notes.html
http://file.bos.redhat.com/jstickle/OSSMDOC-571/service_mesh/v1x/ossm-architecture.html
http://file.bos.redhat.com/jstickle/OSSMDOC-571/service_mesh/v1x/ossm-vs-community.html


<strike>https://deploy-preview-45328--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v1x/servicemesh-release-notes.html 
https://deploy-preview-45328--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v1x/ossm-architecture.html
https://deploy-preview-45328--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v1x/preparing-ossm-installation.html</strike>

PM and Support ack in the program call, Support checked to see if we have boilerplate language for this (we do not) and approved the current text.
Peer review  - johnwilkins