### PR TITLE
Converting 302's to 301 for redirects >2 weeks old

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -145,7 +145,7 @@ AddType text/vtt                            vtt
     RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68|3\.69|3\.70)/?$ /acs/$1/welcome/index.html [L,R=301]
 
     # this pipeline redirect has to come before the latest kicks in generically
-    RewriteRule ^container-platform/latest/pipelines/creating-applications-with-cicd-pipelines.html /container-platform/4.7/cicd/pipelines/creating-applications-with-cicd-pipelines.html [NE,R=302]
+    RewriteRule ^container-platform/latest/pipelines/creating-applications-with-cicd-pipelines.html /container-platform/4.7/cicd/pipelines/creating-applications-with-cicd-pipelines.html [NE,R=301]
 
     # remove aro docs to just the welcome page
     RewriteRule aro/4/(?!welcome)(.*)?$ /container-platform/latest/$1 [L,R=301]
@@ -160,17 +160,17 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform\/3\.(.+)\/release_notes\/ocp_3_((?!\1).+)_release_notes.html /container-platform/3.$1/release_notes/ocp_3_$1_release_notes.html [NE,R=301]
 
     # Redirects for the Updating book
-    RewriteRule ^container-platform/(4\.8|4\.9)/updating/installing-update-service.html /container-platform/$1/updating/updating-restricted-network-cluster.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.8|4\.9)/updating/understanding-the-update-service.html /container-platform/$1/updating/updating-restricted-network-cluster.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.8|4\.9)/updating/installing-update-service.html /container-platform/$1/updating/updating-restricted-network-cluster.html [NE,R=301]
+    RewriteRule ^container-platform/(4\.8|4\.9)/updating/understanding-the-update-service.html /container-platform/$1/updating/updating-restricted-network-cluster.html [NE,R=301]
 
     # CNV scenarios based redirect
     RewriteRule ^container-platform/4\.8/virt/learn_more_about_ov.html /container-platform/4.8/virt/virt-learn-more-about-openshift-virtualization.html [NE,R=301]
 
     # PR https://github.com/openshift/openshift-docs/pull/35208/files for oc-compliance plugin
-    RewriteRule ^container-platform/4\.8/security/oc_compliance_plug_in/oc-compliance-plug-in-using.html /container-platform/4.8/security/compliance_operator/oc-compliance-plug-in-using.html [NE,R=302]
+    RewriteRule ^container-platform/4\.8/security/oc_compliance_plug_in/oc-compliance-plug-in-using.html /container-platform/4.8/security/compliance_operator/oc-compliance-plug-in-using.html [NE,R=301]
 
     # OSD redirects for new content
-    RewriteRule dedicated/4/cloud_infrastructure_access/dedicated-aws-vpn.html dedicated/osd_private_connections/aws-private-connections.html [NE,R=302]
+    RewriteRule dedicated/4/cloud_infrastructure_access/dedicated-aws-vpn.html dedicated/osd_private_connections/aws-private-connections.html [NE,R=301]
 
     # Redirects for the ROSA restructure applied in https://github.com/openshift/openshift-docs/pull/41923 and https://github.com/openshift/openshift-docs/pull/43807
     RewriteRule rosa/rosa_policy/?(.*)$ rosa/rosa_architecture/rosa_policy_service_definition/$1 [NE,R=301]
@@ -213,7 +213,7 @@ AddType text/vtt                            vtt
     RewriteRule rosa/rosa_getting_started/rosa-sts-required-aws-service-quotas.html rosa/rosa_planning/rosa-sts-required-aws-service-quotas.html [NE,R=301]
     RewriteRule rosa/rosa_getting_started/rosa-sts-setting-up-environment.html rosa/rosa_planning/rosa-sts-setting-up-environment.html [NE,R=301]
     RewriteRule rosa/rosa_getting_started/(rosa-getting-started|rosa-sts-getting-started-workflow).html - [L]
-    RewriteRule rosa/rosa_getting_started/?(.*)$ rosa/rosa_install_access_delete_clusters/$1 [NE,R=302]
+    RewriteRule rosa/rosa_getting_started/?(.*)$ rosa/rosa_install_access_delete_clusters/$1 [NE,R=301]
 
     RewriteRule rosa/logging/?(.*)$ rosa/rosa_cluster_admin/rosa_logging/$1 [NE,R=301]
 
@@ -226,7 +226,7 @@ AddType text/vtt                            vtt
     RewriteRule rosa/nodes/nodes-about-autoscaling-nodes.html rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.html [NE,R=301]
 
     # ROSA UI short-term redirect https://issues.redhat.com/browse/OSDOCS-3511
