### PR TITLE
BZ-2095294: Renamed IBM Cloud to IBM Cloud VPC

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -239,21 +239,21 @@ Topics:
     File: installing-restricted-networks-gcp
   - Name: Uninstalling a cluster on GCP
     File: uninstalling-cluster-gcp
-- Name: Installing on IBM Cloud
+- Name: Installing on IBM Cloud VPC
   Dir: installing_ibm_cloud_public
   Distros: openshift-origin,openshift-enterprise
   Topics:
-  - Name: Preparing to install on IBM Cloud
+  - Name: Preparing to install on IBM Cloud VPC
     File: preparing-to-install-on-ibm-cloud
-  - Name: Configuring an IBM Cloud account
+  - Name: Configuring an IBM Cloud account VPC
     File: installing-ibm-cloud-account
-  - Name: Configuring IAM for IBM Cloud
+  - Name: Configuring IAM for IBM Cloud VPC
     File: configuring-iam-ibm-cloud
-  - Name: Installing a cluster on IBM Cloud with customizations
+  - Name: Installing a cluster on IBM Cloud VPC with customizations
     File: installing-ibm-cloud-customizations
-  - Name: Installing a cluster on IBM Cloud with network customizations
+  - Name: Installing a cluster on IBM Cloud VPC with network customizations
     File: installing-ibm-cloud-network-customizations
-  - Name: Uninstalling a cluster on IBM Cloud
+  - Name: Uninstalling a cluster on IBM Cloud VPC
     File: uninstalling-cluster-ibm-cloud
 - Name: Installing on bare metal
   Dir: installing_bare_metal

--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -25,7 +25,7 @@ If you want to install and manage {product-title} yourself, you can install it o
 * Google Cloud Platform (GCP)
 * {rh-openstack-first}
 * {rh-virtualization-first}
-* IBM Cloud
+* IBM Cloud VPC
 * IBM Z and LinuxONE
 * IBM Z and LinuxONE for {op-system-base-full} KVM
 * IBM Power
@@ -36,7 +36,7 @@ If you want to install and manage {product-title} yourself, you can install it o
 
 You can deploy an {product-title} 4 cluster to both on-premise hardware and to cloud hosting services, but all of the machines in a cluster must be in the same datacenter or cloud hosting service.
 
-If you want to use {product-title} but do not want to manage the cluster yourself, you have several managed service options. If you want a cluster that is fully managed by Red Hat, you can use link:https://www.openshift.com/products/dedicated/[OpenShift Dedicated] or link:https://www.openshift.com/products/online/[OpenShift Online]. You can also use OpenShift as a managed service on Azure, AWS, IBM Cloud, or Google Cloud. For more information about managed services, see the link:https://www.openshift.com/products[OpenShift Products] page.
+If you want to use {product-title} but do not want to manage the cluster yourself, you have several managed service options. If you want a cluster that is fully managed by Red Hat, you can use link:https://www.openshift.com/products/dedicated/[OpenShift Dedicated] or link:https://www.openshift.com/products/online/[OpenShift Online]. You can also use OpenShift as a managed service on Azure, AWS, IBM Cloud VPC, or Google Cloud. For more information about managed services, see the link:https://www.openshift.com/products[OpenShift Products] page.
 
 [id="installing-preparing-migrate"]
 === Have you used {product-title} 3 and want to use {product-title} 4?
@@ -123,7 +123,7 @@ Not all installation options are supported for all platforms, as shown in the fo
 //This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
 |===
-||Alibaba |AWS (x86_64) |AWS (arm64) |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal |vSphere |VMC |IBM Cloud |IBM Z |IBM Power
+||Alibaba |AWS (x86_64) |AWS (arm64) |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Power
 
 |Default
 |xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[X]
@@ -283,7 +283,7 @@ endif::openshift-origin[]
 //This table is for OKD only. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifdef::openshift-origin[]
 |===
-||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |oVirt |Bare metal |vSphere |VMC |IBM Cloud |IBM Z |IBM Power
+||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |oVirt |Bare metal |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Power
 
 |Default
 |xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[X]
@@ -435,7 +435,7 @@ endif::openshift-origin[]
 //This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
 |===
-||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
+||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
 
 |Custom
 |
@@ -520,7 +520,7 @@ endif::openshift-origin[]
 //This table is for OKD only. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifdef::openshift-origin[]
 |===
-||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |oVirt |Bare metal |vSphere |VMC |IBM Cloud |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
+||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |oVirt |Bare metal |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
 
 |Custom
 |

--- a/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="configuring-iam-ibm-cloud"]
-= Configuring IAM for IBM Cloud
+= Configuring IAM for IBM Cloud VPC
 include::_attributes/common-attributes.adoc[]
 :context: configuring-iam-ibm-cloud
 
@@ -8,7 +8,7 @@ toc::[]
 
 In environments where the cloud identity and access management (IAM) APIs are not reachable, you must put the Cloud Credential Operator (CCO) into manual mode before you install the cluster.
 
-:FeatureName: IBM Cloud using installer-provisioned infrastructure
+:FeatureName: IBM Cloud VPC using installer-provisioned infrastructure
 include::snippets/technology-preview.adoc[]
 
 include::modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc[leveloffset=+1]
@@ -25,8 +25,8 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_configuring-iam-ibm-cloud-refreshing-ids"]
 .Additional resources
-* xref:../../post_installation_configuration/cluster-tasks.adoc#refreshing-service-ids-ibm-cloud_post-install-cluster-tasks[Rotating API keys for IBM Cloud]
+* xref:../../post_installation_configuration/cluster-tasks.adoc#refreshing-service-ids-ibm-cloud_post-install-cluster-tasks[Rotating API keys for IBM Cloud VPC]
 
 [id="next-steps_configuring-iam-ibm-cloud"]
 == Next steps
-* xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[Installing a cluster on IBM Cloud with customizations]
+* xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[Installing a cluster on IBM Cloud VPC with customizations]

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc
@@ -1,20 +1,20 @@
 :_content-type: ASSEMBLY
 [id="installing-ibm-cloud-account"]
-= Configuring an IBM Cloud account
+= Configuring an IBM Cloud VPC account
 include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-cloud-account
 
 toc::[]
 
-Before you can install {product-title}, you must configure an IBM Cloud account.
+Before you can install {product-title}, you must configure an IBM Cloud VPC account.
 
-:FeatureName: IBM Cloud using installer-provisioned infrastructure
+:FeatureName: IBM Cloud VPC using installer-provisioned infrastructure
 include::snippets/technology-preview.adoc[]
 
 [id="prerequisites_installing-ibm-cloud-account"]
 == Prerequisites
 
-* You have an IBM Cloud account with a subscription. You cannot install {product-title} on a free or trial IBM Cloud account.
+* You have an IBM Cloud VPC account with a subscription. You cannot install {product-title} on a free or trial IBM Cloud VPC account.
 
 include::modules/quotas-and-limits-ibm-cloud.adoc[leveloffset=+1]
 
@@ -27,4 +27,4 @@ include::modules/installation-ibm-cloud-regions.adoc[leveloffset=+1]
 
 [id="next-steps_installing-ibm-cloud-account"]
 == Next steps
-* xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud]
+* xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud VPC]

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
@@ -1,14 +1,14 @@
 :_content-type: ASSEMBLY
 [id="installing-ibm-cloud-customizations"]
-= Installing a cluster on IBM Cloud with customizations
+= Installing a cluster on IBM Cloud VPC with customizations
 include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-cloud-customizations
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a customized cluster on infrastructure that the installation program provisions on IBM Cloud. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
+In {product-title} version {product-version}, you can install a customized cluster on infrastructure that the installation program provisions on IBM Cloud VPC. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
-:FeatureName: IBM Cloud using installer-provisioned infrastructure
+:FeatureName: IBM Cloud VPC using installer-provisioned infrastructure
 include::snippets/technology-preview.adoc[]
 
 [id="prerequisites_installing-ibm-cloud-customizations"]
@@ -16,9 +16,9 @@ include::snippets/technology-preview.adoc[]
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[configured an IBM Cloud account] to host the cluster.
+* You xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[configured an IBM Cloud VPC account] to host the cluster.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
-* You configured the `ccoctl` utility before you installed the cluster. For more information, see xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud].
+* You configured the `ccoctl` utility before you installed the cluster. For more information, see xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud VPC].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
@@ -1,17 +1,17 @@
 :_content-type: ASSEMBLY
 [id="installing-ibm-cloud-network-customizations"]
