### PR TITLE
Changes the example to the relative version

### DIFF
--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -38,8 +38,8 @@ $ oc get clusteroperator baremetal
 .Example output
 [source,terminal]
 ----
-NAME        VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE  
-baremetal   4.10.12   True        False         False      3d15h 
+NAME        VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
+baremetal   4.8.0     True        False         False      3d15h
 ----
 
 . Remove the old `BareMetalHost` and `Machine` objects:
@@ -149,7 +149,7 @@ EOF
 $ oc create -f example.yaml
 ----
 +
-The provisioning process uses the baremetal-operator to install RHCOS and prepare the host to be added to the cluster. 
+The provisioning process uses the baremetal-operator to install RHCOS and prepare the host to be added to the cluster.
 +
 . To view the `BareMetalHost` objects, run the following command:
 +


### PR DESCRIPTION
For 4.8 only.

Issue: https://github.com/openshift/openshift-docs/issues/46414

Preview: 
![image](https://user-images.githubusercontent.com/77019920/173371326-6e164e09-8c28-4a99-8305-3f8d570cb77c.png)

I do not think QE is needed. I ran this command myself and came up with the following results: 

stevsmit@stevsmit:~/pp/openshift-docs (GH46419)$ oc get clusteroperator baremetal
NAME        VERSION                             AVAILABLE   PROGRESSING   DEGRADED   SINCE
baremetal   4.8.0-0.nightly-2022-06-09-201229   True        False         False      21m
