### PR TITLE
WMCO1096: Document BYOH DHCP warning

### DIFF
--- a/modules/byoh-configuring.adoc
+++ b/modules/byoh-configuring.adoc
@@ -45,5 +45,6 @@ data:
   instance.example.com: |-
     username=core
 ----
-<1> An address to SSH in to the instance with. This can be a DNS name or an IPv4 address. A PTR record must exist corresponding to the address used in the config map resolving to the instance host name for successful reverse DNS lookups.
+<1> The address to SSH in to the instance with, either a DNS name or an IPv4 address. A DNS PTR record must exist for this address. It is recommended that you use a DNS name with your BYOH instance if your organization uses DHCP to assign IP addresses. If not, you need to update the `windows-instances` ConfigMap whenever the instance is assigned a new IP address.
 <2> The name of the administrator user created in the prerequisites.
+


### PR DESCRIPTION
https://github.com/openshift/windows-machine-config-operator/pull/1096
https://bugzilla.redhat.com/show_bug.cgi?id=2090681

Preview: [Configuring BYOH Windows instance](http://file.rdu.redhat.com/~mburke/WMCO1096-Document-BYOH-DHCP-warning/windows_containers/byoh-windows-instance.html#configuring-byoh-windows-instance). Added to call-out <1> in step 1.
