### PR TITLE
BZ#2041307 added a note to the unidling applications process

### DIFF
--- a/modules/idle-unidling-applications.adoc
+++ b/modules/idle-unidling-applications.adoc
@@ -30,3 +30,8 @@ HAProxy router.
 ====
 Services do not support automatic unidling if you configure Kuryr-Kubernetes as an SDN.
 ====
+
+[NOTE]
+====
+In {product-title} {product-version}, idled services do not become active again when they receive network traffic if they were idled while the leader `ovnkube-master` process was restarted or after the `ovnkube-master` leader changed. For more information, refer to link:https://access.redhat.com/solutions/6671241[Idled services cannot wake up automatically after restart of ovnkube-master in Red Hat OpenShift Container Platform 4].
+====


### PR DESCRIPTION
Version(s):
4.6, 4.7

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2041307

Link to docs preview (VPN required):
[Unidling applications](http://file.rdu.redhat.com/antaylor/06-09-22/bz2041307/applications/idling-applications.html#idle-unidling-applications_idling-applications)

Additional information:
@andreaskaris pointed out that in 4.6 and 4.7 that under certain circumstances, applications do not unidle correctly. The in-depth explanation is provided in a KCS linked in the note. 
