### PR TITLE
RHDEVDOCS-4103 Replace kubectl with oc in Pipelines docs

### DIFF
--- a/modules/op-configuring-basic-authentication-for-git.adoc
+++ b/modules/op-configuring-basic-authentication-for-git.adoc
@@ -93,5 +93,5 @@ spec:
 +
 [source,terminal]
 ----
-$ kubectl apply --filename secret.yaml,serviceaccount.yaml,run.yaml
+$ oc apply --filename secret.yaml,serviceaccount.yaml,run.yaml
 ----

--- a/modules/op-configuring-ssh-authentication-for-git.adoc
+++ b/modules/op-configuring-ssh-authentication-for-git.adoc
@@ -99,5 +99,5 @@ spec:
 +
 [source,terminal]
 ----
-$ kubectl apply --filename secret.yaml,serviceaccount.yaml,run.yaml
+$ oc apply --filename secret.yaml,serviceaccount.yaml,run.yaml
 ----

--- a/modules/op-specifying-pipelines-resource-quota-using-priority-class.adoc
+++ b/modules/op-specifying-pipelines-resource-quota-using-priority-class.adoc
@@ -52,8 +52,11 @@ spec:
 .Example: Verify resource quota usage for the pipeline
 [source,terminal]
 ----
-$ kubectl describe quota
-
+$ oc describe quota
+----
++
+.Sample output
+----
 Name:       pipeline1-rq
 Namespace:  default
 Resource    Used  Hard
@@ -185,8 +188,11 @@ spec:
 .Example: Verify resource quota usage for the pipeline
 [source,terminal]
 ----
-$ kubectl describe quota
-
+$ oc describe quota
+----
++
+.Sample output
+----
 Name:       pipeline1-rq
 Namespace:  default
 Resource    Used  Hard


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`
- **JIRA issue**: [RHDEVDOCS-4103 Replace kubectl with oc in Pipelines docs](https://issues.redhat.com/browse/RHDEVDOCS-4103)
- **Preview pages**: 
  - [Authenticating pipelines using git secret](https://deploy-preview-45800--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/authenticating-pipelines-using-git-secret.html)
  - [Setting compute resource quota for OpenShift Pipelines](https://deploy-preview-45800--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/setting-compute-resource-quota-for-openshift-pipelines.html)
- **SME review**: @VeereshAradhya       
- **Peer-review**: @JStickler 