### PR TITLE
OSDOCS-3326: ARM updates to AWS UPI install

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -181,7 +181,7 @@ ifndef::openshift-origin[]
 |Restricted network
 |
 |xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[X]
-|
+|xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[X]
 |
 |
 |xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[X]
@@ -437,10 +437,11 @@ endif::openshift-origin[]
 //This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
 |===
-||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
+||Alibaba |AWS (x86_64) |AWS (arm64) |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
 
 |Custom
 |
+|xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[X]
 |xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[X]
 |xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[X]
 |xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installing-azure-stack-hub-user-infra[X]
@@ -466,6 +467,7 @@ ifndef::openshift-origin[]
 |
 |
 |
+|
 |xref:../installing/installing_openstack/installing-openstack-user-kuryr.adoc#installing-openstack-user-kuryr[X]
 |
 |
@@ -481,6 +483,7 @@ ifndef::openshift-origin[]
 
 |Restricted network
 |
+|xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[X]
 |xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[X]
 |
 |
@@ -499,6 +502,7 @@ ifndef::openshift-origin[]
 |
 
 |Shared VPC hosted outside of cluster project
+|
 |
 |
 |

--- a/modules/installation-aws-ami-stream-metadata.adoc
+++ b/modules/installation-aws-ami-stream-metadata.adoc
@@ -32,6 +32,7 @@ or `arm64`
 endif::openshift-origin[]
 AMI for an AWS region, such as `us-west-1`:
 +
+.For x86_64
 [source,terminal]
 ----
 $ openshift-install coreos print-stream-json | jq -r '.architectures.x86_64.images.aws.regions["us-west-1"].image'
@@ -43,4 +44,18 @@ $ openshift-install coreos print-stream-json | jq -r '.architectures.x86_64.imag
 ami-0d3e625f84626bbda
 ----
 +
+ifndef::openshift-origin[]
+.For arm64
+[source,terminal]
+----
+$ openshift-install coreos print-stream-json | jq -r '.architectures.aarch64.images.aws.regions["us-west-1"].image'
+----
++
+.Example output 
+[source,terminal]
+----
+ami-0af1d3b7fa5be2131
+----
++
+endif::openshift-origin[]
 The output of this command is the AWS AMI ID for your designated architecture and the `us-west-1` region. The AMI must belong to the same region as the cluster.

--- a/modules/installation-aws-upload-custom-rhcos-ami.adoc
+++ b/modules/installation-aws-upload-custom-rhcos-ami.adoc
@@ -143,7 +143,11 @@ $ aws ec2 register-image \
    --root-device-name '/dev/xvda' \
    --block-device-mappings 'DeviceName=/dev/xvda,Ebs={DeleteOnTermination=true,SnapshotId=<snapshot_ID>}' <4>
 ----
-<1> The {op-system} VMDK architecture type, like `x86_64`, `s390x`, or `ppc64le`.
+<1> The {op-system} VMDK architecture type, like `x86_64`, 
+ifndef::openshift-origin[]
+`arm64`, 
+endif::openshift-origin[]
+`s390x`, or `ppc64le`.
 <2> The `Description` from the imported snapshot.
 <3> The name of the {op-system} AMI.
 <4> The `SnapshotID` from the imported snapshot.

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -73,9 +73,8 @@ endif::[]
 ifeval::["{context}" == "installing-aws-vpc"]
 :aws:
 endif::[]
-//Starting in 4.10, aws on arm64 is only supported for installation on custom, network custom, private clusters and VPC. This attribute excludes arm64 content from installing in restricted networks upi. When restricted networks upi is supported on arm64, change `aws-restricted` to `aws`.
 ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
-:aws-restricted:
+:aws:
 endif::[]
 ifeval::["{context}" == "installing-azure-customizations"]
 :azure:
@@ -652,10 +651,10 @@ endif::openshift-origin[]
 |`publish`
 |How to publish or expose the user-facing endpoints of your cluster, such as the Kubernetes API, OpenShift routes.
 |
-ifdef::aws,aws-govcloud,aws-secret,aws-restricted,azure,gcp[]
+ifdef::aws,aws-govcloud,aws-secret,azure,gcp[]
 `Internal` or `External`. To deploy a private cluster, which cannot be accessed from the internet, set `publish` to `Internal`. The default value is `External`.
 endif::[]
-ifndef::aws,aws-govcloud,aws-secret,aws-restricted,azure,gcp[]
+ifndef::aws,aws-govcloud,aws-secret,azure,gcp[]
 `Internal` or `External`. The default value is `External`.
 
 Setting this field to `Internal` is not supported on non-cloud platforms and IBM Cloud VPC.
