### PR TITLE
ocprhv-694  Preallocating Disks - additions to default install-config.yaml  

### DIFF
--- a/modules/installing-rhv-example-install-config-yaml.adoc
+++ b/modules/installing-rhv-example-install-config-yaml.adoc
@@ -34,13 +34,19 @@ compute:
 - architecture: amd64
   hyperthreading: Enabled
   name: worker
-  platform: {}
+  platform:
+    ovirt:
+      sparse: false <1>
+      format: raw   <2>
   replicas: 3
 controlPlane:
   architecture: amd64
   hyperthreading: Enabled
   name: master
-  platform: {}
+  platform:
+      ovirt:
+        sparse: false <1>
+        format: raw   <2>
   replicas: 3
 metadata:
   creationTimestamp: null
@@ -72,6 +78,13 @@ pullSecret: '{"auths": ...}'
 sshKey: ssh-ed12345 AAAA...
 ----
 
+<1> Setting this option to `false` enables preallocation of disks. The default is `true`. Setting `sparse` to `true` with `format` set to `raw` is not available for block storage domains. The `raw` format writes the entire virtual disk to the underlying physical disk.
+<2> Can be set to `cow` or `raw`. The default is `cow`. The `cow` format is optimized for virtual machines.
++
+[NOTE]
+====
+Preallocating disks on file storage domains writes zeroes to the file. This might not actually preallocate disks depending on the underlying storage.
+====
 
 [discrete]
 == Example minimal `install-config.yaml` file


### PR DESCRIPTION
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): enterprise-4.11
Issue:
[BZ#[2056460](https://bugzilla.redhat.com/show_bug.cgi?id=2056460)]
[[OCPRHV-694](https://issues.redhat.com/browse/OCPRHV-694)]
Preallocating Disks -parameter additions to default install-config.yaml 

Link to docs preview:

http://file.tlv.redhat.com/emarcus/ocprhv-694b/installing/installing_rhv/installing-rhv-customizations.html#installing-rhv-example-install-config-yaml_installing-rhv-customizations


<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
