### PR TITLE
[RHACS] Remove 3.69.2 Patch Info ACS

### DIFF
--- a/release_notes/369-release-notes.adoc
+++ b/release_notes/369-release-notes.adoc
@@ -9,7 +9,6 @@ toc::[]
 
 - 3.69.0 Release date: March 21, 2022
 - 3.69.1 Release date: April 6, 2022
-- 3.69.2 Release date: June 22, 2022
 
 [id="new-features-369"]
 == New features
@@ -52,13 +51,6 @@ Scanner includes the following new capabilities:
 
 [id="important-bug-fixes-369"]
 == Important bug fixes
-
-[id="fixed-in-version-3692"]
-=== Resolved in version 3.69.2
-
-Release date: June 22, 2022
-
-*ROX-11489*: link:https://access.redhat.com/security/cve/cve-2022-1902[CVE-2022-1902]: Previously, improper sanitization allowed authenticated users to retrieve Notifier secrets from the GraphQL API. This flaw has been fixed.
 
 
 [id="fixed-in-version-3690"]
@@ -131,18 +123,18 @@ For any questions, please contact the Red Hat support team at support@redhat.com
 | Main
 | Includes Central, Sensor, Admission Controller, and Compliance.
 Also includes `roxctl` for use in continuous integration (CI) systems.
-| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.69.2`
+| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.69.1`
 
 | Scanner
 | Scans images and nodes.
-| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:3.69.2`
+| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:3.69.1`
 
 | Scanner DB
 | Stores image scan results and vulnerability definitions.
-| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:3.69.2`
+| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:3.69.1`
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.
-| `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:3.69.2`
-  `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.69.2`
+| `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:3.69.1`
+  `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.69.1`
 |===


### PR DESCRIPTION
Pull back release notes for patch due to release problems

Versions:
- Merge to `rhacs-docs-3.69`
- Cherry pick to `rhacs-docs`

Label: `RHACS`

Issue: none

[Preview link](https://openshift-docs-6b8yzjt1p-kcarmichael08.vercel.app/openshift-acs/master/release_notes/369-release-notes.html)
