### PR TITLE
[SRVCOM-1831] Serverless functions: update abstracts format

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3522,7 +3522,7 @@ Topics:
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions
     File: serverless-developing-typescript-functions
-  - Name: Developing Golang functions
+  - Name: Developing Go functions
     File: serverless-developing-go-functions
   - Name: Developing Python functions
     File: serverless-developing-python-functions

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -322,7 +322,7 @@ Topics:
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions
     File: serverless-developing-typescript-functions
-  - Name: Developing Golang functions
+  - Name: Developing Go functions
     File: serverless-developing-go-functions
   - Name: Developing Python functions
     File: serverless-developing-python-functions

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -433,7 +433,7 @@ Topics:
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions
     File: serverless-developing-typescript-functions
-  - Name: Developing Golang functions
+  - Name: Developing Go functions
     File: serverless-developing-go-functions
   - Name: Developing Python functions
     File: serverless-developing-python-functions

--- a/_unused_topics/serverless-rn-template-module.adoc
+++ b/_unused_topics/serverless-rn-template-module.adoc
@@ -17,7 +17,7 @@
 * {ServerlessProductName} now uses Knative Serving 0.x.
 * {ServerlessProductName} now uses Knative Eventing 0.x.
 * {ServerlessProductName} now uses Kourier 0.x.
-* {ServerlessProductName} now uses Knative `kn` CLI 0.x.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 0.x.
 * {ServerlessProductName} now uses Knative Kafka 0.x.
 * The `kn func` CLI plug-in now uses `func` 0.x.
 

--- a/cli_reference/index.adoc
+++ b/cli_reference/index.adoc
@@ -24,7 +24,7 @@ The following set of CLI tools are available in {product-title}:
 
 * xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[OpenShift CLI (oc)]: This is the most commonly used CLI tool by {product-title} users. It helps both cluster administrators and developers to perform end-to-end operations across {product-title} using the terminal. Unlike the web console, it allows the user to work directly with the project source code using command scripts.
 
-* xref:../cli_reference/kn-cli-tools.adoc#kn-cli-tools[Knative CLI (kn)]: The `kn` CLI tool provides simple and intuitive terminal commands that can be used to interact with OpenShift Serverless components, such as Knative Serving and Eventing.
+* xref:../cli_reference/kn-cli-tools.adoc#kn-cli-tools[Knative CLI (kn)]: The Knative (`kn`) CLI tool provides simple and intuitive terminal commands that can be used to interact with OpenShift Serverless components, such as Knative Serving and Eventing.
 
 * xref:../cli_reference/tkn_cli/installing-tkn.adoc#installing-tkn[Pipelines CLI (tkn)]: OpenShift Pipelines is a continuous integration and continuous delivery (CI/CD) solution in {product-title}, which internally uses Tekton. The `tkn` CLI tool provides simple and intuitive commands to interact with OpenShift Pipelines using the terminal.
 

--- a/cli_reference/kn-cli-tools.adoc
+++ b/cli_reference/kn-cli-tools.adoc
@@ -1,24 +1,24 @@
 :_content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="kn-cli-tools"]
-= Knative CLI (kn) for use with {ServerlessProductName}
+= Knative CLI for use with {ServerlessProductName}
 :context: kn-cli-tools
 
 toc::[]
 
-The Knative `kn` CLI enables simple interaction with Knative components on {product-title}.
+The Knative (`kn`) CLI enables simple interaction with Knative components on {product-title}.
 
 [id="kn-cli-tools-key-features"]
 == Key features
 
-The `kn` CLI is designed to make serverless computing tasks simple and concise.
-Key features of the `kn` CLI include:
+The Knative (`kn`) CLI is designed to make serverless computing tasks simple and concise.
+Key features of the Knative CLI include:
 
 * Deploy serverless applications from the command line.
 * Manage features of Knative Serving, such as services, revisions, and traffic-splitting.
 * Create and manage Knative Eventing components, such as event sources and triggers.
 * Create sink bindings to connect existing Kubernetes applications and Knative services.
-* Extend the `kn` CLI with flexible plug-in architecture, similar to the `kubectl` CLI.
+* Extend the Knative CLI with flexible plug-in architecture, similar to the `kubectl` CLI.
 * Configure autoscaling parameters for Knative services.
 * Scripted usage, such as waiting for the results of an operation, or deploying custom rollout and rollback strategies.
 

--- a/modules/creating-serverless-apps-kn.adoc
+++ b/modules/creating-serverless-apps-kn.adoc
@@ -7,12 +7,12 @@
 [id="creating-serverless-apps-kn_{context}"]
 = Creating serverless applications by using the Knative CLI
 
-Using the `kn` CLI to create serverless applications provides a more streamlined and intuitive user interface over modifying YAML files directly. You can use the `kn service create` command to create a basic serverless application using the `kn` CLI.
+Using the Knative (`kn`) CLI to create serverless applications provides a more streamlined and intuitive user interface over modifying YAML files directly. You can use the `kn service create` command to create a basic serverless application.
 
 .Prerequisites
 
 * {ServerlessOperatorName} and Knative Serving are installed on your cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/delete-kn-trigger.adoc
+++ b/modules/delete-kn-trigger.adoc
@@ -6,7 +6,7 @@
 [id="delete-kn-trigger_{context}"]
 = Deleting a trigger by using the Knative CLI
 
-Using the `kn` CLI to delete a trigger provides a streamlined and intuitive user interface. You can use the `kn trigger delete` command to delete a trigger.
+Using the Knative (`kn`) CLI to delete a trigger provides a streamlined and intuitive user interface. You can use the `kn trigger delete` command to delete a trigger.
 
 .Prerequisites
 

--- a/modules/kn-trigger-describe.adoc
+++ b/modules/kn-trigger-describe.adoc
@@ -6,7 +6,7 @@
 [id="kn-trigger-describe_{context}"]
 = Describing a trigger by using the Knative CLI
 
-Using the `kn` CLI to describe triggers provides a streamlined and intuitive user interface. You can use the `kn trigger describe` command to print information about existing triggers in your cluster by using the `kn` CLI.
+Using the Knative (`kn`) CLI to describe triggers provides a streamlined and intuitive user interface. You can use the `kn trigger describe` command to print information about existing triggers in your cluster by using the Knative CLI.
 
 .Prerequisites
 

--- a/modules/kn-trigger-filtering.adoc
+++ b/modules/kn-trigger-filtering.adoc
@@ -7,7 +7,7 @@
 = Filtering events with triggers by using the Knative CLI
 // should be a procedure module but out of scope for this PR
 
-Using the `kn` CLI to filter events by using triggers provides a streamlined and intuitive user interface. You can use the `kn trigger create` command, along with the appropriate flags, to filter events by using triggers.
+Using the Knative (`kn`) CLI to filter events by using triggers provides a streamlined and intuitive user interface. You can use the `kn trigger create` command, along with the appropriate flags, to filter events by using triggers.
 
 In the following trigger example, only events with the attribute `type: dev.knative.samples.helloworld` are sent to the event sink:
 

--- a/modules/kn-trigger-list.adoc
+++ b/modules/kn-trigger-list.adoc
@@ -6,7 +6,7 @@
 [id="kn-trigger-list_{context}"]
 = Listing triggers by using the Knative CLI
 
-Using the `kn` CLI to list triggers provides a streamlined and intuitive user interface. You can use the `kn trigger list` command to list existing triggers in your cluster.
+Using the Knative (`kn`) CLI to list triggers provides a streamlined and intuitive user interface. You can use the `kn trigger list` command to list existing triggers in your cluster.
 
 .Prerequisites
 

--- a/modules/kn-trigger-update.adoc
+++ b/modules/kn-trigger-update.adoc
@@ -6,7 +6,7 @@
 [id="kn-trigger-update_{context}"]
 = Updating a trigger by using the Knative CLI
 
-Using the `kn` CLI to update triggers provides a streamlined and intuitive user interface. You can use the `kn trigger update` command with certain flags to update attributes for a trigger.
+Using the Knative (`kn`) CLI to update triggers provides a streamlined and intuitive user interface. You can use the `kn trigger update` command with certain flags to update attributes for a trigger.
 
 .Prerequisites
 

--- a/modules/serverless-blue-green-deploy.adoc
+++ b/modules/serverless-blue-green-deploy.adoc
@@ -55,7 +55,7 @@ spec:
 $ oc get ksvc <service_name>
 ----
 
-. Deploy a second revision of your app by modifying at least one field in the `template` spec of the service and redeploying it. For example, you can modify the `image` of the service, or an `env` environment variable. You can redeploy the service by applying the service YAML file, or by using the `kn service update` command if you have installed the `kn` CLI.
+. Deploy a second revision of your app by modifying at least one field in the `template` spec of the service and redeploying it. For example, you can modify the `image` of the service, or an `env` environment variable. You can redeploy the service by applying the service YAML file, or by using the `kn service update` command if you have installed the Knative (`kn`) CLI.
 
 . Find the name of the second, latest revision that was created when you redeployed the service, by running the command:
 +

--- a/modules/serverless-create-broker-kn.adoc
+++ b/modules/serverless-create-broker-kn.adoc
@@ -6,7 +6,7 @@
 [id="serverless-create-broker-kn_{context}"]
 = Creating a broker by using the Knative CLI
 
-Brokers can be used in combination with triggers to deliver events from an event source to an event sink. Using the `kn` CLI to create brokers provides a more streamlined and intuitive user interface over modifying YAML files directly. You can use the `kn broker create` command to create a broker by using the `kn` CLI.
+Brokers can be used in combination with triggers to deliver events from an event source to an event sink. Using the Knative (`kn`) CLI to create brokers provides a more streamlined and intuitive user interface over modifying YAML files directly. You can use the `kn broker create` command to create a broker.
 
 .Prerequisites
 

