### PR TITLE
Wrong description in featuregates document

### DIFF
--- a/modules/nodes-cluster-enabling-features-cli.adoc
+++ b/modules/nodes-cluster-enabling-features-cli.adoc
@@ -36,7 +36,7 @@ spec:
 +
 --
 <1> The name of the `FeatureGate` CR must be `cluster`.
-<2> Add the feature sets that you want to enable in a comma-separated list:
+<2> Add the feature set that you want to enable:
 * `TechPreviewNoUpgrade` enables specific Technology Preview features.
 --
 +

--- a/modules/nodes-cluster-enabling-features-console.adoc
+++ b/modules/nodes-cluster-enabling-features-console.adoc
@@ -37,7 +37,7 @@ spec:
 +
 --
 <1> The name of the `FeatureGate` CR must be `cluster`.
-<2> Add the feature sets that you want to enable in a comma-separated list:
+<2> Add the feature set that you want to enable:
 * `TechPreviewNoUpgrade` enables specific Technology Preview features.
 --
 +

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -12,7 +12,7 @@ include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+1]
 
 .Additional resources
 
-* For more information on the features activated by the `TechPreviewNoUpdate` feature gate, see the following topics:
+* For more information on the features activated by the `TechPreviewNoUpgrade` feature gate, see the following topics:
 ** xref:../../storage/container_storage_interface/persistent-storage-csi-azure-file.adoc#persistent-storage-csi-azure-file[Azure File CSI Driver Operator]
 ** xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration]
 ** xref:../../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_platform-operators-ref[Cluster Cloud Controller Manager Operator]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2084577

Previews
[Enabling feature sets using the web console](https://deploy-preview-45629--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-console_nodes-cluster-enabling). Step 5, updated callout 2 to remove comma-separated list.
[Enabling feature sets using the CLI](https://deploy-preview-45629--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-cli_nodes-cluster-enabling), Step 1, updated callout 2 to remove comma-separated list.
[Additional resources](https://deploy-preview-45629--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html) corrected feature set name in intro paragraph
