### PR TITLE
[SRVOCF-418]: Add builder information to functions docs

### DIFF
--- a/modules/serverless-build-func-kn.adoc
+++ b/modules/serverless-build-func-kn.adoc
@@ -11,13 +11,13 @@ Before you can run a function, you must build the function project by using the 
 .Example `func.yaml`
 [source,yaml]
 ----
-name: example-function
-namespace: default
-runtime: node
+name: <function_name>
+namespace: <function_namespace>
+runtime: <function_runtime>
 image: <image_from_registry>
 imageDigest: ""
 trigger: http
-builder: default
+builder: <builder_type>
 builderMap:
   default: quay.io/boson/faas-nodejs-builder
 envs: {}
@@ -28,7 +28,7 @@ If the image name and registry are not set in the `func.yaml` file, you must eit
 .Example command using the `-r` registry flag
 [source,terminal]
 ----
-$ kn func build [-i <image> -r <registry> -p <path>]
+$ kn func build -r <registry>
 ----
 
 .Example output
@@ -40,7 +40,7 @@ Function image has been built, image: quay.io/username/example-function:latest
 
 This command creates an OCI container image that can be run locally on your computer, or on a Kubernetes cluster.
 
-.Example using the registy prompt
+.Example using the registry prompt
 [source,terminal]
 ----
 $ kn func build

--- a/modules/serverless-deploy-func-kn.adoc
+++ b/modules/serverless-deploy-func-kn.adoc
@@ -6,9 +6,7 @@
 [id="serverless-deploy-func-kn_{context}"]
 = Deploying functions
 
-You can deploy a function to your cluster as a Knative service by using the `kn func deploy` command.
-
-If the targeted function is already deployed, it is updated with a new container image that is pushed to a container image registry, and the Knative service is updated.
+After a container image is created, you can deploy a function to your cluster as a Knative service by using the `kn func deploy` command. If the targeted function is already deployed, it is updated with a new container image that is pushed to a container image registry, and the Knative service is updated.
 
 .Prerequisites
 

--- a/modules/serverless-functions-func-yaml-fields.adoc
+++ b/modules/serverless-functions-func-yaml-fields.adoc
@@ -11,7 +11,12 @@ Many of the fields in `func.yaml` are generated automatically when you create, b
 [id="serverless-functions-func-yaml-builder_{context}"]
 == builder
 
-The `builder` field specifies the Buildpack builder image to use when building the function. In most cases, this value should not be changed. When you do change it, use a value that is listed in the `builders` field.
+The `builder` field specifies the builder image to use when building the function. The accepted values for this field are `S2i` and `pack`. Using the `S2i` value means that the function uses the link:https://cloud.redhat.com/blog/create-s2i-builder-image[source-to-image (S2I)] image builder. Using `pack` means that the builder uses the link:https://buildpacks.io/[Buildpacks] image builder.
+
+[WARNING]
+====
+While the `pack` value is technically accepted in this field, Buildpacks are not currently supported by Red Hat.
+====
 
 [id="serverless-functions-func-yaml-builders_{context}"]
 == builders

--- a/serverless/discover/serverless-functions-about.adoc
+++ b/serverless/discover/serverless-functions-about.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{FunctionsProductName} enables developers to create and deploy stateless, event-driven functions as a Knative service on {product-title}. The `kn func` CLI is provided as a plug-in for the Knative `kn` CLI. {FunctionsProductName} uses the link:https://buildpacks.io/[CNCF Buildpack API] to create container images. After a container image is created, you can use the `kn func` CLI to deploy the container image as a Knative service on the cluster.
+{FunctionsProductName} enables developers to create and deploy stateless, event-driven functions as a Knative service on {product-title}. The `kn func` CLI is provided as a plug-in for the Knative `kn` CLI.
 
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]

--- a/serverless/functions/serverless-functions-getting-started.adoc
+++ b/serverless/functions/serverless-functions-getting-started.adoc
@@ -6,10 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+This guide explains how you can get started with creating, building, and deploying a function on an {ServerlessProductName} installation.
+
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]
-
-This guide explains how you can get started with creating, building, and deploying a function on an {ServerlessProductName} installation.
 
 [id="prerequisites_serverless-functions-getting-started"]
 == Prerequisites
@@ -18,6 +18,11 @@ Before you can complete the following procedures, you must ensure that you have 
 
 include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../serverless/functions/serverless-functions-yaml.adoc[Function project configuration in func.yaml]
+
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-kn-func-invoke.adoc[leveloffset=+1]
 include::modules/serverless-functions-using-integrated-registry.adoc[leveloffset=+1]
@@ -33,5 +38,4 @@ endif::[]
 
 [id="next-steps_serverless-functions-getting-started"]
 == Next steps
-
-* See xref:../../serverless/functions/serverless-functions-eventing.adoc#serverless-functions-eventing[Using functions with Knative Eventing]
+* xref:../../serverless/functions/serverless-functions-eventing.adoc#serverless-functions-eventing[Using functions with Knative Eventing]


### PR DESCRIPTION
Version(s):
OCP 4.6+
OSD 4

Issue:
https://issues.redhat.com/browse/SRVOCF-418

Link to docs preview:
- https://deploy-preview-45774--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-getting-started.html#serverless-build-func-kn_serverless-functions-getting-started (OCP)
- https://deploy-preview-45774--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-yaml.html#serverless-functions-func-yaml-builder_serverless-functions-yaml (OCP)
- https://deploy-preview-45774--osdocs.netlify.app/openshift-enterprise/latest/serverless/discover/serverless-functions-about.html (OCP)
- https://deploy-preview-45774--osdocs.netlify.app/openshift-dedicated/latest/serverless/discover/serverless-functions-about.html (OSD)
- https://deploy-preview-45774--osdocs.netlify.app/openshift-dedicated/latest/serverless/functions/serverless-functions-yaml.html (OSD)
- https://deploy-preview-45774--osdocs.netlify.app/openshift-dedicated/latest/serverless/functions/serverless-functions-getting-started.html#serverless-build-func-kn_serverless-functions-getting-started (OSD)

Additional information:
- Updated func.yaml docs to provide more info about `builders` field
- Added Additional resources link to getting started build docs
- Tidy up `-r` command example so that it only shows field explicitly mentioned; only supposed to show registry options, doesn't need to repeat every config option
- fix typo, other minor fixes