### PR TITLE
[RHACS] Add auto-generated ECR registry integrations doc

### DIFF
--- a/integration/integrate-with-image-registries.adoc
+++ b/integration/integrate-with-image-registries.adoc
@@ -1,3 +1,4 @@
+:_content-type: ASSEMBLY
 [id="integrate-with-image-registries"]
 = Integrating with image registries
 include::modules/common-attributes.adoc[]
@@ -22,7 +23,7 @@ When you integrate with an image registry, {product-title} does not scan all ima
 * Use a continuous integration (CI) system to enforce security policies
 ====
 
-You can integrate {product-title} with several major image registries, including:
+You can integrate {product-title} with major image registries, including:
 
 * link:https://aws.amazon.com/ecr/[Amazon Elastic Container Registry (ECR)]
 * link:https://hub.docker.com[Docker Hub]
@@ -43,7 +44,7 @@ include::modules/automatic-configuration-image-registry.adoc[leveloffset=+1]
 [id="manual-configuration-image-registry"]
 == Manually configuring image registries
 
-If you are using GCR or ECR with node IAM, you must manually create image registry integrations.
+If you are using GCR, you must manually create image registry integrations.
 
 include::modules/manual-configuration-image-registry-ocp.adoc[leveloffset=+2]
 

--- a/modules/automatic-configuration-image-registry.adoc
+++ b/modules/automatic-configuration-image-registry.adoc
@@ -1,17 +1,25 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-image-registries.adoc
-:_module-type: CONCEPT
+:_content-type: CONCEPT
 [id="automatic-configuration-image-registry_{context}"]
 = Automatic Configuration
 
 [role="_abstract"]
-{product-title} includes default integrations with standard registries, such as Docker Hub and others.
-{product-title} also automatically configures integrations based on image pull secrets in the monitored clusters.
-Usually, you do not need to manually configure registry integrations.
+{product-title} includes default integrations with standard registries, such as Docker Hub and others. It can also automatically configure integrations based on artifacts found in the monitored clusters, such as image pull secrets. Usually, you do not need to configure registry integrations manually.
 
 [IMPORTANT]
 ====
-If you use registries like GCR and ECR, and have your clusters set up to pull images using node IAM (Identity and Access Management) instead of image pull secrets, {product-title} does not create a registry integration automatically.
-For such cases you must manually configure your image registries.
+If you are using a GCR registry, {product-title} does not create a registry integration automatically.
 ====
+
+[id="amazon_ecr_{context}"]
+= Amazon ECR integrations
+
+For Amazon ECR integrations, {product-title} automatically generates ECR registry integrations if the following conditions are met:
+
+* The cloud provider for the cluster is AWS.
+* The nodes in your cluster have an Instance Identity and Access Management (IAM) Role association and the Instance Metadata Service is available in the nodes. For example, when using Amazon Elastic Kubernetes Service (EKS) to manage your cluster, this role is known as the EKS Node IAM role.
+* The Instance IAM role has IAM policies granting access to the ECR registries from which you are deploying.
+
+If the listed conditions are met, {product-title} monitors deployments that pull from ECR registries and automatically generates ECR integrations for them. You can edit these integrations after they are automatically generated.

--- a/modules/configuring-assumerole-acs.adoc
+++ b/modules/configuring-assumerole-acs.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-image-registries.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="configuring-assumerole-acs_{context}"]
 = Configuring AssumeRole in {product-title-short}
 
@@ -10,20 +10,15 @@ After configuring AssumeRole in ECR, you can integrate {product-title} with Amaz
 
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
-. Under the *Image Integrations* section, select *Amazon Elastic Container Registry*.
-+
-The *Configure image integration* modal box opens.
+. Under the *Image Integrations* section, select *Amazon ECR*.
 . Click *New Integration*.
 . Enter the details for the following fields:
 .. *Integration Name*: The name of the integration.
 .. *Registry ID*: The ID of the registry.
-.. *Region*: The region for the registry.
-. If you have configured AssumeRole with container IAM leave the *Use container IAM role* option checked. Otherwise, uncheck the *Use custom IAM role* and enter the details for the following fields:
-.. *Access key ID*: The access key ID for the role.
-.. *Secret access key*: The secret access key for the role.
-. Select the *Use AssumeRole* checkbox.
-. Enter the details for the following fields:
+.. *Region*: The region for the registry; for example, `us-west-1`.
+. If you are using IAM, select *Use container IAM role*. Otherwise, clear the *Use custom IAM role* box and enter the *Access key ID* and *Secret access key*.
+. If you are using AssumeRole, select *Use AssumeRole* and enter the details for the following fields:
 .. *AssumeRole ID*: The ID of the role to assume.
 .. *AssumeRole External ID* (optional): If you are using an link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html[external ID with AssumeRole], you can enter it here.
