### PR TITLE
Adding values for bypassing admission control

### DIFF
--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -60,13 +60,20 @@ The default value is `false`.
 | Use this parameter to override the default resource requests for the admission controller.
 
 | `admissionControl.bypass`
-| Use this parameter to bypass the admission controller.
+a| Use one of the following values to configure the bypassing of admission controller enforcement:
+
+    * `BreakGlassAnnotation` to enable bypassing the admission controller via the `admission.stackrox.io/break-glass` annotation.
+    * `Disabled` to disable the ability to bypass admission controller enforcement for the secured cluster.
+
+The default value is `BreakGlassAnnotation`.
 
 | `admissionControl.contactImageScanners`
 a| Use one of the following values to specify if the admission controller must connect to the image scanner:
 
     * `ScanIfMissing` if the scan results for the image are missing.
     * `DoNotScanInline` to skip scanning the image when processing the admission request.
+
+The default value is `DoNotScanInline`.
 
 | `admissionControl.timeoutSeconds`
 | Use this parameter to specify the maximum number of seconds {product-title} must wait for an admission review before marking it as fail open.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
RHACS 3.65+ 

Issue:
https://github.com/openshift/openshift-docs/issues/47037

Link to docs preview:
No preview available

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
This PR adds missing valid values for admissionControl.bypass, including default value.

Slightly out of scope, but the PR also adds the default value to admissionControl.contactImageScanners.


<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
