### PR TITLE
[SRVCOM-1703] Add Serverless docs for ROSA: develop

### DIFF
--- a/modules/serverless-creating-broker-labeling.adoc
+++ b/modules/serverless-creating-broker-labeling.adoc
@@ -19,7 +19,7 @@ Brokers created using this method are not removed if you remove the label. You m
 * Install the OpenShift (`oc`) CLI.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-rosa[]
 * You have cluster or dedicated administrator permissions.
 endif::[]
 

--- a/serverless/develop/serverless-autoscaling-developer.adoc
+++ b/serverless/develop/serverless-autoscaling-developer.adoc
@@ -12,7 +12,7 @@ ifdef::openshift-enterprise[]
 Autoscaling settings for Knative services can be global settings that are configured by cluster administrators, or per-revision settings that are configured for individual services.
 endif::[]
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-rosa[]
 Autoscaling settings for Knative services can be global settings that are configured by cluster or dedicated administrators, or per-revision settings that are configured for individual services.
 endif::[]
 


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-1703

Link to docs preview:
http://file.brq.redhat.com/~msvistun/serverless-rosa/srvls-rosa-develop/serverless/develop/serverless-applications.html

Note:
Topic map for this is in https://github.com/openshift/openshift-docs/pull/46619.