### PR TITLE
Resolving ROSA docs build warning

### DIFF
--- a/modules/rosa-sts-aws-requirements.adoc
+++ b/modules/rosa-sts-aws-requirements.adoc
@@ -47,7 +47,7 @@ The `ocm-role` ARN is stored as a label in your Red Hat organization while the `
 
 .Procedures
 
-1. From the CLI, link your `ocm-role` resource to your Red Hat organization by using your Amazon Resource Name (ARN):
+. From the CLI, link your `ocm-role` resource to your Red Hat organization by using your Amazon Resource Name (ARN):
 +
 [NOTE]
 ====
@@ -66,7 +66,7 @@ I: Linking OCM role
 ? Link the '<AWS ACCOUNT ID>` role with organization '<ORG ID>'? Yes
 I: Successfully linked role-arn '<AWS ACCOUNT ID>' with organization account '<ORG ID>'
 ----
-1. From the CLI, link your `user-role` resource to your Red Hat user account by using your Amazon Resource Name (ARN):
+. From the CLI, link your `user-role` resource to your Red Hat user account by using your Amazon Resource Name (ARN):
 +
 [source,terminal]
 ----


### PR DESCRIPTION
This applies to `main`, `enterprise-4.11` and `enterprise-4.10`.

This resolves a build warning in the ROSA documentation.