### PR TITLE
OSDOCS-3437: RN for installing to the AWS SC2S region

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -88,6 +88,12 @@ By default, the installation program now deploys a Microsoft Azure cluster using
 ==== Default AWS and VMware vSphere compute node resources
 Beginning with {product-title} 4.11, by default, the installation program now deploys AWS and VMware vSphere compute nodes with 4 vCPUs and 16 GB of virtual RAM.
 
+[id="ocp-4-11-aws-sc2s"]
+==== Support for the AWS SC2S region
+{product-title} 4.11 introduces support for the AWS Secret Commercial Cloud Services (SC2S) region. You can now install and update {product-title} clusters in the `us-isob-east-1` SC2S region.
+
+For more information, see xref:../installing/installing_aws/installing-aws-secret-region.adoc#installing-aws-secret-region[Installing a cluster on AWS into a Secret or Top Secret Region]
+
 [id="ocp-4-11-web-console"]
 === Web console
 
@@ -104,7 +110,7 @@ Beginning with {product-title} 4.11, by default, the installation program now de
 === Networking
 ==== New option for Ingress Controllers with the hostnetwork endpoint
 
-This update introduces a new option for Ingress Controllers with the `hostnetwork` endpoint strategy. You can now host multiple Ingress Controllers on the same worker node using `httpPort`, `httpsPort`, and `statsPort` binding ports. 
+This update introduces a new option for Ingress Controllers with the `hostnetwork` endpoint strategy. You can now host multiple Ingress Controllers on the same worker node using `httpPort`, `httpsPort`, and `statsPort` binding ports.
 
 [id="ocp-4-11-ne-tuningoptions-maxconnections"]
 ==== Support for configuring maximum number of connections for HAProxy processes


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR address the release note for [CORS-1951](https://issues.redhat.com/browse/CORS-1951)/[OSDOCS-3437](https://issues.redhat.com/browse/OSDOCS-3437) (Installer support for AWS Secret Region).

Link to docs preview:
[Support for the AWS SC2S region](http://file.rdu.redhat.com/mpytlak/osdocs-3437-rn/release_notes/ocp-4-11-release-notes.html#ocp-4-11-aws-sc2s)
