### PR TITLE
[OSDOCS-3609]: AWS machineset support for IMDS options

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -8,18 +8,32 @@ toc::[]
 
 You can create a different machine set to serve a specific purpose in your {product-title} cluster on Amazon Web Services (AWS). For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
+//[IMPORTANT] admonition for UPI
 include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
+//Machine API overview
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 
+//Sample YAML for a machine set custom resource on AWS
 include::modules/machineset-yaml-aws.adoc[leveloffset=+1]
 
+//Creating a machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 
-include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
+//Machine sets that enable the Amazon EC2 Instance Metadata Service
+include::modules/machineset-imds-options.adoc[leveloffset=+1]
 
-include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+1]
+//Creating machines that use the Amazon EC2 Instance Metadata Service
+include::modules/machineset-creating-imds-options.adoc[leveloffset=+2]
 
+//Machine sets that deploy machines as Dedicated Instances
 include::modules/machineset-dedicated-instances.adoc[leveloffset=+1]
 
-include::modules/machineset-creating-dedicated-instances.adoc[leveloffset=+1]
+//Creating Dedicated Instances by using machine sets
+include::modules/machineset-creating-dedicated-instances.adoc[leveloffset=+2]
+
+//Machine sets that deploy machines as Spot Instances
+include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
+
+//Creating Spot Instances by using machine sets
+include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+2]

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -40,6 +40,7 @@ ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisione
 :restricted:
 endif::[]
 
+:_content-type: REFERENCE
 [id="installation-aws-config-yaml_{context}"]
 = Sample customized `install-config.yaml` file for AWS
 
@@ -93,6 +94,8 @@ endif::gov,china,secret[]
         iops: 4000
         size: 500
         type: io1 <6>
+      metadataService:
+        authentication: Optional <7>
       type: m6i.xlarge
   replicas: 3
 compute: <3>
@@ -104,6 +107,8 @@ compute: <3>
         iops: 2000
         size: 500
         type: io1 <6>
+      metadataService:
+        authentication: Optional <7>
       type: c5.4xlarge
       zones:
 ifdef::china[]
@@ -159,17 +164,17 @@ endif::secret[]
       adminContact: jdoe
       costCenter: 7536
 ifdef::vpc,restricted[]
-    subnets: <7>
+    subnets: <8>
     - subnet-1
     - subnet-2
     - subnet-3
 ifndef::secret,china[]
-    amiID: ami-96c6f8f7 <8>
+    amiID: ami-96c6f8f7 <9>
 endif::secret,china[]
 ifdef::secret,china[]
-    amiID: ami-96c6f8f7 <1> <8>
+    amiID: ami-96c6f8f7 <1> <9>
 endif::secret,china[]
-    serviceEndpoints: <9>
+    serviceEndpoints: <10>
       - name: ec2
 ifndef::china[]
         url: https://vpce-id.ec2.us-west-2.vpce.amazonaws.com
@@ -177,35 +182,35 @@ endif::china[]
 ifdef::china[]
         url: https://vpce-id.ec2.cn-north-1.vpce.amazonaws.com.cn
 endif::china[]
-    hostedZone: Z3URY6TWQ91KVV <10>
+    hostedZone: Z3URY6TWQ91KVV <11>
 endif::vpc,restricted[]
 ifndef::vpc,restricted[]
-    amiID: ami-96c6f8f7 <7>
-    serviceEndpoints: <8>
+    amiID: ami-96c6f8f7 <8>
+    serviceEndpoints: <9>
       - name: ec2
         url: https://vpce-id.ec2.us-west-2.vpce.amazonaws.com
 endif::vpc,restricted[]
 ifdef::vpc,restricted[]
 ifndef::openshift-origin[]
-fips: false <11>
-sshKey: ssh-ed25519 AAAA... <12>
+fips: false <12>
+sshKey: ssh-ed25519 AAAA... <13>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <11>
+sshKey: ssh-ed25519 AAAA... <12>
 endif::openshift-origin[]
 endif::vpc,restricted[]
 ifndef::vpc,restricted[]
 ifndef::openshift-origin[]
-fips: false <9>
-sshKey: ssh-ed25519 AAAA... <10>
+fips: false <10>
+sshKey: ssh-ed25519 AAAA... <11>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <9>
+sshKey: ssh-ed25519 AAAA... <10>
 endif::openshift-origin[]
 endif::vpc,restricted[]
 ifdef::private[]
 ifndef::openshift-origin[]
-publish: Internal <13>
+publish: Internal <14>
 endif::openshift-origin[]
 endif::private[]
 ifndef::restricted[]
