### PR TITLE
Added a release note for forwarding DNS requests over TLS

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -94,6 +94,13 @@ You can now set the maximum number of simultaneous connections that can be estab
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration parameters].
 
+[id="ocp-4-11-coredns-forwarding-DNS-requests-over-TLS"]
+==== Support for CoreDNS forwarding DNS requests over TLS
+
+When working in a highly regulated environment, you might need the ability to secure domain name system (DNS) traffic when forwarding requests to upstream resolvers so that you can ensure additional DNS traffic and data privacy. Cluster administrators can now configure transport layer security (TLS) for forwarded DNS queries. This feature applies only to the DNS Operator and not the CoreDNS instance managed by the Machine Config Operator.
+
+For more information, see xref:../networking/dns-operator.adoc#nw-dns-forward_dns-operator[Using DNS forwarding].
+
 [id="ocp-4-11-hardware"]
 === Hardware
 


### PR DESCRIPTION
Adding a release note for https://issues.redhat.com/browse/NE-703
The configuration details are added in https://github.com/openshift/openshift-docs/pull/45373.

Preview build: https://deploy-preview-45381--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-coredns-forwarding-DNS-requests-over-TLS