### PR TITLE
TELCODOCS-414: add imageStorage parameter to agent_service_config.yam…

### DIFF
--- a/modules/ztp-ai-install-ocp-clusters-on-bare-metal.adoc
+++ b/modules/ztp-ai-install-ocp-clusters-on-bare-metal.adoc
@@ -17,6 +17,11 @@ For distributed units (DUs), {rh-rhacm} supports {product-title} deployments tha
 * Create persistent volume custom resources (CR) for database and file system storage.
 * You have installed the OpenShift CLI (`oc`).
 
+[IMPORTANT]
+====
+Create a persistent volume resource for image storage. Failure to specify persistent volume storage for images can affect cluster performance.
+====
+
 .Procedure
 
 . Modify the `Provisioning` resource to allow the Bare Metal Operator to watch all namespaces:
@@ -42,27 +47,34 @@ spec:
     - ReadWriteOnce
     resources:
       requests:
-        storage: <db_volume_size> <1>
+        storage: <database_volume_size> <1>
   filesystemStorage:
     accessModes:
     - ReadWriteOnce
     resources:
       requests:
-        storage: <fs_volume_size> <2>
-  osImages: <3>
-    - openshiftVersion: "<ocp_version>" <4>
-      version: "<ocp_release_version>" <5>
-      url: "<iso_url>" <6>
-      rootFSUrl: "<root_fs_url>" <7>
+        storage: <file_storage_volume_size> <2>
+  imageStorage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: <image_storage_volume_size> <3>      
+  osImages: <4>
+    - openshiftVersion: "<ocp_version>" <5>
+      version: "<ocp_release_version>" <6>
+      url: "<iso_url>" <7>
+      rootFSUrl: "<root_fs_url>" <8>
       cpuArchitecture: "x86_64"
 ----
 <1> Volume size for the `databaseStorage` field, for example `10Gi`.
 <2> Volume size for the `filesystemStorage` field, for example `20Gi`.
-<3> List of OS image details. Example describes a single {product-title} OS version.
-<4> {product-title} version to install, for example, `4.8`.
-<5> Specific install version, for example, `47.83.202103251640-0`.
-<6> ISO url, for example, `https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso`.
-<7> Root FS image URL, for example, `https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img`
+<3> Volume size for the `imageStorage` field, for example `2Gi`.
+<4> List of OS image details, for example a single {product-title} OS version.
+<5> {product-title} version to install, for example, `"4.8"`.
+<6> Specific install version, for example, `47.83.202103251640-0`.
+<7> ISO url, for example, `https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso`.
+<8> Root FS image URL, for example `https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img`.
 
 .. Create the `AgentServiceConfig` CR by running the following command:
 +


### PR DESCRIPTION
Fixes: [TELCODOCS-414](https://issues.redhat.com/browse/TELCODOCS-414)

For: Version 4.10+

Doc Preview: https://deploy-preview-45802--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#enabling-assisted-installer-service-on-bare-metal_ztp-deploying-disconnected

Signed-off-by: Katie Tothill ktothill@redhat.com