### PR TITLE
TELCODOCS-321: remove docs about provisioningOSDownloadURL

### DIFF
--- a/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
+++ b/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
@@ -34,13 +34,11 @@ oc edit provisioning
     resourceVersion: "551591"
     uid: f76e956f-24c6-4361-aa5b-feaf72c5b526
   spec:
-    preProvisioningOSDownloadURLs: {}
     provisioningDHCPRange: 172.22.0.10,172.22.0.254
     provisioningIP: 172.22.0.3
     provisioningInterface: enp1s0
     provisioningNetwork: Managed
     provisioningNetworkCIDR: 172.22.0.0/24
-    provisioningOSDownloadURL: http://192.168.111.1/images/rhcos-<version>.x86_64.qcow2.gz?sha256=<sha256>
     virtualMediaViaExternalNetwork: true <1>
   status:
     generations:

--- a/modules/nw-enabling-a-provisioning-network-after-installation.adoc
+++ b/modules/nw-enabling-a-provisioning-network-after-installation.adoc
@@ -38,7 +38,7 @@ $ oc get provisioning -o yaml > enable-provisioning-nw.yaml
 $ vim ~/enable-provisioning-nw.yaml
 ----
 +
-Scroll down to the `provisioningNetwork` configuration setting and change it from `Disabled` to `Managed`. Then, add the `provisioningOSDownloadURL`, `provisioningIP`, `provisioningNetworkCIDR`, `provisioningDHCPRange`, `provisioningInterface`, and `watchAllNameSpaces` configuration settings after the `provisioningNetwork` setting. Provide appropriate values for each setting.
+Scroll down to the `provisioningNetwork` configuration setting and change it from `Disabled` to `Managed`. Then, add the `provisioningIP`, `provisioningNetworkCIDR`, `provisioningDHCPRange`, `provisioningInterface`, and `watchAllNameSpaces` configuration settings after the `provisioningNetwork` setting. Provide appropriate values for each setting.
 +
 [source,yaml]
 ----
@@ -50,27 +50,24 @@ items:
     name: provisioning-configuration
   spec:
     provisioningNetwork: <1>
-    provisioningOSDownloadURL: <2>
-    provisioningIP: <3>
-    provisioningNetworkCIDR: <4>
-    provisioningDHCPRange: <5>
-    provisioningInterface: <6>
-    watchAllNameSpaces: <7>
+    provisioningIP: <2>
+    provisioningNetworkCIDR: <3>
+    provisioningDHCPRange: <4>
+    provisioningInterface: <5>
+    watchAllNameSpaces: <6>
 ----
 +
 <1> The `provisioningNetwork` is one of `Managed`, `Unmanaged`, or `Disabled`. When set to `Managed`, Metal3 manages the provisioning network and the CBO deploys the Metal3 pod with a configured DHCP server. When set to `Unmanaged`, the system administrator configures the DHCP server manually.
 +
-<2> The `provisioningOSDownloadURL` is a valid HTTPS URL with a valid sha256 checksum that enables the Metal3 pod to download a qcow2 operating system image ending in `.qcow2.gz` or `.qcow2.xz`. This field is required whether the provisioning network is `Managed`, `Unmanaged`, or `Disabled`. For example: `\http://192.168.0.1/images/{op-system-lowercase}-_<version>_.x86_64.qcow2.gz?sha256=_<sha>_`.
+<2> The `provisioningIP` is the static IP address that the DHCP server and ironic use to provision the network. This static IP address must be within the `provisioning` subnet, and outside of the DHCP range. If you configure this setting, it must have a valid IP address even if the `provisioning` network is `Disabled`. The static IP address is bound to the metal3 pod. If the metal3 pod fails and moves to another server, the static IP address also moves to the new server.
 +
-<3> The `provisioningIP` is the static IP address that the DHCP server and ironic use to provision the network. This static IP address must be within the `provisioning` subnet, and outside of the DHCP range. If you configure this setting, it must have a valid IP address even if the `provisioning` network is `Disabled`. The static IP address is bound to the metal3 pod. If the metal3 pod fails and moves to another server, the static IP address also moves to the new server.
+<3> The Classless Inter-Domain Routing (CIDR) address. If you configure this setting, it must have a valid CIDR address even if the `provisioning` network is `Disabled`. For example: `192.168.0.1/24`.
 +
-<4> The Classless Inter-Domain Routing (CIDR) address. If you configure this setting, it must have a valid CIDR address even if the `provisioning` network is `Disabled`. For example: `192.168.0.1/24`.
+<4> The DHCP range. This setting is only applicable to a `Managed` provisioning network. Omit this configuration setting if the `provisioning` network is `Disabled`. For example: `192.168.0.64, 192.168.0.253`.
 +
-<5> The DHCP range. This setting is only applicable to a `Managed` provisioning network. Omit this configuration setting if the `provisioning` network is `Disabled`. For example: `192.168.0.64, 192.168.0.253`.
+<5> The NIC name for the `provisioning` interface on cluster nodes. The `provisioningInterface` setting is only applicable to `Managed` and `Unmanaged` provisioning networks. Omit the `provisioningInterface` configuration setting if the `provisioning` network is `Disabled`. Omit the `provisioningInterface` configuration setting to use the `bootMACAddress` configuration setting instead.
 +
-<6> The NIC name for the `provisioning` interface on cluster nodes. The `provisioningInterface` setting is only applicable to `Managed` and `Unmanaged` provisioning networks. Omit the `provisioningInterface` configuration setting if the `provisioning` network is `Disabled`. Omit the `provisioningInterface` configuration setting to use the `bootMACAddress` configuration setting instead.
-+
-<7> Set this setting to `true` if you want metal3 to watch namespaces other than the default `openshift-machine-api` namespace. The default value is `false`.
+<6> Set this setting to `true` if you want metal3 to watch namespaces other than the default `openshift-machine-api` namespace. The default value is `false`.
 
 . Save the changes to the provisioning CR file.
 


### PR DESCRIPTION
Prior to 4.10, the provisioningOSDownloadURL of the Provisioning CR was
required for provisioning baremetal hosts. In clusters installed from
4.10 onwards, the default MachineSets use a custom install method in
ironic to write the CoreOS live image to disk, instead of requiring a
separate URL to a qcow image. Therefore, users should never need to set
this value; on older clusters it will already be set and on newer ones
it is not required.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to.
If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
  - The preview will be generated after you open the PR.
  - You will need to edit the comment to add the link after the preview builds.
  - Review the preview build to make sure your changes are rendering properly. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
