### PR TITLE
NE-703, Added config details for TLS for forwarded DNS queries

### DIFF
--- a/modules/nw-dns-forward.adoc
+++ b/modules/nw-dns-forward.adoc
@@ -26,9 +26,9 @@ A DNS forwarding configuration for the default domain can have both the default 
 $ oc edit dns.operator/default
 ----
 +
-This allows the Operator to create and update the ConfigMap named `dns-default` with additional server configuration blocks based on `Server`. If none of the servers has a zone that matches the query, then name resolution falls back to the upstream DNS servers.
+This allows the Operator to create and update the config map named `dns-default` with additional server configuration blocks based on `Server`. If none of the servers have a zone that matches the query, then name resolution falls back to the upstream DNS servers.
 +
-.Sample DNS
+.Configuring DNS forwarding
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -37,7 +37,7 @@ metadata:
   name: default
 spec:
   servers:
-  - name: foo-server <1>
+  - name: example-server <1>
     zones: <2>
     - example.com
     forwardPlugin:
@@ -45,15 +45,6 @@ spec:
       upstreams: <4>
       - 1.1.1.1
       - 2.2.2.2:5353
-  - name: bar-server
-    zones:
-    - bar.com
-    - example.com
-    forwardPlugin:
-      policy: Random
-      upstreams:
-      - 3.3.3.3
-      - 4.4.4.4:5454
   upstreamResolvers: <5>
     policy: Random <6>
     upstreams: <7>
@@ -63,22 +54,71 @@ spec:
       port: 53 <10>
 ----
 <1> Must comply with the `rfc6335` service name syntax.
-<2> Must conform to the definition of a `subdomain` in `rfc1123`. The cluster domain, `cluster.local`, is an invalid `subdomain` for `zones`.
-<3> Defines the policy to select upstream resolvers. Default value is `Random`. You can also use `RoundRobin`, and `Sequential`.
+<2> Must conform to the definition of a subdomain in the `rfc1123` service name syntax. The cluster domain, `cluster.local`, is an invalid subdomain for the `zones` field.
+<3> Defines the policy to select upstream resolvers. Default value is `Random`. You can also use the values `RoundRobin`, and `Sequential`.
 <4> A maximum of 15 `upstreams` is allowed per `forwardPlugin`.
 <5> Optional. You can use it to override the default policy and forward DNS resolution to the specified DNS resolvers (upstream resolvers) for the default domain. If you do not provide any upstream resolvers, the DNS name queries go to the servers in `/etc/resolv.conf`.
 <6> Determines the order in which upstream servers are selected for querying. You can specify one of these values: `Random`, `RoundRobin`, or `Sequential`. The default value is `Sequential`.
 <7> Optional. You can use it to provide upstream resolvers.
 <8> You can specify two types of `upstreams` - `SystemResolvConf` and `Network`. `SystemResolvConf` configures the upstream to use `/etc/resolv.conf` and `Network` defines a `Networkresolver`. You can specify one or both.
-<9> If the specified type is `Network`, you must provide an IP address. `address` must be a valid IPv4 or IPv6 address.
-<10> If the specified type is `Network`, you can optionally provide a port. `port` must be between 1 and 65535.
+<9> If the specified type is `Network`, you must provide an IP address. The `address` field must be a valid IPv4 or IPv6 address.
+<10> If the specified type is `Network`, you can optionally provide a port. The `port` field must have a value between `1` and `65535`. If you do not specify a port for the upstream, by default port 853 is tried.
++
+When working in a highly regulated environment, you might need the ability to secure DNS traffic when forwarding requests to upstream resolvers so that you can ensure additional DNS traffic and data privacy. Cluster administrators can configure transport layer security (TLS) for forwarded DNS queries.
++
+.Configuring DNS forwarding with TLS
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: DNS
+metadata:
+  name: default
+spec:
+  servers:
+  - name: example-server <1>
+    zones: <2>
+    - example.com
+    forwardPlugin:
+      transportConfig:
+        transport: TLS <3>
+        tls:
+          caBundle:
+            name: mycacert
+          serverName: dnstls.example.com  <4>
+      policy: Random <5>
+      upstreams: <6>
+      - 1.1.1.1
+      - 2.2.2.2:5353
+  upstreamResolvers: <7>
+    transportConfig:
+      transport: TLS
+      tls:
+        caBundle:
+          name: mycacert
+        serverName: dnstls.example.com
+    upstreams:
+    - type: Network <8>
+      address: 1.2.3.4 <9>
+      port: 53 <10>
+----
+<1> Must comply with the `rfc6335` service name syntax.
+<2> Must conform to the definition of a subdomain in the `rfc1123` service name syntax. The cluster domain, `cluster.local`, is an invalid subdomain for the `zones` field. The cluster domain, `cluster.local`, is an invalid `subdomain` for `zones`.
+<3> When configuring TLS for forwarded DNS queries, set the `transport` field to have the value `TLS`.
+By default, CoreDNS caches forwarded connections for 10 seconds. CoreDNS will hold a TCP connection open for those 10 seconds if no request is issued. With large clusters, ensure that your DNS server is aware that it might get many new connections to hold open because you can initiate a connection per node. Set up your DNS hierarchy accordingly to avoid performance issues.
+<4> When configuring TLS for forwarded DNS queries, this is a mandatory server name used as part of the server name indication (SNI) to validate the upstream TLS server certificate.
+<5> Defines the policy to select upstream resolvers. Default value is `Random`. You can also use the values `RoundRobin`, and `Sequential`.
+<6> Required. You can use it to provide upstream resolvers. A maximum of 15 `upstreams` entries are allowed per `forwardPlugin` entry.
+<7> Optional. You can use it to override the default policy and forward DNS resolution to the specified DNS resolvers (upstream resolvers) for the default domain. If you do not provide any upstream resolvers, the DNS name queries go to the servers in `/etc/resolv.conf`.
+<8> `Network` type indicates that this upstream resolver should handle forwarded requests separately from the upstream resolvers listed in `/etc/resolv.conf`. Only the `Network` type is allowed when using TLS and you must provide an IP address.
+<9> The `address` field must be a valid IPv4 or IPv6 address.
+<10> You can optionally provide a port. The `port` must have a value between `1` and `65535`. If you do not specify a port for the upstream, by default port 853 is tried.
 +
 [NOTE]
 ====
-If `servers` is undefined or invalid, the ConfigMap only contains the default server.
+If `servers` is undefined or invalid, the config map only contains the default server.
 ====
 +
-. View the ConfigMap:
+. View the config map:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.11

JIRA:
[NE-703](https://issues.redhat.com/browse/NE-703)

 Preview Build:
 https://deploy-preview-45373--osdocs.netlify.app/openshift-enterprise/latest/networking/dns-operator.html#nw-dns-forward_dns-operator