### PR TITLE
Updates the command to create an HTPasswrd secret

### DIFF
--- a/modules/identity-provider-htpasswd-secret.adoc
+++ b/modules/identity-provider-htpasswd-secret.adoc
@@ -19,7 +19,7 @@ contains the HTPasswd user file.
 +
 [source,terminal]
 ----
-$ oc create secret generic htpass-secret --from-file=htpasswd=<path_to_users.htpasswd> -n openshift-config <1>
+$ oc create secret generic htpass-secret --from-file htpasswd=<path_to_users.htpasswd> -n openshift-config <1>
 ----
 <1> The secret key containing the users file for the `--from-file` argument must be named `htpasswd`, as shown in the above command.
 +


### PR DESCRIPTION
Updates the command to create an HTPasswrd secret.

For 4.6+

Issue: https://github.com/openshift/openshift-docs/issues/46138

Preview: 
![image](https://user-images.githubusercontent.com/77019920/173414246-70f66138-0421-45e3-937a-9f0c00bdf5e9.png)


QE ack pending. 