-. Select *Test* (*`checkmark`* icon) to test that the integration with the selected registry is working.
-. Select *Create* (*`save`* icon) to create the configuration.
+. Select *Test* to test that the integration with the selected registry is working.
+. Select *Save*.

--- a/modules/manual-configuration-image-registry-acr.adoc
+++ b/modules/manual-configuration-image-registry-acr.adoc
@@ -1,25 +1,23 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-image-registries.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="manual-configuration-image-registry-acr_{context}"]
 = Manually configuring Microsoft Azure Container Registry
 
 You can integrate {product-title} with Microsoft Azure Container Registry.
 
 .Prerequisites
-* You must have a username and a password or an Azure App ID and a service principal password for authentication.
+* You must have a username and a password for authentication.
 
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
-. Under the *Image Integrations* section, select *Azure Container Registry*.
-+
-The *Configure image integration* modal box opens.
-. Click *New Integration*.
+. Under the *Image Integrations* section, select *Microsoft Azure Container Registry*.
+. Click *New integration*.
 . Enter the details for the following fields:
-.. *Integration Name*: The name of the integration.
-.. *Types*: Select *Registry*.
+.. *Integration name*: The name of the integration.
 .. *Endpoint*: The address of the registry.
-.. *Username or App ID* and *Password or Service Principal Password*.
-. Select *Test* (*`checkmark`* icon) to test that the integration with the selected registry is working.
-. Select *Create* (*`save`* icon) to create the configuration.
+.. *Username* and *Password*.
+. Select *Create integration without testing* to create the integration without testing the connection to the registry.
+. Select *Test* to test that the integration with the selected registry is working.
+. Select *Save*.

--- a/modules/manual-configuration-image-registry-dtr.adoc
+++ b/modules/manual-configuration-image-registry-dtr.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-image-registries.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="manual-configuration-image-registry-dtr_{context}"]
 = Manually configuring Docker Trusted Registry
 
@@ -13,13 +13,13 @@ You can integrate {product-title} with Docker Trusted Registry.
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
 . Under the *Image Integrations* section, select *Docker Trusted Registry*.
-+
-The *Configure image integration* modal box opens.
-. Click *New Integration*.
+. Click *New integration*.
 . Enter the details for the following fields:
-.. *Integration Name*: The name of the integration.
-.. *Types*: Select *Registry*.
+.. *Integration name*: The name of the integration.
+.. *Type*: Select *Registry*.
 .. *Endpoint*: The address of the registry.
 .. *Username* and *Password*.
-. Select *Test* (*`checkmark`* icon) to test that the integration with the selected registry is working.
-. Select *Create* (*`save`* icon) to create the configuration.
+. If you are not using a TLS certificate when connecting to the registry, select *Disable TLS certificate validation (insecure)*.
+. Select *Create integration without testing* to create the integration without testing the connection to the registry.
+. Select *Test* to test that the integration with the selected registry is working.
+. Select *Save*.

--- a/modules/manual-configuration-image-registry-ecr.adoc
+++ b/modules/manual-configuration-image-registry-ecr.adoc
@@ -1,18 +1,21 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-image-registries.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="manual-configuration-image-registry-ecr_{context}"]
 = Manually configuring Amazon Elastic Container Registry
 
-You can integrate {product-title} with Amazon Elastic Container Registry (ECR).
+You can use {product-title} to create and modify Amazon Elastic Container Registry (ECR) integrations manually. If you are deploying from Amazon ECR, integrations for the Amazon ECR registries are usually automatically generated. However, you might want to create integrations on your own to scan images outside deployments. You can also modify the parameters of an automatically-generated integration. For example, you can change the authentication method used by an automatically-generated Amazon ECR integration to use AssumeRole authentication or other authorization models.
+
+[IMPORTANT]
+====
+To erase changes you made to an automatically-generated ECR integration, delete the integration, and {product-title} creates a new integration for you with the automatically-generated parameters when you deploy images from Amazon ECR.
+====
 
 .Prerequisites
