### PR TITLE
[OSDOCS-3535] Release note addition for pod security admission

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -712,6 +712,37 @@ Currently, it is not supported to use Microsoft identity platform when group nam
 
 For the full list of OIDC providers, see xref:../authentication/identity_providers/configuring-oidc-identity-provider.adoc#identity-provider-oidc-supported_configuring-oidc-identity-provider[Supported OIDC providers].
 
+[id="ocp-4-11-auth-pod-security-admission"]
+==== Pod security admission
+
+link:https://kubernetes.io/docs/concepts/security/pod-security-admission/[Pod security admission] is now enabled on {product-title}. 
+
+Pod admission is enforced by both pod security and security context constraint (SCC) admissions. Pod security admission runs globally with "privileged" enforcement and "restricted" audit logging and API warnings.
+
+A controller monitors the xref:../authentication/managing-security-context-constraints.adoc[SCC-related permissions] of service accounts in user-created namespaces and automatically labels these namespaces with link:https://kubernetes.io/docs/concepts/security/pod-security-standards/[pod security admission] `warn` and `audit` labels.
+
+To improve workload security in accordance with the "restricted" pod security profile, this release introduces SCCs that enforce pod security in accordance with new pod security admission controls. These SCCs are:
+
+* `restricted-v2`
+* `hostnetwork-v2`
+* `nonroot-v2`
+
+They correspond to older, similarly named SCCs, but with the following enhancements:
+
+* `ALL` capabilities are dropped from containers. Previously, only the `KILL`, `MKNOD`, `SETUID`, and `SETGID` capabilities were dropped.
+* The `NET_BIND_SERVICE` capability can now be added explicitly.
+* `seccompProfile` is defaulted to `runtime/default` if unset. In previous releases, this field had to be empty.
+* `allowPrivilegeEscalation` must be unset or set to `false` in security contexts. Previously, a `true` value was allowed.
+
+New clusters allow use of the `restricted-v2` SCC for any authenticated user in place of the `restricted` SCC; the `restricted` SCC is no longer available to users of new clusters, unless the access is explicitly granted. Clusters that are upgraded to 4.11 from previous versions allow both `restricted-v2` and `restricted` SCCs. 
+
+You can enable synchronization for most namespaces and disable synchronization for all namespaces. 
+
+For this release, namespaces that are prefixed with `openshift-` will not have restricted enforcement. Restricted enforcement for such namespaces is planned for inclusion in a future release.
+
+// TODO: Add anchor
+// For more information, see xref:../authentication/managing-and-understanding-pod-security-admission.adoc[Understanding and managing pod security admission].
+
 [id="ocp-4-11-notable-technical-changes"]
 == Notable technical changes
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.11


Issue:
[OSDOCS-3535](https://issues.redhat.com//browse/OSDOCS-3535)

Link to docs preview: http://file.rdu.redhat.com/~mbridges/auth-133-rn/release_notes/ocp-4-11-release-notes.html#ocp-4-11-auth-pod-security-admission

Last updated: Mon Jul 25 09:27:47 PM UTC 2022



