### PR TITLE
modules/understanding-upgrade-channels: Support all updates between supported releases

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -20,7 +20,7 @@ You can use the `candidate-{product-version}` channel to update from a previous 
 
 [NOTE]
 ====
-Release candidates differ from the nightly builds. Nightly builds are available for early access to features, but updating to or from nightly builds is neither recommended nor supported. Nightly builds are not available in any upgrade channel. You can reference the {product-title}
+Release candidates differ from the nightly builds. Nightly builds are available for early access to features, but nightly builds are not supported, and updating to or from nightly builds is neither recommended nor supported. Nightly builds are not available in any upgrade channel. You can reference the {product-title}
 ifdef::openshift-origin[]
 link:https://origin-release.apps.ci.l2s4.p1.openshiftapps.com/[release statuses]
 endif::[]
@@ -94,13 +94,13 @@ endif::openshift-origin[]
 The service recommends only upgrades that have been tested and have no serious issues. It will not suggest updating to a version of {product-title} that contains known vulnerabilities. For example, if your cluster is on {product-version}.1 and {product-title} suggests {product-version}.4, then it is safe for you to update from {product-version}.1 to {product-version}.4. Do not rely on consecutive patch numbers. In this example, {product-version}.2 is not and never was available in the channel.
 
 ifndef::openshift-origin[]
-Update stability depends on your channel. The presence of an update recommendation in the `candidate-{product-version}` channel does not imply that the update is supported. It means that no serious issues have been found with the update yet, but there might not be significant traffic through the update to suggest stability. The presence of an update recommendation in the `fast-{product-version}` or `stable-{product-version}` channels at any point is a declaration that the update is supported. While releases will never be removed from a channel, update recommendations that exhibit serious issues will be removed or made conditional from all channels. When an update recommendation is supported, it remains supported for the life of {product-version}, even if the update recommendation is later dropped or made conditional.
+Update stability depends on your channel. The presence of an update recommendation in the `candidate-{product-version}` channel does not imply that the update is supported. It means that no serious issues have been found with the update yet, but there might not be significant traffic through the update to suggest stability. The presence of a release in `fast-{product-version}`, `stable-{product-version}`, or `eus-4.y` channels is a declaration that the release is supported. While releases will never be removed from a channel, update recommendations that exhibit serious issues will be removed or made conditional from all channels. All updates between supported releases are supported, regardless of whether they are or have ever been recommended.
 
-Red Hat will eventually provide supported update paths from any supported release in the `fast-{product-version}` or `stable-{product-version}` channels to the latest release in {product-version}.z, although there can be delays while safe paths away from troubled releases are constructed and verified.
+Red Hat will eventually provide recommended update paths from any supported release to the latest supported release in {product-version}.z in the `fast-{product-version}`, `stable-{product-version}`, and `eus-4.y` channels, although there can be delays while safe paths away from troubled releases are constructed and verified. The recommended update path to reach the latest {product-version}.z may require multiple updates.
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
-The presence of an update recommendation in the `stable-4` channel at any point is a declaration that the update is supported. While releases will never be removed from the channel, update recommendations that exhibit serious issues will be removed or made conditional from all channels. When an update recommendation is supported, it remains supported for the life of {product-version}, even if the update recommendation is later dropped or made conditional.
+The presence of an update recommendation in the `stable-4` channel at any point is a declaration that the update is supported [FIXME: are there supported OKD releases?]. While releases will never be removed from the channel, update recommendations that exhibit serious issues will be removed or made conditional from all channels. When an update recommendation is supported, it remains supported for the life of {product-version}, even if the update recommendation is later dropped or made conditional.
 endif::openshift-origin[]
 
 ifndef::openshift-origin[]
@@ -132,15 +132,19 @@ $ oc adm upgrade channel <channel>
 
 The web console will display an alert if you switch to a channel that does not include the current release. The web console does not recommend any updates while on a channel without the current release. You can return to the original channel at any point, however.
 
-Changing your channel might impact the supportability of your cluster. The following conditions might apply:
+Changing your channel does not impact the supportability of your cluster, but some update recommendations in the `candidate-{product-version}` channel might be unsupported.
 
-* Your cluster is still supported if you change from the `stable-{product-version}` channel to the `fast-{product-version}` channel.
+The following conditions might apply:
 
