### PR TITLE
[SRVCOM-1703] Add Serverless docs for ROSA: install

### DIFF
--- a/modules/serverless-deleting-crds.adoc
+++ b/modules/serverless-deleting-crds.adoc
@@ -21,7 +21,7 @@ ifdef::openshift-enterprise[]
 * You have access to an {product-title} account with cluster administrator access.
 endif::[]
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to an {product-title} account with cluster administrator or dedicated administrator access.
 endif::[]
 

--- a/modules/serverless-install-eventing-web-console.adoc
+++ b/modules/serverless-install-eventing-web-console.adoc
@@ -14,7 +14,7 @@ ifdef::openshift-enterprise[]
 * You have access to an {product-title} account with cluster administrator access.
 endif::[]
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to an {product-title} account with cluster administrator or dedicated administrator access.
 endif::[]
 

--- a/modules/serverless-install-eventing-yaml.adoc
+++ b/modules/serverless-install-eventing-yaml.adoc
@@ -14,7 +14,7 @@ ifdef::openshift-enterprise[]
 * You have access to an {product-title} account with cluster administrator access.
 endif::[]
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to an {product-title} account with cluster administrator or dedicated administrator access.
 endif::[]
 

--- a/modules/serverless-install-serving-web-console.adoc
+++ b/modules/serverless-install-serving-web-console.adoc
@@ -14,7 +14,7 @@ ifdef::openshift-enterprise[]
 * You have access to an {product-title} account with cluster administrator access.
 endif::[]
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to an {product-title} account with cluster administrator or dedicated administrator access.
 endif::[]
 

--- a/modules/serverless-install-serving-yaml.adoc
+++ b/modules/serverless-install-serving-yaml.adoc
@@ -14,7 +14,7 @@ ifdef::openshift-enterprise[]
 * You have access to an {product-title} account with cluster administrator access.
 endif::[]
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to an {product-title} account with cluster administrator or dedicated administrator access.
 endif::[]
 

--- a/modules/serverless-install-web-console.adoc
+++ b/modules/serverless-install-web-console.adoc
@@ -14,7 +14,7 @@ ifdef::openshift-enterprise[]
 * You have access to an {product-title} account with cluster administrator access.
 endif::[]
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to an {product-title} account with cluster or dedicated administrator access.
 endif::[]
 

--- a/modules/serverless-uninstalling-knative-serving.adoc
+++ b/modules/serverless-uninstalling-knative-serving.adoc
@@ -14,7 +14,7 @@ ifdef::openshift-enterprise[]
 * You have access to an {product-title} account with cluster administrator access.
 endif::[]
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to an {product-title} account with cluster administrator or dedicated administrator access.
 endif::[]
 

--- a/serverless/install/install-serverless-operator.adoc
+++ b/serverless/install/install-serverless-operator.adoc
@@ -30,8 +30,8 @@ You can use the {product-title} `MachineSet` API to manually scale your cluster 
 // QE thread related: https://coreos.slack.com/archives/CD87JDUB0/p1643986092796179
 endif::[]
 
-// OSD docs
-ifdef::openshift-dedicated[]
+// OSD and ROSA docs
+ifdef::openshift-dedicated,openshift-rosa[]
 include::modules/serverless-cluster-sizing-req.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-1703

Link to docs preview:
http://file.brq.redhat.com/~msvistun/serverless-rosa/srvls-rosa-install/serverless/install/install-serverless-operator.html

Note:
Topic map for this is in https://github.com/openshift/openshift-docs/pull/46619.