### PR TITLE
OSDOCS-3704: Adding release notes for secondary scheduler operator 1.0.1

### DIFF
--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -12,6 +12,35 @@ These release notes track the development of the {secondary-scheduler-operator-f
 
 For more information, see xref:../../../nodes/scheduling/secondary_scheduler/index.adoc#nodes-secondary-scheduler-about_nodes-secondary-scheduler-about[About the {secondary-scheduler-operator}].
 
+[id="secondary-scheduler-operator-release-notes-1.0.1"]
+== Release notes for {secondary-scheduler-operator-full} 1.0.1
+
+Issued: 2022-07-28
+
+The following advisory is available for the {secondary-scheduler-operator-full} 1.0.1:
+
+* link:https://access.redhat.com/errata/RHSA-2022:5699[RHSA-2022:5699]
+
+[IMPORTANT]
+====
+If you are using {secondary-scheduler-operator-full} 1.0.0, it is expected to be automatically upgraded to version 1.0.1 when you update to the next minor release of {product-title}.
+====
+
+[id="secondary-scheduler-operator-1.0.1-new-features-and-enhancements"]
+=== New features and enhancements
+
+* The maximum {product-title} version for {secondary-scheduler-operator-full} 1.0.1 is 4.11.
+
+[id="secondary-scheduler-1.0.1-bug-fixes"]
+=== Bug fixes
+
+* Previously, the secondary scheduler deployment was not deleted after the secondary scheduler custom resource (CR) was deleted, which prevented the {secondary-scheduler-operator} and operand from being fully uninstalled. The secondary scheduler deployment is now deleted when the secondary scheduler CR is deleted, so that the {secondary-scheduler-operator} can now be fully uninstalled. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2100923[*BZ#2100923*])
+
+[id="secondary-scheduler-operator-1.0.1-known-issues"]
+=== Known issues
+
+* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2071684[*BZ#2071684*])
+
 [id="secondary-scheduler-operator-release-notes-1.0.0"]
 == Release notes for {secondary-scheduler-operator-full} 1.0.0
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.10 and 4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3704

Link to docs preview:
http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3704/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.html#secondary-scheduler-operator-release-notes-1.0.1

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
