### PR TITLE
2075129_Downstream docs do not account for legacy install/upgrade of v1.7.0

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -62,6 +62,7 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.7
+:mtc-version-z:1.7.1
 :mtc-legacy-version: 1.5
 :mtc-legacy-version-z: 1.5.3
 // builds (Valid only in 4.11 and later)

--- a/modules/migration-installing-legacy-operator.adoc
+++ b/modules/migration-installing-legacy-operator.adoc
@@ -41,20 +41,56 @@ endif::[]
 $ sudo podman login registry.redhat.io
 ----
 
-. Download the `operator.yml` file:
+. Download the `operator.yml` file for the version of {mtc-short} you are installing:
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v<mtc-version-number>):/operator.yml ./
+----
++
+.Examples
++
+** MTC version 1.5.3
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/operator.yml ./
 ----
++
+** MTC version 1.7.0
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/operator.yml ./
+----
 
-. Download the `controller.yml` file:
+. Download the `controller.yml` file for the version of {mtc-short} you are installing::
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v<mtc-version-number>):/controller.yml ./
+----
++
+.Examples
++
+** MTC version 1.5.3
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/controller.yml ./
+----
++
+** MTC version 1.7.1
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/controller.yml ./
 ----
 
 ifdef::installing-restricted-3-4,installing-mtc-restricted[]
@@ -92,7 +128,14 @@ containers:
 <2> Specify your mirror registry.
 endif::[]
 
+
+ifdef::installing-3-4,installing-restricted-3-4[]
 . Log in to your {product-title} 3 cluster.
+endif::[]
+
+ifdef::installing-mtc,installing-mtc-restricted[]
+. Log in to your {product-title} source cluster.
+endif::[]
 
 ifdef::installing-3-4,installing-mtc[]
 . Verify that the cluster can authenticate with `registry.redhat.io`:

--- a/modules/migration-upgrading-mtc-with-legacy-operator.adoc
+++ b/modules/migration-upgrading-mtc-with-legacy-operator.adoc
@@ -31,12 +31,30 @@ endif::[]
 $ sudo podman login registry.redhat.io
 ----
 
-. Download the `operator.yml` file:
+. Download the `operator.yml` file for the version of {mtc-short} you are upgrading:
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v<mtc-version-number>):/operator.yml ./
+----
++
+.Examples
++
+** MTC version 1.5.3
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/operator.yml ./
+----
++
+** MTC version 1.7.0
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/operator.yml ./
 ----
 
 . Replace the {mtc-full} Operator:
@@ -67,12 +85,30 @@ $ oc scale -n openshift-migration --replicas=1 deployment/migration-operator
 $ oc -o yaml -n openshift-migration get deployment/migration-operator | grep image: | awk -F ":" '{ print $NF }'
 ----
 
-. Download the `controller.yml` file:
+. Download the `controller.yml` file for the version of {mtc-short} you are upgrading:
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v<mtc-version-number>):/controller.yml ./
+----
++
+.Examples
++
+** MTC version 1.5.3
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/controller.yml ./
+----
++
+** MTC version 1.7.1
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/controller.yml ./
 ----
 
 . Create the `migration-controller` object:


### PR DESCRIPTION
MTC 1.7.1

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2075127 and https://bugzilla.redhat.com/show_bug.cgi?id=2075129 

1. Changes the references to the reference to the 1.5.3 image to a generic image, <mtc-version-number> and gives images for versions 1.5.3 and 1.7.1 as examples, using attributes (the value of 1.5.3 was the value of an attribute).
2. Sets the z-stream version of MTC to 1.7.1.
3. Changes a reference from  "OCP 3 cluster" to "OCP 4 source cluster" in the installation procedures for in _Migration Toolkit for Containers_ (which only deals with migrating between OCP 4 clusters) but not in _Migrating from Version 3 to 4_ (which deals with migrating from OCP 3 to 4). 

Previews:
1. Installing non-restrictive OCP 4: https://deploy-preview-45542--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc.html [Steps 2 - 4 of first procedure]

2. Installing restrictive OCP 4: https://deploy-preview-45542--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc-restricted.html [Steps 2-3 of "Installing the legacy Migration Toolkit for Containers Operator on OpenShift Container Platform 4.2 to 4.5"] 

3. Installing non-restrictive OCP 3: https://deploy-preview-45542--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-3-4.html  [Steps 2 - 4 of first procedure]

4. Installing restrictive OCP 3: https://deploy-preview-45542--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-restricted-3-4.html [Steps 2-3 of "Installing the legacy Migration Toolkit for Containers Operator on OpenShift Container Platform 3"] 

5. Upgrading on OCP 4: https://deploy-preview-45542--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/upgrading-mtc.html [Steps 2 and 7 of "Upgrading the Migration Toolkit for Containers on OpenShift Container Platform versions 4.2 to 4.5"]

6: upgrading from OCP 3: https://deploy-preview-45542--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/upgrading-3-4.html  [Steps 2 and 7 of "Upgrading the Migration Toolkit for Containers on OpenShift Container Platform 3" 
 