### PR TITLE
BZ1851483: Preparing to reinstall a cluster on bare-metal

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -17,6 +17,7 @@ include::modules/ipi-install-extracting-the-openshift-installer.adoc[leveloffset
 include::modules/ipi-install-creating-an-rhcos-images-cache.adoc[leveloffset=+1]
 
 [id="ipi-install-configuration-files"]
+[id="additional-resources_config"]
 == Configuring the install-config.yaml file
 
 include::modules/ipi-install-configuring-the-install-config-file.adoc[leveloffset=+2]
@@ -42,6 +43,7 @@ include::modules/ipi-install-modifying-install-config-for-dual-stack-network.ado
 include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
+[id="additional-resources_relnotes"]
 .Additional resources
 
 * xref:../../release_notes/ocp-4-11-release-notes.adoc#ocp-4-11-known-issues[OpenShift Container Platform 4.11 release notes]
@@ -62,6 +64,7 @@ include::modules/ipi-install-deploying-routers-on-worker-nodes.adoc[leveloffset=
 include::modules/ipi-install-configuring-the-bios.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
+[id="additional-resources_bare_metal_config"]
 .Additional resources
 
 * xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
@@ -69,6 +72,7 @@ include::modules/ipi-install-configuring-the-bios.adoc[leveloffset=+2]
 include::modules/ipi-install-configuring-the-raid.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
+[id="additional-resources_raid_config"]
 .Additional resources
 
 * xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
@@ -83,7 +87,10 @@ include::modules/ipi-install-following-the-installation.adoc[leveloffset=+1]
 
 include::modules/ipi-install-verifying-static-ip-address-configuration.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-== Additional resources
+include::modules/ipi-preparing-reinstall-cluster-bare-metal.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+[id="additional-resources_creating_manifest_ignition"]
+== Additional resources
+* xref:../..//installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-generate-k8s-manifest-ignition_installing-bare-metal.adoc#installation-user-infra-generate-k8s-manifest-ignition_installing-bare-metal[{product-title} Creating the Kubernetes manifest and Ignition config files]
 * xref:../../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[{product-title} upgrade channels and releases]

--- a/modules/ipi-preparing-reinstall-cluster-bare-metal.adoc
+++ b/modules/ipi-preparing-reinstall-cluster-bare-metal.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// //installing/installing_bare_metal_ipi/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+
+[id="ipi-preparing-reinstall-cluster-bare-metal_{context}"]
+
+= Preparing to reinstall a cluster on bare metal
+Before you reinstall a cluster on bare metal, you must perform cleanup operations.
+
+.Procedure
+. Remove or reformat the disks for the bootstrap, control plane node, and worker nodes. If you are working in a hypervisor environment, you must add any disks you removed.
+. Delete the artifacts that the previous installation generated:
++
+[source,terminal]
+----
+$ cd ; /bin/rm -rf auth/ bootstrap.ign master.ign worker.ign metadata.json \
+.openshift_install.log .openshift_install_state.json
+----
+. Generate new manifests and Ignition config files. See “Creating the Kubernetes manifest and Ignition config files" for more information.
+. Upload the new bootstrap, control plane, and compute node Ignition config files that the installation program created to your HTTP server. This will overwrite the previous Ignition files.


### PR DESCRIPTION
Version(s):
From Version 4.9 to 4.11 and beyond. 

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=1851483

Link to docs preview: 

http://file.emea.redhat.com/tmulquee/BZ1851483/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-preparing-reinstall-cluster-bare-metal_ipi-install-installation-workflow

Additional information:
This PR is the parent of 3 child PRs due to divergence of terminology in 4.6, 4.7, and 4.8 (Control Plane node / Control Plane (also known as master) node).

https://github.com/openshift/openshift-docs/pull/46813 (for Version 4.6)

https://github.com/openshift/openshift-docs/pull/46866 (for Version 4.7)

https://github.com/openshift/openshift-docs/pull/46867 (for Version 4.8)

The original text has already been LGTM'd by SME and QE, and Peer Review comments have been addressed. 
<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
