### PR TITLE
OADP-447: PVC Snapshot restore does not work if PVC requested size does not match disk capacity

### DIFF
--- a/modules/oadp-creating-restore-cr.adoc
+++ b/modules/oadp-creating-restore-cr.adoc
@@ -14,6 +14,7 @@ You restore a `Backup` custom resource (CR) by creating a `Restore` CR.
 * You must install the OpenShift API for Data Protection (OADP) Operator.
 * The `DataProtectionApplication` CR must be in a `Ready` state.
 * You must have a Velero `Backup` CR.
+* Adjust the requested size so the persistent volume (PV) capacity matches the requested size at backup time.
 
 .Procedure
 


### PR DESCRIPTION
OADP 1.0.3, OCP 4.6+

Resolves https://issues.redhat.com/browse/OADP-447 by adding a prerequisite to the procedure in section 4.3.1 of _Backup and Restore_

Preview:
![Restore_CDR_Prereqs](https://user-images.githubusercontent.com/60698649/170498130-79aeb30a-a620-4e8f-9d02-0fc6adee04b3.png)

Last prerequisite 