### PR TITLE
Updates for BZ2075009

### DIFF
--- a/modules/ztp-ai-install-ocp-clusters-on-bare-metal.adoc
+++ b/modules/ztp-ai-install-ocp-clusters-on-bare-metal.adoc
@@ -19,13 +19,6 @@ For distributed units (DUs), {rh-rhacm} supports {product-title} deployments tha
 
 .Procedure
 
-. Modify the `HiveConfig` resource to enable the feature gate for Assisted Installer:
-+
-[source,terminal]
-----
- $ oc patch hiveconfig hive --type merge -p '{"spec":{"targetNamespace":"hive","logLevel":"debug","featureGates":{"custom":{"enabled":["AlphaAgentInstallStrategy"]},"featureSet":"Custom"}}}'
-----
-
 . Modify the `Provisioning` resource to allow the Bare Metal Operator to watch all namespaces:
 +
 [source,terminal]


### PR DESCRIPTION
BZ 2075009: Removed the first step of the procedure as hiveagent feature gate is no longer required for hive + assisted installer.

Version(s):
Merge to main. Enterprise 4.10 and 4.11.  

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2075009

Link to docs preview:
https://deploy-preview-45572--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#enabling-assisted-installer-service-on-bare-metal_ztp-deploying-disconnected

<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
