### PR TITLE
[RHACS] Add example word to certificate example per IT request

### DIFF
--- a/modules/custom-cert-existing.adoc
+++ b/modules/custom-cert-existing.adoc
@@ -19,12 +19,12 @@ central:
   defaultTLS:
     cert: |
       -----BEGIN CERTIFICATE-----
-      MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      EXAMPLE!MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
       ...
       -----END CERTIFICATE-----
     key: |
       -----BEGIN EC PRIVATE KEY-----
-      MHcl4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
+      EXAMPLE!MHcl4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
       ...
       -----END EC PRIVATE KEY-----
 ----

--- a/modules/custom-cert-new-install.adoc
+++ b/modules/custom-cert-new-install.adoc
@@ -19,12 +19,12 @@ central:
   defaultTLS:
     cert: |
       -----BEGIN CERTIFICATE-----
-      MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      EXAMPLE!MIIMIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
       ...
       -----END CERTIFICATE-----
     key: |
       -----BEGIN EC PRIVATE KEY-----
-      MHcl4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
+      EXAMPLE!MHcl4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
       ...
       -----END EC PRIVATE KEY-----
 ----


### PR DESCRIPTION
- Version(s)/branches:
	- rhacs-docs
	- rhacs-docs-3.70.0
	- rhacs-docs-3.69.0
	- rhacs-docs-3.68.0
- labels: `RHACS/next`, `RHACS`
- Issue: No JIRA issue, email from IT
- [Preview](http://file.rdu.redhat.com/kcarmich/ITrequest/configuration/add-custom-certificates.html#custom-cert-new-install_add-custom-cert)

Now that we are using manual previews, IT alerted me via email that a potential security leak was in the doc (because their tool scans repos and flags potential leaked info). The system alerted on a fake SSL example (false positive). IT recommends using the text "example" in the example to stop its tool from alerting for a false positive.

**Resolution**: Added the word "example" in the two pieces of text that caused the security alert.
