### PR TITLE
cnv: Clarify that descheduling of VMs will lead to live migration

### DIFF
--- a/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.adoc
@@ -9,7 +9,7 @@ toc::[]
 :FeatureName: Descheduler eviction for virtual machines
 include::snippets/technology-preview.adoc[]
 
-The xref:../../../nodes/scheduling/nodes-descheduler.adoc#nodes-descheduler[descheduler] can be used to evict a running pod to allow the pod to be rescheduled onto a more suitable node. You must install the descheduler by using the {product-title} web console or OpenShift CLI (`oc`) before you can enable it on your virtual machine (VM).
+The xref:../../../nodes/scheduling/nodes-descheduler.adoc#nodes-descheduler[descheduler] can be used to evict a running pod to allow the pod to be rescheduled onto a more suitable node. In the case of virtual machine, the pod eviction will lead to the virtual machine being live migrated to another node. You must install the descheduler by using the {product-title} web console or OpenShift CLI (`oc`) before you can enable it on your virtual machine (VM).
 
 include::modules/nodes-descheduler-profiles.adoc[leveloffset=+1]
 


### PR DESCRIPTION
A small clarification that in the CNV case, pod evictions will trigger VM live migrations.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to.
If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
  - The preview will be generated after you open the PR.
  - You will need to edit the comment to add the link after the preview builds.
  - Review the preview build to make sure your changes are rendering properly. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
