### PR TITLE
Configure CSM for Fujitsu iRMC

### DIFF
--- a/modules/ipi-install-configuring-nodes.adoc
+++ b/modules/ipi-install-configuring-nodes.adoc
@@ -79,6 +79,7 @@ Red Hat only supports manually configured Secure Boot when deploying with Redfis
 
 To enable Secure Boot manually, refer to the hardware guide for the node and execute the following:
 
+.Procedure
 . Boot the node and enter the BIOS menu.
 . Set the node's boot mode to `UEFI Enabled`.
 . Enable Secure Boot.
@@ -87,3 +88,32 @@ To enable Secure Boot manually, refer to the hardware guide for the node and exe
 ====
 Red Hat does not support Secure Boot with self-generated keys.
 ====
+
+
+[discrete]
+[id="configuring-csm-for-fujitsu-irmc_{context}"]
+== Configuring the Compatibility Support Module for Fujitsu iRMC
+
+The Compatibility Support Module (CSM) configuration provides support for legacy BIOS backward compatibility with UEFI systems. You must configure the CSM when you deploy a cluster with Fujitsu iRMC, otherwise the installation might fail.
+
+[NOTE]
+====
+For information about configuring the CSM for your specific node type, refer to the hardware guide for the node.
+====
+
+.Prerequisites
+- Ensure that you have disabled Secure Boot Control. You can disable the feature under *Security* -> *Secure Boot Configuration* -> *Secure Boot Control*.
+
+.Procedure
+. Boot the node and select the BIOS menu.
+. Under the *Advanced* tab, select *CSM Configuration* from the list.
+. Enable the *Launch CSM* option and set the following values:
++
+[options="header"]
+|===
+|Item |Value
+| *Boot option filter* | UEFI and Legacy
+| *Launch PXE OpROM Policy* | UEFI only
+| *Launch Storage OpROM policy* | UEFI only
+| *Other PCI device ROM priority* | UEFI only
+|===


### PR DESCRIPTION
Applies to 4.8+

When deploying with iRMC, CSM Configuration must be configured accordingly, otherwise the cluster installation may fail.

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>