### PR TITLE
add default gateway to static ip example

### DIFF
--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -11,28 +11,6 @@ The following example configuration snippets demonstrate different methods of IP
 
 These examples use the `ethernet` interface type to simplify the example while showing the related context in the policy configuration. These IP management examples can be used with the other interface types.
 
-[id="virt-example-nmstate-IP-management-static_{context}"]
-== Static
-
-The following snippet statically configures an IP address on the Ethernet interface:
-
-[source,yaml]
-----
-...
-    interfaces:
-    - name: eth1
-      description: static IP on eth1
-      type: ethernet
-      state: up
-      ipv4:
-        address:
-        - ip: 192.168.122.250 <1>
-          prefix-length: 24
-        enabled: true
-...
-----
-<1> Replace this value with the static IP address for the interface.
-
 [id="virt-example-nmstate-IP-management-no-ip_{context}"]
 == No IP address
 
@@ -88,6 +66,44 @@ The following snippet configures an Ethernet interface that uses a dynamic IP ad
 ...
 ----
 
+[id="virt-example-nmstate-IP-management-static_{context}"]
+== Static
+
+The following snippet statically configures an IP address, default gateway, and DNS servers:
+
+[source,yaml]
+----
+...
+    interfaces:
+    - name: eth0
+      description: eth0 with static IP addressing
+      type: ethernet
+      state: up
+      ipv4:
+        address:
+        - ip: 192.168.122.250 <1>
+          prefix-length: 24
+        enabled: true
+
+    routes:
+      config:
+      - destination: 0.0.0.0/0
+        next-hop-address: 192.168.122.1 <2>
+        next-hop-interface: eth0
+
+    dns-resolver:
+      config:
+        search:
+        - example.com
+        - example.org
+        server:
+        - 8.8.8.8
+        - 8.8.4.4
+...
+----
+<1> Replace this value with the static IP address for the interface.
+<2> Next hop address for the node traffic. This must be in the same subnet as the IP address set for the Ethernet interface.
+
 [id="virt-example-nmstate-IP-management-dns_{context}"]
 == DNS
 
@@ -119,7 +135,7 @@ You cannot use `br-ex`, an OVNKubernetes-managed Open vSwitch bridge, as the int
 ====
 
 [id="virt-example-nmstate-IP-management-static-routing_{context}"]
-== Static routing
+== Additional static routes
 
 The following snippet configures a static route and a static IP on interface `eth1`.
 


### PR DESCRIPTION
GH#45661: expand static IP example to include default gateway and DNS servers

Issue:
#45661

Link to docs preview:
https://deploy-preview-45662--osdocs.netlify.app/openshift-enterprise/latest/virt/node_network/virt-updating-node-network-config.html#virt-example-nmstate-IP-management-static_virt-updating-node-network-config

Additional information:
I felt this example needed improvement because when I tried to follow the example as written, I got this error:
```
$ oc get nnce/rhclient3.rhclient3-bridge -o yaml
...
      libnmstate.error.NmstateValueError                                                                                                                                     
        Failed to find suitable interface for saving DNS name servers                                                                                                        
...
```
I ultimately found a comment in Bugzilla that identified the source of the problem being a lack of default gateway
https://bugzilla.redhat.com/show_bug.cgi?id=2008446#c9
