### PR TITLE
[enterprise-4.9] CP doc changes for BZ1949962

### DIFF
--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -204,6 +204,11 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 
 | `bootMACAddress`
 |
-| The MAC address of the NIC that the host uses for the `provisioning` network. Ironic retrieves the IP address using the `bootMACAddress` configuration setting. Then, it binds to the host.
+a| The MAC address of the NIC that the host uses for the `provisioning` network. Ironic retrieves the IP address using the `bootMACAddress` configuration setting. Then, it binds to the host.
+
+[NOTE]
+====
+You must provide a valid MAC address from the host if you disabled the `provisioning` network.
+====
 
 |===


### PR DESCRIPTION
Cherry Picked from https://github.com/openshift/openshift-docs/commit/c51e703f9c0e458fb111d5fc015e687503f8c114 xref: https://github.com/openshift/openshift-docs/pull/45323

Version(s): enterprise 4.9