### PR TITLE
Adds notes for 4.10.19 and Telco RAN release

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -123,3 +123,4 @@ endif::[]
 :ibmzProductName: IBM Z
 // Red Hat Quay Container Security Operator
 :rhq-cso: Red Hat Quay Container Security Operator
+:cgu-operator-full: Topology Aware Lifecycle Manager

--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2605,8 +2605,6 @@ Workaround: Use OpenShift OAuth for authentication. (link:https://bugzilla.redha
 
 * For this release, the number of Alertmanager replicas in the monitoring stack was reduced from three to two. However, the persistent volume claim (PVC) for the removed third replica is not automatically removed as part of the upgrade process. After the upgrade, an administrator can remove this PVC manually from the Cluster Monitoring Operator. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2040131[*BZ#2040131*])
 
-* In the default ZTP Argo CD configuration, cluster names cannot begin with `ztp`. Using names starting with `ztp` for clusters deployed with Zero Touch Provisioning (ZTP) results in provisioning not completing. As a workaround, ensure that either cluster names do not start with `ztp`, or adjust the Argo CD policy application namespace to a pattern that excludes the names of your clusters but still matches your policy namespace. For example, if your cluster names start with `ztp`, change the pattern in the Argo CD policy app configuration to something different, like `ztp-`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049154[*BZ#2049154*])
-
 * Previously, the `oc adm must-gather` tool did not collect performance specific data when more than one `--image` argument was supplied. Files, including node and performance related files, were missing when the operation finished. The issue affects {product-title} versions between 4.7 and 4.10. This issue can be resolved by executing the `oc adm must-gather` operation twice, once for each image. As a result, all expected files can be collected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2018159[*BZ#2018159*])
 
 * When using the Technology Preview oc-mirror CLI plug-in, there is a known issue that can occur when updating your cluster after mirroring an updated image set to the mirror registry. If a new version of an Operator is published to a channel by deleting the previous version of that Operator and then replacing it with a new version, an error can occur when applying the generated `CatalogSource` file from the oc-mirror plug-in, because the catalog is seen as invalid. As a workaround, delete the previous catalog image from the mirror registry, generate and publish a new differential image set, and then apply the `CatalogSource` file to the cluster. You must follow this workaround each time you publish a new differential image set, until this issue is resolved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2060837[*BZ#2060837*])
@@ -2977,6 +2975,129 @@ link:https://access.redhat.com/solutions/6962977[{product-title} 4.10.18 contain
 * Previously, the Ingress Operator had unnecessary logic to remove a finalizer on `LoadBalancer-type` services in previous versions of {product-title}. With this update, the Ingress Operator no longer includes this logic. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2082161[*BZ#2082161*])
 
 [id="ocp-4-10-18-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-19"]
+=== RHBA-2022:xxxx - {product-title} 4.10.19 bug fix update
+
+Issued: 2022-06-20
+
+{product-title} release 4.10.19 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:xxxx[RHBA-2022:xxxx] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:xxxx[RHBA-2022:xxxx] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:[{product-title} 4.10.19 container image list]
+
+[id="ocp-4-10-19-features"]
+==== Features
+
+[id="ocp-4-10-redfish-events"]
+===== Low-latency Redfish hardware event delivery (Developer Preview)
+
+{product-title} now provides a hardware event proxy that enables applications running on bare-metal clusters to respond quickly to Redfish hardware events, such as hardware changes and failures.
+
+The hardware event proxy supports a publish-subscribe service that allows relevant applications to consume hardware events detected by Redfish. The proxy must be running on hardware that supports Redfish v1.8 and higher. An Operator manages the lifecycle of the `hw-event-proxy` container.
+
+You can use a REST API to develop applications to consume and respond to events such as breaches of temperature thresholds, fan failure, disk loss, power outages, and memory failure. Reliable end-to-end messaging without persistent stores is based on the Advanced Message Queuing Protocol (AMQP). The latency of the messaging service is in the 10 millisecond range.
+
+[NOTE]
+====
+This feature is supported for single node OpenShift clusters only.
+====
+
+[id="ocp-4-10-topology-aware-lifecycle-operator"]
+===== Updating managed clusters with {cgu-operator-full} (Developer Preview)
+
+You can now use the upstream {cgu-operator-full} to perform updates on multiple single-node Openshift clusters by using {rh-rhacm-first} policies. For more information, see xref:../scalability_and_performance/cnf-talo-for-cluster-upgrades.html#cnf-about-topology-aware-lifecycle-operator-config_cnf-topology-aware-lifecycle-operator[About the {cgu-operator-full} configuration].
+
+[id="ocp-4-10-6-ztp-ga"]
+===== Zero touch provisioning is generally available
+
+Use zero touch provisioning (ZTP) to provision distributed units at new edge sites in a disconnected environment. This feature was previously introduced as a Technology Preview feature in OpenShift Container Platform 4.9 and is now generally available and enabled by default in OpenShift Container Platform 4.11. For more information, see xref:../scalability_and_performance/ztp-deploying-disconnected.adoc[Deploying distributed units at scale in a disconnected environment].
+
+[id="ocp-4-10-6-enhancements-iod"]
+===== Indication of done for ZTP
+
+A new tool is available that simplifies the process of checking for a completed zero touch provisioning (ZTP) installation using the {rh-rhacm-first} static validator inform policy. It provides an Indication of done for ZTP installations by capturing the criteria for a completed installation and validating that it moves to a compliant state only when ZTP provisioning of the spoke cluster is complete.
+
+This policy can be used for deployments of single node clusters, three-node clusters, and standard clusters.
+To learn more about the validator inform policy, see xref:../modules/ztp-definition-of-done-for-ztp-installations.adoc[Indication of done]
+
+[id="ocp-4-10-6-enhancements-ztp"]
+===== Enhancements to ZTP
+
+For {product-title} {product-version}, there are a number of updates that make it easier to configure the hub cluster and generate source CRs. New PTP and UEFI secure boot features for spoke clusters are also available. A summary of these features is below:
+
+* You can add or modify existing source CRs in the `ztp-site-generate` container, rebuild it, and make it available to the hub cluster, typically from the disconnected registry associated with the hub cluster.
+* You can configure PTP fast events for vRAN clusters that are deployed using the GitOps zero touch provisioning (ZTP) pipeline.
+* You can configure UEFI secure boot for vRAN clusters that are deployed using the GitOps ZTP pipeline.
+* You can use {cgu-operator-full} to orchestrate the application of the configuration CRs to the hub cluster.
+
+[id="ocp-4-10-6-multicluster-support-ztp"]
+===== ZTP support for multicluster deployment
+
+Zero touch provisioning (ZTP) provides support for multicluster deployment, including single node clusters, three-node clusters, and standard OpenShift clusters. This includes the installation of OpenShift and deployment of the distributed units (DUs) at scale. This gives you the ability to deploy nodes with master, worker, and master and worker roles.
+ZTP multinode support is implemented through the use of `SiteConfig` and `PolicyGenTemplate` custom resources (CRs). The overall flow is identical to the ZTP support for single node clusters, with some differentiation in configuration depending on the type of cluster:
+
+In the `SiteConfig` file:
+
+    * Single node clusters must have exactly one entry in the `nodes` section.
+    * Three-node clusters must have exactly three entries defined in the `nodes` section.
+    * Standard OpenShift clusters must have exactly three entries in the `nodes` section with role: master and one or more additional entries with role: worker.
+
+The `PolicyGenTemplate` file tells the Policy Generator where to categorize the generated policies. Example `PolicyGenTemplate` files provide you with example files to simplify your deployments:
+
+* The example common `PolicyGenTemplate` file is common across all types of clusters.
+* Example group `PolicyGenTemplate` files for single node, three-node, and standard clusters are provided.
+* Site-specific `PolicyGenTemplate` files specific to each site are provided.
+
+To learn more about multicluster deployment, see xref:../modules/ztp-deploying-a-site.adoc[Deploying a site]
+[id="ocp-4-10-19-upgrading"]
+
+[id"ocp-4-10-19-known-issues"]
+==== Known issues
+
+* The Kubelet service monitor scrape interval is currently set to a hard-coded value. This means that there is less available CPU resources for workloads. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2035046[*BZ#2035046*])
+
+* Deploying a single node OpenShift cluster for vRAN Distributed Units can take up to 4 hours.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2035036[*BZ#2035036*])
+
+* Currently, if an {rh-rhacm} policy was enforced to a target cluster, you can create a `ClusterGroupUpgrade` CR including that enforced policy again as a `managedPolicy` to the same target cluster. This should not be possible. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2044304[*BZ#2044304*])
+
+* If a `ClusterGroupUpgrade` CR has a `blockingCR` specified, and that `blockingCR` fails silently, for example if there is a typo in the list of clusters, the `ClusterGroupUpgrade` CR is applied even though the `blockingCR` is not applied in the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2042601[*BZ#2042601*])
+
+* If a `ClusterGroupUpgrade` CR validation fails for any reason, for example, because of an invalid spoke name, no status is available for the `ClusterGroupUpgrade` CR, as if the CR is disabled. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2040828[*BZ#2040828*])
+
+* Currently, for `ClusterGroupUpgrade` CR state changes, there is only a single condition type available - `Ready`. The `Ready` condition can have a status of `True` or `False` only. This does not reflect the range of states the `ClusterGroupUpgrade` CR can be in. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2042596[*BZ#2042596*])
+
+* When deploying a multi-node cluster on bare-metal nodes, the machine config pool (MCP) adds an additional CRI-O drop-in that circumvents the link:https://github.com/openshift-kni/cnf-features-deploy/blob/master/cnf-tests/README.md#container-mount-namespace[container mount namespace drop-in]. This results in CRI-O being in the base namespace while the kubelet is in the hidden namespace. All containers fail to get any kubelet-mounted filesystems, such as secrets and tokens. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2028590[*BZ#2028590*])
+
+* Installing {rh-rhacm} 2.5.0 in the customized namespace causes the `infrastructure-operator` pod to fail due to insufficient privileges. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2046554[*BZ#2046554*])
+
+*  {product-title} limits object names to 63 characters. If a policy name defined in a `PolicyGenTemplate` CR approaches this limit, the {cgu-operator-full} cannot create child policies. When this occurs, the parent policy will remain in a `NonCompliant` state. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057209[*BZ#2057209*])
+
+* In the default ZTP Argo CD configuration, cluster names cannot begin with `ztp`. Using names starting with `ztp` for clusters deployed with Zero Touch Provisioning (ZTP) results in provisioning not completing. As a workaround, ensure that either cluster names do not start with `ztp`, or adjust the Argo CD policy application namespace to a pattern that excludes the names of your clusters but still matches your policy namespace. For example, if your cluster names start with `ztp`, change the pattern in the Argo CD policy app configuration to something different, like `ztp-`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049154[*BZ#2049154*])
+
+* During a spoke cluster upgrade, one or more reconcile errors is recorded in the container log. The number of errors corresponds to the number of child policies. The error causes no noticeable impact to the cluster. The following is an example of the reconcile error:
++
+[source,terminal]
+----
+2022-01-21T00:14:44.697Z        INFO    controllers.ClusterGroupUpgrade Upgrade is completed
+2022-01-21T00:14:44.892Z        ERROR   controller-runtime.manager.controller.clustergroupupgrade       Reconciler error        {"reconciler group": "ran.openshift.io", "reconciler kind": "ClusterGroupUpgrade", "name": "timeout", "namespace": "default", "error": "Operation cannot be fulfilled on clustergroupupgrades.ran.openshift.io \"timeout\": the object has been modified; please apply your changes to the latest version and try again"}
+sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
+        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.2/pkg/internal/controller/controller.go:253
+sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
+        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.2/pkg/internal/controller/controller.go:214
+----
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2043301[*BZ#2043301*])
+
+* During a spoke cluster upgrade from 4.9 to 4.10, with heavy workload running, the `kube-apiserver` pod can take longer than the expected time to start. As a result, the upgrade does not complete and the `kube-apiserver` rolls back to the previous version. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2064024[*BZ#2064024*])
+
+* If you deploy the AMQ Interconnect Operator, pods run on IPv4 nodes only. The AMQ Interconnect Operator is not supported on IPv6 nodes. (link:https://issues.redhat.com/browse/ENTMQIC-3297[*ENTMQIC-3297*])
+
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.10.19 release and notes for Telco RAN GA.

Version(s):
`enterprise-4.10` only

Link to docs preview:
http://file.rdu.redhat.com/opayne/RNs-4.10.19/release_notes/ocp-4-10-release-notes.html#ocp-4-10-19 

Additional information:
Links to acks in this PR #44003


<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
