### PR TITLE
[OSDOCS-3506] GA HW offload for ShiftStack

### DIFF
--- a/modules/nw-osp-enabling-ovs-offload.adoc
+++ b/modules/nw-osp-enabling-ovs-offload.adoc
@@ -6,10 +6,6 @@
 [id="nw-osp-enabling-ovs-offload_{context}"]
 = Enabling OVS hardware offloading
 
-:FeatureName: OVS hardware offloading
-
-include::snippets/technology-preview.adoc[]
-
 For clusters that run on {rh-openstack-first}, you can enable link:https://www.openvswitch.org/[Open vSwitch (OVS)] hardware offloading. 
 
 OVS is a multi-layer virtual switch that enables large-scale, multi-server network virtualization. 
@@ -21,13 +17,6 @@ OVS is a multi-layer virtual switch that enables large-scale, multi-server netwo
 * You created two `hw-offload` type virtual function (VF) interfaces on your cluster.
 
 .Procedure
-
-. From a command line, enter the following command to disable the admission webhook:
-+
-[source,terminal]
-----
-$ oc patch sriovoperatorconfig default --type=merge -n openshift-sriov-network-operator --patch '{ "spec": { "enableOperatorWebhook": false } }'
-----
 
 . Create an `SriovNetworkNodePolicy` policy for the two `hw-offload` type VF interfaces that are on your cluster:
 +
@@ -122,16 +111,8 @@ metadata:
   annotations:
     irq-load-balancing.crio.io: disable
     cpu-quota.crio.io: disable
-    k8s.v1.cni.cncf.io/networks: '[
-      {
-       "name": "hwoffload9",
-       "namespace": "default"
-      },
-      {
-       "name": "hwoffload10",
-       "namespace": "default"
-      }
-    ]'
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/hwoffload9
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/hwoffload10
 spec:
   restartPolicy: Never
   containers:

--- a/modules/nw-osp-hardware-offload-attaching-network.adoc
+++ b/modules/nw-osp-hardware-offload-attaching-network.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/network-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="nw-osp-hardware-offload-attaching-network_{context}"]
+= Attaching an OVS hardware offloading network
+
+You can attach an Open vSwitch (OVS) hardware offloading network to your cluster.
+
+.Prerequisites
+
+* Your cluster is installed and running.
+* You provisioned an OVS hardware offloading network on {rh-openstack-first} to use with your cluster. 
+
+.Procedure
+
+. Create a file named `network.yaml` from the following template:
++
+[source,yaml]
+----
+spec:
+  additionalNetworks:
+  - name: hwoffload1
+    namespace: cnf
+    rawCNIConfig: '{ "cniVersion": "0.3.1", "name": "hwoffload1", "type": "host-device","pciBusId": "0000:00:05.0", "ipam": {}}' <1>
+    type: Raw
+----
++
+where:
++
+`pciBusId`:: Specifies the device that is connected to the offloading network. If you do not have it, you can find this value by running the following command:
++
+[source,terminal]
+----
+$ oc describe SriovNetworkNodeState -n openshift-sriov-network-operator
+----
+
+. From a command line, enter the following command to patch your cluster with the file:
++
+[source,terminal]
+----
+$ oc apply -f network.yaml
+----

--- a/modules/nw-sriov-hwol-ref-openstack-sriov-policy.adoc
+++ b/modules/nw-sriov-hwol-ref-openstack-sriov-policy.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * networking/configuring-hardware-offloading.adoc
+
+:_content-type: PROCEDURE
+[id="nw-sriov-hwol-ref-openstack-sriov-policy_{context}"]
+= An example SR-IOV network node policy for OpenStack
+
+The following example describes an SR-IOV interface for a network interface controller (NIC) with hardware offloading on {rh-openstack-first}.
+
+.An SR-IOV interface for a NIC with hardware offloading on {rh-openstack}
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: ${name}
+  namespace: openshift-sriov-network-operator
+spec:
+  deviceType: switchdev 
+  isRdma: true
+  nicSelector:
+    netFilter: openstack/NetworkID:${net_id}
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: 'true'
+  numVfs: 1
+  priority: 99
+  resourceName: ${name}
+----

--- a/networking/hardware_networks/configuring-hardware-offloading.adoc
+++ b/networking/hardware_networks/configuring-hardware-offloading.adoc
@@ -30,6 +30,8 @@ include::modules/nw-sriov-hwol-configuring-machine-config-pool.adoc[leveloffset=
 //Configuring the SR-IOV network node policy
 include::modules/nw-sriov-hwol-creating-sriov-policy.adoc[leveloffset=+1]
 
+include::modules/nw-sriov-hwol-ref-openstack-sriov-policy.adoc[leveloffset=+2]
+
 //Creating a Network Attachment Definition
 include::modules/nw-sriov-hwol-creating-network-attachment-definition.adoc[leveloffset=+1]
 

--- a/post_installation_configuration/network-configuration.adoc
+++ b/post_installation_configuration/network-configuration.adoc
@@ -121,3 +121,4 @@ include::modules/installation-osp-configuring-api-floating-ip.adoc[leveloffset=+
 include::modules/installation-osp-kuryr-port-pools.adoc[leveloffset=+2]
 include::modules/installation-osp-kuryr-settings-active.adoc[leveloffset=+2]
 include::modules/nw-osp-enabling-ovs-offload.adoc[leveloffset=+2]
+include::modules/nw-osp-hardware-offload-attaching-network.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): 4.11+

Issue: [OSDOCS-3506](https://issues.redhat.com//browse/OSDOCS-3506)

Link to docs preview: 
- http://file.rdu.redhat.com/~mbridges/12JUL2022/hw-offload/post_installation_configuration/network-configuration.html#nw-osp-hardware-offload-attaching-network_post-install-network-configuration
- http://file.rdu.redhat.com/~mbridges/12JUL2022/hw-offload/networking/hardware_networks/configuring-hardware-offloading.html#nw-sriov-hwol-ref-openstack-sriov-policy_configuring-hardware-offloading

Preview last updated: Tue Jul 26 03:00:46 PM UTC 2022


TODOs:

- [x] Harmonize with existing HW offloading content
- [x] Rectify w/#46276