### PR TITLE
RHDEVDOCS-3959 removed crw references

### DIFF
--- a/adding_service_cluster/available-services.adoc
+++ b/adding_service_cluster/available-services.adoc
@@ -8,5 +8,4 @@ toc::[]
 
 You can add services to your existing {product-title} cluster using the xref:../adding_service_cluster/adding-service.adoc#adding-service[{cluster-manager-first} console].
 
-include::modules/codeready-workspaces.adoc[leveloffset=+1]
 include::modules/osd-rhoam.adoc[leveloffset=+1]

--- a/adding_service_cluster/rosa-available-services.adoc
+++ b/adding_service_cluster/rosa-available-services.adoc
@@ -18,5 +18,4 @@ include::modules/aws-cloudwatch.adoc[leveloffset=+1]
 * xref:../rosa_cluster_admin/rosa_logging/rosa-install-logging.adoc#rosa-install-logging[Installing the CloudWatch logging service]
 * link:https://aws.amazon.com/cloudwatch/[Amazon CloudWatch product information] 
 
-include::modules/codeready-workspaces.adoc[leveloffset=+1]
 include::modules/osd-rhoam.adoc[leveloffset=+1]

--- a/modules/policy-customer-responsibility.adoc
+++ b/modules/policy-customer-responsibility.adoc
@@ -32,10 +32,6 @@ The customer is responsible for the applications, workloads, and data that they 
 * Use the provided tools and features to configure and deploy; keep up-to-date; set up resource requests and limits; size the cluster to have enough resources to run apps; set up permissions; integrate with other services; manage any image streams or templates that the customer deploys; externally serve; save, back up, and restore data; and otherwise manage their highly available and resilient workloads.
 * Maintain responsibility for monitoring the applications run on OpenShift Dedicated; including installing and operating software to gather metrics and create alerts.
 
-|Developer services (CodeReady)
-|Make CodeReady Workspaces available as an add-on through {cluster-manager}.
-|Install, secure, and operate CodeReady Workspaces and the Developer CLI.
-
 |===
 
 // TODO: Should "Red Hat Container Catalog" be "Red Hat Ecosystem Catalog" now?

--- a/modules/rosa-policy-customer-responsibility.adoc
+++ b/modules/rosa-policy-customer-responsibility.adoc
@@ -32,8 +32,4 @@ The customer is responsible for the applications, workloads, and data that they 
 - Use the provided tools and features to configure and deploy; keep up to date; set up resource requests and limits; size the cluster to have enough resources to run apps; set up permissions; integrate with other services; manage any image streams or templates that the customer deploys; externally serve; save, back up, and restore data; and otherwise manage their highly available and resilient workloads.
 - Maintain responsibility for monitoring the applications run on {product-title}, including installing and operating software to gather metrics and create alerts.
 
-|Developer services (CodeReady)
-|Make CodeReady Workspaces available as an add-on through {cluster-manager}.
-|Install, secure, and operate CodeReady Workspaces and the Developer CLI.
-
 |===


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: enterprise-4.10+
- https://issues.redhat.com/browse/RHDEVDOCS-3959
- Direct link to doc preview: 
https://deploy-preview-45638--osdocs.netlify.app/openshift-dedicated/latest/adding_service_cluster/available-services.html
https://deploy-preview-45638--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/policy-responsibility-matrix.html
https://deploy-preview-45638--osdocs.netlify.app/openshift-rosa/latest/adding_service_cluster/rosa-available-services.html
https://deploy-preview-45638--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html
- SME review: not needed
- QE review: not needed
- Peer review: Approved by @rolfedh 
- Please merge now.
