### PR TITLE
OSDOCS-3644 Installer allows users to select optional components

### DIFF
--- a/modules/installation-alibaba-config-yaml.adoc
+++ b/modules/installation-alibaba-config-yaml.adoc
@@ -52,6 +52,10 @@ publish: External
 pullSecret: '{"auths": {"cloud.openshift.com": {"auth": ... }' <5>
 sshKey: |
   ssh-rsa AAAA... <6>
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----
 <1> Required. The installation program prompts you for a cluster name.
 <2> Optional. Specify parameters for machine pools that do not define their own platform configuration.

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -273,7 +273,10 @@ imageContentSources: <15>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 endif::restricted[]
-
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 
 ----
 ifndef::gov,secret,china[]

--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -164,6 +164,10 @@ ifdef::openshift-origin[]
 publish: Internal <16>
 endif::openshift-origin[]
 endif::gov[]
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----
 ifndef::gov[]
 <1> Required. The installation program prompts you for this value.

--- a/modules/installation-azure-stack-hub-config-yaml.adoc
+++ b/modules/installation-azure-stack-hub-config-yaml.adoc
@@ -75,6 +75,10 @@ additionalTrustBundle: | <9>
     -----END CERTIFICATE-----
 sshKey: ssh-ed25519 AAAA... <10>
 endif::openshift-origin[]
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----
 <1> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
 <2> Specify the name of the cluster.
@@ -160,6 +164,10 @@ endif::openshift-origin[]
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
+capabilities:
+    baselineCapabilitySet: None
+    additionalEnabledCapabilities:
+    - openshift-samples
 ----
 <1> Required.
 <2> If you do not provide these parameters and values, the installation program provides the default value.

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -205,6 +205,10 @@ ifndef::ibm-z,ibm-z-kvm[]
 endif::ibm-z,ibm-z-kvm[]
 endif::openshift-origin[]
 endif::restricted[]
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
 <2> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -473,6 +473,18 @@ Optional installation configuration parameters are described in the following ta
 |A PEM-encoded X.509 certificate bundle that is added to the nodes' trusted certificate store. This trust bundle may also be used when a proxy has been configured.
 |String
 
+|`capabilities`
+|Controls the installation of optional core cluster components. You can reduce the footprint of your {product-title} cluster by disabling optional components.
+|String array
+
+|`capabilities.baselineCapabilitySet`
+|Selects an initial set of optional capabilities to enable. Valid values are `None`, `v4.11` and `vCurrent`. `v4.11` enables the `baremetal` Operator, the `marketplace` Operator, and the `openshift-samples` content. `vCurrent` installs the recommended set of capabilities for the current version of {product-title}. The default value is `vCurrent`.
+|String
+
+|`capabilities.additionalEnabledCapabilities`
+|Extends the set of optional capabilities beyond what you specify in `baselineCapabilitySet`. Valid values are `baremetal`, `marketplace` and `openshift-samples`. You may specify multiple capabilities in this parameter.
+|String array
+
 |`cgroupsV2`
 |Enables link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control groups version 2] (cgroups v2) on specific nodes in your cluster. The {product-title} process for enabling cgroups v2 disables all cgroup version 1 controllers and hierarchies. The {product-title} cgroups version 2 feature is in Developer Preview and is not supported by Red Hat at this time.
 |`true`

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -174,6 +174,10 @@ imageContentSources: <12>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 endif::restricted[]
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----
 <1> Required. The installation program prompts you for this value.
 <2> If you do not provide these parameters and values, the installation program provides the default value.

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -66,6 +66,10 @@ ifdef::openshift-origin[]
 sshKey: ssh-ed25519 AAAA... <7>
 publish: Internal <8>
 endif::openshift-origin[]
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----
 <1> Specify the public DNS on the host project.
 <2> If you do not provide these parameters and values, the installation program provides the default value.

--- a/modules/installation-ibm-cloud-config-yaml.adoc
+++ b/modules/installation-ibm-cloud-config-yaml.adoc
@@ -71,6 +71,10 @@ endif::openshift-origin[]
 ifdef::openshift-origin[]
 sshKey: ssh-ed25519 AAAA... <5>
 endif::openshift-origin[]
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----
 <1> Required. The installation program prompts you for this value.
 <2> If you do not provide these parameters and values, the installation program provides the default value.

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -111,6 +111,10 @@ imageContentSources: <12>
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::restricted[]
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this
 base and include the cluster name.

--- a/modules/installation-osp-config-yaml.adoc
+++ b/modules/installation-osp-config-yaml.adoc
@@ -54,4 +54,8 @@ fips: false
 endif::openshift-origin[]
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----

--- a/modules/installation-osp-kuryr-config-yaml.adoc
+++ b/modules/installation-osp-kuryr-config-yaml.adoc
@@ -52,6 +52,10 @@ platform:
     octaviaSupport: true <2>
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----
 <1> The Amphora Octavia driver creates two ports per load balancer. As a
 result, the service subnet that the installer creates is twice the size of the

--- a/modules/installation-osp-restricted-config-yaml.adoc
+++ b/modules/installation-osp-restricted-config-yaml.adoc
@@ -71,4 +71,8 @@ imageContentSources:
 - mirrors:
   - <mirror_registry>/<repo_name>/release
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -99,6 +99,10 @@ imageContentSources: <18>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 endif::restricted[]
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this
 base and include the cluster name.

--- a/modules/installing-rhv-example-install-config-yaml.adoc
+++ b/modules/installing-rhv-example-install-config-yaml.adoc
@@ -70,6 +70,10 @@ platform:
 publish: External
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed12345 AAAA...
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
 ----
 
 


### PR DESCRIPTION
[OSDOCS-3644](https://issues.redhat.com//browse/OSDOCS-3644): Installer allows users to select optional components
PR applies to 4.11
https://issues.redhat.com/browse/OSDOCS-3644
[Doc preview - config parameters table](https://bscott-rh.github.io/openshift-docs/OSDOCS-3644/installing/installing_gcp/installing-gcp-customizations.html#installation-configuration-parameters-optional_installing-gcp-customizations)
[Doc preview - sample install-config.yaml file](https://bscott-rh.github.io/openshift-docs/OSDOCS-3644/installing/installing_gcp/installing-gcp-customizations.html#installation-gcp-config-yaml_installing-gcp-customizations)