### PR TITLE
Add ttlSecondsAfterFinished into LDAP sync cron job

### DIFF
--- a/modules/ldap-auto-syncing.adoc
+++ b/modules/ldap-auto-syncing.adoc
@@ -175,6 +175,7 @@ spec:                                                                           
   jobTemplate:
     spec:
       backoffLimit: 0
+      ttlSecondsAfterFinished: 1800                                                  <3>
       template:
         spec:
           containers:
@@ -183,7 +184,7 @@ spec:                                                                           
               command:
                 - "/bin/bash"
                 - "-c"
-                - "oc adm groups sync --sync-config=/etc/config/sync.yaml --confirm" <3>
+                - "oc adm groups sync --sync-config=/etc/config/sync.yaml --confirm" <4>
               volumeMounts:
                 - mountPath: "/etc/config"
                   name: "ldap-sync-volume"
@@ -197,10 +198,10 @@ spec:                                                                           
                 name: "ldap-group-syncer"
             - name: "ldap-bind-password"
               secret:
-                secretName: "ldap-secret"                                            <4>
+                secretName: "ldap-secret"                                            <5>
             - name: "ldap-ca"
               configMap:
-                name: "ca-config-map"                                                <5>
+                name: "ca-config-map"                                                <6>
           restartPolicy: "Never"
           terminationGracePeriodSeconds: 30
           activeDeadlineSeconds: 500
@@ -209,9 +210,10 @@ spec:                                                                           
 ----
 <1> Configure the settings for the cron job. See "Creating cron jobs" for more information on cron job settings.
 <2> The schedule for the job specified in link:https://en.wikipedia.org/wiki/Cron[cron format]. This example cron job runs every 30 minutes. Adjust the frequency as necessary, making sure to take into account how long the sync takes to run.
-<3> The LDAP sync command for the cron job to run. Passes in the sync configuration file that was defined in the config map.
-<4> This secret was created when the LDAP IDP was configured.
-<5> This config map was created when the LDAP IDP was configured.
+<3> How long, in seconds, to keep finished jobs. This should match the period of the job schedule in order to clean old failed jobs and prevent unnecessary alerts. For more information, see link:https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished[TTL-after-finished Controller] in the Kubernetes documentation.
+<4> The LDAP sync command for the cron job to run. Passes in the sync configuration file that was defined in the config map.
+<5> This secret was created when the LDAP IDP was configured.
+<6> This config map was created when the LDAP IDP was configured.
 
 . Create the cron job:
 +


### PR DESCRIPTION
Upstream Kubernetes documentation is here:
https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/

What this change does - it makes sure that failed jobs do not linger but are
cleaned up by OpenShift. In LDAP sync case the customer should only care about
last sync success or failure.

This should help with alert fatigue from KubeJobFailed when there is a glitch
with LDAP sync.

Similar (unrelated) change in CNO:
https://github.com/openshift/cluster-network-operator/pull/1318

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.8+


Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
