### PR TITLE
Removes two limitations of OVN K that are being remove for 4.11

### DIFF
--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -5,12 +5,7 @@
 [id="nw-ovn-kubernetes-limitations_{context}"]
 = OVN-Kubernetes limitations
 
-The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has the following limitations:
-
-* OVN-Kubernetes does not support setting the internal traffic policy for a Kubernetes service to `local`.
-This limitation can affect network communication to your application when you add a service of type `ClusterIP`, `LoadBalancer`, `NodePort`, or add a service with an external IP.
-
-* The `sessionAffinityConfig.clientIP.timeoutSeconds` service has no effect in an OpenShift OVN environment, but does in an OpenShift SDN environment. This incompatibility can make it difficult for users to migrate from OpenShift SDN to OVN.
+The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has the following limitation:
 
 // The foll limitation is also recorded in the installation section.
 * For clusters configured for dual-stack networking, both IPv4 and IPv6 traffic must use the same network interface as the default gateway.


### PR DESCRIPTION
Removes two limitations of OVN-K that are currently removed in the 4.11 branch but not in Main. 

For main only. 

No QE needed. 

Preview: 

![image](https://user-images.githubusercontent.com/77019920/173846730-0709d208-fc08-425e-9864-8fdaa6b91de2.png)

