### PR TITLE
[RHACS] ROX-11181: Document automated removal of decommissioned clusters

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -107,6 +107,8 @@ Topics:
   File: expose-portal-over-http
 - Name: Configuring automatic upgrades for secured clusters
   File: configure-automatic-upgrades
+- Name: Configuring automatic deletion of unhealthy clusters
+  File: configure-unhealthy-cluster-deletion
 - Name: Configuring a proxy for external network access
   File: configure-proxy
 - Name: Generating a diagnostic bundle

--- a/configuration/configure-unhealthy-cluster-deletion.adoc
+++ b/configuration/configure-unhealthy-cluster-deletion.adoc
@@ -1,0 +1,21 @@
+:_content-type: ASSEMBLY
+[id="configure-unhealthy-cluster-deletion"]
+= Configuring automatic deletion of unhealthy clusters
+include::modules/common-attributes.adoc[]
+:context: configure-unhealthy-cluster-deletion
+
+toc::[]
+
+[role="_abstract"]
+{product-title} ({product-title-short}) provides the ability to automatically delete unhealthy clusters from your system. If this feature is enabled, when Central has been unable to reach Sensor in a cluster for a configured period of time, the cluster is considered unhealthy, or decommissioned. Unhealthy clusters are then automatically deleted based on your configuration settings. With automatic deletion of unhealthy clusters, you can monitor only active clusters. You can configure cluster removal settings by using the {product-title-short} portal or the application programming interface (API). You can specify not to delete an unhealthy cluster by adding a label for the cluster when configuring this feature.
+
+Automatic removal of unhealthy clusters is disabled by default. To enable this setting, enter a nonzero number in the *Decommissioned cluster age* field, as described in the following procedure. The *Decommissioned cluster age* field indicates the number of days that a cluster can remain unreachable before it is considered unhealthy. When a cluster is unhealthy, the *Clusters* page displays the status of the cluster and the number of days after which the cluster will be deleted if it continues to remain unhealthy. After a cluster is deleted, the deletion is documented with an `info` log in the Central logs.
+
+[NOTE]
+====
+There is a 24-hour grace period after enabling this setting before clusters are deleted. The cluster that hosts Central is never deleted.
+====
+
+
+include::modules/configure-cluster-decommissioning.adoc[leveloffset=+1]
+include::modules/view-unhealthy-clusters.adoc[leveloffset=+1]

--- a/modules/configure-cluster-decommissioning.adoc
+++ b/modules/configure-cluster-decommissioning.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * configuration/cluster-decommissioning.adoc
+:_content-type: PROCEDURE
+[id="configure-cluster-decommissioning_{context}"]
+= Configuring cluster decommissioning
+
+[role="_abstract"]
+You can configure {product-title-short} to automatically delete unhealthy clusters, or clusters that have been unreachable by Sensor for a specified period of time. You can also label clusters so that they are not automatically deleted when they are unreachable.
+
+.Procedure
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *System Configuration*.
+. In the *System Configuration* header, click *Edit*.
+. In the *Cluster deletion* section, you can configure the following fields:
+* *Decommissioned cluster age*: The number of days that a cluster is unreachable before it is considered for deletion. If Central cannot reach Sensor on the cluster for this number of days, the cluster and all of its resources are automatically deleted. To leave this feature disabled, which is the default behavior, enter `0` in this field. To enable this feature, enter a nonzero number, such as `90`, to configure the number of unreachable days. 
+* *Ignore clusters which have labels*: To prevent a cluster from deletion, you can configure a label by entering a key and value in this section. Clusters with this label will not be deleted, even if they have been unreachable for the number of days set in the *Decommissioned cluster age* field.
+
+** *Key*: Enter the label to use for the cluster.
+** *Value*: Enter the value associated with the key. 
++
+For example, to preserve production clusters from deletion, you can configure a key of `cluster-type` and a value of `production`.
++
+[NOTE]
+====
+In the *Cluster deletion* section, click *Clusters which have Sensor Status: Unhealthy* to go to the *Clusters* list page. This page is filtered to show unhealthy clusters that are subject to deletion and a timeframe for the deletion.
+====
+. Click *Save*.
+
+[NOTE]
+====
+To view and configure this option by using the API, use the `decommissionedClusterRetention` settings in the request payload for the `/v1/config` and `/v1/config/private` endpoints. For more information, see the API documentation for the `ConfigService` object by navigating to *Help* -> *API reference* in the {product-title-short} portal.
+====
+
+

--- a/modules/view-unhealthy-clusters.adoc
+++ b/modules/view-unhealthy-clusters.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * configuration/cluster-decommissioning.adoc
+:_content-type: PROCEDURE
+[id="view-unhealthy-clusters_{context}"]
+= Viewing unhealthy clusters
+
+.Procedure
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *System Configuration*.
+. In the *Cluster deletion* section, click *Clusters which have Sensor Status: Unhealthy* to go to the *Clusters* list page. This page is filtered to show unhealthy clusters that are subject to deletion and a timeframe for the deletion. 
++
+[NOTE]
+====
+If this feature is enabled after a cluster is considered unhealthy, the counting of days towards deletion starts from the time the cluster became unhealthy, not from the time that the feature was enabled. If there are any unhealthy clusters that you do not want deleted, you can configure a label as described in the "Configuring cluster decommissioning" section. Labeled clusters are ignored when the system automatically deletes unhealthy clusters.
+====
+


### PR DESCRIPTION
Versions: 
- Merge to `rhacs-docs-3.72.0`

Labels:
- `RHACS`
- `RHACS/next`

[Issue](https://issues.redhat.com/browse/ROX-11181)
[Preview](https://openshift-docs-7wjad6wz9-kcarmichael08.vercel.app/openshift-acs/master/configuration/configure-inactive-cluster-deletion.html)
