### PR TITLE
OSDOCS-3661: Adding section for blocking payload registries

### DIFF
--- a/modules/images-configuration-blocked-payload.adoc
+++ b/modules/images-configuration-blocked-payload.adoc
@@ -1,0 +1,70 @@
+//Modules included in the following assemblies
+//
+// * openshift_images/image-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="images-configuration-blocked-payload"]
+
+= Blocking a payload registry
+
+In a mirroring configuration, you can block upstream payload registries in a disconnected environment using a `ImageContentSourcePolicy` (ICSP) object. The following example procedure demonstrates how to block the `quay.io/openshift-payload` payload registry.
+
+.Procedure
+. Create the mirror configuration using an `ImageContentSourcePolicy` (ICSP) object to mirror the payload to a registry in your instance. The following example ICSP file mirrors the payload `internal-mirror.io/openshift-payload`:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  name: my-icsp
+spec:
+  repositoryDigestMirrors:
+  - mirrors:
+    - internal-mirror.io/openshift-payload
+    source: quay.io/openshift-payload
+----
+. After the object deploys onto your nodes, verify that the mirror configuration is set by checking the `/etc/containers/registries.conf` file:
++
+.Example output 
+[source,terminal]
+----
+[[registry]]
+  prefix = ""
+  location = "quay.io/openshift-payload"
+  mirror-by-digest-only = true
+
+[[registry.mirror]]
+  location = "internal-mirror.io/openshift-payload"
+----
+. Use the following command to edit the `image.config.openshift.io` custom resource file:
++
+[source,terminal]
+----
+$ oc edit image.config.openshift.io cluster
+----
+. To block the payload registry, add the following configuration to the `image.config.openshift.io` custom resource file:
++
+[source,yaml]
+----
+spec:
+  registrySource:
+    blockedRegistries:
+     - quay.io/openshift-payload
+----
+
+.Verification
+* Verify that the upstream payload registry is blocked by checking the `/etc/containers/registries.conf` file on the node. 
++ 
+.Example output
+[source,terminal]
+----
+[[registry]]
+  prefix = ""
+  location = "quay.io/openshift-payload"
+  blocked = true
+  mirror-by-digest-only = true
+
+[[registry.mirror]]
+  location = "internal-mirror.io/openshift-payload"
+----

--- a/openshift_images/image-configuration.adoc
+++ b/openshift_images/image-configuration.adoc
@@ -16,6 +16,8 @@ include::modules/images-configuration-allowed.adoc[leveloffset=+2]
 
 include::modules/images-configuration-blocked.adoc[leveloffset=+2]
 
+include::modules/images-configuration-blocked-payload.adoc[leveloffset=+3]
+
 include::modules/images-configuration-insecure.adoc[leveloffset=+2]
 
 include::modules/images-configuration-shortname.adoc[leveloffset=+2]


### PR DESCRIPTION
For version 4.11+
Jira story [OSDOCS-3661](https://issues.redhat.com//browse/OSDOCS-3661) 

Preview: 
[Image configuration registry -> Blocking specific registries](https://kelbrown20.github.io/openshift-docs/OSDOCS-3661-block-payload-registry/openshift_images/image-configuration.html#images-configuration-blocked_image-configuration)
