### PR TITLE
OSDOCS-3677: Add no backup statement for ROSA STS clusters

### DIFF
--- a/modules/rosa-policy-incident.adoc
+++ b/modules/rosa-policy-incident.adoc
@@ -40,8 +40,14 @@ The following activities can trigger notifications:
 - Critical vulnerabilities and resolution
 - Upgrade scheduling
 
-[id="rosa-policy-backup-recovery_{context}"]
-== Backup and recovery
+[id="rosa-policy-backup-recovery-sts_{context}"]
+== Backup and recovery for ROSA clusters with STS
+
+There is no backup method available for ROSA clusters with STS.
+
+[id="rosa-policy-backup-recovery-non-sts_{context}"]
+== Backup and recovery for ROSA clusters without STS
+
 All {product-title} clusters are backed up using AWS snapshots. Notably, this does not include customer data stored on persistent volumes (PVs). All snapshots are taken using the appropriate AWS snapshot APIs and are uploaded to a secure AWS S3 object storage bucket in the same account as the cluster.
 
 [cols= "3a,2a,2a,3a",options="header"]
@@ -55,7 +61,7 @@ All {product-title} clusters are backed up using AWS snapshots. Notably, this do
 .2+|Full object store backup, all SRE-managed cluster PVs
 |Daily
 |7 days
-.2+|This is a full backup of all Kubernetes objects, such as etcd, and all SRE-managed PVs in the cluster. Etcd backup does not apply to STS clusters.
+.2+|This is a full backup of all Kubernetes objects, such as etcd, and all SRE-managed PVs in the cluster.
 
 |Weekly
 |30 days
@@ -64,7 +70,7 @@ All {product-title} clusters are backed up using AWS snapshots. Notably, this do
 |Full object store backup
 |Hourly
 |24-hour
-|This is a full backup of all Kubernetes objects, such as etcd. No PVs are backed up in this backup schedule. Etcd backup does not apply to STS clusters. 
+|This is a full backup of all Kubernetes objects, such as etcd. No PVs are backed up in this backup schedule.
 
 |Node root volume
 |Never


### PR DESCRIPTION
Version(s):
4.10, 4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3677

Link to docs preview:
http://file.rdu.redhat.com/~bmcelvee/20222305/rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.html#rosa-policy-backup-recovery_rosa-policy-process-security (VPN required)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
