### PR TITLE
[RHACS] Fixed the release date in 3.70 release notes.

### DIFF
--- a/release_notes/370-release-notes.adoc
+++ b/release_notes/370-release-notes.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-*Release date:* 23 May 2022
+*Release date:* 2 June 2022
 
 {product-title} is an enterprise-ready, Kubernetes-native container security solution that protects your vital applications across build, deploy, and runtime. It deploys in your infrastructure and integrates with your DevOps tooling and workflows to deliver better security and compliance and to enable DevOps and InfoSec teams to operationalize security.
 


### PR DESCRIPTION
Changed the date from 23 May to 2 June.

Applies to:
- `rhacs-docs-3.70`


---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
