### PR TITLE
OSDOCS-3643: Added Melbourne, Australia (australia-southeast2) to supported GCP regions

### DIFF
--- a/modules/installation-gcp-regions.adoc
+++ b/modules/installation-gcp-regions.adoc
@@ -19,6 +19,7 @@ regions:
 * `asia-southeast1` (Jurong West, Singapore)
 * `asia-southeast2` (Jakarta, Indonesia)
 * `australia-southeast1` (Sydney, Australia)
+* `australia-southeast2` (Melbourne, Australia)
 * `europe-central2` (Warsaw, Poland)
 * `europe-north1` (Hamina, Finland)
 * `europe-west1` (St. Ghislain, Belgium)


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR addresses [OSDOCS-3643](https://issues.redhat.com/browse/OSDOCS-3643)/[BZ 2074210](https://bugzilla.redhat.com/show_bug.cgi?id=2074210)

Link to docs preview:
[Supported GCP regions](https://deploy-preview-45639--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-regions_installing-gcp-account)

Additional information:
Added `australia-southeast2` to list of supported GCP regions.
