### PR TITLE
TELCODOCS-419-RN creating first draft of network level safe sysctl

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -358,6 +358,16 @@ You can now set the maximum number of simultaneous connections that can be estab
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration parameters].
 
+[id="ocp-4-11-configuring-interface-level-safe-network-sysclts"]
+==== Support for configuring interface-level safe network sysctls
+Use the new `tuning-cni` meta plug-in to set an interface level safe network sysctls that only applies to a specific interface. For example, you can change the behavior of `accept_redirects` on a particular network interface by configuring the `tuning-cni` plug-in. A complete list of the interface-specific safe sysclts that can be set is available in the documentation. 
+
+In addition to this enhancement the set of system-wide safe sysctls that can be set has increased to support `net.ipv4.ping_group_range` and `net.ipv4.ip_unprivileged_port_start`. 
+
+For more information about configuring the `tuning-cni` plugin, see xref:../networking/setting-interface-level-network-sysctls.adoc#nodes-setting-interface-level-network-sysctls[Setting interface level network sysctls].
+
+For more information about the newly supported interface level network safe sysclts and updates to the list of supported system-wide safe sysclts, see xref:../nodes/containers/nodes-containers-sysctls.adoc#nodes-containers-sysctls[Using sysctls in containers].
+
 [id="ocp-4-11-coredns-forwarding-DNS-requests-over-TLS"]
 ==== Support for CoreDNS forwarding DNS requests over TLS
 


### PR DESCRIPTION
[TELCODOCS-419]: Creating RN entry for setting network level safe sysctls

Version(s): 4.11 RN

Issue: https://issues.redhat.com/browse/TELCODOCS-419 and https://issues.redhat.com/browse/TELCODOCS-418

Link to docs preview: http://file.emea.redhat.com/kquinn/TELCODOCS-419-RN/release_notes/ocp-4-11-release-notes.html#ocp-4-11-configuring-interface-level-safe-network-sysclts

Additional information:



