### PR TITLE
CFE-331: Docs work for using ExternalDNS Operator  on Infoblox

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -996,6 +996,8 @@ Topics:
     File: nw-creating-dns-records-on-azure
   - Name: Creating DNS records on an public managed zone for GCP
     File: nw-creating-dns-records-on-gcp
+  - Name: Creating DNS records on a public DNS zone for Infoblox
+    File: nw-creating-dns-records-on-infoblox
 - Name: Network policy
   Dir: network_policy
   Topics:

--- a/modules/nw-control-dns-records-public-hosted-zone-infoblox.adoc
+++ b/modules/nw-control-dns-records-public-hosted-zone-infoblox.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * networking/external_dns_operator/nw-creating-dns-records-on-infoblox.adoc
+
+:_content-type: PROCEDURE
+[id="nw-control-dns-records-public-dns-zone-infoblox_{context}"]
+= Creating DNS records on a public DNS zone on Infoblox
+
+You can create DNS records on a public DNS zone on Infoblox by using the Red Hat External DNS Operator.
+
+.Prerequisites
+
+* You have access to the OpenShift CLI (`oc`).
+* You have access to the Infoblox UI.
+
+.Procedure
+
+. Create a `secret` object with Infoblox credentials by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-dns-operator create secret generic infoblox-credentials --from-literal=EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME=<infoblox_username> --from-literal=EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD=<infoblox_password>
+----
+
+. Get the routes objects to check your cluster domain by running the following command:
++
+[source,terminal]
+----
+$ oc get routes --all-namespaces | grep console
+----
++
+.Example Output
+[source,terminal]
+----
+openshift-console          console             console-openshift-console.apps.test.example.com                       console             https   reencrypt/Redirect     None
+openshift-console          downloads           downloads-openshift-console.apps.test.example.com                     downloads           http    edge/Redirect          None
+----
+
+. Create an `ExternalDNS` resource YAML file, for example, sample-infoblox.yaml, as follows:
++
+[source,yaml]
+----
+apiVersion: externaldns.olm.openshift.io/v1beta1
+kind: ExternalDNS
+metadata:
+  name: sample-infoblox
+spec:
+  provider:
+    type: Infoblox
+    infoblox:
+      credentials:
+        name: infoblox-credentials
+      gridHost: ${INFOBLOX_GRID_PUBLIC_IP}
+      wapiPort: 443
+      wapiVersion: "2.3.1"
+  domains:
+  - filterType: Include
+    matchType: Exact
+    name: test.example.com
+  source:
+    type: OpenShiftRoute
+    openshiftRouteOptions:
+      routerName: default
+----
+
+. Create an `ExternalDNS` resource on Infoblox by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sample-infoblox.yaml
+----
+
+. From the Infoblox UI, check the DNS records created for `console` routes:
+
+.. Click *Data Management* -> *DNS* -> *Zones*.
+.. Select the zone name.

--- a/networking/external_dns_operator/nw-creating-dns-records-on-infoblox.adoc
+++ b/networking/external_dns_operator/nw-creating-dns-records-on-infoblox.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="creating-dns-records-on-infoblox"]
+= Creating DNS records on Infoblox
+include::_attributes/common-attributes.adoc[]
+:context: creating-dns-records-on-infoblox
+
+toc::[]
+
+You can create DNS records on Infoblox using the Red Hat External DNS Operator.
+
+include::modules/nw-control-dns-records-public-hosted-zone-infoblox.adoc[leveloffset=+1]


### PR DESCRIPTION
OCP version: 4.11
QE contact @quarterpin- LGTMED 
SME contact @alebedev87-LGTMED
CFE https://issues.redhat.com/browse/CFE-331

Preview:
http://file.rdu.redhat.com/sdudhgao/infoblox/networking/external_dns_operator/nw-creating-dns-records-on-infoblox.html