### PR TITLE
Adds notes for 4.10.14 and console feature

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2866,3 +2866,29 @@ link:https://access.redhat.com/solutions/6956858[{product-title} 4.10.13 contain
 ==== Updating
 
 To upgrade an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-10-14"]
+=== RHBA-2022:2178 - {product-title} 4.10.14 bug fix update
+
+Issued: 2022-05-18
+
+{product-title} release 4.10.14 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:2178[RHBA-2022:2178] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:2177[RHBA-2022:2177] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6958424[{product-title} 4.10.14 container image list]
+
+[id="ocp-4-10-14-features"]
+==== Features
+
+[id="ocp-4-10-14-update-mode-update-cluster"]
+===== Update the control plane independently of other worker nodes
+
+With this update, you can now perform a partial cluster update within the *Update Cluster* modal. You are able to update the worker or custom pool nodes to accommodate the time it takes for maintenance. You can also pause and resume within the progress bar of each pool. If one or more worker or custom pools are paused, an alert is displayed at the top of the *Cluster Settings* page. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2076777[*BZ#2076777*])
+
+For more information, see xref:../updating/preparing-eus-eus-upgrade.adoc[Preparing to perform an EUS-to-EUS update] and xref:../updating/updating-cluster-within-minor.adoc[Updating a cluster using the web console].
+
+[id="ocp-4-10-14-updating"]
+==== Updating
+
+To upgrade an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.10.14 release and adds console feature for updating clusters

- [OSDOCS-3584](https://issues.redhat.com/browse/OSDOCS-3584)

Version(s):
Applies to `enterprise-4.10` only

Link to docs preview:
[Preview link](https://deploy-preview-45730--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-14)

Additional information:
Relates to:[ #11053](https://github.com/openshift/console/pull/11053) 



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