--- a/modules/serverless-create-channel-kn.adoc
+++ b/modules/serverless-create-channel-kn.adoc
@@ -6,7 +6,7 @@
 [id="serverless-create-channel-kn_{context}"]
 = Creating a channel by using the Knative CLI
 
-Using the `kn` CLI to create channels provides a more streamlined and intuitive user interface than modifying YAML files directly. You can use the `kn channel create` command to create a channel by using the `kn` CLI.
+Using the Knative (`kn`) CLI to create channels provides a more streamlined and intuitive user interface than modifying YAML files directly. You can use the `kn channel create` command to create a channel.
 
 .Prerequisites
 

--- a/modules/serverless-create-domain-mapping-kn.adoc
+++ b/modules/serverless-create-domain-mapping-kn.adoc
@@ -18,7 +18,7 @@ You can customize the domain for your Knative service by mapping a custom domain
 ====
 Your custom domain must point to the DNS of the {product-title} cluster.
 ====
-* You have installed the `kn` CLI tool.
+* You have installed the Knative (`kn`) CLI.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-create-func-kn.adoc
+++ b/modules/serverless-create-func-kn.adoc
@@ -7,14 +7,12 @@
 [id="serverless-create-func-kn_{context}"]
 = Creating functions
 
-You can create a basic serverless function using the `kn` CLI.
-
-You can specify the path, runtime, template, and repository with the template as flags on the command line, or use the `-c` flag to start the interactive experience in the terminal.
+Before you can build and deploy a function, you must create it by using the the Knative (`kn`) CLI. You can specify the path, runtime, template, and image registry as flags on the command line, or use the `-c` flag to start the interactive experience in the terminal.
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 
 .Procedure
 

--- a/modules/serverless-create-kn-trigger.adoc
+++ b/modules/serverless-create-kn-trigger.adoc
@@ -6,7 +6,7 @@
 [id="serverless-create-kn-trigger_{context}"]
 = Creating a trigger by using the Knative CLI
 
-Using the `kn` CLI to create triggers provides a more streamlined and intuitive user interface over modifying YAML files directly. You can use the `kn trigger create` command to create a trigger by using the `kn` CLI.
+Using the Knative (`kn`) CLI to create triggers provides a more streamlined and intuitive user interface over modifying YAML files directly. You can use the `kn trigger create` command to create a trigger.
 
 .Prerequisites
 

--- a/modules/serverless-create-traffic-split-kn.adoc
+++ b/modules/serverless-create-traffic-split-kn.adoc
@@ -6,12 +6,12 @@
 [id="serverless-create-traffic-split-kn_{context}"]
 = Creating a traffic split by using the Knative CLI
 
-Using the `kn` CLI to create traffic splits provides a more streamlined and intuitive user interface over modifying YAML files directly. You can use the `kn service update` command to split traffic between revisions of a service.
+Using the Knative (`kn`) CLI to create traffic splits provides a more streamlined and intuitive user interface over modifying YAML files directly. You can use the `kn service update` command to split traffic between revisions of a service.
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on your cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a Knative service.
 
 .Procedure

--- a/modules/serverless-creating-subscriptions-kn.adoc
+++ b/modules/serverless-creating-subscriptions-kn.adoc
@@ -6,7 +6,7 @@
 [id="serverless-creating-subscriptions-kn_{context}"]
 = Creating a subscription by using the Knative CLI
 
-After you have created a channel and an event sink, you can create a subscription to enable event delivery. Using the `kn` CLI to create subscriptions provides a more streamlined and intuitive user interface than modifying YAML files directly. You can use the `kn subscription create` command as well as the appropriate flags to create a subscription by using the `kn` CLI.
+After you have created a channel and an event sink, you can create a subscription to enable event delivery. Using the Knative (`kn`) CLI to create subscriptions provides a more streamlined and intuitive user interface than modifying YAML files directly. You can use the `kn subscription create` command with the appropriate flags to create a subscription.
 
 .Prerequisites
 

--- a/modules/serverless-customize-labels-annotations-routes.adoc
+++ b/modules/serverless-customize-labels-annotations-routes.adoc
@@ -31,7 +31,7 @@ metadata:
     <annotation_name>: <annotation_value>
 ...
 ----
-** To create a service by using the `kn` CLI, enter:
+** To create a service by using the Knative (`kn`) CLI, enter:
 +
 .Example service created by using a `kn` command
 [source,terminal]

--- a/modules/serverless-describe-broker-kn.adoc
+++ b/modules/serverless-describe-broker-kn.adoc
@@ -6,7 +6,7 @@
 [id="serverless-describe-broker-kn_{context}"]
 = Describing an existing broker by using the Knative CLI
 
-Using the `kn` CLI to describe brokers provides a streamlined and intuitive user interface. You can use the `kn broker describe` command to print information about existing brokers in your cluster by using the `kn` CLI.
+Using the Knative (`kn`) CLI to describe brokers provides a streamlined and intuitive user interface. You can use the `kn broker describe` command to print information about existing brokers in your cluster by using the Knative CLI.
 
 .Prerequisites
 

--- a/modules/serverless-describe-subs-kn.adoc
+++ b/modules/serverless-describe-subs-kn.adoc
@@ -6,7 +6,7 @@
 [id="serverless-describe-subs-kn_{context}"]
 = Describing subscriptions by using the Knative CLI
 
-You can use the `kn subscription describe` command to print information about a subscription in the terminal by using the `kn` CLI. Using the `kn` CLI to describe subscriptions provides a more streamlined and intuitive user interface than viewing YAML files directly.
+You can use the `kn subscription describe` command to print information about a subscription in the terminal by using the Knative (`kn`) CLI. Using the Knative CLI to describe subscriptions provides a more streamlined and intuitive user interface than viewing YAML files directly.
 
 .Prerequisites
 

--- a/modules/serverless-functions-adding-annotations.adoc
+++ b/modules/serverless-functions-adding-annotations.adoc
@@ -6,12 +6,12 @@
 [id="serverless-functions-adding-annotations_{context}"]
 = Adding annotations to a function
 
-You can use the following procedure to add annotations to a function.
+You can add annotations to a function. Similar to a label, an annotation is defined as a key-value map. Annotations are useful, for example, for providing metadata about a function, such as the function's author.
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a function.
 
 .Procedure

--- a/modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc
+++ b/modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc
@@ -5,12 +5,12 @@
 [id="serverless-functions-all-values-in-configmap-to-env-variables_{context}"]
 = Setting environment variables from all values defined in a config map
 
-You can use the following procedure to set an environment variable from all values defined in a config map.
+You can set an environment variable from all values defined in a config map. Values previously stored in a config map can then be accessed as environment variables by the function at runtime. This can be useful for simultaneously getting access to a collection of values stored in a config map, for example, a set of data pertaining to a user.
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a function.
 
 .Procedure
@@ -29,5 +29,17 @@ envs:
 - value: '{{ configMap:myconfigmap }}' <1>
 ----
 <1> Substitute `myconfigmap` with the name of the target config map.
++
+For example, to access all user data that is stored in `userdetailsmap`, use the following YAML:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+envs:
+- value: '{{ configMap:userdetailsmap }}'
+----
 
 . Save the file.

--- a/modules/serverless-functions-all-values-in-secret-to-env-variables.adoc
+++ b/modules/serverless-functions-all-values-in-secret-to-env-variables.adoc
@@ -6,12 +6,12 @@
 [id="serverless-functions-all-values-in-secret-to-env-variables_{context}"]
 = Setting environment variables from all values defined in a secret
 
-You can use the following procedure to set an environment variable from all values defined in a secret.
+You can set an environment variable from all values defined in a secret. Values previously stored in a secret can then be accessed as environment variables by the function at runtime. This can be useful for simultaneously getting access to a collection of values stored in a secret, for example, a set of data pertaining to a user.
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a function.
 
 .Procedure
@@ -30,5 +30,17 @@ envs:
 - value: '{{ secret:mysecret }}' <1>
 ----
 <1> Substitute `mysecret` with the name of the target secret.
++
+For example, to access all user data that is stored in `userdetailssecret`, use the following YAML:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+envs:
+- value: '{{ configMap:userdetailssecret }}'
+----
 
 . Save the configuration.

--- a/modules/serverless-functions-func-yaml-environment-variables.adoc
+++ b/modules/serverless-functions-func-yaml-environment-variables.adoc
@@ -6,9 +6,12 @@
 [id="serverless-functions-func-yaml-environment-variables_{context}"]
 = Referencing local environment variables from func.yaml fields
 
-In the `envs` field in the `func.yaml`, you can put a reference to an environment variable available in the local environment. This can be useful for avoiding storing sensitive information, such as an API key in the function configuration.
+If you want to avoid storing sensitive information such as an API key in the function configuration, you can add a reference to an environment variable available in the local environment. You can do this by modifying the `envs` field in the `func.yaml` file.
 
-// no prereqs?
+.Prerequisites
+
+* You need to have the function project created.
+* The local environment needs to contain the variable that you want to reference.
 
 .Procedure
 

--- a/modules/serverless-functions-key-value-in-configmap-to-env-variable.adoc
+++ b/modules/serverless-functions-key-value-in-configmap-to-env-variable.adoc
@@ -6,12 +6,12 @@
 [id="serverless-functions-key-value-in-configmap-to-env-variable_{context}"]
 = Setting environment variable from a key value defined in a config map
 
