### PR TITLE
Fixing an include error in the deployment strategy page

### DIFF
--- a/applications/deployments/deployment-strategies.adoc
+++ b/applications/deployments/deployment-strategies.adoc
@@ -52,5 +52,6 @@ include::modules/odc-starting-recreate-deployment.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../applications/application_life_cycle_management/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating and deploying applications on {product-title} using the *Developer* perspective]
 * xref:../../applications/application_life_cycle_management/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[Viewing the applications in your project, verifying their deployment status, and interacting with them in the *Topology* view]
+
 include::modules/deployments-custom-strategy.adoc[leveloffset=+1]
 include::modules/deployments-lifecycle-hooks.adoc[leveloffset=+1]


### PR DESCRIPTION
This applies to `enterprise-4.7` only.

The PR adds a new line before an include statement, to resolve an AsciiBinder error.

The preview is [here](http://file.fab.redhat.com/pneedle/pr46494/deployment-strategies.html).