### PR TITLE
RHDEVDOCS-4124 Operator displays Trigger metrics in devconsole

### DIFF
--- a/cicd/pipelines/creating-applications-with-cicd-pipelines.adoc
+++ b/cicd/pipelines/creating-applications-with-cicd-pipelines.adoc
@@ -1,5 +1,5 @@
 :_content-type: ASSEMBLY
-[id='creating-applications-with-cicd-pipelines']
+[id="creating-applications-with-cicd-pipelines"]
 = Creating CI/CD solutions for applications using OpenShift Pipelines
 include::_attributes/common-attributes.adoc[]
 :context: creating-applications-with-cicd-pipelines
@@ -63,6 +63,13 @@ include::modules/op-creating-webhooks.adoc[leveloffset=+1]
 
 include::modules/op-triggering-a-pipelinerun.adoc[leveloffset=+1]
 
+include::modules/op-enabling-monitoring-of-event-listeners-for-triggers-for-user-defined-projects.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
+
 [role="_additional-resources"]
 [id="pipeline-addtl-resources"]
 == Additional resources
@@ -70,6 +77,6 @@ include::modules/op-triggering-a-pipelinerun.adoc[leveloffset=+1]
 * For more details on pipelines in the *Developer* perspective, see the xref:../../cicd/pipelines/working-with-pipelines-using-the-developer-perspective.adoc#working-with-pipelines-using-the-developer-perspective[working with pipelines in the *Developer* perspective] section.
 * To learn more about Security Context Constraints (SCCs), see the xref:../../authentication/managing-security-context-constraints.adoc#managing-pod-security-policies[Managing Security Context Constraints] section.
 * For more examples of reusable tasks, see the link:https://github.com/openshift/pipelines-catalog[OpenShift Catalog] repository. Additionally, you can also see the Tekton Catalog in the Tekton project.
-* To install and deploy a custom instance of Tekton Hub for resuable tasks and pipelines, see xref:../../cicd/pipelines/using-tekton-hub-with-openshift-pipelines.adoc#using-tekton-hub-with-openshift-pipelines[Using {tekton-hub} with {pipelines-title}]. 
+* To install and deploy a custom instance of Tekton Hub for reusable tasks and pipelines, see xref:../../cicd/pipelines/using-tekton-hub-with-openshift-pipelines.adoc#using-tekton-hub-with-openshift-pipelines[Using {tekton-hub} with {pipelines-title}]. 
 * For more details on re-encrypt TLS termination, see link:https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html#re-encryption-termination[Re-encryption Termination].
 * For more details on secured routes, see the xref:../../networking/routes/secured-routes.adoc#secured-routes[Secured routes] section.

--- a/modules/op-enabling-monitoring-of-event-listeners-for-triggers-for-user-defined-projects.adoc
+++ b/modules/op-enabling-monitoring-of-event-listeners-for-triggers-for-user-defined-projects.adoc
@@ -1,0 +1,56 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/creating-applications-with-cicd-pipelines.adoc
+
+:_content-type: PROCEDURE
+[id="enabling-monitoring-of-event-listeners-for-triggers-for-user-defined-projects_{context}"]
+= Enabling monitoring of event listeners for Triggers for user-defined projects
+
+As a cluster administrator, to gather event listener metrics for the `Triggers` service in a user-defined project and display them in the {product-title} web console, you can create a service monitor for each event listener. On receiving a HTTP request, event listeners for the `Triggers` service return three metrics -- `eventlistener_http_duration_seconds`, `eventlistener_event_count`, and `eventlistener_triggered_resources`.
+
+.Prerequisites
+
+* You have logged in to the {product-title} web console.
+* You have installed the {pipelines-title} Operator.
+* You have enabled monitoring for user-defined projects.
+
+.Procedure
+
+. For each event listener, create a service monitor. For example, to view the metrics for the `github-listener` event listener in the `test` namespace, create the following service monitor:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: EventListener
+    app.kubernetes.io/part-of: Triggers
+    eventlistener: github-listener
+  annotations: 
+    networkoperator.openshift.io/ignore-errors: ""
+  name: el-monitor
+  namespace: test
+spec:
+  endpoints: 
+    - interval: 10s
+      port: http-metrics
+  jobLabel: name
+  namespaceSelector: 
+    matchNames:
+      - test
+  selector:
+    matchLabels:  
+      app.kubernetes.io/managed-by: EventListener
+      app.kubernetes.io/part-of: Triggers
+      eventlistener: github-listener
+...
+----
+. Test the service monitor by sending a request to the event listener. For example, push an empty commit:
++
+[source,terminal]
+----
+$ git commit -m "empty-commit" --allow-empty && git push origin main
+----
+. On the {product-title} web console, navigate to **Administrator** -> **Observe** -> **Metrics**.
+. To view a metric, search by its name. For example, to view the details of the `eventlistener_http_resources` metric for the `github-listener` event listener, search using the `eventlistener_http_resources` keyword. 


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`
- **JIRA issues**: [RHDEVDOCS-4124 Operator displays Trigger metrics in devconsole](https://issues.redhat.com/browse/RHDEVDOCS-4124)
- **Preview pages**: Due to issues with Netlify, preview pages are not getting generated. However, you can download the [locally generated HTML file](https://drive.google.com/file/d/1_Fc_57TFBRnufIed2c7DeJBHb70NYto5/view?usp=sharing) and open it in your browser. Look for the section "**Enabling monitoring of event listeners for Triggers for user-defined projects**".
- **SME review**: @savitaashture      
- **QE review**: @VeereshAradhya    
- **Peer-review**: @rolfedh 