### PR TITLE
include HomeBrew @ cli-installing

### DIFF
--- a/cli_reference/openshift_cli/getting-started-cli.adoc
+++ b/cli_reference/openshift_cli/getting-started-cli.adoc
@@ -34,6 +34,9 @@ ifndef::openshift-origin[]
 include::modules/cli-installing-cli-rpm.adoc[leveloffset=+2]
 endif::[]
 
+// Installing the CLI by using Homebrew
+include::modules/cli-installing-cli-brew.adoc[leveloffset=+2]
+
 // Logging in to the CLI
 include::modules/cli-logging-in.adoc[leveloffset=+1]
 

--- a/modules/cli-installing-cli-brew.adoc
+++ b/modules/cli-installing-cli-brew.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/openshift_cli/getting-started.adoc
+
+:_content-type: PROCEDURE
+[id="cli-installing-cli-brew_{context}"]
+= Installing the OpenShift CLI by using Homebrew
+
+For macOS, you can install the OpenShift CLI (`oc`) by using the link:https://brew.sh[Homebrew] package manager.
+
+.Prerequisites
+
+* You must have Homebrew (`brew`) installed.
+
+.Procedure
+
+* Run the following command to install the link:https://formulae.brew.sh/formula/openshift-cli[openshift-cli] package:
++
+[source,terminal]
+----
+$ brew install openshift-cli
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.6+

Issue:
Taking over PR #36549

Link to docs preview:
https://deploy-preview-45528--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli-brew_cli-developer-commands

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
