### PR TITLE
BZ#2072087: Add release note for stricter HTTP header validation with HAProxy 2.2

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -492,6 +492,13 @@ For more information, see xref:../networking/ovn_kubernetes_network_provider/tra
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-converting-http-header-case_configuring-ingress[Converting HTTP header case].
 
+[id="ocp-4-8-stricter-http-head-validation-haproxy-2.2"]
+==== Stricter HTTP header validation in {product-title} 4.8
+
+{product-title} updated to HAProxy 2.2, which enforces some additional restrictions on HTTP headers.  These restrictions are intended to mitigate possible security weaknesses in applications.  In particular, HTTP client requests that specify a host name in an HTTP request line may be rejected if the request line and HTTP `host` header in a request do not both either specify or omit the port number.  For example, a request `GET http://hostname:80/path` with the header `host: hostname` will be rejected with an HTTP 400 "Bad request" response because the request line specifies a port number while the `host` header does not.  The purpose of this restriction is to mitigate request smuggling attacks.
+
+This stricter HTTP header validation was also enabled in previous versions of {product-title} when HTTP/2 was enabled.  This means that you can test for problematic client requests by enabling HTTP/2 on a {product-title} 4.7 cluster and checking for HTTP 400 errors.  For information on how to enable HTTP/2, see xref:../networking/ingress-operator.adoc#nw-http2-haproxy_configuring-ingress[Enabling HTTP/2 Ingress connectivity].
+
 
 [id="ocp-4-8-ingress-configuring-global-access-gcp"]
 ==== Configuring global access for an Ingress Controller on GCP


### PR DESCRIPTION
* `release_notes/ocp-4-8-release-notes.adoc`: Add a release note that HAProxy 2.2 enforces stricter HTTP header parsing.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
OpenShift 4.8

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2072087

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
  - The preview will be generated after you open the PR.
  - You will need to edit the comment to add the link after the preview builds.
  - Review the preview build to make sure your changes are rendering properly. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
