### PR TITLE
OSDOCS-3663: Various changes to ROSA prereqs

### DIFF
--- a/modules/osd-applications-config-custom-domains.adoc
+++ b/modules/osd-applications-config-custom-domains.adoc
@@ -3,7 +3,7 @@
 // * applications/deployments/osd-config-custom-domains-applications.adoc
 
 :_content-type: PROCEDURE
-[id="osd-applications-config-custom-domains.adoc_{context}"]
+[id="osd-applications-config-custom-domains_{context}"]
 = Configuring custom domains for applications
 
 Custom domains are specific wildcard domains that can be used with {product-title} applications. The top-level domains (TLDs) are owned by the customer that is operating the {product-title} cluster. The Custom Domains Operator sets up a new `ingresscontroller` with a custom certificate as a second day operation. The public DNS record for this `ingresscontroller` can then be used by an external DNS to create a wildcard CNAME record for use with a custom domain.

--- a/modules/rosa-sts-aws-requirements.adoc
+++ b/modules/rosa-sts-aws-requirements.adoc
@@ -9,22 +9,26 @@ The following prerequisites must be complete before you deploy a {product-title}
 
 [id="rosa-account_{context}"]
 == Account
-* The customer ensures that the link:https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html[AWS limits] are sufficient to support {product-title} provisioned within the customer's AWS account.
-* If SCP policies are applied and enforced, these policies must not be more restrictive than the roles and policies required by the cluster.
-* The customer's AWS account should not be transferable to Red Hat.
-* The customer should not impose additional AWS usage restrictions beyond the defined roles and policies on Red Hat activities. Imposing restrictions will severely hinder Red Hat's ability to respond to incidents.
-* The customer may deploy native AWS services within the same AWS account.
-* The account must have a service-linked role set up as it is required for elastic load balancers (ELBs) to be configured.
+* You must ensure that the AWS limits are sufficient to support {product-title} provisioned within your AWS account. Running `rosa verify quota` in the CLI validates that you have the required quota to run a cluster.
 +
 [NOTE]
 ====
-Customers are encouraged, but not mandated, to deploy resources in a Virtual Private Cloud (VPC) separate from the VPC hosting {product-title} and other Red Hat supported services.
+Quota verification checks your AWS quota, but it does not compare your consumption to your AWS quota. See the "Limits and scalability" link in Additional resources for more information.
+====
++
+* If SCP policies are applied and enforced, these policies must not be more restrictive than the roles and policies required by the cluster.
+* You may deploy native AWS services within the same AWS account.
+* Your account must have a service-linked role set up as it is required for elastic load balancers (ELBs) to be configured. See AWS Limits in Additional resources for information about creating a service-linked role for your ELB if you have not created a load balancer in your AWS account previously.
++
+[NOTE]
+====
+You are encouraged, but not required, to deploy resources in a Virtual Private Cloud (VPC) separate from the VPC hosting {product-title} and other Red Hat supported services.
 ====
 
 [id="rosa-associating-account_{context}"]
 == Associating your AWS account
 
-To perform {product-title} (ROSA) cluster provisioning tasks, you must create `ocm-role` and `user-role` IAM resources in your AWS account and link them to your Red Hat organization.
+{product-title} (ROSA) cluster-provisioning tasks require linking `ocm-role` and `user-role` {cluster-manager} IAM resources to your AWS account using your Amazon Resource Name (ARN).
 
 The `ocm-role` ARN is stored as a label in your Red Hat organization while the `user-role` ARN is stored as a label inside your Red Hat user account. Red Hat uses these ARN labels to confirm that the user is a valid account holder and that the correct permissions are available to perform the necessary tasks in the AWS account.
 
@@ -124,8 +128,9 @@ If you do not specify a profile, the default AWS profile is used.
 == Access requirements
 
 * Red Hat must have AWS console access to the customer-provided AWS account. This access is protected and managed by Red Hat.
