### PR TITLE
JIRA-OSDOCS3542: Updated limited support status in service definition

### DIFF
--- a/modules/life-cycle-limited-support.adoc
+++ b/modules/life-cycle-limited-support.adoc
@@ -5,14 +5,14 @@
 [id="rosa-limited-support_{context}"]
 = Limited support status
 
-When a cluster transitions to a _Limited Support_ status, it means that the SLA is no longer applicable and credits requested against the SLA are denied. It does not mean that you no longer have product support. You can return the cluster to a fully-supported status by remediating the violating factors.
+When a cluster transitions to a _Limited Support_ status, Red Hat no longer proactively monitors the cluster, the SLA is no longer applicable, and credits requested against the SLA are denied. It does not mean that you no longer have product support. In some cases, the cluster can return to a fully-supported status if you remediate the violating factors. However, in other cases, you might have to delete and recreate the cluster.
 
-A cluster transitions to a Limited Support status in the following scenarios:
+A cluster might transition to a Limited Support status for many reasons, including the following scenarios:
 
-If you do not upgrade a cluster to a supported version before the end-of-life date:: Red Hat does not make any runtime or SLA guarantees for versions after their end-of-life date. To receive continued support, upgrade the cluster to a supported version within the 9-month period. If you do not upgrade the cluster within the 9-month period, the cluster transitions to a Limited Support status until you upgrade it to a supported version.
+If you do not upgrade a cluster to a supported version before the end-of-life date:: Red Hat does not make any runtime or SLA guarantees for versions after their end-of-life date. To receive continued support, upgrade the cluster to a supported version prior to the end-of-life date. If you do not upgrade the cluster prior to the end-of-life date, the cluster transitions to a Limited Support status until it is upgraded to a supported version.
 +
 Red Hat provides commercially reasonable support to upgrade from an unsupported version to a supported version. However, if a supported upgrade path is no longer available, you might have to create a new cluster and migrate your workloads.
 
-If you remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat:: If you used the cluster administrator rights, Red Hat is not responsible for any of your or your authorized users’ actions, including those that affect infrastructure services, service availability, or data loss. If Red Hat detects any such actions, the cluster transitions to a Limited Support status. Red Hat notifies you of the status change and you should either revert the action or create a support case to remediate the issue.
+If you remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat:: If cluster administrator permissions were used, Red Hat is not responsible for any of your or your authorized users’ actions, including those that affect infrastructure services, service availability, or data loss. If Red Hat detects any such actions, the cluster might transition to a Limited Support status. Red Hat notifies you of the status change and you should either revert the action or create a support case to explore remediation steps that might require you to delete and recreate the cluster.
 
-If you have questions about the violating factors that cause a cluster to transition to a Limited Support status or need further assistance, open a support ticket.
+If you have questions about a specific action that might cause a cluster to transition to a Limited Support status or need further assistance, open a support ticket.

--- a/modules/rosa-sdpolicy-account-management.adoc
+++ b/modules/rosa-sdpolicy-account-management.adoc
@@ -169,17 +169,17 @@ Any SLAs for the service itself are defined in Appendix 4 of the link:https://ww
 [id="rosa-limited-support_{context}"]
 == Limited support status
 
-When a cluster transitions to a _Limited Support_ status, it means that the SLA is no longer applicable and credits requested against the SLA are denied. It does not mean that you no longer have product support. You can return the cluster to a fully-supported status by remediating the violating factors.
+When a cluster transitions to a _Limited Support_ status, Red Hat no longer proactively monitors the cluster, the SLA is no longer applicable, and credits requested against the SLA are denied. It does not mean that you no longer have product support. In some cases, the cluster can return to a fully-supported status if you remediate the violating factors. However, in other cases, you might have to delete and recreate the cluster.
 
-A cluster transitions to a Limited Support status in the following scenarios:
+A cluster might transition to a Limited Support status for many reasons, including the following scenarios:
 
-If you do not upgrade a cluster to a supported version before the end-of-life date:: Red Hat does not make any runtime or SLA guarantees for versions after their end-of-life date. To receive continued support, upgrade the cluster to a supported version within the 9-month period. If you do not upgrade the cluster within the 9-month period, the cluster transitions to a Limited Support status until you upgrade it to a supported version.
+If you do not upgrade a cluster to a supported version before the end-of-life date:: Red Hat does not make any runtime or SLA guarantees for versions after their end-of-life date. To receive continued support, upgrade the cluster to a supported version prior to the end-of-life date. If you do not upgrade the cluster prior to the end-of-life date, the cluster transitions to a Limited Support status until it is upgraded to a supported version.
 +
 Red Hat provides commercially reasonable support to upgrade from an unsupported version to a supported version. However, if a supported upgrade path is no longer available, you might have to create a new cluster and migrate your workloads.
 
-If you remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat:: If you used the cluster administrator rights, Red Hat is not responsible for any of your or your authorized users’ actions, including those that affect infrastructure services, service availability, or data loss. If Red Hat detects any such actions, the cluster transitions to a Limited Support status. Red Hat notifies you of the status change and you should either revert the action or create a support case to remediate the issue.
+If you remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat:: If cluster administrator permissions were used, Red Hat is not responsible for any of your or your authorized users’ actions, including those that affect infrastructure services, service availability, or data loss. If Red Hat detects any such actions, the cluster might transition to a Limited Support status. Red Hat notifies you of the status change and you should either revert the action or create a support case to explore remediation steps that might require you to delete and recreate the cluster.
 
-If you have questions about the violating factors that cause a cluster to transition to a Limited Support status or need further assistance, open a support ticket.
+If you have questions about a specific action that might cause a cluster to transition to a Limited Support status or need further assistance, open a support ticket.
 
 [id="rosa-sdpolicy-support_{context}"]
 == Support

--- a/modules/sdpolicy-account-management.adoc
+++ b/modules/sdpolicy-account-management.adoc
@@ -195,17 +195,17 @@ Any SLAs for the service itself are defined in Appendix 4 of the link:https://ww
 [id="limited-support_{context}"]
 == Limited support status
 
-When a cluster transitions to a _Limited Support_ status, it means that the SLA is no longer applicable and credits requested against the SLA are denied. It does not mean that you no longer have product support. You can return the cluster to a fully-supported status by remediating the violating factors.
+When a cluster transitions to a _Limited Support_ status, Red Hat no longer proactively monitors the cluster, the SLA is no longer applicable, and credits requested against the SLA are denied. It does not mean that you no longer have product support. In some cases, the cluster can return to a fully-supported status if you remediate the violating factors. However, in other cases, you might have to delete and recreate the cluster.
 
-A cluster transitions to a Limited Support status in the following scenarios:
+A cluster might transition to a Limited Support status for many reasons, including the following scenarios:
 
-If you do not upgrade a cluster to a supported version before the end-of-life date:: Red Hat does not make any runtime or SLA guarantees for versions after their end-of-life date. To receive continued support, upgrade the cluster to a supported version within the 9-month period. If you do not upgrade the cluster within the 9-month period, the cluster transitions to a Limited Support status until you upgrade it to a supported version.
+If you do not upgrade a cluster to a supported version before the end-of-life date:: Red Hat does not make any runtime or SLA guarantees for versions after their end-of-life date. To receive continued support, upgrade the cluster to a supported version prior to the end-of-life date. If you do not upgrade the cluster prior to the end-of-life date, the cluster transitions to a Limited Support status until it is upgraded to a supported version.
 +
 Red Hat provides commercially reasonable support to upgrade from an unsupported version to a supported version. However, if a supported upgrade path is no longer available, you might have to create a new cluster and migrate your workloads.
 
-If you remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat:: If you used the cluster administrator rights, Red Hat is not responsible for any of your or your authorized users’ actions, including those that affect infrastructure services, service availability, or data loss. If Red Hat detects any such actions, the cluster transitions to a Limited Support status. Red Hat notifies you of the status change and you should either revert the action or create a support case to remediate the issue.
+If you remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat:: If cluster administrator permissions were used, Red Hat is not responsible for any of your or your authorized users’ actions, including those that affect infrastructure services, service availability, or data loss. If Red Hat detects any such actions, the cluster might transition to a Limited Support status. Red Hat notifies you of the status change and you should either revert the action or create a support case to explore remediation steps that might require you to delete and recreate the cluster.
 
-If you have questions about the violating factors that cause a cluster to transition to a Limited Support status or need further assistance, open a support ticket.
+If you have questions about a specific action that might cause a cluster to transition to a Limited Support status or need further assistance, open a support ticket.
 
 [id="support_{context}"]
 == Support


### PR DESCRIPTION
This PR is to address the JIRA issue: https://issues.redhat.com/browse/OSDOCS-3542

Following is the change:
There were a few minor updates to the recently updated 'Limited Support Status' section (precursor JIRA issue: [OSDOCS-3384](https://issues.redhat.com/browse/OSDOCS-3384)) in both OSD and ROSA docs. The reason was that the content implied that there were only a limited set of reasons for a cluster to go in Limited Support which is not entirely correct. The latest updates make this content a bit generic.

The **same** doc change is seen in the following topics:
ROSA topics:

- https://deploy-preview-45586--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-limited-support_rosa-service-definition
- https://deploy-preview-45586--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html#rosa-limited-support_rosa-life-cycle

OSD topics:

- https://deploy-preview-45586--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/osd-service-definition.html#limited-support_osd-service-definition
- https://deploy-preview-45586--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/osd-life-cycle.html#rosa-limited-support_osd-life-cycle

Repo: Request cherrypick to enterprise-4.10 and enterprise-4.11