### PR TITLE
[RHACS] Remove 3.70.1 Patch Info ACS

### DIFF
--- a/release_notes/370-release-notes.adoc
+++ b/release_notes/370-release-notes.adoc
@@ -6,8 +6,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-- 3.70.0 Release date: 2 June 2022
-- 3.70.1 Release date: 22 June 2022
+2 June 2022
 
 {product-title} is an enterprise-ready, Kubernetes-native container security solution that protects your vital applications across build, deploy, and runtime. It deploys in your infrastructure and integrates with your DevOps tooling and workflows to deliver better security and compliance and to enable DevOps and InfoSec teams to operationalize security.
 
@@ -168,13 +167,6 @@ In the table, features are marked with the following statuses:
 [id="bug-fixes-3670"]
 == Bug fixes
 
-[id="fixed-in-version-3701"]
-=== Resolved in version 3.70.1
-
-Release date: 22 June 2022
-
-* link:https://access.redhat.com/security/cve/cve-2022-1902[CVE-2022-1902]: Previously, improper sanitization allowed authenticated users to retrieve Notifier secrets from the GraphQL API. This flaw has been fixed. (*ROX-11490*)
-
 [id="fixed-in-version-370"]
 === Resolved in version 3.70.0
 
@@ -199,18 +191,18 @@ Release date: 2 June 2022
 | Main
 | Includes Central, Sensor, Admission Controller, and Compliance.
 Also includes `roxctl` for use in continuous integration (CI) systems.
-| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.70.1`
+| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.70.0`
 
 | Scanner
 | Scans images and nodes.
-| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:3.70.1`
+| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:3.70.0`
 
 | Scanner DB
 | Stores image scan results and vulnerability definitions.
-| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:3.70.1`
+| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:3.70.0`
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.
 | `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:3.70`
-  `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.70.1`
+  `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.70.0`
 |===

--- a/release_notes/370-release-notes.adoc
+++ b/release_notes/370-release-notes.adoc
@@ -138,6 +138,11 @@ In the table, features are marked with the following statuses:
 |DEP
 |REM
 
+|`/v1/policies` API endpoint response: `whitelists` response body parameter
+|DEP
+|DEP
+|REM
+
 |`/v1/nodes` and `/v1/images` API endpoint response: `firstNodeOccurrence` response body parameter
 |GA
 |DEP

--- a/release_notes/370-release-notes.adoc
+++ b/release_notes/370-release-notes.adoc
@@ -138,11 +138,6 @@ In the table, features are marked with the following statuses:
 |DEP
 |REM
 
-|`/v1/policies` API endpoint response: `whitelists` response body parameter
-|DEP
-|DEP
-|REM
-
 |`/v1/nodes` and `/v1/images` API endpoint response: `firstNodeOccurrence` response body parameter
 |GA
 |DEP


### PR DESCRIPTION
Pull back release notes for patch due to release problems

Versions:

- Merge to `rhacs-docs-3.70`
- Cherry pick to `rhacs-docs`

Label: `RHACS`

Issue: none

[Preview link](https://openshift-docs-qlg1719uy-kcarmichael08.vercel.app/openshift-acs/master/release_notes/370-release-notes.html)