-    RewriteRule rosa/post_installation_configuration/machine-configuration-tasks.html rosa/rosa_getting_started/rosa-getting-started.html#rosa-getting-started-configure-an-idp-and-grant-access_rosa-getting-started [NE,R=302]
+    RewriteRule rosa/post_installation_configuration/machine-configuration-tasks.html rosa/rosa_getting_started/rosa-getting-started.html#rosa-getting-started-configure-an-idp-and-grant-access_rosa-getting-started [NE,R=301]
 
     # ACS welcome page redirect to StackRox docs
     # RewriteRule ^acs/?(.*)$ https://help.stackrox.com/ [NE,R=301]
@@ -316,7 +316,7 @@ AddType text/vtt                            vtt
     RewriteRule container-platform/(4\.3|4\.4|4\.5)/serverless/knative_cli/knative-cli.html /container-platform/$1/serverless/knative_serving/serving-kn-commands.html [NE,R=301]
 
     # Service Mesh
-    RewriteRule ^container-platform/(4\.3|4\.4|4\.5|4\.6)/service_mesh/threescale_adapter/threescale-adapter\.html /container-platform/$1/service_mesh/v1x/threescale-adapter.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.3|4\.4|4\.5|4\.6)/service_mesh/threescale_adapter/threescale-adapter\.html /container-platform/$1/service_mesh/v1x/threescale-adapter.html [NE,R=301]
 
     RewriteRule ^container-platform/(4\.3|4\.4|4\.5|4\.6)/service_mesh/servicemesh-release-notes\.html$ /container-platform/$1/service_mesh/v1x/servicemesh-release-notes.html [NE,R=301]
 
@@ -337,10 +337,10 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.3|4\.4|4\.5|4\.6)/service_mesh/service_mesh_support/ossm-collecting-ossm-data\.html$ /container-platform/$1/service_mesh/v1x/servicemesh-release-notes.html [NE,R=301]
 
     RewriteRule ^container-platform/(4\.3|4\.4|4\.5|4\.6)/service_mesh/threescale_adapter/threescale-adapter\.html$ /container-platform/$1/service_mesh/v1x/threescale-adapter.html [NE,R=301]
-    RewriteRule ^container-platform/4\.(.*)/service_mesh/service_mesh_install/updating-ossm\.html$ /container-platform/4.$1/service_mesh/v1x/installing-ossm.html#manual-updates [NE,R=302]
-    RewriteRule ^container-platform/4\.(.*)/service_mesh/service_mesh_install/removing-ossm\.html$ /container-platform/4.$1/service_mesh/v1x/installing-ossm.html#removing-red-hat-openshift-service-mesh [NE,R=302]
+    RewriteRule ^container-platform/4\.(.*)/service_mesh/service_mesh_install/updating-ossm\.html$ /container-platform/4.$1/service_mesh/v1x/installing-ossm.html#manual-updates [NE,R=301]
+    RewriteRule ^container-platform/4\.(.*)/service_mesh/service_mesh_install/removing-ossm\.html$ /container-platform/4.$1/service_mesh/v1x/installing-ossm.html#removing-red-hat-openshift-service-mesh [NE,R=301]
 
-    RewriteRule ^container-platform/4\.(.*)/service_mesh/service_mesh_install/(.*)\.html$ /container-platform/4.$1/service_mesh/v1x/$2.html [NE,R=302]
+    RewriteRule ^container-platform/4\.(.*)/service_mesh/service_mesh_install/(.*)\.html$ /container-platform/4.$1/service_mesh/v1x/$2.html [NE,R=301]
 
 
     # Service Mesh redirect from 3 to 4
@@ -407,7 +407,7 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.2|4\.3)/metering/metering-about-installing-metering.html/?(.*)$ /container-platform/$1/metering-installing-metering.html/$2 [NE,R=301]
 
     # Redirect for OSD 4 to just versionless OSD
-    RewriteRule ^dedicated/4/(?!authentication/using-rbac\.html) /dedicated/welcome/index.html [NE,R=302]
+    RewriteRule ^dedicated/4/(?!authentication/using-rbac\.html) /dedicated/welcome/index.html [NE,R=301]
 
     # Redirect for OSD latest and version less to OSD 3 - this will change when there is no OSD 3 and go to OSD 4
     # Use "/latest" in it's own rule to prevent any ambiguity


### PR DESCRIPTION
Converting older 302 redirects into 301's so they are considered permanent by search engines.