### PR TITLE
Adds notes for 4.10.18 release

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2956,3 +2956,27 @@ link:https://access.redhat.com/solutions/6962052[{product-title} 4.10.17 contain
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-18"]
+=== RHBA-2022:4944 - {product-title} 4.10.18 bug fix and security update
+
+Issued: 2022-06-13
+
+{product-title} release 4.10.18, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:4944[RHBA-2022:4944] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:4943[RHSA-2022:4943] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6962977[{product-title} 4.10.18 container image list]
+
+[id="ocp-4-10-18-bug-fixes"]
+==== Bug fixes
+
+* Previously, Alibaba Cloud was only supported for disk volumes larger than 20 GiB. Consequently, attempts to dynamically provision a new volume for a persistent volume claim (PVC) smaller than 20GiB failed. With this update, {product-title} will automatically increase the volume size for a PVC and it will provision volumes at least with 20 GiB in size.
+ (link:https://bugzilla.redhat.com/show_bug.cgi?id=2076671[*BZ#2076671*])
+
+* Previously, the Ingress Operator had unnecessary logic to remove a finalizer on `LoadBalancer-type` services in previous versions of {product-title}. With this update, the Ingress Operator no longer includes this logic. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2082161[*BZ#2082161*])
+
+[id="ocp-4-10-18-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.10.18 release

Version(s):
`enterprise-4.10` only

Link to docs preview (VPN required)
http://file.rdu.redhat.com/opayne/RNs-4.10.18/release_notes/ocp-4-10-release-notes.html#ocp-4-10-18  





<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
