### PR TITLE
CNV-17454: Network latency checkup

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3358,6 +3358,8 @@ Topics:
     File: virt-reviewing-vm-dashboard
   - Name: OpenShift cluster monitoring, logging, and Telemetry
     File: virt-openshift-cluster-monitoring
+  - Name: Running OpenShift cluster checkups
+    File: virt-running-cluster-checkups
   - Name: Prometheus queries for virtual resources
     File: virt-prometheus-queries
   - Name: Exposing custom metrics for virtual machines

--- a/modules/virt-about-cluster-checkup-framework.adoc
+++ b/modules/virt-about-cluster-checkup-framework.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-running-cluster-checkups.adoc
+
+:_content-type: CONCEPT
+[id="virt-about-cluster-checkup-framework_{context}"]
+= About the {product-title} cluster checkup framework
+
+A _checkup_ is an automated test workload that allows you to verify if a specific cluster functionality works as expected. The cluster checkup framework uses native Kubernetes resources to configure and execute the checkup.
+
+By using predefined checkups, cluster administrators can improve cluster maintainability, troubleshoot unexpected behavior, minimize errors, and save time. They can also review the results of the checkup and share them with experts for further analysis. Vendors can write and publish checkups for features or services that they provide and verify that their customer environments are configured correctly.
+
+Running a predefined checkup in the cluster involves setting up the namespace and service account for the framework, creating the `ClusterRole` and `ClusterRoleBinding` objects for the service account, enabling permissions for the checkup, and creating the input config map and the checkup job. You can run a checkup multiple times. 

--- a/modules/virt-measuring-latency-vm-secondary-network.adoc
+++ b/modules/virt-measuring-latency-vm-secondary-network.adoc
@@ -1,0 +1,256 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-running-cluster-checkups.adoc
+
+:_content-type: PROCEDURE
+[id="virt-measuring-latency-vm-secondary-network_{context}"]
+= Checking network connectivity and latency for virtual machines on a secondary network
+
+As a cluster administrator, you use a predefined checkup to verify network connectivity and measure latency between virtual machines (VMs) that are attached to a secondary network interface.
+
+To run a checkup for the first time, follow the steps in the procedure.
+
+If you have previously run a checkup, skip to step 5 of the procedure because the steps to install the framework and enable permissions for the checkup are not required.
+
+.Prerequisites
+
+* You installed the OpenShift CLI (`oc`).
+* You logged in to the cluster as a user with the `cluster-admin` role.
+* The cluster has at least two worker nodes.
+* The Multus Container Network Interface (CNI) plug-in is installed on the cluster.
+* You configured a network attachment definition for a namespace.
+
+.Procedure
+
+. Create a configuration file that contains the resources to set up the framework. This includes a namespace and service account for the framework, and the `ClusterRole` and `ClusterRoleBinding` objects to define permissions for the service account.
++
+.Example framework manifest file
+[%collapsible]
+====
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kiagnose
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kiagnose
+  namespace: kiagnose
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kiagnose
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+  - apiGroups: [ "" ]
+    resources: [ "namespaces" ]
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - watch
+  - apiGroups: [ "" ]
+    resources: [ "serviceaccounts" ]
+    verbs:
+      - get
+      - list
+      - create
+  - apiGroups: [ "rbac.authorization.k8s.io" ]
+    resources:
+      - roles
+      - rolebindings
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups: [ "rbac.authorization.k8s.io" ]
+    resources:
+      - clusterroles
+    verbs:
+      - get
+      - list
+      - create
+      - bind
+  - apiGroups: [ "batch" ]
+    resources: [ "jobs" ]
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kiagnose
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kiagnose
+subjects:
+  - kind: ServiceAccount
+    name: kiagnose
+    namespace: kiagnose
+...
+----
+====
+
+. Apply the framework manifest:
++
+[source,terminal]
+----
+$ oc apply -f <framework_manifest>.yaml
+----
+
+. Create a configuration file that contains the `ClusterRole` and `Role` objects with permissions that the checkup requires for cluster access:
++
+.Example cluster role manifest file
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubevirt-vm-latency-checker
+rules:
+- apiGroups: ["kubevirt.io"]
+  resources: ["virtualmachineinstances"]
+  verbs: ["get", "create", "delete"]
+- apiGroups: ["subresources.kubevirt.io"]
+  resources: ["virtualmachineinstances/console"]
+  verbs: ["get"]
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources: ["network-attachment-definitions"]
+  verbs: ["get"]
+----
+
+. Apply the checkup roles manifest:
++
+[source,terminal]
+----
+$ oc apply -f <latency_roles>.yaml
+----
+
+. Create a `ConfigMap` manifest that contains the input parameters for the checkup. The config map provides the input for the framework to run the checkup and also stores the results of the checkup.
++
+.Example input config map
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-vm-latency-checkup
+  namespace: kiagnose
+data:
+  spec.image: registry.redhat.io/container-native-virtualization/vm-network-latency-checkup:v4.11.0
+  spec.timeout: 10m
+  spec.clusterRoles: |
+    kubevirt-vmis-manager
+  spec.param.network_attachment_definition_namespace: "default" <1>
+  spec.param.network_attachment_definition_name: "bridge-network" <2>
+  spec.param.max_desired_latency_milliseconds: "10" <3>
+  spec.param.sample_duration_seconds: "5" <4>
+----
+<1> The namespace where the `NetworkAttachmentDefinition` object resides.
+<2> The name of the `NetworkAttachmentDefinition` object.
+<3> Optional: The maximum desired latency, in milliseconds, between the virtual machines. If the measured latency exceeds this value, the check fails.
+<4> Optional: The duration of the latency check, in seconds.
+
+. Create the config map in the framework’s namespace:
++
+[source,terminal]
+----
+$ oc apply -f <latency_config_map>.yaml
+----
+
+. Create a `Job` object to run the checkup:
++
+.Example job manifest
+[source,yaml]
+----
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kubevirt-vm-latency-checkup
+  namespace: kiagnose
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccount: kiagnose
+      restartPolicy: Never
+      containers:
+        - name: framework
+          image: registry.redhat.io/container-native-virtualization/checkup-framework:v4.11.0
+          env:
+            - name: CONFIGMAP_NAMESPACE
+              value: kiagnose
+            - name: CONFIGMAP_NAME
+              value: kubevirt-vm-latency-checkup
+----
+
+. Apply the `Job` manifest. The checkup uses the ping utility to verify connectivity and measure latency.
++
+[source,terminal]
+----
+$ oc apply -f <latency_job>.yaml
+----
+
+. Wait for the job to complete:
++
+[source,terminal]
+----
+$ oc wait --for=condition=complete --timeout=10m job.batch/kubevirt-vm-latency-checkup -n kiagnose
+----
+
+. Review the results of the latency checkup by retrieving the status of the `ConfigMap` object. If the measured latency is greater than the value of the `spec.param.max_desired_latency_milliseconds` attribute, the checkup fails and returns an error.
++
+[source,terminal]
+----
+$ oc get configmap kubevirt-vm-latency-checkup -n kiagnose -o yaml
+----
++
+.Example output config map (success)
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-vm-latency-checkup
+  namespace: kiagnose
+...
+  status.succeeded: "true"
+  status.failureReason: ""
+  status.result.minLatencyNanoSec: 2000
+  status.result.maxLatencyNanoSec: 3000
+  status.result.avgLatencyNanoSec: 2500
+  status.results.measurementDurationSec: 300
+...
+----
+
+. Delete the framework and checkup resources that you previously created. This includes the job, config map, cluster role, and framework manifest files.
++
+[NOTE]
+====
+Do not delete the framework and cluster role manifest files if you plan to run another checkup.
+====
++
+[source,terminal]
+----
+$ oc delete -f <file_name>.yaml
+----

--- a/virt/logging_events_monitoring/virt-running-cluster-checkups.adoc
+++ b/virt/logging_events_monitoring/virt-running-cluster-checkups.adoc
@@ -1,0 +1,22 @@
+:_content-type: ASSEMBLY
+[id="virt-running-cluster-checkups"]
+= Running cluster checkups
+include::_attributes/common-attributes.adoc[]
+:context: virt-running-cluster-checkups
+
+toc::[]
+
+{VirtProductName} {VirtVersion} includes a diagnostic framework to run predefined checkups that can be used for cluster maintenance and troubleshooting.
+
+:FeatureName: The {product-title} cluster checkup framework
+include::snippets/technology-preview.adoc[]
+
+
+include::modules/virt-about-cluster-checkup-framework.adoc[leveloffset=+1]
+
+include::modules/virt-measuring-latency-vm-secondary-network.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_running-cluster-checkups"]
+== Additional resources
+* xref:../../virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc#virt-attaching-vm-multiple-networks[Attaching a virtual machine to multiple networks]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s): 4.11
<!--- Specify the version or versions of OpenShift your PR applies to.
If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Issue: [CNV-17454](https://issues.redhat.com//browse/CNV-17454)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/sjhala/cnv-17454/virt/logging_events_monitoring/virt-running-cluster-checkups.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
  - The preview will be generated after you open the PR.
  - You will need to edit the comment to add the link after the preview builds.
  - Review the preview build to make sure your changes are rendering properly. --->

<!--- Additional information:--->
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