-You can use the following procedure to set an environment variable from a key value defined as a config map.
+You can set an environment variable from a key value defined as a config map. A value previously stored in a config map can then be accessed as an environment variable by the function at runtime. This can be useful for getting access to a value stored in a config map, such as the ID of a user.
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a function.
 
 .Procedure
@@ -34,5 +34,17 @@ envs:
 * Substitute `EXAMPLE` with the name of the environment variable.
 * Substitute `myconfigmap` with the name of the target config map.
 * Substitute `key` with the key mapped to the target value.
++
+For example, to access the user ID that is stored in `userdetailsmap`, use the following YAML:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+envs:
+- value: '{{ configMap:userdetailsmap:userid }}'
+----
 
 . Save the configuration.

--- a/modules/serverless-functions-key-value-in-secret-to-env-variable.adoc
+++ b/modules/serverless-functions-key-value-in-secret-to-env-variable.adoc
@@ -6,12 +6,12 @@
 [id="serverless-functions-key-value-in-secret-to-env-variable_{context}"]
 = Setting environment variable from a key value defined in a secret
 
-You can use the following procedure to set an environment variable from a key value defined as a secret.
+You can set an environment variable from a key value defined as a secret. A value previously stored in a secret can then be accessed as an environment variable by the function at runtime. This can be useful for getting access to a value stored in a secret, such as the ID of a user.
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a function.
 
 .Procedure
@@ -34,5 +34,17 @@ envs:
 * Substitute `EXAMPLE` with the name of the environment variable.
 * Substitute `mysecret` with the name of the target secret.
 * Substitute `key` with the key mapped to the target value.
++
+For example, to access the user ID that is stored in `userdetailssecret`, use the following YAML:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+envs:
+- value: '{{ configMap:userdetailssecret:userid }}'
+----
 
 . Save the configuration.

--- a/modules/serverless-functions-mounting-configmap-as-volume.adoc
+++ b/modules/serverless-functions-mounting-configmap-as-volume.adoc
@@ -6,12 +6,12 @@
 [id="serverless-functions-mounting-configmap-as-volume_{context}"]
 = Mounting a config map as a volume
 
-You can use the following procedure to mount a config map as a volume.
+You can mount a config map as a volume. Once a config map is mounted, you can access it from the function as a regular file. This enables you to store on the cluster data needed by the function, for example, a list of URIs that need to be accessed by the function.
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a function.
 
 .Procedure
@@ -33,5 +33,18 @@ volumes:
 +
 * Substitute `myconfigmap` with the name of the target config map.
 * Substitute `/workspace/configmap` with the path where you want to mount the config map.
++
+For example, to mount the `addresses` config map, use the following YAML:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+volumes:
+- configMap: addresses
+  path: /workspace/configmap-addresses
+----
 
 . Save the configuration.

--- a/modules/serverless-functions-mounting-secret-as-volume.adoc
+++ b/modules/serverless-functions-mounting-secret-as-volume.adoc
@@ -6,12 +6,12 @@
 [id="serverless-functions-mounting-secret-as-volume_{context}"]
 = Mounting a secret as a volume
 
-You can use the following procedure to mount a secret as a volume.
+You can mount a secret as a volume. Once a secret is mounted, you can access it from the function as a regular file. This enables you to store on the cluster data needed by the function, for example, a list of URIs that need to be accessed by the function.
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a function.
 
 .Procedure
@@ -33,5 +33,18 @@ volumes:
 +
 * Substitute `mysecret` with the name of the target secret.
 * Substitute `/workspace/secret` with the path where you want to mount the secret.
++
+For example, to mount the `addresses` secret, use the following YAML:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+volumes:
+- configMap: addresses
+  path: /workspace/secret-addresses
+----
 
 . Save the configuration.

--- a/modules/serverless-functions-podman.adoc
+++ b/modules/serverless-functions-podman.adoc
@@ -4,10 +4,15 @@
 
 :_content-type: PROCEDURE
 [id="serverless-functions-podman_{context}"]
-= Using podman
+= Setting up podman
 
-If you are using podman, you must run the following commands before getting started with {FunctionsProductName}:
+To use advanced container management features, you might want to use podman with {FunctionsProductName}. To do so, you need to start the podman service and configure the Knative (`kn`) CLI to connect to it.
 
+.Procedure
+
+// This step might no longer be needed in the future, when automatic
+// podman startup is reliable.
+// https://github.com/openshift/openshift-docs/pull/46660/files#r907310116
 . Start the podman service that serves the Docker API on a UNIX socket at `${XDG_RUNTIME_DIR}/podman/podman.sock`:
 +
 [source,terminal]

--- a/modules/serverless-functions-quarkus-return-value-types.adoc
+++ b/modules/serverless-functions-quarkus-return-value-types.adoc
@@ -6,15 +6,9 @@
 [id="serverless-functions-quarkus-return-value-types_{context}"]
 = Permitted types
 
-The input and output types of a function can be any of the following:
+The input and output of a function can be any of the `void`, `String`, or `byte[]` types. Additionally, they can be primitive types and their wrappers, for example, `int` and `Integer`. They can also be the following complex objects: Javabeans, maps, lists, arrays, and the special `CloudEvents<T>` type.
 
-* `void`
-* `String`
-* `byte[]`
-* Primitive types and their wrappers (for example, `int` and `Integer`).
-* A JavaBean, if its attributes are of types listed here.
-* A map, list, or array of the types in this list.
-* The special `CloudEvents<T>` type, where the `<T>` type parameter is of a type in this list.
+Maps, lists, arrays, the `<T>` type parameter of the `CloudEvents<T>` type, and attributes of Javabeans can only be of types listed here.
 
 .Example
 [source,java]

--- a/modules/serverless-functions-secrets-configmaps-interactively.adoc
+++ b/modules/serverless-functions-secrets-configmaps-interactively.adoc
@@ -6,12 +6,12 @@
 [id="serverless-functions-secrets-configmaps-interactively_{context}"]
 = Modifying function access to secrets and config maps interactively
 
-You can manage the secrets and config maps accessed by your function by using the `kn func config` interactive utility.
+You can manage the secrets and config maps accessed by your function by using the `kn func config` interactive utility. The available operations include listing, adding, and removing values stored in config maps and secrets as environment variables, as well as listing, adding, and removing volumes. This functionality enables you to manage what data stored on the cluster is accessible by your function.
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a function.
 
 .Procedure

--- a/modules/serverless-go-function-return-values.adoc
+++ b/modules/serverless-go-function-return-values.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-go-function-return-values_{context}"]
-= Golang function return values
+= Go function return values
 
-HTTP triggered functions can set the response directly by using the Golang link:https://golang.org/pkg/net/http/#ResponseWriter[http.ResponseWriter].
+Functions triggered by HTTP requests can set the response directly. You can configure the function to do this by using the Go link:https://golang.org/pkg/net/http/#ResponseWriter[http.ResponseWriter].
 
 .Example HTTP response
 [source,go]

--- a/modules/serverless-go-template.adoc
+++ b/modules/serverless-go-template.adoc
@@ -4,11 +4,11 @@
 
 :_content-type: REFERENCE
 [id="serverless-go-template_{context}"]
-= Golang function template structure
+= Go function template structure
 
-When you create a Golang function using the `kn` CLI, the project directory looks like a typical Go project, with the exception of an additional `func.yaml` configuration file.
+When you create a Go function using the Knative (`kn`) CLI, the project directory looks like a typical Go project. The only exception is the additional `func.yaml` configuration file, which is used for specifying the image.
 
-Golang functions have few restrictions. The only requirements are that your project must be defined in a `function` module, and must export the function `Handle()`.
+Go functions have few restrictions. The only requirements are that your project must be defined in a `function` module, and must export the function `Handle()`.
 
 Both `http` and `event` trigger functions have the same template structure:
 
@@ -24,7 +24,7 @@ fn
 └── handle_test.go
 ----
 <1> The `func.yaml` configuration file is used to determine the image name and registry.
-<2> You can add any required dependencies to the `go.mod` file, which can include additional local Golang files. When the project is built for deployment, these dependencies are included in the resulting runtime container image.
+<2> You can add any required dependencies to the `go.mod` file, which can include additional local Go files. When the project is built for deployment, these dependencies are included in the resulting runtime container image.
 +
 .Example of adding dependencies
 [source,terminal]

--- a/modules/serverless-gpu-resources-kn.adoc
+++ b/modules/serverless-gpu-resources-kn.adoc
@@ -6,12 +6,12 @@
 [id="serverless-gpu-resources-kn_{context}"]
 = Specifying GPU requirements for a service
 
