### PR TITLE
[WIP] Adapt serverless docs for the new KafkaChannel implementation

### DIFF
--- a/modules/serverless-install-kafka-odc.adoc
+++ b/modules/serverless-install-kafka-odc.adoc
@@ -104,9 +104,13 @@ $ oc get pods -n knative-eventing
 .Example output
 [source,terminal]
 ----
-NAME                                            READY   STATUS    RESTARTS   AGE
-kafka-ch-controller-85f879d577-xcbjh            1/1     Running   0          44s
-kafka-ch-dispatcher-55d76d7db8-ggqjl            1/1     Running   0          44s
-kafka-controller-manager-bc994c465-pt7qd        1/1     Running   0          40s
-kafka-webhook-54646f474f-wr7bb                  1/1     Running   0          42s
+NAME                                        READY   STATUS    RESTARTS   AGE
+kafka-broker-dispatcher-7769fbbcbb-xgffn    1/1     Running   0          44s
+kafka-broker-receiver-5fb56f7656-fhq8d      1/1     Running   0          44s
+kafka-channel-dispatcher-84fd6cb7f9-k2tjv   1/1     Running   0          44s
+kafka-channel-receiver-9b7f795d5-c76xr      1/1     Running   0          44s
+kafka-controller-6f95659bf6-trd6r           1/1     Running   0          44s
+kafka-source-dispatcher-6bf98bdfff-8bcsn    1/1     Running   0          44s
+kafka-webhook-eventing-68dc95d54b-825xs     1/1     Running   0          44s
+
 ----

--- a/modules/serverless-kafka-sasl-public-certs.adoc
+++ b/modules/serverless-kafka-sasl-public-certs.adoc
@@ -11,8 +11,9 @@ If you want to use SASL with public CA certificates, you must use the `tls.enabl
 [source,terminal]
 ----
 $ oc create secret --namespace <namespace> generic <kafka_auth_secret> \
+  --from-literal=protocol="SASL_PLAINTEXT" \
   --from-literal=tls.enabled=true \
   --from-literal=password="SecretPassword" \
-  --from-literal=saslType="SCRAM-SHA-512" \
+  --from-literal=sasl.mechanism="SCRAM-SHA-512" \
   --from-literal=user="my-sasl-user"
 ----

--- a/modules/serverless-kafka-sasl.adoc
+++ b/modules/serverless-kafka-sasl.adoc
@@ -27,15 +27,21 @@ Red Hat recommends to enable TLS in addition to SASL.
 [source,terminal]
 ----
 $ oc create secret --namespace <namespace> generic <kafka_auth_secret> \
+  --from-literal=protocol="SASL_SASL" \
   --from-file=ca.crt=caroot.pem \
   --from-literal=password="SecretPassword" \
-  --from-literal=saslType="SCRAM-SHA-512" \
+  --from-literal=sasl.mechanism="SCRAM-SHA-512" \
   --from-literal=user="my-sasl-user"
 ----
 +
 [IMPORTANT]
 ====
-Use the key names `ca.crt`, `password`, and `saslType`. Do not change them.
+Use the key names `protocol`, `ca.crt`, `password`, and `sasl.mechanism`. Do not change them.
+====
+
+[NOTE]
+====
+If TLS is not required, do not specify the `ca.crt` key and change the `protocol` to `SASL_PLAINTEXT`.
 ====
 
 . Start editing the `KnativeKafka` custom resource:

--- a/modules/serverless-kafka-tls.adoc
+++ b/modules/serverless-kafka-tls.adoc
@@ -21,6 +21,7 @@ You can use the following procedure to configure TLS authentication for a Kafka 
 [source,terminal]
 ----
 $ oc create secret -n <namespace> generic <kafka_auth_secret> \
+  --from-literal=protocol="SSL" \
   --from-file=ca.crt=caroot.pem \
   --from-file=user.crt=certificate.pem \
   --from-file=user.key=key.pem

--- a/serverless/admin_guide/serverless-kafka-admin.adoc
+++ b/serverless/admin_guide/serverless-kafka-admin.adoc
@@ -26,7 +26,7 @@ endif::[]
 The `KnativeKafka` CR provides users with additional options, such as:
 
 * Kafka source
-* Kafka channel
+* Kafka channel (Technology Preview)
 * Kafka broker (Technology Preview)
 * Kafka sink (Technology Preview)
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to.
If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
  - The preview will be generated after you open the PR.
  - You will need to edit the comment to add the link after the preview builds.
  - Review the preview build to make sure your changes are rendering properly. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
- Change serverless docs for the new KafkaChannel implementation

- Basically we have these differences:
   - Dataplane looks different (docs updated in this PR)
   - Secrets need to be set differently (docs updated in this PR)

What's not mentioned in this PR and we need to mention:
- Why we have a new KafkaChannel implementation (optional content)
- Serverless operator is providing an automated migration from the old configmap format to new configmap format.
- For the required new keys in the secret (`protocol` and `sasl.mechanism`), we are falling back to the old configmap and secret format and infer the values for these keys. However, this fallback code and inferring will be removed in the future. Thus, after the upgrade, our users should update their secrets to have these 2 keys.

Related upstream docs: https://github.com/knative-sandbox/eventing-kafka-broker/blob/main/docs/channel/README.md

Upstream docs talk a lot about installation and migration. That's not relevant to downstream as the serverless operator takes care of those.

What could be relevant though:
- [Dataplane configuration](https://github.com/knative-sandbox/eventing-kafka-broker/blob/main/docs/channel/README.md#configuring-dataplane): we currently don't have any docs around configuring the dataplane for the old/existing KafkaChannel
- [Discontinued features](https://github.com/knative-sandbox/eventing-kafka-broker/blob/main/docs/channel/README.md#discontinued-features): Was never documented downstream anyway



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
