### PR TITLE
[TELCODOCS-442, TELCODOCS-443] PTP 4.11 - Dual NIC and PTP events

### DIFF
--- a/modules/cnf-configuring-cvl-nic-as-oc.adoc
+++ b/modules/cnf-configuring-cvl-nic-as-oc.adoc
@@ -165,7 +165,7 @@ spec:
 $ oc create -f cvl-ptp-ordinary-clock.yaml
 ----
 
-.Verification steps
+.Verification
 
 . Check that the `PtpConfig` profile is applied to the node.
 

--- a/modules/cnf-configuring-the-ptp-fast-event-publisher.adoc
+++ b/modules/cnf-configuring-the-ptp-fast-event-publisher.adoc
@@ -29,7 +29,7 @@ metadata:
   namespace: openshift-ptp
 spec:
   daemonNodeSelector:
-  node-role.kubernetes.io/worker: ""
+    node-role.kubernetes.io/worker: ""
   ptpEventConfig:
     enableEventPublisher: true <1>
     transportHost: amqp://<instance_name>.<namespace>.svc.cluster.local <2>

--- a/modules/cnf-fast-event-notifications-api-refererence.adoc
+++ b/modules/cnf-fast-event-notifications-api-refererence.adoc
@@ -16,12 +16,18 @@ Use the following API endpoints to subscribe the `cloud-event-consumer` DU appli
 * `/api/cloudNotifications/v1/subscriptions`
 - `POST`: Creates a new subscription
 - `GET`: Retrieves a list of subscriptions
+
 * `/api/cloudNotifications/v1/subscriptions/<subscription_id>`
 - `GET`: Returns details for the specified subscription ID
+
 * `api/cloudNotifications/v1/subscriptions/status/<subscription_id>`
 - `PUT`: Creates a new status ping request for the specified subscription ID
+
 * `/api/cloudNotifications/v1/health`
 - `GET`: Returns the health status of `cloudNotifications` API
+
+* `api/cloudNotifications/v1/publishers`
+- `GET`: Returns an array of `os-clock-sync-state`, `ptp-clock-class-change`, and `lock-state` messages for the cluster node
 
 [NOTE]
 ====
@@ -30,10 +36,12 @@ Use the following API endpoints to subscribe the `cloud-event-consumer` DU appli
 
 == api/cloudNotifications/v1/subscriptions
 
+[discrete]
 === HTTP method
 
 `GET api/cloudNotifications/v1/subscriptions`
 
+[discrete]
 ==== Description
 
 Returns a list of subscriptions. If subscriptions exist, a `200 OK` status code is returned along with the list of subscriptions.
@@ -51,10 +59,12 @@ Returns a list of subscriptions. If subscriptions exist, a `200 OK` status code 
 ]
 ----
 
+[discrete]
 === HTTP method
 
 `POST api/cloudNotifications/v1/subscriptions`
 
+[discrete]
 ==== Description
 
 Creates a new subscription. If a subscription is successfully created, or if it already exists, a `201 Created` status code is returned.
@@ -78,10 +88,12 @@ Creates a new subscription. If a subscription is successfully created, or if it 
 
 == api/cloudNotifications/v1/subscriptions/<subscription_id>
 
+[discrete]
 === HTTP method
 
 `GET api/cloudNotifications/v1/subscriptions/<subscription_id>`
 
+[discrete]
 ==== Description
 
 Returns details for the subscription with ID `<subscription_id>`
@@ -107,10 +119,12 @@ Returns details for the subscription with ID `<subscription_id>`
 
 == api/cloudNotifications/v1/subscriptions/status/<subscription_id>
 
+[discrete]
 === HTTP method
 
 `PUT api/cloudNotifications/v1/subscriptions/status/<subscription_id>`
 
+[discrete]
 ==== Description
 
 Creates a new status ping request for subscription with ID `<subscription_id>`. If a subscription is present, the status request is successful and a `202 Accepted` status code is returned.
@@ -131,10 +145,12 @@ Creates a new status ping request for subscription with ID `<subscription_id>`. 
 
 == api/cloudNotifications/v1/health/
 
+[discrete]
 === HTTP method
 
 `GET api/cloudNotifications/v1/health/`
 
+[discrete]
 ==== Description
 
 Returns the health status for the `cloudNotifications` REST API.
@@ -143,4 +159,133 @@ Returns the health status for the `cloudNotifications` REST API.
 [source,terminal]
 ----
 OK
