### PR TITLE
[RHACS] ROX-10938: Add privilege escalation to policy criteria table

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -511,6 +511,14 @@ For example `oc`, or `kubectl`.
 | ✓
 | Deploy
 
+| Privilege escalation
+| Provides alerts when a development is configured to allow a container process to gain more privileges than its parent process.
+| 3.70 and later
+| ✕
+| ✕
+| ✕
+| Deploy
+
 | Ingress Network Policy
 | Check the presence or absence of ingress Kubernetes network policies.
 | 3.70 and later


### PR DESCRIPTION
- Version(s): `rhacs-docs-3.70.0` for now
-  label: **RHACS/next**
- [Issue](https://issues.redhat.com/browse/ROX-10938)
- [preview](https://deploy-preview-45755--osdocs.netlify.app/openshift-acs/latest/operating/manage-security-policies)
