### PR TITLE
[RHACS] ROX-10264: Doc update for Network Graph UI

### DIFF
--- a/modules/delete-generated-policies.adoc
+++ b/modules/delete-generated-policies.adoc
@@ -10,7 +10,8 @@ If you have applied generated policies directly and want to remove them, select 
 
 .Procedure
 . In the RHACS portal, select *Network Graph* from the left-hand navigation menu.
-. Select a cluster name from the menu on the top bar, if the right one is not already selected.
+. Select a cluster name from the menu on the top bar if the correct one is not already selected.
+. Select one or more namespaces.
 . Select *Network Policy Simulator*.
 . Select *View active YAMLS*.
 . Select the *Revert most recently applied YAML* icon.

--- a/modules/generate-network-policies.adoc
+++ b/modules/generate-network-policies.adoc
@@ -19,12 +19,13 @@ The generated policies apply to the deployments shown in the network graph and t
 
 .Procedure
 . In the RHACS portal, select *Network Graph* from the left-hand navigation menu.
-. Select a cluster name from the menu on the top bar, if the right one is not already selected.
-. If you want to generate policies for only some deployments, use the filter box to filter the deployments you want.
+. Select a cluster name from the menu on the top bar if the correct one is not already selected.
+. Select one or more namespaces.
+. If you want to generate policies for only some deployments, use the *Add one or more deployment filters* field to add criteria by which to filter deployments.
 If you do not add a filter, {product-title} generates policies for all deployments in the cluster.
 . Select an appropriate time from the menu on the top bar.
 If the selected time is too short it leaves out periodic or infrequent network communications.
 . Select *Network Policy Simulator*.
 . In the panel that opens, select *Exclude ports & protocols* if you do not want ports and protocols to be scoped in {product-title} generated policies.
 . Select *Generate and simulate network policies*.
-The generated network policy configuration  YAML opens in the same panel, and the network graph shows the effects of the policies.
+The generated network policy configuration YAML opens in the same panel, and the network graph shows the effects of the policies.

--- a/modules/network-graph-view.adoc
+++ b/modules/network-graph-view.adoc
@@ -11,6 +11,8 @@ The network graph provides visibility and control over:
 * The allowed network connections, as defined by the Kubernetes network policies.
 * The active communications paths among namespaces and deployments.
 
+In the menu bar, choose the cluster for which to view information and at least one namespace.
+
 In the *Network Graph* view, you can configure the type of connections you want to see.
 In the *Flows* section (upper left), select:
 
@@ -19,9 +21,9 @@ In the *Flows* section (upper left), select:
 * *All* to view both active and allowed network connections.
 
 In the network graph, each circle represents a deployment, each surrounding box represents a Kubernetes namespace, and each thick line represents connection between namespaces.
-You can hover over these items to view more details.
+You can hover over these items to view more details. Clicking on an item such as a deployment or a namespace opens a window that displays additional information. The window can be expanded and collapsed by selecting the arrow in the blue bar.
 
-To understand the meaning of other symbols in the network graph, move you mouse over other symbols in the legend (lower left) to view the tooltip indicating the meaning of those symbols.
+To understand the meaning of other symbols in the network graph, move your mouse over other symbols in the legend (lower left) to view the tooltip indicating the meaning of those symbols.
 
 When you hover over:
 

--- a/modules/simulate-network-policies.adoc
+++ b/modules/simulate-network-policies.adoc
@@ -11,6 +11,7 @@ To simulate the effects of a new set of network policies, use the network policy
 
 .Procedure
 . On the RHACS portal, select *Network Graph* from the left-hand navigation menu.
+. Select one or more namespaces.
 . On the *Network Graph* view header, select *Network Policy Simulator*.
 . Select *Upload and simulate network policy YAML* and upload your proposed YAML file.
 The network graph view displays what your proposed network policies would achieve.

--- a/modules/view-network-baselines.adoc
+++ b/modules/view-network-baselines.adoc
@@ -8,7 +8,8 @@
 You can view network baselines from the network graph view.
 
 .Procedure
-. On the *Network Graph* view, select a deployment.
+. On the *Network Graph* view, select one or more namespaces.
+. Select a deployment.
 . The Network Flows details panel show both anomalous and baseline flows.
 From this panel, you can:
 


### PR DESCRIPTION
- Version(s): rhacs-docs-3.70.0 (for right now)
- [Issue](https://issues.redhat.com/browse/ROX-10264)

Previews:
- [Network graph view](https://deploy-preview-45641--osdocs.netlify.app/openshift-acs/latest/operating/manage-network-policies.html#network-graph-view_manage-network-policies)
- [Simulating network policies](https://deploy-preview-45641--osdocs.netlify.app/openshift-acs/latest/operating/manage-network-policies.html#simulate-network-policies_manage-network-policies)
- [Generate network policies](https://deploy-preview-45641--osdocs.netlify.app/openshift-acs/latest/operating/manage-network-policies.html#generate-network-policies_manage-network-policies)
- [Deleting generated policies](https://deploy-preview-45641--osdocs.netlify.app/openshift-acs/latest/operating/manage-network-policies.html#delete-generated-policies_manage-network-policies)
- [Viewing network baselines](https://deploy-preview-45641--osdocs.netlify.app/openshift-acs/latest/operating/manage-network-policies.html#view-network-baselines_manage-network-policies)