### PR TITLE
[SRVCOM-780]: Add performance and scaling info for Serverless on OCP

### DIFF
--- a/serverless/discover/about-serverless.adoc
+++ b/serverless/discover/about-serverless.adoc
@@ -26,12 +26,23 @@ You can propagate an event from an xref:../../serverless/discover/knative-event-
 
 The set of supported features, configurations, and integrations for {ServerlessProductName}, current and past versions, are available at the link:https://access.redhat.com/articles/4912821[Supported Configurations page].
 
-// only included for OCP currently until CRD docs are available in OSD
 ifdef::openshift-enterprise[]
+[id="about-serverless-scalability-performance"]
+== Scalability and performance
+
+{ServerlessProductName} has been tested with a configuration of 3 main nodes and 3 worker nodes, each of which has 64 CPUs, 457 GB of memory, and 394 GB of storage each.
+
+The maximum number of Knative services that can be created using this configuration is 3,000. This corresponds to the xref:../../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#cluster-maximums-major-releases_object-limits[{product-title} Kubernetes services limit of 10,000], since 1 Knative service creates 3 Kubernetes services.
+
+The average scale from zero response time was approximately 3.4 seconds, with a maximum response time of 8 seconds, and a 99.9th percentile of 4.5 seconds for a simple Quarkus application. These times might vary depending on the application and the runtime of the application.
+endif::[]
+
 [id="additional-resources_about-serverless"]
 [role="_additional-resources"]
 == Additional resources
+ifdef::openshift-enterprise[]
 * xref:../../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-extending-api-with-crds[Extending the Kubernetes API with custom resource definitions]
 * xref:../../operators/understanding/crds/crd-managing-resources-from-crds.adoc#crd-managing-resources-from-crds[Managing resources from custom resource definitions]
 endif::[]
+// above links only included for OCP currently until CRD docs are available in OSD
 * link:https://www.redhat.com/en/topics/cloud-native-apps/what-is-serverless[What is serverless?]


### PR DESCRIPTION
Version(s):
OCP 4.6+

Issue:
https://issues.redhat.com/browse/SRVCOM-780

Link to docs preview:
http://file.rdu.redhat.com/abrennan/010622/SRVCOM-780/serverless/discover/about-serverless.html#about-serverless-scalability-performance