### PR TITLE
OSDOCS-3567: Added GA for oc-mirror plug-in to release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -129,6 +129,25 @@ For more information, see xref:../installing/installing_bare_metal_ipi/ipi-insta
 
 For more information, see xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#configuring-the-bios_ipi-install-installation-workflow[Configuring the BIOS] and xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#configuring-the-raid_ipi-install-installation-workflow[Configuring the RAID].
 
+[id="ocp-4-11-oc-mirror-ga"]
+==== Disconnected mirroring with the oc-mirror CLI plug-in is now generally available
+
+You can use the oc-mirror OpenShift CLI (`oc`) plug-in to mirror images in a disconnected environment. This feature was previously introduced as a Technology Preview in {product-title} 4.10 and is now generally available in {product-title} 4.11.
+
+This release of the oc-mirror plug-in includes the following new features:
+
+* Pruning images from the target mirror registry
+* Specifying version ranges for Operator packages and {product-title} releases
+* Generating supporting artifacts for OpenShift Update Service (OSUS) usage
+* Obtaining a template for the initial image set configuration
+
+[IMPORTANT]
+====
+If you used the Technology Preview version of the oc-mirror plug-in for {product-title} 4.10, it is not possible to migrate your mirror registry to {product-title} 4.11. You must download the new oc-mirror plug-in, use a new storage back end, and use a new top-level namespace on the target mirror registry.
+====
+
+For more information, see xref:../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in].
+
 [id="ocp-4-11-web-console"]
 === Web console
 
@@ -1195,7 +1214,7 @@ In the table below, features are marked with the following statuses:
 |Disconnected mirroring with the oc-mirror CLI plug-in
 |-
 |TP
-|
+|GA
 
 |Mount shared entitlements in BuildConfigs in RHEL
 |-
@@ -1276,6 +1295,10 @@ This script removes unauthenticated subjects from the following cluster role bin
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 
 * In the {rh-openstack-first}, a potential issue can affect Kuryr when the ports pools are populated with a variety of bulk port creation requests made at the same time. During these bulk requests, if the IP allocation for one of the IP addresses fails, the Neutron retries the operation for all ports. This issue was resolved in a previous errata; however, Red Hat suggests setting a small value for the ports pools batch to avoid large bulk port creation requests. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2024690[*BZ2024690*])
+
+* The oc-mirror CLI plug-in cannot mirror {product-title} catalogs earlier than version 4.9. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097210[*BZ#2097210*])
+
+* The oc-mirror CLI plug-in can fail to upload an image set to the target mirror registry if the `archiveSize` value in the image set configuration is smaller than the container image size, causing the catalog directory to span multiple archives. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2106461[*BZ#2106461*])
 
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3567

Link to docs preview:
(single page preview) http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3567-rn/release_notes/ocp-4-11-release-notes.html#ocp-4-11-oc-mirror-ga

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
