### PR TITLE
TELCODOCS-627: updating operator reference to include PA controller

### DIFF
--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -23,13 +23,25 @@ ifdef::operators[]
 [discrete]
 == Purpose
 endif::operators[]
-The Node Tuning Operator helps you manage node-level tuning by orchestrating the TuneD daemon. The majority of high-performance applications require some level of kernel tuning. The Node Tuning Operator provides a unified management interface to users of node-level sysctls and more flexibility to add custom tuning specified by user needs.
+The Node Tuning Operator helps you manage node-level tuning by orchestrating the TuneD daemon and achieves low latency performance by using the Performance Profile controller. The majority of high-performance applications require some level of kernel tuning. The Node Tuning Operator provides a unified management interface to users of node-level sysctls and more flexibility to add custom tuning specified by user needs.
 
 The Operator manages the containerized TuneD daemon for {product-title} as a Kubernetes daemon set. It ensures the custom tuning specification is passed to all containerized TuneD daemons running in the cluster in the format that the daemons understand. The daemons run on all nodes in the cluster, one per node.
 
 Node-level settings applied by the containerized TuneD daemon are rolled back on an event that triggers a profile change or when the containerized TuneD daemon is terminated gracefully by receiving and handling a termination signal.
 
+The Node Tuning Operator uses the Performance Profile controller to implement automatic tuning to achieve low latency performance for {product-title} applications. The cluster administrator configures a performance profile to define node-level settings such as the following: 
+
+* Updating the kernel to kernel-rt.
+* Choosing CPUs for housekeeping.
+* Choosing CPUs for running workloads.
+
 The Node Tuning Operator is part of a standard {product-title} installation in version 4.1 and later.
+
+[NOTE]
+====
+In earlier versions of {product-title}, the Performance Addon Operator was used to implement automatic tuning to achieve low latency performance for OpenShift applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. 
+====
+
 ifdef::operators[]
 [discrete]
 == Project

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -56,6 +56,14 @@ include::modules/machine-api-operator.adoc[leveloffset=+1]
 include::modules/machine-config-operator.adoc[leveloffset=+1]
 include::modules/operator-marketplace.adoc[leveloffset=+1]
 include::modules/node-tuning-operator.adoc[leveloffset=+1]
+
+[discrete]
+[role="_additional-resources"]
+[id="platform-operators-ref-nto-addtl-resources"]
+=== Additional resources
+
+* xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#cnf-understanding-low-latency_cnf-master[Low latency tuning of OCP nodes]
+
 include::modules/openshift-apiserver-operator.adoc[leveloffset=+1]
 include::modules/cluster-openshift-controller-manager-operators.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[TELCODOCS-627](https://issues.redhat.com//browse/TELCODOCS-627): Updating the Node Tuning Operator reference section to include information about the Performance Profile controller. This functionality was part of the Performance Addon Operator (PAO). With 4.11, PAO is being subsumed into the Node Tuning Operator. 

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/TELCODOCS-627

Link to docs preview:
http://file.emea.redhat.com/rohennes/TELCODOCS-627/operators/operator-reference.html#about-node-tuning-operator_platform-operators-ref

