### PR TITLE
OSDOCS-3638: Updated AWS and vSphere minimum resource reqs for compute machines

### DIFF
--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -38,6 +38,36 @@
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
 
+ifeval::["{context}" == "installing-aws-customizations"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-vpc"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-private"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-china-region"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-user-infra"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws"]
+:aws:
+endif::[]
 ifeval::["{context}" == "installing-azure-customizations"]
 :azure:
 endif::[]
@@ -136,8 +166,18 @@ ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power[|{op-system}]
 ifndef::ibm-z,ibm-power[|{op-system}, {op-system-base} 8.4, or {op-system-base} 8.5 ^[3]^]
+ifndef::aws[]
 |2
+endif::aws[]
+ifdef::aws[]
+|4
+endif::aws[]
+ifndef::aws[]
 |8 GB
+endif::aws[]
+ifdef::aws[]
+|16 GB
+endif::aws[]
 |100 GB
 ifndef::ibm-z[]
 |300
@@ -188,6 +228,36 @@ You are required to use Azure virtual machines with `premiumIO` set to `true`. T
 ====
 endif::azure[]
 
+ifeval::["{context}" == "installing-aws-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-vpc"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-private"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-china-region"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-user-infra"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws"]
+:!aws:
+endif::[]
 ifeval::["{context}" == "installing-azure-customizations"]
 :!azure:
 endif::[]


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR addresses [CORS-2021](https://issues.redhat.com/browse/CORS-2021)/[OSDOCS-3638](https://issues.redhat.com/browse/OSDOCS-3638).

Link to docs preview:

- (AWS) [Minimum resource requirements](https://deploy-preview-45686--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-minimum-resource-requirements_installing-aws-customizations)
- (vSphere) Minimum resource requirements
