### PR TITLE
BZ#2004210: Restructuring modules and ensuring compliance with style guide.

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -17,24 +17,9 @@ include::modules/ipi-install-extracting-the-openshift-installer.adoc[leveloffset
 include::modules/ipi-install-creating-an-rhcos-images-cache.adoc[leveloffset=+1]
 
 [id="ipi-install-configuration-files"]
-== Configuration files
+== Configuring the install-config.yaml file
 
 include::modules/ipi-install-configuring-the-install-config-file.adoc[leveloffset=+2]
-
-include::modules/ipi-install-setting-proxy-settings-within-install-config.adoc[leveloffset=+2]
-
-include::modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc[leveloffset=+2]
-
-include::modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc[leveloffset=+2]
-
-include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../release_notes/ocp-4-11-release-notes.adoc#ocp-4-11-known-issues[OpenShift Container Platform 4.11 release notes]
-
-include::modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc[leveloffset=+2]
 
 include::modules/ipi-install-additional-install-config-parameters.adoc[leveloffset=+2]
 
@@ -48,19 +33,37 @@ include::modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc[leveloffset=+2
 
 include::modules/ipi-install-root-device-hints.adoc[leveloffset=+2]
 
+include::modules/ipi-install-setting-proxy-settings-within-install-config.adoc[leveloffset=+2]
+
+include::modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc[leveloffset=+2]
+
+include::modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc[leveloffset=+2]
+
+include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../release_notes/ocp-4-11-release-notes.adoc#ocp-4-11-known-issues[OpenShift Container Platform 4.11 release notes]
+
+include::modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc[leveloffset=+2]
+
+[id="ipi-install-manifest-configuration-files"]
+== Manifest configuration files
+
 include::modules/ipi-install-creating-the-openshift-manifests.adoc[leveloffset=+2]
 
 include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leveloffset=+2]
 
 include::modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc[leveloffset=+2]
 
+include::modules/ipi-install-deploying-routers-on-worker-nodes.adoc[leveloffset=+2]
+
 include::modules/ipi-install-configuring-bios-for-worker-node.adoc[leveloffset=+2]
 
 include::modules/ipi-install-configuring-raid-for-worker-node.adoc[leveloffset=+2]
 
 include::modules/ipi-install-creating-a-disconnected-registry.adoc[leveloffset=+1]
-
-include::modules/ipi-install-deploying-routers-on-worker-nodes.adoc[leveloffset=+1]
 
 include::modules/ipi-install-validation-checklist-for-installation.adoc[leveloffset=+1]
 
@@ -71,6 +74,6 @@ include::modules/ipi-install-following-the-installation.adoc[leveloffset=+1]
 include::modules/ipi-install-verifying-static-ip-address-configuration.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
 
 * xref:../../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[{product-title} upgrade channels and releases]

--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -199,6 +199,6 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 
 | `networkConfig`
 |
-| Set this optional parameter to configure the network interface of a host. See "(Optional) Configuring host network interfaces in the `install-config.yaml` file" for additional details.
+| Set this optional parameter to configure the network interface of a host. See "(Optional) Configuring host network interfaces" for additional details.
 
 |===

--- a/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
+++ b/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id='configure-network-components-to-run-on-the-control-plane_{context}']
-= (Optional) Configure network components to run on the control plane
+= (Optional) Configuring network components to run on the control plane
 
 You can configure networking components to run exclusively on the control plane nodes. By default, {product-title} allows any node in the machine config pool to host the `ingressVIP` virtual IP address. However, some environments deploy worker nodes in separate subnets from the control plane nodes. When deploying remote workers in separate subnets, you must place the `ingressVIP` virtual IP address exclusively with the control plane nodes.
 

--- a/modules/ipi-install-configuring-bios-for-worker-node.adoc
+++ b/modules/ipi-install-configuring-bios-for-worker-node.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="configuring-bios-for-worker-node_{context}"]
-= Configuring the BIOS for worker nodes
+= (Optional) Configuring the BIOS for worker nodes
 
 The following procedure configures the BIOS for a worker node during the installation process.
 

--- a/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="configuring-host-network-interfaces-in-the-install-config-yaml-file_{context}"]
-= (Optional) Configuring host network interfaces in the `install-config.yaml` file
+= (Optional) Configuring host network interfaces
 
 During installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState. To use the `networkConfig` configuration setting, you must provide an NMState YAML configuration.
 

--- a/modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="configuring-managed-secure-boot-in-the-install-config-file_{context}"]
-= (Optional) Configuring managed Secure Boot in the `install-config.yaml` file
+= (Optional) Configuring managed Secure Boot
 
 You can enable managed Secure Boot when deploying an installer-provisioned cluster using Redfish BMC addressing, such as `redfish`, `redfish-virtualmedia`, or `idrac-virtualmedia`. To enable managed Secure Boot, add the `bootMode` configuration setting to each node:
 

--- a/modules/ipi-install-configuring-raid-for-worker-node.adoc
+++ b/modules/ipi-install-configuring-raid-for-worker-node.adoc
@@ -4,18 +4,19 @@
 
 :_content-type: PROCEDURE
 [id="configuring-raid-for-worker-node_{context}"]
-= Configuring RAID for worker nodes
+= (Optional) Configuring RAID for worker nodes
 
-The following procedure configures RAID (Redundant Array of Independent Disks) for the worker node during the installation process.
+The following procedure configures a redundant array of independent disks (RAID) for the worker node during the installation process.
 
 [NOTE]
 ====
-. Only nodes with BMC (Baseboard Management Controller) type `irmc` are supported. Other types of nodes are currently not supported.
-. If you want to configure hardware RAID for the node, make sure the node has a RAID controller.
+. Only nodes with baseboard management controller (BMC) type `irmc` are supported. Other types of nodes are currently not supported.
+. If you want to configure a hardware RAID for the node, make sure the node has a RAID controller.
 ====
 
 .Procedure
-. Create manifests.
+
+. Create the manifests.
 
 . Modify the BMH (Bare Metal Host) file corresponding to the worker:
 +
@@ -55,4 +56,4 @@ spec:
 +
 .. If you do not add a `raid` field in the `spec` section, the original RAID configuration is not deleted, and no new configuration will be performed.
 
-. Create cluster.
+. Create the cluster.

--- a/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -26,23 +26,31 @@ Make the following changes to the registry node.
 
 .Procedure
 
-. Open the firewall port on the registry node.
+. Open the firewall port on the registry node:
 +
 [source,terminal]
 ----
 $ sudo firewall-cmd --add-port=5000/tcp --zone=libvirt  --permanent
+----
++
+[source,terminal]
+----
 $ sudo firewall-cmd --add-port=5000/tcp --zone=public   --permanent
+----
++
+[source,terminal]
+----
 $ sudo firewall-cmd --reload
 ----
 
-. Install the required packages for the registry node.
+. Install the required packages for the registry node:
 +
 [source,terminal]
 ----
 $ sudo yum -y install python3 podman httpd httpd-tools jq
 ----
 
-. Create the directory structure where the repository information will be held.
+. Create the directory structure where the repository information will be held:
 +
 [source,terminal]
 ----