+----
+
+== api/cloudNotifications/v1/publishers
+
+[discrete]
+=== HTTP method
+
+`GET api/cloudNotifications/v1/publishers`
+
+[discrete]
+==== Description
+
+Returns an array of `os-clock-sync-state`, `ptp-clock-class-change`, and `lock-state` details for the cluster node. The system generates notifications when the relevant equipment state changes.
+
+* `os-clock-sync-state` notifications describe the host operating system clock synchronization state. Can be in `LOCKED` or `FREERUN` state.
+* `ptp-clock-class-change` notifications describe the current state of the PTP clock class.
+* `lock-state` notifications describe the current status of the PTP equipment lock state. Can be in `LOCKED`, `HOLDOVER` or `FREERUN` state.
+
+.Example API response
+[source,json]
+----
+[
+  {
+    "id": "0fa415ae-a3cf-4299-876a-589438bacf75",
+    "endpointUri": "http://localhost:9085/api/cloudNotifications/v1/dummy",
+    "uriLocation": "http://localhost:9085/api/cloudNotifications/v1/publishers/0fa415ae-a3cf-4299-876a-589438bacf75",
+    "resource": "/cluster/node/compute-1.example.com/sync/sync-status/os-clock-sync-state"
+  },
+  {
+    "id": "28cd82df-8436-4f50-bbd9-7a9742828a71",
+    "endpointUri": "http://localhost:9085/api/cloudNotifications/v1/dummy",
+    "uriLocation": "http://localhost:9085/api/cloudNotifications/v1/publishers/28cd82df-8436-4f50-bbd9-7a9742828a71",
+    "resource": "/cluster/node/compute-1.example.com/sync/ptp-status/ptp-clock-class-change"
+  },
+  {
+    "id": "44aa480d-7347-48b0-a5b0-e0af01fa9677",
+    "endpointUri": "http://localhost:9085/api/cloudNotifications/v1/dummy",
+    "uriLocation": "http://localhost:9085/api/cloudNotifications/v1/publishers/44aa480d-7347-48b0-a5b0-e0af01fa9677",
+    "resource": "/cluster/node/compute-1.example.com/sync/ptp-status/lock-state"
+  }
+]
+----
+
+You can find `os-clock-sync-state`, `ptp-clock-class-change` and `lock-state` events in the logs for the `cloud-event-proxy` container. For example:
+
+[source,terminal]
+----
+$ oc logs -f linuxptp-daemon-cvgr6 -n openshift-ptp -c cloud-event-proxy
+----
+
+.Example os-clock-sync-state event
+[source,json]
+----
+{
+   "id":"c8a784d1-5f4a-4c16-9a81-a3b4313affe5",
+   "type":"event.sync.sync-status.os-clock-sync-state-change",
+   "source":"/cluster/compute-1.example.com/ptp/CLOCK_REALTIME",
+   "dataContentType":"application/json",
+   "time":"2022-05-06T15:31:23.906277159Z",
+   "data":{
+      "version":"v1",
+      "values":[
+         {
+            "resource":"/sync/sync-status/os-clock-sync-state",
+            "dataType":"notification",
+            "valueType":"enumeration",
+            "value":"LOCKED"
+         },
+         {
+            "resource":"/sync/sync-status/os-clock-sync-state",
+            "dataType":"metric",
+            "valueType":"decimal64.3",
+            "value":"-53"
+         }
+      ]
+   }
+}
+----
+
+.Example ptp-clock-class-change event
+[source,json]
+----
+{
+   "id":"69eddb52-1650-4e56-b325-86d44688d02b",
+   "type":"event.sync.ptp-status.ptp-clock-class-change",
+   "source":"/cluster/compute-1.example.com/ptp/ens2fx/master",
+   "dataContentType":"application/json",
+   "time":"2022-05-06T15:31:23.147100033Z",
+   "data":{
+      "version":"v1",
+      "values":[
+         {
+            "resource":"/sync/ptp-status/ptp-clock-class-change",
+            "dataType":"metric",
+            "valueType":"decimal64.3",
+            "value":"135"
+         }
+      ]
+   }
+}
+----
+
+.Example lock-state event
+[source,json]
+----
+{
+   "id":"305ec18b-1472-47b3-aadd-8f37933249a9",
+   "type":"event.sync.ptp-status.ptp-state-change",
+   "source":"/cluster/compute-1.example.com/ptp/ens2fx/master",
+   "dataContentType":"application/json",
+   "time":"2022-05-06T15:31:23.467684081Z",
+   "data":{
+      "version":"v1",
+      "values":[
+         {
+            "resource":"/sync/ptp-status/lock-state",
+            "dataType":"notification",
+            "valueType":"enumeration",
+            "value":"LOCKED"
+         },
+         {
+            "resource":"/sync/ptp-status/lock-state",
+            "dataType":"metric",
+            "valueType":"decimal64.3",
+            "value":"62"
+         }
+      ]
+   }
+}
 ----

--- a/modules/nw-columbiaville-ptp-config-refererence.adoc
+++ b/modules/nw-columbiaville-ptp-config-refererence.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * networking/using-ptp.adoc
+
+:_content-type: REFERENCE
+[id="nw-columbiaville-ptp-config-refererence_{context}"]
+= Intel Columbiaville E800 series NIC as PTP ordinary clock reference
+
+The following table describes the changes that you must make to the reference PTP configuration in order to use Intel Columbiaville E800 series NICs as ordinary clocks. Make the changes in a `PtpConfig` custom resource (CR) that you apply to the cluster.
+
+.Recommended PTP settings for Intel Columbiaville NIC
+[options="header"]
+|====
+|PTP configuration|Recommended setting
+|`phc2sysOpts`|`-a -r -m -n 24 -N 8 -R 16`
+|`tx_timestamp_timeout`|`50`
+|`boundary_clock_jbod`|`0`
+|====
+
+
+

--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -10,13 +10,15 @@ You can configure the `linuxptp` services (`ptp4l`, `phc2sys`) as boundary clock
 
 [NOTE]
 ====
