### PR TITLE
Updated the NFD CR YAML to include the namespace

### DIFF
--- a/modules/psap-using-node-feature-discovery-operator.adoc
+++ b/modules/psap-using-node-feature-discovery-operator.adoc
@@ -32,6 +32,7 @@ apiVersion: nfd.openshift.io/v1
 kind: NodeFeatureDiscovery
 metadata:
   name: nfd-instance
+  namespace: openshift-nfd
 spec:
   instance: "" # instance is empty by default
   topologyupdater: false # False by default


### PR DESCRIPTION
This PR re-introduces the `namespace:` field of the NFD CR. This field was present in 4.9, but is missing in 4.10+. 

Version(s):
4.10+

Issue:
Slack discussion

Preview build  (VPN required):
http://file.rdu.redhat.com/antaylor/05-26-22/nfd-yaml-update/hardware_enablement/psap-node-feature-discovery-operator.html#create-cd-cli_node-feature-discovery-operator