### PR TITLE
Re-adds an OVNK Limitation

### DIFF
--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -5,7 +5,9 @@
 [id="nw-ovn-kubernetes-limitations_{context}"]
 = OVN-Kubernetes limitations
 
-The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has the following limitation:
+The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has the following limitations:
+
+* The `sessionAffinityConfig.clientIP.timeoutSeconds` service has no effect in an OpenShift OVN environment, but does in an OpenShift SDN environment. This incompatibility can make it difficult for users to migrate from OpenShift SDN to OVN.
 
 // The foll limitation is also recorded in the installation section.
 * For clusters configured for dual-stack networking, both IPv4 and IPv6 traffic must use the same network interface as the default gateway.


### PR DESCRIPTION
Fix of https://github.com/openshift/openshift-docs/pull/46736.

Main branch only. 

No QE needed.

Re-adds the sessionAffinityConfig.clientIP.timeoutSeconds limitation. 

Preview:

![image](https://user-images.githubusercontent.com/77019920/173922361-c885b26b-6148-433a-824c-6fb851970f7c.png)
