### PR TITLE
[RHACS] ROX-10938: Add privilege escalation policy criteria to docs

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -527,6 +527,13 @@ For example `oc`, or `kubectl`.
 | ✓
 | Deploy
 
+| Privilege escalation
+| Provides alerts when a deployment is configured to allow a container process to gain more privileges than its parent process.
+| 3.70 and later
+| ✕
+| ✕
+| ✕
+
 |===
 
 [NOTE]


### PR DESCRIPTION
- Version(s): 3.70.0 (for right now)
- [Issue](https://issues.redhat.com/browse/ROX-10938)
- [preview](https://deploy-preview-45664--osdocs.netlify.app/openshift-acs/latest/operating/manage-security-policies.html#policy-criteria_manage-security-policies)
