### PR TITLE
[enterprise-4.10] TELCODOCS-415: Use of openshift-sdn with sno is deprecated.

### DIFF
--- a/modules/install-sno-about-installing-on-a-single-node.adoc
+++ b/modules/install-sno-about-installing-on-a-single-node.adoc
@@ -7,3 +7,8 @@
 = About OpenShift on a single node
 
 You can create a single node cluster with standard installation methods. {product-title} on a single node is a specialized installation that requires the creation of a special ignition configuration ISO. The primary use case is for edge computing workloads, including intermittent connectivity, portable clouds, and 5G radio access networks (RAN) close to a base station. The major tradeoff with an installation on a single node is the lack of high availability.
+
+[IMPORTANT]
+====
+The use of OpenShiftSDN with single-node OpenShift is deprecated. OVN-Kubernetes is the default networking solution for single-node OpenShift deployments.
+====


### PR DESCRIPTION
Fixes: [TELCODOCS-415](https://issues.redhat.com/browse/TELCODOCS-415)

For: Version 4.10 (See [PR 45840](https://github.com.openshift/openshift-docs/pull/45840) for 4.9 and [PR 45830](https://github.com/openshift/openshift-docs/pull/45830) for 4.11)

Doc Preview: 
![image (9)](https://user-images.githubusercontent.com/50421786/176510582-0ef01731-393a-47a5-a4a2-a4dda24d8a6a.png)

Signed-off-by: Katie Tothill ktothill@redhat.com