-= Installing a cluster on IBM Cloud with network customizations
+= Installing a cluster on IBM Cloud VPC with network customizations
 include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-cloud-network-customizations
 
 toc::[]
 
 In {product-title} version {product-version}, you can install a cluster with a
-customized network configuration on infrastructure that the installation program provisions on IBM Cloud. By customizing your network configuration, your cluster can coexist with existing IP address allocations in your environment and integrate with existing MTU and VXLAN configurations. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
+customized network configuration on infrastructure that the installation program provisions on IBM Cloud VPC. By customizing your network configuration, your cluster can coexist with existing IP address allocations in your environment and integrate with existing MTU and VXLAN configurations. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
 You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
 
-:FeatureName: IBM Cloud using installer-provisioned infrastructure
+:FeatureName: IBM Cloud VPC using installer-provisioned infrastructure
 include::snippets/technology-preview.adoc[]
 
 [id="prerequisites_installing-ibm-cloud-network-customizations"]
@@ -19,9 +19,9 @@ include::snippets/technology-preview.adoc[]
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[configured an IBM Cloud account] to host the cluster.
+* You xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[configured an IBM Cloud VPC account] to host the cluster.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
-* You configured the `ccoctl` utility before you installed the cluster. For more information, see xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud].
+* You configured the `ccoctl` utility before you installed the cluster. For more information, see xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud VPC].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc
@@ -1,10 +1,12 @@
 :_content-type: ASSEMBLY
 [id="preparing-to-install-on-ibm-cloud"]
-= Preparing to install on IBM Cloud
+= Preparing to install on IBM Cloud VPC
 include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-ibm-cloud
 
 toc::[]
+
+The installation workflows documented in this section are for IBM Cloud VPC infrastructure environments. IBM Cloud Classic is not supported at this time. For more information on the difference between Classic and VPC infrastructures, see IBM's link:https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure[documentation].
 
 [id="prerequisites_preparing-to-install-on-ibm-cloud"]
 == Prerequisites
@@ -16,34 +18,29 @@ toc::[]
 :FeatureName: IBM Cloud using installer-provisioned infrastructure
 include::snippets/technology-preview.adoc[]
 
-[IMPORTANT]
-====
-The installation workflows documented in this section are for IBM Cloud VPC infrastructure environments. IBM Cloud Classic is not supported at this time. For more information on the difference between Classic and VPC infrastructures, see IBM's link:https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure[documentation].
-====
-
 [id="requirements-for-installing-ocp-on-ibm-cloud"]
-== Requirements for installing {product-title} on IBM Cloud
+== Requirements for installing {product-title} on IBM Cloud VPC
 
-Before installing {product-title} on IBM Cloud, you must create a service account and configure an IBM Cloud account. See xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[Configuring an IBM Cloud account] for details about creating an account, enabling API services, configuring DNS, IBM Cloud account limits, and supported IBM Cloud regions.
+Before installing {product-title} on IBM Cloud VPC, you must create a service account and configure an IBM Cloud VPC account. See xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[Configuring an IBM Cloud VPC account] for details about creating an account, enabling API services, configuring DNS, IBM Cloud VPC account limits, and supported IBM Cloud VPC regions.
 
-You must manually manage your cloud credentials when installing a cluster to IBM Cloud. Do this by configuring the Cloud Credential Operator (CCO) for manual mode before you install the cluster. For more information, see xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud].
+You must manually manage your cloud credentials when installing a cluster to IBM Cloud VPC. Do this by configuring the Cloud Credential Operator (CCO) for manual mode before you install the cluster. For more information, see xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud VPC].
 
 [id="choosing-a-method-to-install-ocp-on-ibm-cloud"]
-== Choosing a method to install {product-title} on IBM Cloud
+== Choosing a method to install {product-title} on IBM Cloud VPC
 
-You can install {product-title} on IBM Cloud using installer-provisioned infrastructure. This process involves using an installation program to provision the underlying infrastructure for your cluster. Installing {product-title} on IBM Cloud using user-provisioned infrastructure is not supported at this time.
+You can install {product-title} on IBM Cloud VPC using installer-provisioned infrastructure. This process involves using an installation program to provision the underlying infrastructure for your cluster. Installing {product-title} on IBM Cloud VPC using user-provisioned infrastructure is not supported at this time.
 
 See xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process] for more information about installer-provisioned installation processes.
 
 [id="choosing-an-method-to-install-ocp-on-ibm-cloud-installer-provisioned"]
 === Installing a cluster on installer-provisioned infrastructure
 
