### PR TITLE
nw-cluster-mtu-change: generate MachineConfigs with Butane

### DIFF
--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -212,90 +212,56 @@ interface-name=enp1s0
 mtu=8051
 ----
 
-... To base64 encode the NetworkManager configuration for inclusion in a `MachineConfig` object, enter the following command:
+... Create two `MachineConfig` objects, one for the control plane nodes and another for the worker nodes in your cluster:
+
+.... Create the following Butane config in the `control-plane-interface.bu` file:
++
+[source,yaml]
+----
+variant: openshift
+version: 4.11.0
+metadata:
+  name: 01-control-plane-interface
+  labels:
+    machineconfiguration.openshift.io/role: master
+storage:
+  files:
+    - path: /etc/NetworkManager/system-connections/<connection_name> <1>
+      contents:
+        local: config.nmconnection <2>
+      mode: 0644
+----
+<1> Specify the NetworkManager connection name for the primary network interface.
+<2> Specify the local filename for the updated NetworkManager configuration file from the previous step.
+
+.... Create the following Butane config in the `worker-interface.bu` file:
++
+[source,yaml]
+----
+variant: openshift
+version: 4.11.0
+metadata:
+  name: 01-worker-interface
+  labels:
+    machineconfiguration.openshift.io/role: worker
+storage:
+  files:
+    - path: /etc/NetworkManager/system-connections/<connection_name> <1>
+      contents:
+        local: config.nmconnection <2>
+      mode: 0644
+----
+<1> Specify the NetworkManager connection name for the primary network interface.
+<2> Specify the local filename for the updated NetworkManager configuration file from the previous step.
+
+.... Create `MachineConfig` objects from the Butane configs by running the following command:
 +
 [source,terminal]
 ----
-$ cat config.nmconnection | base64 -w0
+$ for manifest in control-plane-interface worker-interface; do
+    butane --files-dir . $manifest.bu > $manifest.yaml
+  done
 ----
-
-... Create two `MachineConfig` objects, one for the control plane nodes and another for the worker nodes in your cluster:
-
-.... Create the following `MachineConfig` object in the `machine-config-control-plane.yaml` file:
-+
-[source,yaml]
-----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  labels:
-    machineconfiguration.openshift.io/role: master
-  name: 01-control-plane-interface
-spec:
-  config:
-    ignition:
-      config: {}
-      security:
-        tls: {}
-      timeouts: {}
-      version: 2.2.0
-    networkd: {}
-    passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,<encoded_config>
-          verification: {}
-        filesystem: root
-        mode: 420
-        path: /etc/NetworkManager/system-connections/<connection_name>
-    systemd: {}
-----
-+
---
-where:
-
-`<encoded_config>`:: Specifies the base64 encoding for the updated NetworkManager configuration.
-`<connection_name>`:: Specifies the NetworkManager connection name for the primary network interface.
---
-
-.... Create the following MachineConfig object in the `machine-config-worker.yaml` file:
-+
-[source,yaml]
-----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  labels:
-    machineconfiguration.openshift.io/role: worker
-  name: 01-worker-interface
-spec:
-  config:
-    ignition:
-      config: {}
-      security:
-        tls: {}
-      timeouts: {}
-      version: 2.2.0
-    networkd: {}
-    passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,<encoded_config>
-          verification: {}
-        filesystem: root
-        mode: 420
-        path: /etc/NetworkManager/system-connections/<connection_name>
-    systemd: {}
-----
-+
---
-where:
-
-`<encoded_config>`:: Specifies the base64 encoding for the updated NetworkManager configuration.
-`<connection_name>`:: Specifies the NetworkManager connection name for the primary network interface.
---
 
 . To begin the MTU migration, specify the migration configuration by entering the following command. The Machine Config Operator performs a rolling reboot of the nodes in the cluster in preparation for the MTU change.
 +
@@ -382,7 +348,7 @@ ExecStart=/usr/local/bin/mtu-migration.sh
 +
 [source,terminal]
 ----
-$ for manifest in machine-config-control-plane machine-config-worker; do
+$ for manifest in control-plane-interface worker-interface; do
     oc create -f $manifest.yaml
   done
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.10+

Issue:
n/a

Link to docs preview:
https://deploy-preview-45749--osdocs.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu.html

Additional information:
In recent OpenShift versions, we generally recommend Butane for preprocessing configs, rather than manually base64-encoding files and inserting them inline.  Since the procedure involves extracting and modifying a file, use Butane's local file inclusion rather than inlining the file into the Butane config.

<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
