### PR TITLE
RHDEVDOCS-3864 - monitoring 4.11 release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -628,6 +628,91 @@ For more information, see xref:../nodes/scheduling/nodes-descheduler.adoc#nodes-
 [id="ocp-4-11-monitoring"]
 === Monitoring
 
+The monitoring stack for this release includes the following new and modified features.
+
+[id=ocp-4-11-monitoring-updates-to-monitoring-stack-components-and-dependencies]
+==== Updates to monitoring stack components and dependencies
+
+Updates to versions of monitoring stack components and dependencies include the following:
+
+* Alertmanager to 0.24.0
+* kube-state-metrics to 2.5.0
+* Prometheus to 2.36.2
+* Prometheus operator to 0.57.0
+* Thanos to 0.26.0
+
+[id=ocp-4-11-monitoring-changes-to-alerting-rules]
+==== Changes to alerting rules
+
+[NOTE]
+====
+Red Hat does not guarantee backward compatibility for recording rules or alerting rules.
+====
+
+* *New*
+** Added the `KubePersistentVolumeInodesFillingUp` alert, which functions similarly to the existing `KubePersistentVolumeFillingUp` alert but is applied to inodes rather than volume space.
+** Added the `PrometheusScrapeBodySizeLimitHit` alert to detect targets hitting the body size limit.
+** Added the `PrometheusScrapeSampleLimitHit` alert to detect targets hitting the sample limit.
+
+* *Changed*
+** Fixed the `KubeDaemonSetRolloutStuck` alert to use the updated metric `kube_daemonset_status_updated_number_scheduled` from `kube-state-metrics`.
+** Replaced the `KubeJobCompletion` alert with `KubeJobNotCompleted`. The new `KubeJobNotCompleted` alert avoids false positives when an earlier job failed but the most recent job succeeded.
+** Updated the `NodeNetworkInterfaceFlapping` alert to exclude `tunbr` interfaces from the alert expression.
+
+[id=ocp-4-11-monitoring-enable-alert-routing-for-user-workload-momitoring]
+==== Enable alert routing for user workload monitoring
+A cluster administrator can now enable alert routing for user workload monitoring so that developers and other users can configure custom alerts and alert routing for their user-defined projects.
+
+[id=ocp-4-11-monitoring-enable-dedicated-alertmanager-for-user-defined-alerts]
+==== Enable a dedicated Alertmanager instance for user-defined alerts
+You now have the option to enable a separate instance of Alertmanager dedicated to sending alerts only for user-defined projects.
+This feature can help reduce the load on the default platform Alertmanager instance and can better separate user-defined alerts from default platform alerts.
+
+[id=ocp-4-11-monitoring-use-additional-authenticaion-settings-for-remote-write]
+==== Use additional authentication settings for remote write configuration
+You can now use the following authentication methods to access a remote write endpoint: AWS Signature Version 4, custom Authorization header, and OAuth 2.0. 
+Before this release, you could only use TLS client and basic authentication.
+
+[id=ocp-4-11-monitoring-better-manage-promql-queries-in-web-console]
+==== Create, browse, and manage PromQL queries more easily in the web console
+The Query Browser on the *Observe* -> *Metrics* page of the {product-title} web console adds various enhancements to improve your ability to create, browse, and manage PromQL queries.
+For example, administrators can now duplicate existing queries and use autocomplete suggestions when building and editing queries.
+
+[id=ocp-4-11-monitoring-doubled-scrape-interval-for-servicemonitors-single-node]
+====  Scrape interval doubled for ServiceMonitors in single node deployments
+The scrape interval has been doubled for all Cluster Monitoring Operator (CMO) controlled ServiceMonitors on single-node {product-title} deployments. 
+The maximum interval is now two minutes.
+
+[id=ocp-4-11-monitoring-create-alerting-rules-based-on-platform-metrics]
+==== Create alerting rules based on platform monitoring metrics (Technology Preview)
+This release introduces a Technology Preview feature in which administrators can create alerting rules based on existing platform monitoring metrics.
+This feature helps administrators to more quickly and easily create new alerting rules specific to their environments.
+
+[id=ocp-4-11-monitoring-add-cluster-id-labels-for-remote-write]
+==== Add cluster ID labels to remote write storage
+You can now add cluster ID labels to metrics being sent to remote write storage.
+You can then query these labels to identify the source cluster for a metric and distinguish that metric data from similar metric data sent by other clusters.
+
+[id=ocp-4-11-monitoring-query-metrics-using-federation-endpoint]
+==== Query metrics using the federation endpoint for user workload monitoring
+You can now use the Prometheus `/federate` endpoint to scrape user-defined metrics from a network location outside the cluster.
+Before this release, you could only access the federation endpoint to scrape metrics in default platform monitoring.
+
+[id=ocp-4-11-monitoring-enable-body-size-limit-metrics-scraping]
+==== Enable body size limit for metrics scraping for default platform monitoring
+You can now set the `enforcedBodySizeLimit` config map option for default platform monitoring to enable a body size limit on metrics scraping.
+This setting triggers the new `PrometheusScrapeBodySizeLimitHit` alert when at least one Prometheus scrape target replies with a response body larger than the configured `enforcedBodySizeLimit`.
+The setting can limit the impact that a malicious target can have on both the Prometheus component and on the cluster as a whole.
+
+[id=ocp-4-11-monitoring-confgure-retention-size-for-metrics-storage]
+==== Configure retention size settings for metrics storage
+You can now configure the maximum amount of disk space reserved for retained metrics storage for both default platform monitoring and user-workload monitoring. 
+Before this release, you could not configure this setting.
+
+[id=ocp-4-11-monitoring-confgure-retention-time-for-thanos-ruler]
+==== Configure the retention time period for Thanos Ruler in user-defined projects
+You can now configure the retention time period for Thanos Ruler data in user-defined projects. 
+Before this release, you could not change the default value of `24h`.
 
 [id="ocp-4-11-scalability-and-performance"]
 === Scalability and performance
