### PR TITLE
OSDOCS-3676: Arm support for disconnected install

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -108,7 +108,8 @@ $ RELEASE_NAME="okd"
 endif::[]
 
 ifndef::openshift-origin[]
-.. Export the type of architecture for your server, such as `x86_64`:
+.. Export the type of architecture for your server, such as `x86_64` 
+or `aarch64`:
 +
 [source,terminal]
 ----

--- a/modules/olm-mirroring-catalog-airgapped.adoc
+++ b/modules/olm-mirroring-catalog-airgapped.adoc
@@ -32,7 +32,7 @@ $ oc adm catalog mirror \
 <2> Specify the content to mirror to local files in your current directory.
 <3> Optional: If required, specify the location of your registry credentials file.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are specified as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, and `.*`
+<5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are specified as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, `linux/arm64`, and `.*`
 +
 .Example output
 [source,terminal]
@@ -76,7 +76,7 @@ $ oc adm catalog mirror \
 <2> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator contents to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
 <3> Optional: If required, specify the location of your registry credentials file.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are specified as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, and `.*`
+<5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are specified as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, `linux/arm64`, and `.*`
 +
 [NOTE]
 ====

--- a/modules/olm-mirroring-catalog-colocated.adoc
+++ b/modules/olm-mirroring-catalog-colocated.adoc
@@ -43,7 +43,7 @@ $ oc adm catalog mirror \
 <3> Optional: If required, specify the location of your registry credentials file.
 `{REG_CREDS}` is required for `registry.redhat.io`.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are passed as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, and `.*`
+<5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are passed as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, `linux/arm64`, and `.*`
 <6> Optional: Generate only the manifests required for mirroring, and do not actually mirror the image content to a registry. This option can be useful for reviewing what will be mirrored, and it allows you to make any changes to the mapping list if you require only a subset of packages. You can then use the `mapping.txt` file with the `oc image mirror` command to mirror the modified list of images in a later step. This flag is intended for only advanced selective mirroring of content from the catalog; the `opm index prune` command, if you used it previously to prune the index image, is suitable for most catalog management use cases.
 +
 .Example output


### PR DESCRIPTION
For Version: 4.11+ 
Jira story: [OSDOCS-3676](https://issues.redhat.com/browse/OSDOCS-3676)

Previews and sections with the changes: 

1. [Mirroring for a disconnected installation -> Mirroring the OpenShift Container Platform image repository](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3676-arm-for-disconnected-install/installing/disconnected_install/installing-mirroring-installation-images.html#installation-mirror-repository_installing-mirroring-installation-images)

2. [Mirroring images for a disconnected installation -> Extractions and mirroring contents](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3676-arm-for-disconnected-install/installing/disconnected_install/installing-mirroring-installation-images.html#olm-mirror-catalog-extracting_installing-mirroring-installation-images) 

- Mirroring catalog contents to registries on the same network
- Mirroring catalog contents to airgapped registries