@@ -55,18 +63,45 @@ Generate a self-signed certificate for the registry node and put it in the `/opt
 
 .Procedure
 
-. Adjust the certificate information as appropriate.
+. Adjust the certificate information as appropriate:
 +
 [source,terminal]
 ----
 $ host_fqdn=$( hostname --long )
+----
++
+[source,terminal]
+----
 $ cert_c="<Country Name>"   # Country Name (C, 2 letter code)
+----
++
+[source,terminal]
+----
 $ cert_s="<State>"          # Certificate State (S)
+----
++
+[source,terminal]
+----
 $ cert_l="<Locality>"       # Certificate Locality (L)
+----
++
+[source,terminal]
+----
 $ cert_o="<Organization>"   # Certificate Organization (O)
+----
++
+[source,terminal]
+----
 $ cert_ou="<Org Unit>"      # Certificate Organizational Unit (OU)
+----
++
+[source,terminal]
+----
 $ cert_cn="${host_fqdn}"    # Certificate Common Name (CN)
-
+----
++
+[source,terminal]
+----
 $ openssl req \
     -newkey rsa:4096 \
     -nodes \
@@ -81,11 +116,15 @@ $ openssl req \
 +
 NOTE: When replacing `<Country Name>`, ensure that it only contains two letters. For example, `US`.
 
-. Update the registry node's `ca-trust` with the new certificate.
+. Update the registry node's `ca-trust` with the new certificate:
 +
 [source,terminal]
 ----
 $ sudo cp /opt/registry/certs/domain.crt /etc/pki/ca-trust/source/anchors/
+----
++
+[source,terminal]
+----
 $ sudo update-ca-trust extract
 ----
 
@@ -97,7 +136,7 @@ The registry container uses `httpd` and needs an `htpasswd` file for authenticat
 
 .Procedure
 
-. Create an `htpasswd` file in `/opt/registry/auth` for the container to use.
+. Create an `htpasswd` file in `/opt/registry/auth` for the container to use:
 +
 [source,terminal]
 ----
@@ -106,7 +145,7 @@ $ htpasswd -bBc /opt/registry/auth/htpasswd <user> <passwd>
 +
 Replace `<user>` with the user name and `<passwd>` with the password.
 
-. Create and start the registry container.
+. Create the registry container:
 +
 [source,terminal]
 ----
@@ -125,6 +164,8 @@ $ podman create \
   -v /opt/registry/certs:/certs:z \
   docker.io/library/registry:2
 ----
+
+. Start the registry container:
 +
 [source,terminal]
 ----
@@ -137,21 +178,21 @@ Copy the pull secret file from the provisioner node to the registry node and mod
 
 .Procedure
 
-. Copy the `pull-secret.txt` file.
+. Copy the `pull-secret.txt` file:
 +
 [source,terminal]
 ----
 $ scp kni@provisioner:/home/kni/pull-secret.txt pull-secret.txt
 ----
 
-. Update the `host_fqdn` environment variable with the fully qualified domain name of the registry node.
+. Update the `host_fqdn` environment variable with the fully qualified domain name of the registry node:
 +
 [source,terminal]
 ----
 $ host_fqdn=$( hostname --long )
 ----
 
-. Update the `b64auth` environment variable with the base64 encoding of the `http` credentials used to create the `htpasswd` file.
+. Update the `b64auth` environment variable with the base64 encoding of the `http` credentials used to create the `htpasswd` file:
 +
 [source,terminal]
 ----
@@ -160,14 +201,16 @@ $ b64auth=$( echo -n '<username>:<passwd>' | openssl base64 )
 +
 Replace `<username>` with the user name and `<passwd>` with the password.
 
-. Set the `AUTHSTRING` environment variable to use the `base64` authorization string. The `$USER` variable is an environment variable containing the name of the current user.
+. Set the `AUTHSTRING` environment variable to use the `base64` authorization string:
 +
 [source,terminal]
 ----
 $ AUTHSTRING="{\"$host_fqdn:5000\": {\"auth\": \"$b64auth\",\"email\": \"$USER@redhat.com\"}}"
 ----
++
+The `$USER` variable is an environment variable containing the name of the current user.
 
-. Update the `pull-secret.txt` file.
+. Update the `pull-secret.txt` file:
 +
 [source,terminal]
 ----
@@ -178,7 +221,7 @@ $ jq ".auths += $AUTHSTRING" < pull-secret.txt > pull-secret-update.txt
 
 .Procedure
 
-. Copy the `oc` binary from the provisioner node to the registry node.
+. Copy the `oc` binary from the provisioner node to the registry node:
 +
 [source,terminal]
 ----
@@ -217,7 +260,7 @@ $ LOCAL_REPO='<local_repository_name>'
 For `<local_repository_name>`, specify the name of the repository to create in your
 registry, such as `ocp4/openshift4`.
 
-. Mirror the remote install images to the local repository.
+. Mirror the remote install images to the local repository:
 +
 [source,terminal]
 ----
@@ -234,25 +277,57 @@ On the provisioner node, the `install-config.yaml` file should use the newly cre
 
 .Procedure
 
-. Add the disconnected registry node's certificate to the `install-config.yaml` file. The certificate should follow the `"additionalTrustBundle: |"` line and be properly indented, usually by two spaces.
+. Add the disconnected registry node's certificate to the `install-config.yaml` file:
 +
 [source,terminal]
 ----
 $ echo "additionalTrustBundle: |" >> install-config.yaml
+----
++
+The certificate should follow the `"additionalTrustBundle: |"` line and be properly indented, usually by two spaces.
++
+[source,terminal]
+----
 $ sed -e 's/^/  /' /opt/registry/certs/domain.crt >> install-config.yaml
 ----
 
-. Add the mirror information for the registry to the `install-config.yaml` file.
+. Add the mirror information for the registry to the `install-config.yaml` file:
 +
 [source,terminal]
 ----
 $ echo "imageContentSources:" >> install-config.yaml
-$ echo "- mirrors:" >> install-config.yaml
-$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
-$ echo "  source: quay.io/openshift-release-dev/ocp-release" >> install-config.yaml
-$ echo "- mirrors:" >> install-config.yaml
-$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
-$ echo "  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev" >> install-config.yaml
 ----
 +
-NOTE: Replace `registry.example.com` with the registry's fully qualified domain name.
+[source,terminal]
+----
+$ echo "- mirrors:" >> install-config.yaml
+----
++
+[source,terminal]
+----
+$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
+----
++
+Replace `registry.example.com` with the registry's fully qualified domain name.
++
+[source,terminal]
+----
+$ echo "  source: quay.io/openshift-release-dev/ocp-release" >> install-config.yaml
+----
++
+[source,terminal]
+----
+$ echo "- mirrors:" >> install-config.yaml
+----
++
+[source,terminal]
+----
+$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
+----
++
+Replace `registry.example.com` with the registry's fully qualified domain name.
++
+[source,terminal]
+----
+$ echo "  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev" >> install-config.yaml
+----

--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -133,4 +133,4 @@ platform:
 ----
 <1> Replace `<bootstrap_os_image>` with the value of `$BOOTSTRAP_OS_IMAGE`.
 +
-See the "Configuration files" section for additional details.
+See the "Configuring the install-config.yaml file" section for additional details.

--- a/modules/ipi-install-deploying-routers-on-worker-nodes.adoc
+++ b/modules/ipi-install-deploying-routers-on-worker-nodes.adoc
@@ -5,18 +5,18 @@
 
 :_content-type: PROCEDURE
 [id="deploying-routers-on-worker-nodes_{context}"]
-= Deploying routers on worker nodes
+= (Optional) Deploying routers on worker nodes
 
-During installation, the installer deploys router pods on worker nodes. By default, the installer installs two router pods. If the initial cluster has only one worker node, or if a deployed cluster requires additional routers to handle external traffic loads destined for services within the {product-title} cluster, you can create a `yaml` file to set an appropriate number of router replicas.
+During installation, the installer deploys router pods on worker nodes. By default, the installer installs two router pods. If a deployed cluster requires additional routers to handle external traffic loads destined for services within the {product-title} cluster, you can create a `yaml` file to set an appropriate number of router replicas.
+
+[IMPORTANT]
+====
+Deploying a cluster with only one worker node is not supported. While modifying the router replicas will address issues with the `degraded` state when deploying with one worker, the cluster loses high availability for the ingress API, which is not suitable for production environments.
+====
 
 [NOTE]
 ====
-By default, the installer deploys two routers. If the cluster has at least two worker nodes, you can skip this section.
-====
-
-[NOTE]
-====
-If the cluster has no worker nodes, the installer deploys the two routers on the control plane nodes by default. If the cluster has no worker nodes, you can skip this section.
+By default, the installer deploys two routers. If the cluster has no worker nodes, the installer deploys the two routers on the control plane nodes by default.
 ====
 
 .Procedure
@@ -49,5 +49,5 @@ Replace `<num-of-router-pods>` with an appropriate value. If working with just o
 +
 [source,terminal]
 ----
-cp ~/router-replicas.yaml clusterconfigs/openshift/99_router-replicas.yaml
+$ cp ~/router-replicas.yaml clusterconfigs/openshift/99_router-replicas.yaml
 ----

--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id='modifying-install-config-for-dual-stack-network_{context}']
-= (Optional) Modifying the `install-config.yaml` file for dual-stack network
+= (Optional) Deploying with dual-stack networking
 
 To deploy an {product-title} cluster with dual-stack networking, edit the `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings in the `install-config.yaml` file. Each setting must have two CIDR entries each. Ensure the first CIDR entry is the IPv4 setting and the second CIDR entry is the IPv6 setting.
 