@@ -846,6 +931,16 @@ In the table, features are marked with the following statuses:
 |REM
 |REM
 
+|Grafana component in monitoring stack
+|
+|DEP
+|REM
+
+|Access to Prometheus and Grafana UIs in monitoring stack
+|
+|DEP
+|REM
+
 |vSphere 6.7 Update 2 or earlier
 |DEP
 |DEP
@@ -910,6 +1005,16 @@ The following OpenShift CLI (`oc`) commands were removed with this release:
 * `oc adm migrate image-references`
 * `oc adm migrate legacy-hpa`
 * `oc adm migrate storage`
+
+[id="ocp-4-11-monitoring-grafana-component-removed"]
+==== Grafana component removed from monitoring stack
+The Grafana component is no longer a part of the {product-title} {product-version} monitoring stack.
+As an alternative, go to *Observe* -> *Dashboards* in the {product-title} web console to view monitoring dashboards.
+
+[id="ocp-4-11-monitoring-prometheus-and-grafana-uis-removed"]
+==== Prometheus and Grafana user interface access removed from monitoring stack
+Access to the third-party Prometheus and Grafana user interfaces have been removed from the {product-title} {product-version} monitoring stack.
+As an alternative, click *Observe* in the {product-title} web console to view alerting, metrics, dashboards, and metrics targets for monitoring components.
 
 [id="ocp-4-11-custom-scheduler"]
 ==== Support for manually deploying a custom scheduler has been removed
@@ -996,6 +1101,54 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [discrete]
 [id="ocp-4-11-monitoring-bug-fixes"]
 ==== Monitoring
+
+* Before this update, dashboards in the {product-title} web console that contained queries using a container label for `container_fs*` metrics returned no data points because the container labels had been dropped due to high cardinality. 
+This update resolves the issue, and these dashboards now display data as expected.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2037513[*BZ#2037513*])
+
+* Before this update, the `prometheus-operator` component allowed any time value for `ScrapeTimeout` in the config map. 
+If you set `ScrapeTimeout` to a value greater than the `ScrapeInterval` value, Prometheus would stop loading the config map settings and fail to apply all subsequent configuration changes.
+With this update, if the `ScrapeTimeout` value specified is greater than the `ScrapeInterval` value, the system logs the settings as invalid, but continues loading the other config map settings.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2037762[*BZ#2037762*])
+
+* Before this update, in the *CPU Utilisation* panel on the *Kubernetes / Compute Resources / Cluster* dashboard in the {product-title} web console, the formula used to calculate the CPU utilization of a node could incorrectly display invalid negative values.
+With this update, the formula has been updated, and the *CPU Utilisation* panel now shows correct values.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2040635[*BZ#2040635*])
+
+* Before this update, data from the `prometheus-adapter` component could not be accessed during the automatic update that occurs every 15 days because the update process removed old pods before the new pods became available.
+With this release, the automatic update process now only removes old pods after the new pods are able to serve requests so that data from the old pods continues to be available during the update process.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2048333[*BZ#2048333*])
+
+* Before this update, the following metrics were incorrectly missing from `kube-state-metrics`: `kube_pod_container_status_terminated_reason`, `kube_pod_init_container_status_terminated_reason`, and `kube_pod_status_scheduled_time`.
+With this release, `kube-state-metrics` correctly exposes these metrics so that they are available.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2050120[*BZ#2050120*])
+
+* Before this update, if invalid write relabel config map settings existed for the `prometheus-operator` component, the configuration would still load all subsequent settings.
+With this release, the component checks for valid write relabel settings when loading the configuration.
+If invalid settings exist, an error is logged, and the configuration loading process stops.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2051470[*BZ#2051470*])
+
+* Before this update, the `init-config-reloader` container for the Prometheus pods requested `100m` of CPU and `50Mi` of memory, even though in practice the container needed fewer resources. 
+With this update, the container requests `1m` of CPU and `10Mi` of memory. These settings are consistent with the settings of the `config-reloader` container.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2057025[*BZ#2057025*])
+
+* Before this update, when an administrator enabled user workload monitoring, the `user-workload-monitoring-config` config map was not automatically created.
+Because non-administrator users with the `user-workload-monitoring-config-edit` role did not have permission to create the config map manually, they depended on an administrator to create it.
+With this update, the `user-workload-monitoring-config` config map is now automatically created when an administrator enables user workload monitoring and is available to edit by users with the appropriate role.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2065577[*BZ#2065577*])
+
+* Before this update, after you deleted a deployment, the Cluster Monitoring Operator (CMO) did not wait for the deletion to be completed, which caused reconciliation errors. 
+With this update, the CMO now waits until deployments are deleted before recreating them, which resolves this issue.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2069068[*BZ#2069068*])
+
+* Before this update, for user workload monitoring, if you configured external labels for metrics in Prometheus, the CMO did not correctly propagate these labels to Thanos Ruler. 
+Thus, for user-defined projects, if you queried external metrics not provided by the user workload monitoring instance of Prometheus, you would sometimes not see external labels for these metrics even though you had configured Prometheus to add them. 
+With this update, the CMO now properly propagates the external labels that you configured in Prometheus to Thanos Ruler, and you can see the labels when you query external metrics.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2073112[*BZ#2073112*])
+
+* Before this update, the `tunbr` interface incorrectly triggered the `NodeNetworkInterfaceFlapping` alert.
+With this update, the `tunbr` interface is now included in the list of interfaces that the alert ignores and no longer causes the alert to trigger incorrectly.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2090838[*BZ#2090838*])
 
 [discrete]
 [id="ocp-4-11-networking-bug-fixes"]
@@ -1469,7 +1622,7 @@ In the table below, features are marked with the following statuses:
 |Alert routing for user-defined projects monitoring
 |-
 |TP
-|
+|GA
 
 |Disconnected mirroring with the oc-mirror CLI plug-in
 |-
@@ -1510,6 +1663,11 @@ In the table below, features are marked with the following statuses:
 |TP
 |GA
 |GA
+
+|Alerting rules based on platform monitoring metrics
+|-
+|-
+|TP
 
 |AWS Load Balancer Operator
 |-
@@ -1573,6 +1731,15 @@ This script removes unauthenticated subjects from the following cluster role bin
 
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
+
+* In the monitoring stack, if you have enabled and deployed a dedicated Alertmanager instance for user-defined alerts, you cannot silence alerts in the *Developer* perspective in the {product-title} web console.
+No workaround exists for this issue.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2100860[*BZ#2100860*])
+
+* On a newly installed {product-title} {product-version} cluster, platform monitoring alerts do not have the `openshift_io_alert_source="platform"` label. 
+This issue does not affect clusters upgraded from a previous minor version.
+No workaround exists for this issue.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2103127[*BZ#2103127*])
 
 * In the {rh-openstack-first}, a potential issue can affect Kuryr when the ports pools are populated with a variety of bulk port creation requests made at the same time. During these bulk requests, if the IP allocation for one of the IP addresses fails, the Neutron retries the operation for all ports. This issue was resolved in a previous errata; however, Red Hat suggests setting a small value for the ports pools batch to avoid large bulk port creation requests. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2024690[*BZ2024690*])
 


### PR DESCRIPTION
Summary: This PR adds 4.11 release notes content for monitoring, including new and updated features, bug fixes, and known issues. 

- Aligned team: DevTools
- For branches: 
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3864
- Direct link to doc preview (RH VPN access required): 
- - New and updated features: http://file.rdu.redhat.com/bburt/RHDEVDOCS-3864-monitoring-4-11-release-notes/release_notes/ocp-4-11-release-notes.html#ocp-4-11-monitoring
- - Monitoring section in: http://file.rdu.redhat.com/bburt/RHDEVDOCS-3864-monitoring-4-11-release-notes/release_notes/ocp-4-11-release-notes.html#ocp-4-11-bug-fixes
- - Monitoring bug in  http://file.rdu.redhat.com/bburt/RHDEVDOCS-3864-monitoring-4-11-release-notes/release_notes/ocp-4-11-release-notes.html#ocp-4-11-known-issues
- SME review: @jan--f @simonpasquier 
- QE review: @juzhao 
- Peer review: @ tbd