### PR TITLE
fixed broken link in Regulatory Compliance section

### DIFF
--- a/modules/policy-security-regulation-compliance.adoc
+++ b/modules/policy-security-regulation-compliance.adoc
@@ -67,6 +67,8 @@ Any issues that are discovered are prioritized based on severity. Any issues fou
 
 |===
 
+//This table exists in sdpolicy-security.adoc file also.
+
 [role="_additional-resources"]
 .Additional resources
 

--- a/modules/sdpolicy-security.adoc
+++ b/modules/sdpolicy-security.adoc
@@ -54,7 +54,23 @@ $ oc adm policy add-cluster-role-to-group self-provisioner system:authenticated:
 
 [id="regulatory-compliance_{context}"]
 == Regulatory compliance
-See link:https://www.openshift.com/products/dedicated/process-and-security#compliance[OpenShift Dedicated Process and Security Overview] for the latest compliance information.
+{product-title} follows common industry best practices for security and controls. The certifications are outlined in the following table.
+
+.Security and control certifications for {product-title}
+[cols= "3,3,3",options="header"]
+|===
+| Certification | {product-title} on AWS | {product-title} on GCP
+
+| ISO 27001 | Yes | Yes
+
+| PCI DSS | Yes | Yes
+
+| SOC 2 Type 2 | Yes | Yes
+
+|===
+
+//This table exists in policy-security-regulation-compliance.adoc file also.
+
 
 [id="network-security_{context}"]
 == Network security


### PR DESCRIPTION
[OSDOCS-3694] Broken link

Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/OSDOCS-3694

Link to docs preview:
http://file.rdu.redhat.com/aldiaz/OSDOCS-3694/osd_architecture/osd_policy/osd-service-definition.html#regulatory-compliance_osd-service-definition

Additional information:
Fixed broken link in Regulatory Compliance section.



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
