### PR TITLE
BZ#085084 - Fix to premigration checklist

### DIFF
--- a/migrating_from_ocp_3_to_4/premigration-checklists-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/premigration-checklists-3-4.adoc
@@ -23,7 +23,6 @@ Before you migrate your application workloads with the {mtc-full} ({mtc-short}),
 * [ ] You have installed the correct legacy {mtc-full} Operator version:
 ** `operator-3.7.yml` on {product-title} version 3.7.
 ** `operator.yml` on {product-title} versions 3.9 to 4.5.
-* [ ] The {mtc-short} version is the same on all clusters.
 * [ ] All nodes have an active {product-title} subscription.
 * [ ] You have performed all the link:https://docs.openshift.com/container-platform/3.11/day_two_guide/run_once_tasks.html#day-two-guide-default-storage-class[run-once tasks].
 * [ ] You have performed all the link:https://docs.openshift.com/container-platform/3.11/day_two_guide/environment_health_checks.html[environment health checks].

--- a/migration_toolkit_for_containers/premigration-checklists-mtc.adoc
+++ b/migration_toolkit_for_containers/premigration-checklists-mtc.adoc
@@ -12,7 +12,6 @@ Before you migrate your application workloads with the {mtc-full} ({mtc-short}),
 == Cluster health checklist
 
 * [ ] The clusters meet the minimum hardware requirements for the specific platform and installation method, for example, on xref:../installing/installing_bare_metal/installing-bare-metal.adoc#minimum-resource-requirements_installing-bare-metal[bare metal].
-* [ ] The {mtc-short} version is the same on all clusters.
 * [ ] All xref:../migration_toolkit_for_containers/migrating-applications-with-mtc.adoc#migration-prerequisites_migrating-applications-with-mtc[{mtc-short} prerequisites] are met.
 * [ ] All nodes have an active {product-title} subscription.
 * [ ] You have xref:../support/troubleshooting/verifying-node-health.adoc#verifying-node-health[verified node health].


### PR DESCRIPTION
MTC 1.7.1, CP OCP 4.6+

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2085084: It is incorrect to say that all clusters must have the same MTC version in the premigration checklist.

This PR solves the problem by removing the incorrect item from the MTC documentation.

Previews:
1.    https://deploy-preview-45708--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/premigration-checklists-3-4.html [Premigration checklists for migrating from OCP 3 to 4]
2. https://deploy-preview-45708--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/premigration-checklists-mtc.html  [Premigration checklists for migrating from OCP 4 to 4]