### PR TITLE
Compliance Operator v0.1.52 release notes stub

### DIFF
--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -13,6 +13,26 @@ These release notes track the development of the Compliance Operator in the {pro
 
 For an overview of the Compliance Operator, see xref:../../security/compliance_operator/compliance-operator-understanding.adoc#understanding-compliance-operator[Understanding the Compliance Operator].
 
+[id="compliance-operator-release-notes-0-1-52"]
+== OpenShift Compliance Operator 0.1.52
+
+The following advisory is available for the OpenShift Compliance Operator 0.1.52:
+
+* link:https://access.redhat.com/errata/RHBA-2022:4657[RHBA-2022:4657 - OpenShift Compliance Operator bug fix update]
+
+[id="compliance-operator-0-1-52-bug-fixes"]
+=== Bug fixes
+
+* Previously, the `OpenScap` container would crash due to a mount permission issue in a security environment where `DAC_OVERRIDE` capability is dropped. Now, executable mount permissions are applied to all users. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2082151[*BZ#2082151*])
+
+* Previously, the compliance rule `ocp4-configure-network-policies` could be configured as `MANUAL`. Now, compliance rule `ocp4-configure-network-policies` is set to `AUTOMATIC`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2072431[*BZ#2072431*])
+
+* Previously, the Cluster Autoscaler would fail to scale down because the Compliance Operator scan pods were never removed after a scan. Now, the pods are removed from each node by default unless explicitly saved for debugging purposes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2075029[*BZ#2075029*])
+
+* Previously, applying the Compliance Operator to the `KubeletConfig` would result in the node going into a `NotReady` state due to unpausing the Machine Config Pools too early. Now, the Machine Config Pools are unpaused appropriately and the node operates correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2071854[*BZ#2071854*])
+
+* Previously, the Machine Config Operator used `base64` instead of `url-encoded` code in the latest release, causing Compliance Operator remediation to fail. Now, the Compliance Operator checks encoding to handle both `base64` and `url-encoded` Machine Config code and the remediation applies correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2082431[*BZ#2082431*])
+
 [id="compliance-operator-release-notes-0-1-49"]
 == OpenShift Compliance Operator 0.1.49
 


### PR DESCRIPTION
[CMP-1327](https://issues.redhat.com/browse/CMP-1327)

Version(s):
4.6+

Issue:
[CMP-1327](https://issues.redhat.com/browse/CMP-1327)

Link to docs preview:
http://file.rdu.redhat.com/antaylor/05-31-22/co-0.1.52-RNs/security/compliance_operator/compliance-operator-release-notes.html
(VPN required)