-The following `PtpConfig` CR configures PTP fast events by setting values for `ptp4lOpts`, `ptp4lConf` and `ptpClockThreshold`.
+Use the following example `PtpConfig` CR as the basis to `linuxptp` services as boundary clock for your particular hardware and environment. This example CR also configures PTP fast events by setting appropriate values for `ptp4lOpts`, `ptp4lConf` and `ptpClockThreshold`. `ptpClockThreshold` is used only when events are enabled.
 ====
 
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).
+
 * Log in as a user with `cluster-admin` privileges.
+
 * Install the PTP Operator.
 
 .Procedure
@@ -28,17 +30,16 @@ The following `PtpConfig` CR configures PTP fast events by setting values for `p
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
-  name: boundary-clock-ptp-config <1>
+  name: boundary-clock-ptp-config                     <1>
   namespace: openshift-ptp
 spec:
-  profile: <2>
-  - name: "profile1" <3>
-    interface: "" <4>
-    ptp4lOpts: "-2 -s --summary_interval -4" <5>
-    ptp4lConf: | <6>
-      [ens1f0] <7>
+  profile:                                            <2>
+  - name: "<profile_name>"                            <3>
+    ptp4lOpts: "-2 --summary_interval -4"             <4>
+    ptp4lConf: |                                      <5>
+      [ens1f0]                                        <6>
       masterOnly 0
-      [ens1f3] <8>
+      [ens1f3]                                        <7>
       masterOnly 1
       [global]
       #
@@ -52,127 +53,127 @@ spec:
       #utc_offset                       37
       clockClass                        248
       clockAccuracy                     0xFE
-      offsetScaledLogVariance         0xFFFF
+      offsetScaledLogVariance           0xFFFF
       free_running                      0
-      freq_est_interval               1
+      freq_est_interval                 1
       dscp_event                        0
       dscp_general                      0
-      dataset_comparison              G.8275.x
-      G.8275.defaultDS.localPriority  128
+      dataset_comparison                G.8275.x
+      G.8275.defaultDS.localPriority    128
       #
       # Port Data Set
       #
-      logAnnounceInterval          -3
-      logSyncInterval                -4
-      logMinDelayReqInterval       -4
-      logMinPdelayReqInterval      -4
-      announceReceiptTimeout       3
-      syncReceiptTimeout           0
-      delayAsymmetry                 0
-      fault_reset_interval         4
-      neighborPropDelayThresh      20000000
-      masterOnly                     0
-      G.8275.portDS.localPriority  128
+      logAnnounceInterval              -3
+      logSyncInterval                  -4
+      logMinDelayReqInterval           -4
+      logMinPdelayReqInterval          -4
+      announceReceiptTimeout            3
+      syncReceiptTimeout                0
+      delayAsymmetry                    0
+      fault_reset_interval              4
+      neighborPropDelayThresh           20000000
+      masterOnly                        0
+      G.8275.portDS.localPriority       128
       #
-      # Run time options
+      # Runtime options
       #
-      assume_two_step              0
-      logging_level                6
-      path_trace_enabled         0
-      follow_up_info               0
-      hybrid_e2e                   0
-      inhibit_multicast_service  0
-      net_sync_monitor           0
-      tc_spanning_tree           0
-      tx_timestamp_timeout       10
-      #was 1 (default !)
-      unicast_listen          0
-      unicast_master_table  0
-      unicast_req_duration  3600
-      use_syslog              1
-      verbose                   0
-      summary_interval      -4
-      kernel_leap             1
-      check_fup_sync          0
+      assume_two_step                   0
+      logging_level                     6
+      path_trace_enabled                0
+      follow_up_info                    0
+      hybrid_e2e                        0
+      inhibit_multicast_service         0
+      net_sync_monitor                  0
+      tc_spanning_tree                  0
+      tx_timestamp_timeout              10            <8>
+      unicast_listen                    0
+      unicast_master_table              0
+      unicast_req_duration              3600
+      use_syslog                        1
+      verbose                           0
+      summary_interval                 -4
+      kernel_leap                       1
+      check_fup_sync                    0
       #
       # Servo Options
       #
-      pi_proportional_const     0.0
-      pi_integral_const         0.0
-      pi_proportional_scale     0.0
-      pi_proportional_exponent  -0.3
-      pi_proportional_norm_max  0.7
-      pi_integral_scale         0.0
-      pi_integral_exponent      0.4
-      pi_integral_norm_max      0.3
-      step_threshold              0
-      first_step_threshold      0.00002
-      max_frequency               900000000
-      clock_servo                 pi
-      sanity_freq_limit         200000000
-      ntpshm_segment              0
+      pi_proportional_const             0.0
+      pi_integral_const                 0.0
+      pi_proportional_scale             0.0
+      pi_proportional_exponent         -0.3
+      pi_proportional_norm_max          0.7
+      pi_integral_scale                 0.0
+      pi_integral_exponent              0.4
+      pi_integral_norm_max              0.3
+      step_threshold                    0
+      first_step_threshold              0.00002
+      max_frequency                     900000000
+      clock_servo                       pi
+      sanity_freq_limit                 200000000
+      ntpshm_segment                    0
       #
       # Transport options
       #
-      transportSpecific   0x0
-      ptp_dst_mac          01:1B:19:00:00:00
-      p2p_dst_mac          01:80:C2:00:00:0E
-      udp_ttl                1
-      udp6_scope           0x0E
-      uds_address          /var/run/ptp4l
+      transportSpecific                 0x0
+      ptp_dst_mac                       01:1B:19:00:00:00
+      p2p_dst_mac                       01:80:C2:00:00:0E
+      udp_ttl                           1
+      udp6_scope                        0x0E
+      uds_address                       /var/run/ptp4l
       #
       # Default interface options
       #
-      clock_type             BC
-      network_transport    UDPv4
-      delay_mechanism        E2E
-      time_stamping          hardware
-      tsproc_mode            filter
-      delay_filter           moving_median
-      delay_filter_length  10
-      egressLatency          0
-      ingressLatency         0
-      boundary_clock_jbod  1
+      clock_type                        BC
+      network_transport                 L2
+      delay_mechanism                   E2E
+      time_stamping                     hardware
+      tsproc_mode                       filter
+      delay_filter                      moving_median
+      delay_filter_length               10
+      egressLatency                     0
+      ingressLatency                    0
+      boundary_clock_jbod               0             <9>
       #
       # Clock description
       #
-      productDescription    ;;
-      revisionData            ;;
-      manufacturerIdentity  00:00:00
-      userDescription         ;
-      timeSource              0xA0
-    phc2sysOpts: "-a -r" <9>
-    ptpSchedulingPolicy: SCHED_OTHER <10>
-    ptpSchedulingPriority: 65 <11>
-  ptpClockThreshold: <12>
-    holdOverTimeout: 5
-    maxOffsetThreshold: 100
-    minOffsetThreshold: -100
-  recommend: <13>
-  - profile: "profile1" <14>
-    priority: 10 <15>
-    match: <16>
-    - nodeLabel: "node-role.kubernetes.io/worker" <17>
-      nodeName: "compute-0.example.com" <18>
+      productDescription                ;;
+      revisionData                      ;;
+      manufacturerIdentity              00:00:00
+      userDescription                   ;
+      timeSource                        0xA0
+    phc2sysOpts:                        "-a -r -n 24" <10>
+    ptpSchedulingPolicy:                SCHED_OTHER   <11>
+    ptpSchedulingPriority:              65            <12>
+  ptpClockThreshold:                                  <13>
+    holdOverTimeout:                    5
+    maxOffsetThreshold:                 100
+    minOffsetThreshold:                -100
+  recommend:                                          <14>
+  - profile: "<profile_name>"                         <15>
+    priority: 10                                      <16>
+    match:                                            <17>
+    - nodeLabel: "<node_label>"                       <18>
+      nodeName: "<node_name>"                         <19>
 ----
 <1> The name of the `PtpConfig` CR.
 <2> Specify an array of one or more `profile` objects.
 <3> Specify the name of a profile object which uniquely identifies a profile object.
-<4> This field should remain empty for boundary clock.
-<5> Specify system config options for the `ptp4l` service, for example `-2`. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended.
-<6> Specify the needed configuration to start `ptp4l` as boundary clock. For example, `ens1f0` synchronizes from a grandmaster clock and `ens1f3` synchronizes connected devices.
-<7> The interface that receives the synchronization clock.
-<8> The interface that synchronizes downstream connected devices.
-<9> Specify system config options for the `phc2sys` service, for example `-a -r`. If this field is empty the PTP Operator does not start the `phc2sys` service.
-<10> Scheduling policy for ptp4l and phc2sys processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
-<11> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes. Required if `SCHED_FIFO` is set for `ptpSchedulingPolicy`.
-<12> Optional. If `ptpClockThreshold` stanza is not present, default values are used for `ptpClockThreshold` fields. Stanza shows default `ptpClockThreshold` values.
-<13> Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
-<14> Specify the `profile` object name defined in the `profile` section.
-<15> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
-<16> Specify `match` rules with `nodeLabel` or `nodeName`.
-<17> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command.
-<18> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command.
+<4> Specify system config options for the `ptp4l` service. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended.
+<5> Specify the needed configuration to start `ptp4l` as boundary clock. For example, `ens1f0` synchronizes from a grandmaster clock and `ens1f3` synchronizes connected devices.
+<6> The interface that receives the synchronization clock.
+<7> The interface that sends the synchronization clock.
+<8> For Intel Columbiaville 800 Series NICs, set `tx_timestamp_timeout` to `50`.
+<9> For Intel Columbiaville 800 Series NICs, ensure `boundary_clock_jbod` is set to `0`.
+<10> Specify system config options for the `phc2sys` service. If this field is empty the PTP Operator does not start the `phc2sys` service.
+<11> Scheduling policy for ptp4l and phc2sys processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
+<12> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes. Required if `SCHED_FIFO` is set for `ptpSchedulingPolicy`.
+<13> Optional. If `ptpClockThreshold` stanza is not present, default values are used for `ptpClockThreshold` fields. Stanza shows default `ptpClockThreshold` values.
+<14> Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
+<15> Specify the `profile` object name defined in the `profile` section.
+<16> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
+<17> Specify `match` rules with `nodeLabel` or `nodeName`.
+<18> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command. For example: `node-role.kubernetes.io/worker`.
+<19> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command. For example: `node-role.kubernetes.io/worker`. For example: `compute-0.example.com`.
 
 . Create the CR by running the following command:
 +
@@ -181,7 +182,7 @@ spec:
 $ oc create -f boundary-clock-ptp-config.yaml
 ----
 
-.Verification steps
+.Verification
 
 . Check that the `PtpConfig` profile is applied to the node.
 
@@ -216,7 +217,7 @@ I1115 09:41:17.117604 4143292 daemon.go:109] updating NodePTPProfile to:
 I1115 09:41:17.117607 4143292 daemon.go:110] ------------------------------------
 I1115 09:41:17.117612 4143292 daemon.go:102] Profile Name: profile1
 I1115 09:41:17.117616 4143292 daemon.go:102] Interface:
-I1115 09:41:17.117620 4143292 daemon.go:102] Ptp4lOpts: -2 -s --summary_interval -4
-I1115 09:41:17.117623 4143292 daemon.go:102] Phc2sysOpts: -a -r
+I1115 09:41:17.117620 4143292 daemon.go:102] Ptp4lOpts: -2 --summary_interval -4
+I1115 09:41:17.117623 4143292 daemon.go:102] Phc2sysOpts: -a -r -n 24
 I1115 09:41:17.117626 4143292 daemon.go:116] ------------------------------------
 ----

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -10,7 +10,7 @@ You can configure `linuxptp` services (`ptp4l`, `phc2sys`) as ordinary clock by 
 
 [NOTE]
 ====
-The following `PtpConfig` CR configures PTP fast events by setting values for `ptp4lOpts`, `ptp4lConf` and `ptpClockThreshold`.
+Use the following example `PtpConfig` CR as the basis to `linuxptp` services as ordinary clock for your particular hardware and environment. This example CR also configures PTP fast events by setting appropriate values for `ptp4lOpts`, `ptp4lConf` and `ptpClockThreshold`. `ptpClockThreshold` is used only when events are enabled.
 ====
 
 .Prerequisites
@@ -28,144 +28,146 @@ The following `PtpConfig` CR configures PTP fast events by setting values for `p
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
-  name: ordinary-clock-ptp-config <1>
+  name: ordinary-clock-ptp-config                       <1>
   namespace: openshift-ptp
 spec:
-  profile: <2>
-  - name: "profile1" <3>
-    interface: "ens787f1" <4>
-    ptp4lOpts: "-2 -s --summary_interval -4" <5>
-    phc2sysOpts: "-a -r -n 24" <6>
-    ptp4lConf: | <7>
+  profile:                                              <2>
+  - name: "<profile_name>"                              <3>
+    interface: ""<interface_name>"                      <4>
+    ptp4lOpts: "-2 -s --summary_interval -4"            <5>
+    phc2sysOpts: "-a -r -n 24"                          <6>
+    ptp4lConf: |                                        <7>
      [global]
       #
       # Default Data Set
       #
-      twoStepFlag 1
-      slaveOnly 0
-      priority1 128
-      priority2 128
-      domainNumber 24
-      #utc_offset 37
-      clockClass 248
-      clockAccuracy 0xFE
-      offsetScaledLogVariance 0xFFFF
-      free_running 0
-      freq_est_interval 1
-      dscp_event 0
-      dscp_general 0
-      dataset_comparison ieee1588
-      G.8275.defaultDS.localPriority 128
+      twoStepFlag                        1
+      slaveOnly                          0
+      priority1                          128
+      priority2                          128
+      domainNumber                       24
+      #utc_offset                        37
+      clockClass                         248
+      clockAccuracy                      0xFE
+      offsetScaledLogVariance            0xFFFF
+      free_running                       0
+      freq_est_interval                  1
+      dscp_event                         0
+      dscp_general                       0
+      dataset_comparison                 ieee1588
+      G.8275.defaultDS.localPriority     128
       #
       # Port Data Set
       #
