### PR TITLE
RHIBMCS-126, Added an Egress support statement for clarity

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -8,7 +8,10 @@
 = About network policy
 
 In a cluster using a Kubernetes Container Network Interface (CNI) plug-in that supports Kubernetes network policy, network isolation is controlled entirely by `NetworkPolicy` objects.
+
 In {product-title} {product-version}, OpenShift SDN supports using network policy in its default network isolation mode.
+
+The OpenShift SDN cluster network provider now supports the egress network policy as specified by the `egress` field.
 
 [WARNING]
 ====


### PR DESCRIPTION
Relates to https://issues.redhat.com/browse/RHIBMCS-126 and https://bugzilla.redhat.com/show_bug.cgi?id=2060553

Applies to 4.10 only

Preview build: http://file.rdu.redhat.com/~ahardin/Mar-11-2022/network-policy-egress-note/networking/network_policy/about-network-policy.html