### PR TITLE
Update for BZ2089766

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
@@ -27,9 +27,11 @@ include::modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc[leve
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../post_installation_configuration/bare-metal-configuration.adoc[Bare metal configuration]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-the-unhealthy-etcd-member[Replacing an unhealthy etcd member]
 
-* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[Backing up etcd]
+
+* xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration] 
 
 include::modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc[leveloffset=+1]
 

--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -15,7 +15,32 @@ If you reuse the `BareMetalHost` object definition from an existing control plan
 Existing control plane `BareMetalHost` objects may have the `externallyProvisioned` flag set to `true` if they were provisioned by the {product-title} installation program.
 ====
 
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+* You have taken an etcd backup.
++
+[IMPORTANT]
+====
+Take an etcd backup before performing this procedure so that you can restore your cluster if you encounter any issues. For more information about taking an etcd backup, see the _Additional resources_ section.
+====
+
 .Procedure
+
+. Ensure that the Bare Metal Operator is available:
++
+[source,terminal]
+----
+$ oc get clusteroperator baremetal
+----
++
+.Example output
+[source,terminal]
+----
+NAME        VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE  
+baremetal   4.10.12   True        False         False      3d15h 
+----
 
 . Remove the old `BareMetalHost` and `Machine` objects:
 +


### PR DESCRIPTION
BZ#2089766: Adding some prereqs, a new first step and additional links, to this procedure. The customer needed to ensure they created an etcd backup before they attempted to replace a control node. SME also advised checking the health of the baremetal operator as step one, so the customer could continue to provision the node later.

Version(s):
4.8, 4.9, 4.10, 4.11

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2089766

Link to docs preview:
http://file.emea.redhat.com/rohennes/BZ2089766/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#replacing-a-bare-metal-control-plane-node_ipi-install-expanding

Additional information:
The additional resources don't exist in 4.8 and 4.9. They do exist in 4.10 and 4.11, I am just editing them. (unsure how that works for CPing so let me know if I need to create separate PRs.)