-      logAnnounceInterval -3
-      logSyncInterval -4
-      logMinDelayReqInterval -4
-      logMinPdelayReqInterval -4
-      announceReceiptTimeout 3
-      syncReceiptTimeout 0
-      delayAsymmetry 0
-      fault_reset_interval 4
-      neighborPropDelayThresh 20000000
-      masterOnly 0
-      G.8275.portDS.localPriority 128
+      logAnnounceInterval               -3
+      logSyncInterval                   -4
+      logMinDelayReqInterval            -4
+      logMinPdelayReqInterval           -4
+      announceReceiptTimeout             3
+      syncReceiptTimeout                 0
+      delayAsymmetry                     0
+      fault_reset_interval               4
+      neighborPropDelayThresh            20000000
+      masterOnly                         0
+      G.8275.portDS.localPriority        128
       #
       # Run time options
       #
-      assume_two_step 0
-      logging_level 6
-      path_trace_enabled 0
-      follow_up_info 0
-      hybrid_e2e 0
-      inhibit_multicast_service 0
-      net_sync_monitor 0
-      tc_spanning_tree 0
-      tx_timestamp_timeout 1
-      unicast_listen 0
-      unicast_master_table 0
-      unicast_req_duration 3600
-      use_syslog 1
-      verbose 0
-      summary_interval 0
-      kernel_leap 1
-      check_fup_sync 0
+      assume_two_step                    0
+      logging_level                      6
+      path_trace_enabled                 0
+      follow_up_info                     0
+      hybrid_e2e                         0
+      inhibit_multicast_service          0
+      net_sync_monitor                   0
+      tc_spanning_tree                   0
+      tx_timestamp_timeout               10             <8>
+      unicast_listen                     0
+      unicast_master_table               0
+      unicast_req_duration               3600
+      use_syslog                         1
+      verbose                            0
+      summary_interval                   0
+      kernel_leap                        1
+      check_fup_sync                     0
       #
       # Servo Options
       #
