### PR TITLE
WINC replace troubleshooting assembly

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -581,8 +581,8 @@ Topics:
     File: troubleshooting-s2i
   - Name: Troubleshooting storage issues
     File: troubleshooting-storage-issues
-#  - Name: Troubleshooting Windows container workload issues
-#    File: troubleshooting-windows-container-workload-issues
+  - Name: Troubleshooting Windows container workload issues
+    File: troubleshooting-windows-container-workload-issues
   - Name: Investigating monitoring issues
     File: investigating-monitoring-issues
   - Name: Diagnosing OpenShift CLI (oc) issues


### PR DESCRIPTION
The WINC troubleshooting assembly was [hidden ahead of the 4.9 GA](https://github.com/openshift/openshift-docs/pull/37462). The change got into the 4.10 and subsequently 4.11 branches. The assembly was restored in 4.9. This PR restores the assembly in 4.10 and 4.11.
[
Reported here](https://github.com/openshift/windows-machine-config-operator/pull/1088#discussion_r889152661).

Preview: [Troubleshooting Windows container workload issues](http://file.rdu.redhat.com/~mburke/winc-replace-troubleshooting/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)