### PR TITLE
Default evictionHard configuration for other parameters are wiped after only change memory.available with kubeletconfig

### DIFF
--- a/modules/compliance-removing-kubeletconfig.adoc
+++ b/modules/compliance-removing-kubeletconfig.adoc
@@ -57,7 +57,12 @@ status:
 ----
 <1> The scan name of the remediation.
 <2> The remediation that was added to the `KubeletConfig` objects.
-+  
++
+[NOTE]
+====
+If the remediation invokes an `evictionHard` kubelet configuration, you must specify all of the `evictionHard` parameters: `memory.available`, `nodefs.available`, `nodefs.inodesFree`, `imagefs.available`, and `imagefs.inodesFree`. If you do not specify all parameters, only the specified parameters are applied and the remediation will not function properly.
+====
+
 . Remove the remediation:
 
 .. Set `apply` to false for the remediation object:

--- a/modules/nodes-nodes-garbage-collection-configuring.adoc
+++ b/modules/nodes-nodes-garbage-collection-configuring.adoc
@@ -104,26 +104,28 @@ spec:
       nodefs.inodesFree: "1m30s"
       imagefs.available: "1m30s"
       imagefs.inodesFree: "1m30s"
-    evictionHard:
+    evictionHard: <6>
       memory.available: "200Mi"
       nodefs.available: "5%"
       nodefs.inodesFree: "4%"
       imagefs.available: "10%"
       imagefs.inodesFree: "5%"
-    evictionPressureTransitionPeriod: 0s <6>
-    imageMinimumGCAge: 5m <7>
-    imageGCHighThresholdPercent: 80 <8>
-    imageGCLowThresholdPercent: 75 <9>
+    evictionPressureTransitionPeriod: 0s <7>
+    imageMinimumGCAge: 5m <8>
+    imageGCHighThresholdPercent: 80 <9>
+    imageGCLowThresholdPercent: 75 <10>
 ----
 <1> Name for the object.
 <2> Selector label.
-<3> Type of eviction: `EvictionSoft` and `EvictionHard`.
+<3> Type of eviction: `evictionSoft` or `evictionHard`.
 <4> Eviction thresholds based on a specific eviction trigger signal.
 <5> Grace periods for the soft eviction. This parameter does not apply to `eviction-hard`.
-<6> The duration to wait before transitioning out of an eviction pressure condition.
-<7> The minimum age for an unused image before the image is removed by garbage collection.
-<8> The percent of disk usage (expressed as an integer) which triggers image garbage collection.
-<9> The percent of disk usage (expressed as an integer) to which image garbage collection attempts to free.
+<6> Eviction thresholds based on a specific eviction trigger signal.
+For `evictionHard` you must specify all of these parameters.  If you do not specify all parameters, only the specified parameters are applied and the garbage collection will not function properly.
+<7> The duration to wait before transitioning out of an eviction pressure condition.
+<8> The minimum age for an unused image before the image is removed by garbage collection.
+<9> The percent of disk usage (expressed as an integer) that triggers image garbage collection.
+<10> The percent of disk usage (expressed as an integer) that image garbage collection attempts to free.
 
 . Create the object:
 +

--- a/modules/nodes-nodes-garbage-collection-containers.adoc
+++ b/modules/nodes-nodes-garbage-collection-containers.adoc
@@ -34,6 +34,11 @@ a| * `nodefs.available`
 | The available disk space or inodes on the node root file system, `nodefs`, or image file system, `imagefs`.
 |===
 
+[NOTE]
+====
+For `evictionHard` you must specify all of these parameters.  If you do not specify all parameters, only the specified parameters are applied and the garbage collection will not function properly.
+====
+
 If a node is oscillating above and below a soft eviction threshold, but not exceeding its associated grace period, the corresponding node would constantly oscillate between `true` and `false`. As a consequence, the scheduler could make poor scheduling decisions.
 
 To protect against this oscillation, use the `eviction-pressure-transition-period` flag to control how long {product-title} must wait before transitioning out of a pressure condition. {product-title} will not set an eviction threshold as being met for the specified pressure condition for the period specified before toggling the condition back to false.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2098152

Preview (VPN required)
[Removing a KubeletConfig remediation](http://file.rdu.redhat.com/~mburke/BZ-2098152/security/compliance_operator/compliance-operator-remediation.html#compliance-removing-kubeletconfig_compliance-remediation). Note after callout 2
[Understanding how terminated containers are removed through garbage collection](http://file.rdu.redhat.com/~mburke/BZ-2098152/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-containers_nodes-nodes-configuring) Note after Table 1
[Configuring garbage collection for containers and images](http://file.rdu.redhat.com/~mburke/BZ-2098152/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring). Text added to Procedure step 1, callout 6 