### PR TITLE
[enterprise-4.6] Fixing common attribute includes

### DIFF
--- a/networking/hardware_networks/uninstalling-sriov-operator.adoc
+++ b/networking/hardware_networks/uninstalling-sriov-operator.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 [id="uninstalling-sriov-operator"]
 = Uninstalling the SR-IOV Network Operator
-include::modules/common-attributes.adoc[]
+include::_attributes/common-attributes.adoc[]
 :context: uninstalling-sr-iov-operator
 
 toc::[]


### PR DESCRIPTION
This applies to `enterprise-4.6` only.

The PR fixes some common attribute includes so that they point to the relocated file.

The preview is [here](http://file.fab.redhat.com/pneedle/pr46493/uninstalling-sriov-operator.html).