### PR TITLE
RHDEVDOCS-3824 - Added setting up argo cd instance

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1596,6 +1596,8 @@ Topics:
     File: installing-openshift-gitops
   - Name: Uninstalling OpenShift GitOps
     File: uninstalling-openshift-gitops
+  - Name: Setting up a new Argo CD instance
+    File: setting-up-argocd-instance
   - Name: Configuring an OpenShift cluster by deploying an application with cluster configurations
     File: configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations
   - Name: Deploying a Spring Boot application with Argo CD

--- a/cicd/gitops/setting-up-argocd-instance.adoc
+++ b/cicd/gitops/setting-up-argocd-instance.adoc
@@ -1,0 +1,15 @@
+:_content-type: ASSEMBLY
+[id="setting-up-argocd-instance"]
+= Setting up a new Argo CD instance
+include::_attributes/common-attributes.adoc[]
+:context: setting-up-argocd-instance
+
+toc::[]
+
+By default, the {gitops-title} installs an instance of Argo CD in the `openshift-gitops` namespace with additional permissions for managing certain cluster-scoped resources. To manage cluster configurations or deploy applications, you can install and deploy a new Argo CD instance. By default, any new instance has permissions to manage resources only in the namespace where it is deployed.
+
+include::modules/gitops-argo-cd-installation.adoc[leveloffset=+1]
+
+include::modules/gitops-enable-replicas-for-argo-cd-server.adoc[leveloffset=+1]
+
+include::modules/gitops-deploy-resources-different-namespaces.adoc[leveloffset=+1]

--- a/modules/gitops-argo-cd-installation.adoc
+++ b/modules/gitops-argo-cd-installation.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * gitops-argo-cd-installation.adoc
+
+:_content-type: PROCEDURE
+[id="gitops-argo-cd-installation_{context}"]
+= Installing Argo CD 
+
+To manage cluster configurations or deploy applications, you can install and deploy a new Argo CD instance.
+
+.Procedure
+. Log in to the {product-title} web console. 
+
+. Click *Operators* -> *Installed Operators*.
+
+. Create or select the project where you want to install the Argo CD instance from the *Project* drop-down menu.
+
+. Select *Openshift GitOps Operator* from the installed operators and select the *Argo CD* tab.
+
+. Click *Create* to configure the following parameters:
+
+.. For *Name*, enter `/`.
+
+.. Create an external OS Route to access Argo CD server. Click *Server* -> *Route* and, for *Enable Route*, select *true*.
+
+. To open the Argo CD web UI, click the route that is created in the project where the Argo CD instance is installed.

--- a/modules/gitops-deploy-resources-different-namespaces.adoc
+++ b/modules/gitops-deploy-resources-different-namespaces.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * gitops-argo-cd-installation.adoc
+
+:_content-type: PROCEDURE
+[id="gitops-deploy-resources-different-namespaces_{context}"]
+= Deploying resources to a different namespace
+
+To allow Argo CD to manage resources in other namespaces apart from where it is installed, configure the target namespace with a `argocd.argoproj.io/managed-by` label.
+
+.Procedure
+
+* Configure the namespace:
++
+[source,terminal]
+----
+$ oc label namespace <namespace> && \
+argocd.argoproj.io/managed-by=<instance_name> <1>
+----
+<1> The namespace where Argo CD is installed. 
+

--- a/modules/gitops-enable-replicas-for-argo-cd-server.adoc
+++ b/modules/gitops-enable-replicas-for-argo-cd-server.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * gitops-argo-cd-installation.adoc
+
+:_content-type: PROCEDURE
+[id="gitops-enable-replicas-for-argo-cd-server_{context}"]
+= Enabling replicas for Argo CD server and repo server
+
+Argo CD-server and Argo CD-repo-server workloads are stateless. To better distribute your workloads among pods, you can increase the number of Argo CD-server and  Argo CD-repo-server replicas. However, if a horizontal autoscaler is enabled on the Argo CD-server, it overrides the number of replicas you set.
+
+.Procedure
+
+* Set the `replicas` parameters for the `repo` and `server` spec to the number of replicas you want to run:
++
+.Example Argo CD custom resource
+
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: repo
+spec:
+  repo:
+    replicas: <number_of_replicas>
+  server:
+    replicas: <number_of_replicas>
+    route:
+      enabled: true
+      path: /
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: passthrough
+      wildcardPolicy: None
+----


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.10, 4.11

JIRA issue:
https://issues.redhat.com/browse/RHDEVDOCS-3824

Preview pages: file:///home/deghosh/redhat-work/documentation/openshift-docs/_preview/openshift-enterprise/setting-up-argo-cd-instance-3824/cicd/gitops/setting-up-argocd-instance.html

* SME review completed by @jannfis 
* QE review completed by @varshab1210
* Peer-reviews completed by @rolfedh and @abrennan89