### PR TITLE
TELCODOCS-593: Removing PAO subscriptions from deployed clusters

### DIFF
--- a/modules/cnf-topology-aware-lifecycle-manager-PAO-update.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-PAO-update.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+// Epic CNF-4767 (4.11), Story TELCODOCS-593
+// * scalability_and_performance/ztp-deploying-disconnected.adoc
+
+:_content-type: PROCEDURE
+[id="talm-PAO-update_{context}"]
+= Removing Performance Addon Operator subscriptions from deployed clusters
+
+In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11 or later, these functions are part of the Node Tuning Operator.
+
+Do not install the Performance Addon Operator on clusters running {product-title} 4.11 or later. If you upgrade to {product-title} 4.11 or later, the Node Tuning Operator automatically removes the Performance Addon Operator. However, you  need to manually remove any policies that create Performance Addon Operator subscriptions to prevent a reinstallation of the Operator. The reference DU profile includes the Performance Addon Operator in the `common-ranGen.yaml` `PolicyGenTemplate`. To remove the subscription from deployed spoke clusters, you must update `common-ranGen.yaml`.
+
+[NOTE]
+====
+If you install Performance Addon Operator 4.10.3-5 or later on {product-title} 4.11 or later, the Performance Addon Operator detects the cluster version and automatically hibernates to avoid interfering with the Node Tuning Operator functions. However, to ensure best performance, remove the Performance Addon Operator from your {product-title} 4.11 clusters.
+====
+
+
+.Prerequisites
+
+* Create a Git repository where you manage your custom site configuration data. The repository must be accessible from the hub cluster and be defined as a source repository for Argo CD.
+* Update to {product-title} 4.11 or later. 
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Change the `complianceType` to `mustnothave` for the Performance Addon Operator namespace, Operator group, and subscription in the `common-ranGen.yaml` file.
++
+[source,yaml]
+----
+ -  fileName: PaoSubscriptionNS.yaml
+    policyName: "subscriptions-policy"
+    complianceType: mustnothave
+ -  fileName: PaoSubscriptionOperGroup.yaml
+    policyName: "subscriptions-policy"
+    complianceType: mustnothave
+ -  fileName: PaoSubscription.yaml
+    policyName: "subscriptions-policy"
+    complianceType: mustnothave
+----
++
+. Merge the changes with your custom site repository and wait for the ArgoCD application to synchronize the change to the hub cluster. The status of the `common-subscriptions-policy` policy changes to `Non-Compliant`.
+. Apply the change to your target clusters by using the {cgu-operator-full}. For more information about rolling out configuration changes, see the _Additional resources_ section.
+. Monitor the process. When the status of the `common-subscriptions-policy` policy for a target cluster  is `Compliant`, the Performance Addon Operator has been removed from the cluster. Get the status of the `common-subscriptions-policy` by running the following command: 
++
+[source,terminal]
+----
+$ oc get policy -n common-subscriptions-policy
+----
++
+. Delete the Performance Addon Operator namespace, Operator group and subscription CRs from `.spec.sourceFiles` in the `common-ranGen.yaml` file.
+. Merge the changes with your custom site repository and wait for the ArgoCD application to synchronize the change to the hub cluster. The policy remains compliant. 

--- a/scalability_and_performance/ztp-deploying-disconnected.adoc
+++ b/scalability_and_performance/ztp-deploying-disconnected.adoc
@@ -250,5 +250,11 @@ include::modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc[level
 
 * For more information about updating GitOps ZTP, see xref:../scalability_and_performance/ztp-deploying-disconnected.adoc#ztp-upgrading-gitops-ztp_ztp-deploying-disconnected[Upgrading GitOps ZTP].
 
+include::modules/cnf-topology-aware-lifecycle-manager-PAO-update.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../scalability_and_performance/ztp-deploying-disconnected.adoc#ztp-roll-out-the-configuration-changes_ztp-deploying-disconnected[Upgrading GitOps ZTP].
 
 include::modules/cnf-topology-aware-lifecycle-manager-operator-and-platform-update.adoc[leveloffset=+2]


### PR DESCRIPTION
[TELCODOCS-593](https://issues.redhat.com//browse/TELCODOCS-593): The Performance Addon Operator is replaced by the Node Tuning Operator from OCP 4.11. When you upgrade to 4.11, PAO is automatically removed, however, subscriptions remain that can reinstall on spoke clusters. Adding a procedure module that details how to remove that subscription.

Version(s):
4.11 RAN GA +

Issue:
https://issues.redhat.com/browse/TELCODOCS-593

Link to docs preview:
http://file.emea.redhat.com/rohennes/conPR-telcodocs-593/scalability_and_performance/ztp-deploying-disconnected.html#talm-PAO-update_ztp-deploying-disconnected

Additional information:
I am adding my commit on top of the consolidated PR for 4.10 RAN GA, as this contains content that needs to be updated for PAO removal. My commit only applies to 4.11+ only.

