### PR TITLE
replaced two instances of foo.com

### DIFF
--- a/modules/nw-dns-forward.adoc
+++ b/modules/nw-dns-forward.adoc
@@ -39,7 +39,7 @@ spec:
   servers:
   - name: foo-server <1>
     zones: <2>
-    - foo.com
+    - example.com
     forwardPlugin:
       policy: Random <3>
       upstreams: <4>
@@ -91,7 +91,7 @@ $ oc get configmap/dns-default -n openshift-dns -o yaml
 apiVersion: v1
 data:
   Corefile: |
-    foo.com:5353 {
+    example.com:5353 {
         forward . 1.1.1.1 2.2.2.2:5353
     }
     bar.com:5353 example.com:5353 {


### PR DESCRIPTION
- Applies to 4.6 and above versions.
-  Two instances of foo.com were replaced.
- [Preview](https://deploy-preview-45406--osdocs.netlify.app/openshift-enterprise/latest/networking/dns-operator.html)
@kalexand-rh ptal
