### PR TITLE
WINC update link to 5.1.0 errata

### DIFF
--- a/windows_containers/windows-containers-release-notes-5-x.adoc
+++ b/windows_containers/windows-containers-release-notes-5-x.adoc
@@ -33,7 +33,7 @@ endif::openshift-origin[]
 [id="wmco-5-1-0"]
 == Release notes for Red Hat Windows Machine Config Operator 5.1.0
 
-This release of the WMCO is now available with a bug fix and a few improvements. The components of the WMCO 5.1.0 is now available in link:https://access.redhat.com/errata/RHBA-2022:95425-01[RHBA-2022:95425-01].
+This release of the WMCO is now available with a bug fix and a few improvements. The components of the WMCO 5.1.0 is now available in link:https://access.redhat.com/errata/RHBA-2022:4989[RHBA-2022:4989-01].
 
 === Bug fix
 


### PR DESCRIPTION
Fix bad link to 5.1.0 errata

Preview: [Release notes for Red Hat Windows Machine Config Operator 5.1.0](http://file.rdu.redhat.com/~mburke/enterprise-4.10/windows_containers/windows-containers-release-notes-5-x.html#wmco-5-1-0)