### PR TITLE
[SRVOCF-288] Add on-cluster build docs

### DIFF
--- a/modules/serverless-functions-on-cluster-builds.adoc
+++ b/modules/serverless-functions-on-cluster-builds.adoc
@@ -1,0 +1,88 @@
+// Module included in the following assemblies:
+//
+// * /serverless/functions/serverless-functions-getting-started.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-functions-creating-on-cluster-builds_{context}"]
+= Building and deploying functions on the cluster
+
+You can use the Knative (`kn`) CLI to initiate a function project build and then deploy the function directly on the cluster. To build a function project in this way, the source code for your function project must exist in a Git repository branch that is accessible to your cluster.
+
+:FeatureName: {FunctionsProductName}
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+.Prerequisites
+
+* {pipelines-title} must be installed on your cluster.
+
+* You have installed the OpenShift (`oc`) CLI.
+
+* You have installed the Knative (`kn`) CLI.
+
+.Procedure
+
+. In each namespace where you want to run {pipelines-shortname} and deploy a function, you must create the following resources:
+
+.. Create the functions buildpacks Tekton task to be able to build the function image:
++
+[source,terminal]
+----
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.22.0/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
+----
+
+.. Create the `kn func` deploy Tekton task to be able to deploy the function in the pipeline:
++
+[source,terminal]
+----
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.22.0/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+----
+
+. Create a function:
++
+[source,terminal]
+----
+$ kn func create <function_name> -l <runtime>
+----
+
+. After you have created a new function project, you must add the project to a Git repository and ensure that the repository is available to the cluster. Information about this Git repository is used to update the `func.yaml` file in the next step.
+
+. Update the configuration in the `func.yaml` file for your function project to enable on-cluster builds for the Git repository:
++
+[source,yaml]
+----
+...
+build: git <1>
+git:
+  url: <git_repository_url> <2>
+  revision: main <3>
+  contextDir: <directory_path> <4>
+...
+----
+<1> Required. Specify `git` build type.
+<2> Required. Specify the Git repository that contains your function's source code.
+<3> Optional. Specify the Git repository revision to be used. This can be a branch, tag or commit.
+<4> Optional. Specify the function's directory path if the function is not located in the Git repository root folder.
+
+. Implement the business logic of your function. Then, use Git to commit and push the changes.
+
+. Deploy your function:
++
+[source,terminal]
+----
+$ kn func deploy
+----
++
+If you are not logged into the container registry referenced in your function configuration, you are prompted to provide credentials for the remote container registry that hosts the function image:
++
+.Example output and prompts
+[source,terminal]
+----
+🕕 Creating Pipeline resources
+Please provide credentials for image registry used by Pipeline.
+? Server: https://index.docker.io/v1/
+? Username: my-repo
+? Password: ********
+   Function deployed at URL: http://test-function.default.svc.cluster.local
+----
+
+. To update your function, commit and push new changes by using Git, then run the `kn func deploy` command again.

--- a/serverless/functions/serverless-functions-getting-started.adoc
+++ b/serverless/functions/serverless-functions-getting-started.adoc
@@ -18,6 +18,7 @@ Before you can complete the following procedures, you must ensure that you have 
 
 include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
+include::modules/serverless-functions-on-cluster-builds.adoc[leveloffset=+1]
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-kn-func-invoke.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
OCP 4.6+

Issue:
https://issues.redhat.com/browse/SRVOCF-288

Link to docs preview:
- Pipelines docs not available on OSD, so these docs are not provided there (they have a dependency on Pipelines install docs)
- OCP docs: http://file.rdu.redhat.com/abrennan/310522/SRVOCF-288/serverless/functions/serverless-functions-getting-started.html#serverless-functions-creating-on-cluster-builds_serverless-functions-getting-started