### PR TITLE
Updates for BZ2033931 - info on CPU capacity related to pod scheduling 

### DIFF
--- a/modules/cnf-cpu-infra-container.adoc
+++ b/modules/cnf-cpu-infra-container.adoc
@@ -14,7 +14,7 @@ Generic housekeeping and workload tasks use CPUs in a way that may impact latenc
 |Process type
 |Details
 
-|Burstable and best-effort pods
+|`Burstable` and `BestEffort` pods
 |Runs on any CPU except where low latency workload is running
 
 |Infrastructure pods
@@ -32,6 +32,15 @@ Generic housekeeping and workload tasks use CPUs in a way that may impact latenc
 |OS processes/systemd services
 |Pins to reserved CPUs
 |===
+
+The allocatable capacity of cores on a node for pods of all QoS process types, `Burstable`,  `BestEffort`, or `Guaranteed`, is equal to the capacity of the isolated pool. The capacity of the reserved pool is removed from the node's total core capacity for use by the cluster and operating system housekeeping duties.
+
+.Example 1
+A node features a capacity of 100 cores. Using a performance profile, the cluster administrator allocates 50 cores to the isolated pool and 50 cores to the reserved pool. The cluster administrator assigns 25 cores to QoS `Guaranteed` pods and 25 cores for `BestEffort` or `Burstable` pods. This matches the capacity of the isolated pool. 
+
+.Example 2
+A node features a capacity of 100 cores. Using a performance profile, the cluster administrator allocates 50 cores to the isolated pool and 50 cores to the reserved pool. The cluster administrator assigns 50 cores to QoS `Guaranteed` pods and one core for `BestEffort` or `Burstable` pods. This exceeds the capacity of the isolated pool by one core. Pod scheduling fails because of insufficient CPU capacity.
+
 
 The exact partitioning pattern to use depends on many factors like hardware, workload characteristics and the expected system load. Some sample use cases are as follows:
 


### PR DESCRIPTION
BZ2033931: Adding info to describe how the capacity for cores on a node for pods with any QoS class is equal to the capacity of the isolated pool. 

Version(s):
4.6+ (all supported versions)

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2033931

Link to docs preview:
http://file.emea.redhat.com/rohennes/BZ2033931/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#cnf-cpu-infra-container_cnf-master

Additional information:
I will undoubtedly need to CP as we go back the OCP versions, let me know which ones need CP and I can create separate PRs. 

