### PR TITLE
[enterprise-4.7] Updates a command because there are no pods labeled fluentd in OCP

### DIFF
--- a/modules/cluster-logging-forwarding-json-logs-to-the-default-elasticsearch.adoc
+++ b/modules/cluster-logging-forwarding-json-logs-to-the-default-elasticsearch.adoc
@@ -52,5 +52,5 @@ The Red Hat OpenShift Logging Operator redeploys the Fluentd pods. However, if t
 +
 [source,terminal]
 ----
-$ oc delete pod --selector logging-infra=fluentd
+$ oc delete pod --selector logging-infra=collector
 ----


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/openshift-docs/pull/46618

For 4.7 only. 

Preview in original pull request. 
