### PR TITLE
BZ2089824: Deleting a baremetalhost order

### DIFF
--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -17,16 +17,17 @@ Existing control plane `BareMetalHost` objects may have the `externallyProvision
 
 .Procedure
 
-. Remove the old `baremetalhost`, `machine` and `node` objects:
+. Remove the old `BareMetalHost` and `Machine` objects:
 +
 [source,terminal]
 ----
-$ oc delete node kni1-vmaster-0
 $ oc delete bmh -n openshift-machine-api vmaster-0
 $ oc delete machine -n openshift-machine-api kni1-master-0
 ----
 +
-. Create the new `baremetalhost` object and the secret to store the BMC credentials:
+After you remove the `BareMetalHost` and `Machine` objects, then the Bare Metal Operator automatically deletes the `Node` object.
+
+. Create the new `BareMetalHost` object and the secret to store the BMC credentials:
 +
 [source,terminal]
 ----
@@ -59,9 +60,9 @@ spec:
 EOF
 ----
 +
-After the inspection is complete, the `baremetalhost` object is created and available to be provisioned.
+After the inspection is complete, the `BareMetalHost` object is created and available to be provisioned.
 
-. View available `baremetalhost` objects:
+. View available `BareMetalHost` objects:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.8, 4.9, 4.10, 4.11

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2089824