-      pi_proportional_const 0.0
-      pi_integral_const 0.0
-      pi_proportional_scale 0.0
-      pi_proportional_exponent -0.3
-      pi_proportional_norm_max 0.7
-      pi_integral_scale 0.0
-      pi_integral_exponent 0.4
-      pi_integral_norm_max 0.3
-      step_threshold 0.0
-      first_step_threshold 0.00002
-      max_frequency 900000000
-      clock_servo pi
-      sanity_freq_limit 200000000
-      ntpshm_segment 0
+      pi_proportional_const              0.0
+      pi_integral_const                  0.0
+      pi_proportional_scale              0.0
+      pi_proportional_exponent          -0.3
+      pi_proportional_norm_max           0.7
+      pi_integral_scale                  0.0
+      pi_integral_exponent               0.4
+      pi_integral_norm_max               0.3
+      step_threshold                     0.0
+      first_step_threshold               0.00002
+      max_frequency                      900000000
+      clock_servo                        pi
+      sanity_freq_limit                  200000000
+      ntpshm_segment                     0
       #
       # Transport options
       #
-      transportSpecific 0x0
-      ptp_dst_mac 01:1B:19:00:00:00
-      p2p_dst_mac 01:80:C2:00:00:0E
-      udp_ttl 1
-      udp6_scope 0x0E
-      uds_address /var/run/ptp4l
+      transportSpecific                  0x0
+      ptp_dst_mac                        01:1B:19:00:00:00
+      p2p_dst_mac                        01:80:C2:00:00:0E
+      udp_ttl                            1
+      udp6_scope                         0x0E
+      uds_address                        /var/run/ptp4l
       #
       # Default interface options
       #
-      clock_type OC
-      network_transport L2
-      delay_mechanism E2E
-      time_stamping hardware
-      tsproc_mode filter
-      delay_filter moving_median
-      delay_filter_length 10
-      egressLatency 0
-      ingressLatency 0
-      boundary_clock_jbod 0
+      clock_type                         OC
+      network_transport                  L2
+      delay_mechanism                    E2E
+      time_stamping                      hardware
+      tsproc_mode                        filter
+      delay_filter                       moving_median
+      delay_filter_length                10
+      egressLatency                      0
+      ingressLatency                     0
+      boundary_clock_jbod                0              <9>
       #
       # Clock description
       #
-      productDescription ;;
-      revisionData ;;
-      manufacturerIdentity 00:00:00
-      userDescription ;
-      timeSource 0xA0
-    ptpSchedulingPolicy: SCHED_OTHER <8>
-    ptpSchedulingPriority: 65 <9>
-  ptpClockThreshold: <10>
-    holdOverTimeout: 5
-    maxOffsetThreshold: 100
-    minOffsetThreshold: -100
-  recommend: <11>
-  - profile: "profile1" <12>
-    priority: 10 <13>
-    match: <14>
-    - nodeLabel: "node-role.kubernetes.io/worker" <15>
-      nodeName: "compute-0.example.com" <16>
+      productDescription                 ;;
+      revisionData                       ;;
+      manufacturerIdentity               00:00:00
+      userDescription                    ;
+      timeSource                         0xA0
+    ptpSchedulingPolicy:                 SCHED_OTHER    <10>
+    ptpSchedulingPriority:               65             <11>
+  ptpClockThreshold:                                    <12>
+    holdOverTimeout:                     5
+    maxOffsetThreshold:                  100
+    minOffsetThreshold:                 -100
+  recommend:                                            <13>
+  - profile: "profile1"                                 <14>
+    priority: 0                                         <15>
+    match:                                              <16>
+    - nodeLabel: "node-role.kubernetes.io/worker"       <17>
+      nodeName: "compute-0.example.com"                 <18>
 ----
 <1> The name of the `PtpConfig` CR.
 <2> Specify an array of one or more `profile` objects.
 <3> Specify a unique name for the profile object.
 <4> Specify the network interface to be used by the `ptp4l` service, for example `ens787f1`.
 <5> Specify system config options for the `ptp4l` service, for example `-2` to select the IEEE 802.3 network transport. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended. Append `--summary_interval -4` to use PTP fast events with this interface.
-<6> Specify system config options for the `phc2sys` service, for example `-a -r -n 24`. If this field is empty the PTP Operator does not start the `phc2sys` service.
+<6> Specify system config options for the `phc2sys` service. If this field is empty the PTP Operator does not start the `phc2sys` service. For Intel Columbiaville 800 Series NICs, set `phc2sysOpts` options to `-a -r -m -n 24 -N 8 -R 16`.
 <7> Specify a string that contains the configuration to replace the default `/etc/ptp4l.conf` file. To use the default configuration, leave the field empty.
