### PR TITLE
Updates the download rosa CLI link

### DIFF
--- a/modules/rosa-setting-up-cli.adoc
+++ b/modules/rosa-setting-up-cli.adoc
@@ -13,7 +13,7 @@ To set up the `rosa` CLI, download the latest release, then configure and initia
 
 .Procedure
 
-. Download the latest release of the `rosa` CLI for your operating system from the link:https://access.redhat.com/products/red-hat-openshift-service-aws/[{product-title}] product page.
+. Download the latest release of the `rosa` CLI for your operating system from the *Download* page of link:https://access.redhat.com/products/red-hat-openshift-service-aws/[{product-title}]. 
 +
 . It is recommended that after you download the release, you rename the executable file that you downloaded to `rosa`, and then add `rosa` to your path.
 +


### PR DESCRIPTION
Updates the download rosa CLI link.

For ROSA. 

Preview:

![image](https://user-images.githubusercontent.com/77019920/173132431-8824d599-75cc-472a-a5ea-65baf7191046.png)

Issue: https://github.com/openshift/openshift-docs/issues/46532

Can be merged upon approval. 