-* The customer must not utilize the AWS account to elevate their permissions within the {product-title} cluster.
-* Actions available in the `rosa` CLI utility or {cluster-manager-url} console must not be directly performed in the customer's AWS account.
+* You must not use the AWS account to elevate your permissions within the {product-title} cluster.
+* Actions available in the `rosa` CLI utility or {cluster-manager-url} console must not be directly performed in your AWS account.
+* You do not need to have a preconfigured domain to deploy ROSA clusters. If you want to use a custom domain, see Additional resources for information.
 
 [id="rosa-support-requirements_{context}"]
 == Support requirements
@@ -138,4 +143,4 @@ If you do not specify a profile, the default AWS profile is used.
 == Security requirements
 * Volume snapshots will remain within the customer's AWS account and customer-specified region.
 * Red Hat must have ingress access to EC2 hosts and the API server from allow-listed IP addresses.
-* Red Hat must have egress allowed to the documented domains.
+* Red Hat must have egress allowed to the documented domains. See the "AWS firewall prerequisites" section for the designated domains.

--- a/modules/rosa-troubleshooting-elb-service-role.adoc
+++ b/modules/rosa-troubleshooting-elb-service-role.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc
+:_content-type: PROCEDURE
+[id="rosa-troubleshooting-elb-serivce-role_{context}"]
+= Creating the service role for the elastic load balancer (ELB)
+
+If you have not created a load balancer in your AWS account, it is possible that the service role for the elastic load balancer (ELB) might not exist yet. You may receive the following error:
+
+[source,terminal]
+----
+Error: Error creating network Load Balancer: AccessDenied: User: arn:aws:sts::xxxxxxxxxxxx:assumed-role/ManagedOpenShift-Installer-Role/xxxxxxxxxxxxxxxxxxx is not authorized to perform: iam:CreateServiceLinkedRole on resource: arn:aws:iam::xxxxxxxxxxxx:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"
+----
+
+To resolve this issue, ensure that the role exists on your AWS account. If not, create this role with the following command:
+
+[source,terminal]
+----
+aws iam get-role --role-name "AWSServiceRoleForElasticLoadBalancing" || aws iam create-service-linked-role --aws-service-name "elasticloadbalancing.amazonaws.com"
+----
+
+[NOTE]
+====
+This command only needs to be executed once per account.
+====

--- a/modules/rosa-troubleshooting-general-deployment.adoc
+++ b/modules/rosa-troubleshooting-general-deployment.adoc
@@ -3,7 +3,7 @@
 // * rosa_support/rosa-troubleshooting-deployments.adoc
 :_content-type: PROCEDURE
 [id="rosa-troubleshooting-general-deployment-failure_{context}"]
-= General deployment failure
+== General deployment failure
 
 If a cluster deployment fails, the cluster is put into an "error" state.
 

--- a/rosa_architecture/rosa-sts-about-iam-resources.adoc
+++ b/rosa_architecture/rosa-sts-about-iam-resources.adoc
@@ -52,6 +52,7 @@ AWS IAM roles link to your AWS account to create and manage the clusters. For mo
 include::modules/rosa-sts-ocm-role-creation.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
+[id="additional-resources_about-iam-resources_{context}"]
 .Additional resources
 * link:https://docs.aws.amazon.com/IAM/latest/APIReference/API_Types.html[AWS Identity and Access Management Data Types]
 * link:https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Types.html[Amazon Elastic Computer Cloud Data Types]

--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -34,3 +34,6 @@ include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+1]
 == Additional resources
 * xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-sre-access_rosa-policy-process-security[SRE access to all Red Hat OpenShift Service on AWS clusters]
+* xref:../applications/deployments/osd-config-custom-domains-applications.adoc#osd-applications-config-custom-domains[Configuring custom domains for applications]
+* xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[AWS limits]
+* xref:../rosa_support/rosa-troubleshooting-deployments.adoc#rosa-troubleshooting-general-deployment-elb[Creating the service role for the Elastic load balancer (ELB)]

--- a/rosa_support/rosa-troubleshooting-deployments.adoc
+++ b/rosa_support/rosa-troubleshooting-deployments.adoc
@@ -5,4 +5,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-troubleshooting-cluster-deployments
 toc::[]
 
-include::modules/rosa-troubleshooting-deployment.adoc[leveloffset=+1]
+[id="rosa-troubleshooting-deployment_{context}"]
+= Troubleshooting cluster deployments
+This document describes how to troubleshoot cluster deployment errors.
+
+include::modules/rosa-troubleshooting-general-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-elb-service-role.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.10+

