### PR TITLE
BZ1960690 - Booting the image with virtual media doesn't work

### DIFF
--- a/modules/ipi-install-node-requirements.adoc
+++ b/modules/ipi-install-node-requirements.adoc
@@ -3,7 +3,7 @@
 // * installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
 
 :_content-type: CONCEPT
-[id="node-requirements_{context}"'"]
+[id="node-requirements_{context}"]
 = Node requirements
 
 Installer-provisioned installation involves a number of hardware node requirements:
@@ -36,7 +36,12 @@ Do not deploy a cluster with only one worker node, because the cluster will depl
 
 * *Network interfaces:* Each node must have at least one network interface for the routable `baremetal` network. Each node must have one network interface for a `provisioning` network when using the `provisioning` network for deployment. Using the `provisioning` network is the default configuration.
 
-* *Unified extensible firmware interface (UEFI):* Installer-provisioned installation requires UEFI boot on all {product-title} nodes when using IPv6 addressing on the `provisioning` network. In addition, UEFI Device PXE Settings must be set to use the IPv6 protocol on the `provisioning` network NIC, but omitting the `provisioning` network removes this requirement.
+* *Unified Extensible Firmware Interface (UEFI):* Installer-provisioned installation requires UEFI boot on all {product-title} nodes when using IPv6 addressing on the `provisioning` network. In addition, UEFI Device PXE Settings must be set to use the IPv6 protocol on the `provisioning` network NIC, but omitting the `provisioning` network removes this requirement.
++
+[IMPORTANT]
+====
+When starting the installation from virtual media such as an ISO image, delete all old UEFI boot table entries. If the boot table includes entries that are not generic entries provided by the firmware, the installation might fail.
+====
 
 * *Secure Boot:* Many production scenarios require nodes with Secure Boot enabled to verify the node only boots with trusted software, such as UEFI firmware drivers, EFI applications, and the operating system. You may deploy with Secure Boot manually or managed.
 +


### PR DESCRIPTION
BZ-1960690 - Delete all old UEFI boot table entries that reference the CDROM, if installing from virtual media. 


Version(s):
main, 4.11, 4.10, 4.9, 4.8, 4.7

Issue:
(https://bugzilla.redhat.com/show_bug.cgi?id=1960690)

Link to docs preview:
(http://file.emea.redhat.com/tshwartz/BZ-1960690/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html)

