### PR TITLE
OSDOCS-3575: Windows Server 2022 support in WINC 5.1.0 Take 2

### DIFF
--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -19,7 +19,7 @@ You must use link:https://docs.microsoft.com/en-us/powershell/scripting/install/
 
 .Procedure
 
-. Create a new VM in the vSphere client using the Windows Server Semi-Annual Channel (SAC): Windows Server 20H2 ISO image that includes the link:https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351[Microsoft patch KB4565351]. This patch is required to set the VXLAN UDP port, which is required for clusters installed on vSphere. See the link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.hostclient.doc/GUID-77AB6625-F968-4983-A230-A020C0A70326.html[VMware documentation] for more information.
+. Create a new VM in the vSphere client using the Windows Server 2022 image that includes the link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[Microsoft patch KB5012637].
 +
 [IMPORTANT]
 ====

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -7,10 +7,10 @@
 
 The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator. See the vSphere documentation for any information that is relevant to only that platform.
 
-[id="wmco-prerequisites-supported-5.0.0_{context}"]
-== WMCO 5.0.0 supported platforms and Windows Server versions
+[id="wmco-prerequisites-supported-5.1.0_{context}"]
+== WMCO 5.1.0 supported platforms and Windows Server versions
 
-The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 5.0.0, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
+The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 5.1.0, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
 
 [cols="3,7",options="header"]
 |===
@@ -18,16 +18,41 @@ The following table lists the link:https://docs.microsoft.com/en-us/windows/rele
 |Supported Windows Server version
 
 |Amazon Web Services (AWS)
-|Windows Server 2019
+|Windows Server 2019 (version 1809)
 
 |Microsoft Azure
-|Windows Server 2019
+|Windows Server 2019 (version 1809)
+
+|VMware vSphere
+a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.
+* Windows Server 20H2 
+
+|Bare metal or provider agnostic
+a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.
+* Windows Server 2019 (version 1809)
+|===
+
+[id="wmco-prerequisites-supported-5.0.0_{context}"]
+== WMCO 5.0.0 supported platforms and Windows Server versions
+
+The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 5.0.0, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only the appropriate version for your platform.
+
+[cols="3,7",options="header"]
+|===
+|Platform
+|Supported Windows Server version
+
+|Amazon Web Services (AWS)
+|Windows Server 2019 (version 1809)
+
+|Microsoft Azure
+|Windows Server 2019 (version 1809)
 
 |VMware vSphere
 |Windows Server 20H2 
 
 |Bare metal or provider agnostic
-|Windows Server 2019
+|Windows Server 2019 (version 1809)  
 |===
 
 == Supported networking
@@ -53,15 +78,29 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Hybrid networking with OVN-Kubernetes
 |===
 
-.Hybrid OVN-Kubernetes Windows Server support
+.WMCO 5.1.0 Hybrid OVN-Kubernetes Windows Server support
 [cols="2",options="header"]
 |===
 |Hybrid networking with OVN-Kubernetes
 |Supported Windows Server version
 
 |Default VXLAN port
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+|Windows Server 2019 (version 1809)
 
 |Custom VXLAN port
-|Windows Server Semi-Annual Channel (SAC): Windows Server 20H2
+a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.
+* Windows Server 20H2 
+|===
+
+.WMCO 5.0.0 Hybrid OVN-Kubernetes Windows Server support
+[cols="2",options="header"]
+|===
+|Hybrid networking with OVN-Kubernetes
+|Supported Windows Server version
+
+|Default VXLAN port
+|Windows Server 2019 (version 1809)
+
+|Custom VXLAN port
+|Windows Server 20H2 
 |===


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3575
For 5.1.0:
2022 support for vSphere, and 20H2 still supported
no changes to other platforms

Preview:
WINC prereqs: 
[Supported Windows Server version](http://file.rdu.redhat.com/~mburke/winc-release-notes-tables-5.0-2/windows_containers/windows-containers-release-notes-5-x.html#wmco-prerequisites-supported-5.1.0_windows-containers-release-notes)
[Supported networking](http://file.rdu.redhat.com/~mburke/winc-release-notes-tables-5.0-2/windows_containers/windows-containers-release-notes-5-x.html#supported-networking)
[Creating the vSphere Windows VM golden image](http://file.rdu.redhat.com/~mburke/winc-release-notes-tables-5.0-2/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html#creating-the-vsphere-windows-vm-golden-image_creating-windows-machineset-vsphere). Updated Step 1)

See https://github.com/openshift/openshift-docs/pull/45238 for conversations and reviews