### PR TITLE
Correct the oc delete command for manual storage reclaim

### DIFF
--- a/modules/storage-persistent-storage-reclaim-manual.adoc
+++ b/modules/storage-persistent-storage-reclaim-manual.adoc
@@ -15,7 +15,7 @@ To manually reclaim the PV as a cluster administrator:
 +
 [source,terminal]
 ----
-$ oc delete <pv-name>
+$ oc delete pv <pv-name>
 ----
 +
 The associated storage asset in the external infrastructure, such as an AWS EBS, GCE PD, Azure Disk, or Cinder volume, still exists after the PV is deleted.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.6+

Issue:
In the "Reclaiming Persistent Storage Manually" module, the command "oc delete" should be "oc delete pv"

Link to docs preview:
http://file.rdu.redhat.com/jbrigman/oc-delete-pv/storage/understanding-persistent-storage.html#reclaim-manual_understanding-persistent-storage

Additional information:
This problem identified by @cshulman 

<!--- Next steps after opening your PR:

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
