### PR TITLE
BZ204094 updated pods names for etcd defragmentation 4.9+

### DIFF
--- a/modules/etcd-defrag.adoc
+++ b/modules/etcd-defrag.adoc
@@ -39,7 +39,7 @@ Automatic defragmentation can cause leader election failure in various OpenShift
 ----
 I0907 08:43:12.171919       1
 defragcontroller.go:198] etcd member "ip-
-10-0-191-150.us-west-2.compute.internal"
+10-0-191-150.example.redhat.com"
 backend store fragmented: 39.33 %, dbSize:
 349138944
 ----
@@ -83,7 +83,7 @@ etcd-ip-10-0-199-170.example.redhat.com                3/3     Running     0    
 +
 [source,terminal]
 ----
-$ oc rsh -n openshift-etcd etcd-ip-10-0-159-225.us-west-1.compute.internal etcdctl endpoint status --cluster -w table
+$ oc rsh -n openshift-etcd etcd-ip-10-0-159-225.example.redhat.com etcdctl endpoint status --cluster -w table
 ----
 +
 .Example output


### PR DESCRIPTION
Summary:
Style update to change an actual server name to `example.redhat.com`, which matches other examples elsewhere on this page. 

Version(s):
4.9+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2084094

Link to docs preview:
[etcd defragmentation](https://deploy-preview-45692--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices.html#etcd-defrag_recommended-host-practices)

Additional information:
This PR applies to 4.9+, see #45694 for 4.6-4.8. Two PRs created for two different formats of the same page. 