### PR TITLE
TELCODOCS-450: D/S Docs & RN: MGMT-8501 Subtask MGMT-8793 Update documentation

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -15,6 +15,11 @@ The installation program no longer needs the `clusterOSImage` {op-system} image 
 
 If you are running the installation program on a network with limited bandwidth and the {op-system} images download takes more than 15 to 20 minutes, the installation program will timeout. Caching images on a web server will help in such scenarios.
 
+[WARNING]
+====
+If you enable TLS for the HTTPD server, you must confirm the root certificate is signed by an authority trusted by the client and verify the trusted certificate chain between your {product-title} hub and spoke clusters and the HTTPD server. Using a server configured with an untrusted certificate prevents the images from being downloaded to the image creation service. Using untrusted HTTPS servers is not supported.
+====
+
 Install a container that contains the images.
 
 .Procedure

--- a/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
+++ b/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
@@ -14,6 +14,11 @@ After you have completed the preceding procedure, follow these steps to configur
 
 * Host the `rootfs` and `iso` images on an HTTPD server.
 
+[WARNING]
+====
+If you enable TLS for the HTTPD server, you must confirm the root certificate is signed by an authority trusted by the client and verify the trusted certificate chain between your {product-title} hub and spoke clusters and the HTTPD server. Using a server configured with an untrusted certificate prevents the images from being downloaded to the image creation service. Using untrusted HTTPS servers is not supported.
+====
+
 .Procedure
 
 . Create a `ConfigMap` containing the mirror registry config:


### PR DESCRIPTION
Fixes: [TELCODOCS-450](https://issues.redhat.com/browse/TELCODOCS-450)

For: Version 4.11 

Doc Previews: 
[Configuring a managed cluster for a disconnected environment](http://file.rdu.redhat.com/ktothill/TELCODOCS-450/scalability_and_performance/ztp-deploying-disconnected.html#ztp-configuring-the-cluster-for-a-disconnected-environment_ztp-deploying-disconnected)
[(Optional) Creating an RHCOS images cache](http://file.rdu.redhat.com/ktothill/TELCODOCS-450/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-creating-an-rhcos-images-cache_ipi-install-installation-workflow)

Signed-off-by: Katie Tothill ktothill@redhat.com