### PR TITLE
[SRVKS-919] Add missing TP notes for Serverless 1.22

### DIFF
--- a/modules/serverless-admin-init-containers.adoc
+++ b/modules/serverless-admin-init-containers.adoc
@@ -8,6 +8,9 @@
 
 link:https://kubernetes.io/docs/concepts/workloads/pods/init-containers/[Init containers] are specialized containers that are run before application containers in a pod. They are generally used to implement initialization logic for an application, which may include running setup scripts or downloading required configurations. You can enable the use of init containers for Knative services by modifying the `KnativeServing` custom resource (CR).
 
+:FeatureName: Init containers for Knative services
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
 [NOTE]
 ====
 Init containers may cause longer application start-up times and should be used with caution for serverless applications, which are expected to scale up and down frequently.

--- a/modules/serverless-enabling-pvc-support.adoc
+++ b/modules/serverless-enabling-pvc-support.adoc
@@ -8,6 +8,9 @@
 
 Some serverless applications need permanent data storage. To achieve this, you can configure persistent volume claims (PVCs) for your Knative services.
 
+:FeatureName: PVC support for Knative services
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
 .Procedure
 
 . To enable Knative Serving to use PVCs and write to them, modify the `KnativeServing` custom resource (CR) to include the following YAML:

--- a/modules/serverless-rn-1-22-0.adoc
+++ b/modules/serverless-rn-1-22-0.adoc
@@ -17,8 +17,8 @@
 * {ServerlessProductName} now uses Knative `kn` CLI 1.1.
 * {ServerlessProductName} now uses Knative Kafka 1.1.
 * The `kn func` CLI plug-in now uses `func` 0.23.
-* Knative service specifications now support init containers.
-* The persistent volume claim (PVC) support for Knative services is now available as a Technology Preview.
+* Init containers support for Knative services is now available as a Technology Preview.
+* Persistent volume claim (PVC) support for Knative services is now available as a Technology Preview.
 * The `knative-serving`, `knative-serving-ingress`, `knative-eventing` and `knative-kafka` system namespaces now have the `knative.openshift.io/part-of: "openshift-serverless"` label by default.
 * The *Knative Eventing - Kafka Broker/Trigger* dashboard has been added, which allows visualizing Kafka broker and trigger metrics in the web console.
 * The *Knative Eventing - KafkaSink* dashboard has been added, which allows visualizing KafkaSink metrics in the web console.

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -13,11 +13,12 @@ The following table provides information about which {ServerlessProductName} fea
 // OCP table
 ifdef::openshift-enterprise[]
 .Generally Available and Technology Preview features tracker
-[cols="3,1,1,1,1",options="header"]
+[cols="3,1,1,1,1,1",options="header"]
 |====
-|Feature |1.18|1.19|1.20|1.21
+|Feature |1.18|1.19|1.20|1.21|1.22
 
 |`kn func`
+|TP
 |TP
 |TP
 |TP
@@ -28,8 +29,10 @@ ifdef::openshift-enterprise[]
 |-
 |-
 |TP
+|TP
 
 |Service Mesh mTLS
+|GA
 |GA
 |GA
 |GA
@@ -40,9 +43,11 @@ ifdef::openshift-enterprise[]
 |GA
 |GA
 |GA
+|GA
 
 |HTTPS redirection
 |-
+|GA
 |GA
 |GA
 |GA
@@ -52,8 +57,24 @@ ifdef::openshift-enterprise[]
 |-
 |TP
 |TP
+|TP
 
 |Kafka sink
+|-
+|-
+|-
+|TP
+|TP
+
+|Init containers support for Knative services
+|-
+|-
+|-
+|-
+|TP
+
+|PVC support for Knative services
+|-
 |-
 |-
 |-


### PR DESCRIPTION
Version(s): 4.6+

Issue: https://issues.redhat.com/browse/SRVKS-919

Link to docs preview:
https://deploy-preview-45723--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-tech-preview-features_serverless-release-notes
https://deploy-preview-45723--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-configuration.html#serverless-enabling-pvc-support_serverless-configuration
https://deploy-preview-45723--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-configuration.html#serverless-admin-init-containers_serverless-configuration