### PR TITLE
Removing GCP-related networking note in the ROSA docs

### DIFF
--- a/modules/ocm-networking-tab.adoc
+++ b/modules/ocm-networking-tab.adoc
@@ -12,7 +12,9 @@ The **Networking** tab provides a control plane API endpoint as well as the defa
 For Security Token Service (STS) installations, these options cannot be changed.
 ====
 
+ifndef::openshift-rosa[]
 [IMPORTANT]
 ====
 {cluster-manager-first} does not support the networking tab for {GCP} clusters unless the organization has the `capability.organization.create_gcp_non_ccs_cluster` permission attached.
 ====
+endif::openshift-rosa[]


### PR DESCRIPTION
This applies to `main`, `enterprise-4.11` and `enterprise-4.10` only.

The PR removes a GCP-related networking note from the OCM overview page in the ROSA library. The note is not applicable to ROSA.

Previews for both of the assemblies that use the updated module are as follows:

* OSD: https://deploy-preview-45614--osdocs.netlify.app/openshift-dedicated/latest/ocm/ocm-overview.html#ocm-networking-tab_ocm-overview
* ROSA: https://deploy-preview-45614--osdocs.netlify.app/openshift-rosa/latest/ocm/ocm-overview.html#ocm-networking-tab_ocm-overview