### PR TITLE
[OSDOCS-3570]: Update ccoctl notes for AWS STS

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -14,7 +14,7 @@ Otherwise, you can create the AWS resources individually.
 
 [NOTE]
 ====
-By default, `ccoctl` creates objects in the directory in which the commands are run. To specify a directory, use the `--output-dir` flag. This procedure uses `_<path_to_ccoctl_output_dir>_` to refer to this location.
+By default, `ccoctl` creates objects in the directory in which the commands are run. To create the objects in a different directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this directory.
 ====
 
 .Prerequisites
@@ -25,38 +25,44 @@ By default, `ccoctl` creates objects in the directory in which the commands are 
 
 . Extract the list of `CredentialsRequest` objects from the {product-title} release image:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ oc adm release extract --credentials-requests --cloud=aws --to=__<path_to_directory_with_list_of_credentials_requests>__/credrequests quay.io/__<path_to>__/ocp-release:__<version>__
+$ oc adm release extract \
+--credentials-requests \
+--cloud=aws \
+--to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
 ----
 
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ ccoctl aws create-all --name=__<name>__ --region=__<aws_region>__ --credentials-requests-dir=__<path_to_directory_with_list_of_credentials_requests>__/credrequests
+$ ccoctl aws create-all \
+--name=<name> \
+--region=<aws_region> \
+--credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
 ----
 
 .Verification
 
-* To verify that the {product-title} secrets are created, list the files in the `_<path_to_ccoctl_output_dir>_/manifests` directory:
+* To verify that the {product-title} secrets are created, list the files in the `<path_to_ccoctl_output_dir>/manifests` directory:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ ll __<path_to_ccoctl_output_dir>__/manifests
+$ ll <path_to_ccoctl_output_dir>/manifests
 ----
 +
 .Example output:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
 total 24
--rw-------. 1 __<user>__ __<user>__ 161 Apr 13 11:42 cluster-authentication-02-config.yaml
--rw-------. 1 __<user>__ __<user>__ 379 Apr 13 11:59 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 353 Apr 13 11:59 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 355 Apr 13 11:59 openshift-image-registry-installer-cloud-credentials-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 339 Apr 13 11:59 openshift-ingress-operator-cloud-credentials-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 337 Apr 13 11:59 openshift-machine-api-aws-cloud-credentials-credentials.yaml
+-rw-------. 1 <user> <user> 161 Apr 13 11:42 cluster-authentication-02-config.yaml
+-rw-------. 1 <user> <user> 379 Apr 13 11:59 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
+-rw-------. 1 <user> <user> 353 Apr 13 11:59 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
+-rw-------. 1 <user> <user> 355 Apr 13 11:59 openshift-image-registry-installer-cloud-credentials-credentials.yaml
+-rw-------. 1 <user> <user> 339 Apr 13 11:59 openshift-ingress-operator-cloud-credentials-credentials.yaml
+-rw-------. 1 <user> <user> 337 Apr 13 11:59 openshift-machine-api-aws-cloud-credentials-credentials.yaml
 ----
 
 You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -14,9 +14,9 @@ Otherwise, you can use the `ccoctl aws create-all` command to create the AWS res
 
 [NOTE]
 ====
-By default, `ccoctl` creates objects in the directory in which the commands are run. To specify a directory, use the `--output-dir` flag. This procedure uses `_<path_to_ccoctl_output_dir>_` to refer to this location.
+By default, `ccoctl` creates objects in the directory in which the commands are run. To create the objects in a different directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this directory.
 
-Some `ccoctl` commands make AWS API calls to create or modify AWS resources. To place JSON files on the local file system instead, use the `--dry-run` flag. These JSON files can be reviewed or modified and then applied with the AWS CLI tool using the `--cli-input-json` parameters.
+Some `ccoctl` commands make AWS API calls to create or modify AWS resources. You can use the `--dry-run` flag to avoid making API calls. Using this flag creates JSON files on the local file system instead. You can review and modify the JSON files and then apply them with the AWS CLI tool using the `--cli-input-json` parameters.
 ====
 
 .Prerequisites
@@ -34,60 +34,72 @@ $ ccoctl aws create-key-pair
 +
 .Example output:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
 2021/04/13 11:01:02 Generating RSA keypair
-2021/04/13 11:01:03 Writing private key to /__<path_to_ccoctl_output_dir>__/serviceaccount-signer.private
-2021/04/13 11:01:03 Writing public key to /__<path_to_ccoctl_output_dir>__/serviceaccount-signer.public
+2021/04/13 11:01:03 Writing private key to /<path_to_ccoctl_output_dir>/serviceaccount-signer.private
+2021/04/13 11:01:03 Writing public key to /<path_to_ccoctl_output_dir>/serviceaccount-signer.public
 2021/04/13 11:01:03 Copying signing key for use by installer
 ----
 +
 where `serviceaccount-signer.private` and `serviceaccount-signer.public` are the generated key files.
 +
-This command also creates a private key that the cluster requires during installation in `/_<path_to_ccoctl_output_dir>_/tls/bound-service-account-signing-key.key`.
+This command also creates a private key that the cluster requires during installation in `/<path_to_ccoctl_output_dir>/tls/bound-service-account-signing-key.key`.
 
 . Create an OpenID Connect identity provider and S3 bucket on AWS:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ ccoctl aws create-identity-provider --name=__<name>__ --region=__<aws_region>__ --public-key-file=__<path_to_ccoctl_output_dir>__/serviceaccount-signer.public
+$ ccoctl aws create-identity-provider \
+--name=<name> \
+--region=<aws_region> \
+--public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public
 ----
 +
 where:
 +
-** `_<name>_` is the name used to tag any cloud resources that are created for tracking.
-** `_<aws-region>_` is the AWS region in which cloud resources will be created.
-** `_<path_to_ccoctl_output_dir>_` is the path to the public key file that the `ccoctl aws create-key-pair` command generated.
+--
+** `<name>` is the name used to tag any cloud resources that are created for tracking.
+** `<aws-region>` is the AWS region in which cloud resources will be created.
+** `<path_to_ccoctl_output_dir>` is the path to the public key file that the `ccoctl aws create-key-pair` command generated.
+--
 +
 .Example output:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-2021/04/13 11:16:09 Bucket __<name>__-oidc created
-2021/04/13 11:16:10 OpenID Connect discovery document in the S3 bucket __<name>__-oidc at .well-known/openid-configuration updated
+2021/04/13 11:16:09 Bucket <name>-oidc created
+2021/04/13 11:16:10 OpenID Connect discovery document in the S3 bucket <name>-oidc at .well-known/openid-configuration updated
 2021/04/13 11:16:10 Reading public key
-2021/04/13 11:16:10 JSON web key set (JWKS) in the S3 bucket __<name>__-oidc at keys.json updated
-2021/04/13 11:16:18 Identity Provider created with ARN: arn:aws:iam::__<aws_account_id>__:oidc-provider/__<name>__-oidc.s3.__<aws_region>__.amazonaws.com
+2021/04/13 11:16:10 JSON web key set (JWKS) in the S3 bucket <name>-oidc at keys.json updated
+2021/04/13 11:16:18 Identity Provider created with ARN: arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
 ----
 +
 where `02-openid-configuration` is a discovery document and `03-keys.json` is a JSON web key set file.
 +
-This command also creates a YAML configuration file in `/_<path_to_ccoctl_output_dir>_/manifests/cluster-authentication-02-config.yaml`. This file sets the issuer URL field for the service account tokens that the cluster generates, so that the AWS IAM identity provider trusts the tokens.
+This command also creates a YAML configuration file in `/<path_to_ccoctl_output_dir>/manifests/cluster-authentication-02-config.yaml`. This file sets the issuer URL field for the service account tokens that the cluster generates, so that the AWS IAM identity provider trusts the tokens.
 
 . Create IAM roles for each component in the cluster.
 
 .. Extract the list of `CredentialsRequest` objects from the {product-title} release image:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ oc adm release extract --credentials-requests --cloud=aws --to=__<path_to_directory_with_list_of_credentials_requests>__/credrequests quay.io/__<path_to>__/ocp-release:__<version>__
+$ oc adm release extract \
+--credentials-requests \
+--cloud=aws \
+--to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
 ----
 
 .. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ ccoctl aws create-iam-roles --name=__<name>__ --region=__<aws_region>__ --credentials-requests-dir=__<path_to_directory_with_list_of_credentials_requests>__/credrequests --identity-provider-arn=arn:aws:iam::__<aws_account_id>__:oidc-provider/__<name>__-oidc.s3.__<aws_region>__.amazonaws.com
+$ ccoctl aws create-iam-roles \
+--name=<name> \
+--region=<aws_region> \
+--credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \
+--identity-provider-arn=arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
 ----
 +
 [NOTE]
@@ -99,24 +111,24 @@ For each `CredentialsRequest` object, `ccoctl` creates an IAM role with a trust 
 
 .Verification
 
-* To verify that the {product-title} secrets are created, list the files in the `_<path_to_ccoctl_output_dir>_/manifests` directory:
+* To verify that the {product-title} secrets are created, list the files in the `<path_to_ccoctl_output_dir>/manifests` directory:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ ll __<path_to_ccoctl_output_dir>__/manifests
+$ ll <path_to_ccoctl_output_dir>/manifests
 ----
 +
 .Example output:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
 total 24
