### PR TITLE
Updates for BZ2074893

### DIFF
--- a/modules/psap-installing-node-feature-discovery-operator.adoc
+++ b/modules/psap-installing-node-feature-discovery-operator.adoc
@@ -119,18 +119,13 @@ A successful deployment shows a `Running` status.
 
 As a cluster administrator, you can install the NFD Operator using the web console.
 
-[NOTE]
-====
-It is recommended to create the `Namespace` as mentioned in the previous section.
-====
-
 .Procedure
 
 . In the {product-title} web console, click *Operators* -> *OperatorHub*.
 
 . Choose *Node Feature Discovery* from the list of available Operators, and then click *Install*.
 
-. On the *Install Operator* page, select *a specific namespace on the cluster*, select the namespace created in the previous section, and then click *Install*.
+. On the *Install Operator* page, select *A specific namespace on the cluster*, and then click *Install*. You do not need to create a namespace because it is created for you.
 
 .Verification
 


### PR DESCRIPTION
BZ2074893: When creating a Node Feature Discovery operator using the OCP **web console**, you do not need to create a namespace as it is created for you; this PR removes content stating that you need to create a namespace first. 

Version(s):
4.9 and 4.10

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2074893

Link to docs preview:
https://deploy-preview-45615--osdocs.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-node-feature-discovery-operator.html#install-operator-web-console_node-feature-discovery-operator 

Additional information:
Removed note and edited step 2 in the procedure; both mentioned creating a namespace before installing NFD using the web console, which is not needed. 



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
