### PR TITLE
RHDEVDOCS-4137 - Added 1.5.1 and 1.5.2 release notes

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,6 +23,10 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-5-2.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-5-1.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-5-0.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-4-6.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-5-1.adoc
+++ b/modules/gitops-release-notes-1-5-1.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-5-1_{context}"]
+= Release notes for {gitops-title} 1.5.1
+
+{gitops-title} 1.5.1 is now available on {product-title} 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-5-1_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, if Argo CD's anonymous access was enabled, an unauthenticated user was able to craft a JWT token and get full access to the Argo CD instance. This issue is fixed now. link:https://bugzilla.redhat.com/show_bug.cgi?id=2081686[CVE-2022-29165]
+
+* Before this update, an unauthenticated user was able to display error messages on the login screen while SSO was enabled. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2081689[CVE-2022-24905] 
+
+* Before this update, all unpatched versions of Argo CD v7.0 and later were vulnerable to a symlink-following bug. As a result, an unauthorized user with repository write access would be able to leak sensitive files from Argo CD's repo-server. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2081686[CVE-2022-24904]

--- a/modules/gitops-release-notes-1-5-2.adoc
+++ b/modules/gitops-release-notes-1-5-2.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-5-2_{context}"]
+= Release notes for {gitops-title} 1.5.2
+
+{gitops-title} 1.5.2 is now available on {product-title} 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-5-2_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, images referenced by the `redhat-operator-index` were missing. This issue is now fixed.  link:https://issues.redhat.com/browse/GITOPS-2036[GITOPS-2036]


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.10, 4.11

JIRA issue:
https://issues.redhat.com/browse/RHDEVDOCS-4137

Preview pages: No preview generated due to Netlify issues.

SME review: @iam-veeramalla 
Peer-review: @rolfedh 
QE review: @varshab1210 