### PR TITLE
4.11 Release notes stub

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -141,6 +141,11 @@ For more information, see xref:../installing/installing_bare_metal_ipi/ipi-insta
 [id="ocp-4-11-security"]
 === Security and compliance
 
+[id="ocp-4-11-fedramp-high"]
+==== FedRAMP high SCAP profile
+
+The FedRAMP high SCAP profile is now available for use in {product-title} environments. For more information, See xref:../security/compliance_operator/compliance-operator-supported-profiles.adoc[Supported compliance profiles].
+
 [id="ocp-4-11-networking"]
 === Networking
 ==== New option for Ingress Controllers with the hostnetwork endpoint
@@ -1020,6 +1025,8 @@ This script removes unauthenticated subjects from the following cluster role bin
 
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
+
+* When using Nutanix volumes as the default storage class on a Nutanix cluster, the raw results can only be stored on the worker nodes for Compliance Operator scans. Raw results cannot be stored on the master nodes due to a Nutanix driver limitation that adds master nodes as csinodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2099287[*BZ#2099287*])
 
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Update per https://github.com/openshift/openshift-docs/issues/43249#issuecomment-1157438812

Version(s):
4.11 only

Issue:
https://github.com/openshift/openshift-docs/issues/43249#issuecomment-1157438812

Link to docs preview:
[FedRAMP High SCAP profile](http://file.rdu.redhat.com/antaylor/06-28-22/4.11RNs/release_notes/ocp-4-11-release-notes.html#ocp-4-11-fedramp-high)

[Known Issues](http://file.rdu.redhat.com/antaylor/06-28-22/4.11RNs/release_notes/ocp-4-11-release-notes.html#ocp-4-11-known-issues)

Additional information:
This update applies to 4.11 only and includes the FedRAMP High profile in the "new features and enhancements" section. This section cross references the Supported Compliance Operator profiles table, which will be merged separately: https://github.com/openshift/openshift-docs/pull/47169
     Those changes are made against the main branch so they are available in future releases and the pull request will be merged when the final Operator release version is available. 
     
I also added a bug to the known issue section of the release notes.