### PR TITLE
TELCODOCS-442, TELCODOCS-443: PTP 4.11 release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -421,6 +421,20 @@ With this update, the External DNS Operator provides the following enhancements:
 Ensure that you migrate from TP to GA. The upstream version of `ExternalDNS` for an {product-title} 4.11 is `v0.12.0` and for the TP is `v0.10.2`.
 For more information, see xref:../networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.adoc#nw-installing-external-dns-operator-on-cloud-providers[About the External DNS Operator].
 
+[id="ocp-4-11-networking-linuxptp-dual-nic"]
+==== PTP support for dual NIC boundary clocks
+
+You can now configure dual network interfaces (NICs) as boundary clocks with `PtpConfig` profiles for each NIC channel.
+
+For more information, see xref:../networking/using-ptp.adoc#ptp-dual-nics_using-ptp[Using PTP with dual NIC hardware].
+
+[id="ocp-4-11-networking-linuxptp-events"]
+==== PTP events enhancements
+
+A new PTP events API endpoint is available, `api/cloudNotifications/v1/publishers`. Using this endpoint, you can get PTP `os-clock-sync-state`, `ptp-clock-class-change`, and `lock-state` details for the cluster node.
+
+For more information, see xref:../networking/using-ptp.adoc#cnf-fast-event-notifications-api-refererence_using-ptp[Subscribing DU applications to PTP events REST API reference].
+
 [id="ocp-4-11-support-for-pensando-dsc-cards"]
 ==== SR-IOV Support for Pensando DSC cards
 
@@ -979,10 +993,30 @@ In the table below, features are marked with the following statuses:
 |====
 |Feature |OCP 4.9 |OCP 4.10 | OCP 4.11
 
-|Precision Time Protocol (PTP)
+|Precision Time Protocol (PTP) hardware configured as ordinary clock
+|GA
+|GA
+|GA
+
+|PTP single NIC hardware configured as boundary clock
+|-
 |TP
+|GA
+
+|PTP dual NIC hardware configured as boundary clock
+|-
+|-
 |TP
-|
+
+|PTP events with ordinary clock
+|TP
+|GA
+|GA
+
+|PTP events with boundary clock
+|-
+|TP
+|GA
 
 |`oc` CLI plug-ins
 |GA


### PR DESCRIPTION
Adds release notes for the following PTP 4.11 doc epics: 
* https://issues.redhat.com/browse/TELCODOCS-442
* https://issues.redhat.com/browse/TELCODOCS-443

Version(s):
* enterprise-4.11

Preview:
* http://file.emea.redhat.com/aireilly/ptp-411-release_notes/release_notes/ocp-4-11-release-notes.html#ocp-4-11-technology-preview
* http://file.emea.redhat.com/aireilly/ptp-411-release_notes/release_notes/ocp-4-11-release-notes.html#ocp-4-11-networking-linuxptp
* http://file.emea.redhat.com/aireilly/ptp-411-release_notes/release_notes/ocp-4-11-release-notes.html#ptp-events-enhancements
