### PR TITLE
[enterprise-4.11]Marked CPU manager as GA

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -720,9 +720,9 @@ In the table below, features are marked with the following statuses:
 |GA
 
 |CPU manager
-|-
-|TP
-|
+|GA
+|GA
+|GA
 
 |Pod-level bonding for secondary networks
 |-


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3622

Preview build: https://deploy-preview-45478--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-technology-preview