### PR TITLE
TELCODOCS-607: Bare-metal events monitoring using PolicyGenTemplate

### DIFF
--- a/modules/ztp-configuring-hwevents-using-pgt.adoc
+++ b/modules/ztp-configuring-hwevents-using-pgt.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp-deploying-disconnected.adoc
+
+:_content-type: PROCEDURE
+[id="ztp-creating-hwevents_{context}"]
+= Configuring bare-metal event monitoring using PolicyGenTemplate CRs
+
+You can configure bare-metal hardware events for vRAN clusters that are deployed using the GitOps Zero Touch Provisioning (ZTP) pipeline.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* Create a Git repository where you manage your custom site configuration data.
+
+[NOTE]
+====
+Multiple `HardwareEvent` resources are not permitted.
+====
+
+.Procedure
+
+. To configure the AMQ Interconnect Operator and the {redfish-operator} Operator, add the following YAML to `spec.sourceFiles` in the `common-ranGen.yaml` file:
++
+[source,yaml]
+----
+# AMQ interconnect operator for fast events
+- fileName: AmqSubscriptionNS.yaml
+  policyName: "subscriptions-policy"
+- fileName: AmqSubscriptionOperGroup.yaml
+  policyName: "subscriptions-policy"
+- fileName: AmqSubscription.yaml
+  policyName: "subscriptions-policy"
+# Bare Metal Event Rely operator
+- fileName: BareMetalEventRelaySubscriptionNS.yaml
+  policyName: "subscriptions-policy"
+- fileName: BareMetalEventRelaySubscriptionOperGroup.yaml
+  policyName: "subscriptions-policy"
+- fileName: BareMetalEventRelaySubscription.yaml
+  policyName: "subscriptions-policy"
+----
+
+. Add the `Interconnect` CR to `.spec.sourceFiles` in the site configuration file, for example, the `example-sno-site.yaml` file:
++
+[source,yaml]
+----
+- fileName: AmqInstance.yaml
+  policyName: "config-policy"
+----
+
+. Add the `HardwareEvent` CR to `spec.sourceFiles` in your specific group configuration file, for example, in the `group-du-sno-ranGen.yaml` file:
++
+[source,yaml]
+----
+- fileName: HardwareEvent.yaml
+  policyName: "config-policy"
+  spec:
+    nodeSelector: {}
+    transportHost: "amqp://<amq_interconnect_name>.<amq_interconnect_namespace>.svc.cluster.local" <1>
+    logLevel: "info"
+----
+<1>  The `transportHost` URL is composed of the existing AMQ Interconnect CR `name` and `namespace`. For example, in `transportHost: "amqp://amq-router.amq-router.svc.cluster.local"`, the AMQ Interconnect `name` and `namespace` are both set to `amq-router`.
+
+. Commit the `PolicyGenTemplate` change in Git, and then push the changes to your site configuration repository to deploy bare-metal events monitoring to new sites using GitOps ZTP.
+
+. Create the Redfish Secret by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-bare-metal-events create secret generic redfish-basic-auth \
+--from-literal=username=<bmc_username> --from-literal=password=<bmc_password> \
+--from-literal=hostaddr="<bmc_host_ip_addr>"
+----

--- a/scalability_and_performance/ztp-deploying-disconnected.adoc
+++ b/scalability_and_performance/ztp-deploying-disconnected.adoc
@@ -82,6 +82,17 @@ include::modules/ztp-configuring-ptp-fast-events.adoc[leveloffset=+2]
 
 include::modules/ztp-configuring-uefi-secure-boot.adoc[leveloffset=+2]
 
+include::modules/ztp-configuring-hwevents-using-pgt.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about how to install the {redfish-operator}, see xref:../monitoring/using-rfhe.adoc#nw-rfhe-installing-operator-cli_using-rfhe[Installing the {redfish-operator} using the CLI].
+
+* For more information about how to install the AMQ Interconnect Operator, see xref:../monitoring/using-rfhe.html#hw-installing-amq-interconnect-messaging-bus_using-rfhe[Installing the AMQ messaging bus].
+
+* For more information about how to create the username, password, and the host IP address for the secret, see xref:../monitoring/using-rfhe.html#nw-rfhe-creating-hardware-event_using-rfhe[Creating the bare-metal event and Secret CRs].
+
 include::modules/ztp-installing-the-gitops-ztp-pipeline.adoc[leveloffset=+1]
 
 include::modules/ztp-preparing-the-ztp-git-repository.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.10, 4.11, 4.12

Issue:
https://issues.redhat.com/browse/TELCODOCS-607

Link to docs preview:
http://file.emea.redhat.com/amolnar/TELCODOCS-607/scalability_and_performance/ztp-deploying-disconnected.html#ztp-creating-hwevents_ztp-deploying-disconnected
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
Based on unmerged PR: https://github.com/openshift/openshift-docs/pull/43890
First commit will be dropped once #43890 is merged. 
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
