### PR TITLE
RNs-4.8.44 Added with bug fix update

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -3361,3 +3361,23 @@ link:https://access.redhat.com/solutions/6963444[{product-title} 4.8.43 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-8-44"]
+=== RHBA-2022:5032 - {product-title} 4.8.44 bug fix update
+
+Issued: 2022-06-22
+
+{product-title} release 4.8.44 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5032[RHBA-2022:5032] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5031[RHBA-2022:5031] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6963680[{product-title} 4.8.44 container image list]
+
+[id="ocp-4-8-44-bug-fixes"]
+==== Bug fixes
+* Previously, an API for customized platform routes in {product-title} 4.8 created restrictions on specs and status that excluded custom host names and cluster domains with decimals. This prevented users from specifying host names and installing cluster domains that contained decimals. This fix removes the API restrictions, allowing users to specify all host names and install all cluster domains. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2081457#[BZ#2081457*])
+
+[id="ocp-4-8-44-updating"]
+==== Updating
+
+To update an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
**RNs-4.8.44**
Added with bug fix update

**Version(s):**
PR applies only to enterprise-4.8

**Issue:**
https://issues.redhat.com/browse/OCPPLAN-9321

**Link to docs preview:**
https://wiharris.github.io/openshift-docs/RNs-4.8.44/release_notes/ocp-4-8-release-notes.html#ocp-4-8-44

**Additional information:**
n/a




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
