### PR TITLE
Updates a command because there are no pods labeled fluentd in OCP

### DIFF
--- a/modules/cluster-logging-forwarding-json-logs-to-the-default-elasticsearch.adoc
+++ b/modules/cluster-logging-forwarding-json-logs-to-the-default-elasticsearch.adoc
@@ -52,5 +52,5 @@ The Red Hat OpenShift Logging Operator redeploys the Fluentd pods. However, if t
 +
 [source,terminal]
 ----
-$ oc delete pod --selector logging-infra=fluentd
+$ oc delete pod --selector logging-infra=collector
 ----

--- a/modules/cluster-logging-troubleshooting-log-forwarding.adoc
+++ b/modules/cluster-logging-troubleshooting-log-forwarding.adoc
@@ -15,5 +15,5 @@ When you create a `ClusterLogForwarder` custom resource (CR), if the Red Hat Ope
 +
 [source,terminal]
 ----
-$ oc delete pod --selector logging-infra=fluentd
+$ oc delete pod --selector logging-infra=collector
 ----


### PR DESCRIPTION
Updating a command slightly. 

For 4.6+ 

Preview: Troubleshooting log forwarding

![image](https://user-images.githubusercontent.com/77019920/173422173-a396c8e8-27a6-450d-9fba-c50ed00c4866.png)

Preview: Forwarding JSON logs: 

![image](https://user-images.githubusercontent.com/77019920/173422330-1302184c-ecd6-4df4-a767-f4605eacef30.png)

Issue: https://github.com/openshift/openshift-docs/issues/46089

Pending QE. 
 