### PR TITLE
[RHACS] Fix typo in RHACS docs

### DIFF
--- a/modules/create-a-custom-access-scope.adoc
+++ b/modules/create-a-custom-access-scope.adoc
@@ -28,7 +28,7 @@ Access to a specific cluster provides users with access to the following resourc
 * {ocp} or Kubernetes cluster metadata and security information
 * Compliance information for authorized clusters
 * Node metadata and security information
-* Acess to all namespaces in that cluster and their associated security information
+* Access to all namespaces in that cluster and their associated security information
 ====
 ** Turn on the toggle under the *Manual selection* column for a namespace to allow access to that namespace.
 +
@@ -37,7 +37,7 @@ Access to a specific cluster provides users with access to the following resourc
 Access to a specific namespace gives access to the following information within the scope of the namespace:
 
 * Alerts and violations for deployments
-* Vulerability data for images
+* Vulnerability data for images
 * Deployment metadata and security information
 * Role and user information
 * Network graph, policy, and baseline information for deployments
@@ -46,4 +46,3 @@ Access to a specific namespace gives access to the following information within 
 ====
 . If you want to allow access to clusters and namespaces based on labels, click *Add label selector* under the *Label selection rules* section. Then click *Add rules* to specify *Key* and *Value* pairs for the label selector. You can specify labels for clusters and namespaces.
 . Click *Save*.
-


### PR DESCRIPTION
Version(s): 
- Merge to `rhacs-docs`
- cherry pick to `rhacs-docs-3.70`
- cherry pick to `rhacs-docs-3.69`
- cherry pick to `rhacs-docs-3.68`

Label: `RHACS`
Issue: none
[Preview](https://openshift-docs-6w71s7wdy-kcarmichael08.vercel.app/openshift-acs/master/operating/manage-user-access/manage-role-based-access-control-3630.html)