-* You must have an access key ID and a secret access key. Alternatively, you can use a node-level IAM proxy such as `kiam` or `kube2iam`.
-* The access key must have read access to ECR.
-See link:https://aws.amazon.com/premiumsupport/knowledge-center/create-access-key/[How do I create an AWS access key?]  for more information.
-* If you are running {product-title} in Amazon Elastic Kubernetes Service (EKS) and want to integrate with an ECR from a separate Amazon account, you must first set a repository policy statement in your ECR.
-Follow the instructions at link:https://docs.aws.amazon.com/AmazonECR/latest/userguide/set-repository-policy.html[Setting a repository policy statement]  and for *Actions*, choose the following scopes of the Amazon ECR API operations:
+* You must have an Amazon Identity and Access Management (IAM) access key ID and a secret access key. Alternatively, you can use a node-level IAM proxy such as `kiam` or `kube2iam`.
+* The access key must have read access to ECR. See link:https://aws.amazon.com/premiumsupport/knowledge-center/create-access-key/[How do I create an AWS access key?] for more information.
+* If you are running {product-title} in Amazon Elastic Kubernetes Service (EKS) and want to integrate with an ECR from a separate Amazon account, you must first set a repository policy statement in your ECR. Follow the instructions at link:https://docs.aws.amazon.com/AmazonECR/latest/userguide/set-repository-policy.html[Setting a repository policy statement] and for *Actions*, choose the following scopes of the Amazon ECR API operations:
 
 ** ecr:BatchCheckLayerAvailability
 ** ecr:BatchGetImage
@@ -22,17 +25,18 @@ Follow the instructions at link:https://docs.aws.amazon.com/AmazonECR/latest/use
 
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
-. Under the *Image Integrations* section, select *Amazon Elastic Container Registry*.
-+
-The *Configure image integration* modal box opens.
-. Click *New Integration*.
-. Enter the details for the following fields:
-.. *Integration Name*: The name of the integration.
-.. *Types*: Select *Registry*.
+. Under the *Image Integrations* section, select *Amazon ECR*.
+. Click *New integration*, or click one of the automatically-generated integrations to open it, then click *Edit*.
+. Enter or modify the details for the following fields:
+.. *Update stored credentials*: Clear this box if you are modifying an integration without updating the credentials such as access keys and passwords.
+.. *Integration name*: The name of the integration.
 .. *Registry ID*: The ID of the registry.
-.. *Endpoint (Optional)*: The address of the registry.
-.. *Region*: The region for the registry.
-.. *Use Container IAM Role*: Turn on the toggle if you are using IAM.
-.. *Access Key ID (required if not using IAM)* and *Secret Access Key (required if not using IAM)*: Your access key and secret if you are not using IAM.
-. Select *Test* (*`checkmark`* icon) to test that the integration with the selected registry is working.
-. Select *Create* (*`save`* icon) to create the configuration.
+.. *Endpoint*: The address of the registry. This field is not enabled when the AssumeRole option is selected.
+.. *Region*: The region for the registry; for example, `us-west-1`.
+. If you are using IAM, select *Use Container IAM role*. Otherwise, clear the *Use Container IAM role* box and enter the *Access key ID* and *Secret access key*.
+. If you are using AssumeRole authentication, select *Use AssumeRole* and enter the details for the following fields:
+.. *AssumeRole ID*: The ID of the role to assume.
+.. *AssumeRole External ID* (optional): If you are using an link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html[external ID with AssumeRole], you can enter it here.
+. Select *Create integration without testing* to create the integration without testing the connection to the registry.
+. Select *Test* to test that the integration with the selected registry is working.
+. Select *Save*.

--- a/modules/manual-configuration-image-registry-gar.adoc
+++ b/modules/manual-configuration-image-registry-gar.adoc
@@ -1,26 +1,24 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-image-registries.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="manual-configuration-image-registry-gar_{context}"]
 = Manually configuring Google Artifact Registry
 
 You can integrate {product-title} with Google Artifact Registry.
 
 .Prerequisites
-* You need a service account key with the *Artifact Registry Reader* IAM role `roles/artifactregistry.reader`.
+* You need a service account key with the *Artifact Registry Reader* Identity and Access Management (IAM) role `roles/artifactregistry.reader`.
 
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
 . Under the *Image Integrations* section, select *Google Artifact Registry*.
-+
-The *Configure image integration* modal box opens.
-. Click *New Integration*.
+. Click *New integration*.
 . Enter the details for the following fields:
