### PR TITLE
[OSDOCS-3684]: Relnotes to add multi-configuration for controller and worker nodes 

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -124,6 +124,12 @@ For more information, see xref:../installing/installing_azure/installing-azure-c
 
 This update introduces a new option for Ingress Controllers with the `hostnetwork` endpoint strategy. You can now host multiple Ingress Controllers on the same worker node using `httpPort`, `httpsPort`, and `statsPort` binding ports.
 
+[id=ocp-4-11-multiple-configuration-control-worker-nodes]
+==== Multi-node configuration for control plane and worker nodes
+You can simultaneously apply a single configuration to multiple, bare-metal, installer-provisioned infrastructure nodes in a cluster. Applying a single configuration to multiple nodes reduces the risk of misconfiguration due to the single-provisioning process.
+
+This mechanism is only available for initial deployments when the `install-config` file is used.
+
 [id="ocp-4-11-ne-clb-timeouts"]
 ==== Support for configuring Classic Load Balancer Timeouts on AWS
 You can now configure idle connection timeouts for AWS Classic Load Balancers (CLBs) in the Ingress Controller.


### PR DESCRIPTION
Version: 4.11

Issues:
Engineering epic - [SDN-2585](https://issues.redhat.com/browse/SDN-2585)
Docs JIRA - [OSDOCS -3684](https://issues.redhat.com/browse/OSDOCS-3684)

Link to docs preview:
http://file.rdu.redhat.com/tlove/sdn2585-411-release-note/release_notes/ocp-4-11-release-notes.html#ocp-4-11-multiple-configuration-control-worker-nodes

