### PR TITLE
OSDOCS-3745: This PR adds the call outs back

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -79,7 +79,7 @@ $ aws kms get-key-policy --key-id <key_id_or_arn> --policy-name default --output
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
-                    "arn:aws:iam::<aws-account-id>:role/ManagedOpenShift-Support-Role",
+                    "arn:aws:iam::<aws-account-id>:role/ManagedOpenShift-Support-Role", <1>
                     "arn:aws:iam::<aws-account-id>:role/ManagedOpenShift-Installer-Role",
                     "arn:aws:iam::<aws-account-id>:role/ManagedOpenShift-Worker-Role",
                     "arn:aws:iam::<aws-account-id>:role/ManagedOpenShift-ControlPlane-Role"
@@ -99,7 +99,7 @@ $ aws kms get-key-policy --key-id <key_id_or_arn> --policy-name default --output
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
-                    "arn:aws:iam::<aws-account-id>:role/ManagedOpenShift-Support-Role",
+                    "arn:aws:iam::<aws-account-id>:role/ManagedOpenShift-Support-Role", <1>
                     "arn:aws:iam::<aws-account-id>:role/ManagedOpenShift-Installer-Role",
                     "arn:aws:iam::<aws-account-id>:role/ManagedOpenShift-Worker-Role",
                     "arn:aws:iam::<aws-account-id>:role/ManagedOpenShift-ControlPlane-Role"


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.10+

Link to docs preview:
https://people.redhat.com/eponvell/062222/OSDOCS-3745_Fix/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations

Additional information:
This PR fixes the missing callout from the example.



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
