### PR TITLE
BZ#2093054: remove tech-preview warning from Web Terminal Operator docs as it is now GA

### DIFF
--- a/web_console/odc-about-web-terminal.adoc
+++ b/web_console/odc-about-web-terminal.adoc
@@ -16,8 +16,6 @@ Cluster administrators can access the web terminal in {product-title} 4.7 and la
 This terminal instance is preinstalled with common CLI tools for interacting with the cluster, such as `oc`, `kubectl`,`odo`, `kn`, `tkn`, `helm`, `kubens`, and `kubectx`. It also has the context of the project you are working on and automatically logs you in using your credentials.
 
 :FeatureName: Web terminal
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 include::modules/odc-installing-web-terminal.adoc[leveloffset=+1]
 
 include::modules/odc-using-web-terminal.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s): 4.10 and above

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2093054

Link to docs preview:
http://file.rdu.redhat.com/jrouth/PR46768_amisevek_remove_TP/web_console/odc-about-web-terminal.html

Additional information: 1.5 release of the Web Terminal Operator, released on OpenShift 4.10, is the first generally-available release of the feature. We forgot to update the OpenShift documentation to coincide with this.


<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
