### PR TITLE
[RHACS] Update ordering of Release Note items

### DIFF
--- a/release_notes/370-release-notes.adoc
+++ b/release_notes/370-release-notes.adoc
@@ -22,18 +22,6 @@ toc::[]
 
 You can use {product-title-short} to ensure the integrity of the container images in your clusters by verifying image signatures against preconfigured keys. You can also create policies to block unsigned images and images that do not have a verified signature and enforce the policy by using an admission controller to stop unauthorized deployment creation. Cosign key signature verification is supported. See xref:../operating/verify-image-signatures.adoc#configure-signature-integration_verify-image-signatures[Verifying image signatures] for more information.
 
-[id="integration-ecs-rn"]
-=== Automatic Amazon ECR registry integration
-
-Registry integrations for Amazon Elastic Container Registry (ECR) are now automatically generated for Amazon Web Services (AWS) clusters. This feature requires that the nodes' Instance Identity and Access Management (IAM) Role has been granted access to ECR. You can turn off this feature by disabling the EC2 instance metadata service in your nodes. See xref:../integration/integrate-with-image-registries.adoc#amazon_ecr_integrate-with-image-registries[Amazon ECR integrations] for more information.
-
-== Enhancements
-
-[id="spring-vulnerabilities-rn"]
-=== Identifying Spring critical vulnerabilities
-
-{product-title-short} 3.70 adds a policy to detect the Spring Cloud Function RCE vulnerability (CVE-2022-22963) and the Spring Framework Spring4Shell RCE vulnerability (CVE-2022-22965). The policy has a severity level of Critical and is enabled by default.
-
 [id="identify-missing-policies-rn"]
 === Identifying missing Kubernetes network policies
 
@@ -46,6 +34,18 @@ Kubernetes network policies are vital in helping to enable zero-trust networking
 - This default policy uses a new policy criterion called *Alert on missing ingress Network Policy*.
 
 - To identify pod isolation gaps, you can clone this default policy or create a new one by using the policy criterion and enabling it on selected resources.
+
+== Enhancements
+
+[id="spring-vulnerabilities-rn"]
+=== Identifying Spring critical vulnerabilities
+
+{product-title-short} 3.70 adds a policy to detect the Spring Cloud Function RCE vulnerability link:https://access.redhat.com/security/cve/CVE-2022-22963[(CVE-2022-22963)] and the Spring Framework Spring4Shell RCE vulnerability link:https://access.redhat.com/security/cve/CVE-2022-22965[(CVE-2022-22965)]. The policy has a severity level of Critical and is enabled by default.
+
+[id="integration-ecs-rn"]
+=== Automatic Amazon ECR registry integration
+
+Registry integrations for Amazon Elastic Container Registry (ECR) are now automatically generated for Amazon Web Services (AWS) clusters. This feature requires that the nodes' Instance Identity and Access Management (IAM) Role has been granted access to ECR. You can turn off this feature by disabling the EC2 instance metadata service in your nodes. See xref:../integration/integrate-with-image-registries.adoc#amazon_ecr_integrate-with-image-registries[Amazon ECR integrations] for more information.
 
 [id="allow-privilege-escalation-rn"]
 === Improved validation of pod security context


### PR DESCRIPTION
Changes the order of some items in the Release Notes.

Version(s):

- merge to `rhacs-3.70`
- cherry pick to `rhacs-docs`

Labels:

- `RHACS/next` 
- `RHACS`

Issue: none (verbal slack message from PM)

Preview: https://openshift-docs-o9n7w7zwr-kcarmichael08.vercel.app/openshift-acs/master/release_notes/370-release-notes.html