### PR TITLE
OCP installation document for Power Needs an update to show support for Power10

### DIFF
--- a/modules/minimum-ibm-power-system-requirements.adoc
+++ b/modules/minimum-ibm-power-system-requirements.adoc
@@ -9,23 +9,23 @@
 
 You can install {product-title} version {product-version} on the following IBM hardware:
 
-* IBM POWER8 or POWER9 processor-based systems
+* IBM Power8, Power9, or Power10 processor-based systems
 
 [discrete]
 == Hardware requirements
 
-* 6 IBM Power bare metal servers or 6 LPARs across multiple PowerVM servers
+* Six IBM Power bare metal servers or six LPARs across multiple PowerVM servers
 
 [discrete]
 == Operating system requirements
 
-* One instance of an IBM POWER8 or POWER9 processor-based system
+* One instance of an IBM Power8, Power9, or Power10 processor-based system
 
 On your IBM Power instance, set up:
 
-* 3 guest virtual machines for {product-title} control plane machines
-* 2 guest virtual machines for {product-title} compute machines
-* 1 guest virtual machine for the temporary {product-title} bootstrap machine
+* Three guest virtual machines for {product-title} control plane machines
+* Two guest virtual machines for {product-title} compute machines
+* One guest virtual machine for the temporary {product-title} bootstrap machine
 
 [discrete]
 == Disk storage for the IBM Power guest virtual machines

--- a/modules/recommended-ibm-power-system-requirements.adoc
+++ b/modules/recommended-ibm-power-system-requirements.adoc
@@ -10,18 +10,18 @@
 [discrete]
 == Hardware requirements
 
-* 6 IBM Power bare metal servers or 6 LPARs across multiple PowerVM servers
+* Six IBM Power bare metal servers or six LPARs across multiple PowerVM servers
 
 [discrete]
 == Operating system requirements
 
-* One instance of an IBM POWER8 or POWER9 processor-based system
+* One instance of an IBM Power8, Power9, or Power10 processor-based system
 
 On your IBM Power instance, set up:
 
-* 3 guest virtual machines for {product-title} control plane machines
-* 2 guest virtual machines for {product-title} compute machines
-* 1 guest virtual machine for the temporary {product-title} bootstrap machine
+* Three guest virtual machines for {product-title} control plane machines
+* Two guest virtual machines for {product-title} compute machines
+* One guest virtual machine for the temporary {product-title} bootstrap machine
 
 [discrete]
 == Disk storage for the IBM Power guest virtual machines


### PR DESCRIPTION
- OCP version for cherry-picking: enterprise-4.9, 4.10

    Bugzilla : https://bugzilla.redhat.com/show_bug.cgi?id=2082196

    Preview : 
    https://deploy-preview-45573--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power.html#installation-minimum-resource-requirements_installing-ibm-power
    https://deploy-preview-45573--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power.html#recommended-ibm-power-system-requirements_installing-ibm-power
    

    QE review : Luvella McFadden