### PR TITLE
[enterprise-4.9] Fixing common attribute includes

### DIFF
--- a/networking/hardware_networks/uninstalling-sriov-operator.adoc
+++ b/networking/hardware_networks/uninstalling-sriov-operator.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 [id="uninstalling-sriov-operator"]
 = Uninstalling the SR-IOV Network Operator
-include::modules/common-attributes.adoc[]
+include::_attributes/common-attributes.adoc[]
 :context: uninstalling-sr-iov-operator
 
 toc::[]

--- a/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.adoc
+++ b/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 [id="sno-du-enabling-workload-partitioning-on-single-node-openshift"]
 = Workload partitioning on single node OpenShift
-include::modules/common-attributes.adoc[]
+include::_attributes/common-attributes.adoc[]
 :context: sno-du-enabling-workload-partitioning-on-single-node-openshift
 
 toc::[]


### PR DESCRIPTION
This applies to `enterprise-4.9` only.

The PR fixes some common attribute includes so that they point to the relocated file.

The previews are [here](http://file.fab.redhat.com/pneedle/pr46490/uninstalling-sriov-operator.html) and [here](http://file.fab.redhat.com/pneedle/pr46490/sno-du-enabling-workload-partitioning-on-single-node-openshift.html).