### PR TITLE
removed the admonition on spot instances

### DIFF
--- a/modules/machineset-non-guaranteed-instance.adoc
+++ b/modules/machineset-non-guaranteed-instance.adoc
@@ -28,15 +28,6 @@ ifdef::gcp[]
 You can save on costs by creating a machine set running on GCP that deploys machines as non-guaranteed preemptible VM instances. Preemptible VM instances utilize excess Compute Engine capacity and are less expensive than normal instances. You can use preemptible VM instances for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
 endif::gcp[]
 
-[IMPORTANT]
-====
-It is strongly recommended that control plane machines are not created on
-ifdef::aws[Spot Instances]
-ifdef::azure[Spot VMs]
-ifdef::gcp[preemptible VM instances]
-due to the increased likelihood of the instance being terminated. Manual intervention is required to replace a terminated control plane node.
-====
-
 ifdef::aws[]
 AWS EC2 can terminate a Spot Instance at any time. AWS gives a two-minute warning to the user when an interruption occurs. {product-title} begins to remove the workloads from the affected instances when AWS issues the termination warning.
 


### PR DESCRIPTION
- Applies to **main, 4.11, 4.10,4.9 and 4.8** branches.
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2091928)
- [GCP Preview] (http://file.del.redhat.com/asakthiv/BZ2091928/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-non-guaranteed-instance_creating-machineset-gcp)
- [Azure Preview](http://file.del.redhat.com/asakthiv/BZ2091928/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-creating-non-guaranteed-instance_creating-machineset-azure)
- [AWS preview](http://file.del.redhat.com/asakthiv/BZ2091928/machine_management/creating_machinesets/creating-machineset-aws.html#machineset-creating-non-guaranteed-instance_creating-machineset-aws)
- @miyadav ptal