### PR TITLE
CNV-18642: Quick Start updates

### DIFF
--- a/modules/virt-creating-vm-quick-start-web.adoc
+++ b/modules/virt-creating-vm-quick-start-web.adoc
@@ -10,12 +10,6 @@ The web console provides Quick Starts with instructional guided tours for creati
 
 Tasks in a Quick Start begin with selecting a Red Hat template. Then, you can add a boot source and import the operating system image. Finally, you can save the custom template and use it to create a virtual machine.
 
-Quick Start tours for creating virtual machines include the following:
-
-* Creating a Red Hat Enterprise Linux virtual machine
-* Creating a Windows 10 virtual machine
-* Importing a VMWare virtual machine
-
 .Prerequisites
 * Access to the website where you can download the URL link for the operating system image.
 

--- a/virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.adoc
@@ -10,6 +10,10 @@ A boot source contains a bootable operating system (OS) and all of the configura
 
 You use a boot source to create virtual machine templates with specific configurations. These templates can be used to create any number of available virtual machines.
 
+Quick Start tours are available in the {product-title} web console to assist you in working with boot sources. 
+
+* Uploading boot sources
+
 include::modules/virt-about-vms-and-boot-sources.adoc[leveloffset=+1]
 
 include::modules/virt-importing-rhel-image-boot-source-web.adoc[leveloffset=+1]

--- a/virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.adoc
@@ -10,9 +10,7 @@ A boot source contains a bootable operating system (OS) and all of the configura
 
 You use a boot source to create virtual machine templates with specific configurations. These templates can be used to create any number of available virtual machines.
 
-Quick Start tours are available in the {product-title} web console to assist you in working with boot sources. 
-
-* Uploading boot sources
+Quick Start tours are available in the {product-title} web console to assist you in working with boot sources.
 
 include::modules/virt-about-vms-and-boot-sources.adoc[leveloffset=+1]
 


### PR DESCRIPTION
For 4.11 only

Jira: https://issues.redhat.com/browse/CNV-18642

Direct doc preview links:

- http://file.rdu.redhat.com/bgaydos/CNV-18642/virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.html (see bottom above Additional Resources)
-  http://file.rdu.redhat.com/bgaydos/CNV-18642/virt/virtual_machines/virt-create-vms.html

@apinnick - For Code Review and merge pick. No QE needed.

Avital, if we need to remove the import Quick Start reference back a few more releases, let me know and I will simply create another very small PR to backport those removals as Upload Boot Sources is 4.11 only.