### PR TITLE
[SRVCOM-1703] Add Serverless docs for ROSA: monitor

### DIFF
--- a/modules/serverless-jaeger-config.adoc
+++ b/modules/serverless-jaeger-config.adoc
@@ -14,7 +14,7 @@ ifdef::openshift-enterprise[]
 * You have access to an {product-title} account with cluster administrator access.
 endif::[]
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to an {product-title} account with cluster or dedicated administrator access.
 endif::[]
 

--- a/serverless/monitor/serverless-developer-metrics.adoc
+++ b/serverless/monitor/serverless-developer-metrics.adoc
@@ -12,7 +12,7 @@ ifdef::openshift-enterprise[]
 You can view different metrics for {ServerlessProductName} by navigating to xref:../../monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards-developer_reviewing-monitoring-dashboards[*Dashboards*] in the {product-title} web console *Developer* perspective.
 endif::[]
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-dedicated,openshift-rosa[]
 You can view different metrics for {ServerlessProductName} by navigating to *Dashboards* in the {product-title} web console *Developer* perspective.
 endif::[]
 


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-1703

Link to docs preview:
http://file.brq.redhat.com/~msvistun/serverless-rosa/srvls-rosa-monitor/serverless/monitor/cluster-logging-serverless.html

Note:
Topic map for this is in https://github.com/openshift/openshift-docs/pull/46619.