### PR TITLE
BZ-2082671: Removing networkConfig spec from BareMetalHost definition

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
@@ -16,9 +16,11 @@ Expanding the cluster using RedFish Virtual Media involves meeting minimum firmw
 include::modules/ipi-install-preparing-the-bare-metal-node.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_ipi-install-expanding"]
 .Additional resources
 
 * xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow[(Optional) Configuring host network interfaces in the install-config.yaml file]
+* xref:../../scalability_and_performance/managing-bare-metal-hosts.adoc#automatically-scaling-machines-to-available-bare-metal-hosts_managing-bare-metal-hosts[Automatically scaling machines to the number of available bare metal hosts]
 
 include::modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc[leveloffset=+1]
 

--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -30,7 +30,7 @@ $ curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/ope
 $ sudo cp oc /usr/local/bin
 ----
 
-. Power off the bare metal node by using the baseboard management controller, and ensure it is off.
+. Power off the bare metal node by using the baseboard management controller (BMC), and ensure it is off.
 
 . Retrieve the user name and password of the bare metal node's baseboard management controller. Then, create `base64` strings from the user name and password:
 +
@@ -53,52 +53,68 @@ $ vim bmh.yaml
 +
 [source,yaml]
 ----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshift-worker-<num>-network-config-secret <1> <2>  
+type: Opaque
+stringData:
+ nmstate: |
+   routes:
+     config:
+     - destination: 0.0.0.0/0
+       next-hop-address: 192.168.123.1
+       next-hop-interface: enp0s4
+   dns-resolver:
+     config:
+       server:
+       - 192.168.123.1
+   interfaces:
+   - name: enp0s4
+     state: up
+     ipv4:
+       address:
+       - ip: 192.168.123.16
+         prefix-length: 24
+       enabled: true
+       dhcp: false
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: openshift-worker-<num>-bmc-secret <1>
+  name: openshift-worker-<num>-bmc-secret <2> 
+  namespace: openshift-machine-api
 type: Opaque
 data:
-  username: <base64-of-uid> <2>
-  password: <base64-of-pwd> <3>
+  username: <base64-of-uid> <3>
+  password: <base64-of-pwd> <4>
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: openshift-worker-<num> <1>
+  name: openshift-worker-<num> <2>
+  namespace: openshift-machine-api
 spec:
   online: true
-  bootMACAddress: <NIC1-mac-address> <4>
+  bootMACAddress: <NIC1-mac-address> <5>
   bmc:
-    address: <protocol>://<bmc-ip> <5>
-    credentialsName: openshift-worker-<num>-bmc-secret <1>
-  networkConfig: <6>
-    interfaces:
-    - name: <NIC1_name>
-      type: ethernet
-      state: up
-      ipv4:
-        address:
-        - ip: "<IP_address>"
-          prefix-length: 24
-        enabled: true
-    dns-resolver:
-      config:
-        server:
-        - <DNS_IP_address>
-    routes:
-      config:
-      - destination: 0.0.0.0/0
-        next-hop-address: <IP_address>
-        next-hop-interface: <NIC1_name>
+    address: <protocol>://<bmc-ip> <6>
+    credentialsName: openshift-worker-<num>-bmc-secret <2>
+    disableCertificateVerification: true <7>
+    username: <bmc-username> <8>
+    password: <bmc-password> <9>
+  preprovisioningNetworkDataName: openshift-worker-<num>-network-config-secret <10> <2>
 ----
-<1> Replace `<num>` for the worker number of the bare metal node in the two `name` fields and the `credentialsName` field.
-<2> Replace `<base64-of-uid>` with the `base64` string of the user name.
-<3> Replace `<base64-of-pwd>` with the `base64` string of the password.
-<4> Replace `<NIC1-mac-address>` with the MAC address of the bare metal node's first NIC. See the BMC addressing section for additional BMC configuration options. Replace `<protocol>` with the BMC protocol, such as IPMI, RedFish, or others.
-<5> Replace `<bmc-ip>` with the IP address of the bare metal node's baseboard management controller.
-<6> Optional. You can set the `networkConfig` configuration option to configure host network interfaces. See "(Optional) Configuring host network interfaces in the `install-config.yaml` file" in the "Setting up the environment for an OpenShift installation" section for configuration details. 
+<1> Optional: To configure network for a newly created node, specify the name of the secret that contains the network configuration. Follow the `nmstate` syntax to define the network configuration for your node.
+<2> Replace `<num>` for the worker number of the bare metal node in the `name` fields, the `credentialsName` field, and the `preprovisioningNetworkDataName` field.
+<3> Replace `<base64-of-uid>` with the `base64` string of the user name.
+<4> Replace `<base64-of-pwd>` with the `base64` string of the password.
+<5> Replace `<NIC1-mac-address>` with the MAC address of the bare metal node's first NIC. See the "BMC addressing" section for additional BMC configuration options.
+<6> Replace `<protocol>` with the BMC protocol, such as IPMI, RedFish, or others. Replace `<bmc-ip>` with the IP address of the bare metal node's baseboard management controller.
+<7> To skip certificate validation, set `disableCertificateVerification` to `true`.
+<8> Replace `<bmc-username>` with the `bmc` string of the user name.
+<9> Replace `<bmc-password>` with the `bmc` string of the password.
+<10> Optional: Provide the network configuration secret name in the `preprovisioningNetworkDataName` of the `BareMetalHost` CR if you have configured network for the newly created node.
 +
 [NOTE]
 ====
@@ -115,6 +131,7 @@ $ oc -n openshift-machine-api create -f bmh.yaml
 .Example output
 [source,terminal]
 ----
+secret/openshift-worker-<num>-network-config-secret created
 secret/openshift-worker-<num>-bmc-secret created
 baremetalhost.metal3.io/openshift-worker-<num> created
 ----
@@ -136,3 +153,8 @@ Where `<num>` is the worker node number.
 NAME                    STATE       CONSUMER   ONLINE   ERROR
 openshift-worker-<num>  available              true
 ----
++
+[NOTE]
+====
+To allow the worker node to join the cluster, scale the `machineset` object to the number of the `BareMetalHost` objects. You can scale nodes either manually or automatically. To scale nodes automatically, use the `metal3.io/autoscale-to-hosts` annotation for `machineset`.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s): OpenShift 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to.
If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2082671
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.emea.redhat.com/avbhatt/bz-2082671/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-the-bare-metal-node_ipi-install-expanding
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
  - The preview will be generated after you open the PR.
  - You will need to edit the comment to add the link after the preview builds.
  - Review the preview build to make sure your changes are rendering properly. --->

Additional information: Updated the docs to remove the `networkConfig` spec from `BareMetalHost` definition since it is not included in the API reference documentation for [BareMetalHost [metal3.io/v1alpha1]](https://docs.openshift.com/container-platform/4.10/rest_api/provisioning_apis/baremetalhost-metal3-io-v1alpha1.html) 

Also updated the YAML to reflect the correct `BareMetalHost` spec for configuring network (preprovisioningNetworkDataName)


<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
