### PR TITLE
[enterprise-4.6] [SRVCOM-1944] Re-add older release note versions

### DIFF
--- a/modules/serverless-rn-1-16-0.adoc
+++ b/modules/serverless-rn-1-16-0.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-16-0_{context}"]
+= Release Notes for Red Hat {ServerlessProductName} 1.16.0
+
+{ServerlessProductName} 1.16.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+[id="new-features-1-16-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 0.22.0.
+* {ServerlessProductName} now uses Knative Eventing 0.22.0.
+* {ServerlessProductName} now uses Kourier 0.22.0.
+* {ServerlessProductName} now uses Knative `kn` CLI 0.22.0.
+* {ServerlessProductName} now uses Knative Kafka 0.22.0.
+* The `kn func` CLI plug-in now uses `func` 0.16.0.
+* The `kn func emit` command has been added to the functions `kn` plug-in. You can use this command to send events to test locally deployed functions.
+
+[id="known-issues-1-16-0_{context}"]
+== Known issues
+
+* You must upgrade {product-title} to version 4.6.30, 4.7.11, or higher before upgrading to {ServerlessProductName} 1.16.0.
+
+* The AMQ Streams Operator might prevent the installation or upgrade of the {ServerlessOperatorName}. If this happens, the following error is thrown by Operator Lifecycle Manager (OLM):
++
+[source,terminal]
+----
+WARNING: found multiple channel heads: [amqstreams.v1.7.2 amqstreams.v1.6.2], please check the `replaces`/`skipRange` fields of the operator bundles.
+----
++
+You can fix this issue by uninstalling the AMQ Streams Operator before installing or upgrading the {ServerlessOperatorName}. You can then reinstall the AMQ Streams Operator.
+
+* If Service Mesh is enabled with mTLS, metrics for Knative Serving are disabled by default because Service Mesh prevents Prometheus from scraping metrics. For instructions on enabling Knative Serving metrics for use with Service Mesh and mTLS, see the "Integrating Service Mesh with OpenShift Serverless" section of the Serverless documentation.
+
+* If you deploy Service Mesh CRs with the Istio ingress enabled, you might see the following warning in the `istio-ingressgateway` pod:
++
+[source,terminal]
+----
+2021-05-02T12:56:17.700398Z warning envoy config [external/envoy/source/common/config/grpc_subscription_impl.cc:101] gRPC config for type.googleapis.com/envoy.api.v2.Listener rejected: Error adding/updating listener(s) 0.0.0.0_8081: duplicate listener 0.0.0.0_8081 found
+----
++
+Your Knative services might also not be accessible.
++
+You can use the following workaround to fix this issue by recreating the `knative-local-gateway` service:
+
+.. Delete the existing `knative-local-gateway` service in the `istio-system` namespace:
++
+[source,terminal]
+----
+$ oc delete services -n istio-system knative-local-gateway
+----
+
+.. Create and apply a `knative-local-gateway` service that contains the following YAML:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+ name: knative-local-gateway
+ namespace: istio-system
+ labels:
+   experimental.istio.io/disable-gateway-port-translation: "true"
+spec:
+ type: ClusterIP
+ selector:
+   istio: ingressgateway
+ ports:
+   - name: http2
+     port: 80
+     targetPort: 8081
+----
+
+* If you have 1000 Knative services on a cluster, and then perform a reinstall or upgrade of Knative Serving, there is a delay when you create the first new service after the `KnativeServing` custom resource (CR) becomes `Ready`.
++
+The `3scale-kourier-control` service reconciles all previously existing Knative services before processing the creation of a new service, which causes the new service to spend approximately 800 seconds in an `IngressNotConfigured` or `Unknown` state before the state updates to `Ready`.
+
+* If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
++
+As a result, messages that are sent during the time when the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
++
+For more information about this issue and possible workarounds, see link:https://access.redhat.com/articles/6343981[Knowledge Article #6343981].

--- a/modules/serverless-rn-1-17-0.adoc
+++ b/modules/serverless-rn-1-17-0.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-17-0_{context}"]
+= Release Notes for Red Hat {ServerlessProductName} 1.17.0
+
+{ServerlessProductName} 1.17.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+[id="new-features-1-17-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 0.23.0.
+* {ServerlessProductName} now uses Knative Eventing 0.23.0.
+* {ServerlessProductName} now uses Kourier 0.23.0.
+* {ServerlessProductName} now uses Knative `kn` CLI 0.23.0.
+* {ServerlessProductName} now uses Knative Kafka 0.23.0.
+* The `kn func` CLI plug-in now uses `func` 0.17.0.
+* In the upcoming {ServerlessProductName} 1.19.0 release, the URL scheme of external routes will default to HTTPS for enhanced security.
++
+If you do not want this change to apply for your workloads, you can override the default setting before upgrading to 1.19.0, by adding the following YAML to your `KnativeServing` custom resource (CR):
++
+[source,yaml]
+----
+...
+spec:
+  config:
+    network:
+      defaultExternalScheme: "http"
+...
+----
+
+* mTLS functionality is now Generally Available (GA).
+
+* TypeScript templates are now available when you create a function using `kn func`.
+
+* Changes to API versions in Knative Eventing 0.23.0:
+
+** The `v1alpha1` version of the `KafkaChannel` API, which was deprecated in {ServerlessProductName} version 1.14.0, has been removed. If the `ChannelTemplateSpec` parameters of your config maps contain references to this older version, you must update this part of the spec to use the correct API version.
+
+[id="known-issues-1-17-0_{context}"]
+== Known issues
+
+* If you try to use an older version of the Knative `kn` CLI with a newer {ServerlessProductName} release, the API is not found and an error occurs.
++
+For example, if you use the 1.16.0 release of the `kn` CLI, which uses version 0.22.0, with the 1.17.0 {ServerlessProductName} release, which uses the 0.23.0 versions of the Knative Serving and Knative Eventing APIs, the CLI does not work because it continues to look for the outdated 0.22.0 API versions.
++
+Ensure that you are using the latest `kn` CLI version for your {ServerlessProductName} release to avoid issues.
+
+* Kafka channel metrics are not monitored or shown in the corresponding web console dashboard in this release. This is due to a breaking change in the Kafka dispatcher reconciling process.
+
+* If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
++
+As a result, messages that are sent during the time when the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
++
+For more information about this issue and possible workarounds, see link:https://access.redhat.com/articles/6343981[Knowledge Article #6343981].
+
+* The Camel-K 1.4 release is not compatible with {ServerlessProductName} version 1.17.0. This is because Camel-K 1.4 uses APIs that were removed in Knative version 0.23.0. There is currently no workaround available for this issue. If you need to use Camel-K 1.4 with {ServerlessProductName}, do not upgrade to {ServerlessProductName} version 1.17.0.
++
+[NOTE]
+====
+The issue has been fixed, and Camel-K version 1.4.1 is compatible with {ServerlessProductName} 1.17.0.
+====

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -27,3 +27,7 @@ include::modules/serverless-rn-1-21-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-20-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-19-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-18-0.adoc[leveloffset=+1]
+
+// No longer supported versions
+include::modules/serverless-rn-1-17-0.adoc[leveloffset=+1]
+include::modules/serverless-rn-1-16-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.6

Issue:
[SRVCOM-1944](https://issues.redhat.com/browse/SRVCOM-1944)

Re-adding content removed in https://github.com/openshift/openshift-docs/pull/42096 so no need for QE/SME/peer reviews (this was done when the docs were added the first time).

Preview checked locally before merge