### PR TITLE
Temporary removes arm64 references in the OKD doc flavour

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -19,7 +19,9 @@ If you want to install and manage {product-title} yourself, you can install it o
 
 * Alibaba Cloud
 * Amazon Web Services (AWS) on x86_64 instances
+ifndef::openshift-origin[]
 * Amazon Web Services (AWS) on arm64 instances
+endif::openshift-origin[]
 * Microsoft Azure
 * Microsoft Azure Stack Hub
 * Google Cloud Platform (GCP)

--- a/modules/architecture-rhcos-updating-bootloader.adoc
+++ b/modules/architecture-rhcos-updating-bootloader.adoc
@@ -39,6 +39,7 @@ Component EFI
   Installed: grub2-efi-x64-1:2.04-31.fc33.x86_64,shim-x64-15-8.x86_64
   Update: At latest version
 ----
+ifndef::openshift-origin[]
 +
 .Example output for `arm64`
 [source, terminal]
@@ -47,6 +48,7 @@ Component EFI
   Installed: grub2-efi-aa64-1:2.02-99.el8_4.1.aarch64,shim-aa64-15.4-2.el8_1.aarch64
   Update: At latest version
 ----
+endif::openshift-origin[]
 
 [start=2]
 . {op-system} images created without `bootupd` installed on them require an explicit adoption phase.

--- a/modules/installation-aws-ami-stream-metadata.adoc
+++ b/modules/installation-aws-ami-stream-metadata.adoc
@@ -26,7 +26,11 @@ To parse the stream metadata, use one of the following methods:
 
 * From a command-line utility that handles JSON data, such as `jq`:
 
-** Print the current `x86_64` or `arm64` AMI for an AWS region, such as `us-west-1`:
+** Print the current `x86_64`
+ifndef::openshift-origin[]
+or `arm64`
+endif::openshift-origin[]
+AMI for an AWS region, such as `us-west-1`:
 +
 [source,terminal]
 ----

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -485,6 +485,8 @@ ifdef::rhv[]
 For details, see the "Additional RHV parameters for machine pools" table.
 endif::rhv[]
 
+ifndef::openshift-origin[]
+
 ifndef::aws,bare,ibm-power,ibm-z[]
 |`compute.architecture`
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
@@ -514,6 +516,16 @@ ifdef::ibm-power[]
 |Determines the instruction set architecture of the machines in the pool. Currently, heteregeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `ppc64le` (the default).
 |String
 endif::ibm-power[]
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+|`compute.architecture`
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
+ifdef::aws[]
+See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
+endif::aws[]
+|String
+endif::openshift-origin[]
 
 |`compute.hyperthreading`
 |Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on compute machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
@@ -543,6 +555,7 @@ ifdef::rhv[]
 For details, see the "Additional RHV parameters for machine pools" table.
 endif::rhv[]
 
+ifndef::openshift-origin[]
 ifndef::aws,bare,ibm-z,ibm-power[]
 |`controlPlane.architecture`
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
@@ -572,6 +585,16 @@ ifdef::ibm-power[]
 |Determines the instruction set architecture of the machines in the pool. Currently, heterogeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `ppc64le` (the default).
 |String
 endif::ibm-power[]
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+|`controlPlane.architecture`
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64`.
+ifdef::aws[]
+See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
+endif::aws[]
+|String
+endif::openshift-origin[]
 
 |`controlPlane.hyperthreading`
 |Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on control plane machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
@@ -699,10 +722,12 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |`compute.aws.region`
 |The AWS region that the installation program creates compute resources in.
 |Any valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS region], such as `us-east-1`.
+ifndef::openshift-origin[]
 [IMPORTANT]
 ====
 When running on ARM based AWS instances, ensure that you enter a region where AWS Graviton processors are available. See link:https://aws.amazon.com/ec2/graviton/#Global_availability[Global availability] map in the AWS documentation.
 ====
+endif::openshift-origin[]
 
 
 |`controlPlane.platform.aws.amiID`

--- a/modules/installation-supported-aws-machine-types.adoc
+++ b/modules/installation-supported-aws-machine-types.adoc
@@ -412,7 +412,7 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 |===
 ====
 
-ifndef::aws-restricted-upi,aws-govcloud,aws-secret,aws-china[]
+ifndef::aws-restricted-upi,aws-govcloud,aws-secret,aws-china,openshift-origin[]
 .Machine types based on arm64 architecture
 [%collapsible]
 ====

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -203,7 +203,11 @@ This configuration does not enable serial console access on machines with a grap
 ====
 
 ifndef::only-pxe[]
-** For iPXE (`x86_64` + `arm64`):
+** For iPXE (`x86_64`
+ifndef::openshift-origin[]
++ `arm64`
+endif::openshift-origin[]
+):
 +
 ----
 kernel http://<HTTP_server>/rhcos-<version>-live-kernel-<architecture> initrd=main coreos.live.rootfs_url=http://<HTTP_server>/rhcos-<version>-live-rootfs.<architecture>.img coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <1> <2>
@@ -225,13 +229,14 @@ For example, to use DHCP on a NIC that is named `eno1`, set `ip=eno1:dhcp`.
 This configuration does not enable serial console access on machines with a graphical console.  To configure a different console, add one or more `console=` arguments to the `kernel` line.  For example, add `console=tty0 console=ttyS0` to set the first PC serial port as the primary console and the graphical console as a secondary console.  For more information, see link:https://access.redhat.com/articles/7212[How does one set up a serial terminal and/or console in Red Hat Enterprise Linux?].
 ====
 +
+ifndef::openshift-origin[]
 [NOTE]
 ====
 To network boot the CoreOS `kernel` on `arm64` architecture, you need to use a version of iPXE build with the `IMAGE_GZIP` option enabled. See link:https://ipxe.org/buildcfg/image_gzip[`IMAGE_GZIP` option in iPXE].
 ====
+endif::openshift-origin[]
 endif::only-pxe[]
-
-ifndef::only-pxe[]
+ifndef::only-pxe,openshift-origin[]
 ** For PXE (with UEFI and Grub as second stage) on `arm64`:
 +
 ----
@@ -247,7 +252,7 @@ The `coreos.live.rootfs_url` parameter value is the location of the `rootfs` fil
 For example, to use DHCP on a NIC that is named `eno1`, set `ip=eno1:dhcp`.
 <3> Specify the location of the `initramfs` file that you uploaded to your TFTP server.
 
-endif::only-pxe[]
+endif::only-pxe,openshift-origin[]
 
 . Monitor the progress of the {op-system} installation on the console of the machine.
 +


### PR DESCRIPTION
This PR wants to temporarily remove the arm64 refs in the OKD doc until ARM64 OKD builds will be available.

Version(s): 4.10+

This refers openshift/okd#1165

/cc @LorbusChris @mburke5678 @kelbrown20 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
  - The preview will be generated after you open the PR.
  - You will need to edit the comment to add the link after the preview builds.
  - Review the preview build to make sure your changes are rendering properly. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