-<8> Scheduling policy for `ptp4l` and `phc2sys` processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
-<9> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes. Required if `SCHED_FIFO` is set for `ptpSchedulingPolicy`.
-<10> Optional. If `ptpClockThreshold` stanza is not present, default values are used for `ptpClockThreshold` fields. Stanza shows default `ptpClockThreshold` values.
-<11> Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
-<12> Specify the `profile` object name defined in the `profile` section.
-<13> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
-<14> Specify `match` rules with `nodeLabel` or `nodeName`.
-<15> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command.
-<16> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command.
+<8> For Intel Columbiaville 800 Series NICs, set `tx_timestamp_timeout` to `50`.
+<9> For Intel Columbiaville 800 Series NICs, set `boundary_clock_jbod` to `0`.
+<10> Scheduling policy for `ptp4l` and `phc2sys` processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
+<11> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes. Required if `SCHED_FIFO` is set for `ptpSchedulingPolicy`.
+<12> Optional. If `ptpClockThreshold` stanza is not present, default values are used for `ptpClockThreshold` fields. Stanza shows default `ptpClockThreshold` values.
+<13> Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
+<14> Specify the `profile` object name defined in the `profile` section.
+<15> Set `priority` to `0` for ordinary clock.
+<16> Specify `match` rules with `nodeLabel` or `nodeName`.
+<17> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command.
+<18> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command.
 
 . Create the `PtpConfig` CR by running the following command:
 +
@@ -174,7 +176,7 @@ spec:
 $ oc create -f ordinary-clock-ptp-config.yaml
 ----
 
-.Verification steps
+.Verification
 
 . Check that the `PtpConfig` profile is applied to the node.
 
@@ -210,6 +212,6 @@ I1115 09:41:17.117607 4143292 daemon.go:110] -----------------------------------
 I1115 09:41:17.117612 4143292 daemon.go:102] Profile Name: profile1
 I1115 09:41:17.117616 4143292 daemon.go:102] Interface: ens787f1
 I1115 09:41:17.117620 4143292 daemon.go:102] Ptp4lOpts: -2 -s --summary_interval -4
-I1115 09:41:17.117623 4143292 daemon.go:102] Phc2sysOpts: -a -r
+I1115 09:41:17.117623 4143292 daemon.go:102] Phc2sysOpts: -a -r -n 24
 I1115 09:41:17.117626 4143292 daemon.go:116] ------------------------------------
 ----

--- a/modules/ptp-configuring-linuxptp-services-as-boundary-clock-dual-nic.adoc
+++ b/modules/ptp-configuring-linuxptp-services-as-boundary-clock-dual-nic.adoc
@@ -1,0 +1,106 @@
+// Module included in the following assemblies:
+//
+// * networking/using-ptp.adoc
+
+:_content-type: PROCEDURE
+[id="ptp-configuring-linuxptp-services-as-bc-for-dual-nic_{context}"]
+= Configuring linuxptp services as boundary clocks for dual NIC hardware
+
+You can configure the `linuxptp` services (`ptp4l`, `phc2sys`) as boundary clocks for dual NIC hardware by creating a `PtpConfig` custom resource (CR) object for each NIC.
+
+Dual NIC hardware allows you to connect each NIC to the same upstream leader clock with separate `ptp4l` instances for each NIC feeding the downstream clocks.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
+* Log in as a user with `cluster-admin` privileges.
+
+* Install the PTP Operator.
+
+.Procedure
+
+. Create two separate `PtpConfig` CRs, one for each NIC, using the reference CR in "Configuring linuxptp services as a boundary clock" as the basis for each CR. For example:
+
+.. Create `boundary-clock-ptp-config-nic1.yaml`, specifying values for `phc2sysOpts`:
++
+[source,yaml]
+----
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: boundary-clock-ptp-config-nic1
+  namespace: openshift-ptp
+spec:
+  profile:
+  - name: "profile1"
+    ptp4lOpts: "-2 --summary_interval -4"
+    ptp4lConf: | <1>
+      [ens5f1]
+      masterOnly 1
+      [ens5f0]
+      masterOnly 0
+    ...
+    phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16"
+----
+<1> Specify the required interfaces to start `ptp4l` as a boundary clock. For example, `ens5f0` synchronizes from a grandmaster clock and `ens5f1` synchronizes connected devices.
+
+.. Create `boundary-clock-ptp-config-nic2.yaml`, removing the `phc2sysOpts` field altogether to disable the `phc2sys` service for the second NIC:
++
+[source,yaml]
+----
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: boundary-clock-ptp-config-nic2
+  namespace: openshift-ptp
+spec:
+  profile:
+  - name: "profile2"
+    ptp4lOpts: "-2 --summary_interval -4"
+    ptp4lConf: | <1>
+      [ens7f1]
+      masterOnly 1
+      [ens7f0]
+      masterOnly 0
+...
+----
+<1> Specify the required interfaces to start `ptp4l` as a boundary clock on the second NIC.
++
+[NOTE]
+====
+You must completely remove the `phc2sysOpts` field from the second `PtpConfig` CR to disable the `phc2sys` service on the second NIC.
+====
+
+. Create the dual NIC `PtpConfig` CRs by running the following commands:
+
+.. Create the CR that configures PTP for the first NIC:
++
+[source,terminal]
+----
+$ oc create -f boundary-clock-ptp-config-nic1.yaml
+----
+
+.. Create the CR that configures PTP for the second NIC:
++
+[source,terminal]
+----
+$ oc create -f boundary-clock-ptp-config-nic2.yaml
+----
+
+.Verification
+
+* Check that the PTP Operator has applied the `PtpConfig` CRs for both NICs. Examine the logs for the `linuxptp` daemon corresponding to the node that has the dual NIC hardware installed. For example, run the following command:
++
+[source,terminal]
+----
+$ oc logs linuxptp-daemon-cvgr6 -n openshift-ptp -c linuxptp-daemon-container
+----
++
+.Example output
+[source,terminal]
+----
+ptp4l[80828.335]: [ptp4l.1.config] master offset          5 s2 freq   -5727 path delay       519
+ptp4l[80828.343]: [ptp4l.0.config] master offset         -5 s2 freq  -10607 path delay       533
+phc2sys[80828.390]: [ptp4l.0.config] CLOCK_REALTIME phc offset         1 s2 freq  -87239 delay    539
+----

