### PR TITLE
[SRVCOM-1874] Update pingsource API version and data spec

### DIFF
--- a/modules/serverless-pingsource-yaml.adoc
+++ b/modules/serverless-pingsource-yaml.adoc
@@ -11,13 +11,13 @@ Creating Knative resources by using YAML files uses a declarative API, which ena
 .Example `PingSource` object
 [source,yaml]
 ----
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1
 kind: PingSource
 metadata:
   name: test-ping-source
 spec:
   schedule: "*/2 * * * *" <1>
-  jsonData: '{"message": "Hello world!"}' <2>
+  data: '{"message": "Hello world!"}' <2>
   sink: <3>
     ref:
       apiVersion: serving.knative.dev/v1
@@ -67,13 +67,13 @@ $ oc apply -f <filename>
 +
 [source,yaml]
 ----
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1
 kind: PingSource
 metadata:
   name: test-ping-source
 spec:
   schedule: "*/2 * * * *"
-  jsonData: '{"message": "Hello world!"}'
+  data: '{"message": "Hello world!"}'
   sink:
     ref:
       apiVersion: serving.knative.dev/v1
@@ -97,7 +97,7 @@ $ oc get pingsource.sources.knative.dev <ping_source_name> -oyaml
 .Example output
 [source,terminal]
 ----
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1
 kind: PingSource
 metadata:
   annotations:
@@ -108,10 +108,10 @@ metadata:
   name: test-ping-source
   namespace: default
   resourceVersion: "55257"
-  selfLink: /apis/sources.knative.dev/v1alpha2/namespaces/default/pingsources/test-ping-source
+  selfLink: /apis/sources.knative.dev/v1/namespaces/default/pingsources/test-ping-source
   uid: 3d80d50b-f8c7-4c1b-99f7-3ec00e0a8164
 spec:
-  jsonData: '{ value: "hello" }'
+  data: '{ value: "hello" }'
   schedule: '*/2 * * * *'
   sink:
     ref:


### PR DESCRIPTION
Version(s):
OCP 4.6+
OSD

Issue:
https://issues.redhat.com/browse/SRVCOM-1874

Link to docs preview:
http://file.rdu.redhat.com/abrennan/010622/SRVCOM-1874/serverless/develop/serverless-pingsource.html#serverless-pingsource-yaml_serverless-pingsource