### PR TITLE
Fixed OADP backup hook indentation error

### DIFF
--- a/modules/oadp-creating-backup-hooks.adoc
+++ b/modules/oadp-creating-backup-hooks.adoc
@@ -38,12 +38,12 @@ spec:
             component: server
         pre: <4>
           - exec:
-            container: <container> <5>
-            command:
-            - /bin/uname <6>
-            - -a
-            onError: Fail <7>
-            timeout: 30s <8>
+              container: <container> <5>
+              command:
+              - /bin/uname <6>
+              - -a
+              onError: Fail <7>
+              timeout: 30s <8>
         post: <9>
 ...
 ----


### PR DESCRIPTION
There is no opened issue: This pr add two spaces indentation inside OADP backup hook avoiding Openshift syntax rejection.

Version(s):
4.11, 4.10, 4.9, 4.8, 4.7

Link to docs preview:
https://deploy-preview-45698--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html

Additional information:
I just noticed this working with this feature reading these docs. We can see the Velero example with the correct indentation in https://velero.io/docs/v1.7/api-types/backup/.
