### PR TITLE
Updated SELinux indefinite articles

### DIFF
--- a/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.adoc
+++ b/rest_api/monitoring_apis/alertmanager-monitoring-coreos-com-v1.adoc
@@ -2771,15 +2771,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.containers[].securityContext.windowsOptions
@@ -4488,15 +4488,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.initContainers[].securityContext.windowsOptions
@@ -4954,15 +4954,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.securityContext.sysctls

--- a/rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.adoc
+++ b/rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.adoc
@@ -3778,15 +3778,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.containers[].securityContext.windowsOptions
@@ -5495,15 +5495,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.initContainers[].securityContext.windowsOptions
@@ -8014,15 +8014,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.securityContext.sysctls

--- a/rest_api/monitoring_apis/thanosruler-monitoring-coreos-com-v1.adoc
+++ b/rest_api/monitoring_apis/thanosruler-monitoring-coreos-com-v1.adoc
@@ -2651,15 +2651,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.containers[].securityContext.windowsOptions
@@ -4630,15 +4630,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.initContainers[].securityContext.windowsOptions
@@ -5354,15 +5354,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.securityContext.sysctls

--- a/rest_api/operatorhub_apis/clusterserviceversion-operators-coreos-com-v1alpha1.adoc
+++ b/rest_api/operatorhub_apis/clusterserviceversion-operators-coreos-com-v1alpha1.adoc
@@ -4837,15 +4837,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.install.spec.deployments[].spec.template.spec.containers[].securityContext.seccompProfile
@@ -6645,15 +6645,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.install.spec.deployments[].spec.template.spec.ephemeralContainers[].securityContext.seccompProfile
@@ -8450,15 +8450,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.install.spec.deployments[].spec.template.spec.initContainers[].securityContext.seccompProfile
@@ -8938,15 +8938,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.install.spec.deployments[].spec.template.spec.securityContext.seccompProfile

--- a/rest_api/template_apis/podtemplate-v1.adoc
+++ b/rest_api/template_apis/podtemplate-v1.adoc
@@ -2357,15 +2357,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .template.spec.containers[].securityContext.seccompProfile
@@ -4174,15 +4174,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .template.spec.ephemeralContainers[].securityContext.seccompProfile
@@ -5988,15 +5988,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .template.spec.initContainers[].securityContext.seccompProfile
@@ -6479,15 +6479,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .template.spec.securityContext.seccompProfile

--- a/rest_api/workloads_apis/pod-v1.adoc
+++ b/rest_api/workloads_apis/pod-v1.adoc
@@ -2335,15 +2335,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.containers[].securityContext.seccompProfile
@@ -4152,15 +4152,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.ephemeralContainers[].securityContext.seccompProfile
@@ -5966,15 +5966,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.initContainers[].securityContext.seccompProfile
@@ -6457,15 +6457,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.securityContext.seccompProfile

--- a/rest_api/workloads_apis/replicationcontroller-v1.adoc
+++ b/rest_api/workloads_apis/replicationcontroller-v1.adoc
@@ -2395,15 +2395,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.template.spec.containers[].securityContext.seccompProfile
@@ -4212,15 +4212,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.template.spec.ephemeralContainers[].securityContext.seccompProfile
@@ -6026,15 +6026,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.template.spec.initContainers[].securityContext.seccompProfile
@@ -6517,15 +6517,15 @@ Type::
 
 | `role`
 | `string`
-| Role is a SELinux role label that applies to the container.
+| Role is an SELinux role label that applies to the container.
 
 | `type`
 | `string`
-| Type is a SELinux type label that applies to the container.
+| Type is an SELinux type label that applies to the container.
 
 | `user`
 | `string`
-| User is a SELinux user label that applies to the container.
+| User is an SELinux user label that applies to the container.
 
 |===
 === .spec.template.spec.securityContext.seccompProfile


### PR DESCRIPTION
Version(s):
4.6+

Issue:
Article guidance from the [IBM Style Guide](https://www.ibm.com/docs/en/ibm-style?topic=grammar-articles) states that "If an abbreviation is pronounced as a series of letters, choose the article according to the pronunciation of the first letter." Because SELinux is pronounced as an abbreviation, S. E. Linux, I have updated the terms in the rest API guide to "an SELinux". All other instances in OpenShift documentation are correct. 

Link to docs preview:
See the "Description" field of the table. You may need to `ctrl+f` for `an selinux`:
http://file.rdu.redhat.com/antaylor/06-01-22/selinux-indefinite-articles/rest_api/workloads_apis/pod-v1.html#spec-containers-securitycontext-selinuxoptions
http://file.rdu.redhat.com/antaylor/06-01-22/selinux-indefinite-articles/rest_api/workloads_apis/pod-v1.html#spec-ephemeralcontainers-securitycontext-selinuxoptions

Additional information:
Discussion occurred in [#team-docs](https://coreos.slack.com/archives/C85JYPHL3/p1654093984042859). 