### PR TITLE
[BZ#2095782] - Fix tx_timestamp_timeout Value in PTP Documentation for e810

### DIFF
--- a/modules/cnf-configuring-cvl-nic-as-oc.adoc
+++ b/modules/cnf-configuring-cvl-nic-as-oc.adoc
@@ -3,7 +3,7 @@
 // * networking/using-ptp.adoc
 
 :_content-type: PROCEDURE
-[id="cnf-configuring-cvl-nic-as-ptp-slave_{context}"]
+[id="cnf-configuring-cvl-nic-as-oc_{context}"]
 = Configuring linuxptp services as an ordinary clock for Intel Columbiaville NIC
 
 You can configure `linuxptp` services as a single ordinary clock for nodes with an Intel 800-Series Columbiaville NIC installed.
@@ -85,7 +85,7 @@ spec:
       inhibit_multicast_service 0
       net_sync_monitor 0
       tc_spanning_tree 0
-      tx_timestamp_timeout 10
+      tx_timestamp_timeout 50
       unicast_listen 0
       unicast_master_table 0
       unicast_req_duration 3600

--- a/scalability_and_performance/ztp-deploying-disconnected.adoc
+++ b/scalability_and_performance/ztp-deploying-disconnected.adoc
@@ -113,7 +113,7 @@ When changes are pushed to a site configuration repository, GitOps ZTP applies t
 
 .Additional resources
 
-* For a complete `PtpConfig` CR that configures `linuxptp` as an ordinary clock, see xref:../networking/using-ptp.adoc#cnf-configuring-cvl-nic-as-ptp-slave_using-ptp[Configuring linuxptp services as an ordinary clock for Intel Columbiaville NIC].
+* For a complete `PtpConfig` CR that configures `linuxptp` as an ordinary clock, see xref:../networking/using-ptp.adoc#cnf-configuring-cvl-nic-as-oc_using-ptp[Configuring linuxptp services as an ordinary clock for Intel Columbiaville NIC].
 
 * For further information about configuring PTP fast event notifications, see xref:../networking/using-ptp.adoc#cnf-configuring-the-ptp-fast-event-publisher_using-ptp[Configuring PTP fast events].
 


### PR DESCRIPTION
Fixes tx_timestamp_timeout Value in PTP Documentation for e810

Version(s):
enterprise-4.10 

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2095782

Link to docs preview:
http://file.emea.redhat.com/aireilly/bz2095782/networking/using-ptp.html#cnf-configuring-cvl-nic-as-oc_using-ptp