### PR TITLE
Issue #44643 updating Understanding Operators

### DIFF
--- a/modules/olm-why-use-operators.adoc
+++ b/modules/olm-why-use-operators.adoc
@@ -15,7 +15,7 @@ Operators provide:
 --
 
 Why deploy on Kubernetes?::
-Kubernetes (and by extension, {product-title}) contains all of the primitives needed to build complex distributed systems – secret handling, load balancing, service discovery, autoscaling – that work across on-premise and cloud providers.
+Kubernetes (and by extension, {product-title}) contains all of the primitives needed to build complex distributed systems – secret handling, load balancing, service discovery, autoscaling – that work across on-premises and cloud providers.
 
 Why manage your app with Kubernetes APIs and `kubectl` tooling?::
 These APIs are feature rich, have clients for all platforms and plug into the cluster's access control/auditing. An Operator uses the Kubernetes extension mechanism, custom resource definitions (CRDs), so your custom object, link:https://marketplace.redhat.com/en-us/products/mongodb-enterprise-advanced-from-ibm[for example `MongoDB`], looks and acts just like the built-in, native Kubernetes objects.


### PR DESCRIPTION
Version(s):
4.6+

Issue:
Fixes #44643

Link to docs preview:
[Why deploy on Kubernetes?](http://file.rdu.redhat.com/antaylor/06-16-22/issue-44643/operators/understanding/olm-what-operators-are.html)
Additional information:
Uses "on-premises" as per [IBM style guide](https://www.ibm.com/docs/en/ibm-style?topic=word-usage).