### PR TITLE
OSSMDOC-576: Updating distributed tracing module IDs to match file names.

### DIFF
--- a/modules/distr-tracing-architecture.adoc
+++ b/modules/distr-tracing-architecture.adoc
@@ -4,7 +4,7 @@ This module included in the following assemblies:
 -dist_tracing_arch/distr-tracing-architecture.adoc
 ////
 :_content-type: CONCEPT
-[id="distributed-tracing-architecture_{context}"]
+[id="distr-tracing-architecture_{context}"]
 = {DTProductName} architecture
 
 {DTProductName} is made up of several components that work together to collect, store, and display tracing data.

--- a/modules/distr-tracing-change-operator-20.adoc
+++ b/modules/distr-tracing-change-operator-20.adoc
@@ -3,7 +3,7 @@ This PROCEDURE module included in the following assemblies:
 - /dist_tracing_install/dist-tracing-updating.adoc
 ////
 
-[id="dist-tracing-changing-operator-channel_{context}"]
+[id="distr-tracing-change-operator-20_{context}"]
 = Changing the Operator channel for 2.0
 
 {DTProductName} 2.0.0 made the following changes:

--- a/modules/distr-tracing-config-otel-collector.adoc
+++ b/modules/distr-tracing-config-otel-collector.adoc
@@ -3,7 +3,7 @@ This module included in the following assemblies:
 -distr_tracing_install/distributed-tracing-deploying-otel.adoc
 ////
 :_content-type: REFERENCE
-[id="distributed-tracing-config-otel-collector_{context}"]
+[id="distr-tracing-config-otel-collector_{context}"]
 = OpenTelemetry Collector configuration options
 
 [IMPORTANT]

--- a/modules/distr-tracing-features.adoc
+++ b/modules/distr-tracing-features.adoc
@@ -4,7 +4,7 @@ This module included in the following assemblies:
 -dist_tracing_arch/distr-tracing-architecture.adoc
 ////
 
-[id="distributed-tracing-features_{context}"]
+[id="distr-tracing-features_{context}"]
 = {DTProductName} features
 
 {DTProductName} provides the following capabilities:

--- a/modules/distr-tracing-install-elasticsearch.adoc
+++ b/modules/distr-tracing-install-elasticsearch.adoc
@@ -4,7 +4,7 @@ This module included in the following assemblies:
 ////
 
 :_content-type: PROCEDURE
-[id="distributed-tracing-operator-install-elasticsearch_{context}"]
+[id="distr-tracing-install-elasticsearch_{context}"]
 = Installing the OpenShift Elasticsearch Operator
 
 The default {JaegerName} deployment uses in-memory storage because it is designed to be installed quickly for those evaluating {DTProductName}, giving demonstrations, or using {JaegerName} in a test environment. If you plan to use {JaegerName} in production, you must install and configure a persistent storage option, in this case, Elasticsearch.

--- a/modules/distr-tracing-install-jaeger-operator.adoc
+++ b/modules/distr-tracing-install-jaeger-operator.adoc
@@ -4,7 +4,7 @@ This module included in the following assemblies:
 ////
 
 :_content-type: PROCEDURE
-[id="distr-tracing-jaeger-operator-install_{context}"]
+[id="distr-tracing-install-jaeger-operator_{context}"]
 = Installing the {JaegerName} Operator
 
 To install {JaegerName}, you use the link:https://operatorhub.io/[OperatorHub] to install the {JaegerName} Operator.

--- a/modules/distr-tracing-install-otel-operator.adoc
+++ b/modules/distr-tracing-install-otel-operator.adoc
@@ -4,7 +4,7 @@ This module included in the following assemblies:
 ////
 
 :_content-type: PROCEDURE
-[id="distr-tracing-otel-operator-install_{context}"]
+[id="distr-tracing-install-otel-operator_{context}"]
 = Installing the {OTELName} Operator
 
 [IMPORTANT]

--- a/modules/distr-tracing-install-overview.adoc
+++ b/modules/distr-tracing-install-overview.adoc
@@ -4,7 +4,7 @@ This module included in the following assemblies:
 ////
 
 :_content-type: CONCEPT
-[id="distributed-tracing-install-overview_{context}"]
+[id="distr-tracing-install-overview_{context}"]
 = {DTProductName} installation overview
 
 The steps for installing {DTProductName} are as follows:

--- a/modules/distr-tracing-product-overview.adoc
+++ b/modules/distr-tracing-product-overview.adoc
@@ -5,7 +5,7 @@ This module included in the following assemblies:
 ////
 
 :_content-type: CONCEPT
-[id="distributed-tracing-product-overview_{context}"]
+[id="distr-tracing-product-overview_{context}"]
 = Distributed tracing overview
 
 As a service owner, you can use distributed tracing to instrument your services to gather insights into your service architecture.

--- a/modules/distr-tracing-removing-instance-cli.adoc
+++ b/modules/distr-tracing-removing-instance-cli.adoc
@@ -3,7 +3,7 @@ This module included in the following assemblies:
 - distr_tracing_install/dist-tracing-removing.adoc
 ////
 
-[id="dist-tracing-removing-cli_{context}"]
+[id="distr-tracing-removing-instance-cli_{context}"]
 = Removing a {JaegerName} instance from the CLI
 
 . Log in to the {product-title} CLI.

--- a/modules/distr-tracing-removing-instance.adoc
+++ b/modules/distr-tracing-removing-instance.adoc
@@ -4,7 +4,7 @@ This module included in the following assemblies:
 ////
 
 :_content-type: PROCEDURE
-[id="distr-tracing-removing_{context}"]
+[id="distr-tracing-removing-instance_{context}"]
 = Removing a {JaegerName} instance using the web console
 
 [NOTE]

--- a/modules/distr-tracing-rn-technology-preview.adoc
+++ b/modules/distr-tracing-rn-technology-preview.adoc
@@ -3,7 +3,7 @@ Module included in the following assemblies:
 - rhbjaeger-release-notes.adoc
 ////
 :_content-type: CONCEPT
-[id="distr-tracing-rn-tech-preview_{context}"]
+[id="distr-tracing-rn-technology-preview_{context}"]
 = {DTProductName} Technology Preview
 ////
 Provide the following info for each issue if possible:

--- a/modules/distr-tracing-sidecar-automatic.adoc
+++ b/modules/distr-tracing-sidecar-automatic.adoc
@@ -3,7 +3,7 @@ This module included in the following assemblies:
 - distr_tracing_install/distr-tracing-deploying-jaeger.adoc
 ////
 :_content-type: REFERENCE
-[id="dist-tracing-sidecar-automatic_{context}"]
+[id="distr-tracing-sidecar-automatic_{context}"]
 = Automatically injecting sidecars
 
 To enable this feature, add the `sidecar.jaegertracing.io/inject` annotation to either the string `true` or to the {JaegerShortName} instance name that is returned by running `$ oc get jaegers`.

--- a/modules/distr-tracing-upgrading-es5-es6.adoc
+++ b/modules/distr-tracing-upgrading-es5-es6.adoc
@@ -3,7 +3,7 @@ This module included in the following assemblies:
 - distr_tracing_install/distr-tracing-updating
 ////
 
-[id="upgrading_es5_es6_{context}"]
+[id="distr-tracing-upgrading-es5-es6_{context}"]
 = Upgrading from Elasticsearch 5 to 6
 
 When updating from Elasticsearch 5 to 6, you must delete your {JaegerShortName} instance, and then recreate the {JaegerShortName} instance because of an issue with certificates. Re-creating the {JaegerShortName} instance triggers the creation of a new set of certificates. If you are using persistent storage, the same volumes can be mounted for the new {JaegerShortName} instance as long as the {JaegerShortName} name and namespace for the new {JaegerShortName} instance are the same as the deleted {JaegerShortName} instance.


### PR DESCRIPTION
Between splitting out the Jaeger files from service mesh and then rebranding to distributed tracing, there has been some file name changes.  Updating the distributed tracing module IDs to match the file names.

Version(s): 4.6 - 4.11

Issue: [OSSMDOC-576](https://issues.redhat.com/browse/OSSMDOC-576)

Link to docs preview:

