### PR TITLE
JIRA-OSDOCS3265-update: Updated the release management content for ROSA

### DIFF
--- a/modules/rosa-policy-change-management.adoc
+++ b/modules/rosa-policy-change-management.adoc
@@ -66,7 +66,7 @@ Red Hat does not automatically upgrade your clusters. You can schedule to upgrad
 
 [NOTE]
 ====
-ROSA clusters that use the AWS Security Token Service (STS) need an interruption between upgrades to ensure that the STS roles and policies are updated. Therefore, you cannot schedule recurring upgrades on ROSA clusters with STS.
+Because the required permissions can change between y-stream releases, the policies might have to be updated before an upgrade can be performed. Therefore, you cannot schedule a recurring upgrade on ROSA clusters with STS.
 ====
 
 You can review the history of all cluster upgrade events in the {cluster-manager} web console. For more information about releases, see the link:https://access.redhat.com/support/policy/updates/openshift/dedicated[Life Cycle policy].


### PR DESCRIPTION
This PR is to address the JIRA issue: https://issues.redhat.com/browse/OSDOCS-3265.

Following is the change:
This PR includes a minor update in the note in 'Release Management' section in OSD docs that was identified after the precursor PR https://github.com/openshift/openshift-docs/pull/44691 was merged. 

The change is seen in the following topic:
https://deploy-preview-45575--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security#rosa-policy-patch-management_rosa-policy-process-security

Repo: Request cherrypick to enterprise-4.10 and enterprise-4.11