### PR TITLE
updating for BZ2090218 (draft)

### DIFF
--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -21,9 +21,9 @@ Existing control plane `BareMetalHost` objects may have the `externallyProvision
 +
 [source,terminal]
 ----
-$ oc delete node kni1-vmaster-0
 $ oc delete bmh -n openshift-machine-api vmaster-0
 $ oc delete machine -n openshift-machine-api kni1-master-0
+$ oc delete node kni1-vmaster-0
 ----
 +
 . Create the new `baremetalhost` object and the secret to store the BMC credentials:


### PR DESCRIPTION
BZ2090218: Re-ordering a procedure after feedback from customer. 

Version(s):
4.8 to 4.11

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2090218

Link to docs preview:
http://file.emea.redhat.com/rohennes/BZ2090218/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#replacing-a-bare-metal-control-plane-node_ipi-install-expanding

Additional information: Unsure if additional changes are needed but starting a draft PR now.



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
