### PR TITLE
Update documentation for RAID and BIOS

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -54,9 +54,9 @@ include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leve
 
 include::modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc[leveloffset=+2]
 
-include::modules/ipi-install-configuring-bios-for-worker-node.adoc[leveloffset=+2]
+include::modules/ipi-install-configuring-bios.adoc[leveloffset=+2]
 
-include::modules/ipi-install-configuring-raid-for-worker-node.adoc[leveloffset=+2]
+include::modules/ipi-install-configuring-raid.adoc[leveloffset=+2]
 
 include::modules/ipi-install-creating-a-disconnected-registry.adoc[leveloffset=+1]
 

--- a/modules/ipi-install-configuring-bios.adoc
+++ b/modules/ipi-install-configuring-bios.adoc
@@ -3,19 +3,18 @@
 // * installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
 
 :_content-type: PROCEDURE
-[id="configuring-bios-for-worker-node_{context}"]
-= Configuring the BIOS for worker nodes
+[id="configuring-bios_{context}"]
+= (Optional) Configuring the BIOS
 
-The following procedure configures the BIOS for a worker node during the installation process.
+The following procedure configures the BIOS during the installation process.
 
 .Procedure
 . Create the manifests.
-
-. Modify the BMH file corresponding to the worker:
+. Modify the BMH file corresponding to the node:
 +
 [source,terminal]
 ----
-$ vim clusterconfigs/openshift/99_openshift-cluster-api_hosts-3.yaml
+$ vim clusterconfigs/openshift/99_openshift-cluster-api_hosts-*.yaml
 ----
 
 . Add the BIOS configuration to the `spec` section of the BMH file:

--- a/modules/ipi-install-configuring-raid.adoc
+++ b/modules/ipi-install-configuring-raid.adoc
@@ -3,10 +3,10 @@
 // * installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
 
 :_content-type: PROCEDURE
-[id="configuring-raid-for-worker-node_{context}"]
-= Configuring RAID for worker nodes
+[id="configuring-raid_{context}"]
+= (Optional) Configuring the RAID
 
-The following procedure configures RAID (Redundant Array of Independent Disks) for the worker node during the installation process.
+The following procedure configures RAID (Redundant Array of Independent Disks) during the installation process.
 
 [NOTE]
 ====
@@ -17,11 +17,11 @@ The following procedure configures RAID (Redundant Array of Independent Disks) f
 .Procedure
 . Create manifests.
 
-. Modify the BMH (Bare Metal Host) file corresponding to the worker:
+. Modify the BMH (Bare Metal Host) file corresponding to the node:
 +
 [source,terminal]
 ----
-$ vim clusterconfigs/openshift/99_openshift-cluster-api_hosts-3.yaml
+$ vim clusterconfigs/openshift/99_openshift-cluster-api_hosts-*.yaml
 ----
 +
 [NOTE]
@@ -29,7 +29,7 @@ $ vim clusterconfigs/openshift/99_openshift-cluster-api_hosts-3.yaml
 Because nodes with BMC type `irmc` do not support software RAID, the following RAID configuration uses hardware RAID as an example.
 ====
 +
-.. If you added a specific RAID configuration to the `spec` section, this causes the worker node to delete the original RAID configuration in the `preparing` phase and perform a specified configuration on the RAID. For example:
+.. If you added a specific RAID configuration to the `spec` section, this causes the node to delete the original RAID configuration in the `preparing` phase and perform a specified configuration on the RAID. For example:
 +
 [source,yaml]
 ----
@@ -44,7 +44,7 @@ spec:
 ----
 <1> `level` is a required field, and the others are optional fields.
 +
-.. If you added an empty RAID configuration to the `spec` section, this empty configuration causes the worker node to delete the original RAID configuration during the `preparing` phase, but does not perform a new configuration. For example:
+.. If you added an empty RAID configuration to the `spec` section, this empty configuration causes the node to delete the original RAID configuration during the `preparing` phase, but does not perform a new configuration. For example:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
In OCP4.11, the feature of configuring the RAID and BIOS for master node in the process of IPI has been added.
Update the documents to apply for both worker and master nodes.

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>
