### PR TITLE
MIG-1142: Add DVM supplemental group configuration to downstream documents

### DIFF
--- a/modules/migration-about-configuring-proxies.adoc
+++ b/modules/migration-about-configuring-proxies.adoc
@@ -131,3 +131,34 @@ spec:
       cidrSelector: <cidr_of_source_or_target_cluster>
     type: Deny
 ----
+
+[id="configuring-supplemental-groups-for-rsync-pods{context}"]
+=== Configuring supplemental groups for Rsync pods
+When your PVCs use a shared storage, you can configure the access to that storage by adding supplemental groups to Rsync pod definitions in order for the pods to allow access:
+
+.Supplementary groups for Rsync pods
+[option="header"]
+|===
+|Variable|Type|Default|Description
+
+|`src_supplemental_groups`
+|string
+|Not set
+|Comma-separated list of supplemental groups for source Rsync pods
+
+|`target_supplemental_groups`
+|string
+|Not set
+|Comma-separated list of supplemental groups for target Rsync pods
+|===
+
+.Example usage
+
+The `MigrationController` CR can be updated to set values for these supplemental groups:
+
+[source, yaml]
+----
+spec:
+  src_supplemental_groups: "1000,2000"
+  target_supplemental_groups: "2000,3000"
+----


### PR DESCRIPTION
MTC 1.7.2, OCP 4.6+

Resolves: https://issues.redhat.com/browse/MIG-1142

Preview: 
![configuring_sup_groups_for_Rsync_pods](https://user-images.githubusercontent.com/60698649/174099558-d033e571-4ade-4f31-a5a6-eca2cf89aa26.png)

[last item in "Direct volume migration']


