### PR TITLE
prometheusOperator runs on master node, not infra: infrastructure-moving-monitoring.adoc

### DIFF
--- a/modules/infrastructure-moving-monitoring.adoc
+++ b/modules/infrastructure-moving-monitoring.adoc
@@ -25,30 +25,59 @@ data:
     alertmanagerMain:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
     prometheusK8s:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
-    prometheusOperator:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
     grafana:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
     k8sPrometheusAdapter:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
     kubeStateMetrics:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
     telemeterClient:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
     openshiftStateMetrics:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
     thanosQuerier:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
 ----
 +
 Running this config map forces the components of the monitoring stack to redeploy to infrastructure nodes.

--- a/modules/infrastructure-moving-monitoring.adoc
+++ b/modules/infrastructure-moving-monitoring.adoc
@@ -30,7 +30,7 @@ data:
         node-role.kubernetes.io/infra: ""
     prometheusOperator:
       nodeSelector:
-        node-role.kubernetes.io/infra: ""
+        node-role.kubernetes.io/master: ""
     grafana:
       nodeSelector:
         node-role.kubernetes.io/infra: ""


### PR DESCRIPTION
prometheusOperator runs on master node, not infra

Version(s):
4.10

Issue:

Link to docs preview:

Additional information:
When I tried to use this doc to move monitoring to infra node, prometheus operator pod was stuck in Pending state because it normally runs on master node, but this doc suggests to move it to infra node. So I changed infra to master here and all went fine. Or, may be, prometheusOperator should be excluded from here at all - I don't sure.
