### PR TITLE
TELCODOCS-415: Use of openshift-sdn with sno is deprecated

### DIFF
--- a/modules/install-sno-about-installing-on-a-single-node.adoc
+++ b/modules/install-sno-about-installing-on-a-single-node.adoc
@@ -10,5 +10,5 @@ You can create a single node cluster with standard installation methods. {produc
 
 [IMPORTANT]
 ====
-The use of OpenShift software-defined networking (SDN) with Single Node Openshift (SNO) is deprecated. OVN-Kubernetes is the default networking solution for SNO deployments.
+The use of OpenShiftSDN with single-node OpenShift is deprecated. OVN-Kubernetes is the default networking solution for single-node OpenShift deployments.
 ====

--- a/modules/install-sno-about-installing-on-a-single-node.adoc
+++ b/modules/install-sno-about-installing-on-a-single-node.adoc
@@ -7,3 +7,8 @@
 = About OpenShift on a single node
 
 You can create a single node cluster with standard installation methods. {product-title} on a single node is a specialized installation that requires the creation of a special ignition configuration ISO. The primary use case is for edge computing workloads, including intermittent connectivity, portable clouds, and 5G radio access networks (RAN) close to a base station. The major tradeoff with an installation on a single node is the lack of high availability.
+
+[IMPORTANT]
+====
+The use of OpenShift software-defined networking (SDN) with Single Node Openshift (SNO) is deprecated. OVN-Kubernetes is the default networking solution for SNO deployments.
+====

--- a/modules/install-sno-generating-the-discovery-iso-manually.adoc
+++ b/modules/install-sno-generating-the-discovery-iso-manually.adoc
@@ -105,7 +105,7 @@ sshKey: |
 +
 <4> Set the `metadata` name to the cluster name.
 +
-<5> Set the `networkType`. OVNKubernetes is the default networking for SNO. SDN is deprecated.
+<5> Set the `networkType`. OVN-Kubernetes is the default networking for SNO. OpenShiftSDN is deprecated.
 +
 <6> Set the `clusterNetwork` CIDR.
 +

--- a/modules/install-sno-generating-the-discovery-iso-manually.adoc
+++ b/modules/install-sno-generating-the-discovery-iso-manually.adoc
@@ -82,19 +82,19 @@ controlPlane:
 metadata:
   name: <name> <4>
 networking:
-  networkType: OVNKubernetes
+  networkType: OVNKubernetes <5>
   clusterNetwork:
-  - cidr: <IP_address>/<prefix> <5>
-    hostPrefix: <prefix> <6>
+  - cidr: <IP_address>/<prefix> <6>
+    hostPrefix: <prefix> <7>
   serviceNetwork:
-  - <IP_address>/<prefix> <7>
+  - <IP_address>/<prefix> <8>
 platform:
   none: {}
 bootstrapInPlace:
-  installationDisk: <path_to_install_drive> <8>
-pullSecret: '<pull_secret>' <9>
+  installationDisk: <path_to_install_drive> <9>
+pullSecret: '<pull_secret>' <10>
 sshKey: |
-  <ssh_key> <10>
+  <ssh_key> <11>
 ----
 +
 <1> Add the cluster domain name.
@@ -105,17 +105,19 @@ sshKey: |
 +
 <4> Set the `metadata` name to the cluster name.
 +
-<5> Set the `clusterNetwork` CIDR.
+<5> Set the `networkType`. OVNKubernetes is the default networking for SNO. SDN is deprecated.
 +
-<6> Set the `clusterNetwork` host prefix. Pods receive their IP addresses from this pool.
+<6> Set the `clusterNetwork` CIDR.
 +
-<7> Set the `serviceNetwork` CIDR. Services receive their IP addresses from this pool.
+<7> Set the `clusterNetwork` host prefix. Pods receive their IP addresses from this pool.
 +
-<8> Set the path to the installation disk drive.
+<8> Set the `serviceNetwork` CIDR. Services receive their IP addresses from this pool.
 +
-<9> Copy the {cluster-manager-url-pull}. In step 1, click *Download pull secret* and add the contents to this configuration setting.
+<9> Set the path to the installation disk drive.
 +
-<10> Add the public SSH key from the administration host so that you can log in to the cluster after installation.
+<10> Copy the {cluster-manager-url-pull}. In step 1, click *Download pull secret* and add the contents to this configuration setting.
++
+<11> Add the public SSH key from the administration host so that you can log in to the cluster after installation.
 
 . Generate {product-title} assets:
 +

--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -41,6 +41,8 @@ ifeval::["{context}" == "about-openshift-sdn"]
 
 |Egress router|Supported|Supported ^[2]^
 
+|Hybrid networking|Not supported|Supported
+
 |IPsec encryption|Not supported|Supported
 
 |IPv6|Not supported|Supported ^[3]^

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -12,6 +12,11 @@ OVN-Kubernetes is based on Open Virtual Network (OVN) and provides an overlay-ba
 A cluster that uses the OVN-Kubernetes network provider also runs Open vSwitch (OVS) on each node.
 OVN configures OVS on each node to implement the declared network configuration.
 
+[NOTE]
+====
+OVN is the default networking solution for SNO deployments.
+====
+
 include::modules/nw-ovn-kubernetes-features.adoc[leveloffset=+1]
 
 include::modules/nw-ovn-kubernetes-matrix.adoc[leveloffset=+1]

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -14,7 +14,7 @@ OVN configures OVS on each node to implement the declared network configuration.
 
 [NOTE]
 ====
-OVN is the default networking solution for SNO deployments.
+OVN-Kubernetes is the default networking solution for SNO deployments.
 ====
 
 include::modules/nw-ovn-kubernetes-features.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixes: [TELCODOCS-415](https://issues.redhat.com/browse/TELCODOCS-415)

For: Version 4.11 (see [PR 45840](https://github.com/openshift/openshift-docs/pull/45840) for versions 4.9 & 4.10)

Doc Preview: https://deploy-preview-45830--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/about-openshift-sdn.html

Signed-off-by: Katie Tothill ktothill@redhat.com
