### PR TITLE
TELCODOCS-580: D/S Docs & RN: CNF-3431 Move PAO under NTO as new controller: Performance Profile doc updates

### DIFF
--- a/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
+++ b/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
@@ -11,7 +11,7 @@ The Performance Profile Creator (PPC) tool requires `must-gather` data. As a clu
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
-* Access to the Performance Addon Operator image.
+* Access to the Performance Addon Operator `must gather` image.
 * The OpenShift CLI (`oc`) installed.
 
 .Procedure
@@ -22,20 +22,19 @@ The Performance Profile Creator (PPC) tool requires `must-gather` data. As a clu
 +
 [source,terminal]
 ----
-$ oc adm must-gather --image=<PAO_image> --dest-dir=<dir>
+$ oc adm must-gather --image=<PAO_must_gather_image> --dest-dir=<dir>
 ----
 +
 [NOTE]
 ====
 `must-gather` must be run with the `performance-addon-operator-must-gather` image. The output can optionally be compressed. Compressed output is required if you are running the Performance Profile Creator wrapper script.
 ====
-
 +
 .Example
 +
 [source,terminal]
 ----
-$ oc adm must-gather --image=registry.redhat.io/openshift4/performance-addon-operator-must-gather-rhel8:v4.10 --dest-dir=must-gather
+$ oc adm must-gather --image=registry.redhat.io/openshift4/performance-addon-operator-must-gather-rhel8:v4.11 --dest-dir=must-gather
 ----
 . Create a compressed file from the `must-gather` directory:
 +

--- a/modules/cnf-how-run-podman-to-create-profile.adoc
+++ b/modules/cnf-how-run-podman-to-create-profile.adoc
@@ -18,7 +18,7 @@ Run `podman` to create the performance profile:
 
 [source,terminal]
 ----
-$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.10 --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true --split-reserved-cpus-across-numa=true --must-gather-dir-path /must-gather > my-performance-profile.yaml
+$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-operator:v4.11 --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true --split-reserved-cpus-across-numa=true --must-gather-dir-path /must-gather > my-performance-profile.yaml
 ----
 
 The created profile is described in the following YAML:

--- a/modules/cnf-running-the-performance-creator-profile-offline.adoc
+++ b/modules/cnf-running-the-performance-creator-profile-offline.adoc
@@ -10,7 +10,7 @@ The performance profile wrapper script simplifies the running of the Performance
 
 .Prerequisites
 
-* Access to the Performance Addon Operator image.
+* Access to the Node Tuning Operator image.
 * Access to the `must-gather` tarball.
 
 .Procedure
@@ -35,7 +35,7 @@ readonly IMG_EXISTS_CMD="${CONTAINER_RUNTIME} image exists"
 readonly IMG_PULL_CMD="${CONTAINER_RUNTIME} image pull"
 readonly MUST_GATHER_VOL="/must-gather"
 
-PAO_IMG="registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.10"
+NTO_IMG="registry.redhat.io/openshift4/ose-cluster-node-tuning-operator:v4.11"
 MG_TARBALL=""
 DATA_DIR=""
 
