### PR TITLE
[enterprise-4.6] [SRVCOM-780]: Add performance and scaling info for Serverless on OCP

### DIFF
--- a/serverless/discover/about-serverless.adoc
+++ b/serverless/discover/about-serverless.adoc
@@ -26,6 +26,15 @@ You can propagate an event from an xref:../../serverless/discover/knative-event-
 
 The set of supported features, configurations, and integrations for {ServerlessProductName}, current and past versions, are available at the link:https://access.redhat.com/articles/4912821[Supported Configurations page].
 
+[id="about-serverless-scalability-performance"]
+== Scalability and performance
+
+{ServerlessProductName} has been tested with a configuration of 3 main nodes and 3 worker nodes, each of which has 64 CPUs, 457 GB of memory, and 394 GB of storage each.
+
+The maximum number of Knative services that can be created using this configuration is 3,000. This corresponds to the xref:../../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#cluster-maximums-major-releases_object-limits[{product-title} Kubernetes services limit of 10,000], since 1 Knative service creates 3 Kubernetes services.
+
+The average scale from zero response time was approximately 3.4 seconds, with a maximum response time of 8 seconds, and a 99.9th percentile of 4.5 seconds for a simple Quarkus application. These times might vary depending on the application and the runtime of the application.
+
 [id="additional-resources_about-serverless"]
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
Cherrypicked from https://github.com/openshift/openshift-docs/pull/45767/commits/d5c15e32acc370576ceb5bf2d85c4d1bf7e3c789 xref: https://github.com/openshift/openshift-docs/pull/45767