### PR TITLE
BZ2083845: poddisruptionbudget example contains deprecated policy/v1beta1

### DIFF
--- a/modules/nodes-pods-pod-disruption-configuring.adoc
+++ b/modules/nodes-pods-pod-disruption-configuring.adoc
@@ -19,7 +19,7 @@ To configure a pod disruption budget:
 +
 [source,yaml]
 ----
-apiVersion: policy/v1beta1 <1>
+apiVersion: policy/v1 <1>
 kind: PodDisruptionBudget
 metadata:
   name: my-pdb
@@ -29,17 +29,17 @@ spec:
     matchLabels:
       foo: bar
 ----
-<1> `PodDisruptionBudget` is part of the `policy/v1beta1` API group.
+<1> `PodDisruptionBudget` is part of the `policy/v1` API group.
 <2> The minimum number of pods that must be available simultaneously. This can
 be either an integer or a string specifying a percentage, for example, `20%`.
 <3> A label query over a set of resources. The result of `matchLabels` and
- `matchExpressions` are logically conjoined.
+ `matchExpressions` are logically conjoined. Leave this paramter blank, for example `selector {}`, to select all pods in the project.
 +
 Or:
 +
 [source,yaml]
 ----
-apiVersion: policy/v1beta1 <1>
+apiVersion: policy/v1 <1>
 kind: PodDisruptionBudget
 metadata:
   name: my-pdb
@@ -49,11 +49,11 @@ spec:
     matchLabels:
       foo: bar
 ----
-<1> `PodDisruptionBudget` is part of the `policy/v1beta1` API group.
+<1> `PodDisruptionBudget` is part of the `policy/v1` API group.
 <2> The maximum number of pods that can be unavailable simultaneously. This can
 be either an integer or a string specifying a percentage, for example, `20%`.
 <3> A label query over a set of resources. The result of `matchLabels` and
- `matchExpressions` are logically conjoined.
+ `matchExpressions` are logically conjoined. Leave this paramter blank, for example `selector {}`, to select all pods in the project.
 
 . Run the following command to add the object to project:
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2083845

poddisruptionbudget should be version policy/v1  not policy/v1beta1 as of kubernetes v1.21.

4.8+ as Kubernetes 1.21 was introduced in 4.8.

Preview: [Specifying the number of pods that must be up with pod disruption budgets](https://deploy-preview-45589--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-pod-disruption-configuring_nodes-pods-configuring)