-You can install a cluster on IBM Cloud infrastructure that is provisioned by the {product-title} installation program by using one of the following methods:
+You can install a cluster on IBM Cloud VPC infrastructure that is provisioned by the {product-title} installation program by using one of the following methods:
 
-* **xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[Installing a customized cluster on IBM Cloud]**: You can install a customized cluster on IBM Cloud infrastructure that the installation program provisions. The installation program allows for some customization to be applied at the installation stage. Many other customization options are available xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[post-installation].
+* **xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[Installing a customized cluster on IBM Cloud VPC]**: You can install a customized cluster on IBM Cloud VPC infrastructure that the installation program provisions. The installation program allows for some customization to be applied at the installation stage. Many other customization options are available xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[post-installation].
 
-* **xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc#installing-ibm-cloud-network-customizations[Installing a cluster on IBM Cloud with network customizations]**: You can customize your {product-title} network configuration during installation, so that your cluster can coexist with your existing IP address allocations and adhere to your network requirements.
+* **xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc#installing-ibm-cloud-network-customizations[Installing a cluster on IBM Cloud VPC with network customizations]**: You can customize your {product-title} network configuration during installation, so that your cluster can coexist with your existing IP address allocations and adhere to your network requirements.
 
 [id="next-steps_preparing-to-install-on-ibm-cloud"]
 == Next steps
-* xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[Configuring an IBM Cloud account]
+* xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[Configuring an IBM Cloud VPC account]

--- a/installing/installing_ibm_cloud_public/uninstalling-cluster-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/uninstalling-cluster-ibm-cloud.adoc
@@ -1,11 +1,11 @@
 :_content-type: ASSEMBLY
 [id="uninstalling-cluster-ibm-cloud"]
-= Uninstalling a cluster on IBM Cloud
+= Uninstalling a cluster on IBM Cloud VPC
 include::_attributes/common-attributes.adoc[]
 :context: uninstalling-cluster-ibm-cloud
 
 toc::[]
 
-You can remove a cluster that you deployed to IBM Cloud.
+You can remove a cluster that you deployed to IBM Cloud VPC.
 
 include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]

--- a/modules/installation-cis-ibm-cloud.adoc
+++ b/modules/installation-cis-ibm-cloud.adoc
@@ -6,11 +6,11 @@
 [id="installation-cis-ibm-cloud_{context}"]
 = Configuring DNS resolution using Cloud Internet Services
 
-IBM Cloud Internet Services (CIS) is used by the installation program to configure cluster DNS resolution and provide name lookup for the cluster to external resources. Only public DNS is supported with IBM Cloud.
+IBM Cloud Internet Services (CIS) is used by the installation program to configure cluster DNS resolution and provide name lookup for the cluster to external resources. Only public DNS is supported with IBM Cloud VPC.
 
 [NOTE]
 ====
-IBM Cloud does not support IPv6, so dual stack or IPv6 environments are not possible.
+IBM Cloud VPC does not support IPv6, so dual stack or IPv6 environments are not possible.
 ====
 
 You must create a domain zone in CIS in the same account as your cluster. You must also ensure the zone is authoritative for the domain. You can do this using a root domain or subdomain.

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -635,7 +635,7 @@ endif::[]
 ifndef::aws,aws-govcloud,aws-secret,aws-restricted,azure,gcp[]
 `Internal` or `External`. The default value is `External`.
 
-Setting this field to `Internal` is not supported on non-cloud platforms and IBM Cloud.
+Setting this field to `Internal` is not supported on non-cloud platforms and IBM Cloud VPC.
 ifeval::[{product-version} <= 4.7]
 [IMPORTANT]
 ====
