### PR TITLE
[RHACS] Fix typo in installation instructions

### DIFF
--- a/modules/install-acs-operator.adoc
+++ b/modules/install-acs-operator.adoc
@@ -24,7 +24,7 @@ Using the OperatorHub provided with {ocp} is the easiest way to install {product
 . On the *Install Operator* page:
 
 ** Keep the default value for *Installation mode* as *All namespaces on the cluster*.
-** Choose a specific namespace in which to install the Operator for the *Installed namespace* field. Red Hat recommends installing the {product-title} Operator in the *rhacs-operators* namespace.
+** Choose a specific namespace in which to install the Operator for the *Installed namespace* field. Red Hat recommends installing the {product-title} Operator in the *rhacs-operator* namespace.
 ** Select automatic or manual updates for *Update approval*.
 +
 If you choose automatic updates, when a new version of the Operator is available, Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator.


### PR DESCRIPTION
Version(s):

- rhacs-docs

Cherrypicked to:
- rhacs-docs-3.68
- rhacs-docs-3.69
- rhacs-docs-3.70

labels: **rhacs**

Issue: none (reported via gchat)

[Preview](https://openshift-docs-jw5g3hkdp-kcarmichael08.vercel.app/openshift-acs/master/installing/install-ocp-operator.html#install-acs-operator_install-ocp-operator)
