### PR TITLE
OSDOCS-3638: Release note for AWS/vSphere default compute node resources

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -84,6 +84,10 @@ For more information, see xref:../installing/installing-troubleshooting.adoc#ins
 ==== Support for Microsoft Hyper-V generation version 2
 By default, the installation program now deploys a Microsoft Azure cluster using Hyper-V generation version 2 virtual machines (VMs). If the installation program detects that the instance type selected for the VMs does not support version 2, it uses version 1 for the deployment.
 
+[id="ocp-4-11-worker-nodes"]
+==== Default AWS and VMware vSphere compute node resources
+Beginning with {product-title} 4.11, by default, the installation program now deploys AWS and VMware vSphere compute nodes with 4 vCPUs and 16 GB of virtual RAM.
+
 [id="ocp-4-11-web-console"]
 === Web console
 


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR addresses [OSDOCS-3638](https://issues.redhat.com/browse/OSDOCS-3638) and [CORS-2021](https://issues.redhat.com/browse/CORS-2021)

Link to docs preview:
[Default AWS and VMware vSphere compute node resources](http://file.rdu.redhat.com/mpytlak/osdocs-3638-rn/release_notes/ocp-4-11-release-notes.html#ocp-4-11-worker-nodes)


