### PR TITLE
OSDOCS-3327: ARM doc updates to metal IPI

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -125,7 +125,7 @@ Not all installation options are supported for all platforms, as shown in the fo
 //This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
 |===
-||Alibaba |AWS (x86_64) |AWS (arm64) |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Power
+||Alibaba |AWS (x86_64) |AWS (arm64) |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Power
 
 |Default
 |xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[X]
@@ -137,6 +137,7 @@ ifndef::openshift-origin[]
 |
 |
 |xref:../installing/installing_rhv/installing-rhv-default.adoc#installing-rhv-default[X]
+|xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[X]
 |xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[X]
 |xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc#installing-vsphere-installer-provisioned[X]
 |xref:../installing/installing_vmc/installing-vmc.adoc#installing-vmc[X]
@@ -155,6 +156,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_openstack/installing-openstack-installer-sr-iov.adoc#installing-openstack-installer-sr-iov[X]
 |xref:../installing/installing_rhv/installing-rhv-customizations.adoc#installing-rhv-customizations[X]
 |
+|
 |xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installing-vsphere-installer-provisioned-customizations[X]
 |xref:../installing/installing_vmc/installing-vmc-customizations.adoc#installing-vmc-customizations[X]
 |xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[X]
@@ -169,6 +171,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc#installing-azure-stack-hub-network-customizations[X]
 |xref:../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[X]
 |xref:../installing/installing_openstack/installing-openstack-installer-kuryr.adoc#installing-openstack-installer-kuryr[X]
+|
 |
 |
 |
@@ -189,6 +192,7 @@ ifndef::openshift-origin[]
 |
 |xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[X]
 |
+|
 |xref:../installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[X]
 |xref:../installing/installing_vmc/installing-restricted-networks-vmc.adoc#installing-restricted-networks-vmc[X]
 |
@@ -202,6 +206,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[X]
 |
 |xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[X]
+|
 |
 |
 |
@@ -228,12 +233,14 @@ ifndef::openshift-origin[]
 |
 |
 |
+|
 
 |Government regions
 |
 |xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[X]
 |
 |xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[X]
+|
 |
 |
 |
@@ -262,10 +269,12 @@ ifndef::openshift-origin[]
 |
 |
 |
+|
 
 |China regions
 |
 |xref:../installing/installing_aws/installing-aws-china.adoc#installing-aws-china-region[X]
+|
 |
 |
 |

--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -143,6 +143,10 @@ a|`provisioningNetworkCIDR`
 | `provisioning`
 | The name of the `provisioning` bridge on the `provisioner` host attached to the `provisioning` network.
 
+|`architecture`
+|
+|Defines the host architecture for your cluster. Valid values are `amd64` or `arm64`.
+
 | `defaultMachinePlatform`
 |
 | The default configuration used for machine pools without a platform configuration.

--- a/modules/ipi-install-bmc-addressing.adoc
+++ b/modules/ipi-install-bmc-addressing.adoc
@@ -64,3 +64,62 @@ platform:
           password: <password>
           disableCertificateVerification: True
 ----
+[discrete]
+== Redfish APIs
+
+Several redfish API endpoints are called onto your BCM when using the bare-metal installer-provisioned infrastructure.
+
+[IMPORTANT]
+====
+You need to ensure that your BMC supports all of the redfish APIs before installation.
+====
+
+List of redfish APIs::
+* Power on
++
+[source, terminal]
+----
+curl -u $USER:$PASS -X POST -H'Content-Type: application/json' -H'Accept: application/json' -d '{"Action": "Reset", "ResetType": "On"}' https://$SERVER/redfish/v1/Systems/$SystemID/Actions/ComputerSystem.Reset
+----
+* Power off
++
+[source, terminal]
+----
+curl -u $USER:$PASS -X POST -H'Content-Type: application/json' -H'Accept: application/json' -d '{"Action": "Reset", "ResetType": "ForceOff"}' https://$SERVER/redfish/v1/Systems/$SystemID/Actions/ComputerSystem.Reset
+----
+* Temporary boot using `pxe` 
++
+[source, terminal]
+----
+curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json"  https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideTarget": "pxe", "BootSourceOverrideEnabled": "Once"}}
+----
+* Set BIOS boot mode using `Legacy` or `UEFI`
++
+[source, terminal]
+----
+curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json"  https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideMode":"UEFI"}}
+----
+
+List of redfish-virtualmedia APIs::
+* Set temporary boot device using `cd` or `dvd`
++
+[source, terminal]
+----
+curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json" https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideTarget": "cd", "BootSourceOverrideEnabled": "Once"}}'
+----
+* Mount virtual media
++
+[source, terminal]
+----
+curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json" -H "If-Match: *" https://$Server/redfish/v1/Managers/$ManagerID/VirtualMedia/$VmediaId -d '{"Image": "https://example.com/test.iso", "TransferProtocolType": "HTTPS", "UserName": "", "Password":""}'
+----
+
+[NOTE]
+====
+The `PowerOn` and `PowerOff` commands for redfish APIs are the same for the redfish-virtualmedia APIs.
+====
+
+[IMPORTANT]
+====
+`HTTPS` and `HTTP` are the only supported parameter types for `TransferProtocolTypes`.
+====

--- a/modules/ipi-install-mirroring-for-disconnected-registry.adoc
+++ b/modules/ipi-install-mirroring-for-disconnected-registry.adoc
@@ -208,20 +208,20 @@ mirrored, extract it and pin it to the release:
 +
 [source,terminal]
 ----
-$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}"
+$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-baremetal-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}"
 ----
 ** If the local container registry is connected to the mirror host, run the following command:
 +
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}"
+$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-baremetal-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}"
 ----
 endif::[]
 ifndef::openshift-origin[]
 [source,terminal]
 ----
-$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}"
+$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-baremetal-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}"
 ----
 endif::[]
 +
@@ -240,5 +240,5 @@ If you are in a disconnected environment, use the `--image` flag as part of must
 +
 [source,terminal]
 ----
-$ openshift-install
+$ openshift-baremetal-install
 ----

--- a/modules/ipi-install-node-requirements.adoc
+++ b/modules/ipi-install-node-requirements.adoc
@@ -8,8 +8,11 @@
 
 Installer-provisioned installation involves a number of hardware node requirements:
 
-* *CPU architecture:* All nodes must use `x86_64` CPU architecture.
-
+* *CPU architecture:* All nodes must use `x86_64` 
+ifndef::openshift-origin[]
+or `arm64` 
+endif::openshift-origin[]
+CPU architecture.
 * *Similar nodes:* Red Hat recommends nodes have an identical configuration per role. That is, Red Hat recommends nodes be the same brand and model with the same CPU, memory, and storage configuration.
 
 * *Baseboard Management Controller:* The `provisioner` node must be able to access the baseboard management controller (BMC) of each {product-title} cluster node. You may use IPMI, Redfish, or a proprietary protocol.

--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -55,7 +55,7 @@ ifndef::openshift-origin[]
 [source,terminal]
 ----
 $ sudo subscription-manager register --username=<user> --password=<pass> --auto-attach
-$ sudo subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms --enable=rhel-8-for-x86_64-baseos-rpms
+$ sudo subscription-manager repos --enable=rhel-8-for-<architecture>-appstream-rpms --enable=rhel-8-for-<architecture>-baseos-rpms
 ----
 +
 [NOTE]

--- a/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
+++ b/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
@@ -40,7 +40,7 @@ oc edit provisioning
     provisioningInterface: enp1s0
     provisioningNetwork: Managed
     provisioningNetworkCIDR: 172.22.0.0/24
-    provisioningOSDownloadURL: http://192.168.111.1/images/rhcos-<version>.x86_64.qcow2.gz?sha256=<sha256>
+    provisioningOSDownloadURL: http://192.168.111.1/images/rhcos-<version>.<architecture>.qcow2.gz?sha256=<sha256>
     virtualMediaViaExternalNetwork: true <1>
   status:
     generations:
@@ -105,8 +105,8 @@ oc edit machineset
             apiVersion: baremetal.cluster.k8s.io/v1alpha1
             hostSelector: {}
             image:
-              checksum: http:/172.22.0.3:6181/images/rhcos-<version>.x86_64.qcow2.<md5sum> <1>
-              url: http://172.22.0.3:6181/images/rhcos-<version>.x86_64.qcow2 <2>
+              checksum: http:/172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2.<md5sum> <1>
+              url: http://172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2 <2>
             kind: BareMetalMachineProviderSpec
             metadata:
               creationTimestamp: null

--- a/modules/ipi-install-retrieving-the-openshift-installer.adoc
+++ b/modules/ipi-install-retrieving-the-openshift-installer.adoc
@@ -6,11 +6,17 @@
 [id="retrieving-the-openshift-installer_{context}"]
 = Retrieving the {product-title} installer
 
-Use the `stable-4.x` version of the installer to deploy the generally
-available stable version of {product-title}:
+Use the `stable-4.x` version of the installation program and your selected architecture to deploy the generally available stable version of {product-title}:
 
-[source,terminal,subs="attributes"]
+[source,terminal,subs="attributes+"]
 ----
 $ export VERSION=stable-{product-version}