@@ -677,7 +676,7 @@ a|For example, `sshKey: ssh-ed25519 AAAA..`.
 
 |====
 
-ifdef::aws,aws-govcloud,aws-secret,aws-restricted[]
+ifdef::aws,aws-govcloud,aws-secret[]
 [id="installation-configuration-parameters-optional-aws_{context}"]
 == Optional AWS configuration parameters
 
@@ -782,7 +781,7 @@ host must trust the certificate.
 |Valid subnet IDs.
 
 |====
-endif::aws,aws-govcloud,aws-secret,aws-restricted[]
+endif::aws,aws-govcloud,aws-secret[]
 
 ifdef::osp[]
 [id="installation-configuration-parameters-additional-osp_{context}"]
@@ -1550,7 +1549,7 @@ ifeval::["{context}" == "installing-aws-vpc"]
 :!aws:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
-:!aws-restricted:
+:!aws:
 endif::[]
 ifeval::["{context}" == "installing-azure-customizations"]
 :!azure:

--- a/modules/installation-creating-aws-bootstrap.adoc
+++ b/modules/installation-creating-aws-bootstrap.adoc
@@ -147,7 +147,7 @@ requires:
 config files for the cluster.
 <2> Specify the infrastructure name that you extracted from the Ignition config
 file metadata, which has the format `<cluster-name>-<random-string>`.
-<3> Current {op-system-first} AMI to use for the bootstrap node.
+<3> Current {op-system-first} AMI to use for the bootstrap node based on your selected architecture.
 <4> Specify a valid `AWS::EC2::Image::Id` value.
 <5> CIDR block to allow SSH access to the bootstrap node.
 <6> Specify a CIDR block in the format `x.x.x.x/16-24`.

--- a/modules/installation-creating-aws-control-plane.adoc
+++ b/modules/installation-creating-aws-control-plane.adoc
@@ -92,7 +92,7 @@ requires:
   },
   {
     "ParameterKey": "MasterInstanceType", <21>
-    "ParameterValue": "m6i.xlarge" <22>
+    "ParameterValue": "" <22>
   },
   {
     "ParameterKey": "AutoRegisterELB", <23>
@@ -120,7 +120,7 @@ requires:
 config files for the cluster.
 <2> Specify the infrastructure name that you extracted from the Ignition config
 file metadata, which has the format `<cluster-name>-<random-string>`.
-<3> Current{op-system-first} AMI to use for the control plane machines.
+<3> Current {op-system-first} AMI to use for the control plane machines based on your selected architecture.
 <4> Specify an `AWS::EC2::Image::Id` value.
 <5> Whether or not to perform DNS etcd registration.
 <6> Specify `yes` or `no`. If you specify `yes`, you must provide hosted zone
@@ -149,9 +149,12 @@ directory. This value is the long string with the format
 <19> The IAM profile to associate with control plane nodes.
 <20> Specify the `MasterInstanceProfile` parameter value from the output of
 the CloudFormation template for the security group and roles.
-<21> The type of AWS instance to use for the control plane machines.
+<21> The type of AWS instance to use for the control plane machines based on your selected architecture.
 <22> The instance type value corresponds to the minimum resource requirements for
-control plane machines.
+control plane machines. For example `m6i.xlarge` is a type for `x86_64`
+ifndef::openshift-origin[]
+and `m6g.xlarge` is a type for `arm64`.
+endif::openshift-origin[]
 <23> Whether or not to register a network load balancer (NLB).
 <24> Specify `yes` or `no`. If you specify `yes`, you must provide a Lambda
 Amazon Resource Name (ARN) value.

--- a/modules/installation-creating-aws-worker.adoc
+++ b/modules/installation-creating-aws-worker.adoc
@@ -78,7 +78,7 @@ template requires:
   },
   {
     "ParameterKey": "WorkerInstanceType", <15>
-    "ParameterValue": "m6i.large" <16>
+    "ParameterValue": "" <16>
   }
 ]
 ----
@@ -86,7 +86,7 @@ template requires:
 config files for the cluster.
 <2> Specify the infrastructure name that you extracted from the Ignition config
 file metadata, which has the format `<cluster-name>-<random-string>`.
-<3> Current {op-system-first} AMI to use for the worker nodes.
+<3> Current {op-system-first} AMI to use for the worker nodes based on your selected architecture.
 <4> Specify an `AWS::EC2::Image::Id` value.
 <5> A subnet, preferably private, to launch the worker nodes on.
 <6> Specify a subnet from the `PrivateSubnets` value from the output of the
