### PR TITLE
OSDOCS: General OCM link cleanup.

### DIFF
--- a/modules/disabling-insights-advisor-recommendations.adoc
+++ b/modules/disabling-insights-advisor-recommendations.adoc
@@ -6,26 +6,26 @@
 [id="disabling-insights-advisor-recommendations_{context}"]
 = Disabling Insights Advisor recommendations
 
-You can disable specific recommendations that affect your clusters, so that they no longer appear in your reports. It is possible to disable a recommendation for a single cluster or all of your clusters. 
+You can disable specific recommendations that affect your clusters, so that they no longer appear in your reports. It is possible to disable a recommendation for a single cluster or all of your clusters.
 
 [NOTE]
 ====
-Disabling a recommendation for all of your clusters also applies to any future clusters. 
+Disabling a recommendation for all of your clusters also applies to any future clusters.
 ====
 
 .Prerequisites
 
 * Remote health reporting is enabled, which is the default.
-* Your cluster is registered on link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
-* You are logged in to link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
+* Your cluster is registered on {cluster-manager-url}.
+* You are logged in to {cluster-manager-url}.
 
 .Procedure
 
-. Navigate to *Advisor* -> *Recommendations* on link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
-. Click the name of the recommendation to disable. You are directed to the single recommendation page. 
+. Navigate to *Advisor* -> *Recommendations* on {cluster-manager-url}.
+. Click the name of the recommendation to disable. You are directed to the single recommendation page.
 . To disable the recommendation for a single cluster:
 .. Click the *Options* menu {kebab} for that cluster, and then click *Disable recommendation for cluster*.
-.. Enter a justification note and click *Save*. 
+.. Enter a justification note and click *Save*.
 . To disable the recommendation for all of your clusters:
-.. Click *Actions* -> *Disable recommendation*. 
-.. Enter a justification note and click *Save*. 
+.. Click *Actions* -> *Disable recommendation*.
+.. Enter a justification note and click *Save*.

--- a/modules/displaying-all-insights-advisor-recommendations.adoc
+++ b/modules/displaying-all-insights-advisor-recommendations.adoc
@@ -12,11 +12,11 @@ The Recommendations view, by default, only displays the recommendations that are
 
 * Remote health reporting is enabled, which is the default.
 * Your cluster is link:https://console.redhat.com/openshift/register[registered] on Red Hat Hybrid Cloud Console.
-* You are logged in to link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
+* You are logged in to {cluster-manager-url}.
 
-.Procedure 
+.Procedure
 
-. Navigate to *Advisor* -> *Recommendations* on link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
+. Navigate to *Advisor* -> *Recommendations* on {cluster-manager-url}.
 . Click the *X* icons next to the *Clusters Impacted* and *Status* filters.
-+ 
-You can now browse through all of the potential recommendations for your cluster. 
++
+You can now browse through all of the potential recommendations for your cluster.

--- a/modules/displaying-potential-issues-with-your-cluster.adoc
+++ b/modules/displaying-potential-issues-with-your-cluster.adoc
@@ -6,19 +6,19 @@
 [id="displaying-potential-issues-with-your-cluster_{context}"]
 = Displaying potential issues with your cluster
 
-This section describes how to display the Insights report in *Insights Advisor* on link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
+This section describes how to display the Insights report in *Insights Advisor* on {cluster-manager-url}.
 
 Note that Insights repeatedly analyzes your cluster and shows the latest results. These results can change, for example, if you fix an issue or a new issue has been detected.
 
 .Prerequisites
 
-* Your cluster is registered on link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
+* Your cluster is registered on {cluster-manager-url}.
 * Remote health reporting is enabled, which is the default.
-* You are logged in to link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
+* You are logged in to {cluster-manager-url}.
 
 .Procedure
 
-. Navigate to *Advisor* -> *Recommendations* on link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
+. Navigate to *Advisor* -> *Recommendations* on {cluster-manager-url}.
 +
 Depending on the result, Insights Advisor displays one of the following:
 +

--- a/modules/enabling-insights-advisor-recommendations.adoc
+++ b/modules/enabling-insights-advisor-recommendations.adoc
@@ -11,12 +11,12 @@ When a recommendation is disabled for all clusters, you will no longer see the r
 .Prerequisites
 
 * Remote health reporting is enabled, which is the default.
-* Your cluster is registered on link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
-* You are logged in to link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
+* Your cluster is registered on {cluster-manager-url}.
+* You are logged in to {cluster-manager-url}.
 
 .Procedure
 
-. Navigate to *Advisor* -> *Recommendations* on link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
+. Navigate to *Advisor* -> *Recommendations* on {cluster-manager-url}.
 . Filter the recommendations by *Status* -> *Disabled*.
 . Locate the recommendation to enable.
 . Click the *Options* menu {kebab}, and then click *Enable recommendation*.

