### PR TITLE
Bug 2043736 - State only migration that includes Kubernetes resources is under-documented

### DIFF
--- a/modules/migration-kubernetes-objects.adoc
+++ b/modules/migration-kubernetes-objects.adoc
@@ -7,7 +7,12 @@
 [id="migration-kubernetes-objects_{context}"]
 = Migrating Kubernetes objects
 
-You can perform a one-time migration of Kubernetes objects that constitute an application's state.
+You can use the {mtc-short} API to perform a one-time migration of Kubernetes objects that constitute an application's state.
+
+[NOTE]
+====
+You can perform this kind of migration _only_ with the {mtc-short} API, not with the {mtc-short} web console.
+====
 
 [NOTE]
 ====


### PR DESCRIPTION
 1.7.1
 
 Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2043736 by adding that the migration method discussed can be done only by the MTC API, not the web console. 

Preview: https://deploy-preview-45711--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/advanced-migration-options-mtc.html#migration-kubernetes-objects_advanced-migration-options-mtc [the start of "Migrating Kubernetes objects"] 