### PR TITLE
Netlify preview build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ git:
 jobs:
   include:
     - stage: build
-      name: "Build openshift-enterprise distro"  
+      name: "Build openshift-enterprise distro"
       before_install:
         - gem install asciidoctor
         - gem install asciidoctor-diagram
@@ -54,8 +54,14 @@ jobs:
     # - stage: automerge
     #   if: env(PR_AUTHOR)=openshift-cherrypick-robot
     #   script: bash ./automerge.sh
+    - stage: netlify
+      language: minimal
+      if: branch IN (main, enterprise-4.11, enterprise-4.12)
+      script:
+        - chmod +x autopreview.sh && ./autopreview.sh
 
 stages:
   - build
   - check-with-vale
   #- automerge
+  - netlify

--- a/autopreview.sh
+++ b/autopreview.sh
@@ -1,27 +1,29 @@
 #!/bin/bash
 set -ev
 
-ALLOWED_USERS=("aireilly" "mburke5678" "vikram-redhat" "abrennan89" "ahardin-rh" "kalexand-rh" "adellape" "bmcelvee" "ousleyp" "lamek" "JStickler" "rh-max" "bergerhoffer" "sheriff-rh" "jboxman" "bobfuru" "aburdenthehand" "boczkowska" "Preeticp" "neal-timpe" "codyhoag" "apinnick" "bgaydosrh" "lmandavi" "maxwelldb" "pneedle-rh" "lbarbeevargas" "jeana-redhat" "RichardHoch" "johnwilkins" "sjhala-ccs" "mgarrellRH" "SNiemann15" "sfortner-RH" "jonquilwilliams" "ktania46" "wking" "
-jc-berger" "rishumehra" "iranzo" "abhatt-rh" "@mohit-sheth" "stoobie" "emarcusRH" "kquinn1204" "mikemckiernan" "skrthomas" "sagidlow" "rolfedh")
+#ALLOWED_USERS=("aireilly" "mburke5678" "vikram-redhat" "abrennan89" "ahardin-rh" "kalexand-rh" "adellape" "bmcelvee" "ousleyp" "lamek" "JStickler" "rh-max" "bergerhoffer" "sheriff-rh" "jboxman" "bobfuru" "aburdenthehand" "boczkowska" "Preeticp" "neal-timpe" "codyhoag" "apinnick" "bgaydosrh" "lmandavi" "maxwelldb" "pneedle-rh" "lbarbeevargas" "jeana-redhat" "RichardHoch" "johnwilkins" "sjhala-ccs" "mgarrellRH" "SNiemann15" "sfortner-RH" "jonquilwilliams" "ktania46" "wking" "
+#jc-berger" "rishumehra" "iranzo" "abhatt-rh" "@mohit-sheth" "stoobie" "emarcusRH" "kquinn1204" "mikemckiernan" "skrthomas" "sagidlow" "rolfedh")
 USERNAME=${TRAVIS_PULL_REQUEST_SLUG::-15}
 COMMIT_HASH="$(git rev-parse @~)"
 mapfile -t FILES_CHANGED < <(git diff --name-only "$COMMIT_HASH")
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then #to make sure it only runs on PRs and not all merges
-    if [[ " ${ALLOWED_USERS[*]} " =~ " ${USERNAME} " ]]; then # to make sure it only runs on PRs from @openshift/team-documentation
-        if [ "${TRAVIS_PULL_REQUEST_BRANCH}" != "master" ] ; then # to make sure it does not run for direct master changes
-            if [[ " ${FILES_CHANGED[*]} " = *".adoc"* ]] || [[ " ${FILES_CHANGED[*]} " = *"_topic_map.yml"* ]] || [[ " ${FILES_CHANGED[*]} " = *"_distro_map.yml"* ]] ; then # to make sure this doesn't run for general modifications
+    if [ "${TRAVIS_PULL_REQUEST_BRANCH}" != "main" ] ; then # to make sure it does not run for direct main changes
+        if [[ " ${FILES_CHANGED[*]} " = *".adoc"* ]] || [[ " ${FILES_CHANGED[*]} " = *"_topic_map.yml"* ]] || [[ " ${FILES_CHANGED[*]} " = *"_distro_map.yml"* ]] ; then # to make sure this doesn't run for general modifications
+            if [ "$USERNAME" != "openshift-cherrypick-robot" ] ; then # to make sure it doesn't run for USERNAME openshift-cherrypick-robot
                 echo "{\"PR_BRANCH\":\"${TRAVIS_PULL_REQUEST_BRANCH}\",\"BASE_REPO\":\"${TRAVIS_REPO_SLUG}\",\"PR_NUMBER\":\"${TRAVIS_PULL_REQUEST}\",\"USER_NAME\":\"${USERNAME}\",\"BASE_REF\":\"${TRAVIS_BRANCH}\",\"REPO_NAME\":\"${TRAVIS_PULL_REQUEST_SLUG}\"}" > buildset.json
-                curl -H 'Content-Type: application/json' --request POST --data @buildset.json "https://roomy-tungsten-cylinder.glitch.me"
+
+                curl -H 'Content-Type: application/json' --request POST --data @buildset.json "https://eoa6vg2jiwjbnh6.m.pipedream.net"
+
                 echo -e "\\n\\033[0;32m[✓] Sent request for building a preview.\\033[0m"
             else
-                echo -e "\\n\\033[1;33m[!] No .adoc files modified, not building a preview.\\033[0m"
+                echo -e "\\n\\033[0;32m[✓] Skipping preview build for openshift-cherrypick-robot.\\033[0m"
             fi
         else
-            echo -e "\\n\\033[1;33m[!] Direct PR for master branch, not building a preview.\\033[0m"
+            echo -e "\\n\\033[1;33m[!] No .adoc files modified, not building a preview.\\033[0m"
         fi
     else
-        echo -e "\\n\\033[1;33m[!] ${USERNAME} is not a team member of @openshift/team-documentation, not building a preview.\\033[0m"
+        echo -e "\\n\\033[1;33m[!] Direct PR for main branch, not building a preview.\\033[0m"
     fi
 else
     echo -e "\\n\\033[1;33m[!] Not a PR, not building a preview.\\033[0m"


### PR DESCRIPTION
Enables Netlify preview builds for all PRs. Only publishing is happening on Netlify, the builds are building on Circle CI.

1. The previews link will be `<PR_NUMBER>--docspreview.netlify.app`
2. The preview site is usually live in around 10 minutes.

**How this works:**
1. Travis job sends request with PR data to pipedream webhook.
2. Pipedream webhook parses the request and creates a new Circle CI build. 
3. Circle CI builds the site and uploads it to Netlify. [CircleCI config](https://github.com/ocpdocs-previewbot/openshift-docs/blob/main/.circleci/config.yml)
4. Netlify publishes the site. 

**Issues:**
~~1. Doesn't work for RHDEVDOCS because the [`scripts\ocpdocs`](https://github.com/openshift/openshift-docs/tree/main/scripts/ocpdocs) folder is missing. Example: https://github.com/bburt-rh/openshift-docs/tree/RHDEVDOCS-4146-backport-federation-for-uwm-metrics/scripts~~ EDIT: Fixed.

It is similar to what we had earlier https://medium.com/@gauravnelson/here-is-how-i-built-the-openshift-docs-preview-bot-cdf90e3b6e1, but, slightly different.


Preview:https://46864--docspreview.netlify.app/