### PR TITLE
BZ-2097748 creating the initial PR for this BZ

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
@@ -16,6 +16,9 @@ include::modules/dr-restoring-cluster-state.adoc[leveloffset=+1]
 include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources"]
+== Additional resources
 
-* See xref:../../../networking/accessing-hosts.adoc#accessing-hosts[Accessing the hosts] for how to create a bastion host to access {product-title} instances and the control plane nodes with SSH.
+* xref:../../../networking/accessing-hosts.adoc#accessing-hosts[Creating a bastion host to access {product-title} instances and the control plane nodes with SSH].
+
+* xref:../../../installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc#replacing-a-bare-metal-control-plane-node_ipi-install-expanding[Replacing a bare-metal control plane node]. 

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -287,6 +287,11 @@ If the status is `Pending`, or the output lists more than one running etcd pod, 
 
 . Delete and recreate other non-recovery, control plane machines, one by one. After these machines are recreated, a new revision is forced and etcd scales up automatically.
 +
+[WARNING]
+====
+For bare metal installations on installer-provisioned infrastructure, control plane machines are not recreated. For more information, see "Replacing a bare-metal control plane node".
+====
++
 If you are running installer-provisioned infrastructure, or you used the Machine API to create your machines, follow these steps. Otherwise, you must create the new master node using the same method that was used to originally create it.
 +
 [WARNING]


### PR DESCRIPTION
[BZ 2097748]: Clarify machine deletion during disaster recovery for baremetal IPI deployments


Version(s):
PR applies to 

- 4.11
- 4.10
- main

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2097748

Link to docs preview:
http://file.emea.redhat.com/kquinn/BZ-2097748/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state