### PR TITLE
Fixed incorrect style usage that was missed in peer review of PR 43012

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1336,7 +1336,7 @@ in vSphere.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
 |`platform.vsphere.resourcePool`
-|_Optional_. The absolute path of an existing resource pool where the installer creates the virtual machines. If you do not specify a value, resources are installed in the root of the cluster `/<datacenter_name>/host/<cluster_name>/Resources`.
+|Optional. The absolute path of an existing resource pool where the installer creates the virtual machines. If you do not specify a value, resources are installed in the root of the cluster `/<datacenter_name>/host/<cluster_name>/Resources`.
 |String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
 |`platform.vsphere.network`


### PR DESCRIPTION
Version(s):
CP to 4.10 and 4.11

Issue:
This PR fixes incorrect style usage that was missed in the peer review of PR [43012](https://github.com/openshift/openshift-docs/pull/43012).

Link to docs preview:
