### PR TITLE
Correct seccomp RuntimeDefault configuration

### DIFF
--- a/modules/configuring-default-seccomp-profile.adoc
+++ b/modules/configuring-default-seccomp-profile.adoc
@@ -9,8 +9,10 @@ OpenShift ships with a default seccomp profile that is referenced as `runtime/de
 spec:
   securityContext:
     seccompProfile:
-    - runtime/default  
       type: RuntimeDefault
 ----
 
 Alternatively, you can use the pod annotations `seccomp.security.alpha.kubernetes.io/pod: runtime/default` and `container.seccomp.security.alpha.kubernetes.io/<container_name>: runtime/default`. However, this method is deprecated in {product-title} {product-version}.
+
+Default SCCs other than `privileged` SCC restrict the setting of seccompProfile.
+If you configure seccompProfile for a pod or container, you must use the `privileged` SCC or a customized SCC.


### PR DESCRIPTION
Version(s):
4.8+

Issue:
The configuration of default seccomp profile is not correct in ["Configuring seccomp profiles" document](https://docs.openshift.com/container-platform/4.10/security/seccomp-profiles.html).
`- runtime/default` is not needed for the pod's or container's securityContext. This setting is supposed to be for SCC.

The above setting (`- runtime/default`) was merged in [PR#39790](https://github.com/openshift/openshift-docs/pull/39790). Looking at the ([BZ2024266](https://bugzilla.redhat.com/show_bug.cgi?id=2024266)), it is an improvement for SCC, not Pod/Container. Perhaps you modified the documentation by mistake.