### PR TITLE
[RHACS] ROX-10983: Add PSPs to Deprecated Features List

### DIFF
--- a/release_notes/370-release-notes.adoc
+++ b/release_notes/370-release-notes.adoc
@@ -111,6 +111,11 @@ In the table, features are marked with the following statuses:
 |GA
 |DEP
 
+| `PodSecurityPolicy` (PSP) Kubernetes objects
+| GA
+| GA
+| DEP
+
 |`RenamePolicyCategory` and `DeletePolicyCategory` API endpoints
 |GA
 |GA


### PR DESCRIPTION
- Version(s): `rhacs-docs-3.70.0` for now
- [Issue](https://issues.redhat.com/browse/ROX-10983)
- [Preview](https://deploy-preview-45776--osdocs.netlify.app/openshift-acs/latest/release_notes/370-release-notes.html)
- Label: **RHACS/next**