### PR TITLE
[OSDOCS-3502] Add ShiftStack external cloud provider RN item for 4.12

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -143,6 +143,13 @@ In earlier versions of {product-title}, Ironic container images used {op-system-
 
 For more information about the Ironic provisioning service, see xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc[Deploying installer-provisioned clusters on bare metal].
 
+[id="ocp-4-12-openstack-external-cloud-control-upgrade"]
+=== Cloud provider configuration updates for clusters that run on {rh-openstack}
+
+In {product-title} 4.12, clusters that run on {rh-openstack-first} are switched from the legacy OpenStack cloud provider to the external Cloud Controller Manager (CCM). This change follows the move in Kubernetes from in-tree, legacy cloud providers to external cloud providers that are implemented by using the link:https://kubernetes.io/docs/concepts/architecture/cloud-controller/[Cloud Controller Manager].
+
+// For more information, see [LINK TO DOC ONCE AVAILABLE]
+
 [id="ocp-4-12-post-installation"]
 === Post-installation configuration
 


### PR DESCRIPTION
Version(s):
~~4.11~~ 4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-3502

Link to docs preview:
https://45518--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-openstack-external-cloud-control-upgrade

Additional information:
WIP. Adds [OSASINFRA-2757](https://issues.redhat.com//browse/OSASINFRA-2757) to 4.12 release notes.

