### PR TITLE
BZ:2062628: This confuses me, in the old 3.11 documentation it states

### DIFF
--- a/modules/deployments-deploymentconfigs.adoc
+++ b/modules/deployments-deploymentconfigs.adoc
@@ -57,6 +57,6 @@ spec:
   strategy:
     type: Rolling      <3>
 ----
-<1> A config change trigger causes a new deployment to be created any time the replication controller template changes.
+<1> A configuration change trigger results in a new replication controller whenever changes are detected in the pod template of the deployment configuration.
 <2> An image change trigger causes a new deployment to be created each time a new version of the backing image is available in the named image stream.
 <3> The default `Rolling` strategy makes a downtime-free transition between deployments.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2062628

This confuses me, in the old 3.11 documentation it states:

"The ConfigChange trigger results in a new replication controller whenever changes are detected in the pod template of the deployment configuration."
https://docs.openshift.com/container-platform/3.11/dev_guide/deployments/basic_deployment_operations.html#config-change-trigger

How can it be that we change the RC template, and in consequence a new deployment is to be created? Isn't it the other way round? Change the deploymentconfig and then a new RC is created.