### PR TITLE
BZ-2100612: Updated ASH GA release note with new disk type support

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -177,6 +177,10 @@ If your cluster is deployed on vSphere, and the preceding components are lower t
 
 {product-title} {product-version} introduces support for installing a cluster on Azure Stack Hub using installer-provisioned infrastructure. This type of installation lets you use the installation program to deploy a cluster on infrastructure that the installation program provisions and the cluster maintains.
 
+[NOTE]
+====
+Beginning with {product-title} 4.10.14, you can deploy control plane and compute nodes with the `premium_LRS`, `standardSSD_LRS`, or `standard_LRS` disk type. By default, the installation program deploys control plane and compute nodes with the `premium_LRS` disk type. In earlier 4.10 releases, only the `standard_LRS` disk type was supported.
+====
 For more information, see xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc#installing-azure-stack-hub-default[Installing a cluster on Azure Stack Hub with an installer-provisioned infrastructure].
 
 [id="ocp-4-10-conditional-updates"]
@@ -2914,6 +2918,10 @@ For more information, see xref:../updating/preparing-eus-eus-upgrade.adoc[Prepar
 ===== General availability of the Web Terminal Operator
 
 With this update, the link:https://docs.openshift.com/container-platform/4.10/web_console/odc-about-web-terminal.html[*Web Terminal Operator*] is now generally available.
+
+[id="ocp-4-10-14-aws-disk-types"]
+===== Support for the AWS premium_LRS and standardSSD_LRS disk types
+With this update, you can deploy control plane and compute nodes with the `premium_LRS`, `standardSSD_LRS`, or `standard_LRS` disk type. By default, the installation program deploys control plane and compute nodes with the `premium_LRS` disk type. In earlier 4.10 releases, only the `standard_LRS` disk type was supported. (https://bugzilla.redhat.com/show_bug.cgi?id=2079589[*BZ#2079589*])
 
 [id="ocp-4-10-14-updating"]
 ==== Updating


### PR DESCRIPTION
Version(s):
CP to 4.10

Issue:
This is the first of two PRs[1] that address BZ [2100612](https://bugzilla.redhat.com/show_bug.cgi?id=2100612). This PR updates the 4.10 release notes to declare ASH support of two additional disk types beginning with 4.10.14.

Link to docs preview:
[Installing a cluster on Microsoft Azure Stack Hub using installer-provisioned infrastructure](http://file.rdu.redhat.com/mpytlak/bz2100612-rn/release_notes/ocp-4-10-release-notes.html#ocp-4-10-installation-and-upgrade-ash-ipi)

Additional information:
ASH install doc updates: https://github.com/openshift/openshift-docs/pull/47247
