### PR TITLE
BZ-2058050-410 adding first commit for BZ-2058050 on 410

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
@@ -13,3 +13,10 @@ include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leve
 include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]
 
 include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
+include::modules/ipi-manual-migration-to-customdeploy.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_ipi-install-post-installation-configuration"]
+== Additional resources
+* xref:../../machine_management/modifying-machineset.adoc#modifying-machineset[Modifying a machine set].

--- a/modules/ipi-manual-migration-to-customdeploy.adoc
+++ b/modules/ipi-manual-migration-to-customdeploy.adoc
@@ -1,0 +1,49 @@
+// This is included in the following assemblies:
+//
+// ipi-install-post-installation-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="manual-migration-to-new-customdeploy-install-method_{context}"]
+
+= Manual migration to new customDeploy install method
+
+A new deployment method introduced in {product-title} 4.10 allows you to customize the network configuration (`networkConfig`) in the `install-config.yaml` file by host during the installation and provisioning process. You can also set static IPs per host and additional advanced network configurations.
+
+When you upgrade to version 4.10, {product-title} is not automatically upgraded to the new deployment method and you need to perform the following manual steps. Although the functioning of {product-title} is not affected, this change is necessary before trying to scale up the cluster.
+
+.Procedure
+
+. Log in to `oc` as a user with `cluster-admin` permission.
+
+. Find out what machineSets exists:
++
+[source,terminal]
+----
+$ oc get machinesets -A
+----
+
+. Edit each machineSet:
++
+[source,terminal]
+----
+$ oc edit machineset <machineset> -n openshift-machine-api
+----
+
+.. Change to include the following:
++
+[source,yaml]
+----
+spec:
+  providerSpec:
+    value:
+      customDeploy:
+        method: install_coreos
+      image:
+        checksum: ""
+        url: ""
+----
++
+[NOTE]
+====
+The change removes the image `checksum/url` and adds the `customDeploy` field.
+====


### PR DESCRIPTION
[BZ#2058050]: [IPI baremetal ] Document manual migration to new customDeploy install method

Version(s): 4.10 (relevant only for upgrade) 

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2058050

Link to docs preview: https://deploy-preview-45864--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.html

Additional information:
Raised incorrectly here https://github.com/openshift/openshift-docs/pull/45170 
The change landed in 4.10, so to opt-in to the new flow after any
upgrade from pre-4.10 this change will be relevant (so 4.9->4.10 and
eus-eus upgrades e.g 4.8->4.10[1], I'm not sure if we support
skip-level 4.9->4.11 non-eus upgrades?)