### PR TITLE
OSSMDOC-525: Preliminary Jupiter updates, second half of Service Mesh files

### DIFF
--- a/modules/ossm-kiali-viewing-metrics.adoc
+++ b/modules/ossm-kiali-viewing-metrics.adoc
@@ -7,7 +7,7 @@ Module included in the following assemblies:
 [id="ossm-viewing-metrics_{context}"]
 = Viewing metrics in the Kiali console
 
-You can view inbound and outbound metrics for your applications, workloads, and services in the Kiali console.  The Detail pages include the following tabs:
+You can view inbound and outbound metrics for your applications, workloads, and services in the Kiali console. The Detail pages include the following tabs:
 
 * inbound Application metrics
 * outbound Application metrics
@@ -38,6 +38,6 @@ The Kiali Overview page displays namespaces that have been added to the mesh tha
 
 . On the *Applications*, *Workloads*, or *Services* page, select the project from the *Namespace* menu.
 
-. If necessary, use the filter to find the application, workload, or service whose logs you want to view.  Click the *Name*.
+. If necessary, use the filter to find the application, workload, or service whose logs you want to view. Click the *Name*.
 
 . On the *Application Detail*, *Workload Details*, or *Service Details* page, click either the *Inbound Metrics* or *Outbound Metrics* tab to view the metrics.

--- a/modules/ossm-load-test-results.adoc
+++ b/modules/ossm-load-test-results.adoc
@@ -33,7 +33,7 @@ The CPU consumption scales with the following factors:
 
 However this part is inherently horizontally scalable.
 
-//Do we support namespace isolation?  When namespace isolation is enabled, a single Istiod instance can support 1000 services, 2000 sidecars with 1 vCPU and 1.5 GB of memory.
+//Do we support namespace isolation? When namespace isolation is enabled, a single Istiod instance can support 1000 services, 2000 sidecars with 1 vCPU and 1.5 GB of memory.
 //You can increase the number of Istiod instances to reduce the amount of time it takes for the configuration to reach all proxies.
 
 == Data plane performance

--- a/modules/ossm-member-roll-create.adoc
+++ b/modules/ossm-member-roll-create.adoc
@@ -46,8 +46,8 @@ You can add one or more projects to the {SMProductShortName} member roll from th
 
 . Click *Create*.
 
-[id="ossm-member-roll-create-cli_{context}"]
-== Creating the member roll from the CLI
+
+.Procedure from the CLI
 
 You can add a project to the `ServiceMeshMemberRoll` from the command line.
 
@@ -57,7 +57,6 @@ You can add a project to the `ServiceMeshMemberRoll` from the command line.
 * List of projects to add to the service mesh.
 * Access to the OpenShift CLI (`oc`).
 
-.Procedure
 
 . Log in to the {product-title} CLI.
 +

--- a/modules/ossm-member-roll-modify.adoc
+++ b/modules/ossm-member-roll-modify.adoc
@@ -38,7 +38,7 @@ You can add or remove projects from an existing {SMProductShortName} `ServiceMes
 
 . Click the YAML tab.
 
-. Modify the YAML to add or remove projects as members.  You can add any number of projects, but a project can only belong to *one* `ServiceMeshMemberRoll` resource.
+. Modify the YAML to add or remove projects as members. You can add any number of projects, but a project can only belong to *one* `ServiceMeshMemberRoll` resource.
 
 . Click *Save*.
 
@@ -70,7 +70,7 @@ $ oc edit smmr -n <controlplane-namespace>
 ----
 +
 
-. Modify the YAML to add or remove projects as members.  You can add any number of projects, but a project can only belong to *one* `ServiceMeshMemberRoll` resource.
+. Modify the YAML to add or remove projects as members. You can add any number of projects, but a project can only belong to *one* `ServiceMeshMemberRoll` resource.
 
 +
 .Example servicemeshmemberroll-default.yaml

--- a/modules/ossm-migrating-to-20.adoc
+++ b/modules/ossm-migrating-to-20.adoc
@@ -55,7 +55,7 @@ $ oc patch smcp.v1.maistra.io <smcp_name> --type json --patch '[{"op": "replace"
 $ oc edit smcp.v1.maistra.io <smcp_name>
 ----
 +
-. Back up your control plane configuration. Switch to the project that contains your `ServiceMeshControlPlane` resource.  In this example, `istio-system` is the name of the control plane project.
+. Back up your control plane configuration. Switch to the project that contains your `ServiceMeshControlPlane` resource. In this example, `istio-system` is the name of the control plane project.
 +
 [source,terminal]
 ----
@@ -123,7 +123,7 @@ The following annotations are no longer supported in v2.0. If you are using one 
 * `sidecar.maistra.io/proxyCPULimit` has been replaced with `sidecar.istio.io/proxyCPULimit`. If you were using `sidecar.maistra.io` annotations on your workloads, you must modify those workloads to use `sidecar.istio.io` equivalents instead.
 * `sidecar.maistra.io/proxyMemoryLimit` has been replaced with `sidecar.istio.io/proxyMemoryLimit`
 * `sidecar.istio.io/discoveryAddress` is no longer supported. Also, the default discovery address has moved from `pilot.<control_plane_namespace>.svc:15010` (or port 15011, if mtls is enabled) to `istiod-<smcp_name>.<control_plane_namespace>.svc:15012`.
-* The health status port is no longer configurable and is hard-coded to 15021.  * If you were defining a custom status port, for example, `status.sidecar.istio.io/port`, you must remove the override before moving the workload to a v2.0 control plane. Readiness checks can still be disabled by setting the status port to `0`.
+* The health status port is no longer configurable and is hard-coded to 15021. * If you were defining a custom status port, for example, `status.sidecar.istio.io/port`, you must remove the override before moving the workload to a v2.0 control plane. Readiness checks can still be disabled by setting the status port to `0`.
 * Kubernetes Secret resources are no longer used to distribute client certificates for sidecars. Certificates are now distributed through Istiod's SDS service. If you were relying on mounted secrets, they are longer available for workloads in v2.0 control planes.
 
 [id="ossm-migrating-differences-behavior_{context}"]
@@ -149,7 +149,7 @@ Mutual TLS enforcement is accomplished using the `security.istio.io/v1beta1` Pee
 
 .Authentication
 
-Additional authentication methods specified in `spec.origins`, must be mapped into a `security.istio.io/v1beta1` RequestAuthentication resource.  `spec.selector.matchLabels` must be configured similarly to the same field on PeerAuthentication. Configuration specific to JWT principals from `spec.origins.jwt` items map to similar fields in `spec.rules` items.
+Additional authentication methods specified in `spec.origins`, must be mapped into a `security.istio.io/v1beta1` RequestAuthentication resource. `spec.selector.matchLabels` must be configured similarly to the same field on PeerAuthentication. Configuration specific to JWT principals from `spec.origins.jwt` items map to similar fields in `spec.rules` items.
 
 * `spec.origins[x].jwt.triggerRules` specified in the Policy must be mapped into one or more `security.istio.io/v1beta1` AuthorizationPolicy resources. Any `spec.selector.labels` must be configured similarly to the same field on RequestAuthentication.
 * `spec.origins[x].jwt.triggerRules.excludedPaths` must be mapped into an AuthorizationPolicy whose spec.action is set to ALLOW, with `spec.rules[x].to.operation.path` entries matching the excluded paths.
@@ -157,7 +157,7 @@ Additional authentication methods specified in `spec.origins`, must be mapped in
 
 .ServiceMeshPolicy (maistra.io/v1)
 
-ServiceMeshPolicy was configured automatically for the control plane through the `spec.istio.global.mtls.enabled` in the v1 resource or `spec.security.dataPlane.mtls` in the v2 resource setting. For v2 control planes, a functionally equivalent PeerAuthentication resource is created during installation. This feature is deprecated in {SMProductName} version 2.0
+ServiceMeshPolicy was configured automatically for the control plane through the `spec.istio.global.mtls.enabled` in the v1 resource or `spec.security.dataPlane.mtls` in the v2 resource setting. For v2 control planes, a functionally equivalent PeerAuthentication resource is created during installation. This feature is deprecated in {SMProductName} version 2.0.
 
 .RbacConfig, ServiceRole, ServiceRoleBinding (rbac.istio.io/v1alpha1)
 
@@ -166,7 +166,7 @@ These resources were replaced by the `security.istio.io/v1beta1` AuthorizationPo
 Mimicking RbacConfig behavior requires writing a default AuthorizationPolicy whose settings depend on the spec.mode specified in the RbacConfig.
 
 * When `spec.mode` is set to `OFF`, no resource is required as the default policy is ALLOW, unless an AuthorizationPolicy applies to the request.
-* When `spec.mode` is set to ON, set `spec: {}`.  You must create AuthorizationPolicy policies for all services in the mesh.
+* When `spec.mode` is set to ON, set `spec: {}`. You must create AuthorizationPolicy policies for all services in the mesh.
 * `spec.mode` is set to `ON_WITH_INCLUSION`, must create an AuthorizationPolicy with `spec: {}` in each included namespace. Inclusion of individual services is not supported by AuthorizationPolicy. However, as soon as any AuthorizationPolicy is created that applies to the workloads for the service, all other requests not explicitly allowed will be denied.
 * When `spec.mode` is set to `ON_WITH_EXCLUSION`, it is not supported by AuthorizationPolicy. A global DENY policy can be created, but an AuthorizationPolicy must be created for every workload in the mesh because there is no allow-all policy that can be applied to either a namespace or a workload.
 
@@ -174,12 +174,12 @@ AuthorizationPolicy includes configuration for both the selector to which the co
 
 .ServiceMeshRbacConfig (maistra.io/v1)
 
-This resource is replaced by using a `security.istio.io/v1beta1` AuthorizationPolicy resource with an empty spec.selector in the control plane's namespace.  This policy will be the default authorization policy applied to all workloads in the mesh.  For specific migration details, see RbacConfig above.
+This resource is replaced by using a `security.istio.io/v1beta1` AuthorizationPolicy resource with an empty spec.selector in the control plane's namespace. This policy will be the default authorization policy applied to all workloads in the mesh. For specific migration details, see RbacConfig above.
 
 [id="ossm-migrating-mixer_{context}"]
 === Mixer plugins
 
-Mixer components are disabled by default in version 2.0. If you rely on Mixer plug-ins for your workload, you must configure your version 2.0 `ServiceMeshControlPlane` to include the Mixer components.
+Mixer components are disabled by default in version 2.0. If you rely on Mixer plugins for your workload, you must configure your version 2.0 `ServiceMeshControlPlane` to include the Mixer components.
 
 To enable the Mixer policy components, add the following snippet to your `ServiceMeshControlPlane`.
 

--- a/modules/ossm-mixer-policy-1x.adoc
+++ b/modules/ossm-mixer-policy-1x.adoc
@@ -11,7 +11,10 @@ In previous versions of {SMProductName}, Mixer's policy enforcement was enabled 
 .Prerequisites
 * Access to the OpenShift CLI (`oc`).
 
-NOTE: The examples use `<istio-system>` as the control plane namespace. Replace this value with the namespace where you deployed the Service Mesh Control Plane (SMCP).
+[NOTE]
+====
+The examples use `<istio-system>` as the control plane namespace. Replace this value with the namespace where you deployed the Service Mesh Control Plane (SMCP).
+====
 
 .Procedure
 

--- a/modules/ossm-observability-addresses.adoc
+++ b/modules/ossm-observability-addresses.adoc
@@ -18,7 +18,7 @@ When you install the Service Mesh control plane, it automatically generates rout
 
 .Prerequisite
 
-* The component must be enabled and installed.  For example, if you did not install distributed tracing, you will not be able to access the Jaeger console.
+* The component must be enabled and installed. For example, if you did not install distributed tracing, you will not be able to access the Jaeger console.
 
 .Procedure from OpenShift console
 
@@ -30,7 +30,7 @@ When you install the Service Mesh control plane, it automatically generates rout
 +
 The *Location* column displays the linked address for each route.
 +
-. If necessary, use the filter to find the component console whose route you want to access.  Click the route *Location* to launch the console.
+. If necessary, use the filter to find the component console whose route you want to access. Click the route *Location* to launch the console.
 
 . Click *Log In With OpenShift*.
 
@@ -42,7 +42,7 @@ The *Location* column displays the linked address for each route.
 $ oc login https://<HOSTNAME>:6443
 ----
 +
-. Switch to the control plane project. In this example, `istio-system` is the control plane project.  Run the following command:
+. Switch to the control plane project. In this example, `istio-system` is the control plane project. Run the following command:
 +
 [source,terminal]
 ----

--- a/modules/ossm-observability-visual.adoc
+++ b/modules/ossm-observability-visual.adoc
@@ -33,7 +33,7 @@ The layout for the Kiali graph can render differently depending on your applicat
 
 .Prerequisites
 
-*  If you do not have your own application installed, install the Bookinfo sample application.  Then generate traffic for the Bookinfo application by entering the following command several times.
+* If you do not have your own application installed, install the Bookinfo sample application. Then generate traffic for the Bookinfo application by entering the following command several times.
 +
 [source,terminal]
 ----

--- a/modules/ossm-recommended-resources.adoc
+++ b/modules/ossm-recommended-resources.adoc
@@ -7,7 +7,7 @@ This module included in the following assemblies:
 [id="ossm-recommended-resources_{context}"]
 = Setting limits on compute resources
 
-By default, `spec.proxy` has the settings `cpu: 10m` and  `memory: 128M`. If you are using Pilot, `spec.runtime.components.pilot` has the same default values.
+By default, `spec.proxy` has the settings `cpu: 10m` and `memory: 128M`. If you are using Pilot, `spec.runtime.components.pilot` has the same default values.
 
 The settings in the following example are based on 1,000 services and 1,000 requests per second. You can change the values for `cpu` and `memory` in the `ServiceMeshControlPlane`.
 

--- a/modules/ossm-remove-cleanup-1x.adoc
+++ b/modules/ossm-remove-cleanup-1x.adoc
@@ -44,7 +44,6 @@ $ oc delete -n openshift-operators daemonset/istio-node
 ----
 $ oc delete clusterrole/istio-admin clusterrole/istio-cni clusterrolebinding/istio-cni
 ----
-// needs a slash?  What is the format here?
 +
 [source,terminal]
 ----

--- a/modules/ossm-rn-deprecated-features-1x.adoc
+++ b/modules/ossm-rn-deprecated-features-1x.adoc
@@ -5,7 +5,7 @@ Module included in the following assemblies:
 
 [id="ossm-deprecated-features-1x_{context}"]
 ////
-Description - Description of the any features (including technology previews) that have been removed from the product.  Write the description from a customer perspective, what UI elements, commands, or options are no longer available.
+Description - Description of the any features (including technology previews) that have been removed from the product. Write the description from a customer perspective, what UI elements, commands, or options are no longer available.
 Consequence or a recommended replacement - Description of what the customer can no longer do, and recommended replacement (if known).
 ////
 = Deprecated features

--- a/modules/ossm-rn-fixed-issues-1x.adoc
+++ b/modules/ossm-rn-fixed-issues-1x.adoc
@@ -54,7 +54,7 @@ The following issues been resolved in the current release:
 
 * link:https://issues.jboss.org/browse/MAISTRA-357[MAISTRA-357] In OpenShift 4 Beta on AWS, it is not possible, by default, to access a TCP or HTTPS service through the ingress gateway on a port other than port 80. The AWS load balancer has a health check that verifies if port 80 on the service endpoint is active. Without a service running on port 80, the load balancer health check fails.
 
-* link:https://issues.jboss.org/browse/MAISTRA-348[MAISTRA-348] OpenShift 4 Beta on AWS does not support ingress gateway traffic on ports other than 80 or 443.  If you configure your ingress gateway to handle TCP traffic with a port number other than 80 or 443, you have to use the service hostname provided by the AWS load balancer rather than the OpenShift router as a workaround.
+* link:https://issues.jboss.org/browse/MAISTRA-348[MAISTRA-348] OpenShift 4 Beta on AWS does not support ingress gateway traffic on ports other than 80 or 443. If you configure your ingress gateway to handle TCP traffic with a port number other than 80 or 443, you have to use the service hostname provided by the AWS load balancer rather than the OpenShift router as a workaround.
 
 * link:https://issues.jboss.org/browse/MAISTRA-193[MAISTRA-193] Unexpected console info messages are visible when health checking is enabled for citadel.
 

--- a/modules/ossm-rn-known-issues-1x.adoc
+++ b/modules/ossm-rn-known-issues-1x.adoc
@@ -7,9 +7,9 @@ Module included in the following assemblies:
 = Known issues
 
 ////
-*Consequence* - What user action or situation would make this problem appear (Selecting the Foo option with the Bar version 1.3 plugin enabled results in an error message)?  What did the customer experience as a result of the issue? What was the symptom?
+*Consequence* - What user action or situation would make this problem appear (Selecting the Foo option with the Bar version 1.3 plugin enabled results in an error message)? What did the customer experience as a result of the issue? What was the symptom?
 *Cause* (if it has been identified) - Why did this happen?
-*Workaround* (If there is one)- What can you do to avoid or negate the effects of this issue in the meantime?  Sometimes if there is no workaround it is worthwhile telling readers to contact support for advice. Never promise future fixes.
+*Workaround* (If there is one)- What can you do to avoid or negate the effects of this issue in the meantime? Sometimes if there is no workaround it is worthwhile telling readers to contact support for advice. Never promise future fixes.
 *Result* - If the workaround does not completely address the problem.
 ////
 
@@ -54,7 +54,7 @@ If the `istio-operator` pod is evicted while deploying the control pane, delete 
 
 [NOTE]
 ====
-New issues for Kiali should be created in the link:https://issues.redhat.com/projects/OSSM/[OpenShift Service Mesh]  project with the `Component` set to `Kiali`.
+New issues for Kiali should be created in the link:https://issues.redhat.com/projects/OSSM/[OpenShift Service Mesh] project with the `Component` set to `Kiali`.
 ====
 
 These are the known issues in Kiali:

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -7,9 +7,9 @@ Module included in the following assemblies:
 = Known issues
 
 ////
-*Consequence* - What user action or situation would make this problem appear (Selecting the Foo option with the Bar version 1.3 plugin enabled results in an error message)?  What did the customer experience as a result of the issue? What was the symptom?
+*Consequence* - What user action or situation would make this problem appear (Selecting the Foo option with the Bar version 1.3 plugin enabled results in an error message)? What did the customer experience as a result of the issue? What was the symptom?
 *Cause* (if it has been identified) - Why did this happen?
-*Workaround* (If there is one)- What can you do to avoid or negate the effects of this issue in the meantime?  Sometimes if there is no workaround it is worthwhile telling readers to contact support for advice. Never promise future fixes.
+*Workaround* (If there is one)- What can you do to avoid or negate the effects of this issue in the meantime? Sometimes if there is no workaround it is worthwhile telling readers to contact support for advice. Never promise future fixes.
 *Result* - If the workaround does not completely address the problem.
 ////
 

--- a/modules/ossm-rn-new-features-1x.adoc
+++ b/modules/ossm-rn-new-features-1x.adoc
@@ -81,7 +81,7 @@ Istio generates hostnames for both the hostname itself and all matching ports. F
 
 Your cluster is impacted if you have `AuthorizationPolicy` resources using exact string comparison for the rule to determine link:https://istio.io/latest/docs/reference/config/security/authorization-policy/#Operation[hosts or notHosts].
 
-You must update your authorization policy link:https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule[rules] to use prefix match instead of exact match.  For example, replacing `hosts: ["httpbin.com"]` with `hosts: ["httpbin.com:*"]` in the first `AuthorizationPolicy` example.
+You must update your authorization policy link:https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule[rules] to use prefix match instead of exact match. For example, replacing `hosts: ["httpbin.com"]` with `hosts: ["httpbin.com:*"]` in the first `AuthorizationPolicy` example.
 
 .First example AuthorizationPolicy using prefix match
 [source,yaml]
@@ -192,7 +192,7 @@ Istio supports the following normalization schemes on the request paths before e
 |`DECODE_AND_MERGE_SLASHES`
 |The strictest setting when you allow all traffic by default. This setting is recommended, with the caveat that you must thoroughly test your authorization policies routes. https://tools.ietf.org/html/rfc3986#section-2.1[Percent-encoded] slash and backslash characters (`%2F`, `%2f`, `%5C` and `%5c`) are decoded to `/` or `\`, before the `MERGE_SLASHES` normalization.
 |`/a%2fb` is normalized to `/a/b`.
-|Update to this setting to mitigate CVE-2021-31920.  This setting is more secure, but also has the potential to break applications.  Test your applications before deploying to production.
+|Update to this setting to mitigate CVE-2021-31920. This setting is more secure, but also has the potential to break applications. Test your applications before deploying to production.
 |====
 
 The normalization algorithms are conducted in the following order:
@@ -306,7 +306,7 @@ The fix for link:https://bugzilla.redhat.com/show_bug.cgi?id=1844254[CVE-2020-86
 These manual steps are required to mitigate this CVE whether you are using the 1.1 version or the 1.0 version of {SMProductName}.
 ====
 
-This new configuration option is called `overload.global_downstream_max_connections`, and it is configurable as a proxy `runtime` setting.  Perform the following steps to configure limits at the Ingress Gateway.
+This new configuration option is called `overload.global_downstream_max_connections`, and it is configurable as a proxy `runtime` setting. Perform the following steps to configure limits at the Ingress Gateway.
 
 .Procedure
 
@@ -322,7 +322,7 @@ This new configuration option is called `overload.global_downstream_max_connecti
 +
 [source,terminal]
 ----
-$  oc create secret generic -n <SMCPnamespace> gateway-bootstrap --from-file=bootstrap-override.json
+$ oc create secret generic -n <SMCPnamespace> gateway-bootstrap --from-file=bootstrap-override.json
 ----
 +
 . Update the SMCP configuration to activate the override.
@@ -346,11 +346,11 @@ spec:
 ----
 +
 
-. To set the new configuration option, create a secret that has the desired value for the `overload.global_downstream_max_connections` setting.  The following example uses a value of `10000`:
+. To set the new configuration option, create a secret that has the desired value for the `overload.global_downstream_max_connections` setting. The following example uses a value of `10000`:
 +
 [source,terminal]
 ----
-$  oc create secret generic -n <SMCPnamespace> gateway-settings --from-literal=overload.global_downstream_max_connections=10000
+$ oc create secret generic -n <SMCPnamespace> gateway-settings --from-literal=overload.global_downstream_max_connections=10000
 ----
 +
 
@@ -384,9 +384,9 @@ spec:
 [id="upgrading_es5_es6_{context}"]
 === Upgrading from Elasticsearch 5 to Elasticsearch 6
 
-When updating from Elasticsearch 5 to Elasticsearch 6, you must delete your Jaeger instance, then recreate the Jaeger instance because of an issue with certificates. Re-creating the Jaeger instance triggers creating a new set of certificates.   If you are using persistent storage the same volumes can be mounted for the new Jaeger instance as long as the Jaeger name and namespace for the new Jaeger instance are the same as the deleted Jaeger instance.
+When updating from Elasticsearch 5 to Elasticsearch 6, you must delete your Jaeger instance, then recreate the Jaeger instance because of an issue with certificates. Re-creating the Jaeger instance triggers creating a new set of certificates. If you are using persistent storage the same volumes can be mounted for the new Jaeger instance as long as the Jaeger name and namespace for the new Jaeger instance are the same as the deleted Jaeger instance.
 
-.Procedure if Jaeger is installed as part of Red Hat Service Mesh
+.Procedure if Jaeger is installed as part of {SMProductName}
 
 . Determine the name of your Jaeger custom resource file:
 +
@@ -432,7 +432,7 @@ $ rm /tmp/jaeger-cr.yaml
 ----
 
 
-.Procedure if Jaeger not installed as part of Red Hat Service Mesh
+.Procedure if Jaeger not installed as part of {SMProductName}
 
 Before you begin, create a copy of your Jaeger custom resource file.
 
@@ -465,10 +465,7 @@ $ oc get pods -n jaeger-system -w
 ----
 +
 
-
-
-
-== New features {SMProductName} 1.1.3
+== New features {ProductName} 1.1.3
 
 This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 

--- a/modules/ossm-routing-bookinfo-example.adoc
+++ b/modules/ossm-routing-bookinfo-example.adoc
@@ -8,7 +8,7 @@
 
 The {SMProductShortName} Bookinfo sample application consists of four separate microservices, each with multiple versions. After installing the Bookinfo sample application, three different versions of the `reviews` microservice run concurrently.
 
-When you access the Bookinfo app `/product` page in a browser and refresh several times, sometimes the book review output contains star ratings and other times it does not. Without an explicit default service version to route to, {SMProductShortName} routes requests to all available versions one after the other. 
+When you access the Bookinfo app `/product` page in a browser and refresh several times, sometimes the book review output contains star ratings and other times it does not. Without an explicit default service version to route to, {SMProductShortName} routes requests to all available versions one after the other.
 
 This tutorial helps you apply rules that route all traffic to `v1` (version 1) of the microservices. Later, you can apply a rule to route traffic based on the value of an HTTP request header.
 

--- a/modules/ossm-routing-bookinfo-route.adoc
+++ b/modules/ossm-routing-bookinfo-route.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/ossm-traffic-manage.adoc
+
 :_content-type: PROCEDURE
 [id="ossm-routing-bookinfo-route_{context}"]
 = Route based on user identity

--- a/modules/ossm-routing-bookinfo-test.adoc
+++ b/modules/ossm-routing-bookinfo-test.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/ossm-traffic-manage.adoc
+
 :_content-type: PROCEDURE
 [id="ossm-routing-bookinfo-test_{context}"]
 = Testing the new route configuration

--- a/modules/ossm-routing-ingress.adoc
+++ b/modules/ossm-routing-ingress.adoc
@@ -19,7 +19,7 @@ Ingress configuration differs depending on if your environment supports an exter
 $ oc get svc istio-ingressgateway -n istio-system
 ----
 
-That command returns the `NAME`, `TYPE`, `CLUSTER-IP`, `EXTERNAL-IP`,    `PORT(S)`, and `AGE` of each item in your namespace.
+That command returns the `NAME`, `TYPE`, `CLUSTER-IP`, `EXTERNAL-IP`, `PORT(S)`, and `AGE` of each item in your namespace.
 
 If the `EXTERNAL-IP` value is set, your environment has an external load balancer that you can use for the ingress gateway.
 

--- a/modules/ossm-security-cert-manage.adoc
+++ b/modules/ossm-security-cert-manage.adoc
@@ -45,7 +45,7 @@ spec:
       istiod:
         type: PrivateKey
         privateKey:
-          rootCADir: /etc/cacerts
+          rootCADir:  /etc/cacerts
 ----
 
 . After creating/changing/deleting the `cacert` secret, the control plane `istiod` and `gateway` pods must be restarted so the changes go into effect. Use the following command to restart the pods:

--- a/modules/ossm-security-cipher.adoc
+++ b/modules/ossm-security-cipher.adoc
@@ -14,7 +14,7 @@ Set your cipher suites in the comma separated list in order of priority. For exa
 
 [NOTE]
 ====
-You must include either `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` or  `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256` when you configure the cipher suite. HTTP/2 support requires at least one of these cipher suites.
+You must include either `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` or `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256` when you configure the cipher suite. HTTP/2 support requires at least one of these cipher suites.
 
 ====
 

--- a/modules/ossm-threescale-authentication.adoc
+++ b/modules/ossm-threescale-authentication.adoc
@@ -5,6 +5,7 @@
 
 [id="ossm-threescale-authentication_{context}"]
 = Authenticating requests
+
 This release supports the following authentication methods:
 
 * *Standard API Keys*: single randomized strings or hashes acting as an identifier and a secret token.

--- a/modules/ossm-threescale-caching.adoc
+++ b/modules/ossm-threescale-caching.adoc
@@ -5,6 +5,7 @@
 
 [id="ossm-threescale-caching_{context}"]
 = Caching behavior
+
 Responses from 3scale System APIs are cached by default within the adapter. Entries will be purged from the cache when they become older than the `cacheTTLSeconds` value. Also by default, automatic refreshing of cached entries will be attempted seconds before they expire, based on the `cacheRefreshSeconds` value. You can disable automatic refreshing by setting this value higher than the `cacheTTLSeconds` value.
 
 Caching can be disabled entirely by setting `cacheEntriesMax` to a non-positive value.

--- a/modules/ossm-threescale-integrate-1x.adoc
+++ b/modules/ossm-threescale-integrate-1x.adoc
@@ -22,7 +22,6 @@ You can use these examples to configure requests to your services using the 3sca
 To configure the 3scale Istio Adapter, refer to {SMProductName} custom resources for instructions on adding adapter parameters to the custom resource file.
 ====
 
-
 [NOTE]
 ====
 Pay particular attention to the `kind: handler` resource. You must update this with your 3scale account credentials. You can optionally add a `service_id` to a handler, but this is kept for backwards compatibility only, since it would render the handler only useful for one service in your 3scale account. If you add `service_id` to a handler, enabling 3scale for other services requires you to create more handlers with different `service_ids`.

--- a/modules/ossm-threescale-metrics-1x.adoc
+++ b/modules/ossm-threescale-metrics-1x.adoc
@@ -5,4 +5,5 @@
 
 [id="ossm-threescale-metrics-1x_{context}"]
 = 3scale Adapter metrics
+
 The adapter, by default reports various Prometheus metrics that are exposed on port `8080` at the `/metrics` endpoint. These metrics provide insight into how the interactions between the adapter and 3scale are performing. The service is labeled to be automatically discovered and scraped by Prometheus.

--- a/modules/ossm-threescale-metrics.adoc
+++ b/modules/ossm-threescale-metrics.adoc
@@ -5,9 +5,13 @@
 
 [id="ossm-threescale-metrics_{context}"]
 = 3scale Adapter metrics
+
 The adapter, by default reports various Prometheus metrics that are exposed on port `8080` at the `/metrics` endpoint. These metrics provide insight into how the interactions between the adapter and 3scale are performing. The service is labeled to be automatically discovered and scraped by Prometheus.
 
-NOTE: There are incompatible changes in the 3scale Istio Adapter metrics since the previous releases in Service Mesh 1.x.
+[NOTE]
+====
+There are incompatible changes in the 3scale Istio Adapter metrics since the previous releases in Service Mesh 1.x.
+====
 
 In Prometheus, metrics have been renamed with one addition for the backend cache, so that the following metrics exist as of Service Mesh 2.0:
 

--- a/modules/ossm-threescale-routing.adoc
+++ b/modules/ossm-threescale-routing.adoc
@@ -6,6 +6,7 @@
 :_content-type: PROCEDURE
 [id="ossm-threescale-routing_{context}"]
 = Routing service traffic through the adapter
+
 Follow these steps to drive traffic for your service through the 3scale adapter.
 
 .Prerequisites

--- a/modules/ossm-threescale-webassembly-module-examples-for-credentials-use-cases.adoc
+++ b/modules/ossm-threescale-webassembly-module-examples-for-credentials-use-cases.adoc
@@ -59,7 +59,7 @@ The resolution here assigns the `app_key` if there is one or two outputted at th
 The `authorization` header specifies a value with the type of authorization and its value is encoded as `Base64`. This means you can split the value by a space character, take the second output and then split it again using a colon (:) as the separator. For example, if you use this format `app_id:app_key`, the header looks like the following example for `credential`:
 
 ----
-aladdin:opensesame:  Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l
+aladdin:opensesame: Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l
 ----
 
 You must use lower case header field names as shown in the following example:

--- a/modules/ossm-tutorial-bookinfo-install.adoc
+++ b/modules/ossm-tutorial-bookinfo-install.adoc
@@ -24,7 +24,7 @@ The Bookinfo sample application cannot be installed on IBM Z and IBM Power Syste
 
 [NOTE]
 ====
-The commands in this section assume the control plane project is `istio-system`.  If you installed the control plane in another namespace, edit each command before you run it.
+The commands in this section assume the control plane project is `istio-system`. If you installed the control plane in another namespace, edit each command before you run it.
 ====
 
 .Procedure
@@ -74,7 +74,7 @@ spec:
   - bookinfo
 ----
 +
-.. Run the following command to upload that file and create the `ServiceMeshMemberRoll` resource in the `istio-system` namespace.   In this example, `istio-system` is the name of the control plane project.
+.. Run the following command to upload that file and create the `ServiceMeshMemberRoll` resource in the `istio-system` namespace. In this example, `istio-system` is the name of the control plane project.
 +
 [source,terminal]
 ----

--- a/modules/ossm-tutorial-grafana-accessing.adoc
+++ b/modules/ossm-tutorial-grafana-accessing.adoc
@@ -18,10 +18,10 @@ The Grafana dashboard's web-based interface lets you visualize your metrics data
 . A route to access the Grafana dashboard already exists. In this example, `istio-system` is the name of the control plane project. Query for details of the route:
 +
 ----
-  $ export GRAFANA_URL=$(oc get route -n istio-system grafana -o jsonpath='{.spec.host}')
+$ export GRAFANA_URL=$(oc get route -n istio-system grafana -o jsonpath='{.spec.host}')
 ----
 +
-. Launch a browser and navigate to navigate to `http://<GRAFANA_URL>`.  You see Grafana's home screen, as shown in the following figure:
+. Launch a browser and navigate to navigate to `http://<GRAFANA_URL>`. You see Grafana's home screen, as shown in the following figure:
 +
 image::ossm-grafana-home-screen.png[]
 +

--- a/modules/ossm-tutorial-jaeger-generating-traces.adoc
+++ b/modules/ossm-tutorial-jaeger-generating-traces.adoc
@@ -49,4 +49,4 @@ echo $JAEGER_URL
 
 . In the left pane of the Jaeger dashboard, from the *Service* menu, select *productpage.bookinfo* and click *Find Traces* at the bottom of the pane. A list of traces is displayed.
 
-. Click one of the traces in the list to open a detailed view of that trace.  If you click the first one in the list, which is the most recent trace, you see the details that correspond to the latest refresh of the `/productpage`.
+. Click one of the traces in the list to open a detailed view of that trace. If you click the first one in the list, which is the most recent trace, you see the details that correspond to the latest refresh of the `/productpage`.

--- a/modules/ossm-tutorial-prometheus-querying-metrics.adoc
+++ b/modules/ossm-tutorial-prometheus-querying-metrics.adoc
@@ -46,7 +46,7 @@ $ curl -o /dev/null http://$GATEWAY_URL/productpage
 $ export PROMETHEUS_URL=$(oc get route -n istio-system prometheus -o jsonpath='{.spec.host}')
 ----
 +
-. Launch a browser and navigate to  `http://<PROMETHEUS_URL>`. You will see the Prometheus home screen, similar to the following figure:
+. Launch a browser and navigate to `http://<PROMETHEUS_URL>`. You will see the Prometheus home screen, similar to the following figure:
 +
 image::ossm-prometheus-home-screen.png[]
 +
@@ -54,7 +54,7 @@ image::ossm-prometheus-home-screen.png[]
 +
 image::ossm-prometheus-metrics.png[]
 +
-. You can narrow down queries by using selectors. For example `istio_request_duration_seconds_count{destination_workload="reviews-v2"}`  shows only counters with the matching *destination_workload* label. For more information about using queries, see the link:https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors[Prometheus documentation].
+. You can narrow down queries by using selectors. For example `istio_request_duration_seconds_count{destination_workload="reviews-v2"}` shows only counters with the matching *destination_workload* label. For more information about using queries, see the link:https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors[Prometheus documentation].
 +
 . To list all available Prometheus metrics, run the following command:
 +
@@ -63,4 +63,4 @@ image::ossm-prometheus-metrics.png[]
 $ oc get prometheus -n istio-system -o jsonpath='{.items[*].spec.metrics[*].name}' requests_total request_duration_seconds request_bytes response_bytes tcp_sent_bytes_total tcp_received_bytes_total
 ----
 +
-Note that returned metric names must be prepended with `istio_` when used in queries, for example,  `requests_total` is `istio_requests_total`.
+Note that returned metric names must be prepended with `istio_` when used in queries, for example, `requests_total` is `istio_requests_total`.

--- a/modules/ossm-understanding-versions.adoc
+++ b/modules/ossm-understanding-versions.adoc
@@ -1,5 +1,4 @@
 // Module included in the following assemblies:
-// * service_mesh/v1x/upgrading-ossm.adoc  ???
 // * service_mesh/v2x/upgrading-ossm.adoc
 // * service_mesh/v2x/ossm-troubleshooting.adoc
 

--- a/modules/ossm-upgrading-to-21.adoc
+++ b/modules/ossm-upgrading-to-21.adoc
@@ -57,7 +57,7 @@ For example:
 ----
 spec:
   policy:
-    type: Istiod
+    type: Istoid
   telemetry:
     type: Istiod
   version: v2.1

--- a/service_mesh/v2x/ossm-extensions.adoc
+++ b/service_mesh/v2x/ossm-extensions.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use WebAssembly extensions to add new features directly into the {SMProductName} proxies, allowing you to move even more common functionality out of your applications, and implement them in a single language that compiles to WebAssembly bytecode.
+You can use WebAssembly extensions to add new features directly into the {SMProductName} proxies, allowing you to move even more common functionality out of your applications, and implement them in a single language that compiles to WebAssembly bytecode. 
 
 == WebAssembly extensions
 


### PR DESCRIPTION
Version(s): 4.6 - 4.11

Issue: [OSSMDOC-525](https://issues.redhat.com/browse/OSSMDOC-525)

Link to docs preview: No visible changes in output?

This PR is not intended to address all required Jupiter changes, it only includes some preliminary cleanup done while scoping Jupiter work for the Epic [OSSMDOC-523](https://issues.redhat.com/browse/OSSMDOC-523). This PR may include:

-  updating IDs to match headings
-  Deleting comments or notes
-  replacing text with attributes
-  Adding empty lines required by formatting
-  Deleting double spaces after a period