--- a/modules/ptp-dual-nics.adoc
+++ b/modules/ptp-dual-nics.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * networking/using-ptp.adoc
+
+:_module-type: CONCEPT
+[id="ptp-dual-nics_{context}"]
+= Using PTP with dual NIC hardware
+
+{product-title} supports single and dual NIC hardware for precision PTP timing in the cluster.
+
+For 5G telco networks that deliver mid-band spectrum coverage, each virtual distributed unit (vDU) requires connections to 6 radio units (RUs). To make these connections, each vDU host requires 2 NICs configured as boundary clocks.
+
+Dual NIC hardware allows you to connect each NIC to the same upstream leader clock with separate `ptp4l` instances for each NIC feeding the downstream clocks.

--- a/networking/using-ptp.adoc
+++ b/networking/using-ptp.adoc
@@ -34,6 +34,8 @@ include::modules/nw-ptp-introduction.adoc[leveloffset=+1]
 Before enabling PTP, ensure that NTP is disabled for the required nodes. You can disable the chrony time service (`chronyd`) using a `MachineConfig` custom resource. For more information, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#cnf-disable-chronyd_post-install-machine-configuration-tasks[Disabling chrony time service].
 ====
 
+include::modules/ptp-dual-nics.adoc[leveloffset=+2]
+
 include::modules/nw-ptp-installing-operator-cli.adoc[leveloffset=+1]
 
 include::modules/nw-ptp-installing-operator-web-console.adoc[leveloffset=+1]
@@ -50,7 +52,14 @@ include::modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc[lev
 
 include::modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc[leveloffset=+2]
 
-include::modules/cnf-configuring-cvl-nic-as-oc.adoc[leveloffset=+2]
+include::modules/ptp-configuring-linuxptp-services-as-boundary-clock-dual-nic.adoc[leveloffset=+2]
+
+include::modules/nw-columbiaville-ptp-config-refererence.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For a complete example CR that configures `linuxptp` services as an ordinary clock with PTP fast events, see xref:../networking/using-ptp.adoc#configuring-linuxptp-services-as-ordinary-clock_using-ptp[Configuring linuxptp services as ordinary clock].
 
 include::modules/cnf-configuring-fifo-priority-scheduling-for-ptp.adoc[leveloffset=+2]
 
@@ -72,7 +81,7 @@ include::modules/cnf-configuring-the-ptp-fast-event-publisher.adoc[leveloffset=+
 [role="_additional-resources"]
 .Additional resources
 
-* For a complete example CR that configures `linuxptp` services with PTP fast events, see xref:../networking/using-ptp.adoc#configuring-linuxptp-services-as-ordinary-clock_using-ptp[Configuring linuxptp services as ordinary clock].
+* For a complete example CR that configures `linuxptp` services as an ordinary clock with PTP fast events, see xref:../networking/using-ptp.adoc#configuring-linuxptp-services-as-ordinary-clock_using-ptp[Configuring linuxptp services as ordinary clock].
 
 include::modules/cnf-fast-event-notifications-api-refererence.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Updates for PTP 4.11 - Dual NIC BC and PTP events

Version(s):
Merge to main, enterprise-4.11

Issues:
* https://issues.redhat.com/browse/TELCODOCS-443
* https://issues.redhat.com/browse/TELCODOCS-442
* [BZ2070349: PTP Operator Config CR misaligned](https://github.com/openshift-kni/cnf-features-deploy/commit/8ad782c560e29be078b259b701c736bcb292b098)

Link to docs preview:
* [Dual NIC hardware](http://file.emea.redhat.com/aireilly/td-443/networking/using-ptp.html#ptp-dual-nics_using-ptp)
* [Configuring linuxptp services as a boundary clock for dual NIC hardware](http://file.emea.redhat.com/aireilly/td-443/networking/using-ptp.html#ptp-configuring-linuxptp-services-as-bc-for-dual-nic_using-ptp)
* [api/cloudNotifications/v1/publishers](http://file.emea.redhat.com/aireilly/td-443/networking/using-ptp.html#apicloudnotificationsv1publishers)
