### PR TITLE
OSDOCS-3503: RelNotes for Defining Kuryr ports pools & CIDR Ranges

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -197,6 +197,10 @@ For more information, see xref:../networking/external_dns_operator/nw-installing
 
 SR-IOV support is now available for xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Pensando DSC cards]. OpenShift SR-IOV is supported, but you must set a static, Virtual Function (VF) media access control (MAC) address using the SR-IOV CNI config file when using SR-IOV.
 
+[id="ocp-4-11-cidr-ranges-for-network"]
+==== {product-title} CIDR Ranges for Networks
+Be aware that CIDR ranges for networks are not adjustable after cluster installation. Red Hat does not provide direct guidance on determining the range because it requires careful consideration of the number of pods created.
+
 [id="ocp-4-11-hardware"]
 === Hardware
 
@@ -1075,6 +1079,8 @@ This script removes unauthenticated subjects from the following cluster role bin
 
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
+
+* In the {rh-openstack-first}, a potential issue can affect Kuryr when the ports pools are populated with a variety of bulk port creation requests made at the same time. During these bulk requests, if the IP allocation for one of the IP addresses fails, the Neutron retries the operation for all ports. This issue was resolved in a previous errata; however, Red Hat suggests setting a small value for the ports pools batch to avoid large bulk port creation requests. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2024690[*BZ2024690*])
 
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
[OSDOCS-3503](https://issues.redhat.com/browse/OSDOCS-3503)
Release Notes for Kuryr ports pools known issue & CIDR sizes on namespaces 

**Version(s):**
enterprise-4.11 only

**Issues**

- Engineering epic - https://issues.redhat.com/browse/OSASINFRA-2734
- Docs JIRA - https://issues.redhat.com/browse/OSDOCS-3726

**Link to doc preview:**

- [OpenShift Container Platform Cluster Ranges for Networks](https://wiharris.github.io/openshift-docs/OSDOCS-3726/release_notes/ocp-4-11-release-notes.html#ocp-4-11-cidr-ranges-for-network)
- [Known issues](https://wiharris.github.io/openshift-docs/OSDOCS-3726/release_notes/ocp-4-11-release-notes.html#ocp-4-11-known-issues)

**Additional Information**
**QE** -   @itzikb-redhat 

<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
