### PR TITLE
adds mention of 4.10 Egress IPs on cloud platforms

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -157,7 +157,9 @@ Egress IP addresses are implemented as additional IP addresses on the primary ne
 ====
 Egress IP addresses must not be configured in any Linux network configuration files, such as `ifcfg-eth0`.
 
-Allowing additional IP addresses on the primary network interface might require extra configuration when using some cloud or VM solutions.
+Egress IPs on Amazon Web Services (AWS), Google Cloud Platform (GCP), and Azure are supported only on {product-title} version 4.10 and later.
+
+Allowing additional IP addresses on the primary network interface might require extra configuration when using some virtual machine solutions.
 ====
 
 You can assign egress IP addresses to namespaces by setting the `egressIPs` parameter of the `NetNamespace` object. After an egress IP is associated with a project, OpenShift SDN allows you to assign egress IPs to hosts in two ways:
@@ -205,7 +207,7 @@ The automatic assignment approach works best for clusters installed in environme
 [id="considerations-manual-egress-ips"]
 == Considerations when using manually assigned egress IP addresses
 
-This approach is recommended for clusters installed in public cloud environments, where there can be limitations on associating additional IP addresses with nodes.
+This approach is used for clusters where there can be limitations on associating additional IP addresses with nodes such as in public cloud environments.
 
 When using the manual assignment approach for egress IP addresses the following considerations apply:
 
@@ -214,7 +216,6 @@ When using the manual assignment approach for egress IP addresses the following 
 
 When a namespace has multiple egress IP addresses, if the node hosting the first egress IP address is unreachable, {product-title} will automatically switch to using the next available egress IP address until the first egress IP address is reachable again.
 
-This approach is recommended for clusters installed in public cloud environments, where there can be limitations on associating additional IP addresses with nodes.
 endif::openshift-sdn[]
 
 ifdef::openshift-sdn[]


### PR DESCRIPTION
[BZ#1920232
](https://bugzilla.redhat.com/show_bug.cgi?id=1920232)
Adds to IMPORTANT callout to clarify limitations of 4.6-4.9 with respect to Egress IPs on public cloud and removes mention of public cloud from another section. 
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.6-4.9
<!--- Specify the version or versions of OpenShift your PR applies to.
If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Link to docs preview:
[Preview](https://deploy-preview-45697--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/assigning-egress-ips.html)
[Preview](https://joealdinger.github.io/openshift-docs/BZ-1920232-4.9/networking/openshift_sdn/assigning-egress-ips.html) for 4.8 and 4.9

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
  - The preview will be generated after you open the PR.
  - You will need to edit the comment to add the link after the preview builds.
  - Review the preview build to make sure your changes are rendering properly. --->

Additional information:
Adds to IMPORTANT callout to clarify limitations of 4.6-4.9 with respect to Egress IPs on public cloud and removes mention of public cloud from another section. 

Same changes in 4.7-4.9. 
4.7 PR that makes the same changes #46262
4.8 PR that makes the same changes #46264 
4.9 PR that makes the same changes #46527
     Section "Considerations when using manually assigned egress IP addresses" has a small difference in addressing 
     multiple egress IPs. 4.8 and 4.9 share these differences. The changes though remain the same in these branches.

<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
