### PR TITLE
OSSMDOC-598: Update locations of resources in install/troubleshooting.

### DIFF
--- a/modules/ossm-install-ossm-operator.adoc
+++ b/modules/ossm-install-ossm-operator.adoc
@@ -14,30 +14,27 @@ To install {SMProductName}, install following Operators in this order. Repeat th
 * Kiali
 * {SMProductName}
 
+[NOTE]
+====
+If you have already installed the OpenShift Elasticsearch Operator as part of OpenShift Logging, you do not need to install the OpenShift Elasticsearch Operator again. The {JaegerName} Operator will create the Elasticsearch instance using the installed OpenShift Elasticsearch Operator.
+====
+
 .Procedure
 
-. Log in to the {product-title} web console as a user with the `cluster-admin` role.
+. Log in to the {product-title} web console as a user with the `cluster-admin` role. If you use {product-dedicated}, you must have an account with the `dedicated-admin` role.
 
 . In the {product-title} web console, click *Operators* -> *OperatorHub*.
 
 . Type the name of the Operator into the filter box and select the Red Hat version of the Operator. Community versions of the Operators are not supported.
 
 . Click *Install*.
-+
-[NOTE]
-====
-If you have already installed the OpenShift Elasticsearch Operator as part of OpenShift
-Logging, you do not need to install the OpenShift Elasticsearch Operator again. The
-{JaegerName} Operator will create the Elasticsearch instance using the installed OpenShift
-Elasticsearch Operator.
-====
 
-. On the *Install Operator* page, select installation options.
-.. For the OpenShift Elasticsearch Operator, in the *Update Channel* section, select *stable-5.x*.
-.. For the {JaegerName}, Kiali, and {SMProductName} Operators, accept the defaults.
-+
-The Kiali and {SMProductName} Operators are installed in the `openshift-operators` namespace. The {JaegerName} is installed in the `openshift-distributed-tracing` namespace. The OpenShift Elasticsearch Operator is installed in the `openshift-operators-redhat` namespace.
+. On the *Install Operator* page for each Operator, accept  the default settings.
 
 . Click *Install*. Wait until the Operator has installed before repeating the steps for the next Operator in the list.
++
+* The OpenShift Elasticsearch Operator is installed in the `openshift-operators-redhat` namespace and is available for all namespaces in the cluster.
+* The {JaegerName} is installed in the `openshift-distributed-tracing` namespace and is available for all namespaces in the cluster.
+* The Kiali and {SMProductName} Operators are installed in the `openshift-operators` namespace and are available for all namespaces in the cluster.
 
 . After all you have installed all four Operators, click *Operators* -> *Installed Operators* to verify that your Operators installed.

--- a/modules/ossm-validating-smcp.adoc
+++ b/modules/ossm-validating-smcp.adoc
@@ -12,6 +12,7 @@ When you create the Service Mesh control plane, the {SMProductShortName} Operato
 ** `istio-egressgateway`
 ** `grafana`
 ** `prometheus`
+** `wasm-cacher`
 * Calls the Kiali Operator to create Kaili deployment based on configuration in either the SMCP or the Kiali custom resource.
 +
 [NOTE]
