### PR TITLE
BZ#2093929:Issue in MTC installation documentation

### DIFF
--- a/modules/migration-installing-legacy-operator.adoc
+++ b/modules/migration-installing-legacy-operator.adoc
@@ -146,7 +146,7 @@ rolebindings.rbac.authorization.k8s.io "system:image-builders" already exists <1
 Error from server (AlreadyExists): error when creating "./operator.yml":
 rolebindings.rbac.authorization.k8s.io "system:image-pullers" already exists
 ----
-<1> You can ignore `Error from server (AlreadyExists)` messages. They are caused by the {mtc-full} Operator creating resources for earlier versions of {product-title} 3 that are provided in later releases.
+<1> You can ignore `Error from server (AlreadyExists)` messages. They are caused by the {mtc-full} Operator creating resources for earlier versions of {product-title} 4 that are provided in later releases.
 
 . Create the `MigrationController` object:
 +


### PR DESCRIPTION
MTC 1.7.0+, OCP 4.6+
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2093929

Changes callout 1 of the Example output after step 6 of "Installing the legacy Migration Toolkit for Containers Operator on OpenShift Container Platform 4.2 to 4.5" to refer to OCP 4, not 3.

Preview:
![step 6](https://user-images.githubusercontent.com/60698649/172410499-93c094f7-2373-4408-b544-5c592a4f4444.png)
 