### PR TITLE
BZ#2070016: Adds "Increase network MTU" section to 4.8.

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -9,6 +9,11 @@ Installer-provisioned installation of {product-title} involves several network r
 
 image::210_OpenShift_Baremetal_IPI_Deployment_updates_0122_2.png[Installer-provisioned networking]
 
+[id="network-requirements-increase-mtu_{context}"]
+== Increase the network MTU
+
+Before deploying {product-title}, increase the network maximum transmission unit (MTU) to 1500 or more. If the MTU is lower than 1500, the Ironic image that is used to boot the node might fail to communicate with the Ironic inspector pod, and inspection will fail. If this occurs, installation stops because the nodes are not available for installation.
+
 [id='network-requirements-config-nics_{context}']
 == Configuring NICs
 
@@ -126,7 +131,7 @@ External load balancing services and the control plane nodes must run on the sam
 ====
 Do not change a worker node's IP address manually after deployment. To change the IP address of a worker node after deployment, you must mark the worker node unschedulable, evacuate the pods, delete the node, and recreate it with the new IP address. See "Working with nodes" for additional details. To change the IP address of a control plane node after deployment, contact support.
 
-The storage interface requires a DHCP reservation. 
+The storage interface requires a DHCP reservation.
 ====
 
 The following table provides an exemplary embodiment of fully qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The hostnames of the control plane and worker nodes are exemplary, so you can use any host naming convention you prefer.


### PR DESCRIPTION
This PR adds an "Increase network MTU" section that was already added, tested and peer reviewed to 4.10 and 4.9. It apparently wasn't cherry-picked to 4.8. This PR is the same content applied to the 4.8 release. 

Release: 4.8
See: https://github.com/openshift/openshift-docs/pull/44847 and https://github.com/openshift/openshift-docs/pull/44993 for pre-existing PRs.

See https://bugzilla.redhat.com/show_bug.cgi?id=2070016 for the original bug re-opened to get this cherry picked to 4.8. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
