### PR TITLE
OSDOCS-3744: Removing conditional for SRE mandatory service

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -202,16 +202,14 @@ Alternatively, if you choose to not use a wildcard for Amazon Web Services (AWS)
 |443
 |This alerting service is used by the in-cluster alertmanager to send alerts notifying Red Hat SRE of an event to take action on.
 
-ifdef::openshift-dedicated[]
-
 |`api.deadmanssnitch.com`
 |443
-|Alerting service used by OpenShift Dedicated to send periodic pings that indicate whether the cluster is available and running.
+|Alerting service used by {product-title} to send periodic pings that indicate whether the cluster is available and running.
 
 |`nosnch.in`
 |443
-|Alerting service used by OpenShift Dedicated to send periodic pings that indicate whether the cluster is available and running.
-endif::[]
+|Alerting service used by {product-title} to send periodic pings that indicate whether the cluster is available and running.
+
 |`*.osdsecuritylogs.splunkcloud.com`
 OR
 `inputs1.osdsecuritylogs.splunkcloud.com`


### PR DESCRIPTION
Version(s): PR applies to all active versions of ROSA documentation. 
Issue: [OSDOCS-3744](https://issues.redhat.com/browse/OSDOCS-3744): Missing nosnch.in endpoint in firewall prereqs

Link to docs preview: pending