### PR TITLE
[enterprise-4.6] BZ1851483: Preparing to reinstall a cluster on bare-metal 

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -49,3 +49,5 @@ include::modules/ipi-install-validation-checklist-for-installation.adoc[leveloff
 include::modules/ipi-install-deploying-the-cluster-via-the-openshift-installer.adoc[leveloffset=+1]
 
 include::modules/ipi-install-following-the-installation.adoc[leveloffset=+1]
+
+include::modules/ipi-preparing-reinstall-cluster-bare-metal.adoc[leveloffset=+1]

--- a/modules/ipi-preparing-reinstall-cluster-bare-metal.adoc
+++ b/modules/ipi-preparing-reinstall-cluster-bare-metal.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// //installing/installing_bare_metal_ipi/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+
+[id="ipi-preparing-reinstall-cluster-bare-metal_{context}"]
+
+= Preparing to reinstall a cluster on bare metal
+Before you reinstall a cluster on bare metal, you must perform cleanup operations.
+
+.Procedure
+. Remove or reformat the disks for the bootstrap, control plane (also known as master) node, and worker nodes. If you are working in a hypervisor environment, you must add any disks you removed.
+. Delete the artifacts that the previous installation generated:
++
+[source,terminal]
+----
+$ cd ; /bin/rm -rf auth/ bootstrap.ign master.ign worker.ign metadata.json \
+.openshift_install.log .openshift_install_state.json
+----
+. Generate new manifests and Ignition config files. See “Creating the Kubernetes manifest and Ignition config files" for more information.
+. Upload the new bootstrap, control plane, and compute node Ignition config files that the installation program created to your HTTP server. This will overwrite the previous Ignition files.


### PR DESCRIPTION
Version:
OCP v4.6

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=1851483 

Link to docs preview: http://file.emea.redhat.com/tmulquee/BZ1851483_46/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-preparing-reinstall-cluster-bare-metal_ipi-install-installation-workflow





<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
  - The preview will be generated after you open the PR.
  - You will need to edit the comment to add the link after the preview builds.
  - Review the preview build to make sure your changes are rendering properly. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
