### PR TITLE
OSSMDOC-578: Update Jaeger Operator default namespace.

### DIFF
--- a/modules/ossm-install-ossm-operator.adoc
+++ b/modules/ossm-install-ossm-operator.adoc
@@ -36,7 +36,7 @@ Elasticsearch Operator.
 .. For the OpenShift Elasticsearch Operator, in the *Update Channel* section, select *stable-5.x*.
 .. For the {JaegerName}, Kiali, and {SMProductName} Operators, accept the defaults.
 +
-The {JaegerName}, Kiali and {SMProductName} Operators are installed in the `openshift-operators` namespace. The OpenShift Elasticsearch Operator is installed in the `openshift-operators-redhat` namespace.
+The Kiali and {SMProductName} Operators are installed in the `openshift-operators` namespace. The {JaegerName} is installed in the `openshift-distributed-tracing` namespace. The OpenShift Elasticsearch Operator is installed in the `openshift-operators-redhat` namespace.
 
 . Click *Install*. Wait until the Operator has installed before repeating the steps for the next Operator in the list.
 

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -45,6 +45,8 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
+With this release, the {JaegerName} Operator is now installed to the `openshift-distributed-tracing` namespace by default.  Previously the default installation had been in the `openshift-operator` namespace.
+
 === Component versions included in {SMProductName} version 2.1.2
 
 |===


### PR DESCRIPTION
Version(s): 4.6 - 4.11

Issue: [OSSMDOC-578](https://issues.redhat.com/browse/OSSMDOC-578)
With Jaeger 1.30.1 the default installation namespace changed from 'openshift-operators' to 'openshift-distributed-tracing'.  This change was noted in the distributed tracing release notes, but the Service Mesh documentation was not updated.

Link to docs preview: https://deploy-preview-45632--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-2-1-2
AND
https://deploy-preview-45632--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/installing-ossm.html#ossm-install-ossm-operator_installing-ossm

QE review - mattmahoneyrh
Peer review - rh-tokeefe, bburt-rh