### PR TITLE
OSSMDOC-528 Distributed Tracing 2.4 Release Notes.

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -101,13 +101,13 @@ endif::[]
 //distributed tracing
 :DTProductName: Red Hat OpenShift distributed tracing
 :DTShortName: distributed tracing
-:DTProductVersion: 2.3
+:DTProductVersion: 2.4
 :JaegerName: Red Hat OpenShift distributed tracing platform
 :JaegerShortName: distributed tracing platform
-:JaegerVersion: 1.30.1
+:JaegerVersion: 1.34.1
 :OTELName: Red Hat OpenShift distributed tracing data collection
 :OTELShortName: distributed tracing data collection
-:OTELVersion: 0.44.0
+:OTELVersion: 0.49
 //logging
 :logging-title: logging subsystem for Red Hat OpenShift
 :logging-title-uc: Logging subsystem for Red Hat OpenShift

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -13,17 +13,48 @@ Result – If changed, describe the current user experience.
 
 This release adds improvements related to the following components and concepts.
 
+== New features and enhancements {DTProductName} 2.4
+
+This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
+
+This release also adds support for auto-provisioning certificates using the Red Hat Elasticsearch Operator.
+
+* Self-provisioning, which means using the {JaegerName} Operator to call the Red Hat Elasticsearch Operator during installation. Self provisioning is fully supported with this release.
+* Creating the Elasticsearch instance and certificates first and then configuring the {JaegerShortName} to use the certificate is a Technology Preview for this release.
+
+[NOTE]
+====
+When upgrading to Elasticsearch 2.4, the Operator recreates the Elasticsearch instance, which might take five to ten minutes.
+====
+
+=== Component versions supported in {DTProductName} version 2.4
+
+[options="header"]
+|===
+|Operator |Component |Version
+|{OTELName}
+|Jaeger
+|1.34.1
+
+|{OTELName}
+|OpenTelemetry
+|0.49
+|===
+
 == New features and enhancements {DTProductName} 2.3.1
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
 === Component versions supported in {DTProductName} version 2.3.1
 
+[options="header"]
 |===
-|Component |Version
+|Operator |Component |Version
+|{OTELName}
 |Jaeger
 |1.30.2
 
+|{OTELName}
 |OpenTelemetry
 |0.44.1-1
 |===
@@ -36,11 +67,14 @@ With this release, the {JaegerName} Operator is now installed to the `openshift-
 
 === Component versions supported in {DTProductName} version 2.3.0
 
+[options="header"]
 |===
-|Component |Version
+|Operator |Component |Version
+|{OTELName}
 |Jaeger
 |1.30.1
 
+|{OTELName}
 |OpenTelemetry
 |0.44.0
 |===
@@ -51,11 +85,14 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 === Component versions supported in {DTProductName} version 2.2.0
 
+[options="header"]
 |===
-|Component |Version
+|Operator |Component |Version
+|{OTELName}
 |Jaeger
 |1.30.0
 
+|{OTELName}
 |OpenTelemetry
 |0.42.0
 |===
@@ -66,11 +103,14 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 === Component versions supported in {DTProductName} version 2.1.0
 
+[options="header"]
 |===
-|Component |Version
+|Operator |Component |Version
+|{OTELName}
 |Jaeger
 |1.29.1
 
+|{OTELName}
 |OpenTelemetry
 |0.41.1
 |===
@@ -99,11 +139,14 @@ This release also addresses Common Vulnerabilities and Exposures (CVEs) and bug 
 
 === Component versions supported in {DTProductName} version 2.0.0
 
+[options="header"]
 |===
-|Component |Version
+|Operator |Component |Version
+|{OTELName}
 |Jaeger
 |1.28.0
 
+|{OTELName}
 |OpenTelemetry
 |0.33.0
 |===

--- a/modules/distr-tracing-rn-technology-preview.adoc
+++ b/modules/distr-tracing-rn-technology-preview.adoc
@@ -17,6 +17,13 @@ Technology Preview features are not supported with Red Hat production service le
 These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/.
 ====
 
+== {DTProductName} 2.4.0 Technology Preview
+
+This release also adds support for auto-provisioning certificates using the Red Hat Elasticsearch Operator.
+
+* Self-provisioning, which means using the {JaegerName} Operator to call the Red Hat Elasticsearch Operator during installation. Self provisioning is fully supported with this release.
+* Creating the Elasticsearch instance and certificates first and then configuring the {JaegerShortName} to use the certificate is a Technology Preview for this release.
+
 == {DTProductName} 2.2.0 Technology Preview
 
 Unsupported OpenTelemetry Collector components included in the 2.1 release have been removed.


### PR DESCRIPTION
Version(s): 4.6 - 4.11

Issue: [OSSMDOC-528](https://issues.redhat.com/browse/OSSMDOC-528)
Documents [TRACING-1990](https://issues.redhat.com/browse/TRACING-1990)
Resolves [TRACING-2635](https://issues.redhat.com/browse/TRACING-2635)

Link to docs preview: http://file.bos.redhat.com/jstickle/OSSMDOC-528/distr_tracing/distributed-tracing-release-notes.html

<strike>https://deploy-preview-45350--osdocs.netlify.app/openshift-enterprise/latest/distr_tracing/distributed-tracing-release-notes.html</strike>

Eng review - frzifus, pavollloffay
QE review - iblancasa
Peer review - jc-berger