### PR TITLE
[RHACS] Release Notes for 3.70

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -33,6 +33,8 @@ Name: Release notes
 Dir: release_notes
 Distros: openshift-acs
 Topics:
+- Name: Red Hat Advanced Cluster Security for Kubernetes 3.70
+  File: 370-release-notes
 - Name: Red Hat Advanced Cluster Security for Kubernetes 3.69
   File: 369-release-notes
 - Name: Red Hat Advanced Cluster Security for Kubernetes 3.68

--- a/release_notes/370-release-notes.adoc
+++ b/release_notes/370-release-notes.adoc
@@ -1,0 +1,188 @@
+:_content-type: ASSEMBLY
+[id="release-notes-370"]
+= Red Hat Advanced Cluster Security for Kubernetes 3.70
+include::modules/common-attributes.adoc[]
+:context: release-notes-370
+
+toc::[]
+
+*Release date:* 23 May 2022
+
+{product-title} is an enterprise-ready, Kubernetes-native container security solution that protects your vital applications across build, deploy, and runtime. It deploys in your infrastructure and integrates with your DevOps tooling and workflows to deliver better security and compliance and to enable DevOps and InfoSec teams to operationalize security.
+
+[id="about-this-release-370"]
+
+{product-title} ({product-title-short}) 3.70 includes feature enhancements, bug fixes, scale improvements, and other changes.
+
+[id="new-features-370"]
+== New features and enhancements
+
+[id="verify-image-signatures-rn"]
+=== Verifying image signatures against Cosign public keys
+
+You can use {product-title-short} to ensure the integrity of the container images in your clusters by verifying image signatures against preconfigured keys. You can also create policies to block unsigned images and images that do not have a verified signature and enforce the policy by using an admission controller to stop unauthorized deployment creation. Cosign key signature verification is supported. See _Verifying image signatures_ in the {product-title-short} Operating documentation for more information.
+
+[id="integration-ecs-rn"]
+=== Autogeneration of Amazon ECR registry integrations
+
+Registry integrations for Amazon Elastic Container Registry (ECR) are now automatically generated for Amazon Web Services (AWS) clusters. This feature requires that the nodes' Instance Identity and Access Management (IAM) Role has been granted access to ECR. You can turn off this feature by disabling the EC2 instance metadata service in your nodes. See _Amazon ECR integrations_ in the {product-title-short} Integrating documentation for more information.
+
+[id="identify-missing-policies-rn"]
+=== Identifying missing Kubernetes network policies
+
+Kubernetes network policies are vital in helping to enable zero-trust networking within a cluster. They reduce the impact of network attacks by limiting the opportunity for lateral movement. By default, Kubernetes resources are not isolated. Applying network policies is a recommended best practice left to the user.
+
+{product-title-short} 3.70 ships with a new default policy that allows you to easily identify deployments that are not restricted by any ingress network policy and to trigger violation alerts accordingly.
+
+- The default policy is named *Deployments should have at least one ingress Network Policy*. It is disabled by default.
+
+- This default policy uses a new policy criterion called *Alert on missing ingress Network Policy*.
+
+- To identify pod isolation gaps, you can clone this default policy or create a new one by using the policy criterion and enabling it on selected resources.
+
+[id="spring-vulnerabilities-rn"]
+=== Identifying Spring critical vulnerabilities
+
+A policy to detect the Spring Cloud Function RCE vulnerability (CVE-2022-22963) and the Spring Framework Spring4Shell RCE vulnerability (CVE-2022-22965) has been added. It has a severity level of Critical and is enabled by default.
+
+[id="allow-privilege-escalation-rn"]
+=== Improved validation of pod security context
+
+A new policy criterion has been added to validate the value of `allowPrivilegeEscalation` within the Kubernetes security context. You can use this policy criterion to provide alerts when a deployment is configured to allow a container process to gain more privileges than its parent process.
+
+[id="admin-credentials-link-ocp-rn"]
+=== Finding ACS admin user credentials easily in the {ocp} console
+
+Customers using the recommended Operator method to deploy {product-title-short} on {ocp} can now view the credentials for the `admin` user in the {ocp} console. When viewing the Central object, the *Details* tab provides a clickable link to the credentials under *Admin Password Secret Reference*. The displayed credentials are the default generated password or a previously configured and stored custom secret. See xref:../installing/install-ocp-operator.adoc#verify-central-install-operator_install-ocp-operator[Verifying Central installation] for more information.
+
+[id="scope-increase-rn"]
+=== Increased number of allowed inclusion and exclusion scopes
+Previously, {product-title-short} limited the number of allowed inclusion and exclusion scopes within a scope to ten each. This restriction has been removed.
+
+[id="notable-tech-changes-370"]
+== Notable technical changes
+
+[id="vuln-scanning-rhcos-rn"]
+=== Vulnerability scanning and reporting for {op-system} nodes
+
+Vulnerability scanning and reporting for {op-system-first} nodes has been disabled until scanning improvements are made for improved accuracy and to support full host-level scanning beyond just Kubernetes components. Currently, {op-system} uses National Vulnerability Database (NVD) vulnerability data for reporting vulnerabilities for Kubernetes components from {op-system}. In the enhanced version, vulnerability reporting will be based on Red Hat published security data. (**ROX-10662**)
+
+[id="deprecation-notices-370"]
+== Deprecated and removed features
+
+Some features available in previous releases have been deprecated or removed.
+
+Deprecated functionality is still included in {product-title-short} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. For the most recent list of major functionality deprecated and removed, refer to the table below. Additional information about some removed or deprecated functionality is available after the table.
+
+In the table, features are marked with the following statuses:
+
+- GA: General Availability
+- TP: Technology Preview
+- DEP: Deprecated
+- REM: Removed
+
+.Deprecated and removed features tracker
+[cols="3,1,1,1",options="header"]
+|====
+|Feature |{product-title-short} 3.68 |{product-title-short} 3.69 | {product-title-short} 3.70
+
+|Ability to delete default policies
+|DEP
+|DEP
+|REM
+
+|Ability to add comments to alerts and processes
+|GA
+|DEP
+|DEP
+
+|Anchore, Tenable, and Docker Trusted registry integrations
+|GA
+|DEP
+|DEP
+
+|External authorization plug-in for scoped access control
+|GA
+|DEP
+|DEP
+
+|`FROM` option in the Disallowed Dockerfile line policy field
+|GA
+|GA
+|DEP
+
+|`RenamePolicyCategory` and `DeletePolicyCategory` API endpoints
+|GA
+|GA
+|DEP
+
+| `--rhacs` option for the `roxctl` helm output command
+| GA
+| DEP
+| DEP
+
+|Security policies without a `policyVersion`
+|DEP
+|DEP
+|REM
+
+|`/v1/policies` API endpoint response: `field` response body parameter.
+|DEP
+|DEP
+|REM
+
+|====
+
+[id="deprecated-features-370"]
+=== Deprecated features
+
+** *Anchore*, *Tenable*, and *Docker Trusted Registry* integrations: The {product-title-short} scanner supersedes these integrations.
+** *External authorization plug-in for scoped access control*: Use the existing in-product scoped access control.
+** *FROM option in the Disallowed Dockerfile line policy field*: Any policies containing the Disallowed Dockerfile line policy field with the `FROM` option must be updated to remove those policy sections.
+
+[id="removed-features-370"]
+=== Removed features
+
+* {product-title-short} 3.70 no longer supports security policies that do not have `policyVersion` 1.1, including (but not limited to) importing policies.
+* {product-title} will not allow deleting default policies. Rather than deleting policies, you can disable default policies that you do not need.
+* The `/v1/policies` API endpoint response will not return the `field` response body parameter.
+
+[id="bug-fixes-3670"]
+== Bug fixes
+
+* When configuring a JFrog Artifactory integration, the username and password fields are now optional to allow anonymous pulls. (**ROX-10090**)
+* Validation to the web user interface for endpoint URLs in the generic webhook integration caused errors. This issue was fixed. (**ROX-9902**)
+* The policy *OpenShift: Kubeadmin Secret Accessed* is no longer triggered if the request was from the default OpenShift `oauth-apiserver-sa` service account, because this is an expected access pattern for the OpenShift API server. (**ROX-10018**)
+* The ability to enable notifications for multiple policies selected in the **Policies** list has been reinstated. To enable notifications, select one or more policies and choose Enable notification from the Bulk Actions menu. (**ROX-9985**)
+* Read/write permission issue for vulnerability reports has been fixed. (**ROX-9880**)
+* The ability to enable notifications for multiple policies selected in the **Policies** list has been reinstated. To enable notifications, select one or more policies and choose *Enable notification* from the *Bulk Actions* menu. (**ROX-9985**)
+* Read/write permission issue for vulnerability reports has been fixed. (**ROX-9880**)
+* Fixed issue that caused connection problems to the {ocp} console after connecting to {product-title-short} or the inability to connect to {product-title-short} if a connection to the {ocp} console existed. Central will now respond with a `421 Misdirected Request` status code to requests where the `ServerName` sent via TLS SNI does not match the `:authority` (Host) header. This feature can be turned off by setting the environment variable `ROX_ALLOW_MISDIRECTED_REQUESTS=true`. (**ROX-9625**)
+* When editing a policy, the **Violations Preview** window was unavailable for disabled policies. This issue has been fixed. (**ROX-9435**)
+
+
+[id="image-versions-370"]
+== Image versions
+
+[%header,cols="1,1,2"]
+|===
+| Image | Description | Current version
+
+| Main
+| Includes Central, Sensor, Admission Controller, and Compliance.
+Also includes `roxctl` for use in continuous integration (CI) systems.
+| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.70`
+
+| Scanner
+| Scans images and nodes.
+| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:3.70`
+
+| Scanner DB
+| Stores image scan results and vulnerability definitions.
+| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:3.70`
+
+| Collector
+| Collects runtime activity in Kubernetes or {ocp} clusters.
+| `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:3.70`
+  `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.70`
+|===


### PR DESCRIPTION
Release notes for RHACS version 3.70

**NOTE: The references in the first two new features ("See xxx in xxx") will be replaced with the actual references once those PRs are merged - trying to use the references now results in the build failing)**

- Versions: `rhacs-docs-3.70.0` only (until after May 23)
- [Preview](https://deploy-preview-45372--osdocs.netlify.app/openshift-acs/latest/release_notes/370-release-notes.html)