### PR TITLE
Fix level headings

### DIFF
--- a/serverless/admin_guide/serverless-ha.adoc
+++ b/serverless/admin_guide/serverless-ha.adoc
@@ -11,6 +11,6 @@ High availability (HA) is a standard feature of Kubernetes APIs that helps to en
 HA in {ServerlessProductName} is available through leader election, which is enabled by default after the Knative Serving or Eventing control plane is installed. When using a leader election HA pattern, instances of controllers are already scheduled and running inside the cluster before they are required.
 These controller instances compete to use a shared resource, known as the leader election lock. The instance of the controller that has access to the leader election lock resource at any given time is called the leader.
 
-include::modules/serverless-config-replicas-serving.adoc[leveloffset=+2]
-include::modules/serverless-config-replicas-eventing.adoc[leveloffset=+2]
-include::modules/serverless-config-replicas-kafka.adoc[leveloffset=+2]
+include::modules/serverless-config-replicas-serving.adoc[leveloffset=+1]
+include::modules/serverless-config-replicas-eventing.adoc[leveloffset=+1]
+include::modules/serverless-config-replicas-kafka.adoc[leveloffset=+1]


### PR DESCRIPTION
No Jira for this one - incorrect level headings were causing the builds to throw errors.

Applies for OCP 4.6+