--- a/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id='modifying-install-config-for-no-provisioning-network_{context}']
-= (Optional) Modifying the `install-config.yaml` file for no `provisioning` network
+= (Optional) Deploying with no `provisioning` network
 
 To deploy an {product-title} cluster without a `provisioning` network, make the following changes to the `install-config.yaml` file.
 

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -111,7 +111,7 @@ For the `baremetal` network, a network administrator must reserve a number of IP
 [IMPORTANT]
 .Reserving IP addresses so they become static IP addresses
 ====
-Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To configure static IP addresses with NMState, see "(Optional) Configuring host network interfaces in the `install-config.yaml` file" in the "Setting up the environment for an OpenShift installation" section.
+Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To configure static IP addresses with NMState, see "(Optional) Configuring host network interfaces" in the "Setting up the environment for an OpenShift installation" section.
 ====
 
 [IMPORTANT]

--- a/modules/ipi-install-setting-proxy-settings-within-install-config.adoc
+++ b/modules/ipi-install-setting-proxy-settings-within-install-config.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id='ipi-install-setting-proxy-settings-within-install-config_{context}']
-= (Optional) Setting proxy settings within the `install-config.yaml` file
+= (Optional) Setting proxy settings
 
 To deploy an {product-title} cluster using a proxy, make the following changes to the `install-config.yaml` file.
 

