### PR TITLE
Release note CNF-3431 PAO to NTO (DRAFTING) 

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -216,6 +216,18 @@ For more information, see xref:../networking/external_dns_operator/nw-installing
 [id="ocp-4-11-osdk"]
 === Operator development
 
+[id="ocp-4-11-PAO-to-NTO"]
+==== Performance Addon Operator functions moved to the Node Tuning Operator
+
+In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. The Node Tuning Operator is part of the standard installation for {product-title} 4.11. If you upgrade to {product-title} 4.11, the Node Tuning Operator removes the Performance Addon Operator and all related artifacts on startup. 
+
+For more information, see xref:../operators/operator-reference.adoc#about-node-tuning-operator_platform-operators-ref[Node Tuning Operator].
+
+[NOTE]
+====
+You must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command with the Performance Profile Creator. For more information, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#gathering-data-about-your-cluster-using-must-gather_cnf-create-performance-profiles[Gathering data about your cluster using must-gather]
+====
+
 [id="ocp-4-11-builds"]
 === Builds
 


### PR DESCRIPTION
[CNF-3431](https://issues.redhat.com//browse/CNF-3431): Release note describing that the functions under the Performance Addon Operator are now subsumed by the Node Tuning Operator from version 4.11

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/CNF-3431

Link to docs preview: http://file.emea.redhat.com/rohennes/RN-[CNF-3431](https://issues.redhat.com//browse/CNF-3431)-4.11/release_notes/ocp-4-11-release-notes.html#performance-addon-operator-functions-moved-to-the-node-tuning-operator

Additional information:
QE and SME approved