### PR TITLE
 control plan machines can not be deleted

### DIFF
--- a/machine_management/deleting-machine.adoc
+++ b/machine_management/deleting-machine.adoc
@@ -9,3 +9,9 @@ toc::[]
 You can delete a specific machine.
 
 include::modules/machine-delete.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_unhealthy-etcd-member"]
+== Additional resources
+
+* xref:../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc[Replacing an unhealthy etcd member].

--- a/modules/machine-delete.adoc
+++ b/modules/machine-delete.adoc
@@ -7,7 +7,12 @@
 [id="machine-delete_{context}"]
 = Deleting a specific machine
 
-You can delete a specific machine.
+You can delete a specific machine. 
+
+[NOTE]
+====
+You cannot delete a control plane machine.
+====  
 
 .Prerequisites
 


### PR DESCRIPTION
- Applies to 4.6+ versions
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1940773)
- [Preview](http://file.del.redhat.com/asakthiv/BZ1940773/machine_management/deleting-machine.html)
-@zhsun ptal