### PR TITLE
[enterprise-4.11]Added a release note for OSDOCS-3619

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -159,6 +159,12 @@ For more information, see xref:../networking/dns-operator.adoc#nw-dns-forward_dn
 
 // Note: use [discrete] for these sub-headings.
 
+[discrete]
+[id="ocp-4-11-router-load-balancing-algorithm-default-update"]
+==== Update in default value for setting the router load-balancing algorithm
+
+The `haproxy.router.openshift.io/balance` variable, which sets the router load-balancing algorithm, now defaults to the value `random` instead of `leastconn`. See xref:../networking/routes/route-configuration.adoc#nw-route-specific-annotations_route-configuration[Route-specific annotations] for more information.
+
 [id="ocp-4-11-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Release note for https://issues.redhat.com/browse/OSDOCS-3619
Related to https://github.com/openshift/openshift-docs/pull/44889


[Preview Build](http://file.rdu.redhat.com/~ahardin/Mar-11-2022/RN-router-default-random/release_notes/ocp-4-11-release-notes.html#ocp-4-11-router-load-balancing-algorithm-default-update)