### PR TITLE
OSDOCS3082: Networking Operators

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -959,6 +959,8 @@ Topics:
   File: understanding-networking
 - Name: Accessing hosts
   File: accessing-hosts
+- Name: Networking Operators overview
+  File: networking-operators-overview
 - Name: Understanding the Cluster Network Operator
   File: cluster-network-operator
   Distros: openshift-enterprise,openshift-origin

--- a/networking/networking-operators-overview.adoc
+++ b/networking/networking-operators-overview.adoc
@@ -1,0 +1,21 @@
+:_content-type: ASSEMBLY
+[id="networking-operators-overview"]
+= Networking Operators overview
+include::_attributes/common-attributes.adoc[]
+:context: networking-operators-overview
+
+toc::[]
+
+{product-title} supports multiple types of networking Operators. You can manage the cluster networking using these networking Operators.
+
+[id="networking-operators-overview-cluster-network-operator"]
+== Cluster Network Operator
+The Cluster Network Operator (CNO) deploys and manages the cluster network components in an {product-title} cluster. This includes deployment of the Container Network Interface (CNI) default network provider plug-in selected for the cluster during installation. For more information, see xref:../networking/cluster-network-operator.adoc#cluster-network-operator[Cluster Network Operator in {product-title}].
+
+[id="networking-operators-overview-dns-operator"]
+== DNS Operator
+The DNS Operator deploys and manages CoreDNS to provide a name resolution service to pods. This enables DNS-based Kubernetes Service discovery in {product-title}. For more information, see xref:../networking/dns-operator.adoc#dns-operator[DNS Operator in {product-title}].
+
+[id="networking-operators-overview-ingress-operator"]
+== Ingress Operator
+When you create your {product-title} cluster, pods and services running on the cluster are each allocated IP addresses. The IP addresses are accessible to other pods and services running nearby but are not accessible to external clients. The Ingress Operator implements the Ingress Controller API and is responsible for enabling external access to {product-title} cluster services. For more information, see xref:../networking/ingress-operator.adoc#configuring-ingress[Ingress Operator in {product-title}].


### PR DESCRIPTION
[Preview](https://deploy-preview-45515--osdocs.netlify.app/openshift-enterprise/latest/networking/networking-operators-overview.html)

QE contact: @zhaozhanqi 

OCP version: 4.6, 4.7, 4.8, and 4.9 only
There is a different [PR](https://github.com/openshift/openshift-docs/pull/45517) for 4.10+ versions

[Jira](https://issues.redhat.com/browse/OSDOCS-3082)

