### PR TITLE
Updates for BZ2033931 adding info on CPU capacity related to pod scheduling

### DIFF
--- a/modules/cnf-cpu-infra-container.adoc
+++ b/modules/cnf-cpu-infra-container.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+
+:_content-type: PROCEDURE
+[id="cnf-cpu-infra-container_{context}"]
+= Restricting CPUs for infra and application containers
+
+Generic housekeeping and workload tasks use CPUs in a way that may impact latency-sensitive processes. By default, the container runtime uses all online CPUs to run all containers together, which can result in context switches and spikes in latency. Partitioning the CPUs prevents noisy processes from interfering with latency-sensitive processes by separating them from each other. The following table describes how processes run on a CPU after you have tuned the node using the Performance Add-On Operator:
+
+.Process' CPU assignments
+[%header,cols=2*]
+|===
+|Process type
+|Details
+
+|`Burstable` and `BestEffort` pods
+|Runs on any CPU except where low latency workload is running
+
+|Infrastructure pods
+|Runs on any CPU except where low latency workload is running
+
+|Interrupts
+|Redirects to reserved CPUs (optional in {product-title} 4.7 and later)
+
+|Kernel processes
+|Pins to reserved CPUs
+
+|Latency-sensitive workload pods
+|Pins to a specific set of exclusive CPUs from the isolated pool
+
+|OS processes/systemd services
+|Pins to reserved CPUs
+|===
+
+The allocatable capacity of cores on a node for pods of all QoS process types, `Burstable`,  `BestEffort`, or `Guaranteed`, is equal to the capacity of the isolated pool. The capacity of the reserved pool is removed from the node's total core capacity for use by the cluster and operating system housekeeping duties.
+
+.Example 1
+A node features a capacity of 100 cores. Using a performance profile, the cluster administrator allocates 50 cores to the isolated pool and 50 cores to the reserved pool. The cluster administrator assigns 25 cores to QoS `Guaranteed` pods and 25 cores for `BestEffort` or `Burstable` pods. This matches the capacity of the isolated pool. 
+
+.Example 2
+A node features a capacity of 100 cores. Using a performance profile, the cluster administrator allocates 50 cores to the isolated pool and 50 cores to the reserved pool. The cluster administrator assigns 50 cores to QoS `Guaranteed` pods and one core for `BestEffort` or `Burstable` pods. This exceeds the capacity of the isolated pool by one core. Pod scheduling fails because of insufficient CPU capacity.
+
+
+The exact partitioning pattern to use depends on many factors like hardware, workload characteristics and the expected system load. Some sample use cases are as follows:
+
+* If the latency-sensitive workload uses specific hardware, such as a network interface controller (NIC), ensure that the CPUs in the isolated pool are as close as possible to this hardware. At a minimum, you should place the workload in the same Non-Uniform Memory Access (NUMA) node.
+
+* The reserved pool is used for handling all interrupts. When depending on system networking, allocate a sufficiently-sized reserve pool to handle all the incoming packet interrupts. In {product-version} and later versions, workloads can optionally be labeled as sensitive.
+
+The decision regarding which specific CPUs should be used for reserved and isolated partitions requires detailed analysis and measurements. Factors like NUMA affinity of devices and memory play a role. The selection also depends on the workload architecture and the specific use case.
+
+[IMPORTANT]
+====
+The reserved and isolated CPU pools must not overlap and together must span all available cores in the worker node.
+====
+
+To ensure that housekeeping tasks and workloads do not interfere with each other, specify two groups of CPUs in the `spec` section of the performance profile.
+
+* `isolated` - Specifies the CPUs for the application container workloads. These CPUs have the lowest latency. Processes in this group have no interruptions and can, for example, reach much higher DPDK zero packet loss bandwidth.
+
+* `reserved` - Specifies the CPUs for the cluster and operating system housekeeping duties. Threads in the `reserved` group are often busy. Do not run latency-sensitive applications in the `reserved` group. Latency-sensitive applications run in the `isolated` group.
+
+.Procedure
+
+. Create a performance profile appropriate for the environment's hardware and topology.
+
+. Add the `reserved` and `isolated` parameters with the CPUs you want reserved and isolated for the infra and application containers:
++
+[source,yaml]
+----
+﻿apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: infra-cpus
+spec:
+  cpu:
+    reserved: "0-4,9" <1>
+    isolated: "5-8" <2>
+  nodeSelector: <3>
+    node-role.kubernetes.io/worker: ""
+----
+<1> Specify which CPUs are for infra containers to perform cluster and operating system housekeeping duties.
+<2> Specify which CPUs are for application containers to run workloads.
+<3> Optional: Specify a node selector to apply the performance profile to specific nodes.

--- a/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+++ b/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
@@ -33,6 +33,8 @@ include::modules/cnf-configuring-huge-pages.adoc[leveloffset=+1]
 
 include::modules/cnf-allocating-multiple-huge-page-sizes.adoc[leveloffset=+1]
 
+include::modules/cnf-cpu-infra-container.adoc[leveloffset=+1]
+
 include::modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc[leveloffset=+1]
 
 include::modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc[leveloffset=+1]


### PR DESCRIPTION
[CP to 4.7]
BZ2033931: Adding info to describe how the capacity for cores on a node for pods with any QoS class is equal to the capacity of the isolated pool.

Version(s):
CP to 4.7

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2033931

Link to docs preview:
http://file.emea.redhat.com/rohennes/BZ2033931-4.7/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#cnf-cpu-infra-container_cnf-master

Additional information:
I could not find "modules/cnf-cpu-infra-container.adoc" in the enterprise 4.7 branch repo. I had a "deleted by us" merge conflict for the file after I CP'd, which I think means it doesn't exit in the master version of enterprise 4.7. I added it. And then I updated the parent assembly so the module renders. 
![image](https://user-images.githubusercontent.com/104497497/174321344-777d1fe2-5e33-4963-9521-e5ea07940aa2.png)
