### PR TITLE
GH#42468 updated the globallyDisableIrqLoadBalancing function defintion

### DIFF
--- a/modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc
+++ b/modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc
@@ -10,7 +10,7 @@ When you upgrade the Performance Addon Operator performance profile custom resou
 
 [NOTE]
 ====
-When `globallyDisableIrqLoadBalancing` is set to `true`, device interrupts are processed across all CPUs as long as they don't belong to a guaranteed pod.
+`globallyDisableIrqLoadBalancing` toggles whether IRQ load balancing will be disabled for the Isolated CPU set. When the option is set to `true` it disables IRQ load balancing for the Isolated CPU set. Setting the option to `false` allows the IRQs to be balanced across all CPUs.
 ====
 
 [id="pao_supported_api_versions_{context}"]


### PR DESCRIPTION
Version(s):
4.7+

Issue:
Fixes #42468

Link to docs preview (VPN required):
[Upgrading the performance profile to use device interrupt processing](http://file.rdu.redhat.com/antaylor/06-10-22/issue42468/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#use-device-interrupt-processing-for-isolated-cpus_cnf-master)

Additional information:
Updated the note to reflect the correct definition of True and False per [upstream documentation](https://github.com/openshift-kni/performance-addon-operators/blob/master/docs/performance_profile.md).
