### PR TITLE
[RHACS] Fixes portal format issue

### DIFF
--- a/modules/acs-quick-install-secured-cluster-using-helm.adoc
+++ b/modules/acs-quick-install-secured-cluster-using-helm.adoc
@@ -27,6 +27,8 @@ $ helm install -n stackrox --create-namespace \
     --set clusterName=<name_of_the_secured_cluster> \
     --set centralEndpoint=<endpoint_of_central_service> <2>
 ----
+<1> Use the `-f` option to specify the path for the init bundle.
+<2> Specify the address and port number for Central.
 
 * Run the following command on {ocp} clusters:
 +


### PR DESCRIPTION
Fixes formatting issue at https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.70/html-single/installing/index#installing-secured-cluster-services-quickly_acs-install-helm-quick

Applies to the following branches:
- `rhacs-docs-3.69`
- `rhacs-docs-3.70`

Preview: https://openshift-docs-pkw119iwn-gnelson.vercel.app/openshift-acs/master/installing/installing_helm/install-helm-quick.html#installing-secured-cluster-services-quickly_acs-install-helm-quick

![image](https://user-images.githubusercontent.com/23069445/171794430-3910b616-6052-444f-808a-d4abae0ec9b1.png)

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
