### PR TITLE
BZ2084094 updated pods names for etcd deframentation 4.6 - 4.8

### DIFF
--- a/modules/etcd-defrag.adoc
+++ b/modules/etcd-defrag.adoc
@@ -47,7 +47,7 @@ etcd-ip-10-0-199-170.example.redhat.com                3/3     Running     0    
 +
 [source,terminal]
 ----
-$ oc rsh -n openshift-etcd etcd-ip-10-0-159-225.us-west-1.compute.internal etcdctl endpoint status --cluster -w table
+$ oc rsh -n openshift-etcd etcd-ip-10-0-159-225.example.redhat.com etcdctl endpoint status --cluster -w table
 ----
 +
 .Example output


### PR DESCRIPTION
Summary:
Style update to change an actual server name to `example.redhat.com`, which matches other examples elsewhere on this page. 

Version(s):
4.6 - 4.8

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2084094

Link to docs preview:
[etcd defragmentation](https://deploy-preview-45694--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices.html#etcd-defrag_recommended-host-practices)

Additional information:
This PR applies to 4.6 - 4.8, see #45692 for 4.9+. Two PRs created for two different formats of the same page. 