Issue:
This PR adds changes that cover the following JIRA cards:

1. https://issues.redhat.com/browse/OSDOCS-3564
2. https://issues.redhat.com/browse/OSDOCS-3663
2. https://issues.redhat.com/browse/OSDOCS-3664
3. https://issues.redhat.com/browse/OSDOCS-3665
4. https://issues.redhat.com/browse/OSDOCS-3666
5. https://issues.redhat.com/browse/OSDOCS-3667
6. https://issues.redhat.com/browse/OSDOCS-3669

Link to docs preview:

- **_[OSDOCS-3564](https://issues.redhat.com/browse/OSDOCS-3564)_**: This section is ported from OCP - https://people.redhat.com/eponvell/053122/OSDOCS-3663_Prereq-Improvements/rosa_planning/rosa-sts-aws-prereqs.html#installation-aws-route53_rosa-sts-aws-prereqs
- **_[OSDOCS-3663](https://issues.redhat.com/browse/OSDOCS-3663)_**: Removed items from the list -  https://people.redhat.com/eponvell/053122/OSDOCS-3663_Prereq-Improvements/rosa_planning/rosa-sts-aws-prereqs.html#rosa-account_rosa-sts-aws-prereqs
- **_[OSDOCS-3664](https://issues.redhat.com/browse/OSDOCS-3664)_**: Added [a reference to check the additional resources for a link on ELBs](https://people.redhat.com/eponvell/053122/OSDOCS-3663_Prereq-Improvements/rosa_planning/rosa-sts-aws-prereqs.html#rosa-account_rosa-sts-aws-prereqs). I also modified [the ELB destination a bit](https://people.redhat.com/eponvell/053122/OSDOCS-3663_Prereq-Improvements/rosa_support/rosa-troubleshooting-deployments.html#rosa-troubleshooting-general-deployment-elb_rosa-troubleshooting-cluster-deployments) - https://people.redhat.com/eponvell/053122/OSDOCS-3663_Prereq-Improvements/rosa_planning/rosa-sts-aws-prereqs.html#additional-resources
- **_[OSDOCS-3665](https://issues.redhat.com//browse/OSDOCS-3665)_** - Cleaned the language that these roles are attaching to your AWS account via the ARN: https://people.redhat.com/eponvell/053122/OSDOCS-3663_Prereq-Improvements/rosa_planning/rosa-sts-aws-prereqs.html#rosa-associating-account_rosa-sts-aws-prereqs
- **_[OSDOCS-3666](https://issues.redhat.com/browse/OSDOCS-3666)_** - I added [a reference to the additional resources](https://people.redhat.com/eponvell/053122/OSDOCS-3663_Prereq-Improvements/rosa_planning/rosa-sts-aws-prereqs.html#rosa-account_rosa-sts-aws-prereqs) to the documentation. The [link in additional resources links ](https://people.redhat.com/eponvell/053122/OSDOCS-3663_Prereq-Improvements/rosa_planning/rosa-limits-scalability.html#rosa-limits-scalability) to the AWS limits: https://people.redhat.com/eponvell/053122/OSDOCS-3663_Prereq-Improvements/rosa_planning/rosa-sts-aws-prereqs.html#additional-resources 
- **_[OSDOCS-3667](https://issues.redhat.com/browse/OSDOCS-3667)_** - I simply added some text to point to the "AWS firewall preqs" in the same topic: https://people.redhat.com/eponvell/053122/OSDOCS-3663_Prereq-Improvements/rosa_planning/rosa-sts-aws-prereqs.html#rosa-security-requirements_rosa-sts-aws-prereqs
- **_[OSDOCS-3669](https://issues.redhat.com/browse/OSDOCS-3669)_** - I added the command to verify the quota to the main bulleted list: https://people.redhat.com/eponvell/053122/OSDOCS-3663_Prereq-Improvements/rosa_planning/rosa-sts-aws-prereqs.html#rosa-account_rosa-sts-aws-prereqs

Additional information:
This PR tracks changes from 7 JIRA cards. The changes are individually small, and I note which link relates to which JIRA card.