### PR TITLE
ECOPROJECT-53: Adding limits to some SNR/PP config parameters 

### DIFF
--- a/modules/eco-poison-pill-operator-about.adoc
+++ b/modules/eco-poison-pill-operator-about.adoc
@@ -28,7 +28,7 @@ metadata:
   namespace: openshift-operators
 spec:
   safeTimeToAssumeNodeRebootedSeconds: 180 <1>
-  watchdogFilePath: /test/watchdog1 <2>
+  watchdogFilePath: /dev/watchdog <2>
   isSoftwareRebootEnabled: true <3>
   apiServerTimeout: 15s <4>
   apiCheckInterval: 5s <5>
@@ -44,13 +44,13 @@ spec:
 +
 If a watchdog device is unavailable, the `PoisonPillConfig` CR uses a software reboot.
 <3> Specify if you want to enable software reboot of the unhealthy nodes. By default, the value of `isSoftwareRebootEnabled` is set to `true`. To disable the software reboot, set the parameter value to `false`.
-<4> Specify the timeout duration to check connectivity with each API server. When this duration elapses, the Operator starts remediation.
-<5> Specify the frequency to check connectivity with each API server.
-<6> Specify a threshold value. After reaching this threshold, the node starts contacting its peers.
-<7> Specify the timeout duration for the peer to connect the API server.
-<8> Specify the timeout duration for establishing connection with the peer.
-<9> Specify the timeout duration to get a response from the peer.
-<10> Specify the frequency to update peer information, such as IP address.
+<4> Specify the timeout duration to check connectivity with each API server. When this duration elapses, the Operator starts remediation. The timeout duration must be more than or equal to 10ms.
+<5> Specify the frequency to check connectivity with each API server. The timeout duration must be more than or equal to 1 second.
+<6> Specify a threshold value. After reaching this threshold, the node starts contacting its peers. The threshold value must be more than or equal to 1 second.
+<7> Specify the duration of the timeout for the peer to connect the API server. The timeout duration must be more than or equal to 10 milliseconds.
+<8> Specify the duration of the timeout for establishing connection with the peer. The timeout duration must be more than or equal to 10 milliseconds.
+<9> Specify the duration of the timeout to get a response from the peer. The timeout duration must be more than or equal to 10 milliseconds.
+<10> Specify the frequency to update peer information, such as IP address. The timeout duration must be more than or equal to 10 seconds.
 
 [id="understanding-poison-pill-remediation-template-config_{context}"]
 == Understanding the Poison Pill Remediation Template configuration


### PR DESCRIPTION
[TELCODOCS-497](https://issues.redhat.com//browse/TELCODOCS-497): This PR documents limits for the a couple of poison-pill/self-node-remediation config parameters.

Version(s): OpenShift 4.11+ (main, enterprise-4.11, and later)
<!--- Specify the version or versions of OpenShift your PR applies to.
If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Issue: https://issues.redhat.com/browse/TELCODOCS-497
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.emea.redhat.com/avbhatt/td-497/nodes/nodes/eco-poison-pill-operator.html#understanding-poison-pill-operator-config_poison-pill-operator-remediate-nodes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
  - The preview will be generated after you open the PR.
  - You will need to edit the comment to add the link after the preview builds.
  - Review the preview build to make sure your changes are rendering properly. --->


