### PR TITLE
Adds a release note for implement internal traffic support for OVN K

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -131,6 +131,13 @@ When working in a highly regulated environment, you might need the ability to se
 
 For more information, see xref:../networking/dns-operator.adoc#nw-dns-forward_dns-operator[Using DNS forwarding].
 
+[id="ocp-4-11-ovn-internal-traffic-policy-support"]
+==== Internal traffic support for OVN-Kubernetes
+
+As a cluster administrator, you can configure `internalTrafficPolicy=Local` on a Kubernetes service object when using the OVN-Kubernetes Container Network Interface (CNI) cluster network provider. This feature allows cluster administrators to route traffic to an endpoint on the same node that the traffic originated from. If there are no local node endpoints, traffic will be dropped.
+
+For more information, see link:https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy[Service Internal Traffic Policy].
+
 [id="ocp-4-11-hardware"]
 === Hardware
 


### PR DESCRIPTION
Adds a release note for implement internal traffic support for OVN K

Version(s): 4.11

Issue: https://issues.redhat.com/browse/SDN-2568 release note

Link to docs preview: https://stevsmit.github.io/openshift-docs/OSDOCS-3497-RN/release_notes/ocp-4-11-release-notes.html#ocp-4-11-ovn-internal-traffic-policy-support


Additional information:
