### PR TITLE
Changing the format of an additional resource heading

### DIFF
--- a/rosa_architecture/rosa-sts-about-iam-resources.adoc
+++ b/rosa_architecture/rosa-sts-about-iam-resources.adoc
@@ -52,7 +52,7 @@ AWS IAM roles link to your AWS account to create and manage the clusters. For mo
 include::modules/rosa-sts-ocm-role-creation.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 * link:https://docs.aws.amazon.com/IAM/latest/APIReference/API_Types.html[AWS Identity and Access Management Data Types]
 * link:https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Types.html[Amazon Elastic Computer Cloud Data Types]
 * link:https://docs.aws.amazon.com/STS/latest/APIReference/API_Types.html[AWS Token Security Service Data Types]


### PR DESCRIPTION
This applies to `main`, `enterprise-4.11` and `enterprise-4.10`.

The PR updates the format of an additional resources heading to `.Additional resources`, because it is positioned in the middle of several `include` statements and not at the end of the assembly. This also provides consistency with the similar additional resource headings in assembly.