### PR TITLE
RHDEVDOCS-4159 - Release Notes for SBO 1.1.1

### DIFF
--- a/applications/connecting_applications_to_services/sbo-release-notes.adoc
+++ b/applications/connecting_applications_to_services/sbo-release-notes.adoc
@@ -48,6 +48,7 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 |*{servicebinding-title}* 2+|*API Group and Support Status*|*OpenShift Versions*
 
 |*Version*|*`binding.operators.coreos.com`* |*`servicebinding.io`* |
+|1.1.1    |GA                               |TP                    |4.7-4.10
 |1.1      |GA                               |TP                    |4.7-4.10
 |1.0.1    |GA                               |TP                    |4.7-4.9
 |1.0      |GA                               |TP                    |4.7-4.9
@@ -60,6 +61,7 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
 
 // Modules included, most to least recent
+include::modules/sbo-release-notes-1-1-1.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-1.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-0-1.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-0.adoc[leveloffset=+1]

--- a/modules/sbo-release-notes-1-1-1.adoc
+++ b/modules/sbo-release-notes-1-1-1.adoc
@@ -1,0 +1,58 @@
+[id="sbo-release-notes-1-1-1_{context}"]
+// Module included in the following assembly:
+//
+// * applications/connecting_applications_to_services/sbo-release-notes.adoc
+:_content-type: REFERENCE
+= Release notes for {servicebinding-title} 1.1.1
+
+{servicebinding-title} 1.1.1 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-1-1_{context}"]
+== Fixed issues
+* Before this update, a security vulnerability `CVE-2021-38561` was noted for {servicebinding-title} Helm chart. This update fixes the `CVE-2021-38561` error and updates the `golang.org/x/text` package from v0.3.6 to v0.3.7. link:https://issues.redhat.com/browse/APPSVC-1124[APPSVC-1124]
+
+* Before this update, users of the Developer Sandbox did not have sufficient permissions to read `ClusterWorkloadResourceMapping` resources. As a result, {servicebinding-title} prevented all service bindings from being successful. With this update, the {servicebinding-title} now includes the appropriate role-based access control (RBAC) rules for any authenticated subject including the Developer Sandbox users. These RBAC rules allow the {servicebinding-title} to `get`, `list`, and `watch` the `ClusterWorkloadResourceMapping` resources for the Developer Sandbox users and to process service bindings successfully. link:https://issues.redhat.com/browse/APPSVC-1135[APPSVC-1135]
+
+[id="known-issues-1-1-1_{context}"]
+== Known issues
+* There is currently a known issue with installing {servicebinding-title} in a single namespace installation mode. The absence of an appropriate namespace-scoped role-based access control (RBAC) rule prevents the successful binding of an application to a few known Operator-backed services that the {servicebinding-title} can automatically detect and bind to. When this happens, it generates an error message similar to the following example:
++
+.Example error message
+[source,text]
+----
+`postgresclusters.postgres-operator.crunchydata.com "hippo" is forbidden:
+        User "system:serviceaccount:my-petclinic:service-binding-operator" cannot
+        get resource "postgresclusters" in API group "postgres-operator.crunchydata.com"
+        in the namespace "my-petclinic"`
+----
++
+Workaround 1: Install the {servicebinding-title} in the `all namespaces` installation mode. As a result, the appropriate cluster-scoped RBAC rule now exists and the binding succeeds.
++
+Workaround 2: If you cannot install the {servicebinding-title} in the `all namespaces` installation mode, install the following role binding into the namespace where the {servicebinding-title} is installed: 
++
+.Example: Role binding for Crunchy Postgres Operator
+[source,yaml]
+----
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: service-binding-crunchy-postgres-viewer
+subjects:
+  - kind: ServiceAccount
+    name: service-binding-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: service-binding-crunchy-postgres-viewer-role
+----
+link:https://issues.redhat.com/browse/APPSVC-1062[APPSVC-1062]
+
+* Currently, when you modify the `ClusterWorkloadResourceMapping` resources, the {servicebinding-title} does not implement correct behavior. As a workaround, perform the following steps:
++
+--
+. Delete any `ServiceBinding` resources that use the corresponding `ClusterWorkloadResourceMapping` resource.
+. Modify the `ClusterWorkloadResourceMapping` resource.
+. Re-apply the `ServiceBinding` resources that you previously removed in step 1.
+--
++
+link:https://issues.redhat.com/browse/APPSVC-1102[APPSVC-1102]


### PR DESCRIPTION
[RHDEVDOCS-4159](https://issues.redhat.com//browse/RHDEVDOCS-4159): Release Notes for SBO 1.1.1

- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: enterprise-`4.10` and later
- **JIRA issues**: [RHDEVDOCS-4159](https://issues.redhat.com/browse/RHDEVDOCS-4159)
- **Preview pages**: [Download to see the preview in your browser.](https://drive.google.com/file/d/1R9HlXI3i4r_2xdPRd7g3Dw_1Nd-QVk7D/view?usp=sharing)
- **SME Review**: @dperaza4dustbit, @Kartikey-star 
- **QE review**: @pmacik 
- **Peer-review**: @jc-berger 
