### PR TITLE
Remove SNO and Assisted Installer from OKD

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -269,13 +269,13 @@ Topics:
     File: installing-restricted-networks-bare-metal
 - Name: Installing on-premise with Assisted Installer
   Dir: installing_on_prem_assisted
-  Distros: openshift-origin,openshift-enterprise
+  Distros: openshift-enterprise
   Topics:
   - Name: Installing an on-premise cluster using the Assisted Installer
     File: installing-on-prem-assisted
 - Name: Installing on a single node
   Dir: installing_sno
-  Distros: openshift-origin,openshift-enterprise
+  Distros: openshift-enterprise
   Topics:
   - Name: Preparing to install OpenShift on a single node
     File: install-sno-preparing-to-install-sno


### PR DESCRIPTION
https://github.com/openshift/okd/discussions/1235
https://github.com/openshift/openshift-docs/issues/39759

Single node install and Assisted Installer is vastly different in OKD. Removing these topic from OKD until we devise a solution. 

Preview: 
OKD: Assemblies not present 
http://file.rdu.redhat.com/~mburke/okd-remove-sno-and-ai/installing/

OCP: Assemblies present 
[Installing an on-premise cluster using the Assisted Installer](http://file.rdu.redhat.com/mburke/okd-remove-sno-and-ai-ocp/installing/installing_on_prem_assisted/installing-on-prem-assisted.html) 
[Preparing to install on a single node](http://file.rdu.redhat.com/mburke/okd-remove-sno-and-ai-ocp/installing/installing_sno/install-sno-preparing-to-install-sno.html)