### PR TITLE
RNs-4.6.58 Added with bug fix and security update

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3586,3 +3586,19 @@ Starting with {product-title} 4.6.57, support for using the Cloud Credential Ope
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-6-58"]
+=== RHSA-2022:2264 - {product-title} 4.6.58 bug fix and security update
+
+Issued: 2022-05-25
+
+{product-title} release 4.6.58, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:2264[RHSA-2022:2264] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:2263[RHSA-2022:2263] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6960549[{product-title} 4.6.58 container image list]
+
+[id="ocp-4-6-58-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
**RNs-4.6.58**
Added with bux fix and security update

**Version(s):**
enterprise-4.6 only

**Jira**
https://issues.redhat.com/browse/OCPPLAN-9093

**Link to docs preview:**
[RNs-4.6.58/release_notes/ocp-4-6-release-notes.html](https://wiharris.github.io/openshift-docs/RNs-4.6.58/release_notes/ocp-4-6-release-notes.html#ocp-4-6-58)

**Additional information:**
This PR is not to be merged until **2022.05.26**



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
