### PR TITLE
[OSDOCS-3662] changed 48 hours to 2 business days

### DIFF
--- a/modules/life-cycle-mandatory-upgrades.adoc
+++ b/modules/life-cycle-mandatory-upgrades.adoc
@@ -7,9 +7,10 @@
 
 In the event that a Critical or Important CVE, or other bug identified by Red Hat, significantly
 impacts the security or stability of the cluster, the customer must upgrade to the next supported
-patch release within 48 hours.
+patch release within two link:https://access.redhat.com/articles/2623321[business days].
 
 In extreme circumstances and based on Red Hat's assessment of the CVE criticality to the
-environment, if the upgrade to the next supported patch release has not been performed within 48
-hours of notification, the cluster will be automatically updated to the latest patch release to
-mitigate potential security breach or instability.
+environment, if the upgrade to the next supported patch release has not been performed within
+two link:https://access.redhat.com/articles/2623321[business days] of notification, the cluster
+will be automatically updated to the latest patch release to mitigate potential security breach
+or instability.


### PR DESCRIPTION
[OSDOCS-3662] Changed "48 hours" to "2 business days"

Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/OSDOCS-3662

Link to docs preview:
ROSA: http://file.rdu.redhat.com/bmcelvee/20222505/rosa_policy_service_definition/rosa-life-cycle.html#rosa-mandatory-upgrades_rosa-life-cycle
OSD: http://file.rdu.redhat.com/bmcelvee/20222505/osd_policy/osd-life-cycle.html#rosa-mandatory-upgrades_osd-life-cycle


Additional information:
Changed inline text from "48 hours" to "2 business days" to match support information.



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
