### PR TITLE
[RHACS] Release Notes for RHACS 3.68.2

### DIFF
--- a/release_notes/368-release-notes.adoc
+++ b/release_notes/368-release-notes.adoc
@@ -7,7 +7,9 @@ toc::[]
 
 {product-title} ({product-title-short}) 3.68 includes feature enhancements, bug fixes, scale improvements, and other changes.
 
-*Release date:* February 2, 2022
+*3.68 Release date:* February 2, 2022 +
+*3.68.1 Release date:* February 14, 2022 +
+*3.68.2 Release date:* June 14, 2022
 
 [id="new-features-368"]
 == New features
@@ -52,6 +54,13 @@ Release date: February 14, 2022
 * *ROX-9243*: In {product-title-short} 3.68.0, Central would sometimes stop responding if the vulnerability data was not available.
 This issue has been fixed.
 Central now reports an error for such cases.
+
+[id="resolved-in-version-3682"]
+=== Resolved in version 3.68.2
+
+Release date: June 14, 2022
+
+* *ROX-10845*: link:https://access.redhat.com/security/cve/cve-2022-1902[CVE-2022-1902]: GraphQL exposes Notifiers secrets.
 
 [id="security-update"]
 == Security update


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs-3.68.2`
- Cherry pick to `rhacs-docs`

Label: `RHACS`

[Issue](https://issues.redhat.com/browse/ROX-11327)

[Link to docs preview](https://openshift-docs-h8vgho828-kcarmichael08.vercel.app/openshift-acs/master/release_notes/368-release-notes.html#resolved-in-version-3682)
