### PR TITLE
OSDOCS-3628: Adding ability to create an ingress route with a custom certificate

### DIFF
--- a/modules/nw-ingress-creating-a-route-via-an-ingress.adoc
+++ b/modules/nw-ingress-creating-a-route-via-an-ingress.adoc
@@ -24,6 +24,7 @@ metadata:
   name: frontend
   annotations:
     route.openshift.io/termination: "reencrypt" <1>
+    route.openshift.io/destination-ca-certificate-secret: secret-ca-cert <2>
 spec:
   rules:
   - host: www.example.com
@@ -63,14 +64,18 @@ other values are silently ignored. When the annotation value is unset, `edge` is
               port:
                 number: 443
 ----
-
 +
 [source,terminal]
 ----
 $ oc apply -f ingress.yaml
 ----
 +
+<2> The `route.openshift.io/destination-ca-certificate-secret` can be used on an Ingress Object to define a route with a custom certificate (CA). The annotation references a kubernetes secret, `secret-ca-cert` that is inserted into the generated route.
 
+
+.. To specify a route object with a destination CA from an ingress object, you must create a `kubernetes.io/tls` or `Opaque` type secret with a certificate in PEM-encoded format in the `data.tls.crt` specifier of the secret.
+
++
 . List your routes:
 +
 [source,terminal]
@@ -117,6 +122,10 @@ spec:
       [...]
       -----END RSA PRIVATE KEY-----
     termination: reencrypt
+    destinationCACertificate: |-
+      -----BEGIN CERTIFICATE-----
+      [...]
+      -----END CERTIFICATE-----
   to:
     kind: Service
     name: frontend

--- a/modules/nw-ingress-reencrypt-route-custom-cert.adoc
+++ b/modules/nw-ingress-reencrypt-route-custom-cert.adoc
@@ -1,0 +1,54 @@
+// This is included in the following assemblies:
+//
+// networking/routes/route-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="creating-re-encrypt-route-with-custom-certificate_{context}"]
+= Creating an Ingress route with a custom certificate
+The `route.openshift.io/destination-ca-certificate-secret` annotation can be used to define an Ingress route with a custom certificate (CA).
+
+.Prerequisites
+* You must have a certificate/key pair in PEM-encoded files, where the certificate is valid for the route host.
+* You may have a separate CA certificate in a PEM-encoded file that completes the certificate chain.
+* You must have a separate destination CA certificate in a PEM-encoded file.
+* You must have a service that you want to expose.
+
+
+.Procedure
+
+. Add the `route.openshift.io/destination-ca-certificate-secret` to the Ingress object annotations:
++
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+  annotations:
+    route.openshift.io/termination: "reencrypt"
+    route.openshift.io/destination-ca-certificate-secret: secret-ca-cert <1>
+...
+----
+<1> The annotation references a kubernetes secret.
+
++
+. The Ingress-to-route controller inserts the value of the secret object into the target route
++
+.Example output
+[source,yaml]
+----
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: frontend
+  Annotations:
+    route.openshift.io/termination: reencrypt
+    route.openshift.io/destination-ca-certificate-secret: secret-ca-cert
+spec:
+...
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+    creadestinationCACertificate: cacert-string
+...
+----


### PR DESCRIPTION
Version:
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3628

Link to docs preview: https://deploy-preview-45603--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#creating-re-encrypt-route-with-custom-certificate_route-configuration

