### PR TITLE
CNV-18183: Clarify that descheduling of VMs results in live migration

### DIFF
--- a/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.adoc
@@ -7,12 +7,18 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 :FeatureName: Descheduler eviction for virtual machines
-include::snippets/technology-preview.adoc[]
 
-The xref:../../../nodes/scheduling/nodes-descheduler.adoc#nodes-descheduler[descheduler] can be used to evict a running pod to allow the pod to be rescheduled onto a more suitable node. You must install the descheduler by using the {product-title} web console or OpenShift CLI (`oc`) before you can enable it on your virtual machine (VM).
+You can use the descheduler to evict pods so that the pods can be rescheduled onto more appropriate nodes. If the pod is a virtual machine, the pod eviction causes the virtual machine to be live migrated to another node.
+
+include::snippets/technology-preview.adoc[]
 
 include::modules/nodes-descheduler-profiles.adoc[leveloffset=+1]
 
 include::modules/nodes-descheduler-installing.adoc[leveloffset=+1]
 
 include::modules/virt-enabling-descheduler-evictions.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_enabling-descheduler-evictions"]
+== Additional resources
+* xref:../../../nodes/scheduling/nodes-descheduler.adoc#nodes-descheduler[Evicting pods using the descheduler]


### PR DESCRIPTION
Version(s): 4.10 and later

Issue: [CNV-18183](https://issues.redhat.com//browse/CNV-18183)

Link to docs preview: http://file.rdu.redhat.com/sjess/CNV18183/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.html