### PR TITLE
BZ2092859: Change default network name from "red" to "default"

### DIFF
--- a/modules/virt-configuring-masquerade-mode-cli.adoc
+++ b/modules/virt-configuring-masquerade-mode-cli.adoc
@@ -30,16 +30,16 @@ spec:
   domain:
     devices:
       interfaces:
-        - name: red
+        - name: default
           masquerade: {} <1>
           ports: <2>
             - port: 80
   networks:
-  - name: red
+  - name: default
     pod: {}
 ----
-<1> Connect using masquerade mode
-<2> Optional: List the ports that you want to expose from the virtual machine, each specified by the `port` field. The `port` value must be a number between 0 and 65536. When the `ports` array is not used, all ports in the valid range are open to incoming traffic. In this example, incoming traffic is allowed on port 80.
+<1> Connect using masquerade mode.
+<2> Optional: List the ports that you want to expose from the virtual machine, each specified by the `port` field. The `port` value must be a number between 0 and 65536. When the `ports` array is not used, all ports in the valid range are open to incoming traffic. In this example, incoming traffic is allowed on port `80`.
 +
 [NOTE]
 ====

--- a/modules/virt-configuring-masquerade-mode-dual-stack.adoc
+++ b/modules/virt-configuring-masquerade-mode-dual-stack.adoc
@@ -28,12 +28,12 @@ metadata:
   name: example-vm-ipv6
 ...
           interfaces:
-            - name: red
+            - name: default
               masquerade: {} <1>
               ports:
                 - port: 80 <2>
       networks:
-      - name: red
+      - name: default
         pod: {}
       volumes:
       - cloudInitNoCloud:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.6+
<!--- Specify the version or versions of OpenShift your PR applies to.

Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: [BZ2092859](https://bugzilla.redhat.com/show_bug.cgi?id=2092859)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- [Configuring masquerade mode from the command line](http://file.tlv.redhat.com/apinnick/bz2092859-default-network-name/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html#virt-configuring-masquerade-mode-cli_virt-using-the-default-pod-network-with-virt)
- [Configuring masquerade mode with dual-stack (IPv4 and IPv6)](http://file.tlv.redhat.com/apinnick/bz2092859-default-network-name/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html#virt-configuring-masquerade-mode-dual-stack_virt-using-the-default-pod-network-with-virt)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information: No QE required
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
