### PR TITLE
[OSDOCS-3317] removed incorrect text

### DIFF
--- a/modules/osd-aws-privatelink-architecture.adoc
+++ b/modules/osd-aws-privatelink-architecture.adoc
@@ -8,7 +8,7 @@ The Red Hat managed infrastructure that creates AWS PrivateLink clusters is host
 AWS PrivateLink is supported on existing VPCs only.
 ====
 
-The following diagram shows a multiple availability zone (Multi-AZ) PrivateLink cluster deployed on private subnets.
+The following diagram shows network connectivity of a PrivateLink cluster.
 
 .Multi-AZ AWS PrivateLink cluster deployed on private subnets
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/OSDOCS-3317

Link to docs preview:
https://deploy-preview-45728--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_architecture_sub/rosa-architecture-models#osd-aws-privatelink-architecture.adoc_rosa-architecture-models

Additional information:
Changed text above diagram to "The following diagram shows network connectivity of a PrivateLink cluster."

<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
