### PR TITLE
Fixes a slight wording error in the Operator guide

### DIFF
--- a/modules/getting-started-openshift-common-terms.adoc
+++ b/modules/getting-started-openshift-common-terms.adoc
@@ -56,4 +56,4 @@ An Operator is a Kubernetes-native application. The goal of an Operator is to pu
 +
 Operators are purpose-built for your applications. They implement and automate common Day 1 activities such as installation and configuration as well as Day 2 activities such as scaling up and down, reconfiguration, updates, backups, fail overs, and restores in a piece of software running inside your Kubernetes cluster by integrating natively with Kubernetes concepts and APIs. This is called a Kubernetes-native application.
 +
-With Operators, you have to treat an application as a collection of primitives such as pods, deployments, services, or config maps. Instead you can treat it as a single object that exposes only the options that make sense for the application.
+With Operators, applications must not be treated as a collection of primitives, such as pods, deployments, services, or config maps. Instead, Operators should be treated as a single object that exposes the options that make sense for the application.


### PR DESCRIPTION
For 4.10 and 4.11 only.

Issue: https://github.com/openshift/openshift-docs/issues/46419

Preview: 
![image](https://user-images.githubusercontent.com/77019920/173141128-086cbedd-25d8-46ee-82e6-24d6ce9fcdfc.png)


No QE needed. 


