### PR TITLE
OSDOCS-3339 - Adding network verfication content for OSD and ROSA

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -187,6 +187,8 @@ Topics:
   Topics:
   - Name: Enabling multicast for a project
     File: enabling-multicast
+- Name: Network verification
+  File: network-verification
 - Name: Configuring a cluster-wide proxy during installation
   File: configuring-cluster-wide-proxy
 - Name: CIDR range definitions

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -284,6 +284,8 @@ Topics:
   Topics:
   - Name: Enabling multicast for a project
     File: enabling-multicast
+- Name: Network verification
+  File: network-verification
 - Name: Configuring a cluster-wide proxy during installation
   File: configuring-cluster-wide-proxy
 - Name: CIDR range definitions

--- a/modules/automatic-network-verification-bypassing.adoc
+++ b/modules/automatic-network-verification-bypassing.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * networking/network-verification.adoc
+
+:_content-type: CONCEPT
+[id="automatic-network-verification-bypassing_{context}"]
+= Automatic network verification bypassing
+
+You can bypass the automatic network verification if you want to deploy  
+ifdef::openshift-dedicated[]
+an {product-title} 
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+a {product-title} (ROSA) 
+endif::openshift-rosa[]
+cluster with known network configuration issues into an existing Virtual Private Cloud (VPC).
+
+If you bypass the network verification when you create a cluster, the cluster has a limited support status. After installation, you can resolve the issues and then manually run the network verification. The limited support status is removed after the verification succeeds.
+
+ifdef::openshift-rosa[]
+.Bypassing automatic network verification by using {cluster-manager}
+
+endif::openshift-rosa[]
+When you install a cluster into an existing VPC by using {cluster-manager-first}, you can bypass the automatic verification by selecting *Bypass network verification* on the *Virtual Private Cloud (VPC) subnet settings* page.
+
+ifdef::openshift-rosa[]
+.Bypassing automatic network verification by using the ROSA CLI
+
+When you install a cluster into an existing VPC by using the `rosa create cluster` command, you can bypass the automatic verification by including the `--bypass-network-verify --force` arguments. The following example bypasses the network verification before creating a cluster:
+
+[source,terminal]
+----
+$ rosa create cluster --cluster-name mycluster \
+                      --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc \
+                      --bypass-network-verify --force
+----
+
+[NOTE]
+====
+Alternatively, you can specify the `--interactive` argument and select the option in the interactive prompts to bypass the network verification checks.
+====
+endif::openshift-rosa[]

--- a/modules/rosa-sdpolicy-networking.adoc
+++ b/modules/rosa-sdpolicy-networking.adoc
@@ -71,3 +71,10 @@ Red Hat site reliability engineers (SREs) do not monitor private network connect
 [id="rosa-sdpolicy-dns-forwarding_{context}"]
 == DNS forwarding
 For {product-title} clusters that have a private cloud network configuration, a customer can specify internal DNS servers available on that private connection, that should be queried for explicitly provided domains.
+
+[id="rosa-sdpolicy-network-verification_{context}"]
+== Network verification
+
+Network verification checks run automatically when you deploy a {product-title} cluster into an existing Virtual Private Cloud (VPC) or create an additional machine pool with a subnet that is new to your cluster. The checks validate your network configuration and highlight errors, enabling you to resolve configuration issues prior to deployment.
+
+You can also run the network verification checks manually to validate the configuration for an existing cluster.

--- a/modules/running-network-verification-manually-cli.adoc
+++ b/modules/running-network-verification-manually-cli.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * networking/network-verification.adoc
+
+:_content-type: PROCEDURE
+[discrete]
+[id="running-network-verification-manually-cli_{context}"]
+= Running the network verification manually using the CLI
+
+You can manually run the network verification checks for an existing {product-title} (ROSA) cluster by using the ROSA CLI (`rosa`).
+
+When you run the network verification, you can specify a set of VPC subnet IDs or a cluster name. If you are using a proxy service, you can specify a proxy URL.
+
+.Prerequisites
+
+* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host.
+* You have an existing ROSA cluster.
+* You are the cluster owner or you have the cluster editor role.
+
+.Procedure
+
+* Verify the network configuration by using one of the following methods: 
+** Verify the network configuration by specifying the cluster name. The subnet IDs are automatically detected:
++
+[source,terminal]
+----
+$ rosa verify network -c <cluster_name> <1>
+----
+<1> Replace `<cluster_name>` with the name of your cluster.
++
+.Example output
+[source,terminal]
+----
+I: ✓ Network verification successful
+----
++
+[TIP]
+====
+To output the full list of verification tests, you can include the `--debug` argument when you run `rosa verify network`.
+====
++
+** Verify the network configuration by specifying the VPC subnets IDs:
++
+[source,terminal]
+----
+$ rosa verify network --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc
+----
++
+.Example output
+[source,terminal]
+----
+E: Validating Subnet subnet-03146b9b52b6024cb egress
+E: X Egress failed to https://events.pagerduty.com
+----
++
+** Verify the network configuration by specifying the VPC subnets IDs and a proxy URL:
++
+[source,terminal]
+----
+$ rosa verify network --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc \
+                      --additional-trust-bundle-file /path/to/ca.cert \
+                      --https-proxy <proxy_url> <1>
+----
+<1> Replace `<proxy_url>` with the URL of your proxy service, for example `\https://10.10.0.1`.
++
+.Example output
+[source,terminal]
+----
+I: Using proxy configuration
+I: Subnet IDs detected:  subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc
+
+E: Validating Subnet subnet-03146b9b52b6024cb egress
+E: X Egress failed to https://events.pagerduty.com
+----

