### PR TITLE
Bug 2018481: OpenStack: Add note about ETP=Local and Octavia

### DIFF
--- a/modules/installation-osp-setting-cloud-provider-options.adoc
+++ b/modules/installation-osp-setting-cloud-provider-options.adoc
@@ -39,16 +39,30 @@ Configuring Octavia for load balancing is a common case. For example:
 [LoadBalancer]
 use-octavia=true <1>
 lb-provider = "amphora" <2>
-floating-network-id="d3deb660-4190-40a3-91f1-37326fe6ec4a"<3>
+floating-network-id="d3deb660-4190-40a3-91f1-37326fe6ec4a" <3>
+create-monitor = True <4>
+monitor-delay = 10s <5>
+monitor-timeout = 10s <6>
+monitor-max-retries = 1 <7>
 #...
 ----
 <1> This property enables Octavia integration.
 <2> This property sets the Octavia provider that your load balancer uses. It accepts `"ovn"` or `"amphora"` as values. If you choose to use OVN, you must also set `lb-method` to `SOURCE_IP_PORT`.
 <3> This property is required if you want to use multiple external networks with your cluster. The cloud provider creates floating IP addresses on the network that is specified here.
+<4> This property controls whether the cloud provider creates health monitors for Octavia load balancers. Set the value to `True` to create health monitors. As of {rh-openstack} 16.1 and 16.2, this feature is only available for the Amphora provider.
+<5> This property sets the frequency with which endpoints are monitored. The value must be in the `time.ParseDuration()` format. This property is required if the value of the `create-monitor` property is `True`.
+<6> This property sets the time that monitoring requests are open before timing out. The value must be in the `time.ParseDuration()` format. This property is required if the value of the `create-monitor` property is `True`.
+<7> This property defines how many successful monitoring requests are required before a load balancer is marked as online. The value must be an integer. This property is required if the value of the `create-monitor` property is `True`.
+
 +
 [IMPORTANT]
 ====
 Prior to saving your changes, verify that the file is structured correctly. Clusters might fail if properties are not placed in the appropriate section.
+====
++
+[IMPORTANT]
+====
+You must set the value of the `create-monitor` property to `True` if you use services that have the value of the `.spec.endpointTrafficPolicy` property set to `Local`. The OVN Octavia provider in {rh-openstack} 16.1 and 16.2 does not support health monitors. Therefore, services that have `ETP` parameter values set to `Local` might not respond when the `lb-provider` value is set to `"ovn"`.
 ====
 
 . Save the changes to the file and proceed with installation.

--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -62,6 +62,13 @@ spec:
       statsPort: 1936
 ----
 ====
++
+[NOTE]
+====
+On {rh-openstack-first}, the `LoadBalancerService` endpoint publishing strategy is only supported if a cloud provider is configured to create health monitors. For {rh-openstack} 16.1 and 16.2, this strategy is only possible if you use the Amphora Octavia provider.
+
+For more information, see the "Setting cloud provider options" section of the {rh-openstack} installation documentation.
+====
 
 For most platforms, the `endpointPublishingStrategy` value can be updated. On GCP, you can configure the following `endpointPublishingStrategy` fields:
 


### PR DESCRIPTION
Setting `.spec.endpointTrafficPolicy=Local` disables node's ability to
redirect NodePort traffic to other nodes when no endpoint of that
NodePort Service exists on the target node. This means that LoadBalancer
Services need to be smart and only direct traffic to nodes that host the
endpoint pods.

This is normally achieved by using endpoint healthchecks. This commit
adds a note that it is required to enable "health monitors" support in
OpenStack cloud-provider configuration in order to support `ETP=Local`
Services.

As OVN Octavia provider in OSP16 does not support health monitors, a
note is added that `ETP=Local` Services will not function properly with
OVN Octavia provider.

Version(s): 4.11, 4.10

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2018481

Previews: 
- https://46245--docspreview.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress
- https://46245--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#installation-osp-setting-cloud-provider-options_installing-openstack-installer-custom
