### PR TITLE
removed mentions of managed in table descriptions

### DIFF
--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -638,7 +638,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
 |Resource|Description
 
 |`ManagedOpenShift-openshift-ingress-operator-cloud-credentials`
-|A managed IAM policy that provides the ROSA Ingress Operator with the permissions required to manage external access to a cluster.
+|An IAM policy that provides the ROSA Ingress Operator with the permissions required to manage external access to a cluster.
 
 |===
 
@@ -672,7 +672,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
 |Resource|Description
 
 |`ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials`
-|A managed IAM policy required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
+|An IAM policy required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
 
 |===
 
@@ -716,7 +716,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
 |Resource|Description
 
 |`ManagedOpenShift-openshift-machine-api-aws-cloud-credentials`
-|A managed IAM policy that provides the ROSA Machine Config Operator with the permissions required to perform core cluster functionality.
+|An IAM policy that provides the ROSA Machine Config Operator with the permissions required to perform core cluster functionality.
 
 |===
 
@@ -790,7 +790,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
 |Resource|Description
 
 |`ManagedOpenShift-openshift-cloud-credential-operator-cloud-credentials`
-|A managed IAM policy that provides the ROSA Cloud Credential Operator with the permissions required to manage cloud provider credentials.
+|An IAM policy that provides the ROSA Cloud Credential Operator with the permissions required to manage cloud provider credentials.
 
 |===
 
@@ -823,7 +823,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
 |Resource|Description
 
 |`ManagedOpenShift-openshift-image-registry-installer-cloud-credentials`
-|A managed IAM policy that provides the ROSA Image Registry Operator with the permissions required to manage the internal registry storage in AWS S3 for a cluster.
+|An IAM policy that provides the ROSA Image Registry Operator with the permissions required to manage the internal registry storage in AWS S3 for a cluster.
 
 |===
 


### PR DESCRIPTION
[OSDOCS-3287] removed mentions of "managed" in table descriptions

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-3287

Link to docs preview:
http://file.rdu.redhat.com/aldiaz/OSDOCS-3287/rosa_architecture/rosa-sts-about-iam-resources.html

<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
