### PR TITLE
[BZ2076635]: Fix the parameters in the example YAML

### DIFF
--- a/modules/nw-metallb-configure-bfdprofle.adoc
+++ b/modules/nw-metallb-configure-bfdprofle.adoc
@@ -25,13 +25,12 @@ metadata:
   name: doc-example-bfd-profile-full
   namespace: metallb-system
 spec:
-  receiveInterval: 35
-  transmitInterval: 35
+  receiveInterval: 300
+  transmitInterval: 300
   detectMultiplier: 3
-  echoInterval: 35
-  echoMode: true
+  echoMode: false
   passiveMode: true
-  minimumTtl: 10
+  minimumTtl: 254
 ----
 
 . Apply the configuration for the BFD profile:


### PR DESCRIPTION
OCP versions: 4.10 and 4.11
[Preview](https://deploy-preview-45401--osdocs.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-bfd-profiles.html#nw-metallb-configure-bfdprofile_configure-metallb-bfd-profiles)
QA contact: @zhaozhanqi
[Bug](https://bugzilla.redhat.com/show_bug.cgi?id=2076635)