### PR TITLE
Adding Vale error checking in the OCP docs travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: python
 cache: pip
 # env:
 #   - PR_AUTHOR=${TRAVIS_PULL_REQUEST_SLUG::-15}
-
+git:
+  depth: 1
 jobs:
   include:
     - stage: build
+      name: "Build openshift-enterprise distro"  
       before_install:
         - gem install asciidoctor
         - gem install asciidoctor-diagram
@@ -16,6 +18,7 @@ jobs:
         - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.11 --no-upstream-fetch && python3 makeBuild.py
     - # stage name not required, will continue to use `build`
       if: branch IN (main, enterprise-4.11, enterprise-4.12)
+      name: "Build openshift-dedicated distro"
       before_install:
         - gem install asciidoctor
         - gem install asciidoctor-diagram
@@ -26,6 +29,7 @@ jobs:
         - python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch && python3 makeBuild.py
     - # stage name not required, will continue to use `build`
       if: branch IN (main, enterprise-4.11, enterprise-4.12)
+      name: "Build openshift-rosa distro"
       before_install:
         - gem install asciidoctor
         - gem install asciidoctor-diagram
@@ -34,6 +38,18 @@ jobs:
         - pip3 install aura.tar.gz
       script:
         - python3 build.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch && python3 makeBuild.py
+    - stage: check-with-vale
+      if: type IN (pull_request)
+      name: "Run Vale against PR asciidoc files"
+      before_script:
+        - gem install asciidoctor
+      script:
+        - wget https://github.com/errata-ai/vale/releases/download/v2.20.1/vale_2.20.1_Linux_64-bit.tar.gz
+        - mkdir bin && tar -xvzf vale_2.20.1_Linux_64-bit.tar.gz -C bin
+        - export PATH=./bin:"$PATH"
+        - vale sync # pull down VRH rules package
+        - chmod +x ./scripts/check-with-vale.sh
+        - ./scripts/check-with-vale.sh $TRAVIS_PULL_REQUEST $TRAVIS_PULL_REQUEST_SHA
     # Commenting out to disable auto-merging of PRs
     # - stage: automerge
     #   if: env(PR_AUTHOR)=openshift-cherrypick-robot
@@ -41,4 +57,5 @@ jobs:
 
 stages:
   - build
-  # - automerge
+  - check-with-vale
+  #- automerge

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,13 @@
+StylesPath = .vale/styles
+
+MinAlertLevel = error
+
+Packages = RedHat
+
+#ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
+[[!.]*.adoc]
+BasedOnStyles = RedHat
+
+#optional: pass doc attributes to asciidoctor before linting
+#[asciidoctor]
+#openshift-enterprise = YES

--- a/scripts/check-with-vale.sh
+++ b/scripts/check-with-vale.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+# list of *.adoc files ignoring files in /rest_api and generated files
+FILES=$(git diff-tree HEAD HEAD~1 --no-commit-id -r --name-only "*.adoc" ':(exclude)rest_api/*' ':(exclude)modules/example-content.adoc' ':(exclude)modules/oc-adm-by-example-content.adoc')
+
+if [ -n "${FILES}" ]
+    then
+        echo "Validating language usage in added or modified asciidoc files with $(vale -v)"
+        echo ""
+        echo "==============================================================================================================================="
+        echo "Read about the error terms that cause the build to fail at https://redhat-documentation.github.io/vale-at-red-hat/docs/reference-guide/termserrors/"
+        echo "==============================================================================================================================="
+        echo ""
+        #clean out conditional markup
+        sed -i -e 's/ifdef::.*\|ifndef::.*\|ifeval::.*\|endif::.*/ /' ${FILES}
+        vale ${FILES} --minAlertLevel=error --glob='*.adoc' --no-exit 
+        #run again, and this time send to pipedream
+        set -x
+        PR_DATA=''
+        if [ "$1" == false ] ; then
+            PR_DATA='{"PR": [{"Number": "None", "SHA": "None"}],'
+        else
+            PR_DATA='{"PR": [{"Number": "'"$1"'", "SHA": "'"$2"'"}]',
+        fi
+        echo "${PR_DATA}" > vale_errors.json
+        ERROR_DATA=$(vale ${FILES} --minAlertLevel=error --glob='*.adoc' --output=JSON --no-exit)
+        echo "${ERROR_DATA:1}" >> vale_errors.json
+        curl -H "Content-Type: text/json" --data "@vale_errors.json" https://eox4isrzuh8pnai.m.pipedream.net
+    else
+        echo "No asciidoc files added or modified."
+fi


### PR DESCRIPTION
Updates the Travis CI with Vale error checking using the Vale at Red Hat (VRH) style. The build uses the [Vale error terms rules](https://github.com/redhat-documentation/vale-at-red-hat/blob/main/.vale/styles/RedHat/TermsErrors.yml) which are themselves based on the Red Hat SSG.

Description of changes: 

* `.travis.yml`: Updated to download and configure the latest vale executable with the latest VRH style configuration package
* Adds `--depth=1` to the travis build.
* `get-vale.sh`, `check-with-vale.sh`, `get-vale-styles.sh`: New scripts which install and configure vale 
* only runs on PR builds
* Vale runs against modified files in the PR only, not the entire repo.
* Initially, to trial the changes, builds will run with `--no-exit`. This will allow us to run the build and review errors without negatively affecting users. Once we are happy that Vale is doing good work, we will turn it on to fail on errors.
* The following generated files and folders are excluded from the Vale checking: 
  - `rest_api/*`, `modules/example-content.adoc`, `modules/oc-adm-by-example-content.adoc` 
* Travis errors are silently added to the following spreadsheet for review: https://docs.google.com/spreadsheets/d/1nYu77sKaR7IZDrigUYANsbuMA4Mj3xZPSIClTe2rWMY/edit#gid=0 (Thanks @gaurav-nelson!). 

Example error log: https://app.travis-ci.com/github/openshift/openshift-docs/jobs/579401076#L267