### PR TITLE
Allow more leeway to writers when constructing step commands 

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -940,12 +940,12 @@ This renders as:
 The following guidelines go into more detail about specific requirements and
 recommendations when using code blocks:
 
-* If a step in a procedure is to run a command, make sure that the step
-text includes an explicit instruction to "run" or "enter" the command. In most cases,
-use one of the following patterns to introduce the code block:
+* If a step in a procedure is to run a command, make sure that the step text includes either an explicit instruction to "run" or "enter" the command, or a verb such as "check" or "add" to apply to the object of the command. In most cases, use one of the following patterns to introduce the code block:
 
 ** <Step description>, run the following command:
 ** <Step description>, enter the following command:
+
+In procedures with a number of short steps containing successive commands, you do not need to add "run" or "enter" instructions for every command.
 
 * Do NOT use any markup in code blocks; code blocks generally do not accept any markup.
 

--- a/migrating_from_ocp_3_to_4/upgrading-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/upgrading-3-4.adoc
@@ -19,4 +19,5 @@ If you are upgrading from {mtc-short} version 1.3, you must perform an additiona
 include::modules/migration-upgrading-mtc-on-ocp-4.adoc[leveloffset=+1]
 include::modules/migration-upgrading-mtc-with-legacy-operator.adoc[leveloffset=+1]
 include::modules/migration-upgrading-from-mtc-1-3.adoc[leveloffset=+1]
+
 :upgrading-3-4!:

--- a/modules/migration-upgrading-mtc-with-legacy-operator.adoc
+++ b/modules/migration-upgrading-mtc-with-legacy-operator.adoc
@@ -24,7 +24,7 @@ endif::[]
 
 .Procedure
 
-. Log in to `registry.redhat.io` with your Red Hat Customer Portal credentials:
+. Log in to `registry.redhat.io` with your Red Hat Customer Portal credentials by running the following command:
 +
 [source,terminal]
 ----
@@ -49,35 +49,35 @@ $ sudo podman cp $(sudo podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/operator.yml ./
 ----
 
-. Replace the {mtc-full} Operator:
+. Replace the {mtc-full} Operator by running the following command:
 +
 [source,terminal]
 ----
 $ oc replace --force -f operator.yml
 ----
 
-. Scale the `migration-operator` deployment to `0` to stop the deployment:
+. Scale the `migration-operator` deployment to `0` to stop the deployment by running the following command:
 +
 [source,terminal]
 ----
 $ oc scale -n openshift-migration --replicas=0 deployment/migration-operator
 ----
 
-. Scale the `migration-operator` deployment to `1` to start the deployment and apply the changes:
+. Scale the `migration-operator` deployment to `1` to start the deployment and apply the changes. Run the following command:
 +
 [source,terminal]
 ----
 $ oc scale -n openshift-migration --replicas=1 deployment/migration-operator
 ----
 
-. Verify that the `migration-operator` was upgraded:
+. Verify that the `migration-operator` was upgraded by running the following command:
 +
 [source,terminal]
 ----
 $ oc -o yaml -n openshift-migration get deployment/migration-operator | grep image: | awk -F ":" '{ print $NF }'
 ----
 
-. Download the `controller.yml` file:
+. Download the `controller.yml` file by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -85,7 +85,7 @@ $ sudo podman cp $(sudo podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/controller.yml ./
 ----
 
-. Create the `migration-controller` object:
+. Create the `migration-controller` object by running the following command:
 +
 [source,terminal]
 ----
@@ -95,7 +95,7 @@ $ oc create -f controller.yml
 ifdef::upgrading-3-4[]
 . If you have previously added the {product-title} 3 cluster to the {mtc-short} web console, you must update the service account token in the web console because the upgrade process deletes and restores the `openshift-migration` namespace:
 
-.. Obtain the service account token:
+.. Obtain the service account token by running the following command:
 +
 [source,terminal]
 ----
@@ -108,7 +108,7 @@ $ oc sa get-token migration-controller -n openshift-migration
 .. Click *Update cluster* and then click *Close*.
 endif::[]
 
-. Verify that the {mtc-short} pods are running:
+. Verify that the {mtc-short} pods are running by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
The current OCP and ISG guidance is to include the word "command" and an accompanying verb for every step that includes a command. In my opinion, this is overly prescriptive and goes against minimalism principles. 

There is wide divergence in peer reviews in applying this directive. Some reviewers recommend you apply the ISG to the letter, others do not. 

For current guidance, see: 
* [ibm.com/docs/en/ibm-style](https://www.ibm.com/docs/en/ibm-style?topic=elements-commands#commands-parameters-and-options-in-instructions) and 
* [contributing_to_docs/doc_guidelines.adoc](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#code-blocks-command-syntax-and-example-output)

This PR suggests an update to the OCP style guide that allows more leeway for writers in how they construct the step command sentence.

[This example preview](http://file.emea.redhat.com/aireilly/update-step-command/migrating_from_ocp_3_to_4/upgrading-3-4.html#migration-upgrading-mtc-with-legacy-operator_upgrading-3-4) illustrates how applying the current guidance to every step command results is a repetitive and overly verbose procedure.<sup>*</sup>

<sup>*</sup>Example will be removed before merge.