### PR TITLE
[OSDOCS-3608]: Relnotes for Enhancement to scale-up operations for etcd clusters

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -186,8 +186,12 @@ For more information, see xref:../nodes/scheduling/nodes-descheduler.adoc#nodes-
 [id="ocp-4-11-scalability-and-performance"]
 === Scalability and performance
 
+[id=ocp-4-11-enhance-scaleup-operations-etcd-clusters]
+==== Enhancement to scale-up operations for etcd clusters
+The Raft algorithm allows for scaling of etcd members using a new `learner` state. As a result, maintaining cluster quorum, adding and removing new members, and promoting `learners` occur without disrupting the cluster operation.
+
 [id=ocp-4-11-ne-livenessProbe-readinessProbe-startupProbe-timeout-configuration]
-/This is a 4.11 Network Edge feature that is located in the Scalability and Performance area of the docs, requested to be placed here by Miciah Masters -Sara T./
+// This is a 4.11 Network Edge feature that is located in the Scalability and Performance area of the docs, requested to be placed here by Miciah Masters -Sara T.
 ==== Configuring Ingress Controller (router) Liveness, Readiness, and Startup probes
 {product-title} 4.11 introduces the ability to configure the timeout values for the kubelet’s liveness, readiness, and startup probes for router deployments that are managed by the OpenShift Container Platform ingress operator. The ability to set larger timeout values can reduce the risk of unnecessary and unwanted restarts that are caused by short default timeout of 1 second.
 


### PR DESCRIPTION
Version(s): 4.11
 - Engineering epic - [ETCD-235](https://issues.redhat.com/browse/ETCD-235)
 - Docs JIRA - [OSDOCS-3608](https://issues.redhat.com/browse/OSDOCS-3608)
 - Relnotes JIRA: [[OSDOCS-3720](https://issues.redhat.com/browse/OSDOCS-3720)]
Link to docs preview:
http://file.rdu.redhat.com/tlove/etcd-relnote-osdocs-3608-new/release_notes/ocp-4-11-release-notes.html#ocp-4-11-enhance-scaleup-operations-etcd-clusters

Urgency: Medium





 

