### PR TITLE
OSDOCS-3418: RN for liveness, readiness, and startup probe config

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -127,6 +127,13 @@ For more information, see xref:../getting_started/openshift-overview.adoc[Gettin
 [id="ocp-4-11-scalability-and-performance"]
 === Scalability and performance
 
+[id=ocp-4-11-ne-livenessProbe-readinessProbe-startupProbe-timeout-configuration]
+/This is a 4.11 Network Edge feature that is located in the Scalability and Performance area of the docs, requested to be placed here by Miciah Masters -Sara T./
+==== Configuring Ingress Controller (router) Liveness, Readiness, and Startup probes
+{product-title} 4.11 introduces the ability to configure the timeout values for the kubelet’s liveness, readiness, and startup probes for router deployments that are managed by the OpenShift Container Platform ingress operator. The ability to set larger timeout values can reduce the risk of unnecessary and unwanted restarts that are caused by short default timeout of 1 second.
+
+For more information see, xref:../scalability_and_performance/routing-optimization.adoc#configuring-ingress-controller-router-liveness-readiness-and-startup-probes[Configuring Ingress Controller (router) Liveness, Readiness, and Startup probes]
+
 [id="ocp-4-11-backup-and-restore"]
 === Backup and restore
 


### PR DESCRIPTION
Version(s):
4.11 RN

Issue:
Feature PR: https://github.com/openshift/openshift-docs/pull/43824#issuecomment-1125749329
Jira: https://issues.redhat.com/browse/NE-683

Link to docs preview:
RN link will resolve once feature PR is merged.
