### PR TITLE
RHDEVDOCS-4050 small correction on adding subscription entitlements

### DIFF
--- a/modules/builds-source-secrets-entitlements.adoc
+++ b/modules/builds-source-secrets-entitlements.adoc
@@ -10,7 +10,7 @@ Builds that use Red Hat subscriptions to install content must include the entitl
 
 .Prerequisites
 
-You must have access to Red Hat entitlements through your subscription, and the entitlements must have separate public and private key files.
+You must have access to Red Hat entitlements through your subscription. The entitlement secret is automatically created by the insights operator.
 
 
 [TIP]
@@ -25,15 +25,7 @@ RUN rm /etc/rhsm-host
 
 .Procedure
 
-. Create a secret containing your entitlements, ensuring that there are separate files containing the public and private keys:
-+
-[source,terminal]
-----
-$  oc create secret generic etc-pki-entitlement --from-file /path/to/entitlement/{ID}.pem \
-> --from-file /path/to/entitlement/{ID}-key.pem ...
-----
-
-. Add the secret as a build volume in the build configuration’s Docker strategy:
+. Add the etc-pki-entitlement secret as a build volume in the build configuration’s Docker strategy:
 +
 [source,yaml]
 ----

--- a/modules/builds-source-secrets-entitlements.adoc
+++ b/modules/builds-source-secrets-entitlements.adoc
@@ -10,7 +10,7 @@ Builds that use Red Hat subscriptions to install content must include the entitl
 
 .Prerequisites
 
-You must have access to Red Hat entitlements through your subscription. The entitlement secret is automatically created by the insights operator.
+You must have access to Red Hat entitlements through your subscription. The entitlement secret is automatically created by the Insights Operator.
 
 
 [TIP]


### PR DESCRIPTION
Updating modules/builds-source-secrets-entitlements.adoc based 
on ticket: https://issues.redhat.com/browse/RHDEVDOCS-4050 
and issue: https://github.com/openshift/openshift-docs/issues/43099 

  * PR applies to all versions after a specific version (e.g. 4.9): 4.9+
  * PR applies to the version 4.8, but the text of the second point has to be changed very slightly

### What changes?
The first step (Create a secret containing your entitlements, ensuring that there are separate files containing the public and private keys) is unnecessary. The insights operator automatically creates this secret if the account has the SCA certificates enabled, which comes as a default.



