### PR TITLE
OSDOCS-3679: Adding steps to change the mode to automatic to actually…

### DIFF
--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -16,6 +16,8 @@ endif::[]
 
 The descheduler is not available by default. To enable the descheduler, you must install the Kube Descheduler Operator from OperatorHub and enable one or more descheduler profiles.
 
+By default, the descheduler runs in predictive mode, which means that it only simulates pod evictions. You must change the mode to automatic for the descheduler to perform the pod evictions.
+
 .Prerequisites
 
 * Cluster administrator privileges.
@@ -43,6 +45,8 @@ endif::[]
 .. From the *Operators* -> *Installed Operators* page, click the *Kube Descheduler Operator*.
 .. Select the *Kube Descheduler* tab and click *Create KubeDescheduler*.
 .. Edit the settings as necessary.
+... To evict pods instead of simulating the evictions, change the *Mode* field to *Automatic*.
+
 ifdef::virt[]
 ... Expand the *Profiles* section and select `DevPreviewLongLifecycle`. The `AffinityAndTaints` profile is enabled by default.
 +


### PR DESCRIPTION
… evict pods

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3679

Link to docs preview:
http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3679/nodes/scheduling/nodes-descheduler.html#nodes-descheduler-installing_nodes-descheduler

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
