### PR TITLE
OADP 473 - Document how to enable Velero debug loglevel

### DIFF
--- a/modules/oadp-debugging-oc-cli.adoc
+++ b/modules/oadp-debugging-oc-cli.adoc
@@ -34,33 +34,33 @@ $ oc logs pod/<velero>
 [id="oc-velero-debug-logs_{context}"]
 == Velero pod debug logs
 
-Use the `oc edit` command to set the `Velero` pod logs to debug level:
+You can specify the Velero log level in the `DataProtectionApplication` resource as shown in the following example.
 
-. Edit the `Velero` deployment:
-+
-[source,terminalsubs="attributes+"]
-----
-$ oc edit deployment/velero -n {namespace}
-----
+[NOTE]
+====
+This option is available starting from OADP 1.0.3.
+====
 
-. Add `--log-level` and `debug` to the `spec.template.spec.containers.velero.args` array:
-+
 [source,yaml]
 ----
-apiVersion: apps/v1
-kind: Deployment
-...
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: velero-sample
 spec:
-  template:
-    spec:
-      containers:
-      - name: velero
-        image: velero/velero:latest
-        command:
-          - /velero
-        args:
-          - server
-          - --log-level
-          - debug
-...
+  configuration:
+    velero:
+      logLevel: warning
 ----
+
+The following `logLevel` values are available:
+
+* `trace`
+* `debug`
+* `info`
+* `warning`
+* `error`
+* `fatal`
+* `panic`
+
+It is recommended to use `debug` for most logs.


### PR DESCRIPTION
OADP 473 - Document how to enable Velero debug loglevel

https://issues.redhat.com/browse/OADP-473

OCP 4.x starting from 4.6

Preview:

