### PR TITLE
[enterprise-4.6]Marked CPU manager as GA

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -2214,6 +2214,11 @@ In the table below, features are marked with the following statuses:
 |
 |
 |DEP
+
+|CPU manager
+|TP
+|TP
+|GA
 |====
 
 [id="ocp-4-6-known-issues"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3622

preview build: https://deploy-preview-45477--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes#ocp-4-6-technology-preview