### PR TITLE
[RHACS] Add deprecated item to Release Notes

### DIFF
--- a/release_notes/370-release-notes.adoc
+++ b/release_notes/370-release-notes.adoc
@@ -133,10 +133,15 @@ In the table, features are marked with the following statuses:
 |DEP
 |REM
 
-|`/v1/policies` API endpoint response: `field` response body parameter.
+|`/v1/policies` API endpoint response: `field` response body parameter
 |DEP
 |DEP
 |REM
+
+|`/v1/nodes` and `/v1/images` API endpoint response: `firstNodeOccurrence` response body parameter
+|GA
+|DEP
+|DEP
 
 |====
 


### PR DESCRIPTION
Version(s): 
- `rhacs-docs`
- cherry pick to `rhacs-docs-3.70`

Labels:

- `RHACS`

Issue: none (via Slack)

[Link to docs preview](https://openshift-docs-s0jzbxrni-kcarmichael08.vercel.app/openshift-acs/master/release_notes/370-release-notes.html)
