### PR TITLE
[enterprise-4.10]Marked CPU manager as GA in 4.10 RNs

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2428,9 +2428,9 @@ In the table below, features are marked with the following statuses:
 |GA
 
 |CPU manager
-|-
-|-
-|TP
+|GA
+|GA
+|GA
 
 |Pod-level bonding for secondary networks
 |-


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3622

Preview build: https://deploy-preview-45447--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-technology-preview