-* You can switch to the `candidate-{product-version}` channel at any time, but some releases for this channel might be unsupported.
+* You can switch from the `stable-{product-version}` channel to the `fast-{product-version}` or `eus-4.y` channel at any time.
+
+* You can switch from the `eus-{product-version}` channel to the `fast-{product-version}` or `stable-4.y` channel at any time.
+
+* You can switch to the `candidate-{product-version}` channel at any time, but some update recommendations in this channel might be unsupported.
 
 * You can switch from the `candidate-{product-version}` channel to the `fast-{product-version}` channel if your current release is a general availability release.
 
-* You can always switch from the `fast-{product-version}` channel to the `stable-{product-version}` channel. There is a possible delay of up to a day for the release to be promoted to `stable-{product-version}` if the current release was recently promoted.
+* You can always switch from the `fast-{product-version}` channel to the `stable-{product-version}` or `eus-4.y` channel. There is a possible delay for the release to be promoted to `stable-{product-version}` and `eus-4.7` if the current release was recently promoted to `fast-{product-version}`.
 endif::openshift-origin[]
 
 [id="conditional-updates-overview_{context}"]

--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -34,7 +34,7 @@ Two controllers run during continuous update mode. The first controller continuo
 
 [IMPORTANT]
 ====
-Only upgrading to a newer version is supported. Reverting or rolling back your cluster to a previous version is not supported. If your update fails, contact Red Hat support.
+Only upgrading to a newer version is recommended. Reverting or rolling back your cluster to a previous version is not recommended. If your update fails, contact Red Hat support.
 ====
 
 During the update process, the Machine Config Operator (MCO) applies the new configuration to your cluster machines. The MCO cordons the number of nodes as specified by the `maxUnavailable` field on the machine configuration pool and marks them as unavailable. By default, this value is set to `1`. The MCO updates the affected nodes alphabetically by zone, based on the `topology.kubernetes.io/zone` label. If a zone has more than one node, the oldest nodes are updated first. For nodes that do not use zones, such as in bare metal deployments, the nodes are upgraded by age, with the oldest nodes updated first. The MCO updates the number of nodes as specified by the `maxUnavailable` field on the machine configuration pool at a time. The MCO then applies the new configuration and reboots the machine.


### PR DESCRIPTION
Consider the following example, which we'll call a "never-recommended update between supported releases":

1. 4.y.z created and added to candidate-4.y.
2. 4.y.z released and added to fast-4.y.
3. 4.y.z' created and added to candidate-4.y.
4. Issue discovered with the update into 4.y.z', so all updates to 4.y.z' are blocked (no longer recommended).
5. 4.y.z' has useful installer fixes, so 4.y.z' is released and added to fast-4.y.
6. Customer updates from 4.y.z to 4.y.z', and experiences problems.

The outgoing wording included:

> When an update recommendation is supported, it remains supported for the life of {product-version}, even if the update recommendation is later dropped or made conditional.

That's still true.  But it does not speak to never-recommended updates between supported releases.  The incoming wording is:

> All updates between supported releases are supported, regardless of whether they are or have ever been recommended.

which does explicitly extend support to never-recommended updates between supported releases (although while those updates are supported, they are clearly not recommended, and are likely to break your cluster).

Also:

* Explicitly point out that nightlies are not supported.  Previously we had only talked about updates involving nightlies.  But users can install nightlies without updating, and those clusters are not supported.  And now we say that clearly.

* Similarly, now that all updates between supported releases are supported, make fast-or-later channel membership a declaration of support for the releases themselves.  We haven't had a Cincinnati-first release (where we promote 4.y.z to fast-4.y before shipping the errata) in a while, but we want to preserve that safety valve in case the errata-shipping pipeline breaks and we really want to declare support for a release without waiting on the errata.

* Include `eus-4.y` in places where we are listing supported channels.

* Point out that we are committing to get folks a recommended path to the z-stream tip.  E.g. from 4.y.z to 4.y.zFinal.  And, because 4.(y-1).z are also in the fast-4.y channel, also from any 4.(y-1).z to 4.y.zFinal.  Previous language had just talked about supported update paths.  The new recommended path commitment is stronger.

* Point out that the path to 4.y.zFinal path may involve multiple hops (e.g. 4.(y-1).z -> 4.(y-1).z' -> 4.y.zFinal).

* Explain that changing the channel alone does not affect support. It's updating to unsupported releases via the candidate-4.y channel that we're concerned about.  Preserve the discussion of channel-changing options, so folks can understand the VersionNotFound implications.

* Drop a stale "delay of up to a day", catching this section up with 3e702f16d3 (#22816).