### PR TITLE
Added tolerations for infra nodes for router pod placement to infrastructure-moving-router.adoc

### DIFF
--- a/modules/infrastructure-moving-router.adoc
+++ b/modules/infrastructure-moving-router.adoc
@@ -66,6 +66,10 @@ Add the `nodeSelector` stanza that references the `infra` label to the `spec` se
       nodeSelector:
         matchLabels:
           node-role.kubernetes.io/infra: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
 ----
 
 . Confirm that the router pod is running on the `infra` node.


### PR DESCRIPTION
Added tolerations for infra nodes for router pod placement

Version(s):
4.10

Issue:

Link to docs preview: (requires RH VPN)
[Moving the router](http://file.rdu.redhat.com/jrouth/PR46124-nvsmirnov-tolerations-for-infra-nodes/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-router_creating-infrastructure-machinesets) (step 2)

Additional information:
When I tried to use this doc to move router to infra node, pod was stuck in Pending state because there was no toleration for running on infra node. Whan I added it, all went fine then.