@@ -104,10 +104,12 @@ directory. This value is the long string with the format
 <13> The IAM profile to associate with worker nodes.
 <14> Specify the `WorkerInstanceProfile` parameter value from the output of
 the CloudFormation template for the security group and roles.
-<15> The type of AWS instance to use for the compute machines.
+<15> The type of AWS instance to use for the compute machines based on your selected architecture.
 <16> The instance type value corresponds to the minimum resource requirements
-for compute machines.
-
+for compute machines. For example `m6i.large` is a type for `x86_64`
+ifndef::openshift-origin[]
+ and `m6g.large` is a type for `arm64`.
+endif::openshift-origin[]
 . Copy the template from the *CloudFormation template for worker machines*
 section of this topic and save it as a YAML file on your computer. This template
 describes the networking objects and load balancers that your cluster requires.

--- a/modules/installation-supported-aws-machine-types.adoc
+++ b/modules/installation-supported-aws-machine-types.adoc
@@ -10,10 +10,6 @@
 // * installing/installing_aws/installing-aws-private.adoc
 // * installing/installing_aws/installing-aws-china.adoc
 
-//Starting in 4.10, aws on arm64 is only supported for installation on custom, network custom, private clusters and VPC. This attribute excludes arm64 content from installing in restricted networks upi. When restricted networks upi is supported on arm64, remove this ifdevel.
-ifeval::["{context}" == "installing-restricted-networks-aws"]
-:aws-restricted-upi:
-endif::[]
 //Starting in 4.10, aws on arm64 is only supported for installation on custom, network custom, private clusters and VPC. This attribute excludes arm64 content from installing on gov regions. When government regions are supported on arm64, remove this ifdevel.
 ifeval::["{context}" == "installing-aws-government-region"]
 :aws-govcloud:
@@ -412,7 +408,7 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 |===
 ====
 
-ifndef::aws-restricted-upi,aws-govcloud,aws-secret,aws-china,openshift-origin[]
+ifndef::aws-govcloud,aws-secret,aws-china,openshift-origin[]
 .Machine types based on arm64 architecture
 [%collapsible]
 ====


### PR DESCRIPTION
**For Version:** 4.11+
**Jira story:** [OSDOCS-3326](https://issues.redhat.com//browse/OSDOCS-3326)

**Description:** Updates AWS UPI documentation for ARM support

**Previews:** 

- [Selecting an installation method and preparing a cluster](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing-preparing.html#supported-installation-methods-for-different-platforms)
- [Installing a cluster on AWS in a restricted network](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.html#installation-configuration-parameters_installing-restricted-networks-aws-installer-provisioned)
- Installing a cluster on AWS using Cloud Formation templates 
1.  [Supported AWS Machine types](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing_aws/installing-aws-user-infra.html#installation-supported-aws-machine-types_installing-aws-user-infra)
2. [Accessing RHCOS AMIs with stream metadata](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing_aws/installing-aws-user-infra.html#installation-aws-ami-stream-metadata_installing-aws-user-infra)
3. [Uploading a custom RHCOS AMI in AWS](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing_aws/installing-aws-user-infra.html#installation-aws-upload-custom-rhcos-ami_installing-aws-user-infra)
4. [Creating the bootstrap node in AWS](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing_aws/installing-aws-user-infra.html#installation-creating-aws-bootstrap_installing-aws-user-infra)
5. [Creating the control plane machines in AWS](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing_aws/installing-aws-user-infra.html#installation-creating-aws-control-plane_installing-aws-user-infra)
6. [Creating the worker nodes in AWS](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing_aws/installing-aws-user-infra.html#installation-creating-aws-worker_installing-aws-user-infra)
- Installing a cluster on AWS in a restricted network with user-provisioned infrastructure
1. [Supported AWS Machine types](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing_aws/installing-restricted-networks-aws.html#installation-supported-aws-machine-types_installing-restricted-networks-aws)
2. [Accessing RHCOS AMIs with stream metadata](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing_aws/installing-restricted-networks-aws.html#installation-aws-ami-stream-metadata_installing-restricted-networks-aws)
3. [Creating the bootstrap node in AWS](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing_aws/installing-restricted-networks-aws.html#installation-creating-aws-bootstrap_installing-restricted-networks-aws)
4. [Creating the control plane machines in AWS](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing_aws/installing-restricted-networks-aws.html#installation-creating-aws-control-plane_installing-restricted-networks-aws)
5. [Creating the worker nodes in AWS](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3326-arm-aws-updates-4.11/installing/installing_aws/installing-restricted-networks-aws.html#installation-creating-aws-worker_installing-restricted-networks-aws)