### PR TITLE
OSDOCS-3435: RN for Nutanix IPI installation

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -94,6 +94,12 @@ Beginning with {product-title} 4.11, by default, the installation program now de
 
 For more information, see xref:../installing/installing_aws/installing-aws-secret-region.adoc#installing-aws-secret-region[Installing a cluster on AWS into a Secret or Top Secret Region]
 
+[id="ocp-4-11-nutanix"]
+==== Installing a cluster on Nutanix using installer-provisioned infrastructure
+{product-title} 4.11 introduces support for installing a cluster on Nutanix using installer-provisioned infrastructure. This type of installation lets you use the installation program to deploy a cluster on infrastructure that the installation program provisions and the cluster maintains.
+
+//For more information, see ../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#installing-nutanix-installer-provisioned[Installing a cluster on Nutanix].
+
 [id="ocp-4-11-web-console"]
 === Web console
 


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR address the release note for [OSDOCS-3435](https://issues.redhat.com/browse/OSDOCS-3435)/[SPLAT-393](https://issues.redhat.com/browse/SPLAT-393)

Link to docs preview:
[Installing a cluster on Nutanix using installer-provisioned infrastructure](http://file.rdu.redhat.com/mpytlak/osdocs-3435-rn/release_notes/ocp-4-11-release-notes.html#ocp-4-11-nutanix)

Note: PR [44537](https://github.com/openshift/openshift-docs/pull/44537) address the doc for installing a Nutanix cluster.