### PR TITLE
Adds notes for 4.10.16 release

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2919,3 +2919,19 @@ link:https://access.redhat.com/solutions/6960407[{product-title} 4.10.15 contain
 ==== Updating
 
 To upgrade an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-10-16"]
+=== RHBA-2022:4754 - {product-title} 4.10.16 bug fix update
+
+Issued: 2022-05-31
+
+{product-title} release 4.10.16 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:4754[RHBA-2022:4754] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:4753[RHBA-2022:4753] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6961369[{product-title} 4.10.16 container image list]
+
+[id="ocp-4-10-16-updating"]
+==== Updating
+
+To upgrade an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.10.16 release

Version(s):
`enterprise-4.10` only

Link to docs preview:
[Preview link](http://file.rdu.redhat.com/opayne/053122/RNs-4.10.16/release_notes/ocp-4-10-release-notes.html#ocp-4-10-16)




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
