### PR TITLE
OSDOCS-3503: Defining CIDR Ranges for Networks

### DIFF
--- a/modules/installation-osp-custom-subnet.adoc
+++ b/modules/installation-osp-custom-subnet.adoc
@@ -32,3 +32,8 @@ Clusters that use custom subnets have the following limitations:
 By default, the API VIP takes x.x.x.5 and the Ingress VIP takes x.x.x.7 from your network's CIDR block. To override these default values,
 set values for `platform.openstack.apiVIP` and `platform.openstack.ingressVIP` that are outside of the DHCP allocation pool.
 ====
+
+[IMPORTANT]
+====
+The CIDR ranges for networks are not adjustable after cluster installation. Red Hat does not provide direct guidance on determining the range during cluster installation because it requires careful consideration of the number of created pods per namespace.
+====


### PR DESCRIPTION
[OSDOCS-3503](https://issues.redhat.com/browse/OSDOCS-3503)
Defining CIDR Ranges for Networks

**Version(s):**
versions 4.11 and beyond 

**Issue:**

- Engineering epic -[ https://issues.redhat.com/browse/OSASINFRA-2734](https://issues.redhat.com/browse/OSASINFRA-2734)
- Docs JIRA - https://issues.redhat.com/browse/OSDOCS-3503

**Link to docs preview:**
https://wiharris.github.io/openshift-docs/OSDOCS-3726-B/installing/installing_openstack/installing-openstack-installer-kuryr.html#installation-osp-custom-subnet_installing-openstack-installer-kuryr


**Additional information:**
QA: @itzikb-redhat & @MaysaMacedo 



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
