### PR TITLE
OSDOCS-3674: Update ROSA CLI download link

### DIFF
--- a/modules/rosa-setting-up-cli.adoc
+++ b/modules/rosa-setting-up-cli.adoc
@@ -13,7 +13,7 @@ To set up the `rosa` CLI, download the latest release, then configure and initia
 
 .Procedure
 
-. Download the latest release of the `rosa` CLI for your operating system from the *Download* page of link:https://access.redhat.com/products/red-hat-openshift-service-aws/[{product-title}]. 
+. Download the latest release of the `rosa` CLI for your operating system from the *Download* page of link:https://console.redhat.com/openshift/downloads?quickstart=getting-started#tool-rosa[{product-title}]. 
 +
 . It is recommended that after you download the release, you rename the executable file that you downloaded to `rosa`, and then add `rosa` to your path.
 +


### PR DESCRIPTION
Version(s):
4.10, 4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3674

Link to docs preview:
http://file.rdu.redhat.com/bmcelvee/20222806/rosa_cli/rosa-get-started-cli.html#rosa-setting-up-cli_rosa-getting-started-cli


Additional information:
No QE review required. 



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
