### PR TITLE
BZ#2094666: Missing container name in oc logs

### DIFF
--- a/modules/nw-ingress-operator-logs.adoc
+++ b/modules/nw-ingress-operator-logs.adoc
@@ -14,5 +14,5 @@ You can view your Ingress Controller logs.
 +
 [source,terminal]
 ----
-$ oc logs --namespace=openshift-ingress-operator deployments/ingress-operator
+$ oc logs --namespace=openshift-ingress-operator deployments/ingress-operator -c <container_name>
 ----


### PR DESCRIPTION
BZ#2094666: Missing container name in oc logs

Version(s): 4.10+

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2094666

Link to docs preview:
http://file.rdu.redhat.com/snarayan/BZ2094666_missing_container_name/networking/ingress-operator.html