### PR TITLE
TELCODOCS626 - replacing instances of PAO in install instructions

### DIFF
--- a/installing/installing_openstack/installing-openstack-installer-ovs-dpdk.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-ovs-dpdk.adoc
@@ -63,20 +63,20 @@ The cluster is installed and prepared for configuration. You must now perform th
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
 .Additional resources
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+[role="_additional-resources"]
 [id="additional-resources_installing-openstack-installer-ovs-dpdk"]
 == Additional resources
-* See xref:../../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#cnf-understanding-low-latency_cnf-master[Performance Addon Operator for low latency nodes] for information about configuring your deployment for real-time running and low latency.
+* xref:../../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#cnf-understanding-low-latency_cnf-master[Low latency tuning of OpenShift Container Platform nodes]
 
 [id="next-steps_installing-openstack-installer-ovs-dpdk"]
 == Next steps
 
-* To complete OVS-DPDK configuration for your cluster:
-** xref:../../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#installing-the-performance-addon-operator_cnf-master[Install the Performance Addon Operator].
-** xref:../../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#what-huge-pages-do_huge-pages[Configure the Performance Addon Operator with huge pages support].
+* To complete OVS-DPDK configuration for your cluster, xref:../../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#what-huge-pages-do_huge-pages[Configure huge pages support].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_openstack/installing-openstack-installer-sr-iov.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-sr-iov.adoc
@@ -59,11 +59,11 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+[id="next-steps_installing-openstack-installer-sr-iov"]
 == Next steps
 
 * To complete SR-IOV configuration for your cluster:
-** xref:../../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#installing-the-performance-addon-operator_cnf-master[Install the Performance Addon Operator].
-** xref:../../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#what-huge-pages-do_huge-pages[Configure the Performance Addon Operator with huge pages support].
+** xref:../../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#what-huge-pages-do_huge-pages[Configure huge pages support].
 ** xref:../../networking/hardware_networks/installing-sriov-operator.adoc#installing-sr-iov-operator_installing-sriov-operator[Install the SR-IOV Operator].
 ** xref:../../networking/hardware_networks/configuring-sriov-device.adoc#nw-sriov-networknodepolicy-object_configuring-sriov-device[Configure your SR-IOV network device].
 ** xref:../../machine_management/creating_machinesets/creating-machineset-osp.adoc#machineset-yaml-osp-sr-iov_creating-machineset-osp[Add an SR-IOV compute machine set].

--- a/installing/installing_openstack/installing-openstack-user-sr-iov.adoc
+++ b/installing/installing_openstack/installing-openstack-user-sr-iov.adoc
@@ -76,19 +76,21 @@ The cluster is installed and prepared for SR-IOV configuration. You must now per
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_cluster-telemetry"]
 .Additional resources
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
 [role="_additional-resources"]
+[id="additional-resources_installing-openstack-user-sr-iov"]
 == Additional resources
-* See xref:../../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#cnf-understanding-low-latency_cnf-master[Performance Addon Operator for low latency nodes] for information about configuring your deployment for real-time running and low latency.
+* xref:../../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#cnf-understanding-low-latency_cnf-master[Low latency tuning of OpenShift Container Platform nodes]
 
+[id="next-steps_installing-user-sr-iov"]
 == Next steps
 
 * To complete SR-IOV configuration for your cluster:
-** xref:../../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#installing-the-performance-addon-operator_cnf-master[Install the Performance Addon Operator].
-** xref:../../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.html#what-huge-pages-do_huge-pages[Configure the Performance Addon Operator with huge pages support].
+** xref:../../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.html#what-huge-pages-do_huge-pages[Configure huge pages support].
 ** xref:../../networking/hardware_networks/installing-sriov-operator.html#installing-sr-iov-operator_installing-sriov-operator[Install the SR-IOV Operator].
 ** xref:../../networking/hardware_networks/configuring-sriov-device.html#nw-sriov-networknodepolicy-object_configuring-sriov-device[Configure your SR-IOV network device].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].


### PR DESCRIPTION
JIRA - [TELCODOCS-626](https://issues.redhat.com//browse/TELCODOCS-626): Update install docs to change references to Performance Addon Operator. This functionality is being subsumed into the Node Tuning Operator. 

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/TELCODOCS-626

Link to docs preview:
- http://file.emea.redhat.com/rohennes/telcodocs-626/installing/installing_openstack/installing-openstack-installer-sr-iov.html#next-steps
- http://file.emea.redhat.com/rohennes/telcodocs-626/installing/installing_openstack/installing-openstack-installer-ovs-dpdk.html#additional-resources_installing-openstack-installer-ovs-dpdk
- http://file.emea.redhat.com/rohennes/telcodocs-626/installing/installing_openstack/installing-openstack-user-sr-iov.html#additional-resources

Additional information:
For release with 4.11