### PR TITLE
Clarify how version parameter is applied.

### DIFF
--- a/modules/ossm-cr-version.adoc
+++ b/modules/ossm-cr-version.adoc
@@ -2,7 +2,8 @@
 //
 // * service_mesh/v2x/ossm-reference-smcp.adoc
 
+:_content-type: REFERENCE
 [id="ossm-cr-version_{context}"]
 = version parameter
 
-You use the `version` parameter to specify what version of the control plane to install. When you create a `ServiceMeshControlPlane` object with an empty `version` parameter, the admission webhook sets the version to the current version. New `ServiceMeshControlPlanes` objects with an empty `version` parameter are set to `v2.0`. Existing `ServiceMeshControlPlanes` objects with an empty `version` parameter keep their setting.
+The {SMProductName} Operator supports installation of different versions of the `ServiceMeshControlPlane`. You use the version parameter to specify what version of the control plane to install. If you do not specify a version parameter when creating your SMCP, the Operator sets the value to the latest version: ({MaistraVersion}). Existing `ServiceMeshControlPlane` objects keep their version setting during upgrades of the Operator.


### PR DESCRIPTION
Version(s): 4.6 - 4.11

Update based on a Slack conversation that we should update this section.  Note that the version number is a two digit variable to match to the SMCP version, which is two digits.

Link to docs preview:  https://deploy-preview-45784--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-reference-smcp.html#ossm-cr-version_ossm-reference

Eng review - jwendell
Peer review - 