@@ -213,15 +218,15 @@ pullSecret: '{"auths": ...}' <1>
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <13>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <14>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <12>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <13>
 endif::openshift-origin[]
 endif::restricted[]
 ifdef::secret[]
 ifndef::openshift-origin[]
-additionalTrustBundle: | <14>
+additionalTrustBundle: | <15>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
@@ -229,12 +234,12 @@ endif::openshift-origin[]
 endif::secret[]
 ifdef::private[]
 ifdef::openshift-origin[]
-publish: Internal <12>
+publish: Internal <13>
 endif::openshift-origin[]
 endif::private[]
 ifdef::secret[]
 ifdef::openshift-origin[]
-additionalTrustBundle: | <13>
+additionalTrustBundle: | <14>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
@@ -242,11 +247,11 @@ endif::openshift-origin[]
 endif::secret[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-additionalTrustBundle: | <14>
+additionalTrustBundle: | <15>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <15>
+imageContentSources: <16>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -255,11 +260,11 @@ imageContentSources: <15>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-additionalTrustBundle: | <13>
+additionalTrustBundle: | <14>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <14>
+imageContentSources: <15>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -303,47 +308,53 @@ disable simultaneous multithreading.
 ====
 <6> To configure faster storage for etcd, especially for larger clusters, set the
 storage type as `io1` and set `iops` to `2000`.
+<7> Whether to require the link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html[Amazon EC2 Instance Metadata Service v2] (IMDSv2). To require IMDSv2, set the parameter value to `Required`. To allow the use of both IMDSv1 and IMDSv2, set the parameter value to `Optional`. If no value is specified, both IMDSv1 and IMDSv2 are allowed.
++
+[NOTE]
+====
+The IMDS configuration for control plane machines that is set during cluster installation can only be changed by using the AWS CLI. The IMDS configuration for compute machines can be changed by using machine sets.
+====
 ifdef::vpc,restricted[]
-<7> If you provide your own VPC, specify subnets for each availability zone that your cluster uses.
+<8> If you provide your own VPC, specify subnets for each availability zone that your cluster uses.
+<9> The ID of the AMI used to boot machines for the cluster. If set, the AMI
+must belong to the same region as the cluster.
+<10> The AWS service endpoints. Custom endpoints are required when installing to
+an unknown AWS region. The endpoint URL must use the `https` protocol and the
+host must trust the certificate.
+<11> The ID of your existing Route 53 private hosted zone. Providing an existing hosted zone requires that you supply your own VPC and the hosted zone is already associated with the VPC prior to installing your cluster. If undefined, the installation program creates a new hosted zone.
+ifndef::openshift-origin[]
+<12> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
+<13> You can optionally provide the `sshKey` value that you use to access the
+machines in your cluster.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<12> You can optionally provide the `sshKey` value that you use to access the
+machines in your cluster.
+endif::openshift-origin[]
+endif::vpc,restricted[]
+ifndef::vpc,restricted[]
 <8> The ID of the AMI used to boot machines for the cluster. If set, the AMI
 must belong to the same region as the cluster.
 <9> The AWS service endpoints. Custom endpoints are required when installing to
 an unknown AWS region. The endpoint URL must use the `https` protocol and the
 host must trust the certificate.
-<10> The ID of your existing Route 53 private hosted zone. Providing an existing hosted zone requires that you supply your own VPC and the hosted zone is already associated with the VPC prior to installing your cluster. If undefined, the installation program creates a new hosted zone.
 ifndef::openshift-origin[]
-<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<10> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
-<12> You can optionally provide the `sshKey` value that you use to access the
-machines in your cluster.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
 <11> You can optionally provide the `sshKey` value that you use to access the
 machines in your cluster.
 endif::openshift-origin[]
-endif::vpc,restricted[]
-ifndef::vpc,restricted[]
-<7> The ID of the AMI used to boot machines for the cluster. If set, the AMI
-must belong to the same region as the cluster.
-<8> The AWS service endpoints. Custom endpoints are required when installing to
-an unknown AWS region. The endpoint URL must use the `https` protocol and the
-host must trust the certificate.
-ifndef::openshift-origin[]
-<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
-+
-[IMPORTANT]
-====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
-====
-<10> You can optionally provide the `sshKey` value that you use to access the
-machines in your cluster.
-endif::openshift-origin[]
 ifdef::openshift-origin[]
-<9> You can optionally provide the `sshKey` value that you use to access the
+<10> You can optionally provide the `sshKey` value that you use to access the
 machines in your cluster.
 endif::openshift-origin[]
 endif::vpc,restricted[]
@@ -354,36 +365,36 @@ For production {product-title} clusters on which you want to perform installatio
 ====
 ifdef::private[]
 ifndef::openshift-origin[]
-<13> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
+<14> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<12> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
+<13> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
 endif::openshift-origin[]
 endif::private[]
 ifdef::secret[]
 ifndef::openshift-origin[]
-<14> The custom CA certificate. This is required when deploying to the AWS C2S Top Secret Region because the AWS API requires a custom CA trust bundle.
+<15> The custom CA certificate. This is required when deploying to the AWS C2S Top Secret Region because the AWS API requires a custom CA trust bundle.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<13> The custom CA certificate. This is required when deploying to the AWS C2S Top Secret Region because the AWS API requires a custom CA trust bundle.
+<14> The custom CA certificate. This is required when deploying to the AWS C2S Top Secret Region because the AWS API requires a custom CA trust bundle.
 endif::openshift-origin[]
 endif::secret[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
+<14> For `<local_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example
+`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+specify the base64-encoded user name and password for your mirror registry.
+<15> Provide the contents of the certificate file that you used for your mirror registry.
+<16> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
 <13> For `<local_registry>`, specify the registry domain name, and optionally the
 port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
 <14> Provide the contents of the certificate file that you used for your mirror registry.
 <15> Provide the `imageContentSources` section from the output of the command to mirror the repository.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<12> For `<local_registry>`, specify the registry domain name, and optionally the
-port, that your mirror registry uses to serve content. For example
-`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
-specify the base64-encoded user name and password for your mirror registry.
-<13> Provide the contents of the certificate file that you used for your mirror registry.
-<14> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]
 

--- a/modules/machineset-creating-imds-options.adoc
+++ b/modules/machineset-creating-imds-options.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-aws.adoc
+
+:_content-type: PROCEDURE
+[id="machineset-creating-imds-options_{context}"]
+= Configuring IMDS by using machine sets
+
+You can specify whether to require the use of IMDSv2 by adding or editing the value of `metadataServiceOptions.authentication` in the machine set YAML file for your compute machines.
+
+.Procedure
+* Add or edit the following lines under the `providerSpec` field:
++
+[source,yaml]
+----
+providerSpec:
+  value:
+    metadataServiceOptions:
+      authentication: Required <1>
+----
+<1> To require IMDSv2, set the parameter value to `Required`. To allow the use of both IMDSv1 and IMDSv2, set the parameter value to `Optional`. If no value is specified, both IMDSv1 and IMDSv2 are allowed.

--- a/modules/machineset-imds-options.adoc
+++ b/modules/machineset-imds-options.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-aws.adoc
+
+:_content-type: CONCEPT
+[id="machineset-imds-options_{context}"]
+= Machine set options for the Amazon EC2 Instance Metadata Service
+
+You can use machine sets to create compute machines that use a specific version of the Amazon EC2 Instance Metadata Service (IMDS). Machine sets can create compute machines that allow the use of both IMDSv1 and link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html[IMDSv2] or compute machines that require the use of IMDSv2.
+
+To change the IMDS configuration for existing compute machines, edit the machine set YAML file that manages those machines. To deploy new compute machines with your preferred IMDS configuration, create a machine set YAML file with the appropriate values.
+
+The IMDS configuration for control plane machines is set during cluster installation. To change the control plane machine IMDS configuration, you must use the AWS CLI. For more information, see the AWS documentation about how to link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html#configuring-IMDS-existing-instances[Modify instance metadata options for existing instances].
+
+[IMPORTANT]
+====
+Before configuring a machine set to create compute machines that require IMDSv2, ensure that any workloads that interact with the AWS metadata service support IMDSv2.
+====


### PR DESCRIPTION
Version(s):
4.11

Issue:
[OSDOCS-3609](https://issues.redhat.com//browse/OSDOCS-3609) for [OCPCLOUD-1436](https://issues.redhat.com//browse/OCPCLOUD-1436)

Link to docs preview:
- [Sample customized install-config.yaml file for AWS](http://file.rdu.redhat.com/jrouth/OSDOCS-3609-AWS-EC2-machineset-support-IMDSv2-IMDSv1//installing/installing_aws/installing-aws-customizations.html#installation-aws-config-yaml_installing-aws-customizations)
- [Machine set options for the Amazon EC2 Instance Metadata Service](http://file.rdu.redhat.com/jrouth/OSDOCS-3609-AWS-EC2-machineset-support-IMDSv2-IMDSv1//machine_management/creating_machinesets/creating-machineset-aws.html#machineset-imds-options_creating-machineset-aws)

Additional information: