### PR TITLE
[WIP] OSDOCS-3371 - Adding tagging policy sections for OSD and ROSA

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -91,6 +91,8 @@ Topics:
   File: creating-an-aws-cluster
 - Name: Creating a cluster on GCP
   File: creating-a-gcp-cluster
+- Name: Restricting cluster permissions using AWS tagging policies
+  File: osd-restricting-aws-permissions-using-tagging-policies
 - Name: Configuring your identity providers
   File: config-identity-providers
 - Name: Notifications for OpenShift Dedicated clusters

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -129,6 +129,8 @@ Topics:
   File: rosa-sts-interactive-mode-reference
 - Name: Creating an AWS PrivateLink cluster on ROSA
   File: rosa-aws-privatelink-creating-cluster
+- Name: Restricting cluster permissions using AWS tagging policies
+  File: rosa-sts-restricting-aws-permissions-using-tagging-policies
 - Name: Accessing a ROSA cluster
   File: rosa-sts-accessing-cluster
 - Name: Configuring identity providers using Red Hat OpenShift Cluster Manager

--- a/modules/creating-aws-tagging-policies-to-restrict-cluster-permissions.adoc
+++ b/modules/creating-aws-tagging-policies-to-restrict-cluster-permissions.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * rosa_install_access_delete_clusters/rosa-sts-restricting-aws-permissions-using-tagging-policies.adoc
+
+:_content-type: PROCEDURE
+[id="creating-aws-tagging-policies-to-restrict-cluster-permissionscontext"]
+= Creating tagging policies to restrict cluster permissions in AWS accounts
+
+After creating 
+ifdef::openshift-dedicated[]
+an {product-title} cluster, 
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS), 
+endif::openshift-rosa[]
+you can create tagging policies to enable fine grained restrictions for 
+ifdef::openshift-rosa[]
+STS 
+endif::openshift-rosa[]
+IAM resources that include the `red-hat-managed=true` tag. 
+
+.Prerequisites
+
+* TBC
+
+.Procedure
+
+. TBC

--- a/modules/policy-tagging-for-cluster-iam-resources-in-aws.adoc
+++ b/modules/policy-tagging-for-cluster-iam-resources-in-aws.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * rosa_install_access_delete_clusters/rosa-sts-restricting-aws-permissions-using-tagging-policies.adoc
+
+:_content-type: CONCEPT
+[id="policy-tagging-for-cluster-iam-resources-in-awscontext"]
+= Policy tagging for cluster IAM resources in AWS accounts
+
+When {product-title} 
+ifdef::openshift-rosa[]
+(ROSA) 
+endif::openshift-rosa[]
+clusters 
+ifdef::openshift-rosa[]
+that use the AWS Security Token Service (STS) 
+endif::openshift-rosa[]
+are created in customer AWS accounts, the cluster and the associated 
+ifdef::openshift-rosa[]
+STS 
+endif::openshift-rosa[]
+IAM resources are tagged by default with a `red-hat-managed=true` policy tag. This enables you to create tagging policies that provide fine grained restrictions for cluster IAM resources in your AWS account. The policies allow Red Hat to manage only the cluster resources.
+
+For more information about policy tagging, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_iam-tags.html[Controlling access to and for IAM users and roles using tags] in the AWS documentation.
+
+For detailed steps to create the tagging policies, see _Creating tagging policies to restrict cluster permissions in AWS accounts_.

--- a/osd_install_access_delete_cluster/osd-restricting-aws-permissions-using-tagging-policies.adoc
+++ b/osd_install_access_delete_cluster/osd-restricting-aws-permissions-using-tagging-policies.adoc
@@ -1,0 +1,12 @@
+:_content-type: ASSEMBLY
+[id="osd-restricting-aws-permissions-using-tagging-policies"]
+= Restricting permissions in AWS accounts by using tagging policies
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: osd-restricting-aws-permissions-using-tagging-policies
+
+toc::[]
+
+A default `red-hat-managed=true` policy tag is applied to {product-title} IAM resources when they are created in AWS accounts. You can create tagging policies for this default tag to permit clusters and the Red Hat Site Reliability Engineering (SRE) team to manage only the resources required for your clusters.
+
+include::modules/policy-tagging-for-cluster-iam-resources-in-aws.adoc[leveloffset=+1]
+include::modules/creating-aws-tagging-policies-to-restrict-cluster-permissions.adoc[leveloffset=+1]

--- a/rosa_install_access_delete_clusters/rosa-sts-restricting-aws-permissions-using-tagging-policies.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-restricting-aws-permissions-using-tagging-policies.adoc
@@ -1,0 +1,12 @@
+:_content-type: ASSEMBLY
+[id="rosa-sts-restricting-aws-permissions-using-tagging-policies"]
+= Restricting permissions in AWS accounts by using tagging policies
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-sts-restricting-aws-permissions-using-tagging-policies
+
+toc::[]
+
+When you create a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS), a default `red-hat-managed=true` policy tag is applied to the STS IAM resources. You can create tagging policies for this default tag to permit clusters and the Red Hat Site Reliability Engineering (SRE) team to manage only the resources required for your clusters.
+
+include::modules/policy-tagging-for-cluster-iam-resources-in-aws.adoc[leveloffset=+1]
+include::modules/creating-aws-tagging-policies-to-restrict-cluster-permissions.adoc[leveloffset=+1]


### PR DESCRIPTION
**This PR is a work in progress. Do not merge.**

This applies to `main`, `enterprise-4.11` and `enterprise-4.10`.

The PR relates to https://issues.redhat.com/browse/OSDOCS-3371. The PR provides concept and procedure sections in the OSD and ROSA distributions about using policy tagging to restrict cluster permissions in AWS accounts.

The previews are as follows:

* OSD: **Creating a cluster** -> [**Restricting permissions in AWS accounts by using tagging policies**](http://file.fab.redhat.com/pneedle/pr45404/osd/osd_install_access_delete_cluster/osd-restricting-aws-permissions-using-tagging-policies.html)
* ROSA: **Installing, accessing, and deleting ROSA clusters** -> [**Restricting permissions in AWS accounts by using tagging policies**](http://file.fab.redhat.com/pneedle/pr45404/rosa/rosa_install_access_delete_clusters/rosa-sts-restricting-aws-permissions-using-tagging-policies.html)