-After GPU resources are enabled for your {product-title} cluster, you can specify GPU requirements for a Knative service using the `kn` CLI.
+After GPU resources are enabled for your {product-title} cluster, you can specify GPU requirements for a Knative service using the Knative (`kn`) CLI.
 
 .Prerequisites
 
 * The {ServerlessOperatorName}, Knative Serving and Knative Eventing are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * GPU resources are enabled for your {product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 

--- a/modules/serverless-invoking-go-functions-cloudevent.adoc
+++ b/modules/serverless-invoking-go-functions-cloudevent.adoc
@@ -6,9 +6,9 @@
 [id="serverless-invoking-go-functions-cloudevent_{context}"]
 = Functions triggered by a cloud event
 
-When an incoming cloud event is received, the event is invoked by the link:https://cloudevents.github.io/sdk-go/[CloudEvents Golang SDK] and the `Event` type as a parameter.
+When an incoming cloud event is received, the event is invoked by the link:https://cloudevents.github.io/sdk-go/[CloudEvents Go SDK]. The invocation uses the `Event` type as a parameter.
 
-You can leverage the Golang link:https://golang.org/pkg/context/[Context] as an optional parameter in the function contract, as shown in the list of supported function signatures:
+You can leverage the Go link:https://golang.org/pkg/context/[Context] as an optional parameter in the function contract, as shown in the list of supported function signatures:
 
 .Supported function signatures
 [source,go]
@@ -59,7 +59,7 @@ func Handle(ctx context.Context, event cloudevents.Event) (err error) {
 }
 ----
 
-Alternatively, a Golang `encoding/json` package could be used to access the cloud event directly as JSON in the form of a bytes array:
+Alternatively, a Go `encoding/json` package could be used to access the cloud event directly as JSON in the form of a bytes array:
 
 [source,go]
 ----

--- a/modules/serverless-invoking-go-functions-http.adoc
+++ b/modules/serverless-invoking-go-functions-http.adoc
@@ -6,12 +6,7 @@
 [id="serverless-invoking-go-functions-http_{context}"]
 = Functions triggered by an HTTP request
 
-When an incoming HTTP request is received, your function is invoked with a standard Golang link:https://golang.org/pkg/context/[Context] as the first parameter, followed by two more parameters:
-
-* link:https://golang.org/pkg/net/http/#ResponseWriter[`http.ResponseWriter`]
-* link:https://golang.org/pkg/net/http/#Request[`http.Request`]
-
-You can use standard Golang techniques to access the request, and set a proper HTTP response of your function.
+When an incoming HTTP request is received, functions are invoked with a standard Go link:https://golang.org/pkg/context/[Context] as the first parameter, followed by the link:https://golang.org/pkg/net/http/#ResponseWriter[`http.ResponseWriter`] and link:https://golang.org/pkg/net/http/#Request[`http.Request`] parameters. You can use standard Go techniques to access the request, and set a corresponding HTTP response for your function.
 
 .Example HTTP response
 [source,go]

--- a/modules/serverless-invoking-python-functions.adoc
+++ b/modules/serverless-invoking-python-functions.adoc
@@ -6,7 +6,9 @@
 [id="serverless-invoking-python-functions_{context}"]
 = About invoking Python functions
 
-Python functions can be invoked with a simple HTTP request. When an incoming request is received, functions are invoked with a `context` object as the first parameter. The `context` object is a Python class with two attributes:
+Python functions can be invoked with a simple HTTP request. When an incoming request is received, functions are invoked with a `context` object as the first parameter.
+
+The `context` object is a Python class with two attributes:
 
 * The `request` attribute is always present, and contains the Flask `request` object.
 * The second attribute, `cloud_event`, is populated if the incoming request is a `CloudEvent` object.

--- a/modules/serverless-kafka-source-kn.adoc
+++ b/modules/serverless-kafka-source-kn.adoc
@@ -7,7 +7,7 @@
 [id="serverless-kafka-source-kn_{context}"]
 = Creating a Kafka event source by using the Knative CLI
 
-You can use the `kn source kafka create` command to create a Kafka source by using the `kn` CLI. Using the `kn` CLI to create event sources provides a more streamlined and intuitive user interface than modifying YAML files directly.
+You can use the `kn source kafka create` command to create a Kafka source by using the Knative (`kn`) CLI. Using the Knative CLI to create event sources provides a more streamlined and intuitive user interface than modifying YAML files directly.
 
 .Prerequisites
 

--- a/modules/serverless-kn-config.adoc
+++ b/modules/serverless-kn-config.adoc
@@ -6,14 +6,14 @@
 [id="serverless-kn-config_{context}"]
 = Customizing the Knative CLI
 
-You can customize your `kn` CLI setup by creating a `config.yaml` configuration file. You can provide this configuration by using the `--config` flag, otherwise the configuration is picked up from a default location. The default configuration location conforms to the https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html[XDG Base Directory Specification], and is different for Unix systems and Windows systems.
+You can customize your Knative (`kn`) CLI setup by creating a `config.yaml` configuration file. You can provide this configuration by using the `--config` flag, otherwise the configuration is picked up from a default location. The default configuration location conforms to the https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html[XDG Base Directory Specification], and is different for Unix systems and Windows systems.
 
 For Unix systems:
 
-* If the `XDG_CONFIG_HOME` environment variable is set, the default configuration location that the `kn` CLI looks for is `$XDG_CONFIG_HOME/kn`.
-* If the `XDG_CONFIG_HOME` environment variable is not set, the `kn` CLI looks for the configuration in the home directory of the user at `$HOME/.config/kn/config.yaml`.
+* If the `XDG_CONFIG_HOME` environment variable is set, the default configuration location that the Knative CLI looks for is `$XDG_CONFIG_HOME/kn`.
+* If the `XDG_CONFIG_HOME` environment variable is not set, the Knative CLI looks for the configuration in the home directory of the user at `$HOME/.config/kn/config.yaml`.
 
-For Windows systems, the default `kn` CLI configuration location is `%APPDATA%\kn`.
+For Windows systems, the default Knative CLI configuration location is `%APPDATA%\kn`.
 
 .Example configuration file
 [source,yaml]
@@ -28,8 +28,8 @@ eventing:
     version: v1 <6>
     resource: services <7>
 ----
-<1> Specifies whether the `kn` CLI should look for plug-ins in the `PATH` environment variable. This is a boolean configuration option. The default value is `false`.
-<2> Specifies the directory where the `kn` CLI will look for plug-ins. The default path depends on the operating system, as described above. This can be any directory that is visible to the user.
+<1> Specifies whether the Knative CLI should look for plug-ins in the `PATH` environment variable. This is a boolean configuration option. The default value is `false`.
+<2> Specifies the directory where the Knative CLI will look for plug-ins. The default path depends on the operating system, as described above. This can be any directory that is visible to the user.
 <3> The `sink-mappings` spec defines the Kubernetes addressable resource that is used when you use the `--sink` flag with a `kn` CLI command.
 <4> The prefix you want to use to describe your sink. `svc` for a service, `channel`, and `broker` are predefined prefixes in `kn`.
 <5> The API group of the Kubernetes resource.

--- a/modules/serverless-kn-containersource.adoc
+++ b/modules/serverless-kn-containersource.adoc
@@ -8,7 +8,7 @@
 = Creating and managing container sources by using the Knative CLI
 // needs to be revised as separate procedure modules; out of scope for this PR
 
-You can use the `kn source container` commands to create  and manage container sources by using the `kn` CLI. Using the `kn` CLI to create event sources provides a more streamlined and intuitive user interface than modifying YAML files directly. 
+You can use the `kn source container` commands to create  and manage container sources by using the Knative (`kn`) CLI. Using the Knative CLI to create event sources provides a more streamlined and intuitive user interface than modifying YAML files directly. 
 
 .Create a container source
 [source,terminal]

--- a/modules/serverless-list-broker-kn.adoc
+++ b/modules/serverless-list-broker-kn.adoc
@@ -6,7 +6,7 @@
 [id="serverless-list-broker-kn_{context}"]
 = Listing existing brokers by using the Knative CLI
 
-Using the `kn` CLI to list brokers provides a streamlined and intuitive user interface. You can use the `kn broker list` command to list existing brokers in your cluster by using the `kn` CLI.
+Using the Knative (`kn`) CLI to list brokers provides a streamlined and intuitive user interface. You can use the `kn broker list` command to list existing brokers in your cluster by using the Knative CLI.
 
 .Prerequisites
 

--- a/modules/serverless-list-source-types-kn.adoc
+++ b/modules/serverless-list-source-types-kn.adoc
@@ -6,7 +6,7 @@
 [id="serverless-list-source-types-kn_{context}"]
 = Listing available event source types by using the Knative CLI
 
-Using the `kn` CLI provides a streamlined and intuitive user interface to view available event source types on your cluster. You can list event source types that can be created and used on your cluster by using the `kn source list-types` CLI command.
+Using the Knative (`kn`) CLI provides a streamlined and intuitive user interface to view available event source types on your cluster. You can list event source types that can be created and used on your cluster by using the `kn source list-types` CLI command.
 
 .Prerequisites
 

--- a/modules/serverless-list-source.adoc
+++ b/modules/serverless-list-source.adoc
@@ -6,7 +6,7 @@
 [id="serverless-list-source_{context}"]
 = Listing available event sources by using the Knative CLI
 
-Using the `kn` CLI provides a streamlined and intuitive user interface to view existing event sources on your cluster. You can list existing event sources by using the `kn source list` command.
+Using the Knative (`kn`) CLI provides a streamlined and intuitive user interface to view existing event sources on your cluster. You can list existing event sources by using the `kn source list` command.
 
 .Prerequisites
 

--- a/modules/serverless-list-subs-kn.adoc
+++ b/modules/serverless-list-subs-kn.adoc
@@ -6,7 +6,7 @@
 [id="serverless-list-subs-kn_{context}"]
 = Listing subscriptions by using the Knative CLI
 
-You can use the `kn subscription list` command to list existing subscriptions on your cluster by using the `kn` CLI. Using the `kn` CLI to list subscriptions provides a streamlined and intuitive user interface.
+You can use the `kn subscription list` command to list existing subscriptions on your cluster by using the Knative (`kn`) CLI. Using the Knative CLI to list subscriptions provides a streamlined and intuitive user interface.
 
 .Prerequisites
 

--- a/modules/serverless-manage-domain-mapping-kn.adoc
+++ b/modules/serverless-manage-domain-mapping-kn.adoc
@@ -6,13 +6,13 @@
 [id="serverless-manage-domain-mapping-kn_{context}"]
 = Managing custom domain mappings by using the Knative CLI
 
-After you have created a `DomainMapping` custom resource (CR), you can list existing CRs, view information about an existing CR, update CRs, or delete CRs by using the `kn` CLI.
+After you have created a `DomainMapping` custom resource (CR), you can list existing CRs, view information about an existing CR, update CRs, or delete CRs by using the Knative (`kn`) CLI.
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on your cluster.
 * You have created at least one `DomainMapping` CR.
-* You have installed the `kn` CLI tool.
+* You have installed the Knative (`kn`) CLI tool.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
 .Procedure

--- a/modules/serverless-nodejs-context-object-reference.adoc
+++ b/modules/serverless-nodejs-context-object-reference.adoc
@@ -6,7 +6,7 @@
 [id="serverless-nodejs-context-object-reference_{context}"]
 = Node.js context object reference
 
-The `context` object has several properties that can be accessed by the function developer.
+The `context` object has several properties that can be accessed by the function developer. Accessing these properties can provide information about HTTP requests and write output to the cluster logs.
 
 [id="serverless-nodejs-context-object-reference-log_{context}"]
 == log

--- a/modules/serverless-nodejs-functions-context-objects.adoc
+++ b/modules/serverless-nodejs-functions-context-objects.adoc
@@ -6,7 +6,7 @@
 [id="serverless-nodejs-functions-context-objects_{context}"]
 = Node.js context objects
 
-Functions are invoked by providing a `context` object as the first parameter.
+Functions are invoked by providing a `context` object as the first parameter. This object provides access to the incoming HTTP request information.
 
 .Example context object
 [source,javascript]
@@ -14,7 +14,7 @@ Functions are invoked by providing a `context` object as the first parameter.
 function handle(context, data)
 ----
 
-This object provides access to the incoming HTTP request information, including the HTTP request method, any query strings or headers sent with the request, the HTTP version, and the request body. Incoming requests that contain a CloudEvent attach the incoming instance of the CloudEvent to the context object so that it can be accessed by using `context.cloudevent`.
+This information includes the HTTP request method, any query strings or headers sent with the request, the HTTP version, and the request body. Incoming requests that contain a `CloudEvent` attach the incoming instance of the CloudEvent to the context object so that it can be accessed by using `context.cloudevent`.
 
 [id="serverless-nodejs-functions-context-objects-methods_{context}"]
 == Context object methods

--- a/modules/serverless-nodejs-template.adoc
+++ b/modules/serverless-nodejs-template.adoc
@@ -6,7 +6,7 @@
 [id="serverless-nodejs-template_{context}"]
 = Node.js function template structure
 
-When you create a Node.js function using the `kn` CLI, the project directory looks like a typical Node.js project, with the exception of an additional `func.yaml` configuration file.
+When you create a Node.js function using the Knative (`kn`) CLI, the project directory looks like a typical Node.js project. The only exception is the additional `func.yaml` file, which is used to configure the function.
 
 Both `http` and `event` trigger functions have the same template structure:
 

--- a/modules/serverless-pingsource-kn.adoc
+++ b/modules/serverless-pingsource-kn.adoc
@@ -7,7 +7,7 @@
 [id="serverless-pingsource-kn_{context}"]
 = Creating a ping source by using the Knative CLI
 
-You can use the `kn source ping create` command to create a ping source by using the `kn` CLI. Using the `kn` CLI to create event sources provides a more streamlined and intuitive user interface than modifying YAML files directly.
+You can use the `kn source ping create` command to create a ping source by using the Knative (`kn`) CLI. Using the Knative CLI to create event sources provides a more streamlined and intuitive user interface than modifying YAML files directly.
 
 .Prerequisites
 

--- a/modules/serverless-python-function-return-values.adoc
+++ b/modules/serverless-python-function-return-values.adoc
@@ -6,7 +6,7 @@
 [id="serverless-python-function-return-values_{context}"]
 = Python function return values
 
-Functions can return any value supported by link:https://flask.palletsprojects.com/en/1.1.x/quickstart/#about-responses[Flask] because the invocation framework proxies these values directly to the Flask server.
+Functions can return any value supported by link:https://flask.palletsprojects.com/en/1.1.x/quickstart/#about-responses[Flask]. This is because the invocation framework proxies these values directly to the Flask server.
 
 .Example
 [source,python]

--- a/modules/serverless-python-template.adoc
+++ b/modules/serverless-python-template.adoc
@@ -6,9 +6,7 @@
 [id="serverless-python-template_{context}"]
 = Python function template structure
 
-When you create a Python function by using the `kn` CLI, the project directory looks similar to a typical Python project.
-
-Python functions have very few restrictions. The only requirements are that your project contains a `func.py` file that contains a `main()` function, and a `func.yaml` configuration file.
+When you create a Python function by using the Knative (`kn`) CLI, the project directory looks similar to a typical Python project. Python functions have very few restrictions. The only requirements are that your project contains a `func.py` file that contains a `main()` function, and a `func.yaml` configuration file.
 
 Developers are not restricted to the dependencies provided in the template `requirements.txt` file. Additional dependencies can be added as they would be in any other Python project. When the project is built for deployment, these dependencies will be included in the created runtime container image.
 

--- a/modules/serverless-quarkus-function-return-values.adoc
+++ b/modules/serverless-quarkus-function-return-values.adoc
@@ -6,11 +6,7 @@
 [id="serverless-quarkus-function-return-values_{context}"]
 = Quarkus function return values
 
-Functions can return an instance of:
-
-* Any type from the list of permitted types.
-
-* The `Uni<T>` type, where the `<T>` type parameter can be of any type from the permitted types.
+Functions can return an instance of any type from the list of permitted types. Alternatively, they can return the `Uni<T>` type, where the `<T>` type parameter can be of any type from the permitted types.
 
 The `Uni<T>` type is useful if a function calls asynchronous APIs, because the returned object is serialized in the same format as the received object. For example:
 

--- a/modules/serverless-quarkus-template.adoc
+++ b/modules/serverless-quarkus-template.adoc
@@ -6,7 +6,7 @@
 [id="serverless-quarkus-template_{context}"]
 = Quarkus function template structure
 
-When you create a Quarkus function by using the `kn` CLI, the project directory looks similar to a typical Maven project.
+When you create a Quarkus function by using the Knative (`kn`) CLI, the project directory looks similar to a typical Maven project. Additionally, the project contains the `func.yaml` file, which is used for configuring the function.
 
 Both `http` and `event` trigger functions have the same template structure:
 

--- a/modules/serverless-rn-1-18-0.adoc
+++ b/modules/serverless-rn-1-18-0.adoc
@@ -14,7 +14,7 @@
 * {ServerlessProductName} now uses Knative Serving 0.24.0.
 * {ServerlessProductName} now uses Knative Eventing 0.24.0.
 * {ServerlessProductName} now uses Kourier 0.24.0.
-* {ServerlessProductName} now uses Knative `kn` CLI 0.24.0.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 0.24.0.
 * {ServerlessProductName} now uses Knative Kafka 0.24.7.
 * The `kn func` CLI plug-in now uses `func` 0.18.0.
 * In the upcoming {ServerlessProductName} 1.19.0 release, the URL scheme of external routes will default to HTTPS for enhanced security.

--- a/modules/serverless-rn-1-19-0.adoc
+++ b/modules/serverless-rn-1-19-0.adoc
@@ -14,7 +14,7 @@
 * {ServerlessProductName} now uses Knative Serving 0.25.
 * {ServerlessProductName} now uses Knative Eventing 0.25.
 * {ServerlessProductName} now uses Kourier 0.25.
-* {ServerlessProductName} now uses Knative `kn` CLI 0.25.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 0.25.
 * {ServerlessProductName} now uses Knative Kafka 0.25.
 * The `kn func` CLI plug-in now uses `func` 0.19.
 

--- a/modules/serverless-rn-1-20-0.adoc
+++ b/modules/serverless-rn-1-20-0.adoc
@@ -14,7 +14,7 @@
 * {ServerlessProductName} now uses Knative Serving 0.26.
 * {ServerlessProductName} now uses Knative Eventing 0.26.
 * {ServerlessProductName} now uses Kourier 0.26.
-* {ServerlessProductName} now uses Knative `kn` CLI 0.26.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 0.26.
 * {ServerlessProductName} now uses Knative Kafka 0.26.
 * The `kn func` CLI plug-in now uses `func` 0.20.
 

--- a/modules/serverless-rn-1-21-0.adoc
+++ b/modules/serverless-rn-1-21-0.adoc
@@ -14,7 +14,7 @@
 * {ServerlessProductName} now uses Knative Serving 1.0
 * {ServerlessProductName} now uses Knative Eventing 1.0.
 * {ServerlessProductName} now uses Kourier 1.0.
-* {ServerlessProductName} now uses Knative `kn` CLI 1.0.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.0.
 * {ServerlessProductName} now uses Knative Kafka 1.0.
 * The `kn func` CLI plug-in now uses `func` 0.21.
 * The Kafka sink is now available as a Technology Preview.

--- a/modules/serverless-rn-1-22-0.adoc
+++ b/modules/serverless-rn-1-22-0.adoc
@@ -14,7 +14,7 @@
 * {ServerlessProductName} now uses Knative Serving 1.1.
 * {ServerlessProductName} now uses Knative Eventing 1.1.
 * {ServerlessProductName} now uses Kourier 1.1.
-* {ServerlessProductName} now uses Knative `kn` CLI 1.1.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.1.
 * {ServerlessProductName} now uses Knative Kafka 1.1.
 * The `kn func` CLI plug-in now uses `func` 0.23.
 * Init containers support for Knative services is now available as a Technology Preview.

--- a/modules/serverless-rn-1-23-0.adoc
+++ b/modules/serverless-rn-1-23-0.adoc
@@ -14,7 +14,7 @@
 * {ServerlessProductName} now uses Knative Serving 1.2.
 * {ServerlessProductName} now uses Knative Eventing 1.2.
 * {ServerlessProductName} now uses Kourier 1.2.
-* {ServerlessProductName} now uses Knative `kn` CLI 1.2.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.2.
 * {ServerlessProductName} now uses Knative Kafka 1.2.
 * The `kn func` CLI plug-in now uses `func` 0.24.
 

--- a/modules/serverless-sinkbinding-kn.adoc
+++ b/modules/serverless-sinkbinding-kn.adoc
@@ -6,7 +6,7 @@
 [id="serverless-sinkbinding-kn_{context}"]
 = Creating a sink binding by using the Knative CLI
 
-You can use the `kn source binding create` command to create a sink binding by using the `kn` CLI. Using the `kn` CLI to create event sources provides a more streamlined and intuitive user interface than modifying YAML files directly.
+You can use the `kn source binding create` command to create a sink binding by using the Knative (`kn`) CLI. Using the Knative CLI to create event sources provides a more streamlined and intuitive user interface than modifying YAML files directly.
 
 .Prerequisites
 

--- a/modules/serverless-testing-go-functions.adoc
+++ b/modules/serverless-testing-go-functions.adoc
@@ -4,14 +4,14 @@
 
 :_content-type: PROCEDURE
 [id="serverless-testing-go-functions_{context}"]
-= Testing Golang functions
+= Testing Go functions
 
-Golang functions can be tested locally on your computer. In the default project that is created when you create a function using `kn func create`, there is a `handle_test.go` file which contains some basic tests. These tests can be extended as needed.
+Go functions can be tested locally on your computer. In the default project that is created when you create a function using `kn func create`, there is a `handle_test.go` file, which contains some basic tests. These tests can be extended as needed.
 
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a function by using `kn func create`.
 
 .Procedure

--- a/modules/serverless-testing-nodejs-functions.adoc
+++ b/modules/serverless-testing-nodejs-functions.adoc
@@ -11,7 +11,7 @@ Node.js functions can be tested locally on your computer. In the default project
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a function by using `kn func create`.
 
 .Procedure

--- a/modules/serverless-testing-quarkus-functions.adoc
+++ b/modules/serverless-testing-quarkus-functions.adoc
@@ -6,11 +6,12 @@
 [id="serverless-testing-quarkus-functions_{context}"]
 = Testing Quarkus functions
 
-You can test Quarkus functions locally on your computer by running the Maven tests that are included in the project template.
+Quarkus functions can be tested locally on your computer. In the default project that is created when you create a function using `kn func create`, there is the  `src/test/` directory, which contains basic Maven tests. These tests can be extended as needed.
 
 .Prerequisites
 
 * You have created a Quarkus function.
+* You have installed the Knative (`kn`) CLI.
 
 .Procedure
 

--- a/modules/serverless-testing-typescript-functions.adoc
+++ b/modules/serverless-testing-typescript-functions.adoc
@@ -11,7 +11,7 @@ TypeScript functions can be tested locally on your computer. In the default proj
 .Prerequisites
 
 * The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
-* You have installed the `kn` CLI.
+* You have installed the Knative (`kn`) CLI.
 * You have created a function by using `kn func create`.
 
 .Procedure

--- a/modules/serverless-traffic-splitting-flags-kn.adoc
+++ b/modules/serverless-traffic-splitting-flags-kn.adoc
@@ -6,7 +6,7 @@
 [id="serverless-traffic-splitting-flags-kn_{context}"]
 = Knative CLI traffic management flags
 
-The `kn` CLI supports traffic operations on the traffic block of a service as part of the `kn service update` command.
+The Knative (`kn`) CLI supports traffic operations on the traffic block of a service as part of the `kn service update` command.
 
 The following table displays a summary of traffic splitting flags, value formats, and the operation the flag performs. The *Repetition* column denotes whether repeating the particular value of flag is allowed in a `kn service update` command.
 

--- a/modules/serverless-typescript-context-object-reference.adoc
+++ b/modules/serverless-typescript-context-object-reference.adoc
@@ -6,7 +6,7 @@
 [id="serverless-typescript-context-object-reference_{context}"]
 = TypeScript context object reference
 
-The `context` object has several properties that can be accessed by the function developer.
+The `context` object has several properties that can be accessed by the function developer. Accessing these properties can provide information about incoming HTTP requests and write output to the cluster logs.
 
 [id="serverless-typescript-context-object-reference-log_{context}"]
 == log

--- a/modules/serverless-typescript-functions-context-objects.adoc
+++ b/modules/serverless-typescript-functions-context-objects.adoc
@@ -6,7 +6,7 @@
 [id="serverless-typescript-functions-context-objects_{context}"]
 = TypeScript context objects
 
-Functions are invoked with a `context` object as the first parameter.
+To invoke a function, you provide a `context` object as the first parameter. Accessing properties of the `context` object can provide information about the incoming HTTP request.
 
 .Example context object
 [source,javascript]
@@ -14,7 +14,7 @@ Functions are invoked with a `context` object as the first parameter.
 function handle(context:Context): string
 ----
 
-This object provides access to the incoming HTTP request information, including the HTTP request method, any query strings or headers sent with the request, the HTTP version, and the request body. Incoming requests that contain a CloudEvent attach the incoming instance of the CloudEvent to the context object so that it can be accessed by using `context.cloudevent`.
+This information includes the HTTP request method, any query strings or headers sent with the request, the HTTP version, and the request body. Incoming requests that contain a `CloudEvent` attach the incoming instance of the CloudEvent to the context object so that it can be accessed by using `context.cloudevent`.
 
 [id="serverless-typescript-functions-context-objects-methods_{context}"]
 == Context object methods

--- a/modules/serverless-typescript-template.adoc
+++ b/modules/serverless-typescript-template.adoc
@@ -6,7 +6,7 @@
 [id="serverless-typescript-template_{context}"]
 = TypeScript function template structure
 
-When you create a TypeScript function using the `kn` CLI, the project directory looks like a typical TypeScript project with the exception of an additional `func.yaml` configuration file.
+When you create a TypeScript function using the Knative (`kn`) CLI, the project directory looks like a typical TypeScript project. The only exception is the additional `func.yaml` file, which is used for configuring the function.
 
 Both `http` and `event` trigger functions have the same template structure:
 

--- a/modules/serverless-update-subscriptions-kn.adoc
+++ b/modules/serverless-update-subscriptions-kn.adoc
@@ -6,7 +6,7 @@
 [id="serverless-update-subscriptions-kn_{context}"]
 = Updating subscriptions by using the Knative CLI
 
-You can use the `kn subscription update` command as well as the appropriate flags to update a subscription from the terminal by using the `kn` CLI. Using the `kn` CLI to update subscriptions provides a more streamlined and intuitive user interface than updating YAML files directly.
+You can use the `kn subscription update` command as well as the appropriate flags to update a subscription from the terminal by using the Knative (`kn`) CLI. Using the Knative CLI to update subscriptions provides a more streamlined and intuitive user interface than updating YAML files directly.
 
 .Prerequisites
 

--- a/serverless/cli_tools/kn-serving-ref.adoc
+++ b/serverless/cli_tools/kn-serving-ref.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use the following `kn` CLI commands to complete Knative Serving tasks on the cluster.
+You can use the following Knative (`kn`) CLI commands to complete Knative Serving tasks on the cluster.
 
 [id="kn-serving-ref-kn-service"]
 == kn service commands

--- a/serverless/develop/serverless-applications.adoc
+++ b/serverless/develop/serverless-applications.adoc
@@ -15,7 +15,7 @@ You can create a serverless application by using one of the following methods:
 ifdef::openshift-enterprise[]
 See xref:../../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating applications using the Developer perspective] for more information.
 endif::[]