-.. *Integration Name*: The name of the integration.
-.. *Types*: Select *Registry*.
-.. *Registry Endpoint*: The address of the registry.
+.. *Integration name*: The name of the integration.
+.. *Registry endpoint*: The address of the registry.
 .. *Project*: The Google Cloud project name.
-.. *Service Account Key (JSON)* Your service account key for authentication.
-. Select *Test* (*`checkmark`* icon) to test that the integration with the selected registry is working.
-. Select *Create* (*`save`* icon) to create the configuration.
+.. *Service account key (JSON)* Your service account key for authentication.
+. Select *Create integration without testing* to create the integration without testing the connection to the registry.
+. Select *Test* to test that the integration with the selected registry is working.
+. Select *Save*.

--- a/modules/manual-configuration-image-registry-gcr.adoc
+++ b/modules/manual-configuration-image-registry-gcr.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-image-registries.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="manual-configuration-image-registry-gcr_{context}"]
 = Manually configuring Google Container Registry
 
@@ -19,14 +19,13 @@ See link:https://cloud.google.com/container-registry/docs/access-control[Configu
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
 . Under the *Image Integrations* section, select *Google Container Registry*.
-+
-The *Configure image integration* modal box opens.
-. Click *New Integration*.
+. Click *New integration*.
 . Enter the details for the following fields:
-.. *Integration Name*: The name of the integration.
-.. *Types*: Select *Registry*.
+.. *Integration name*: The name of the integration.
+.. *Type*: Select *Registry*.
 .. *Registry Endpoint*: The address of the registry.
 .. *Project*: The Google Cloud project name.
-.. *Service Account Key (JSON)* Your service account key for authentication.
-. Select *Test* (*`checkmark`* icon) to test that the integration with the selected registry is working.
-. Select *Create* (*`save`* icon) to create the configuration.
+.. *Service account key (JSON)* Your service account key for authentication.
+. Select *Create integration without testing* to create the integration without testing the connection to the registry.
+. Select *Test* to test that the integration with the selected registry is working.
+. Select *Save*.

--- a/modules/manual-configuration-image-registry-ibm.adoc
+++ b/modules/manual-configuration-image-registry-ibm.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-image-registries.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="manual-configuration-image-registry-ibm_{context}"]
 = Manually configuring IBM Cloud Container Registry
 
@@ -13,13 +13,10 @@ You can integrate {product-title} with IBM Cloud Container Registry.
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
 . Under the *Image Integrations* section, select *IBM Cloud Container Registry*.
-+
-The *Configure image integration* modal box opens.
-. Click *New Integration*.
+. Click *New integration*.
 . Enter the details for the following fields:
-.. *Integration Name*: The name of the integration.
-.. *Types*: Select *Registry*.
+.. *Integration name*: The name of the integration.
 .. *Endpoint*: The address of the registry.
-.. *API Key*.
-. Select *Test* (*`checkmark`* icon) to test that the integration with the selected registry is working.
-. Select *Create* (*`save`* icon) to create the configuration.
+.. *API key*.
+. Select *Test* to test that the integration with the selected registry is working.
+. Select *Save*.

--- a/modules/manual-configuration-image-registry-jfrog.adoc
+++ b/modules/manual-configuration-image-registry-jfrog.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-image-registries.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="manual-configuration-image-registry-jfrog_{context}"]
 = Manually configuring JFrog Artifactory
 
@@ -13,13 +13,12 @@ You can integrate {product-title} with JFrog Artifactory.
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
 . Under the *Image Integrations* section, select *JFrog Artifactory*.
-+
-The *Configure image integration* modal box opens.
-. Click *New Integration*.
+. Click *New integration*.
 . Enter the details for the following fields:
-.. *Integration Name*: The name of the integration.
-.. *Types*: Select *Registry*.
+.. *Integration name*: The name of the integration.
 .. *Endpoint*: The address of the registry.
 .. *Username* and *Password*.
-. Select *Test* (*`checkmark`* icon) to test that the integration with the selected registry is working.
-. Select *Create* (*`save`* icon) to create the configuration.
+. If you are not using a TLS certificate when connecting to the registry, select *Disable TLS certificate validation (insecure)*.
+. Select *Create integration without testing* to create the integration without testing the connection to the registry.
+. Select *Test* to test that the integration with the selected registry is working.
+. Select *Save*.

--- a/modules/manual-configuration-image-registry-ocp.adoc
+++ b/modules/manual-configuration-image-registry-ocp.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-image-registries.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="manual-configuration-image-registry-ocp_{context}"]
 = Manually configuring {ocp} registry
 
@@ -13,13 +13,12 @@ You can integrate {product-title} with {ocp} built-in container image registry.
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
 . Under the *Image Integrations* section, select *Generic Docker Registry*.
-+
-The *Configure image integration* modal box opens.
-. Click *New Integration*.
+. Click *New integration*.
 . Enter the details for the following fields:
-.. *Integration Name*: The name of the integration.
-.. *Types*: Select *Registry*.
+.. *Integration name*: The name of the integration.
 .. *Endpoint*: The address of the registry.
 .. *Username* and *Password*.
-. Select *Test* (*`checkmark`* icon) to test that the integration with the selected registry is working.
-. Select *Create* (*`save`* icon) to create the configuration.
+. If you are not using a TLS certificate when connecting to the registry, select *Disable TLS certificate validation (insecure)*.
+. Select *Create integration without testing* to create the integration without testing the connection to the registry.
+. Select *Test* to test that the integration with the selected registry is working.
+. Select *Save*.

--- a/modules/manual-configuration-image-registry-qcr.adoc
+++ b/modules/manual-configuration-image-registry-qcr.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-image-registries.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="manual-configuration-image-registry-qcr_{context}"]
 = Manually configuring Quay Container Registry
 
@@ -12,14 +12,14 @@ You can integrate {product-title} with Quay Container Registry.
 
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
-. Under the *Image Integrations* section, select *Quay Container Registry*.
-+
-The *Configure image integration* modal box opens.
-. Click *New Integration*.
+. Under the *Image Integrations* section, select *Red Hat Quay.io*.
+. Click *New integration*.
 . Enter the details for the following fields:
-.. *Integration Name*: The name of the integration.
-.. *Types*: Select *Registry*.
+.. *Integration name*: The name of the integration.
+.. *Type*: Select *Registry*.
 .. *Endpoint*: The address of the registry.
 .. *OAuth Token*
-. Select *Test* (*`checkmark`* icon) to test that the integration with the selected registry is working.
-. Select *Create* (*`save`* icon) to create the configuration.
+. If you are not using a TLS certificate when connecting to the registry, select *Disable TLS certificate validation (insecure)*.
+. Select *Create integration without testing* to create the integration without testing the connection to the registry.
+. Select *Test* to test that the integration with the selected registry is working.
+. Select *Save*.

--- a/modules/manual-configuration-image-registry-redhat.adoc
+++ b/modules/manual-configuration-image-registry-redhat.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-image-registries.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="manual-configuration-image-registry-redhat_{context}"]
 = Manually configuring Red Hat Container Registry
 
@@ -12,14 +12,12 @@ You can integrate {product-title} with Red Hat Container Registry.
 
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
-. Under the *Image Integrations* section, select *Red Hat Container Registry*.
-+
-The *Configure image integration* modal box opens.
-. Click *New Integration*.
+. Under the *Image Integrations* section, select *Red Hat Registry*.
+. Click *New integration*.
 . Enter the details for the following fields:
-.. *Integration Name*: The name of the integration.
-.. *Types*: Select *Registry*.
+.. *Integration name*: The name of the integration.
 .. *Endpoint*: The address of the registry.
 .. *Username* and *Password*.
-. Select *Test* (*`checkmark`* icon) to test that the integration with the selected registry is working.
-. Select *Create* (*`save`* icon) to create the configuration.
+. Select *Create integration without testing* to create the integration without testing the connection to the registry.
+. Select *Test* to test that the integration with the selected registry is working.
+. Select *Save*.


### PR DESCRIPTION
- Version(s): rhacs-docs-3.70.0 (for right now)
- Labels: `rhacs`
- Issue: [ROX-9532](https://issues.redhat.com/browse/ROX-9532)

Docs preview: 
- [Integrating with image registries](https://deploy-preview-45653--osdocs.netlify.app/openshift-acs/latest/integration/integrate-with-image-registries.html)
 - [Amazon ECR integrations](https://deploy-preview-45653--osdocs.netlify.app/openshift-acs/latest/integration/integrate-with-image-registries.html#amazon_ecr_integrate-with-image-registries)
 - [Manually configuring image registries](https://deploy-preview-45653--osdocs.netlify.app/openshift-acs/latest/integration/integrate-with-image-registries.html#manual-configuration-image-registry)

Additional information: 
- 	original PR: https://github.com/openshift/openshift-docs/pull/44071