### PR TITLE
Adds release notes for OMR

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -111,7 +111,7 @@ Topics:
   Topics:
   - Name: About disconnected installation mirroring
     File: index
-  - Name: Creating a mirror registry
+  - Name: Creating a mirror registry with mirror registry for Red Hat OpenShift
     File: installing-mirroring-creating-registry
   - Name: Mirroring images for a disconnected installation
     File: installing-mirroring-installation-images

--- a/installing/disconnected_install/installing-mirroring-creating-registry.adoc
+++ b/installing/disconnected_install/installing-mirroring-creating-registry.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="installing-mirroring-creating-registry"]
-= Creating a mirror registry
+= Creating a mirror registry with mirror registry for Red Hat OpenShift
 include::_attributes/common-attributes.adoc[]
 :context: installing-mirroring-creating-registry
 
@@ -33,6 +33,7 @@ include::modules/mirror-registry-remote.adoc[leveloffset=+1]
 include::modules/mirror-registry-update.adoc[leveloffset=+1]
 include::modules/mirror-registry-uninstall.adoc[leveloffset=+1]
 include::modules/mirror-registry-flags.adoc[leveloffset=+1]
+include::modules/mirror-registry-release-notes.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * installing/disconnected_install/installing-mirroring-installation-images.adoc
+
+[id="mirror-registry-release-notes_{context}"]
+= Mirror registry for Red Hat OpenShift release notes
+
+The _mirror registry for Red Hat OpenShift_ is a small and streamlined container registry that you can use as a target for mirroring the required container images of {product-title} for disconnected installations.
+
+These release notes track the development of the _mirror registry for Red Hat Openshift_ in {product-title}.
+
+For an overview of the _mirror registry for Red Hat OpenShift_, see xref:../../installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-flags_installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red Hat OpenShift].
+
+[id="mirror-registry-for-openshift-1-2-0"]
+== Mirror registry for Red Hat OpenShift 1.2.0
+
+_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.7.1.
+
+The following advisory is available for the _mirror registry for Red Hat OpenShift_:
+
+* link:https://errata.devel.redhat.com/docs/show/94693[RHBA-2022:4986 - mirror registry for Red Hat OpenShift 1.2.0]
+
+
+[id="mirror-registry-1-2-0-bug-fixes"]
+=== Bug fixes
+
+* Previously, all components and workers running inside of the Quay pod Operator had log levels set to `DEBUG`. As a result, large traffic logs were created that consumed unnecessary space. With this update, log levels are set to `WARN` by default, which reduces traffic information while emphasizing problem scenarios. (link:https://issues.redhat.com/browse/PROJQUAY-3504[*PROJQUAY-3504*])
+
+[id="mirror-registry-for-openshift-1-1-0"]
+== Mirror registry for Red Hat OpenShift 1.1.0
+
+The following advisory is available for the _mirror registry for Red Hat OpenShift_:
+
+link:https://errata.devel.redhat.com/advisory/89511[RHBA-2022:0956 - mirror registry for Red Hat OpenShift 1.1.0]
+
+[id="mirror-registry-1-2-0-new-features"]
+=== New features
+
+* A new command, `mirror-registry upgrade` has been added. This command upgrades all container images without interfering with configurations or data.
++
+[NOTE]
+====
+If `quayRoot` was previously set to something other than default, it must be passed into the upgrade command.
+====
+
+[id="mirror-registry-1-1-0-bug-fixes"]
+=== Bug fixes
+
+* Previously, the absence of `quayHostname` or `targetHostname` did not default to the local hostname. With this update, `quayHostname` and `targetHostname` now default to the local hostname if they are missing. (link:https://issues.redhat.com/browse/PROJQUAY-3079[*PROJQUAY-3079*])
+
+* Previously, the command `./mirror-registry --version` returned an `unknown flag` error. Now, running `./mirror-registry --version` returns the current version of the _mirror registry for Red Hat OpenShift_. (link:https://issues.redhat.com/browse/PROJQUAY-3086[*PROJQUAY-3086*])
+
+* Previously, users could not set a password during installation, for example, when running `./mirror-registry install --initUser <user_name> --initPassword <password> --verbose`. With this update, users can set a password during installation. (link:https://issues.redhat.com/browse/PROJQUAY-3149[*PROJQUAY-3149*])
+
+* Previously, the _mirror registry for Red Hat OpenShift_ did not recreate pods if they were destroyed. Now, pods are recreated if they are destroyed. (link:https://issues.redhat.com/browse/PROJQUAY-3261[*PROJQUAY-3261*])


### PR DESCRIPTION
Release notes for OMR. 

For 4.10 and 4.11

Preview: https://stevsmit.github.io/openshift-docs/PROJQUAY-3504/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-release-notes_installing-mirroring-creating-registry

No QE needed.

Issue: https://issues.redhat.com/browse/PROJQUAY-3931?jql=project%20%3D%20PROJQUAY%20AND%20component%20%3D%20OMR