-* Create a Knative service by using the `kn` CLI.
+* Create a Knative service by using the Knative (`kn`) CLI.
 * Create and apply a Knative `Service` object as a YAML file, by using the `oc` CLI.
 
 // create service using CLI

--- a/serverless/develop/serverless-autoscaling-developer.adoc
+++ b/serverless/develop/serverless-autoscaling-developer.adoc
@@ -16,7 +16,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 Autoscaling settings for Knative services can be global settings that are configured by cluster or dedicated administrators, or per-revision settings that are configured for individual services.
 endif::[]
 
-You can modify per-revision settings for your services by using the {product-title} web console, by modifying the YAML file for your service, or by using the `kn` CLI.
+You can modify per-revision settings for your services by using the {product-title} web console, by modifying the YAML file for your service, or by using the Knative (`kn`) CLI.
 
 [NOTE]
 ====

--- a/serverless/develop/serverless-event-sinks.adoc
+++ b/serverless/develop/serverless-event-sinks.adoc
@@ -17,7 +17,7 @@ include::modules/specifying-sink-flag-kn.adoc[leveloffset=+1]
 
 [TIP]
 ====
-You can configure which CRs can be used with the `--sink` flag for `kn` CLI commands by xref:../../serverless/cli_tools/advanced-kn-config.adoc#advanced-kn-config[Customizing `kn`].
+You can configure which CRs can be used with the `--sink` flag for Knative (`kn`) CLI commands by xref:../../serverless/cli_tools/advanced-kn-config.adoc#advanced-kn-config[Customizing `kn`].
 ====
 
 // Connect sinks to sources in ODC

