### PR TITLE
CNV-16555: Backup and Restore - removing admin requirements

### DIFF
--- a/virt/backup_restore/virt-backup-restore-overview.adoc
+++ b/virt/backup_restore/virt-backup-restore-overview.adoc
@@ -6,8 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you back up and restore {VirtProductName} virtual machines (VMs) by using the OpenShift API for Data Protection (OADP).
-// Non-admin user [https://issues.redhat.com/browse/OADP-203] is targeted for OADP 1.1.
+You back up and restore {VirtProductName} virtual machines (VMs) by using the OpenShift API for Data Protection (OADP).
 
 You install the OADP Operator by using Operator Lifecycle Manager. The Operator installs link:https://velero.io/docs/v1.7/[Velero 1.7]. You create a `Secret` for the backup storage provider and then you install the Data Protection Application.
 

--- a/virt/backup_restore/virt-installing-configuring-oadp.adoc
+++ b/virt/backup_restore/virt-installing-configuring-oadp.adoc
@@ -10,7 +10,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you install the OpenShift API for Data Protection (OADP) by installing the OADP Operator. The Operator installs link:https://{velero-domain}/docs/v1.7/[Velero 1.7].
+You install the OpenShift API for Data Protection (OADP) by installing the OADP Operator. The Operator installs link:https://{velero-domain}/docs/v1.7/[Velero 1.7].
 
 You create a default `Secret` for your backup storage provider and then you install the Data Protection Application.
 


### PR DESCRIPTION
[OSDOCS-CNV-1655]: Removing admin requirements for these two backup and restore assemblies.

Version(s):
4.11 only.

Issue:
Jira: https://issues.redhat.com/browse/CNV-16555

My understanding is that the only change for 4.11 is removing the requirement that these tasks are admin only.

Tagging @apinnick for code review as she did the initial pass.
Tagging Natalia Gavrilov in the Jira for QE review.

Link to docs preview:
https://deploy-preview-45456--osdocs.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-overview.html
https://deploy-preview-45456--osdocs.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-installing-configuring-oadp.html
