### PR TITLE
BZ2087697: Section on Verifying that the interface is successfully partitioned added

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
@@ -27,9 +27,11 @@ include::modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc[leve
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../post_installation_configuration/bare-metal-configuration.adoc[Bare metal configuration]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-the-unhealthy-etcd-member[Replacing an unhealthy etcd member]
 
-* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[Backing up etcd]
+
+* xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration] 
 
 include::modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc[leveloffset=+1]
 

--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -15,7 +15,32 @@ If you reuse the `BareMetalHost` object definition from an existing control plan
 Existing control plane `BareMetalHost` objects may have the `externallyProvisioned` flag set to `true` if they were provisioned by the {product-title} installation program.
 ====
 
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+* You have taken an etcd backup.
++
+[IMPORTANT]
+====
+Take an etcd backup before performing this procedure so that you can restore your cluster if you encounter any issues. For more information about taking an etcd backup, see the _Additional resources_ section.
+====
+
 .Procedure
+
+. Ensure that the Bare Metal Operator is available:
++
+[source,terminal]
+----
+$ oc get clusteroperator baremetal
+----
++
+.Example output
+[source,terminal]
+----
+NAME        VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE  
+baremetal   4.10.12   True        False         False      3d15h 
+----
 
 . Remove the old `BareMetalHost` and `Machine` objects:
 +

--- a/modules/nw-sriov-nic-partitioning.adoc
+++ b/modules/nw-sriov-nic-partitioning.adoc
@@ -69,3 +69,26 @@ spec:
     pfNames: ["netpf0#8-15"]
   deviceType: vfio-pci
 ----
+
+.Verifying that the interface is successfully partitioned
+Confirm that the interface partitioned to virtual functions (VFs) for the SR-IOV device by running the following command.
+
+[source,terminal]
+----
+$ ip link show <interface> <1>
+----
+
+<1> Replace `<interface>` with the interface that you specified when partitioning to VFs for the SR-IOV device, for example, `ens3f1`.
+
+.Example output
+[source,terminal]
+----
+5: ens3f1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+link/ether 3c:fd:fe:d1:bc:01 brd ff:ff:ff:ff:ff:ff
+
+vf 0     link/ether 5a:e7:88:25:ea:a0 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
+vf 1     link/ether 3e:1d:36:d7:3d:49 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
+vf 2     link/ether ce:09:56:97:df:f9 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
+vf 3     link/ether 5e:91:cf:88:d1:38 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
+vf 4     link/ether e6:06:a1:96:2f:de brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
+----


### PR DESCRIPTION
Bugzilla
https://bugzilla.redhat.com/show_bug.cgi?id=2087697

Preview
http://file.emea.redhat.com/pogrady/BZ2087697/networking/hardware_networks/configuring-sriov-device.html#nw-sriov-nic-partitioning_configuring-sriov-device

See new section 'Verifying that the interface is successfully partitioned'

Versions:
Applies to OpenShift version : 4.10+

@SchSeba can you please review/approve? Thank you