-export RELEASE_IMAGE=$(curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/release.txt | grep 'Pull From: quay.io' | awk -F ' ' '{print $3}')
+----
+[source,terminal,subs="attributes+"]
+----
+$ export RELEASE_ARCH=<architecture>
+----
+[source,terminal,subs="attributes+"]
+----
+$ export RELEASE_IMAGE=$(curl -s https://mirror.openshift.com/pub/openshift-v4/$RELEASE_ARCH/clients/ocp/$VERSION/release.txt | grep 'Pull From: quay.io' | awk -F ' ' '{print $3}')
 ----

--- a/modules/ipi-install-troubleshooting-bootstrap-vm-inspecting-logs.adoc
+++ b/modules/ipi-install-troubleshooting-bootstrap-vm-inspecting-logs.adoc
@@ -10,8 +10,8 @@ When experiencing issues downloading or accessing the {op-system} images, first 
 .Example of internal webserver hosting {op-system} images
 [source,yaml]
 ----
-bootstrapOSImage: http://<ip:port>/rhcos-43.81.202001142154.0-qemu.x86_64.qcow2.gz?sha256=9d999f55ff1d44f7ed7c106508e5deecd04dc3c06095d34d36bf1cd127837e0c
-clusterOSImage: http://<ip:port>/rhcos-43.81.202001142154.0-openstack.x86_64.qcow2.gz?sha256=a1bda656fa0892f7b936fdc6b6a6086bddaed5dafacedcd7a1e811abb78fe3b0
+bootstrapOSImage: http://<ip:port>/rhcos-43.81.202001142154.0-qemu.<architecture>.qcow2.gz?sha256=9d999f55ff1d44f7ed7c106508e5deecd04dc3c06095d34d36bf1cd127837e0c
+clusterOSImage: http://<ip:port>/rhcos-43.81.202001142154.0-openstack.<architecture>.qcow2.gz?sha256=a1bda656fa0892f7b936fdc6b6a6086bddaed5dafacedcd7a1e811abb78fe3b0
 ----
 
 The `ipa-downloader` and `coreos-downloader` containers download resources from a webserver or the external link:https://quay.io[quay.io] registry, whichever the `install-config.yaml` configuration file specifies. Verify the following two containers are up and running and inspect their logs as needed:

--- a/modules/ipi-install-troubleshooting-install-config.adoc
+++ b/modules/ipi-install-troubleshooting-install-config.adoc
@@ -16,7 +16,7 @@ The `install-config.yaml` configuration file represents all of the nodes that ar
 +
 [source,terminal]
 ----
-$ curl -s -o /dev/null -I -w "%{http_code}\n" http://webserver.example.com:8080/rhcos-44.81.202004250133-0-qemu.x86_64.qcow2.gz?sha256=7d884b46ee54fe87bbc3893bf2aa99af3b2d31f2e19ab5529c60636fbd0f1ce7
+$ curl -s -o /dev/null -I -w "%{http_code}\n" http://webserver.example.com:8080/rhcos-44.81.202004250133-0-qemu.<architecture>.qcow2.gz?sha256=7d884b46ee54fe87bbc3893bf2aa99af3b2d31f2e19ab5529c60636fbd0f1ce7
 ----
 +
 If the output is `200`, there is a valid response from the webserver storing the bootstrap VM image.


### PR DESCRIPTION
**For versions:** 4.11+
**Jira story**: [OSDOCS-3327](https://issues.redhat.com//browse/OSDOCS-3327)

**Description:** Doc updates for Metal IPI install on arm

**Previews:**

- [Selecting a cluster installation method and preparing it for users](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3327-arm-metal-ipi-docs-4.11/installing/installing-preparing.html#supported-installation-methods-for-different-platforms)
- [Prerequisites -> Node requirements](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3327-arm-metal-ipi-docs-4.11/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#node-requirements_ipi-install-prerequisites)
- [Retrieving the OpenShift container Platform installer](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3327-arm-metal-ipi-docs-4.11/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#retrieving-the-openshift-installer_ipi-install-installation-workflow)
- [Additional `install-config` parameters](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3327-arm-metal-ipi-docs-4.11/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#additional-install-config-parameters_ipi-install-installation-workflow)
- [BMC addressing -> Redfish APIs](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3327-arm-metal-ipi-docs-4.11/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#bmc-addressing_ipi-install-installation-workflow)
- [Mirroring the OpenShift container platform image repository for a disconnected registry](https://kelbrown20.github.io/OCP-on-arm-doc-previews-4.11/OSDOCS-3327-arm-metal-ipi-docs-4.11/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-mirroring-for-disconnected-registry_ipi-install-installation-workflow)