### PR TITLE
LegacyServiceAccountTokenNoAutoGeneration release note update

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -298,6 +298,17 @@ For the full list of OIDC providers, see xref:../authentication/identity_provide
 
 The `haproxy.router.openshift.io/balance` variable, which sets the router load-balancing algorithm, now defaults to the value `random` instead of `leastconn`. See xref:../networking/routes/route-configuration.adoc#nw-route-specific-annotations_route-configuration[Route-specific annotations] for more information.
 
+[discrete]
+[id="ocp-4-11-legacy-service-account"]
+==== LegacyServiceAccountTokenNoAutoGeneration is on by default
+To align with upstream Kubernetes moving the `LegacyServiceAccountTokenNoAutoGeneration` feature gate to beta and enabling it by default, {product-title} now also follows this security feature and ships with the feature enabled.
+
+This feature removes automatic generation of Service Account token secrets, meaning that a Service Account no longer receives an  automatically generated token upon its creation.
+
+However, OpenShift Controller Manager still requires Service Account tokens to appear in secrets in order to function properly, and it will continue to request these tokens in secrets in {product-title} 4.11. In a future release, the `TokenRequest` API will be used instead.
+
+Service Account token secrets will still appear as auto-generated in {product-title} 4.11. However, instead of two secrets per Service Account, there will now be only one, which will be further reduced to zero in a future release. For now, dockercfg secrets will still be generated as secrets and no secrets will be deleted during upgrades.
+
 [id="ocp-4-11-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Update per https://github.com/openshift/openshift-docs/issues/43249#issuecomment-1164418757

Version(s):
4.11 only

Preview build: http://file.rdu.redhat.com/~ahardin/Mar-11-2022/LegacyServiceAccountTokenNoAutoGeneration-update/release_notes/ocp-4-11-release-notes.html#ocp-4-11-legacy-service-account