### PR TITLE
Fixing AsciiBinder warning in the about NMState page

### DIFF
--- a/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
+++ b/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
@@ -5,7 +5,8 @@
 :_content-type: PROCEDURE
 [id="installing-the-kubernetes-nmstate-operator-CLI_{context}"]
 = Installing the Kubernetes NMState Operator using the CLI
-You can also install the Kubernetes NMState Operator by using the {product-title} CLI (oc).
+
+You can install the Kubernetes NMState Operator by using the OpenShift CLI (`oc)`. After it is installed, the Operator can deploy the NMState State Controller as a daemon set across all of the cluster nodes.
 
 .Prerequisites
 
@@ -85,14 +86,15 @@ EOF
 ----
 
 .Verification
-Confirm that the deployment for the `nmstate` operator is running:
 
+* Confirm that the deployment for the `nmstate` operator is running:
++
 [source,terminal]
 ----
 oc get clusterserviceversion -n openshift-nmstate \
  -o custom-columns=Name:.metadata.name,Phase:.status.phase
 ----
-
++
 .Example output
 [source, terminal]
 ----

--- a/modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc
+++ b/modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc
@@ -3,11 +3,14 @@
 // networking/k8s_nmstate/k8s-nmstate-about-the-kubernetes-nmstate-operator.adoc
 
 :_content-type: PROCEDURE
-[id="installing-the-kubernetes-nmstate-operator_{context}"]
+[id="installing-the-kubernetes-nmstate-operator-web-console_{context}"]
+= Installing the Kubernetes NMState Operator using the web console
 
-= Installing the Kubernetes NMState Operator
+You can install the Kubernetes NMState Operator by using the web console. After it is installed, the Operator can deploy the NMState State Controller as a daemon set across all of the cluster nodes.
 
-You must install the Kubernetes NMState Operator from the web console while logged in with administrator privileges. After it is installed, the Operator can deploy the NMState State Controller as a daemon set across all of the cluster nodes.
+.Prerequisites
+
+* You are logged in as a user with `cluster-admin` privileges.
 
 .Procedure
 

--- a/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -1,6 +1,7 @@
 :_content-type: ASSEMBLY
 [id="k8s-nmstate-about-the-k8s-nmstate-operator"]
 = About the Kubernetes NMState Operator
+include::_attributes/common-attributes.adoc[]
 :FeatureName: Kubernetes NMState Operator
 :context: k8s-nmstate-operator
 
@@ -14,7 +15,11 @@ Red Hat supports the Kubernetes NMState Operator in production environments on b
 ====
 
 Before you can use NMState with {product-title}, you must install the Kubernetes NMState Operator.
-[id="{context}_installation_and_deployment"]
-=== Installing the nmstate operator
-include::modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc[leveloffset=+1]
+
+[id="installing-the-kubernetes-nmstate-operator-cli"]
+== Installing the Kubernetes NMState Operator
+
+You can install the Kubernetes NMState Operator by using the web console or the CLI.
+
+include::modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc[leveloffset=+2]
 include::modules/k8s-nmstate-deploying-nmstate-CLI.adoc[leveloffset=+2]


### PR DESCRIPTION
This applies to `main`, `enterprise-4.11` and `enterprise-4.10`.

The PR resolves an AsciiBinder build warning relating to the "About the Kubernetes NMState Operator" page. The PR also enhances some formatting within the page, including reintroduction of the TOC.

The preview is [here](http://file.fab.redhat.com/pneedle/pr46488/k8s-nmstate-about-the-k8s-nmstate-operator.html).