### PR TITLE
BZ2091546 note added regarding protectKernelDefaults: false

### DIFF
--- a/modules/compliance-apply-remediation-for-customized-mcp.adoc
+++ b/modules/compliance-apply-remediation-for-customized-mcp.adoc
@@ -1,8 +1,13 @@
 :_content-type: PROCEDURE
-[id="complianc-operator-apply-remediation-for-customized-mcp"]
+[id="compliance-operator-apply-remediation-for-customized-mcp"]
 = Applying remediation when using customized machine config pools
 
 When you create a custom `MachineConfigPool`, add a label to the `MachineConfigPool` so that `machineConfigPoolSelector` present in the `KubeletConfig` can match the label with `MachineConfigPool`.
+
+[IMPORTANT]
+====
+Do not set `protectKernelDefaults: false` in the `KubeletConfig` file, because the `MachineConfigPool` object might fail to unpause unexpectedly after the Compliance Operator finishes applying remediation.
+====
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
4.6+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2091546

Link to docs preview:
[Applying remediation when using customized machine config pools
](http://file.rdu.redhat.com/antaylor/06-30-22/bz2091546/security/compliance_operator/compliance-operator-remediation.html#compliance-operator-apply-remediation-for-customized-mcp)

Additional information:
Added an `[IMPORTANT]` note regarding a bug that exists in the Compliance Operator. I worded this specifically to avoid blame or indicate that a fix is in progress. 

I also fixed a typo in the `id=` field. 