### PR TITLE
BZ2085097 Document limitations of PV data transfer to AWS EFS storage

### DIFF
--- a/modules/migration-mtc-release-notes-1-7.adoc
+++ b/modules/migration-mtc-release-notes-1-7.adoc
@@ -23,4 +23,5 @@ This release has the following new features and enhancements:
 This release has the following known issues:
 
 * `MigPlan` custom resource does not display a warning when an AWS gp2 PVC has no available space. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1963927[*BZ#1963927*])
+* Direct and indirect data transfers do not work if the destination storage is a PV that is dynamically provisioned by the AWS Elastic File System (EFS). This is due to limitations of the AWS EFS Container Storage Interface (CSI) driver. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2085097[*BZ#2085097*])
 * Block storage for IBM Cloud must be in the same availability zone. See the link:https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-vpc-faq[IBM FAQ for block storage for virtual private cloud].


### PR DESCRIPTION
Document limitations of PV data transfer to AWS EFS storage

https://bugzilla.redhat.com/show_bug.cgi?id=2085097

OCP 4.x from 4.6