--- a/modules/running-network-verification-manually-ocm.adoc
+++ b/modules/running-network-verification-manually-ocm.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * networking/network-verification.adoc
+
+:_content-type: PROCEDURE
+ifdef::openshift-dedicated[]
+[id="running-network-verification-manually-ocm_{context}"]
+= Running the network verification manually
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+[discrete]
+[id="running-network-verification-manually-ocm_{context}"]
+= Running the network verification manually using {cluster-manager}
+endif::openshift-rosa[]
+
+You can manually run the network verification checks for an existing 
+ifdef::openshift-dedicated[]
+{product-title} 
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+{product-title} (ROSA) 
+endif::openshift-rosa[]
+cluster by using {cluster-manager-first}.
+
+.Prerequisites
+
+* You have an existing 
+ifdef::openshift-dedicated[]
+{product-title} 
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+ROSA 
+endif::openshift-rosa[]
+cluster.
+* You are the cluster owner or you have the cluster editor role.
+
+.Procedure
+
+. Navigate to {cluster-manager-url} and select your cluster.
+
+. Select *Verify networking* from the *Actions* drop-down menu.

--- a/modules/running-network-verification-manually.adoc
+++ b/modules/running-network-verification-manually.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * networking/network-verification.adoc
+
+:_content-type: CONCEPT
+[id="running-network-verification-manually_{context}"]
+= Running the network verification manually
+
+After installing a {product-title} (ROSA) cluster, you can run the network verification checks manually by using {cluster-manager-first} or the ROSA CLI (`rosa`).

--- a/modules/sdpolicy-networking.adoc
+++ b/modules/sdpolicy-networking.adoc
@@ -1,4 +1,3 @@
-
 // Module included in the following assemblies:
 //
 // * assemblies/osd-service-definition.adoc
@@ -80,3 +79,10 @@ Red Hat SREs do not monitor private network connections. Monitoring these connec
 [id="dns-forwarding_{context}"]
 == DNS forwarding
 For {product-title} clusters that have a private cloud network configuration, a customer can specify internal DNS servers available on that private connection that should be queried for explicitly provided domains.
+
+[id="osd-network-verification_{context}"]
+== Network verification
+
+Network verification checks run automatically when you deploy an {product-title} cluster into an existing Virtual Private Cloud (VPC) or create an additional machine pool with a subnet that is new to your cluster. The checks validate your network configuration and highlight errors, enabling you to resolve configuration issues prior to deployment.
+
+You can also run the network verification checks manually to validate the configuration for an existing cluster.

--- a/modules/understanding-network-verification.adoc
+++ b/modules/understanding-network-verification.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * networking/network-verification.adoc
+
+:_content-type: CONCEPT
+ifdef::openshift-dedicated[]
+[id="osd-understanding-network-verification_{context}"]
+= Understanding network verification for {product-title} clusters
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+[id="rosa-understanding-network-verification_{context}"]
+= Understanding network verification for ROSA clusters
+endif::openshift-rosa[]
+
+When you deploy 
+ifdef::openshift-dedicated[]
+an {product-title} 
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+a {product-title} (ROSA) 
+endif::openshift-rosa[]
+cluster into an existing Virtual Private Cloud (VPC) or create an additional machine pool with a subnet that is new to your cluster, network verification runs automatically. This helps you to identify and resolve configuration issues prior to deployment.
+
+ifdef::openshift-dedicated[]
+When you prepare to install your cluster by using {cluster-manager-first}, the automatic checks run after you input a subnet into a subnet ID field on the *Virtual Private Cloud (VPC) subnet settings* page.
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+When you prepare to install your cluster by using {cluster-manager-first}, the automatic checks run after you input a subnet into a subnet ID field on the *Virtual Private Cloud (VPC) subnet settings* page. If you create your cluster by using the ROSA CLI (`rosa`) with the interactive mode, the checks run after you provide the required VPC network information. If you use the CLI without the interactive mode, the checks begin immediately prior to the cluster creation.
+endif::openshift-rosa[]
+
+When you add a machine pool with a subnet that is new to your cluster, the automatic network verification checks the subnet to ensure that network connectivity is available before the machine pool is provisioned.
+
+After automatic network verification completes, a record is sent to the service log. The record provides the results of the verification check, including any network configuration errors. You can resolve the identified issues before a deployment and the deployment has a greater chance of success.
+
+You can also run the network verification manually for an existing cluster. This enables you to verify the network configuration for your cluster after making configuration changes. For steps to run the network verification checks manually, see _Running the network verification manually_.

--- a/networking/network-verification.adoc
+++ b/networking/network-verification.adoc
@@ -1,0 +1,55 @@
+:_content-type: ASSEMBLY
+ifdef::openshift-dedicated[]
+[id="osd-network-verification_{context}"]
+= Network verification for {product-title} clusters
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+[id="rosa-network-verification_{context}"]
+= Network verification for ROSA clusters
+endif::openshift-rosa[]
+include::_attributes/common-attributes.adoc[]
+ifdef::openshift-dedicated,openshift-rosa[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+endif::[]
+:context: network-verification
+
+toc::[]
+
+Network verification checks run automatically when you deploy 
+ifdef::openshift-dedicated[]
+an {product-title} 
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+a {product-title} (ROSA) 
+endif::openshift-rosa[]
+cluster into an existing Virtual Private Cloud (VPC) or create an additional machine pool with a subnet that is new to your cluster. The checks validate your network configuration and highlight errors, enabling you to resolve configuration issues prior to deployment.
+
+You can also run the network verification checks manually to validate the configuration for an existing cluster.
+
+include::modules/understanding-network-verification.adoc[leveloffset=+1]
+
+[id="scope-of-the-network-verification-checks_{context}"]
+== Scope of the network verification checks
+
+The network verification includes checks for each of the following requirements:
+
+* The parent Virtual Private Cloud (VPC) exists.
+* All specified subnets belong to the VPC.
+* The VPC has `enableDnsSupport` enabled.
+* The VPC has `enableDnsHostnames` enabled.
+ifdef::openshift-dedicated[]
+* Egress is available to the required domain and port combinations.
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+* Egress is available to the required domain and port combinations that are specified in the xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS firewall prerequisites] section.
+endif::openshift-rosa[]
+
+include::modules/automatic-network-verification-bypassing.adoc[leveloffset=+1]
+ifdef::openshift-dedicated[]
+include::modules/running-network-verification-manually-ocm.adoc[leveloffset=+1]
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+include::modules/running-network-verification-manually.adoc[leveloffset=+1]
+include::modules/running-network-verification-manually-ocm.adoc[leveloffset=+2]
+include::modules/running-network-verification-manually-cli.adoc[leveloffset=+2]
+endif::openshift-rosa[]

--- a/osd_architecture/osd_policy/osd-service-definition.adoc
+++ b/osd_architecture/osd_policy/osd-service-definition.adoc
@@ -10,6 +10,12 @@ include::modules/sdpolicy-account-management.adoc[leveloffset=+1]
 include::modules/sdpolicy-logging.adoc[leveloffset=+1]
 include::modules/sdpolicy-monitoring.adoc[leveloffset=+1]
 include::modules/sdpolicy-networking.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about the network verification checks, see xref:../../networking/network-verification.adoc#network-verification[Network verification].
+
 include::modules/sdpolicy-storage.adoc[leveloffset=+1]
 include::modules/sdpolicy-platform.adoc[leveloffset=+1]
 include::modules/sdpolicy-security.adoc[leveloffset=+1]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
@@ -12,11 +12,18 @@ include::modules/rosa-sdpolicy-account-management.adoc[leveloffset=+1]
 include::modules/rosa-sdpolicy-logging.adoc[leveloffset=+1]
 include::modules/rosa-sdpolicy-monitoring.adoc[leveloffset=+1]
 include::modules/rosa-sdpolicy-networking.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about the network verification checks, see xref:../../networking/network-verification.adoc#network-verification[Network verification].
+
 include::modules/rosa-sdpolicy-storage.adoc[leveloffset=+1]
 include::modules/rosa-sdpolicy-platform.adoc[leveloffset=+1]
 include::modules/rosa-sdpolicy-security.adoc[leveloffset=+1]
 
-
+[role="_additional-resources"]
+[id="additional-resources_rosa-service-definition"]
 == Additional resources
 
 * See xref:../rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding process and security for ROSA] for the latest compliance information.


### PR DESCRIPTION
**Please do not merge this PR.**

This applies to `main`, `enterprise-4.11` and `enterprise-4.10`.

The PR relates to https://issues.redhat.com/browse/OSDOCS-3339. The PR adds network verification content to the OSD and ROSA libraries.

The previews are as follows:

### **OSD**

* **Introduction to OpenShift Dedicated** -> **Policies and service definition** -> **OpenShift Dedicated service definition** -> **Networking** -> [**Network verification**](http://file.fab.redhat.com/pneedle/pr46772/osd/osd_architecture/osd_policy/osd-service-definition.html#osd-network-verification_osd-service-definition)
* **Networking** -> [**Network verification**](http://file.fab.redhat.com/pneedle/pr46772/osd/networking/network-verification.html)

### **ROSA**

* **Introduction to ROSA** -> **Policies and service definition** -> **ROSA service definition** -> **Networking** -> [**Network verification**](http://file.fab.redhat.com/pneedle/pr46772/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-network-verification_rosa-service-definition)
* **Networking** -> [**Network verification**](http://file.fab.redhat.com/pneedle/pr46772/rosa/networking/network-verification.html)