### PR TITLE
RHDEVDOCS-4141 - release note for backport of Prometheus config for stored retention time

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1102,6 +1102,7 @@ Access to the third-party Alertmanager web user interface from the {product-titl
 ==== Prometheus
 
 * {product-title} cluster administrators can now configure query logging for Prometheus.
+* {product-title} cluster administrators can now configure how long Prometheus retains stored metrics data.
 * Access to the third-party Prometheus web user interface is deprecated and will be removed in a future {product-title} release.
 
 [id="ocp-4.10-monitoring-prometheus-adapter"]


### PR DESCRIPTION
Summary: This PR adds an item to the OCP 4.10 release notes documenting the backported feature for Prometheus in which a cluster admin can configure a retention time for stored metrics data.

- Aligned team: DevTools
- For branches: 4.10 ONLY
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4141
- Direct link to doc preview (RH VPN access only): http://file.rdu.redhat.com/bburt/RHDEVDOCS-4125-release-note-for-retention-time-backport/release_notes/ocp-4-10-release-notes.html#ocp-4-10-monitoring-prometheus
- SME review: @jan--f 
- QE review: N/A
- Peer review: @jc-berger 