--- a/serverless/develop/serverless-listing-event-sources.adoc
+++ b/serverless/develop/serverless-listing-event-sources.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-It is possible to view a list of all event sources or event source types that exist or are available for use on your {product-title} cluster. You can use the `kn` CLI or the *Developer* perspective in the {product-title} web console to list available event sources or event source types.
+It is possible to view a list of all event sources or event source types that exist or are available for use on your {product-title} cluster. You can use the Knative (`kn`) CLI or the *Developer* perspective in the {product-title} web console to list available event sources or event source types.
 
 include::modules/serverless-list-source-types-kn.adoc[leveloffset=+1]
 include::modules/serverless-list-source-types-odc.adoc[leveloffset=+1]

--- a/serverless/develop/serverless-traffic-management.adoc
+++ b/serverless/develop/serverless-traffic-management.adoc
@@ -20,7 +20,7 @@ The revisions specified in a `traffic` spec can either be a fixed, named revisio
 The `traffic` spec can be modified by:
 
 * Editing the YAML of a `Service` object directly.
-* Using the `kn` CLI `--traffic` flag.
+* Using the Knative (`kn`) CLI `--traffic` flag.
 * Using the {product-title} web console.
 
 When you create a Knative service, it does not have any default `traffic` spec settings.

--- a/serverless/develop/serverless-using-brokers.adoc
+++ b/serverless/develop/serverless-using-brokers.adoc
@@ -13,7 +13,7 @@ include::modules/serverless-broker-types.adoc[leveloffset=+1]
 [id="serverless-using-brokers-creating-brokers"]
 == Creating a broker that uses default settings
 
