### PR TITLE
BZ2073880: Adding EvictionStrategy Known Issue to release notes for 4.10.1 release

### DIFF
--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -284,3 +284,8 @@ $ oc annotate --overwrite -n openshift-cnv hco kubevirt-hyperconverged 'networka
 
 * The web console does not display virtual machine templates that are deployed to a custom namespace. Only templates deployed to the default namespace display in the web console. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054650[*BZ#2054650*])
 ** As a workaround, avoid deploying templates to a custom namespace.
+
+* On a Single Node OpenShift (SNO) cluster, updating the cluster fails if a VMI has the `spec.evictionStrategy` field set to `LiveMigrate`. For live migration to succeed, the cluster must have more than one worker node. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2073880[*BZ#2073880*])
+** There are two workaround options:
+*** Remove the `spec.evictionStrategy` field from the VM declaration.
+*** Manually stop the VM before you update {product-title}.


### PR DESCRIPTION
This PR relates to a Known Issue bug [BZ2073880](https://bugzilla.redhat.com/show_bug.cgi?id=2073880). We are adding this Known Issue to the release notes for the 4.10.1 release.

Version(s): 4.10

Issue: [BZ2073880](https://bugzilla.redhat.com/show_bug.cgi?id=2073880)

Link to docs preview: The final bulleted item starting with "If a VMI has the spec.evictionStrategy field" in https://deploy-preview-45712--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-10-release-notes.html#virt-4-10-known-issues
