### PR TITLE
RNs-4.9.38 Added with bug fix and security update

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2904,3 +2904,24 @@ link:https://access.redhat.com/solutions/6961861[{product-title} 4.9.37 containe
 ==== Updating
 
 To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-9-38"]
+=== RHBA-2022:2283 - {product-title} 4.9.38 bug fix and security update
+
+Issued: 2022-06-14
+
+{product-title} release 4.9.38, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:4973[RHBA-2022:4973] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:4972[RHSA-2022:4972] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6962832[{product-title} 4.9.38 container image list]
+
+[id="ocp-4-9-38-bug-fixes"]
+==== Bug fixes
+
+* There is a race condition between {rh-openstack-first} credential secret creation and `kube-conroller-manager` start up. If this happens, the {rh-openstack} cloud provider does not get configured with {rh-openstack} credentials, which would break support for creating Octavia load balancers for `LoadBalancer` services. Users should try fetching the {rh-openstack} credentials secret until it succeeds during the `kube-controller-manager` process. This allows the {rh-openstack} cloud provider to consistently initialize when `kube-controller-manager` starts. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2059677#[BZ#2059677*])
+
+[id="ocp-4-9-38-updating"]
+==== Updating
+
+To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
**RNs-4.9.38**
Added with bug fix and security update

**Version(s):**
enterprise-4.9 only

**Issue:**
https://issues.redhat.com/browse/OCPPLAN-9296

**Link to docs preview:**
https://wiharris.github.io/openshift-docs/RNs-4.9.38/release_notes/ocp-4-9-release-notes.html#ocp-4-9-38

**Additional information:**
N/A



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
