### PR TITLE
GH#41565: updating the OSDK make bundle procedure

### DIFF
--- a/modules/osdk-bundle-operator.adoc
+++ b/modules/osdk-bundle-operator.adoc
@@ -45,21 +45,11 @@ $ make docker-build IMG=<registry>/<user>/<operator_image_name>:<tag>
 $ make docker-push IMG=<registry>/<user>/<operator_image_name>:<tag>
 ----
 
-. Update your `Makefile` by setting the `IMG` URL to your Operator image name and tag that you pushed:
-+
-[source,terminal]
-----
-$ # Image URL to use all building/pushing image targets
-IMG ?= <registry>/<user>/<operator_image_name>:<tag>
-----
-+
-This value is used for subsequent operations.
-
 . Create your Operator bundle manifest by running the `make bundle` command, which invokes several commands, including the Operator SDK `generate bundle` and `bundle validate` subcommands:
 +
 [source,terminal]
 ----
-$ make bundle
+$ make bundle IMG=<registry>/<user>/<operator_image_name>:<tag>
 ----
 +
 Bundle manifests for an Operator describe how to display, create, and manage an application. The `make bundle` command creates the following files and directories in your Operator project:


### PR DESCRIPTION
Version(s):
4.7+

Issue:
Fixes #41565

Link to docs preview (VPN required):
[Bundling an Operator](http://file.rdu.redhat.com/antaylor/06-08-22/issue41565/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-bundle-deploy-olm_osdk-golang-tutorial)

Additional information:
As the documentation is currently written, users must modify the makefile, when in fact the `IMG=` string can be added to the `make bundle` step with the same result. 
