### PR TITLE
OSDOCS-3678: Adding RNs for descheduler priority threshold

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -241,6 +241,18 @@ To evict pods instead of simulating the evictions, change the descheduler mode t
 
 For more information, see xref:../nodes/scheduling/nodes-descheduler.adoc#nodes-descheduler[Evicting pods using the descheduler].
 
+[id="ocp-4-11-nodes-descheduler-customizations"]
+==== New descheduler customizations
+
+This release introduces the following customizations for the descheduler:
+
+* Priority threshold filtering: Set the priority threshold either by class name (`thresholdPriorityClassName`) or by numeric value (`thresholdPriority`) to not evict pods that have a priority that is equal to or greater than that value.
+
+* Namespace filtering: Set a list of user-created namespaces to include or exclude from descheduler operations. Note that protected namespaces (`openshift-*`, `kube-system`, `hypershift`) are always excluded.
+
+* Thresholds for the `LowNodeUtilization` strategy: Set experimental thresholds for underutilization and overutilization for the `LowNodeUtilization` strategy.
+
+For more information, see xref:../nodes/scheduling/nodes-descheduler.adoc#nodes-descheduler[Evicting pods using the descheduler].
 
 [id="ocp-4-11-logging"]
 === Logging


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3678

Link to docs preview:
http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3678-rn/release_notes/ocp-4-11-release-notes.html#ocp-4-11-nodes-descheduler-priority-threshold

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
