### PR TITLE
OKD Hide Web Terminal Assembly

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -613,6 +613,7 @@ Topics:
   File: odc-about-developer-perspective
 - Name: Web terminal
   File: odc-about-web-terminal
+  Distros: openshift-enterprise,openshift-online
 - Name: Disabling the web console
   File: disabling-web-console
   Distros: openshift-enterprise,openshift-origin


### PR DESCRIPTION
The Web Terminal Operator is not supported in OKD. This PR hides the _About the web terminal in the web console_ assembly.

https://github.com/openshift/okd/issues/456#issuecomment-1038373575

Previews;
OKD - [Assembly is not present](http://file.rdu.redhat.com/~mburke/okd-remove-web-terminal/web_console/odc-about-developer-perspective.html)
OCP - [Assembly is present](http://file.rdu.redhat.com/~mburke/ocp-remove-web-terminal/web_console/odc-about-web-terminal.html)