### PR TITLE
No_bug_assigned: Update EDNS Operator content

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -984,16 +984,18 @@ Topics:
 - Name: External DNS Operator
   Dir: external_dns_operator
   Topics:
+  - Name: Understanding the External DNS Operator
+    File: understanding-external-dns-operator
   - Name: Installing the External DNS Operator
-    File: nw-installing-external-dns-operator
+    File: nw-installing-external-dns-operator-on-cloud-providers
   - Name: External DNS Operator configuration parameters
-    File: nw-external-dns-operator-configuration-parameters
+    File: nw-configuration-parameters
   - Name: Creating DNS records on an public hosted zone for AWS
-    File: nw-control-dns-records-public-hosted-zone-aws
+    File: nw-creating-dns-records-on-aws
   - Name: Creating DNS records on an public zone for Azure
-    File: nw-control-dns-records-public-hosted-zone-azure
+    File: nw-creating-dns-records-on-azure
   - Name: Creating DNS records on an public managed zone for GCP
-    File: nw-control-dns-records-public-managed-zone-gcp
+    File: nw-creating-dns-records-on-gcp
 - Name: Network policy
   Dir: network_policy
   Topics:

--- a/modules/nw-control-dns-records-public-hosted-zone-aws.adoc
+++ b/modules/nw-control-dns-records-public-hosted-zone-aws.adoc
@@ -58,7 +58,7 @@ $ aws route53 list-hosted-zones | grep testextdnsoperator.apacshift.support
 HOSTEDZONES	terraform	/hostedzone/Z02355203TNN1XXXX1J6O	testextdnsoperator.apacshift.support.	5
 ----
 
-. Create `ExternalDNS` CR for `route` source:
+. Create `ExternalDNS` resource for `route` source:
 +
 [source,yaml]
 ----
@@ -77,8 +77,9 @@ spec:
       type: OpenShiftRoute <7>
       openshiftRouteOptions:
         routerName: default <8>
+EOF
 ----
-<1> Defines the name of external DNS CR.
+<1> Defines the name of external DNS resource.
 <2> By default all hosted zones are selected as potential targets. You can include a hosted zone that you need.
 <3> The matching of the target zone's domain has to be exact (as opposed to regular expression match).
 <4> Specify the exact domain of the zone you want to update. The hostname of the routes must be subdomains of the specified domain.

--- a/modules/nw-control-dns-records-public-hosted-zone-azure.adoc
+++ b/modules/nw-control-dns-records-public-hosted-zone-azure.adoc
@@ -62,7 +62,7 @@ openshift-console          downloads           downloads-openshift-console.apps.
 $ az network dns zone list --resource-group "${RESOURCE_GROUP}"
 ----
 
-. Create `ExternalDNS` CR for `route` source:
+. Create `ExternalDNS` resource for `route` source:
 +
 [source,yaml]
 ----
@@ -79,10 +79,11 @@ spec:
     openshiftRouteOptions: <4>
       routerName: default <5>
     type: OpenShiftRoute <6>
+EOF
 ----
-<1> defines the name of External DNS CR.
+<1> Specifies the name of External DNS CR.
 <2> Define the zone ID.
-<3> defines the Azure DNS provider.
+<3> Defines the Azure DNS provider.
 <4> You can define options for the source of DNS records.
 <5> If the source is `OpenShiftRoute` then you can pass the OpenShift Ingress Controller name. External DNS selects the canonical hostname of that router as the target while creating CNAME record.
 <6> Defines OpenShift `route` resource as the source for the DNS records which gets created in the previously specified DNS provider.
@@ -93,7 +94,7 @@ spec:
 ----
 $ az network dns record-set list -g "${RESOURCE_GROUP}"  -z test.azure.example.com | grep console
 ----
-
++
 [NOTE]
 ====
 To create records on private hosted zones on private Azure dns, you need to specify the private zone under `zones` which populates the provider type to `azure-private-dns` in the `ExternalDNS` container args.

--- a/modules/nw-control-dns-records-public-managed-zone-gcp.adoc
+++ b/modules/nw-control-dns-records-public-managed-zone-gcp.adoc
@@ -1,10 +1,10 @@
 
 // Module included in the following assemblies:
 //
-// * networking/external_dns_operator/nw-creating-dns-records-on-gc.adoc
+// * networking/external_dns_operator/nw-creating-dns-records-on-gcp.adoc
 
 :_content-type: PROCEDURE
-[id="nw-control-dns-records-public-hosted-zone-gcp_{context}"]
+[id="nw-control-dns-records-public-managed-zone-gcp_{context}"]
 = Creating DNS records on an public managed zone for GCP by using Red Hat External DNS Operator
 
 You can create DNS records on a public managed zone for GCP by using Red Hat External DNS Operator.
@@ -31,7 +31,7 @@ system:admin
 $ oc get secret gcp-credentials -n kube-system --template='{{$v := index .data "service_account.json"}}{{$v}}' | base64 -d - > decoded-gcloud.json
 ----
 
-. Export Google credentials by running the following command:
+. Export Google credentials:
 +
 [source,terminal]
 ----
@@ -45,14 +45,14 @@ $ export GOOGLE_CREDENTIALS=decoded-gcloud.json
 $ gcloud auth activate-service-account  <client_email as per decoded-gcloud.json> --key-file=decoded-gcloud.json
 ----
 
-. Set your project by running the following command:
+. Set your project:
 +
 [source,terminal]
 ----
 $ gcloud config set project <project_id as per decoded-gcloud.json>
 ----
 
-. Get the routes to check the domain by running the following command:
+. Get the routes to check the domain:
 +
 [source,terminal]
 ----
@@ -74,7 +74,7 @@ $ gcloud dns managed-zones list | grep test.gcp.example.com
 qe-cvs4g-private-zone test.gcp.example.com
 ----
 
-. Create `ExternalDNS` CR for `route` source:
+. Create `ExternalDNS` resource for `route` source:
 +
 [source,yaml]
 ----
@@ -93,8 +93,9 @@ spec:
     openshiftRouteOptions: <6>
       routerName: default <7>
     type: OpenShiftRoute <8>
+EOF
 ----
-<1> Defines the name of External DNS CR.
+<1> Specifies the name of External DNS CR.
 <2> By default all hosted zones are selected as potential targets. You can include a hosted zone that you need.
 <3> The matching of the target zone's domain has to be exact (as opposed to regular expression match).
 <4> Specify the exact domain of the zone you want to update. The hostname of the routes must be subdomains of the specified domain.

--- a/modules/nw-external-dns-operator-configuration-parameters.adoc
+++ b/modules/nw-external-dns-operator-configuration-parameters.adoc
@@ -76,7 +76,7 @@ source: <1>
   - "{{.Name}}.myzonedomain.com" <6>
 ----
 <1> Defines the settings for the source of DNS records.
-<2> `ExternalDNS` uses `Service` type as source for creating dns records.
+<2> The `ExternalDNS` uses `Service` type as source for creating dns records.
 <3> Sets `service-type-filter` flag in `ExternalDNS`. The `serviceType` contains the following fields:
 * `default`: `LoadBalancer`
 * `expected`: `ClusterIP`

--- a/modules/nw-external-dns-operator-logs.adoc
+++ b/modules/nw-external-dns-operator-logs.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+// * networking/understanding-external-dns-operator.adoc
+
+:_content-type: PROCEDURE
+[id="nw-external-dns-operator-logs_{context}"]
+= External DNS Operator logs
+
+You can view External DNS Operator logs by using the `oc logs` command.
+
+.Procedure
+
+. View the logs of the External DNS Operator:
++
+[source,terminal]
+----
+$ oc logs -n external-dns-operator deployment/external-dns-operator -c external-dns-operator
+----

--- a/modules/nw-external-dns-operator.adoc
+++ b/modules/nw-external-dns-operator.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+// * networking/understanding-external-dns-operator.adoc
+
+:_content-type: PROCEDURE
+[id="nw-dns-operator_{context}"]
+= External DNS Operator
+
+The External DNS Operator implements the External DNS API from the `olm.openshift.io` API group. The External DNS Operator deploys the `ExternalDNS` using a deployment resource. The ExternalDNS deployment watches the resources such as services and routes in the cluster and updates the external DNS providers.
+
+.Procedure
+
+You can deploy the ExternalDNS Operator on demand from the OperatorHub, this creates a `Subscription` object.
+
+. Check the name of an install plan:
++
+[source,terminal]
+----
+$ oc -n external-dns-operator get sub external-dns-operator -o yaml | yq '.status.installplan.name'
+----
++
+.Example output
+[source,terminal]
+----
+install-zcvlr
+----
+
+. Check the status of an install plan, the status of an install plan must be `Complete`:
++
+[source,terminal]
+----
+$ oc -n external-dns-operator get ip <INSTALL_PLAN_NAME> -o yaml | yq .status.phase'
+----
++
+.Example output
+[source,terminal]
+----
+Complete
+----
+
+. Use the `oc get` command to view the `Deployment` status:
++
+[source,terminal]
+----
+$ oc get -n external-dns-operator deployment/external-dns-operator
+NAME                    READY     UP-TO-DATE   AVAILABLE   AGE
+external-dns-operator   1/1       1            1           23h
+----

--- a/modules/nw-installing-external-dns-operator.adoc
+++ b/modules/nw-installing-external-dns-operator.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.adoc
+
+:_content-type: PROCEDURE
+[id="nw-installing-external-dns-operator_{context}"]
+= Installing the External DNS Operator
+
+You can install the External DNS Operator using the {product-title} OperatorHub.
+
+.Procedure
+
+. Click *Operators* → *OperatorHub* in the {product-title} Web Console.
+. Click *External DNS Operator*.
+  You can use the *Filter by keyword* text box or the filter list to search for External DNS Operator from the list of Operators.
+. Select the `external-dns-operator` namespace.
+. On the External DNS Operator page, click *Install*.
+. On the *Install Operator* page, ensure that you selected the following options:
+.. Update the channel as *stable-v1.0*.
+.. Installation mode as *A specific name on the cluster*.
+.. Installed namespace as `external-dns-operator`. If namespace `external-dns-operator` does not exist, it gets created during the Operator installation.
+.. Select *Approval Strategy* as *Automatic* or *Manual*. Approval Strategy is set to *Automatic* by default.
+.. Click *Install*.
+
+If you select *Automatic* updates, the Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without any intervention.
+
+If you select *Manual* updates, the OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the Operator updated to the new version.
+
+
+.Verification
+
+Verify that External DNS Operator shows the *Status* as *Succeeded* on the Installed Operators dashboard.

--- a/networking/external_dns_operator/nw-creating-dns-records-on-gcp.adoc
+++ b/networking/external_dns_operator/nw-creating-dns-records-on-gcp.adoc
@@ -8,4 +8,4 @@ toc::[]
 
 You can create DNS records on GCP using External DNS Operator.
 
-include::modules/nw-control-dns-records-public-hosted-zone-gcp.adoc[leveloffset=+1]
+include::modules/nw-control-dns-records-public-managed-zone-gcp.adoc[leveloffset=+1]

--- a/networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.adoc
+++ b/networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.adoc
@@ -8,4 +8,7 @@ toc::[]
 
 You can install External DNS Operator on cloud providers such as AWS, Azure and GCP.
 
+:FeatureName: External DNS Operator deployment
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
 include::modules/nw-installing-external-dns-operator.adoc[leveloffset=+1]

--- a/networking/external_dns_operator/understanding-external-dns-operator.adoc
+++ b/networking/external_dns_operator/understanding-external-dns-operator.adoc
@@ -1,0 +1,13 @@
+:_content-type: ASSEMBLY
+[id="external-dns-operator"]
+= External DNS Operator in {product-title}
+include::_attributes/common-attributes.adoc[]
+:context: external-dns-operator
+
+toc::[]
+
+The External DNS Operator deploys and manages `ExternalDNS` to provide the name resolution for services and routes from the external DNS provider to {product-title}.
+
+include::modules/nw-external-dns-operator.adoc[leveloffset=+1]
+
+include::modules/nw-external-dns-operator-logs.adoc[leveloffset=+1]


### PR DESCRIPTION
OCP versions: 4.10+

SME: @alebedev87 
QE: @lihongan  

Previews:
[nw-control-dns-records-public-hosted-zone-azure](https://deploy-preview-45514--osdocs.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-control-dns-records-public-hosted-zone-azure.html)
[nw-control-dns-records-public-managed-zone-gcp](https://deploy-preview-45514--osdocs.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-control-dns-records-public-managed-zone-gcp.html)
[nw-control-dns-records-public-managed-hosted-aws](https://deploy-preview-45514--osdocs.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-control-dns-records-public-hosted-zone-aws.html)
[understanding-the-external-dns-operator](https://deploy-preview-45514--osdocs.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/understanding-external-dns-operator.html)
[External-DNS-Operator-logs](https://deploy-preview-45514--osdocs.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/understanding-external-dns-operator.html#nw-external-dns-operator-logs_external-dns-operator)
[nw-installing-external-dns-operator](https://deploy-preview-45514--osdocs.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-installing-external-dns-operator.html)


http://file.rdu.redhat.com/sdudhgao/EDNS-update/networking/external_dns_operator/understanding-external-dns-operator.html
