### PR TITLE
Telcodocs 506 MetalLB 411 Release Notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -409,6 +409,29 @@ Be aware that CIDR ranges for networks are not adjustable after cluster installa
 
 If you are using the OVN-Kubernetes cluster network provider, you can now enable IPsec encryption after cluster installation. For more information about how to enable IPsec, see xref:../networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption].
 
+[id="ocp-4-11-additional-metallb-CRDs-logging-control"]
+==== Support for additional MetalLB CRDs and control over logging verbosity
+
+Additional MetalLB custom resource defintions (CRDs) have been added to support more complex configurations.
+
+The following CRDs have been added: 
+
+* `IPAddressPools`
+* `L2Advertisement`
+* `BGPAdvertisement`
+* `Community`
+
+With these enhancements, you can use the Operator for more complex configurations. For example, you can use the enhancements to isolate nodes or segment the network. In addition, the enhancements made to the FRRouting (FRR) logging component allow you to control the verbosity of the logs generated.
+
+[NOTE]
+====
+The CRDs documented for {product-title} 4.10 and the existing ways to configure MetalLB as described in link:https://docs.openshift.com/container-platform/4.10/networking/metallb/about-metallb.html[About MetalLB and the MetalLB Operator] are still supported but deprecated. The `AddressPool` configuration is deprecated. 
+
+In 4.10, layer 2 and BGP IP addresses using the `AddressPool` were assigned from different address pools. In {product-title} 4.11, layer 2 and BGP IP addresses can be assigned from the same address pool.
+====
+
+For more information, see xref:../networking/metallb/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator].
+
 [id="ocp-4-11-hardware"]
 === Hardware
 


### PR DESCRIPTION
[TELCODOCS-506]: Enhancements to MetalLB

Version(s):
Release note for 4.11

Issue:
Issue: https://issues.redhat.com/browse/TELCODOCS-506 also addressing https://issues.redhat.com/browse/TELCODOCS-421 and https://issues.redhat.com/browse/TELCODOCS-441
Link to docs preview:
http://file.emea.redhat.com/kquinn/TELCODOCS-506-411-RN/release_notes/ocp-4-11-release-notes.html#ocp-4-11-new-metallb-CRDs-logging-control