### PR TITLE
[RHACS] Correct date for RHACS 3.68.2 Patch Release

### DIFF
--- a/release_notes/368-release-notes.adoc
+++ b/release_notes/368-release-notes.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 - 3.68.0 Release date: February 2, 2022
 - 3.68.1 Release date: February 14, 2022
-- 3.68.2 Release date: June 14, 2022
+- 3.68.2 Release date: June 20, 2022
 
 [id="new-features-368"]
 == New features
@@ -46,7 +46,7 @@ Therefore, when an application does not need to access the service account direc
 [id="resolved-in-version-3682"]
 === Resolved in version 3.68.2
 
-Release date: June 14, 2022
+Release date: June 20, 2022
 
 * *ROX-10845*: link:https://access.redhat.com/security/cve/cve-2022-1902[CVE-2022-1902]: GraphQL exposes Notifiers secrets.
 


### PR DESCRIPTION
Versions:
- merge to `rhacs-docs`
- cherry pick to `rhacs-docs-3.68`

Issue: None - I forgot to update the date per the errata which has 6/20/2020 as the "shipped date"

Preview: https://openshift-docs-dhd1pqx42-kcarmichael08.vercel.app/openshift-acs/master/release_notes/368-release-notes.html


