### PR TITLE
Adds a technology preview note to the External DNS Operator page

### DIFF
--- a/networking/external_dns_operator/nw-installing-external-dns-operator.adoc
+++ b/networking/external_dns_operator/nw-installing-external-dns-operator.adoc
@@ -6,6 +6,12 @@
 [id="nw-installing-external-dns-operator_{context}"]
 = Installing the External DNS Operator
 
+[IMPORTANT]
+====
+The External DNS Operator is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/.
+====
+
 You can install the External DNS Operator using the Red Hat OpenShift Container Platform Operator Hub.
 
 .Procedure


### PR DESCRIPTION
External DNS Operator is TP, so I added the TP note at the top of the page. See https://docs.openshift.com/container-platform/4.10/release_notes/ocp-4-10-release-notes.html#ocp-4-10-networking-external-dns-operator. 

For 4.10+

Issue: https://github.com/openshift/openshift-docs/issues/46242

Preview: 
![image](https://user-images.githubusercontent.com/77019920/173401195-61ec263f-bd90-410d-9d31-209842509aee.png)

QE not needed. 