--- a/modules/ipi-install-validation-checklist-for-installation.adoc
+++ b/modules/ipi-install-validation-checklist-for-installation.adoc
@@ -13,6 +13,6 @@
 * [ ] The `bmc` parameter for the `install-config.yaml` has been configured.
 * [ ] Conventions for the values configured in the `bmc` `address` field have been applied.
 * [ ] Created the {product-title} manifests.
-* [ ] Created a disconnected registry (optional).
-* [ ] (optional) Validate disconnected registry settings if in use.
-* [ ] (optional) Deployed routers on worker nodes.
+* [ ] (Optional) Deployed routers on worker nodes.
+* [ ] (Optional) Created a disconnected registry.
+* [ ] (Optional) Validate disconnected registry settings if in use.


### PR DESCRIPTION
This PR:

1. Restructures the order in which modules appear in the TOC.
2. Shortens title lengths to omit install-config.yaml where the context is now implied.
3. Creates a "Manifest configuration files" section for modules that are related to manifests and not install-config.yaml.
4. Makes modifications to several modules to bring them into style compliance with the style guide.
5. Adds (Optional) to modules which are optional.

Preview URL: https://deploy-preview-45611--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-configuration-files

Versions: 4.10, 4.11
Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2004210

Signed-off-by: John Wilkins <jowilkin@redhat.com>