### PR TITLE
BZ-1905797: Add guidance on using cloud-provided DNS server when deploying to an existing VNet/VPC

### DIFF
--- a/modules/installation-about-custom-azure-vnet.adoc
+++ b/modules/installation-about-custom-azure-vnet.adoc
@@ -32,6 +32,8 @@ When you deploy a cluster by using an existing VNet, you must perform additional
 * VNets
 * Network Security Groups
 
+include::snippets/custom-dns-server.adoc[]
+
 If you use a custom VNet, you must correctly configure it and its subnets for the installation program and the cluster to use. The installation program cannot subdivide network ranges for the cluster to use, set route tables for the subnets, or set VNet options like DHCP, so you must do so before you install the cluster.
 
 The cluster must be able to access the resource group that contains the existing VNet and subnets. While all of the resources that the cluster creates are placed in a separate resource group that it creates, some network resources are used from a separate group. Some cluster Operators must be able to access resources in both resource groups. For example, the Machine API controller attaches NICS for the virtual machines that it creates to subnets from the networking resource group.

--- a/modules/installation-custom-aws-vpc.adoc
+++ b/modules/installation-custom-aws-vpc.adoc
@@ -36,6 +36,8 @@ The installation program no longer creates the following components:
 * VPC DHCP options
 * VPC endpoints
 
+include::snippets/custom-dns-server.adoc[]
+
 If you use a custom VPC, you must correctly configure it and its subnets for the installation program and the cluster to use. See link:https://docs.aws.amazon.com/vpc/latest/userguide/VPC_wizard.html[Amazon VPC console wizard configurations] and link:https://docs.aws.amazon.com/vpc/latest/userguide/working-with-vpcs.html[Work with VPCs and subnets] in the AWS documentation for more information on creating and managing an AWS VPC.
 
 The installation program cannot:

--- a/modules/installation-custom-gcp-vpc.adoc
+++ b/modules/installation-custom-gcp-vpc.adoc
@@ -20,6 +20,8 @@ The installation program does not create the following components:
 * Route tables
 * VPC network
 
+include::snippets/custom-dns-server.adoc[]
+
 [id="installation-custom-gcp-vpc-validation_{context}"]
 == VPC validation
 

--- a/snippets/custom-dns-server.adoc
+++ b/snippets/custom-dns-server.adoc
@@ -1,0 +1,12 @@
+// Text snippet included in the following modules:
+//
+// * modules/installation-custom-aws-vpc.adoc
+// * modules/installation-about-custom-azure-vnet.adoc
+// * modules/installation-custom-gcp-vpc.adoc
+
+:_content-type: SNIPPET
+
+[NOTE]
+====
+The installation program requires that you use the cloud-provided DNS server. Using a custom DNS server is not supported and causes the installation to fail.
+====


### PR DESCRIPTION
Version(s):
CP to 4.6+

Issue:
This PR addresses BZ [1905797](https://bugzilla.redhat.com/show_bug.cgi?id=1905797).

Link to docs preview:

- (Azure) [Requirements for using your VNet](http://file.rdu.redhat.com/mpytlak/bz1905797/installing/installing_azure/installing-azure-vnet.html#installation-about-custom-azure-vnet-requirements_installing-azure-vnet)
- (AWS) [Requirements for using your VPC](http://file.rdu.redhat.com/mpytlak/bz1905797/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-requirements_installing-aws-vpc)
- (GCP) [Requirements for using your VPC](http://file.rdu.redhat.com/mpytlak/bz1905797/installing/installing_gcp/installing-gcp-vpc.html#installation-custom-gcp-vpc-requirements_installing-gcp-vpc)