### PR TITLE
Add the oVirt restricted install to OKD

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -387,12 +387,16 @@ Topics:
   Dir: installing_rhv
   Distros: openshift-origin
   Topics:
+  - Name: Preparing to install on RHV
+    File: preparing-to-install-on-rhv
   - Name: Installing a cluster quickly on oVirt
     File: installing-rhv-default
   - Name: Installing a cluster on oVirt with customizations
     File: installing-rhv-customizations
   - Name: Installing a cluster on oVirt with user-provisioned infrastructure
     File: installing-rhv-user-infra
+  - Name: Installing a cluster on RHV in a restricted network
+    File: installing-rhv-restricted-network
   - Name: Uninstalling a cluster on oVirt
     File: uninstalling-cluster-rhv
 - Name: Installing on vSphere

--- a/installing/installing_rhv/preparing-to-install-on-rhv.adoc
+++ b/installing/installing_rhv/preparing-to-install-on-rhv.adoc
@@ -14,7 +14,7 @@ toc::[]
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
 [id="choosing-an-method-to-install-ocp-on-rhv"]
-== Choosing a method to install {product-title} on RHV
+== Choosing a method to install {product-title} on {rh-virtualization}
 
 You can install {product-title} on installer-provisioned or user-provisioned infrastructure. The default installation type uses installer-provisioned infrastructure, where the installation program provisions the underlying infrastructure for the cluster. You can also install {product-title} on infrastructure that you provision. If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself.
 
@@ -25,15 +25,15 @@ See xref:../../architecture/architecture-installation.adoc#installation-process_
 
 You can install a cluster on {rh-virtualization-first} virtual machines that are provisioned by the {product-title} installation program, by using one of the following methods:
 
-* **xref:../../installing/installing_rhv/installing-rhv-default.adoc#installing-rhv-default[Installing a cluster quickly on RHV]**: You can quickly install {product-title} on {rh-virtualization} virtual machines that the {product-title} installation program provisions.
+* **xref:../../installing/installing_rhv/installing-rhv-default.adoc#installing-rhv-default[Installing a cluster quickly on {rh-virtualization}]**: You can quickly install {product-title} on {rh-virtualization} virtual machines that the {product-title} installation program provisions.
 
-* **xref:../../installing/installing_rhv/installing-rhv-customizations.adoc#installing-rhv-customizations[Installing a cluster on RHV with customizations]**: You can install a customized {product-title} cluster on installer-provisioned guests on {rh-virtualization}. The installation program allows for some customization to be applied at the installation stage. Many other customization options are available xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[post-installation].
+* **xref:../../installing/installing_rhv/installing-rhv-customizations.adoc#installing-rhv-customizations[Installing a cluster on {rh-virtualization} with customizations]**: You can install a customized {product-title} cluster on installer-provisioned guests on {rh-virtualization}. The installation program allows for some customization to be applied at the installation stage. Many other customization options are available xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[post-installation].
 
 [id="choosing-an-method-to-install-ocp-on-rhv-user-provisioned"]
 === Installing a cluster on user-provisioned infrastructure
 
 You can install a cluster on {rh-virtualization} virtual machines that you provision, by using one of the following methods:
 
-* **xref:../../installing/installing_rhv/installing-rhv-user-infra.adoc#installing-rhv-user-infra[Installing a cluster on RHV with user-provisioned infrastructure]**: You can install {product-title} on {rh-virtualization} virtual machines that you provision. You can use the provided Ansible playbooks to assist with the installation.
+* **xref:../../installing/installing_rhv/installing-rhv-user-infra.adoc#installing-rhv-user-infra[Installing a cluster on {rh-virtualization} with user-provisioned infrastructure]**: You can install {product-title} on {rh-virtualization} virtual machines that you provision. You can use the provided Ansible playbooks to assist with the installation.
 
-* **xref:../../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[Installing a cluster on RHV in a restricted network]**: You can install {product-title} on {rh-virtualization} in a restricted or disconnected network by creating an internal mirror of the installation release content. You can use this method to install a user-provisioned cluster that does not require an active internet connection to obtain the software components. You can also use this installation method to ensure that your clusters only use container images that satisfy your organizational controls on external content.
+* **xref:../../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[Installing a cluster on {rh-virtualization} in a restricted network]**: You can install {product-title} on {rh-virtualization} in a restricted or disconnected network by creating an internal mirror of the installation release content. You can use this method to install a user-provisioned cluster that does not require an active internet connection to obtain the software components. You can also use this installation method to ensure that your clusters only use container images that satisfy your organizational controls on external content.


### PR DESCRIPTION
The assembly for installing oVirt (RHV) in a restricted environment was not in the OKD docs. According to Vadim, it should be, This PR places/replaces the assembly. Also added the oVirt preparing assembly.

Previews: 
[Preparing to install on oVirt](http://file.rdu.redhat.com/~mburke/okd-replace-ovirt-restricted/installing/installing_rhv/preparing-to-install-on-rhv.html)
[Installing a cluster on RHV in a restricted network](http://file.rdu.redhat.com/~mburke/okd-replace-ovirt-restricted/installing/installing_rhv/installing-rhv-restricted-network.html)