### PR TITLE
TELCODOCS-416: CNF-3205 Telco friendly workload specific PerformanceProfile API WIP

### DIFF
--- a/modules/cnf-configuring-workload-hints.adoc
+++ b/modules/cnf-configuring-workload-hints.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+
+:_content-type: CONCEPT
+[id="configuring-workload-hints_{context}"]
+= Configuring workload hints manually
+
+.Procedure
+
+. Create a `PerformanceProfile` appropriate for the environment's hardware and topology as described in the table in "Understanding workload hints". Adjust the profile to match the expected workload. In this example, we tune for the lowest possible latency.
+
+. Add the `highPowerConsumption` and `realtime` workload hints. Both are set to `true` here.
++
+[source,yaml]
+----
+    apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    metadata:
+      name: workload-hints
+    spec:
+      ...
+      workloadHints:
+        highPowerConsumption: true <1>
+        realtime: true <2>
+----
+<1> If `highPowerConsumption` is `true`, the node is tuned for very low latency at the cost of increased power consumption.
+<2> Disables some debugging and monitoring features that can affect system latency.

--- a/modules/cnf-performance-profile-creator-arguments.adoc
+++ b/modules/cnf-performance-profile-creator-arguments.adoc
@@ -52,9 +52,9 @@ a|The power consumption mode.
 
 Possible values:
 
-* `default`
-* `low-latency`
-* `ultra-low-latency`
+* `default`: CPU partitioning with enabled power management and basic low-latency.
+* `low-latency`: Enhanced measures to improve latency figures.
+* `ultra-low-latency`: Priority given to optimal latency, at the expense of power management.
 
 Default: `default`.
 

--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -155,6 +155,9 @@ spec:
     topologyPolicy: single-numa-node
   realTimeKernel:
     enabled: true
+  workloadHints:
+    highPowerConsumption: true
+    realtime: true
 ----
 
 . Apply the generated profile:

--- a/modules/cnf-understanding-low-latency.adoc
+++ b/modules/cnf-understanding-low-latency.adoc
@@ -42,8 +42,22 @@ set values, installing a kernel, and reconfiguring the machine. But this method
 requires setting up four different Operators and performing many configurations
 that, when done manually, is complex and could be prone to mistakes.
 
-{product-title} provides a Performance Addon Operator to implement automatic
+{product-title} uses the Node Tuning Operator to implement automatic
 tuning to achieve low latency performance for OpenShift applications.
 The cluster administrator uses this performance profile configuration that makes
 it easier to make these changes in a more reliable way. The administrator can
 specify whether to update the kernel to kernel-rt, reserve CPUs for cluster and operating system housekeeping duties, including pod infra containers, and isolate CPUs for application containers to run the workloads.
+
+{product-title} also supports workload hints for the Node Tuning Operator that can tune the `PerformanceProfile` to meet the demands of different industry environments. Workload hints are available for `highPowerConsumption` (very low latency at the cost of increased power consumption) and `realtime` (priority given to optimum latency). A combination of `true/false` settings for these hints can be used to deal with application-specific workload profiles and requirements.
+
+Workload hints simplify the fine-tuning of performance to industry sector settings. Instead of a “one size fits all” approach, workload hints can cater to usage patterns such as placing priority on:
+
+* Low latency
+* Real-time capability
+* Efficient use of power
+
+In an ideal world, all of those would be prioritized: in real life, some come at the expense of others. The Node Tuning Operator is now aware of the workload expectations and better able to meet the demands of the workload. The cluster admin can now specify into which use case that workload falls. The Node Tuning Operator uses the `PerformanceProfile` to fine tune the performance settings for the workload.
+
+The environment in which an application is operating influences its behavior. For a typical data center with no strict latency requirements, only minimal default tuning is needed that enables CPU partitioning for some high performance workload pods.
+For data centers and workloads where latency is a higher priority, measures are still taken to optimize power consumption.
+The most complicated cases are clusters close to latency-sensitive equipment such as manufacturing machinery and software-defined radios. This last class of deployment is often referred to as Far edge. For Far edge deployments, ultra-low latency is the ultimate priority, and is achieved at the expense of power management.

--- a/modules/cnf-understanding-workload-hints.adoc
+++ b/modules/cnf-understanding-workload-hints.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+
+:_content-type: CONCEPT
+[id="cnf-understanding-workload-hints_{context}"]
+= Understanding workload hints
+
+The following table describes how combinations of power consumption and real-time settings impact on latency.
+[NOTE]
+====
+The following workload hints can be configured manually. See "Creating a performance profile" for further information. You can also work with workload hints using the Performance Profile Creator. See "Creating a performance profile" for further information.
+====
+
+[cols="1,1,1,1",options="header"]
+|===
+    | Performance Profile creator setting| Hint | Environment | Description
+
+    | Default
+    a|[source,terminal]
+----
+workloadHints:
+highPowerConsumption: false
+realtime: false
+----
+    | High throughput cluster without latency requirements
+    | Performance achieved through CPU partitioning only.
+
+
+
+    | Low-latency
+    a|[source,terminal]
+----
+workloadHints:
+highPowerConsumption: false
+realtime: true
+----
+    | Regional datacenters
+    | Both energy savings and low-latency are desirable: compromise between power management, latency and throughput.
+
+
+    | Ultra-low-latency
+    a|[source,terminal]
+----
+workloadHints:
+highPowerConsumption: true
+realtime: true
+----
+    | Far edge clusters, latency critical workloads
+    | Optimized for absolute minimal latency and maximum determinism at the cost of increased power consumption.
+
+|===

--- a/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+++ b/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
@@ -25,10 +25,6 @@ include::modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-iso
 
 include::modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc[leveloffset=+2]
 
-include::modules/cnf-configure_for_irq_dynamic_load_balancing.adoc[leveloffset=+2]
-
-include::modules/configuring_hyperthreading_for_a_cluster.adoc[leveloffset=+2]
-
 include::modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -39,6 +35,19 @@ include::modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc[le
 include::modules/cnf-configuring-huge-pages.adoc[leveloffset=+2]
 
 include::modules/cnf-allocating-multiple-huge-page-sizes.adoc[leveloffset=+2]
+
+include::modules/cnf-configure_for_irq_dynamic_load_balancing.adoc[leveloffset=+2]
+
+include::modules/configuring_hyperthreading_for_a_cluster.adoc[leveloffset=+2]
+
+include::modules/cnf-understanding-workload-hints.adoc[leveloffset=+2]
+
+include::modules/cnf-configuring-workload-hints.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For information on using the Performance Profile Creator (PPC) to generate a performance profile, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-create-performance-profiles[Creating a performance profile].
 
 include::modules/cnf-cpu-infra-container.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.11 and onwards.
Issue:
https://issues.redhat.com/browse/TELCODOCS-416

Issue:
https://issues.redhat.com/browse/TELCODOCS-416

First mention in main body of docs. Final paragraph of "Understanding law latency" concept topic.

http://file.emea.redhat.com/tmulquee/TELCODOCS-416/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html
Topic on Configuring workload hints: planning issues:

http://file.emea.redhat.com/tmulquee/TELCODOCS-416/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#cnf-configuring-workload-hints_cnf-master
Sample output from cat yaml now includes workflow hints (step 6):

http://file.emea.redhat.com/tmulquee/TELCODOCS-416/scalability_and_performance/cnf-create-performance-profiles.html#running-the-performance-profile-profile-cluster-using-podman_cnf-create-performance-profiles

Topic on arguments for Performance Profile (power-consumption-mode row in table):

http://file.emea.redhat.com/tmulquee/TELCODOCS-416/scalability_and_performance/cnf-create-performance-profiles.html#performance-profile-creator-arguments_cnf-create-performance-profiles




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
