### PR TITLE
Update control plane node sizing

### DIFF
--- a/modules/master-node-sizing.adoc
+++ b/modules/master-node-sizing.adoc
@@ -6,34 +6,37 @@
 [id="master-node-sizing_{context}"]
 =  Control plane node sizing
 
-The control plane node resource requirements depend on the number of nodes in the cluster. The following control plane node size recommendations are based on the results of control plane density focused testing. The control plane tests create the following objects across the cluster in each of the namespaces depending on the node counts:
+The control plane node resource requirements depend on the number and type of nodes and objects in the cluster. The following control plane node size recommendations are based on the results of a control plane density focused testing, or _Cluster-density_. This test creates the following objects across a given number of namespaces:
 
-- 12 image streams
-- 3 build configurations
-- 6 builds
-- 1 deployment with 2 pod replicas mounting two secrets each
-- 2 deployments with 1 pod replica mounting two secrets
-- 3 services pointing to the previous deployments
-- 3 routes pointing to the previous deployments
-- 10 secrets, 2 of which are mounted by the previous deployments
-- 10 config maps, 2 of which are mounted by the previous deployments
+- 1 image stream
+- 1 build
+- 5 deployments, with 2 pod replicas in a `sleep` state, mounting 4 secrets, 4 config maps, and 1 downward API volume each
+- 5 services, each one pointing to the TCP/8080 and TCP/8443 ports of one of the previous deployments
+- 1 route pointing to the first of the previous services
+- 10 secrets containing 2048 random string characters
+- 10 config maps containing 2048 random string characters
 
 
 [options="header",cols="4*"]
 |===
-| Number of worker nodes |Cluster load (namespaces) | CPU cores |Memory (GB)
+| Number of worker nodes |Cluster-density (namespaces) | CPU cores |Memory (GB)
 
-| 25
+| 27
 | 500
 | 4
 | 16
 
-| 100
+| 120
 | 1000
 | 8
 | 32
 
-| 250
+| 252
+| 4000
+| 16
+| 64
+
+| 501
 | 4000
 | 16
 | 96


### PR DESCRIPTION
Version(s):
4.10

Issue:
This fixes #46244

Link to docs preview:
[Control plane node sizing](http://file.rdu.redhat.com/antaylor/06-15-22/cp-node-sizing/scalability_and_performance/recommended-host-practices.html#master-node-sizing_recommended-host-practices)

Additional information:
This PR addresses 4.10-specific capabilities; however some terminology updates (cluster-density) and other phrasing should be carried to 4.11+, so I made the pull request against the main branch. 