### PR TITLE
OADP_476:Where to get Velero CLI tool

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -17,6 +17,14 @@ You can check xref:../../backup_and_restore/application_backup_and_restore/troub
 
 You can collect logs, CR information, and Prometheus metric data by using the xref:../../backup_and_restore/application_backup_and_restore/troubleshooting.adoc#migration-using-must-gather_oadp-troubleshooting[`must-gather` tool].
 
+You can obtain the Velero CLI tool by:
+
+* Downloading the Velero CLI tool
+* Accessing the Velero binary in the Velero deployment in the cluster
+
+include::modules/velero-obtaining-by-downloading.adoc[leveloffset=+1]
+include::modules/velero-obtaining-by-accessing-binary.adoc[leveloffset=+1]
+
 include::modules/oadp-debugging-oc-cli.adoc[leveloffset=+1]
 include::modules/migration-debugging-velero-resources.adoc[leveloffset=+1]
 

--- a/modules/velero-obtaining-by-accessing-binary.adoc
+++ b/modules/velero-obtaining-by-accessing-binary.adoc
@@ -10,7 +10,7 @@ You can use a shell command to access the Velero binary in the Velero deployment
 
 .Prerequisites
 
-* Your Data Protection Application custom resource has a status of `Reconcile complete`.
+* our Data Protection Application custom resource has a status of `Reconcile complete`.
 
 .Procedure
 

--- a/modules/velero-obtaining-by-accessing-binary.adoc
+++ b/modules/velero-obtaining-by-accessing-binary.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+
+:_content-type: PROCEDURE
+[id="velero-obtaining-by-accessing-binary_{context}"]
+= Accessing the Velero binary in the Velero deployment in the cluster
+
+You can use a shell command to access the Velero binary in the Velero deployment in the cluster.
+
+.Prerequisites
+
+* Your Data Protection Application custom resource has a status of `Reconcile complete`.
+
+.Procedure
+
+* Set the following alias:
++
+[source,terminal]
+----
+$ alias velero='oc -n openshift-adp exec deployment/velero -c velero -it -- ./velero'
+----

--- a/modules/velero-obtaining-by-downloading.adoc
+++ b/modules/velero-obtaining-by-downloading.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+
+:_content-type: PROCEDURE
+[id="velero-obtaining-by-downloading_{context}"]
+= Downloading the Velero CLI tool
+
+You can download and install the Velero CLI tool by following the instructions on the link:https://velero.io/docs/v1.8/basic-install/#install-the-cli[Veleo documentation page].
+
+The page includes instructions for:
+
+* MacOS using Homebrew
+* GitHub
+* Windows using Chocolatey
+
+.Prerequisites
+
+* Access to a Kubernetes cluster, v1.16 or later, with DNS and container networking enabled.
+* `kubectl` installed locally.
+
+.Procedure
+
+. Open a browser and navigate to link:https://velero.io/docs/v1.8/basic-install/#install-the-cli["Install the CLI" on the Verleo website].
+. Follow the appropriate procedure for MacOS, GitHub, or Windows.
+. If possible, download the Velero version appropriate for your version of OADP, according to the table that follows:
+
+[cols="2", options="header"]
+.OADP-Velero version relationship
+|===
+|OADP version |Velero version
+|0.2.6 |1.6.0
+|0.5.5 |1.7.1
+|1.0.0 |1.7.1
+|1.0.1 |1.7.1
+|1.0.2 |1.7.1
+|1.0.3 |1.7.1
+|===

--- a/modules/velero-obtaining-by-downloading.adoc
+++ b/modules/velero-obtaining-by-downloading.adoc
@@ -15,7 +15,6 @@ The page includes instructions for:
 * Windows using Chocolatey
 
 .Prerequisites
-
 * Access to a Kubernetes cluster, v1.16 or later, with DNS and container networking enabled.
 * `kubectl` installed locally.
 


### PR DESCRIPTION
OADP 1.0.3, OCP 4.6+

Resolves https://issues.redhat.com/browse/OADP-476

Adds information about how to acquire the Velero CLI tool and which version to get.
