### PR TITLE
Suggestions for install instructions.

### DIFF
--- a/contributing_to_docs/tools_and_setup.adoc
+++ b/contributing_to_docs/tools_and_setup.adoc
@@ -81,11 +81,23 @@ link:https://atom.io/[Atom].
 The following instructions describe how to install all the required tools to do
 live content editing on a Fedora Linux system.
 
-1. Install the _RubyGems_ package with `yum install rubygems`
+1. Install _Ruby_ development packages with `sudo dnf install ruby-devel`
+2. Install _gcc_ with `sudo dnf install gcc-c++`
+[WARNING]
+====
+Do not use `sudo` to execute `gem install`.
+====
+3. Install _asciidoctor-diagram_ with `gem install asciidoctor-diagram`
+4. Install the _ascii_binder_ gem with `gem install ascii_binder`
+
+NOTE: If you already have AsciiBinder installed, you might be due for an update.
+These directions assume that you are using AsciiBinder 0.2.0 or newer. To check
+and update if necessary, simply run `gem update ascii_binder`.
+
 +
 [NOTE]
 ====
-On certain systems, `yum` installs an older version of RubyGems that can cause issues. As an alternative, you can install RubyGems by using RVM. The following example is referenced from the link:https://rvm.io/rvm/install[RVM site]:
+As an alternative, you can install RubyGems by using RVM. The following example is referenced from the link:https://rvm.io/rvm/install[RVM site]:
 
 [source,terminal]
 ----
@@ -93,16 +105,6 @@ $ curl -sSL https://get.rvm.io | bash -s stable --ruby
 ----
 ====
 
-2. Install _Ruby_ development packages with `yum install ruby-devel`
-3. Install _gcc_ with `yum install gcc-c++`
-4. Install _redhat-rpm-config_ with `yum install redhat-rpm-config`
-5. Install _make_ with `yum install make`
-6. Install _asciidoctor-diagram_ with `gem install asciidoctor-diagram`
-7. Install the _ascii_binder_ gem with `gem install ascii_binder`
-
-NOTE: If you already have AsciiBinder installed, you might be due for an update.
-These directions assume that you are using AsciiBinder 0.2.0 or newer. To check
-and update if necessary, simply run `gem update ascii_binder`. Note that you might require root permissions.
 
 === Building the collection
 With the initial setup complete, you are ready to build the collection.


### PR DESCRIPTION
Suggestions: 
- installs require elevated privileges 
- yum was replaced by dnf as the primary package manager in Fedora 22. 
- "On certain systems, `yum` installs an older version of RubyGems that can cause issues." -- This is vague, why not add a version of rubygems to the min requirements list instead?
- A warning to not use 'sudo gem install' might be valuable.