### PR TITLE
RHDEVDOCS-4070 Pipelines 1.7.1 Release Notes

### DIFF
--- a/modules/op-advantages-and-disadvantages-of-non-versioned-and-versioned-cluster-tasks.adoc
+++ b/modules/op-advantages-and-disadvantages-of-non-versioned-and-versioned-cluster-tasks.adoc
@@ -26,7 +26,7 @@ a|
 a| 
 * If you continue using an earlier version of a cluster task, you might miss the latest features and critical security updates.
 * The earlier versions of cluster tasks that are not operational consume cluster resources.  
-* When upgraded , the Operator cannot manage the earlier VCT. You can delete the earlier VCT manually using the `oc delete clustertask` command, but you cannot restore it.  
+* * After it is upgraded, the Operator cannot manage the earlier VCT. You can delete the earlier VCT manually by using the `oc delete clustertask` command, but you cannot restore it.  
 |
 
 |===

--- a/modules/op-release-notes-1-7.adoc
+++ b/modules/op-release-notes-1-7.adoc
@@ -5,7 +5,7 @@
 [id="op-release-notes-1-7_{context}"]
 = Release notes for {pipelines-title} General Availability 1.7
 
-With this update, {pipelines-title} General Availability (GA) 1.7 is available on {product-title} 4.10.
+With this update, {pipelines-title} General Availability (GA) 1.7 is available on {product-title} 4.9, 4.10, and 4.11.
 
 [id="new-features-1-7_{context}"]
 == New features
@@ -339,4 +339,26 @@ time="2021-11-04T13:05:26Z" level=error msg="exit status 127"
 // https://github.com/tektoncd/operator/pull/599
 
 
+[id="release-notes-1-7-1_{context}"]
+== Release notes for {pipelines-title} General Availability 1.7.1
+
+With this update, {pipelines-title} General Availability (GA) 1.7.1 is available on {product-title} 4.9, 4.10, and 4.11.
+
+[id="fixed-issues-1-7-1_{context}"]
+=== Fixed issues
+
+* Before this update, upgrading the {pipelines-title} Operator deleted the data in the database associated with {tekton-hub} and installed a new database. With this update, an Operator upgrade preserves the data.
+// https://issues.redhat.com/browse/SRVKP-2280
+
+* Before this update, only cluster administrators could access pipeline metrics in the {product-title} console. With this update, users with other cluster roles also can access the pipeline metrics.
+// https://issues.redhat.com/browse/SRVKP-2129
+
+* Before this update, pipeline runs failed for pipelines containing tasks that emit large termination messages. The pipeline runs failed because the total size of termination messages of all containers in a pod cannot exceed 12 KB. With this update, the `place-tools` and `step-init` initialization containers that uses the same image are merged to reduce the number of containers running in each tasks's pod. The solution reduces the chance of failed pipeline runs by minimizing the number of containers running in a task's pod. However, it does not remove the limitation of the maximum allowed size of a termination message.
+// https://issues.redhat.com/browse/SRVKP-2243
+
+* Before this update, attempts to access resource URLs directly from the {tekton-hub} web console resulted in an Nginx `404` error. With this update, the {tekton-hub} web console image is fixed to allow accessing resource URLs directly from the {tekton-hub} web console.
+// https://issues.redhat.com/browse/SRVKP-2196
+
+* Before this update, for each namespace the resource pruner job created a separate container to prune resources. With this update, the resource pruner job runs commands for all namespaces as a loop in one container.
+// https://issues.redhat.com/browse/SRVKP-2160
 


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.10`, `enterprise-4.11`
- **JIRA issues**: [RHDEVDOCS-4070 RN and Errata for Pipelines 1.7.1](https://issues.redhat.com/browse/RHDEVDOCS-4070)
- **Preview pages**: Due to issues with Netlify, preview pages are not getting generated. Download and see this [locally generated HTML](https://drive.google.com/file/d/1oOrp9E5o8_MmrwXfwHfGQobx1AJPbUrb/view?usp=sharing) page on your browser. Look for the section "**Release notes for Red Hat OpenShift Pipelines General Availability 1.7.1**".
- **SME review**: @concaf @pradeepitm12      
- **QE review**: @ppitonak    
- **Peer-review**: @jc-berger 
- [**Engineering draft**](https://docs.google.com/document/d/1uab5nyKnyCGKxsfS_NRmauSE6rSsWHWh0sA7XZb1g9A/edit#heading=h.b47brzfzy6lx)