### PR TITLE
[BZ2061567]: Add vSphere cred rotation procedure

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc
@@ -97,6 +97,10 @@ If `CredentialsRequest` CRs change over time as the cluster is upgraded, you mus
 //Rotating cloud provider credentials manually
 include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc[vSphere CSI Driver Operator]
+
 [id="passthrough-mode-reduce-permissions"]
 == Reducing permissions after installation
 When using passthrough mode, each component has the same permissions used by all other components. If you do not reduce the permissions after installing, all components have the broad permissions that are required to run the installer.

--- a/modules/manually-rotating-cloud-creds.adoc
+++ b/modules/manually-rotating-cloud-creds.adoc
@@ -4,6 +4,9 @@
 // * authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
 // * authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc
 
+ifeval::["{context}" == "post-install-cluster-tasks"]
+:post-install:
+endif::[]
 ifeval::["{context}" == "cco-mode-mint"]
 :mint:
 endif::[]
@@ -71,9 +74,10 @@ ifndef::mint[]
 |{rh-virtualization}
 |`ovirt-credentials`
 
-|vSphere
+|VMware vSphere
 |`vsphere-creds`
 endif::mint[]
+
 |===
 
 . Click the *Options* menu {kebab} in the same row as the secret and select *Edit Secret*.
@@ -82,8 +86,39 @@ endif::mint[]
 
 . Update the text in the *Value* field or fields with the new authentication information for your cloud provider, and then click *Save*.
 
-. If the CCO for your cluster is configured to use mint mode, delete each component secret that is referenced by the individual `CredentialsRequest` objects.
+ifndef::mint[]
+. If you are updating the credentials for a vSphere cluster that does not have the vSphere CSI Driver Operator enabled, you must force a rollout of the Kubernetes controller manager to apply the updated credentials.
++
+[NOTE]
+====
+If the vSphere CSI Driver Operator is enabled, this step is not required.
+====
++
+To apply the updated vSphere credentials, log in to the {product-title} CLI as a user with the `cluster-admin` role and run the following command:
++
+[source,terminal]
+----
+$ oc patch kubecontrollermanager cluster \
+  -p='{"spec": {"forceRedeploymentReason": "recovery-'"$( date )"'"}}' \
+  --type=merge
+----
++
+While the credentials are rolling out, the status of the Kubernetes Controller Manager Operator reports `Progressing=true`. To view the status, run the following command:
++
+[source,terminal]
+----
+$ oc get co kube-controller-manager
+----
+endif::mint[]
 
+ifdef::post-install[]
+. If the CCO for your cluster is configured to use mint mode, delete each component secret that is referenced by the individual `CredentialsRequest` objects.
+endif::post-install[]
+ifdef::mint[]
+. Delete each component secret that is referenced by the individual `CredentialsRequest` objects.
+endif::mint[]
+
+ifndef::passthrough[]
 .. Log in to the {product-title} CLI as a user with the `cluster-admin` role.
 
 .. Get the names and namespaces of all referenced component secrets:
@@ -98,15 +133,7 @@ where `<provider_spec>` is the corresponding value for your cloud provider:
 +
 --
 * AWS: `AWSProviderSpec`
-ifndef::mint[]
-* Azure: `AzureProviderSpec`
-endif::mint[]
 * GCP: `GCPProviderSpec`
-ifndef::mint[]
-* {rh-openstack}: `OpenStackProviderSpec`
-* {rh-virtualization}: `OvirtProviderSpec`
-* vSphere: `VSphereProviderSpec`
-endif::mint[]
 --
 +
 .Partial example output for AWS
@@ -127,7 +154,7 @@ endif::mint[]
 +
 [source,terminal]
 ----
-$ oc delete secret <secret_name> \ <1>
+$ oc delete secret <secret_name> \//<1>
   -n <secret_namespace> <2>
 ----
 +
@@ -142,6 +169,7 @@ $ oc delete secret ebs-cloud-credentials -n openshift-cluster-csi-drivers
 ----
 +
 You do not need to manually delete the credentials from your provider console. Deleting the referenced component secrets will cause the CCO to delete the existing credentials from the platform and create new ones.
+endif::passthrough[]
 
 .Verification
 
@@ -201,6 +229,9 @@ Where `<example-iam-username>` is the name of an IAM user on the cloud provider.
 .. For each IAM username, view the details for the user on the cloud provider. The credentials should show that they were created after being rotated on the cluster.
 ////
 
+ifeval::["{context}" == "post-install-cluster-tasks"]
+:!post-install:
+endif::[]
 ifeval::["{context}" == "cco-mode-mint"]
 :!mint:
 endif::[]

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -675,16 +675,26 @@ To allow the cluster to use the new credentials, you must update the secrets tha
 // Right now only IBM can do this, but it makes sense to set this up so that other clouds can be added.
 The Cloud Credential Operator (CCO) utility `ccoctl` supports updating secrets for clusters installed on IBM Cloud.
 
+//Rotating IBM Cloud credentials with ccoctl
 include::modules/refreshing-service-ids-ibm-cloud.adoc[leveloffset=+3]
 
+//Rotating cloud provider credentials manually
 include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+2]
-
-include::modules/manually-removing-cloud-creds.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
+* xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc[vSphere CSI Driver Operator]
 
+//Removing cloud provider credentials manually
+include::modules/manually-removing-cloud-creds.adoc[leveloffset=+2]
+
+//These additional resources are for the "Rotating or removing cloud provider credentials" section, do not separate them from that content.
+[role="_additional-resources"]
+.Additional resources
 * xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator]
+* xref:../installing/installing_aws/manually-creating-iam.adoc#admin-credentials-root-secret-formats_manually-creating-iam-aws[Amazon Web Services (AWS) secret format]
+* xref:../installing/installing_azure/manually-creating-iam-azure.adoc#admin-credentials-root-secret-formats_manually-creating-iam-azure[Microsoft Azure secret format]
+* xref:../installing/installing_gcp/manually-creating-iam-gcp.adoc#admin-credentials-root-secret-formats_manually-creating-iam-gcp[Google Cloud Platform (GCP) secret format]
 
 [id="post-install-must-gather-disconnected"]
 == Configuring image streams for a disconnected cluster


### PR DESCRIPTION
Version(s):
4.8+ 

Issue:
[BZ2061567](https://bugzilla.redhat.com/show_bug.cgi?id=2061567)

Link to docs preview:
* **Post-installation cluster tasks**:
  * Added a vSphere-specific cred rotation step to [Rotating cloud provider credentials manually](https://45998--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#manually-rotating-cloud-creds_post-install-cluster-tasks) (step 6)
  * Updated table in step 2 of same for missing platform details
  * Also fixed some additional refs that had become orphaned
* **Using passthrough mode**
  * Added [Rotating cloud provider credentials manually](https://45998--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-passthrough.html#manually-rotating-cloud-creds_cco-mode-passthrough)
* **Using mint mode**
  * Added some conditions to make the reuse of [Rotating cloud provider credentials manually](https://45998--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-mint.html#manually-rotating-cloud-creds_cco-mode-mint) less clunky

Additional information:
- Working off the content @rvanderp3 provided in #42916 :bow: :tada: 