--rw-------. 1 __<user>__ __<user>__ 161 Apr 13 11:42 cluster-authentication-02-config.yaml
--rw-------. 1 __<user>__ __<user>__ 379 Apr 13 11:59 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 353 Apr 13 11:59 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 355 Apr 13 11:59 openshift-image-registry-installer-cloud-credentials-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 339 Apr 13 11:59 openshift-ingress-operator-cloud-credentials-credentials.yaml
--rw-------. 1 __<user>__ __<user>__ 337 Apr 13 11:59 openshift-machine-api-aws-cloud-credentials-credentials.yaml
+-rw-------. 1 <user> <user> 161 Apr 13 11:42 cluster-authentication-02-config.yaml
+-rw-------. 1 <user> <user> 379 Apr 13 11:59 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
+-rw-------. 1 <user> <user> 353 Apr 13 11:59 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
+-rw-------. 1 <user> <user> 355 Apr 13 11:59 openshift-image-registry-installer-cloud-credentials-credentials.yaml
+-rw-------. 1 <user> <user> 339 Apr 13 11:59 openshift-ingress-operator-cloud-credentials-credentials.yaml
+-rw-------. 1 <user> <user> 337 Apr 13 11:59 openshift-machine-api-aws-cloud-credentials-credentials.yaml
 ----
 
 You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.

--- a/modules/cco-ccoctl-upgrading.adoc
+++ b/modules/cco-ccoctl-upgrading.adoc
@@ -10,9 +10,9 @@ The process for upgrading an {product-title} cluster configured for manual mode 
 
 [NOTE]
 ====
-By default, `ccoctl` creates objects in the directory in which the commands are run. To specify a directory, use the `--output-dir` flag. This procedure uses `_<path_to_ccoctl_output_dir>_` to refer to this location.
+By default, `ccoctl` creates objects in the directory in which the commands are run. To create the objects in a different directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this directory.
 
-Some `ccoctl` commands make AWS API calls to create or modify AWS resources. To place JSON files on the local file system instead, use the `--dry-run` flag. These JSON files can be reviewed or modified and then applied with the AWS CLI tool using the `--cli-input-json` parameters.
+Some `ccoctl` commands make AWS API calls to create or modify AWS resources. You can use the `--dry-run` flag to avoid making API calls. Using this flag creates JSON files on the local file system instead. You can review and modify the JSON files and then apply them with the AWS CLI tool using the `--cli-input-json` parameters.
 ====
 
 .Prerequisites
@@ -25,9 +25,12 @@ Some `ccoctl` commands make AWS API calls to create or modify AWS resources. To 
 
 . Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ oc adm release extract --credentials-requests --cloud=aws --to=__<path_to_directory_with_list_of_credentials_requests>__/credrequests quay.io/__<path_to>__/ocp-release:__<version>__
+$ oc adm release extract \
+--credentials-requests \
+--cloud=aws \
+--to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
 ----
 
 . For each `CredentialsRequest` CR in the release image, ensure that a namespace that matches the text in the `spec.secretRef.namespace` field exists in the cluster. This field is where the generated secrets that hold the credentials configuration are stored.
@@ -60,23 +63,29 @@ spec:
 
 . For any `CredentialsRequest` CR for which the cluster does not already have a namespace with the name specified in `spec.secretRef.namespace`, create the namespace:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ oc create namespace __<component_namespace>__
+$ oc create namespace <component_namespace>
 ----
 
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ ccoctl aws create-iam-roles --name __<name>__ --region=__<aws_region>__ --credentials-requests-dir=__<path_to_directory_with_list_of_credentials_requests>__/credrequests --identity-provider-arn arn:aws:iam::__<aws_account_id>__:oidc-provider/__<name>__-oidc.s3.__<aws_region>__.amazonaws.com
+$ ccoctl aws create-iam-roles \
+--name <name> \
+--region=<aws_region> \
+--credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \
+--identity-provider-arn arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
 ----
 +
 where:
 +
-** _<name>_ is the name used to tag any cloud resources that are created for tracking. For upgrades, use the same value that was used for the initial installation.
-** _<aws_account_id>_ is the AWS account ID.
-** _<aws_region>_ is the AWS region in which cloud resources will be created.
+--
+** `<name>` is the name used to tag any cloud resources that are created for tracking. For upgrades, use the same value that was used for the initial installation.
+** `<aws_account_id>` is the AWS account ID.
+** `<aws_region>` is the AWS region in which cloud resources will be created.
+--
 +
 [NOTE]
 ====
@@ -87,9 +96,9 @@ For each `CredentialsRequest` object, `ccoctl` creates an IAM role with a trust 
 
 . Apply the secrets to your cluster:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal]
 ----
-$ ls __<path_to_ccoctl_output_dir>__/manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
+$ ls <path_to_ccoctl_output_dir>/manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
 ----
 
 .Verification


### PR DESCRIPTION
Version(s):
4.8+

Issue:
[OSDOCS-3570](https://issues.redhat.com//browse/OSDOCS-3570)

Link to docs preview:
- [Creating AWS resources individually](https://deploy-preview-45578--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-individually_cco-mode-sts)
- [Creating AWS resources with a single command](https://deploy-preview-45578--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-at-once_cco-mode-sts)
- [Updating AWS resources with the Cloud Credential Operator utility](https://deploy-preview-45578--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-upgrading_sts-mode-upgrading)

Additional information:
Part of #42921 was applicable to 4.8+, but not in a way that was easy to cleanly cherrypick from `main`. This PR takes care of those items in those branches.

DPM [approved](https://github.com/openshift/openshift-docs/pull/45578#issuecomment-1123896419) non-traditional cherrypick to 4.8