### PR TITLE
JIRA-OSDOCS3200: Added Autoscaling intro and hyperlink in ROSA service definition

### DIFF
--- a/modules/rosa-sdpolicy-platform.adoc
+++ b/modules/rosa-sdpolicy-platform.adoc
@@ -52,7 +52,12 @@ The following table shows the frequency of backups:
 
 [id="rosa-sdpolicy-autoscaling_{context}"]
 == Autoscaling
-Node autoscaling is available on {product-title}.
+Node autoscaling is available on {product-title}. You can configure the autoscaler option to automatically scale the number of machines in a cluster.
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.adoc#rosa-nodes-about-autoscaling-nodes[About autoscaling nodes on a cluster]
+
 
 [id="rosa-sdpolicy-daemonsets_{context}"]
 == Daemonsets


### PR DESCRIPTION
Versions:
PR applies to all versions after a specific version: 4.9+

Issue:
https://issues.redhat.com/browse/OSDOCS-3200

Link to docs preview:
http://file.rdu.redhat.com/sayjadha/JIRA-OSDOCS3200/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-autoscaling_rosa-service-definition

Change request:
Added introduction of autoscaling nodes and a cross-reference to the related documentation. 