-{ServerlessProductName} provides a `default` Knative broker that you can create by using the `kn` CLI. You can also create the `default` broker by adding the `eventing.knative.dev/injection: enabled` annotation to a trigger, or by adding the `eventing.knative.dev/injection=enabled` label to a namespace.
+{ServerlessProductName} provides a `default` Knative broker that you can create by using the Knative (`kn`) CLI. You can also create the `default` broker by adding the `eventing.knative.dev/injection: enabled` annotation to a trigger, or by adding the `eventing.knative.dev/injection=enabled` label to a namespace.
 
 include::modules/serverless-create-broker-kn.adoc[leveloffset=+2]
 include::modules/serverless-creating-broker-annotation.adoc[leveloffset=+2]
@@ -35,7 +35,7 @@ include::modules/serverless-kafka-broker-with-kafka-topic.adoc[leveloffset=+2]
 [id="serverless-using-brokers-managing-brokers"]
 == Managing brokers
 
-The `kn` CLI provides commands that can be used to list, describe, update, and delete brokers.
+The Knative (`kn`) CLI provides commands that can be used to list, describe, update, and delete brokers.
 
 include::modules/serverless-list-broker-kn.adoc[leveloffset=+2]
 include::modules/serverless-describe-broker-kn.adoc[leveloffset=+2]

--- a/serverless/discover/knative-event-sources.adoc
+++ b/serverless/discover/knative-event-sources.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 A Knative _event source_ can be any Kubernetes object that generates or imports cloud events, and relays those events to another endpoint, known as a xref:../../serverless/develop/serverless-event-sinks.adoc#serverless-event-sinks[_sink_]. Sourcing events is critical to developing a distributed system that reacts to events.
 
-You can create and manage Knative event sources by using the *Developer* perspective in the {product-title} web console, the `kn` CLI, or by applying YAML files.
+You can create and manage Knative event sources by using the *Developer* perspective in the {product-title} web console, the Knative (`kn`) CLI, or by applying YAML files.
 
 Currently, {ServerlessProductName} supports the following event source types:
 

--- a/serverless/discover/serverless-functions-about.adoc
+++ b/serverless/discover/serverless-functions-about.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{FunctionsProductName} enables developers to create and deploy stateless, event-driven functions as a Knative service on {product-title}. The `kn func` CLI is provided as a plug-in for the Knative `kn` CLI. {FunctionsProductName} uses the link:https://buildpacks.io/[CNCF Buildpack API] to create container images. After a container image is created, you can use the `kn func` CLI to deploy the container image as a Knative service on the cluster.
+With {FunctionsProductName}, developers can create and deploy stateless, event-driven functions as a Knative service on {product-title}. The Knative (`kn`) CLI is provided as a plug-in for the Knative CLI. {FunctionsProductName} uses the link:https://buildpacks.io/[CNCF Buildpack API] to create container images. After a container image is created, you can use the `kn func` CLI to deploy the container image as a Knative service on the cluster.
 
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]
@@ -19,7 +19,7 @@ include::snippets/technology-preview.adoc[leveloffset=+2]
 // add xref links to docs once added
 * xref:../../serverless/functions/serverless-developing-nodejs-functions.adoc#serverless-developing-nodejs-functions[Node.js]
 * xref:../../serverless/functions/serverless-developing-python-functions.adoc#serverless-developing-python-functions[Python]
-* xref:../../serverless/functions/serverless-developing-go-functions.adoc#serverless-developing-go-functions[Golang]
+* xref:../../serverless/functions/serverless-developing-go-functions.adoc#serverless-developing-go-functions[Go]
 * xref:../../serverless/functions/serverless-developing-quarkus-functions.adoc#serverless-developing-quarkus-functions[Quarkus]
 * xref:../../serverless/functions/serverless-developing-typescript-functions.adoc#serverless-developing-typescript-functions[TypeScript]
 

--- a/serverless/functions/serverless-developing-go-functions.adoc
+++ b/serverless/functions/serverless-developing-go-functions.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="serverless-developing-go-functions"]
-= Developing Golang functions
+= Developing Go functions
 :context: serverless-developing-go-functions
 include::_attributes/common-attributes.adoc[]
 
@@ -9,7 +9,7 @@ toc::[]
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a Golang function project], you can modify the template files provided to add business logic to your function.
+After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a Go function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 [id="prerequisites_serverless-developing-go-functions"]
 == Prerequisites
@@ -19,9 +19,9 @@ After you have xref:../../serverless/functions/serverless-functions-getting-star
 include::modules/serverless-go-template.adoc[leveloffset=+1]
 
 [id="serverless-developing-go-functions-about-invoking"]
-== About invoking Golang functions
+== About invoking Go functions
 
-Golang functions are invoked by using different methods, depending on whether they are triggered by an HTTP request or a CloudEvent.
+When using the Knative (`kn`) CLI to create a function project, you can generate a project that responds to CloudEvents, or one that responds to simple HTTP requests. Go functions are invoked by using different methods, depending on whether they are triggered by an HTTP request or a CloudEvent.
 
 include::modules/serverless-invoking-go-functions-http.adoc[leveloffset=+2]
 include::modules/serverless-invoking-go-functions-cloudevent.adoc[leveloffset=+2]

--- a/serverless/functions/serverless-developing-nodejs-functions.adoc
+++ b/serverless/functions/serverless-developing-nodejs-functions.adoc
@@ -9,7 +9,7 @@ toc::[]
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a Node.js function project], you can modify the template files provided to add business logic to your function.
+After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a Node.js function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 [id="prerequisites_serverless-developing-nodejs-functions"]
 == Prerequisites
@@ -21,7 +21,7 @@ include::modules/serverless-nodejs-template.adoc[leveloffset=+1]
 [id="serverless-developing-nodejs-functions-about-invoking"]
 == About invoking Node.js functions
 
-When using the `kn` CLI to create a function project, you can generate a project that responds to CloudEvents, or one that responds to simple HTTP requests. CloudEvents in Knative are transported over HTTP as a POST request, so both function types listen for and respond to incoming HTTP events.
+When using the Knative (`kn`) CLI to create a function project, you can generate a project that responds to CloudEvents, or one that responds to simple HTTP requests. CloudEvents in Knative are transported over HTTP as a POST request, so both function types listen for and respond to incoming HTTP events.
 
 Node.js functions can be invoked with a simple HTTP request. When an incoming request is received, functions are invoked with a `context` object as the first parameter.
 

--- a/serverless/functions/serverless-developing-python-functions.adoc
+++ b/serverless/functions/serverless-developing-python-functions.adoc
@@ -9,7 +9,7 @@ toc::[]
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a Python function project], you can modify the template files provided to add business logic to your function.
+After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a Python function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 [id="prerequisites_serverless-developing-python-functions"]
 == Prerequisites

--- a/serverless/functions/serverless-developing-quarkus-functions.adoc
+++ b/serverless/functions/serverless-developing-quarkus-functions.adoc
@@ -9,7 +9,7 @@ toc::[]
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a Quarkus function project], you can modify the template files provided to add business logic to your function.
+After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a Quarkus function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 [id="prerequisites_serverless-developing-quarkus-functions"]
 == Prerequisites

--- a/serverless/functions/serverless-developing-typescript-functions.adoc
+++ b/serverless/functions/serverless-developing-typescript-functions.adoc
@@ -9,7 +9,7 @@ toc::[]
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a TypeScript function project], you can modify the template files provided to add business logic to your function.
+After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a TypeScript function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 [id="prerequisites_serverless-developing-typescript-functions"]
 == Prerequisites
@@ -21,7 +21,7 @@ include::modules/serverless-typescript-template.adoc[leveloffset=+1]
 [id="serverless-developing-typescript-functions-about-invoking"]
 == About invoking TypeScript functions
 
-When using the `kn` CLI to create a function project, you can generate a project that responds to CloudEvents or one that responds to simple HTTP requests. CloudEvents in Knative are transported over HTTP as a POST request, so both function types listen for and respond to incoming HTTP events.
+When using the Knative (`kn`) CLI to create a function project, you can generate a project that responds to CloudEvents or one that responds to simple HTTP requests. CloudEvents in Knative are transported over HTTP as a POST request, so both function types listen for and respond to incoming HTTP events.
 
 TypeScript functions can be invoked with a simple HTTP request. When an incoming request is received, functions are invoked with a `context` object as the first parameter.
 

--- a/serverless/functions/serverless-functions-accessing-secrets-configmaps.adoc
+++ b/serverless/functions/serverless-functions-accessing-secrets-configmaps.adoc
@@ -21,7 +21,7 @@ include::modules/serverless-functions-secrets-configmaps-interactively-specializ
 [id="serverless-functions-secrets-configmaps-manually_{context}"]
 == Adding function access to secrets and config maps manually
 
-You can manually add configuration for accessing secrets and config maps to your function.
+You can manually add configuration for accessing secrets and config maps to your function. This might be preferable to using the `kn func config` interactive utility and commands, for example when you have an existing configuration snippet.
 
 include::modules/serverless-functions-mounting-secret-as-volume.adoc[leveloffset=+2]
 include::modules/serverless-functions-mounting-configmap-as-volume.adoc[leveloffset=+2]

--- a/serverless/functions/serverless-functions-annotations.adoc
+++ b/serverless/functions/serverless-functions-annotations.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can add Kubernetes annotations to a deployed Serverless function by adding them to the `annotations` section in the `func.yaml` configuration file.
+You can add Kubernetes annotations to a deployed Serverless function. Annotations enable you to attach arbitrary metadata to a function, for example, a note about the function's purpose. Annotations are added to the `annotations` section of the `func.yaml` configuration file.
 
 There are two limitations of the function annotation feature:
 

--- a/serverless/functions/serverless-functions-annotations.html
+++ b/serverless/functions/serverless-functions-annotations.html
@@ -1,0 +1,547 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.17">
+<title>Adding annotations to functions</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
+dfn{font-style:italic}
+hr{height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type=checkbox],input[type=radio]{padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+</head>
+<body id="serverless-functions-attributes" class="article">
+<div id="header">
+<h1>Adding annotations to functions</h1>
+</div>
+<div id="content">
+<div id="preamble">
+<div class="sectionbody">
+<div id="toc" class="toc">
+<div id="toctitle" class="title"></div>
+<ul class="sectlevel1">
+<li><a href="#serverless-functions-adding-annotations_serverless-functions-annotations">Adding annotations to a function</a></li>
+</ul>
+</div>
+<div class="paragraph">
+<p>You can add Kubernetes annotations to a deployed Serverless function. This is done in the <code>annotations</code> section of the <code>func.yaml</code> configuration file.</p>
+</div>
+<div class="paragraph">
+<p>There are two limitations of the function annotation feature:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>After a function annotation propagates to the corresponding Knative service on the cluster, it cannot be removed from the service by deleting it from the <code>func.yaml</code> file. You must remove the annotation from the Knative service by modifying the YAML file of the service directly, or by using the {product-title} web console.</p>
+</li>
+<li>
+<p>You cannot set annotations that are set by Knative, for example, the <code>autoscaling</code> annotations.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="serverless-functions-adding-annotations_serverless-functions-annotations">Adding annotations to a function</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>You can use the following procedure to add annotations to a function.</p>
+</div>
+<div class="ulist">
+<div class="title">Prerequisites</div>
+<ul>
+<li>
+<p>The OpenShift Serverless Operator and Knative Serving are installed on the cluster.</p>
+</li>
+<li>
+<p>You have installed the <code>kn</code> CLI.</p>
+</li>
+<li>
+<p>You have created a function.</p>
+</li>
+</ul>
+</div>
+<div class="olist arabic">
+<div class="title">Procedure</div>
+<ol class="arabic">
+<li>
+<p>Open the <code>func.yaml</code> file for your function.</p>
+</li>
+<li>
+<p>For every annotation that you want to add, add the following YAML to the <code>annotations</code> section:</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-yaml" data-lang="yaml">name: test
+namespace: ""
+runtime: go
+...
+annotations:
+  &lt;annotation_name&gt;: "&lt;annotation_value&gt;" <img src="data:image/png;base64," alt="1"></code></pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><img src="data:image/png;base64," alt="1"></td>
+<td>Substitute <code>&lt;annotation_name&gt;: "&lt;annotation_value&gt;"</code> with your annotation.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>For example, to indicate that a function was authored by Alice, you might include the following annotation:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-yaml" data-lang="yaml">name: test
+namespace: ""
+runtime: go
+...
+annotations:
+  author: "alice@example.com"</code></pre>
+</div>
+</div>
+</li>
+<li>
+<p>Save the configuration.</p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p>The next time you deploy your function to the cluster, the annotations are added to the corresponding Knative service.</p>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2022-06-14 15:43:29 +0200
+</div>
+</div>
+</body>
+</html>

--- a/serverless/functions/serverless-functions-eventing.adoc
+++ b/serverless/functions/serverless-functions-eventing.adoc
@@ -9,6 +9,6 @@ toc::[]
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-Functions are deployed as a Knative service on an {product-title} cluster, and can be connected as a sink to Knative Eventing components.
+Functions are deployed as Knative services on an {product-title} cluster. You can connect functions as an event sink to Knative Eventing components so that they can receive incoming events.
 
 include::modules/serverless-connect-sink-source-odc.adoc[leveloffset=+1]

--- a/serverless/functions/serverless-functions-getting-started.adoc
+++ b/serverless/functions/serverless-functions-getting-started.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This guide explains how you can get started with creating, building, and deploying a function on an {ServerlessProductName} installation. When building and deploying functions, the resulting container image is stored in an image registry.
+Function lifecycle management includes creating, building, and deploying a function. Optionally, you can also test a deployed function by invoking it. You can do all of these operations on {ServerlessProductName} using the `kn func` tool.
 
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]

--- a/serverless/functions/serverless-functions-reference-guide.adoc
+++ b/serverless/functions/serverless-functions-reference-guide.adoc
@@ -9,17 +9,17 @@ toc::[]
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-{FunctionsProductName} provides templates that can be used to create basic functions for the following runtimes:
+{FunctionsProductName} provides templates that can be used to create basic functions. A template initiates the function project boilerplate and prepares it for use with the `kn func` tool. Each function template is tailored for a specific runtime and follows its conventions. With a template, you can initiate your function project automatically.
+
+Templates for the following runtimes are available:
 
 // add xref links to docs once added
 * xref:../../serverless/functions/serverless-developing-nodejs-functions.adoc#serverless-developing-nodejs-functions[Node.js]
 * xref:../../serverless/functions/serverless-developing-python-functions.adoc#serverless-developing-python-functions[Python]
-* xref:../../serverless/functions/serverless-developing-go-functions.adoc#serverless-developing-go-functions[Golang]
+* xref:../../serverless/functions/serverless-developing-go-functions.adoc#serverless-developing-go-functions[Go]
 * xref:../../serverless/functions/serverless-developing-quarkus-functions.adoc#serverless-developing-quarkus-functions[Quarkus]
 * xref:../../serverless/functions/serverless-developing-typescript-functions.adoc#serverless-developing-typescript-functions[TypeScript]
 //* SpringBoot - TBC
-
-This guide provides reference information that you can use to develop functions.
 
 include::modules/serverless-nodejs-context-object-reference.adoc[leveloffset=+1]
 include::modules/serverless-typescript-context-object-reference.adoc[leveloffset=+1]

--- a/serverless/functions/serverless-functions-setup.adoc
+++ b/serverless/functions/serverless-functions-setup.adoc
@@ -9,7 +9,7 @@ toc::[]
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-Before you can develop functions on {ServerlessProductName}, you must complete the set up steps.
+To improve the process of deployment of your application code, you can use {ServerlessProductName} to deploy stateless, event-driven functions as a Knative service on {product-title}. If you want to develop functions, you must complete the set up steps.
 
 [id="prerequisites_serverless-functions-setup"]
 == Prerequisites
@@ -32,7 +32,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * The `oc` CLI is installed on your cluster.
 endif::[]
 
-* The xref:../../serverless/cli_tools/installing-kn.adoc#installing-kn[Knative (`kn`) CLI] is installed on your cluster. Installing the `kn` CLI enables the use of `kn func` commands which you can use to create and manage functions.
+* The xref:../../serverless/cli_tools/installing-kn.adoc#installing-kn[Knative (`kn`) CLI] is installed on your cluster. Installing the Knative CLI enables the use of `kn func` commands which you can use to create and manage functions.
 
 * You have installed Docker Container Engine or podman version 3.3 or higher, and have access to an available image registry.
 

--- a/serverless/functions/serverless-functions-yaml.adoc
+++ b/serverless/functions/serverless-functions-yaml.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The `func.yaml` file contains the configuration for your function project. These values are used when you execute a `kn func` command. For example, when you run the `kn func build` command, the value in the `builder` field is used. In some cases, you can override these values with command line flags or environment variables.
+The `func.yaml` file contains the configuration for your function project. Values specified in `func.yaml` are used when you execute a `kn func` command. For example, when you run the `kn func build` command, the value in the `builder` field is used. In some cases, you can override these values with command line flags or environment variables.
 
 include::modules/serverless-functions-func-yaml-fields.adoc[leveloffset=+1]
 include::modules/serverless-functions-func-yaml-environment-variables.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.6+

Issue:
https://issues.redhat.com/browse/SRVCOM-1831

Link to docs preview:
(Red Hat VPN needed) The whole "Functions" section, from:
http://file.brq.redhat.com/~msvistun/serverless-functions-abstracts/srvls-functions-abstracts/serverless/functions/serverless-functions-setup.html
To:
http://file.brq.redhat.com/~msvistun/serverless-functions-abstracts/srvls-functions-abstracts/serverless/functions/serverless-functions-reference-guide.html