### PR TITLE
[GH#46005] Minor sentence fix

### DIFF
--- a/modules/deployments-rolling-strategy.adoc
+++ b/modules/deployments-rolling-strategy.adoc
@@ -14,7 +14,7 @@ A rolling deployment typically waits for new pods to become `ready` via a readin
 - When you want to take no downtime during an application update.
 - When your application supports having old code and new code running at the same time.
 
-A rolling deployment means you to have both old and new versions of your code running at the same time. This typically requires that your application handle N-1 compatibility.
+A rolling deployment means you have both old and new versions of your code running at the same time. This typically requires that your application handle N-1 compatibility.
 
 .Example rolling strategy definition
 [source,yaml]


### PR DESCRIPTION
Version(s): This applies to 4.6 through 4.11. 

Issue: https://github.com/openshift/openshift-docs/issues/46005

Notes: Just a minor sentence fix that removes an unnecessary "to."  

Link to docs preview: Below is a local asciibinder preview for the said change. 
<img width="956" alt="ascii preview" src="https://user-images.githubusercontent.com/105671279/175354660-5730afd8-cc9a-4cdf-b782-ab37fd886431.png">


