### PR TITLE
OADP-440 DeploymentConfig restic workaround to include templateinstances

### DIFF
--- a/modules/oadp-restic-issues.adoc
+++ b/modules/oadp-restic-issues.adoc
@@ -53,13 +53,13 @@ The `DeploymentConfig` object redeploys the `Restore` pod, causing the `Restore`
 
 .Solution
 
-. Create a `Restore` CR that excludes the `ReplicationController` and `DeploymentConfig` resources:
+. Create a `Restore` CR that excludes the `ReplicationController`, `DeploymentConfig`, and `TemplateInstances` resources:
 +
 [source,terminal]
 ----
 $ velero restore create --from-backup=<backup> -n openshift-adp \ <1>
   --include-namespaces <namespace> \ <2>
-  --exclude-resources replicationcontroller,deploymentconfig \
+  --exclude-resources replicationcontroller,deploymentconfig,templateinstances.template.openshift.io \
   --restore-volumes=true
 ----
 <1> Specify the name of the `Backup` CR.


### PR DESCRIPTION
[OADP-440](https://issues.redhat.com//browse/OADP-440) DeploymentConfig restic workaround needs to include templateinstances

https://issues.redhat.com/browse/OADP-440

OCP 4.x

https://issues.redhat.com/browse/OADP-440
