### PR TITLE
Updated File Integrity Operator release notes to include v0.1.24

### DIFF
--- a/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
@@ -7,11 +7,29 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The File Integrity Operator for {product-title} deploys file integrity checking for {op-system} nodes.
+The File Integrity Operator for {product-title} continually runs file integrity checks on {op-system} nodes.
 
 These release notes track the development of the File Integrity Operator in the {product-title}.
 
 For an overview of the File Integrity Operator, see xref:../../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-operator[Understanding the File Integrity Operator].
+
+[id="file-integrity-operator-release-notes-0-1-24"]
+== OpenShift File Integrity Operator 0.1.24
+
+The following advisory is available for the OpenShift File Integrity Operator 0.1.24:
+
+* link:https://access.redhat.com/errata/RHBA-2022:1331[RHBA-2022:1331 OpenShift File Integrity Operator Bug Fix]
+
+[id="file-integrity-operator-0-1-24-new-features-and-enhancements"]
+=== New features and enhancements
+
+* You can now configure the maximum number of backups stored in the `FileIntegrity` Custom Resource (CR) with the `config.maxBackups` attribute. This attribute specifies the number of AIDE database and log backups left over from the `re-init` process to keep on the node. Older backups beyond the configured number are automatically pruned. The default is set to five backups.
+
+[id="openshift-file-integrity-operator-0-1-24-bug-fixes"]
+=== Bug fixes
+* Previously, upgrading the Operator from versions older than 0.1.21 to 0.1.22 could cause the `re-init` feature to fail. This was a result of the Operator failing to update `configMap` resource labels. Now, upgrading to the latest version fixes the resource labels. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049206[*BZ#2049206*])
+
+* Previously, when enforcing the default `configMap` script contents, the wrong data keys were compared. This resulted in the `aide-reinit` script not being updated properly after an Operator upgrade, and caused the `re-init` process to fail. Now,`daemonSets` run to completion and the AIDE database `re-init` process executes successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2072058[*BZ#2072058*])
 
 [id="file-integrity-operator-release-notes-0-1-22"]
 == OpenShift File Integrity Operator 0.1.22


### PR DESCRIPTION
File Integrity Operator 0.1.24 release notes stub added.

Version(s):
4.6+

Link to docs preview:
[OpenShift File Integrity Operator 0.1.24](https://deploy-preview-45684--osdocs.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/file-integrity-operator-release-notes.html#file-integrity-operator-release-notes-0-1-24)