### PR TITLE
BZ2077336 Updated tag for OCS must-gather images

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -43,7 +43,7 @@ ifdef::openshift-dedicated[]
 |Data collection for migration-related information.
 endif::openshift-dedicated[]
 
-|`registry.redhat.io/odf4/ocs-must-gather-rhel8:v4.9`
+|`registry.redhat.io/ocs4/ocs-must-gather-rhel8:v4.9`
 |Data collection for {rh-storage-first}.
 
 |`registry.redhat.io/openshift-logging/cluster-logging-rhel8-operator`


### PR DESCRIPTION
**BZ2077336**
Updated tag for OCS must-gather images

**Version(s):**
Applies to versions 4.9 and beyond. 

**Bugzilla:**
https://bugzilla.redhat.com/show_bug.cgi?id=2077336

**Link to docs preview:**
https://wiharris.github.io/openshift-docs/BZ2077336/support/gathering-cluster-data.html#gathering-data-specific-features_gathering-cluster-data

**Additional information:**
N/A



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
