### PR TITLE
Cherry pick to 4.8 for BZ2084113

### DIFF
--- a/installing/index.adoc
+++ b/installing/index.adoc
@@ -10,6 +10,15 @@ include::modules/installation-overview.adoc[leveloffset=+1]
 
 include::modules/installation-process.adoc[leveloffset=+2]
 
+include::modules/ipi-verifying-nodes-after-installation.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-install-troubleshooting-following-the-installation_ipi-install-installation-workflow[Following the installation]
+
+* xref:../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation]
+
 [discrete]
 === Installation scope
 

--- a/modules/installation-process.adoc
+++ b/modules/installation-process.adoc
@@ -101,4 +101,7 @@ Bootstrapping a cluster involves the following steps:
 . The control plane sets up the compute nodes.
 . The control plane installs additional services in the form of a set of Operators.
 
-The result of this bootstrapping process is a fully running {product-title} cluster. The cluster then downloads and configures remaining components needed for the day-to-day operation, including the creation of compute machines in supported environments.
+The result of this bootstrapping process is a running {product-title} cluster. The cluster then downloads and configures remaining components needed for the day-to-day operation, including the creation of compute machines in supported environments.
+
+
+

--- a/modules/ipi-verifying-nodes-after-installation.adoc
+++ b/modules/ipi-verifying-nodes-after-installation.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * installing/index.adoc
+
+:_module-type: PROCEDURE
+[id="ipi-verifying-nodes-after-installation_{context}"]
+= Verifying node state after installation
+
+[role="_abstract"]
+The {product-title} installation completes when the following installation health checks are successful:
+
+* The provisioning host can access the {product-title} web console.
+
+* All control plane nodes are ready.
+
+* All cluster Operators are available.
+
+[NOTE]
+====
+After the installation completes, the specific cluster Operators responsible for the worker nodes continuously attempt to provision all worker nodes. It can take some time before all worker nodes report as `READY`. For installations on bare metal, wait a minimum of 60 minutes before troubleshooting a worker node. For installations on all other platforms, wait a minimum of 40 minutes before troubleshooting a worker node. A `DEGRADED` state for the cluster Operators responsible for the worker nodes depends on the Operators' own resources and not on the state of the nodes.
+==== 
+
+After your installation completes, you can continue to monitor the condition of the nodes in your cluster using the following steps. 
+
+.Prerequisites
+* The installation program resolves successfully in the terminal.
+
+.Procedure
+. Show the status of all worker nodes:
+
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
++
+.Example output
+[source,terminal]
+----
+NAME                           STATUS   ROLES    AGE   VERSION
+example-compute1.example.com   Ready    worker   13m   v1.21.6+bb8d50a
+example-compute2.example.com   Ready    worker   13m   v1.21.6+bb8d50a
+example-compute4.example.com   Ready    worker   14m   v1.21.6+bb8d50a
+example-control1.example.com   Ready    master   52m   v1.21.6+bb8d50a
+example-control2.example.com   Ready    master   55m   v1.21.6+bb8d50a
+example-control3.example.com   Ready    master   55m   v1.21.6+bb8d50a
+----
+
+. Show the phase of all worker machine nodes:
+
++
+[source,terminal]
+----
+$ oc get machines -A
+----
+
++
+.Example output
+[source,terminal]
+----
+NAMESPACE               NAME                           PHASE         TYPE   REGION   ZONE   AGE
+openshift-machine-api   example-zbbt6-master-0         Running                              95m
+openshift-machine-api   example-zbbt6-master-1         Running                              95m
+openshift-machine-api   example-zbbt6-master-2         Running                              95m
+openshift-machine-api   example-zbbt6-worker-0-25bhp   Running                              49m
+openshift-machine-api   example-zbbt6-worker-0-8b4c2   Running                              49m
+openshift-machine-api   example-zbbt6-worker-0-jkbqt   Running                              49m
+openshift-machine-api   example-zbbt6-worker-0-qrl5b   Running                              49m
+----


### PR DESCRIPTION
BZ2084113: A PR was already merged to 4.10 and 4.11 for this bug (https://github.com/openshift/openshift-docs/pull/45677). However, I needed to remove one link from installing/index.adoc for merging to 4.8, as this link is not relevant to this version. 

Version(s):
4.8

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2084113

Link to docs preview:
http://file.emea.redhat.com/rohennes/BZ2084113-4.8/installing/index.html#ipi-verifying-nodes-after-installation_ocp-installation-overview

Already ACk'd by QE and SME, peer reviewed and merged in https://github.com/openshift/openshift-docs/pull/45677



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
