### PR TITLE
OSDOCS-3621: add spec.subdomain enhancement

### DIFF
--- a/modules/nw-ingress-sharding-route-configuration.adoc
+++ b/modules/nw-ingress-sharding-route-configuration.adoc
@@ -1,0 +1,111 @@
+// Module included in the following assemblies:
+//
+// * configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc
+// * networking/routes/route-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="nw-ingress-sharding-route-configuration_{context}"]
+= Creating a route for Ingress Controller sharding
+
+A route allows you to host your application at a URL. In this case, the hostname is not set and the route uses a subdomain instead. When you specify a subdomain, you automatically use the domain of the Ingress Controller that exposes the route. For situations where a route is exposed by multiple Ingress Controllers, the route is hosted at multiple URLs.
+
+The following procedure describes how to create a route for Ingress Controller sharding, using the `hello-openshift` application as an example.
+
+Ingress Controller sharding is useful when balancing incoming traffic load among a set of Ingress Controllers and when isolating traffic to a specific Ingress Controller. For example, company A goes to one Ingress Controller and company B to another.
+
+.Prerequisites
+
+* You installed the OpenShift CLI (`oc`).
+* You are logged in as a project administrator.
+* You have a web application that exposes a port and an HTTP or TLS endpoint listening for traffic on the port.
+* You have configured the Ingress Controller for sharding.
+
+.Procedure
+
+. Create a project called `hello-openshift` by running the following command:
++
+[source,terminal]
+----
+$ oc new-project hello-openshift
+----
+
+. Create a pod in the project by running the following command:
++
+[source,terminal]
+----
+$ oc create -f https://raw.githubusercontent.com/openshift/origin/master/examples/hello-openshift/hello-pod.json
+----
+
+. Create a service called `hello-openshift` by running the following command:
++
+[source,terminal]
+----
+$ oc expose pod/hello-openshift
+----
+
+. Create a route definition called `hello-openshift-route.yaml`:
++
+.YAML definition of the created route for sharding:
+[source,yaml]
+----
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    type: sharded <1>
+  name: hello-openshift-edge
+  namespace: hello-openshift
+spec:
+  subdomain: hello-openshift <2>
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: hello-openshift
+----
+<1> Both the label key and its corresponding label value must match the ones specified in the Ingress Controller. In this example, the Ingress Controller has the label key and value `type: sharded`.
+<2> The route will be exposed using the value of the `subdomain` field. When you specify the `subdomain` field, you must leave the hostname unset. If you specify both the `host` and `subdomain` fields, then the route will use the value of the `host` field, and ignore the `subdomain` field.
+
+. Use `hello-openshift-route.yaml` to create a route to the `hello-openshift` application by running the following command:
++
+[source,terminal]
+----
+$ oc -n hello-openshift create -f hello-openshift-route.yaml
+----
+
+.Verification
+* Get the status of the route with the following command:
++
+[source,terminal]
+----
+$ oc -n hello-openshift get routes/hello-openshift-edge -o yaml
+----
++
+The resulting `Route` resource should look similar to the following:
++
+.Example output
+[source,yaml]
+----
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    type: sharded
+  name: hello-openshift-edge
+  namespace: hello-openshift
+spec:
+  subdomain: hello-openshift
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: hello-openshift
+status:
+  ingress:
+  - host: hello-openshift.<apps-sharded.basedomain.example.net> <1>
+    routerCanonicalHostname: router-sharded.<apps-sharded.basedomain.example.net> <2>
+    routerName: sharded <3>
+----
+<1> The hostname the Ingress Controller, or router, uses to expose the route. The value of the `host` field is automatically determined by the Ingress Controller, and uses its domain. In this example, the domain of the Ingress Controller is `<apps-sharded.basedomain.example.net>`.
+<2> The hostname of the Ingress Controller.
+<3> The name of the Ingress Controller. In this example, the Ingress Controller has the name `sharded`.

--- a/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc
@@ -44,10 +44,13 @@ include::modules/nw-creating-project-and-service.adoc[leveloffset=+1]
 
 include::modules/nw-exposing-service.adoc[leveloffset=+1]
 
+// Router sharding
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 include::modules/nw-ingress-sharding-route-labels.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-sharding-namespace-labels.adoc[leveloffset=+1]
+
+include::modules/nw-ingress-sharding-route-configuration.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources

--- a/networking/routes/route-configuration.adoc
+++ b/networking/routes/route-configuration.adoc
@@ -11,7 +11,10 @@ toc::[]
 
 //Creating an insecure route
 include::modules/nw-creating-a-route.adoc[leveloffset=+1]
-//
+
+// Creating a route for router sharding
+include::modules/nw-ingress-sharding-route-configuration.adoc[leveloffset=+1]
+
 //Creating route timeouts
 include::modules/nw-configuring-route-timeouts.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to.

Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: https://issues.redhat.com/browse/OSDOCS-3621
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
New procedure lives in two locations:

- in Route configuration assembly: http://file.rdu.redhat.com/jdohmann/OSDOCS-3621/networking/routes/route-configuration#nw-ingress-sharding-route-configuration_route-configuration
- in Configuring ingress cluster traffic using an Ingress Controller assembly: http://file.rdu.redhat.com/jdohmann/OSDOCS-3621/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller#nw-ingress-sharding-route-configuration_configuring-ingress-cluster-traffic-ingress-controller

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
