### PR TITLE
OSDOCS-3678: Adding docs for specifying a threshold priority for the …

### DIFF
--- a/modules/nodes-descheduler-configuring-profiles.adoc
+++ b/modules/nodes-descheduler-configuring-profiles.adoc
@@ -36,17 +36,23 @@ spec:
   managementState: Managed
   operatorLogLevel: Normal
   profileCustomizations:
-    podLifetime: 48h        <1>
-  profiles:                 <2>
+    namespaces:                                        <1>
+      excluded:
+      - my-namespace
+    podLifetime: 48h                                   <2>
+    thresholdPriorityClassName: my-priority-class-name <3>
+  profiles:                                            <4>
   - AffinityAndTaints
-  - TopologyAndDuplicates   <3>
+  - TopologyAndDuplicates                              <5>
   - LifecycleAndUtilization
   - EvictPodsWithLocalStorage
   - EvictPodsWithPVC
 ----
-<1> Optional: Enable a custom pod lifetime value for the `LifecycleAndUtilization` profile. Valid units are `s`, `m`, or `h`. The default pod lifetime is 24 hours.
-<2> Add one or more profiles to enable. Available profiles: `AffinityAndTaints`, `TopologyAndDuplicates`, `LifecycleAndUtilization`, `SoftTopologyAndDuplicates`, `EvictPodsWithLocalStorage`, and `EvictPodsWithPVC`.
-<3> Do not enable both `TopologyAndDuplicates` and `SoftTopologyAndDuplicates`. Enabling both results in a conflict.
+<1> Optional: Set a list of user-created namespaces to include or exclude from descheduler operations. Use `excluded` to set a list of namespaces to exclude or use `included` to set a list of namespaces to include. Note that protected namespaces (`openshift-*`, `kube-system`, `hypershift`) are always excluded.
+<2> Optional: Enable a custom pod lifetime value for the `LifecycleAndUtilization` profile. Valid units are `s`, `m`, or `h`. The default pod lifetime is 24 hours.
+<3> Optional: Specify a priority threshold to consider pods for eviction only if their priority is lower than the specified level. Use the `thresholdPriority` field to set a numerical priority threshold (for example, `10000`) or use the `thresholdPriorityClassName` field to specify a certain priority class name (for example, `my-priority-class-name`). If you specify a priority class name, it must already exist or the descheduler will throw an error. Do not set both `thresholdPriority` and `thresholdPriorityClassName`.
+<4> Add one or more profiles to enable. Available profiles: `AffinityAndTaints`, `TopologyAndDuplicates`, `LifecycleAndUtilization`, `SoftTopologyAndDuplicates`, `EvictPodsWithLocalStorage`, and `EvictPodsWithPVC`.
+<5> Do not enable both `TopologyAndDuplicates` and `SoftTopologyAndDuplicates`. Enabling both results in a conflict.
 +
 You can enable multiple profiles; the order that the profiles are specified in is not important.
 

--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -64,7 +64,31 @@ ifdef::nodes[]
 ====
 Do not enable both `TopologyAndDuplicates` and `SoftTopologyAndDuplicates`. Enabling both results in a conflict.
 ====
-... Optional: Expand the *Profile Customizations* section to set a custom pod lifetime value for the `LifecycleAndUtilization` profile. Valid units are `s`, `m`, or `h`. The default pod lifetime is 24 hours.
+... Optional: Expand the *Profile Customizations* section to set optional configurations for the descheduler.
+**** Set a custom pod lifetime value for the `LifecycleAndUtilization` profile. Use the *podLifetime* field to set a numerical value and a valid unit (`s`, `m`, or `h`). The default pod lifetime is 24 hours (`24h`).
+
+**** Set a custom priority threshold to consider pods for eviction only if their priority is lower than a specified priority level. Use the *thresholdPriority* field to set a numerical priority threshold or use the *thresholdPriorityClassName* field to specify a certain priority class name.
++
+[NOTE]
+====
+Do not specify both *thresholdPriority* and *thresholdPriorityClassName* for the descheduler.
+====
+
+**** Set specific namespaces to exclude or include from descheduler operations. Expand the *namespaces* field and add namespaces to the *excluded* or *included* list. You can only either set a list of namespaces to exclude or a list of namespaces to include.
+
+**** Experimental: Set thresholds for underutilization and overutilization for the `LowNodeUtilization` strategy. Use the *devLowNodeUtilizationThresholds* field to set one of the following values:
++
+--
+***** `Low`: 10% underutilized and 30% overutilized
+***** `Medium`: 20% underutilized and 50% overutilized (Default)
+***** `High`: 40% underutilized and 70% overutilized
+--
++
+[NOTE]
+====
+This setting is experimental and should not be used in a production environment.
+====
+
 ... Optional: Use the *Descheduling Interval Seconds* field to change the number of seconds between descheduler runs. The default is `3600` seconds.
 .. Click *Create*.
 


### PR DESCRIPTION
…descheduler

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3678

Link to docs preview:
* http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3678/nodes/scheduling/nodes-descheduler.html#nodes-descheduler-installing_nodes-descheduler
* http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3678/nodes/scheduling/nodes-descheduler.html#nodes-descheduler-configuring-profiles_nodes-descheduler

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
