### PR TITLE
OSDOCS-3415: Add warning and procedure for manually configuring integrated image registry pull secrets with service accounts

### DIFF
--- a/authentication/understanding-and-creating-service-accounts.adoc
+++ b/authentication/understanding-and-creating-service-accounts.adoc
@@ -15,3 +15,5 @@ include::modules/service-accounts-creating.adoc[leveloffset=+1]
 // include::modules/service-accounts-configuration-parameters.adoc[leveloffset=+1]
 
 include::modules/service-accounts-granting-roles.adoc[leveloffset=+1]
+
+include::modules/registry-configuring-pullsecrets-service-accounts.adoc[leveloffset=+1]

--- a/modules/registry-configuring-pullsecrets-service-accounts.adoc
+++ b/modules/registry-configuring-pullsecrets-service-accounts.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * openshift_images/managing_images/using-image-pull-secrets.adoc
+// * authentication/understanding-and-creating-service-accounts.adoc
+
+
+:_content-type: CONCEPT
+[id="registry-configuring-pullsecrets-service-accounts_{context}"]
+= Manually configuring service account pull secrets for the integrated image registry
+
+When a service account is created, it is automatically provisioned with pull secrets for the integrated image registry. The provisioning of pull secrets happens quickly, but is not immediate.
+
+[WARNING]
+====
+If a pod is created before the service account is provisioned with the pull secret, it cannot pull images from the image registry even after the service account pull secret is  provisioned.
+====
+
+If you need to create workloads or pods that pull images from the integrated image registry immediately, you can manually configure service account pull secrets for the integrated image registry.
+
+.Prerequisites
+
+* You have created a service account.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Create a `./config.json` file to place the pull secret for your service account:
++
+[source,terminal]
+----
+$ oc registry login -n <NAMESPACE> -z <SERVICEACCOUNT> --to=./config.json
+----
++
+. Create a pull secret:
++
+[source,terminal]
+----
+$ oc create secret generic <PULL_SECRET_NAME> \
+    --from-file=.dockerconfigjson=./config.json \
+    --type=kubernetes.io/dockerconfigjson
+----
++
+. Link the pull secret to your service account:
++
+[source,terminal]
+----
+$ oc secrets link <SERVICEACCOUNT> <PULL_SECRET_NAME> --for=pull
+----

--- a/openshift_images/managing_images/using-image-pull-secrets.adoc
+++ b/openshift_images/managing_images/using-image-pull-secrets.adoc
@@ -14,6 +14,8 @@ You can obtain the image {cluster-manager-url-pull}. This pull secret is called 
 
 You use this pull secret to authenticate with the services that are provided by the included authorities, link:https://quay.io/[Quay.io] and link:https://registry.redhat.io[registry.redhat.io], which serve the container images for {product-title} components.
 
+include::modules/registry-configuring-pullsecrets-service-accounts.adoc[leveloffset=+1]
+
 include::modules/images-allow-pods-to-reference-images-across-projects.adoc[leveloffset=+1]
 
 include::modules/images-allow-pods-to-reference-images-from-secure-registries.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/OSDOCS-3415

Link to docs preview:
http://file.rdu.redhat.com/bmcelvee/20220603/managing_images/using-image-pull-secrets.html#registry-configuring-pullsecrets-service-accounts_using-image-pull-secrets

http://file.rdu.redhat.com/bmcelvee/20220603/authentication/understanding-and-creating-service-accounts.html#registry-configuring-pullsecrets-service-accounts_understanding-service-accounts

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