@@ -1109,11 +1109,11 @@ The GCP Compute Engine System service account email, like `<service_account_name
 endif::gcp[]
 ifdef::ibm-cloud[]
 [id="installation-configuration-parameters-additional-ibm-cloud_{context}"]
-== Additional IBM Cloud configuration parameters
+== Additional IBM Cloud VPC configuration parameters
 
-Additional IBM Cloud configuration parameters are described in the following table:
+Additional IBM Cloud VPC configuration parameters are described in the following table:
 
-.Additional IBM Cloud parameters
+.Additional IBM Cloud VPC parameters
 [cols=".^1,.^6a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
@@ -1124,15 +1124,15 @@ Additional IBM Cloud configuration parameters are described in the following tab
 
 |`platform.ibmcloud.dedicatedHosts.profile`
 |The new dedicated host to create. If you specify a value for `platform.ibmcloud.dedicatedHosts.name`, this parameter is not required.
-|Valid IBM Cloud dedicated host profile, such as `cx2-host-152x304`. [^2^]
+|Valid IBM Cloud VPC dedicated host profile, such as `cx2-host-152x304`. [^2^]
 
 |`platform.ibmcloud.dedicatedHosts.name`
 |An existing dedicated host. If you specify a value for `platform.ibmcloud.dedicatedHosts.profile`, this parameter is not required.
 |String, for example `my-dedicated-host-name`.
 
 |`platform.ibmcloud.type`
-|The instance type for all IBM Cloud machines.
-|Valid IBM Cloud instance type, such as `bx2-8x32`. [^2^]
+|The instance type for all IBM Cloud VPC machines.
+|Valid IBM Cloud VPC instance type, such as `bx2-8x32`. [^2^]
 
 |====
 [.small]

--- a/modules/installation-ibm-cloud-config-yaml.adoc
+++ b/modules/installation-ibm-cloud-config-yaml.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 :_content-type: REFERENCE
 [id="installation-ibm-cloud-config-yaml_{context}"]
-= Sample customized install-config.yaml file for IBM Cloud
+= Sample customized install-config.yaml file for IBM Cloud VPC
 
 You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
 

--- a/modules/installation-ibm-cloud-creating-api-key.adoc
+++ b/modules/installation-ibm-cloud-creating-api-key.adoc
@@ -6,15 +6,15 @@
 [id="installation-ibm-cloud-creating-api-key_{context}"]
 = Creating an API key
 
-You must create a user API key or a service ID API key for your IBM Cloud account.
+You must create a user API key or a service ID API key for your IBM Cloud VPC account.
 
 .Prerequisites
 
-* You have assigned the required access policies to your IBM Cloud account.
+* You have assigned the required access policies to your IBM Cloud VPC account.
 * You have attached you IAM access policies to an access group, or other appropriate resource.
 
 .Procedure
 
 * Create an API key, depending on how you defined your IAM access policies.
 +
-For example, if you assigned your access policies to a user, you must create a link:https://cloud.ibm.com/docs/account?topic=account-userapikey[user API key]. If you assigned your access policies to a service ID, you must create a link:https://cloud.ibm.com/docs/account?topic=account-serviceidapikeys[service ID API key]. If your access policies are assigned to an access group, you can use either API key type. For more information on IBM Cloud API keys, see link:https://cloud.ibm.com/docs/account?topic=account-manapikey&interface=ui[Understanding API keys].
+For example, if you assigned your access policies to a user, you must create a link:https://cloud.ibm.com/docs/account?topic=account-userapikey[user API key]. If you assigned your access policies to a service ID, you must create a link:https://cloud.ibm.com/docs/account?topic=account-serviceidapikeys[service ID API key]. If your access policies are assigned to an access group, you can use either API key type. For more information on IBM Cloud VPC API keys, see link:https://cloud.ibm.com/docs/account?topic=account-manapikey&interface=ui[Understanding API keys].

--- a/modules/installation-ibm-cloud-export-variables.adoc
+++ b/modules/installation-ibm-cloud-export-variables.adoc
@@ -5,17 +5,17 @@
 
 :_content-type: PROCEDURE
 [id="installation-ibm-cloud-export-variables_{context}"]
-= Exporting the IBM Cloud API key
+= Exporting the IBM Cloud VPC API key
 
-You must set the IBM Cloud API key you created as a global variable; the installation program ingests the variable during startup to set the API key.
+You must set the IBM Cloud VPC API key you created as a global variable; the installation program ingests the variable during startup to set the API key.
 
 .Prerequisties
 
-* You have created either a user API key or service ID API key for your IBM Cloud account.
+* You have created either a user API key or service ID API key for your IBM Cloud VPC account.
 
 .Procedure
 
-* Export your IBM Cloud API key as a global variable:
+* Export your IBM Cloud VPC API key as a global variable:
 +
 [source,terminal]
 ----

--- a/modules/installation-ibm-cloud-iam-policies-api-key.adoc
+++ b/modules/installation-ibm-cloud-iam-policies-api-key.adoc
@@ -4,16 +4,16 @@
 
 :_content-type: CONCEPT
 [id="installation-ibm-cloud-iam-policies-api-key_{context}"]
-= IBM Cloud IAM Policies and API Key
+= IBM Cloud VPC IAM Policies and API Key
 
-To install {product-title} into your IBM Cloud account, the installation program requires an IAM API key, which provides authentication and authorization to access IBM Cloud service APIs. You can use an existing IAM API key that contains the required policies or create a new one.
+To install {product-title} into your IBM Cloud VPC account, the installation program requires an IAM API key, which provides authentication and authorization to access IBM Cloud service APIs. You can use an existing IAM API key that contains the required policies or create a new one.
 
 For an IBM Cloud IAM overview, see the IBM Cloud link:https://cloud.ibm.com/docs/account?topic=account-iamoverview[documentation].
 
 [id="required-access-policies-ibm-cloud_{context}"]
 == Required access policies
 
-You must assign the required access policies to your IBM Cloud account.
+You must assign the required access policies to your IBM Cloud VPC account.
 
 .Required access policies
 [cols="1,2,2,2,3",options="header"]
@@ -61,7 +61,7 @@ You must assign the required access policies to your IBM Cloud account.
 [id="access-policy-assignment-ibm-cloud_{context}"]
 == Access policy assignment
 
-In IBM Cloud IAM, access policies can be attached to different subjects:
+In IBM Cloud VPC IAM, access policies can be attached to different subjects:
 
 * Access group (Recommended)
 * Service ID

--- a/modules/installation-ibm-cloud-regions.adoc
+++ b/modules/installation-ibm-cloud-regions.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: REFERENCE
 [id="installation-ibm-cloud-regions_{context}"]
-= Supported IBM Cloud regions
+= Supported IBM Cloud VPC regions
 
 You can deploy an {product-title} cluster to the following regions:
 

--- a/modules/manually-create-iam-ibm-cloud.adoc
+++ b/modules/manually-create-iam-ibm-cloud.adoc
@@ -5,11 +5,11 @@
 
 :_content-type: PROCEDURE
 [id="manually-create-iam-ibm-cloud_{context}"]
-= Manually creating IAM for IBM Cloud
+= Manually creating IAM for IBM Cloud VPC
 
 Installing the cluster requires that the Cloud Credential Operator (CCO) operate in manual mode. While the installation program configures the CCO for manual mode, you must specify the identity and access management secrets for you cloud provider.
 
-You can use the Cloud Credential Operator (CCO) utility (`ccoctl`) to create the required IBM Cloud resources.
+You can use the Cloud Credential Operator (CCO) utility (`ccoctl`) to create the required IBM Cloud VPC resources.
 
 .Prerequisites
 
@@ -93,7 +93,7 @@ This command creates a YAML file for each `CredentialsRequest` object.
         - crn:v1:bluemix:public:iam::::role:Viewer
 ----
 
-. Create the service ID for each credential request, assign the policies defined, create an API key in IBM Cloud, and generate the secret:
+. Create the service ID for each credential request, assign the policies defined, create an API key in IBM Cloud VPC, and generate the secret:
 +
 [source,terminal]
 ----

--- a/modules/quotas-and-limits-ibm-cloud.adoc
+++ b/modules/quotas-and-limits-ibm-cloud.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: CONCEPT
 [id="quotas-and-limits-ibm-cloud_{context}"]
-= Quotas and limits on IBM Cloud
+= Quotas and limits on IBM Cloud VPC
 
-The {product-title} cluster uses a number of IBM Cloud components, and the default quotas and limits affect your ability to install {product-title} clusters. If you use certain cluster configurations, deploy your cluster in certain regions, or run multiple clusters from your account, you might need to request additional resources for your IBM Cloud account.
+The {product-title} cluster uses a number of IBM Cloud VPC components, and the default quotas and limits affect your ability to install {product-title} clusters. If you use certain cluster configurations, deploy your cluster in certain regions, or run multiple clusters from your account, you might need to request additional resources for your IBM Cloud VPC account.
 
 For a comprehensive list of the default IBM Cloud VPC quotas and service limits, see IBM Cloud's documentation for link:https://cloud.ibm.com/docs/vpc?topic=vpc-quotas[Quotas and service limits].
 
@@ -26,7 +26,7 @@ By default, each cluster creates three application load balancers (ALBs):
 
 You can create additional `LoadBalancer` service objects to create additional ALBs. The default quota of VPC ALBs are 50 per region. To have more than 50 ALBs, you must increase this quota.
 
-VPC ALBs are supported. Classic ALBs are not supported for IBM Cloud.
+VPC ALBs are supported. Classic ALBs are not supported for IBM Cloud VPC.
 
 [discrete]
 == Floating IP address
@@ -39,7 +39,7 @@ The default quota for a floating IP address is 20 addresses per availability zon
 * One floating IP address in the `us-east-2` secondary zone.
 * One floating IP address in the `us-east-3` secondary zone.
 
-IBM Cloud can support up to 19 clusters per region in an account. If you plan to have more than 19 default clusters, you must increase this quota.
+IBM Cloud VPC can support up to 19 clusters per region in an account. If you plan to have more than 19 default clusters, you must increase this quota.
 
 [discrete]
 == Virtual Server Instances (VSI)
@@ -62,7 +62,7 @@ For more information, see IBM Cloud's documentation on link:https://cloud.ibm.co
 .VSI component quotas and limits
 [cols="2,2,4,2",options="header"]
 |===
-|VSI component |Default IBM Cloud quota |Default cluster configuration |Maximum number of clusters
+|VSI component |Default IBM Cloud VPC quota |Default cluster configuration |Maximum number of clusters
 
 |vCPU
 |200 vCPUs per region
@@ -80,9 +80,9 @@ For more information, see IBM Cloud's documentation on link:https://cloud.ibm.co
 |19 per region
 |===
 
-If you plan to exceed the resources stated in the table, you must increase your IBM Cloud account quota.
+If you plan to exceed the resources stated in the table, you must increase your IBM Cloud VPC account quota.
 
 [discrete]
 == Block Storage Volumes
 
-For each VPC machine, a block storage device is attached for its boot volume. The default cluster configuration creates seven VPC machines, resulting in seven block storage volumes. Additional Kubernetes persistent volume claims (PVCs) of the IBM Cloud storage class create additional block storage volumes. The default quota of VPC block storage volumes are 300 per region. To have more than 300 volumes, you must increase this quota.
+For each VPC machine, a block storage device is attached for its boot volume. The default cluster configuration creates seven VPC machines, resulting in seven block storage volumes. Additional Kubernetes persistent volume claims (PVCs) of the IBM Cloud VPC storage class create additional block storage volumes. The default quota of VPC block storage volumes are 300 per region. To have more than 300 volumes, you must increase this quota.


### PR DESCRIPTION
Version(s):
CP to 4.10 and 4.11

Issue:
This PR addresses doc bug [2095294](https://bugzilla.redhat.com/show_bug.cgi?id=2095294).

Link to docs preview:

- [Supported installation methods for different platforms](http://file.rdu.redhat.com/mpytlak/IBMCloudVPC/installing/installing-preparing.html#supported-installation-methods-for-different-platforms)
- [Preparing to install on IBM Cloud VPC](http://file.rdu.redhat.com/mpytlak/IBMCloudVPC/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.html)
- [Configuring an IBM Cloud VPC account](http://file.rdu.redhat.com/mpytlak/IBMCloudVPC/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.html)
- [Configuring IAM for IBM Cloud VPC](http://file.rdu.redhat.com/mpytlak/IBMCloudVPC/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.html)
- [Installing a cluster on IBM Cloud VPC with customizations](http://file.rdu.redhat.com/mpytlak/IBMCloudVPC/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.html)
- [Installing a cluster on IBM Cloud VPC with network customizations](http://file.rdu.redhat.com/mpytlak/IBMCloudVPC/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.html)
- [Uninstalling a cluster on IBM Cloud VPC](http://file.rdu.redhat.com/mpytlak/IBMCloudVPC/installing/installing_ibm_cloud_public/uninstalling-cluster-ibm-cloud.html)