### PR TITLE
Update control plane node sizing

### DIFF
--- a/modules/master-node-sizing.adoc
+++ b/modules/master-node-sizing.adoc
@@ -6,38 +6,40 @@
 [id="master-node-sizing_{context}"]
 =  Control plane node sizing
 
-The control plane node resource requirements depend on the number of nodes in the cluster. The following control plane node size recommendations are based on the results of control plane density focused testing. The control plane tests create the following objects across the cluster in each of the namespaces depending on the node counts:
+The control plane node resource requirements depend on the number and type of nodes and objects in the cluster. The following control plane node size recommendations are based on the results of a control plane density focused testing (cluster-density). This test create the following objects across a given number of namespaces.
 
-- 12 image streams
-- 3 build configurations
-- 6 builds
-- 1 deployment with 2 pod replicas mounting two secrets each
-- 2 deployments with 1 pod replica mounting two secrets
-- 3 services pointing to the previous deployments
-- 3 routes pointing to the previous deployments
-- 10 secrets, 2 of which are mounted by the previous deployments
-- 10 config maps, 2 of which are mounted by the previous deployments
+- 1 image streams
+- 1 build
+- 5 deployments with 2 pod replcias (sleep) mounting 4 secrets, 4 configmaps and 1 downwardAPI volume each
+- 5 services, each one pointing to the TCP/8080 and TCP/8443 ports of one of the previous deployments
+- 1 route pointing to the to first of the previous services
+- 10 secrets containing 2048 random string characters
+- 10 configMaps containing 2048 random string characters
 
 
 [options="header",cols="4*"]
 |===
-| Number of worker nodes |Cluster load (namespaces) | CPU cores |Memory (GB)
+| Number of worker nodes |Cluster-density (namespaces) | CPU cores |Memory (GB)
 
-| 25
+| 27
 | 500
 | 4
 | 16
 
-| 100
+| 120
 | 1000
 | 8
 | 32
 
-| 250
+| 252
+| 4000
+| 16
+| 64
+
+| 501
 | 4000
 | 16
 | 96
-
 |===
 
 On a large and dense cluster with three masters or control plane nodes, the CPU and memory usage will spike up when one of the nodes is stopped, rebooted or fails. The failures can be due to unexpected issues with power, network or underlying infrastructure in addition to intentional cases where the cluster is restarted after shutting it down to save costs. The remaining two control plane nodes must handle the load in order to be highly available which leads to increase in the resource usage. This is also expected during upgrades because the masters are cordoned, drained, and rebooted serially to apply the operating system updates, as well as the control plane Operators update. To avoid cascading failures, keep the overall CPU and memory resource usage on the control plane nodes to at most 60% of all available capacity to handle the resource usage spikes. Increase the CPU and memory on the control plane nodes accordingly to avoid potential downtime due to lack of resources.


### PR DESCRIPTION
Some of the control plane node sizing values are outdated as of 4.10

Version(s):
 4.10 + versions

cc: @ahardin-rh @sheriff-rh  @mohit-sheth @amitsagtani97 @afcollins

