### PR TITLE
OSDOCS-3516: windows nodes certificates are updated

### DIFF
--- a/windows_containers/windows-containers-release-notes-5-x.adoc
+++ b/windows_containers/windows-containers-release-notes-5-x.adoc
@@ -21,12 +21,20 @@ ifndef::openshift-origin[]
 
 {productwinc} is provided and available as an optional, installable component. Windows Container Support for Red Hat OpenShift is not part of the {product-title} subscription. It requires an additional Red Hat subscription and is supported according to the link:https://access.redhat.com/support/offerings/production/soc/[Scope of coverage] and link:https://access.redhat.com/support/offerings/production/sla[Service level agreements].
 
-You must have this separate subscription to receive support for Windows Container Support for Red Hat OpenShift. Without this additional Red Hat subscription, deploying Windows container workloads in production clusters is not supported. You can request support through the link:http://access.redhat.com/[Red Hat Customer Portal]. 
+You must have this separate subscription to receive support for Windows Container Support for Red Hat OpenShift. Without this additional Red Hat subscription, deploying Windows container workloads in production clusters is not supported. You can request support through the link:http://access.redhat.com/[Red Hat Customer Portal].
 
 For more information, see the Red Hat OpenShift Container Platform Life Cycle Policy document for link:https://access.redhat.com/support/policy/updates/openshift#windows[Red Hat OpenShift support for Windows Containers].
 
-If you do not have this additional Red Hat subscription, you can use the Community Windows Machine Config Operator, a distribution that lacks official support. 
+If you do not have this additional Red Hat subscription, you can use the Community Windows Machine Config Operator, a distribution that lacks official support.
 endif::openshift-origin[]
+
+[id="wmco-5-1-0"]
+== Release notes for Red Hat Windows Machine Config Operator 5.1.0
+=== New features and improvements
+[id="wmco-5-1.0-node-certificates"]
+==== Windows node certificates are updated
+
+With this release, the WMCO updates the Windows node certificates when the node certificates are rotated.
 
 [id="wmco-5-0-0"]
 == Release notes for Red Hat Windows Machine Config Operator 5.0.0
@@ -51,4 +59,3 @@ Running Windows container workloads is not supported for clusters in a restricte
 ====
 
 Version 5.x of the WMCO is only compatible with {product-title} 4.10.
-


### PR DESCRIPTION
- Applies to 4.10 only
- [Jira](https://issues.redhat.com/browse/OSDOCS-3516)
- [Preview](https://deploy-preview-45643--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-5-x#wmco-5-1-0)
- @jrvaldes ptal 