### PR TITLE
BZ#2075129 and others: Legacy install/upgrade of v1.7.1

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -62,8 +62,9 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.7
+:mtc-version-z: 1.7.1
 :mtc-legacy-version: 1.5
-:mtc-legacy-version-z: 1.5.3
+:mtc-legacy-version-z: 1.5.5
 // builds (Valid only in 4.11 and later)
 :builds-v2title: Builds for Red Hat OpenShift
 :builds-v2shortname: OpenShift Builds v2

--- a/modules/migration-installing-legacy-operator.adoc
+++ b/modules/migration-installing-legacy-operator.adoc
@@ -42,6 +42,8 @@ $ sudo podman login registry.redhat.io
 ----
 
 . Download the `operator.yml` file:
+
+.. For the stable version, enter the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -49,12 +51,30 @@ $ sudo podman cp $(sudo podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/operator.yml ./
 ----
 
+.. For the latest version, enter the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/operator.yml ./
+----
+
 . Download the `controller.yml` file:
+
+.. For the stable version, enter the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/controller.yml ./
+----
+
+.. For the latest version, enter the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/controller.yml ./
 ----
 
 ifdef::installing-restricted-3-4,installing-mtc-restricted[]
@@ -92,7 +112,7 @@ containers:
 <2> Specify your mirror registry.
 endif::[]
 
-. Log in to your {product-title} 3 cluster.
+. Log in to your {product-title} source cluster.
 
 ifdef::installing-3-4,installing-mtc[]
 . Verify that the cluster can authenticate with `registry.redhat.io`:

--- a/modules/migration-migrating-on-prem-to-cloud.adoc
+++ b/modules/migration-migrating-on-prem-to-cloud.adoc
@@ -27,9 +27,9 @@ A service created on the destination cluster exposes the source cluster's API to
 
 . Install the `crane` utility:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal,subs=attributes+]
 ----
-$ podman cp $(podman create registry.redhat.io/rhmtc/openshift-migration-controller-rhel8:v1.7.0):/crane ./
+$ podman cp $(podman create registry.redhat.io/rhmtc/openshift-migration-controller-rhel8:v{mtc-version-z}):/crane ./
 ----
 . Log in remotely to a node on the source cluster and a node on the destination cluster.
 

--- a/modules/migration-upgrading-mtc-with-legacy-operator.adoc
+++ b/modules/migration-upgrading-mtc-with-legacy-operator.adoc
@@ -32,11 +32,21 @@ $ sudo podman login registry.redhat.io
 ----
 
 . Download the `operator.yml` file:
+
+.. For the stable version, enter the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/operator.yml ./
+----
+
+.. For the latest version, enter the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/operator.yml ./
 ----
 
 . Replace the {mtc-full} Operator:


### PR DESCRIPTION
MTC 1.5.5, 1.6.5, 1.7.1, OCP 4.6+
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2075127 and https://bugzilla.redhat.com/show_bug.cgi?id=2075129

1. Adds a new attribute, {mtc-version-z}, to specify the current MTC z-stream. 
2. Updates the value of the legacy version to 1.5.5. 
3. Changes  "your  OpenShift Container Platform 3 cluster" to "your OpenShift Container Platform source cluster" in the installation procedures for in Migration Toolkit for Containers.
4. Fixes reference to "1.7.0" in Migrating an application from on-premises to a cloud-based cluster

Previews:

1 Installing non-restrictive OCP 4: 
![install_non_restrictive_4](https://user-images.githubusercontent.com/60698649/170989874-645c1bc1-d02a-47fb-a7da-a47fdcba5ea6.png)
2. Installing restrictive OCP 4:
![install_restrictive_4](https://user-images.githubusercontent.com/60698649/170990030-6de2e25b-d979-44d9-8175-1a0fa85cd8da.png)
3. Installing non-restrictive OCP 3: 
![install_non_restrictive_3](https://user-images.githubusercontent.com/60698649/170990101-74ffa64c-014f-40a7-a94f-f07d05aae36b.png)
4. Installing restrictive OCP 3: 
![install_restrictive_3](https://user-images.githubusercontent.com/60698649/170979255-9684d319-bf56-4bda-a6f5-76b853fa01b4.png)
5. Upgrading on OCP 4:  
![upgrade_from_4_to_4](https://user-images.githubusercontent.com/60698649/170990214-d438618c-28d6-4bfa-b05e-2637765f2741.png)
6: Upgrading from OCP 3: 
![upgrade_in_3_to_4](https://user-images.githubusercontent.com/60698649/170990282-de0c0062-fafa-4fd8-8f4d-9961af0c19cc.png)
7. Migrating an application from on-premises to a cloud-based cluster:
![cloud_to_prem](https://user-images.githubusercontent.com/60698649/170545150-3c120c61-724f-45d3-b327-f79fc6686211.png)
 