@@ -45,10 +45,10 @@ usage() {
   print ""
   print "Options:"
   print "   -h                 help for ${CURRENT_SCRIPT}"
-  print "   -p                 Performance Addon Operator image"
+  print "   -p                 Node Tuning Operator image"
   print "   -t                 path to a must-gather tarball"
 
-  ${IMG_EXISTS_CMD} "${PAO_IMG}" && ${CMD} "${PAO_IMG}" -h
+  ${IMG_EXISTS_CMD} "${NTO_IMG}" && ${CMD} "${NTO_IMG}" -h
 }
 
 function cleanup {
@@ -67,8 +67,8 @@ print() {
 }
 
 check_requirements() {
-  ${IMG_EXISTS_CMD} "${PAO_IMG}" || ${IMG_PULL_CMD} "${PAO_IMG}" || \
-      exit_error "Performance Addon Operator image not found"
+  ${IMG_EXISTS_CMD} "${NTO_IMG}" || ${IMG_PULL_CMD} "${NTO_IMG}" || \
+      exit_error "Node Tuning Operator image not found"
 
   [ -n "${MG_TARBALL}" ] || exit_error "Must-gather tarball file path is mandatory"
   [ -f "${MG_TARBALL}" ] || exit_error "Must-gather tarball file not found"
@@ -88,7 +88,7 @@ main() {
         exit 0
         ;;
       p)
-        PAO_IMG="${OPTARG}"
+        NTO_IMG="${OPTARG}"
         ;;
       t)
         MG_TARBALL="${OPTARG}"
@@ -102,7 +102,7 @@ main() {
 
   check_requirements || exit 1
 
-  ${CMD} -v "${DATA_DIR}:${MUST_GATHER_VOL}:z" "${PAO_IMG}" "$@" --must-gather-dir-path "${MUST_GATHER_VOL}"
+  ${CMD} -v "${DATA_DIR}:${MUST_GATHER_VOL}:z" "${NTO_IMG}" "$@" --must-gather-dir-path "${MUST_GATHER_VOL}"
   echo "" 1>&2
 }
 
@@ -132,7 +132,7 @@ Wrapper usage:
 
 Options:
    -h                 help for run-perf-profile-creator.sh
-   -p                 Performance Addon Operator image <1>
+   -p                 Node Tuning Operator image <1>
    -t                 path to a must-gather tarball <2>
 
 A tool that automates creation of Performance Profiles
@@ -163,7 +163,7 @@ There two types of arguments:
 * PPC arguments
 ====
 +
-<1> Optional: Specify the Performance Addon Operator image. If not set, the default upstream image is used: `registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.10`.
+<1> Optional: Specify the Node Tuning Operator image. If not set, the default upstream image is used: `registry.redhat.io/openshift4/ose-cluster-node-tuning-operator:v4.11`.
 <2> `-t` is a required wrapper script argument and specifies the path to a `must-gather` tarball.
 
 . Run the performance profile creator tool in discovery mode:

--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -13,12 +13,11 @@ As a cluster administrator, you can run `podman` and the Performance Profile Cre
 * Access to the cluster as a user with the `cluster-admin` role.
 * A cluster installed on bare metal hardware.
 * A node with `podman` and OpenShift CLI (`oc`) installed.
-
+* Access to the Node Tuning Operator image.
 
 .Procedure
 
 . Check the machine config pool:
-
 +
 [source,terminal]
 ----
@@ -50,7 +49,7 @@ Password: ************
 +
 [source,terminal]
 ----
-$ podman run --entrypoint performance-profile-creator registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.10 -h
+$ podman run --entrypoint performance-profile-creator registry.redhat.io/openshift4/ose-cluster-node-tuning-operator:v4.11 -h
 ----
 +
 .Example output
@@ -91,7 +90,7 @@ Using this information you can set appropriate values for some of the arguments 
 +
 [source,terminal]
 ----
-$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.10 --info log --must-gather-dir-path /must-gather
+$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-operator:v4.11 --info log --must-gather-dir-path /must-gather
 ----
 +
 [NOTE]
@@ -105,12 +104,12 @@ The `-v` option can be the path to either:
 
 The `info` option requires a value which specifies the output format. Possible values are log and JSON. The JSON format is reserved for debugging.
 ====
-+
+
 . Run `podman`:
 +
 [source,terminal]
 ----
-$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.10 --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true --split-reserved-cpus-across-numa=false --topology-manager-policy=single-numa-node --must-gather-dir-path /must-gather  --power-consumption-mode=ultra-low-latency > my-performance-profile.yaml
+$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-operator:v4.11 --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true --split-reserved-cpus-across-numa=false --topology-manager-policy=single-numa-node --must-gather-dir-path /must-gather  --power-consumption-mode=ultra-low-latency > my-performance-profile.yaml
 ----
 +
 [NOTE]
@@ -123,7 +122,7 @@ The Performance Profile Creator arguments are shown in the Performance Profile C
 
 The `mcp-name` argument in this example is set to `worker-cnf` based on the output of the command `oc get mcp`. For Single Node OpenShift (SNO) use `--mcp-name=master`.
 ====
-+
+
 . Review the created YAML file:
 +
 [source,terminal]
@@ -163,7 +162,6 @@ spec:
 ====
 Install the Performance Addon Operator before applying the profile.
 ====
-
 +
 [source,terminal]
 ----


### PR DESCRIPTION
OCP v4.11 uses the Node Tuning Operator rather than the Performance Addon Operator when creating a performance profile. This PR reflects the necessary documentation changes to reflect the difference between v4.10 and v4.11.

Fixes: [TELCODOCS-580](https://issues.redhat.com//browse/TELCODOCS-580)

See https://issues.redhat.com/browse/TELCODOCS-580 for additional details.

Preview URL:

For release(s): 4.11
Signed-off-by: John Wilkins <jowilkin@redhat.com>