--- a/modules/understanding-telemetry-and-insights-operator-data-flow.adoc
+++ b/modules/understanding-telemetry-and-insights-operator-data-flow.adoc
@@ -8,7 +8,7 @@
 
 The Telemeter Client collects selected time series data from the Prometheus API. The time series data is uploaded to api.openshift.com every four minutes and thirty seconds for processing.
 
-The Insights Operator gathers selected data from the Kubernetes API and the Prometheus API into an archive. The archive is uploaded to link:https://console.redhat.com[console.redhat.com] every two hours for processing. The Insights Operator also downloads the latest Insights analysis from link:https://console.redhat.com[console.redhat.com]. This is used to populate the *Insights status* pop-up that is included in the *Overview* page in the {product-title} web console.
+The Insights Operator gathers selected data from the Kubernetes API and the Prometheus API into an archive. The archive is uploaded to {cluster-manager-url} every two hours for processing. The Insights Operator also downloads the latest Insights analysis from {cluster-manager-url}. This is used to populate the *Insights status* pop-up that is included in the *Overview* page in the {product-title} web console.
 
 All of the communication with Red Hat occurs over encrypted channels by using Transport Layer Security (TLS) and mutual certificate authentication. All of the data is encrypted in transit and at rest.
 

--- a/monitoring/osd-managing-metrics.adoc
+++ b/monitoring/osd-managing-metrics.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-{product-title} collects metrics for <noun_goes_here>, and you can use <noun_goes_here> to query and visualize them.
+You can collect metrics to monitor how cluster components and your own workloads are performing.
 
 // Understanding metrics
 include::modules/osd-monitoring-understanding-metrics.adoc[leveloffset=+1]

--- a/support/remote_health_monitoring/about-remote-health-monitoring.adoc
+++ b/support/remote_health_monitoring/about-remote-health-monitoring.adoc
@@ -15,7 +15,7 @@ A cluster that reports data to Red Hat through Telemetry and the Insights Operat
 
 *Telemetry* is the term that Red Hat uses to describe the information being sent to Red Hat by the {product-title} Telemeter Client. Lightweight attributes are sent from connected clusters to Red Hat to enable subscription management automation, monitor the health of clusters, assist with support, and improve customer experience.
 
-The *Insights Operator* gathers {product-title} configuration data and sends it to Red Hat. The data is used to produce insights about potential issues that a cluster might be exposed to. These insights are communicated to cluster administrators on link:https://console.redhat.com/openshift[console.redhat.com/openshift].
+The *Insights Operator* gathers {product-title} configuration data and sends it to Red Hat. The data is used to produce insights about potential issues that a cluster might be exposed to. These insights are communicated to cluster administrators on {cluster-manager-url}.
 
 More information is provided in this document about these two processes.
 
@@ -31,7 +31,7 @@ Telemetry and the Insights Operator enable the following benefits for end-users:
 
 * *A streamlined support experience*. You can provide a cluster ID for a connected cluster when creating a support ticket on the link:https://access.redhat.com/support/[Red Hat Customer Portal]. This enables Red Hat to deliver a streamlined support experience that is specific to your cluster, by using the connected information. This document provides more information about that enhanced support experience.
 
-* *Predictive analytics*. The insights displayed for your cluster on link:https://console.redhat.com/openshift/[console.redhat.com/openshift] are enabled by the information collected from connected clusters. Red Hat is investing in applying deep learning, machine learning, and artificial intelligence automation to help identify issues that {product-title} clusters are exposed to.
+* *Predictive analytics*. The insights displayed for your cluster on {cluster-manager-url} are enabled by the information collected from connected clusters. Red Hat is investing in applying deep learning, machine learning, and artificial intelligence automation to help identify issues that {product-title} clusters are exposed to.
 
 ifdef::openshift-origin[]
 {product-title} may be installed without a pull secret received at console.redhat.com. In this case default imagestreams will not be imported and telemetry data will not be sent.

--- a/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
+++ b/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
@@ -9,7 +9,7 @@ endif::[]
 
 toc::[]
 
-Insights repeatedly analyzes the data Insights Operator sends. Users of {product-title} can display the report in the *Insights* tab of each cluster on link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
+Insights repeatedly analyzes the data Insights Operator sends. Users of {product-title} can display the report in the *Insights* tab of each cluster on {cluster-manager-url}.
 
 include::modules/insights-operator-advisor-overview.adoc[leveloffset=+1]
 include::modules/insights-operator-advisor-recommendations.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
Enterprise 4.9+

Link to docs preview:

- Managing Metrics - Fixed the `<add_noun>` placeholder - https://deploy-preview-45604--osdocs.netlify.app/openshift-dedicated/latest/monitoring/osd-managing-metrics.html
- About Remote Health Monitoring - https://deploy-preview-45604--osdocs.netlify.app/openshift-dedicated/latest/support/remote_health_monitoring/about-remote-health-monitoring.html
- This page should have the rest of the modules - https://deploy-preview-45604--osdocs.netlify.app/openshift-dedicated/latest/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.html

Additional information:
This PR fixes some relic links to OCM.