### PR TITLE
[RHACS] ROX-11277: Add removed API parameter to RNs

### DIFF
--- a/release_notes/370-release-notes.adoc
+++ b/release_notes/370-release-notes.adoc
@@ -138,6 +138,11 @@ In the table, features are marked with the following statuses:
 |DEP
 |REM
 
+|`/v1/policies` API endpoint response: `whitelists` response body parameter
+|DEP
+|DEP
+|REM
+
 |`/v1/nodes` and `/v1/images` API endpoint response: `firstNodeOccurrence` response body parameter
 |GA
 |DEP


### PR DESCRIPTION
Version(s):
- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.70`

Label: `RHACS`

[Issue](https://issues.redhat.com/browse/ROX-11277)

[Preview](https://openshift-docs-12x55acaz-kcarmichael08.vercel.app/openshift-acs/master/release_notes/370-release-notes.html)