### PR TITLE
BZ#2084195: PTP - Network transport is L2, not UDPv4

### DIFF
--- a/modules/cnf-configuring-cvl-nic-as-oc.adoc
+++ b/modules/cnf-configuring-cvl-nic-as-oc.adoc
@@ -124,7 +124,7 @@ spec:
       # Default interface options
       #
       clock_type OC
-      network_transport UDPv4
+      network_transport L2
       delay_mechanism E2E
       time_stamping hardware
       tsproc_mode filter

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -120,7 +120,7 @@ spec:
       # Default interface options
       #
       clock_type OC
-      network_transport UDPv4
+      network_transport L2
       delay_mechanism E2E
       time_stamping hardware
       tsproc_mode filter

--- a/modules/sno-du-configuring-ptp.adoc
+++ b/modules/sno-du-configuring-ptp.adoc
@@ -108,7 +108,7 @@ spec:
         # Default interface options
         #
         clock_type OC
-        network_transport UDPv4
+        network_transport L2
         delay_mechanism E2E
         time_stamping hardware
         tsproc_mode filter


### PR DESCRIPTION
Based on updates in https://bugzilla.redhat.com/show_bug.cgi?id=2060492, docs are out of date. Network_transport is L2, not UDPv4 for PTP.

Version(s): Merge to main, enterprise-4.10, enterprise-4.11 

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2084195

Link to docs preview (Search for `network_transport L2`):
* https://deploy-preview-45631--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-configuring-single-node-cluster-deployment-during-installation.html#sno-du-configuring-ptp_sno-du-deploying-distributed-units-manually-on-single-node-openshift
* https://deploy-preview-45631--osdocs.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#configuring-linuxptp-services-as-ordinary-clock_using-ptp
* https://deploy-preview-45631--osdocs.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#cnf-configuring-cvl-nic-as-ptp-slave_using-ptp