@@ -23,7 +24,7 @@ You view the Kiali components under the Kiali Operator, not the {SMProductShortN
 +
 [NOTE]
 ====
-You view the Jaeger components under the {JaegerName} Operator and the Elasticsearch components under the Elasticsearch Operator, not the {SMProductShortName} Operator.
+You view the Jaeger components under the {JaegerName} Operator and the Elasticsearch components under the Red Hat Elasticsearch Operator, not the {SMProductShortName} Operator.
 ====
 +
 .From the {product-title} console
@@ -33,10 +34,31 @@ You can verify the Service Mesh control plane installation in the {product-title
 . Navigate to *Operators* -> *Installed Operators*.
 . Select the `<istio-system>` namespace.
 . Select the {SMProductName} Operator.
-. Click the *Istio Service Mesh Control Plane* tab.
-. Click the name of your control plane, for example `basic`.
-. To view the resources created by the deployment, click the *Resources* tab. You can use the filter to narrow your view, for example, to check that all the *Pods* have a status of `running`.
-. If the SMCP status indicates any problems, check the `status:` output in the YAML file for more information.
+.. Click the *Istio Service Mesh Control Plane* tab.
+.. Click the name of your control plane, for example `basic`.
+.. To view the resources created by the deployment, click the *Resources* tab. You can use the filter to narrow your view, for example, to check that all the *Pods* have a status of `running`.
+.. If the SMCP status indicates any problems, check the `status:` output in the YAML file for more information.
+.. Navigate back to *Operators* -> *Installed Operators*.
+
+. Select the OpenShift Elasticsearch Operator.
+.. Click the *Elasticsearch* tab.
+.. Click the name of the deployment, for example `elasticsearch`.
+.. To view the resources created by the deployment, click the *Resources* tab. .
+.. If the `Status` column any problems, check the `status:` output on the *YAML* tab for more information.
+.. Navigate back to *Operators* -> *Installed Operators*.
+
+. Select the {JaegerName} Operator.
+.. Click the *Jaeger* tab.
+.. Click the name of your deployment, for example `jaeger`.
+.. To view the resources created by the deployment, click the *Resources* tab.
+.. If the `Status` column indicates any problems, check the `status:` output on the *YAML* tab for more information.
+.. Navigate to *Operators* -> *Installed Operators*.
+
+. Select the Kiali Operator.
+.. Click the *Istio Service Mesh Control Plane* tab.
+.. Click the name of your deployment, for example `kiali`.
+.. To view the resources created by the deployment, click the *Resources* tab.
+.. If the `Status` column any problems, check the `status:` output on the *YAML* tab for more information.
 
 .From the command line
 
@@ -50,13 +72,15 @@ $ oc get pods -n istio-system
 .Example output
 [source,terminal]
 ----
-NAME                                    READY   STATUS    RESTARTS   AGE
-grafana-6c47888749-dsztv                2/2     Running   0          37s
-istio-egressgateway-85fdc5b466-dgqgt    1/1     Running   0          36s
-istio-ingressgateway-844f785b79-pxbvb   1/1     Running   0          37s
-istiod-basic-c89b5b4bb-5jh8b            1/1     Running   0          104s
-jaeger-6ff889f874-rz2nm                 2/2     Running   0          34s
-prometheus-578df79589-p7p9k             3/3     Running   0          69s
+NAME                                   READY   STATUS    RESTARTS   AGE
+grafana-6776785cfc-6fz7t               2/2     Running   0          102s
+istio-egressgateway-5f49dd99-l9ppq     1/1     Running   0          103s
+istio-ingressgateway-6dc885c48-jjd8r   1/1     Running   0          103s
+istiod-basic-6c9cc55998-wg4zq          1/1     Running   0          2m14s
+jaeger-6865d5d8bf-zrfss                2/2     Running   0          100s
+kiali-579799fbb7-8mwc8                 1/1     Running   0          46s
+prometheus-5c579dfb-6qhjk              2/2     Running   0          115s
+wasm-cacher-basic-5b99bfcddb-m775l     1/1     Running   0          86s
 ----
 +
 . Check the status of the control plane deployment with the following command, where `istio-system` is the namespace where you deployed the SMCP.
@@ -72,7 +96,7 @@ The installation has finished successfully when the STATUS column is `Components
 [source,terminal]
 ----
 NAME    READY   STATUS            PROFILES      VERSION   AGE
-basic   9/9     ComponentsReady   ["default"]   2.0.1.1   19m
+basic   10/10   ComponentsReady   ["default"]   2.1.3     4m2s
 ----
 
 +
@@ -82,7 +106,7 @@ If you have modified and redeployed your control plane, the status should read `
 [source,terminal]
 ----
 NAME            READY     STATUS             TEMPLATE   VERSION   AGE
-basic-install   9/9       UpdateSuccessful   default               v1.1          3d16h
+basic-install   10/10     UpdateSuccessful   default     v1.1     3d16h
 ----
 +
 . If the SMCP status indicates anything other than `ComponentsReady` check the `status:` output in the SCMP resource for more information.
@@ -97,4 +121,32 @@ $ oc describe smcp <smcp-name> -n <controlplane-namespace>
 [source,terminal]
 ----
 $ oc describe smcp basic -n istio-system
+----
++
+. Check the status of the Jaeger deployment with the following command, where `istio-system` is the namespace where you deployed the SMCP.
++
+[source,terminal]
+----
+$ oc get jaeger -n <istio-system>
+----
++
+.Example output
+[source,terminal]
+----
+NAME     STATUS    VERSION   STRATEGY   STORAGE   AGE
+jaeger   Running   1.30.0    allinone   memory    15m
+----
++
+. Check the status of the Kiali deployment with the following command, where `istio-system` is the namespace where you deployed the SMCP.
++
+[source,terminal]
+----
+$ oc get kiali -n <istio-system>
+----
++
+.Example output
+[source,terminal]
+----
+NAME    AGE
+kiali   15m
 ----


### PR DESCRIPTION
Update the installation and troubleshooting documentation with where the various service mesh components are installed, and where to view them when troubleshooting the installation.

Issue: [OSSMDOC-598](https://issues.redhat.com/browse/OSSMDOC-598)

Version(s): 4.6 - 4.11

Link to docs preview: http://file.bos.redhat.com/jstickle/OSSMDOC-598/service_mesh/v2x/installing-ossm.html#ossm-install-ossm-operator_installing-ossm
And 
http://file.bos.redhat.com/jstickle/OSSMDOC-598/service_mesh/v2x/ossm-troubleshooting-istio.html#troubleshooting-the-control-plane

Eng review - rcernich
QE review - FilipB
Peer review - sherrif-rh