### PR TITLE
[RHACS] Release Notes for ACS 3.68.2

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -42,7 +42,7 @@ endif::[]
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 3.68.1
+:rhacs-version: 3.68.2
 :ocp-supported-version: 4.5
 // Following are used in modules/configure-policy-notifications.adoc
 :toolname: PagerDuty

--- a/release_notes/368-release-notes.adoc
+++ b/release_notes/368-release-notes.adoc
@@ -7,7 +7,9 @@ toc::[]
 
 {product-title} ({product-title-short}) 3.68 includes feature enhancements, bug fixes, scale improvements, and other changes.
 
-*Release date:* February 2, 2022
+- 3.68.0 Release date: February 2, 2022
+- 3.68.1 Release date: February 14, 2022
+- 3.68.2 Release date: June 14, 2022
 
 [id="new-features-368"]
 == New features
@@ -40,9 +42,12 @@ Therefore, when an application does not need to access the service account direc
 [id="important-bug-fixes-368"]
 == Important bug fixes
 
-* *ROX-8709*: Previously, searching for CVEs with a specific severity did not returned any results. This issue has been fixed.
-* *ROX-8983*: Previously, when configuring the *Manage Watches* feature, if you added more than 12 images to the watch list, the image list did not display properly. This issue has been fixed.
-* *ROX-8276*: Previously, when the {product-title-short} Operator accessed the `central-htpasswd` secret, it created a false positive policy violation for the *OpenShift: Advanced Cluster Security Central Admin Secret Accessed* default policy. This issue has been fixed.
+[id="resolved-in-version-3682"]
+=== Resolved in version 3.68.2
+
+Release date: June 14, 2022
+
+* *ROX-10845*: link:https://access.redhat.com/security/cve/cve-2022-1902[CVE-2022-1902]: GraphQL exposes Notifiers secrets.
 
 [id="resolved-in-version-3681"]
 === Resolved in version 3.68.1
@@ -53,13 +58,19 @@ Release date: February 14, 2022
 This issue has been fixed.
 Central now reports an error for such cases.
 
+[id="resolved-in-version-3680"]
+=== Resolved in version 3.68.0
+
+* *ROX-8709*: Previously, searching for CVEs with a specific severity did not returned any results. This issue has been fixed.
+* *ROX-8983*: Previously, when configuring the *Manage Watches* feature, if you added more than 12 images to the watch list, the image list did not display properly. This issue has been fixed.
+* *ROX-8276*: Previously, when the {product-title-short} Operator accessed the `central-htpasswd` secret, it created a false positive policy violation for the *OpenShift: Advanced Cluster Security Central Admin Secret Accessed* default policy. This issue has been fixed.
+
 [id="security-update"]
 == Security update
 In earlier versions of {product-title}, the `write` permission for the `APIToken` resource allowed users to create API tokens for any role, including the `admin` role. This issue has been fixed.
 
 [id="important-system-changes-368"]
 == Important system changes
-
 
 [id="changes-in-version-3681"]
 === Changes in version 3.68.1
@@ -142,18 +153,18 @@ In addition, due to the change in image repository names in `registry.redhat.io`
 | Main
 | Includes Central, Sensor, Admission Controller, and Compliance.
 Also includes `roxctl` for use in continuous integration (CI) systems.
-| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.68.1`
+| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.68.2`
 
 | Scanner
 | Scans images and nodes.
-| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:3.68.1`
+| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:3.68.2`
 
 | Scanner DB
 | Stores image scan results and vulnerability definitions.
-| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:3.68.1`
+| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:3.68.2`
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.
-| `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:3.68.1`
-  `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.68.1`
+| `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:3.68.2`
+  `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.68.2`
 |===


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs-3.68`
- Cherry pick to `rhacs-docs`

Label: `RHACS`

[Issue](https://issues.redhat.com/browse/ROX-11327)

[Link to docs preview](https://openshift-docs-5lqcb6d19-kcarmichael08.vercel.app/openshift-acs/master/release_notes/368-release-notes.html)
