### PR TITLE
BZ#2093925: Edit text of upgrading MTC procedure

### DIFF
--- a/modules/migration-upgrading-mtc-on-ocp-4.adoc
+++ b/modules/migration-upgrading-mtc-on-ocp-4.adoc
@@ -24,6 +24,4 @@ Operators that have a pending upgrade display an *Upgrade available* status.
 . Click *1 requires approval*, then click *Preview Install Plan*.
 . Review the resources that are listed as available for upgrade and click *Approve*.
 . Navigate back to the *Operators -> Installed Operators* page to monitor the progress of the upgrade. When complete, the status changes to *Succeeded* and *Up to date*.
-. Click *{mtc-full} Operator*.
-. Under *Provided APIs*, locate the *Migration Controller* tile, and click *Create Instance*.
 . Click *Workloads* -> *Pods* to verify that the {mtc-short} pods are running.


### PR DESCRIPTION
MTC 1.7.1, OCP 4.6+

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2093925

Removes Steps 7 and 8 in https://docs.openshift.com/container-platform/4.9//migration_toolkit_for_containers/upgrading-mtc.html#migration-upgrading-mtc-on-ocp-4_upgrading-mtc 

Preview: 
![Upgrading MTC](https://user-images.githubusercontent.com/60698649/172429224-d171062a-8797-4e8b-8f3b-1d08e4cad64d.png)

