### PR TITLE
RHDEVDOCS-4208 - Added release notes for 1.5.3 and 1.5.4

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,6 +23,10 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-5-4.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-5-3.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-5-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-5-1.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-5-1.adoc
+++ b/modules/gitops-release-notes-1-5-1.adoc
@@ -18,4 +18,4 @@ The following issues have been resolved in the current release:
 
 * Before this update, an unauthenticated user was able to display error messages on the login screen while SSO was enabled. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2081689[CVE-2022-24905] 
 
-* Before this update, all unpatched versions of Argo CD v7.0 and later were vulnerable to a symlink-following bug. As a result, an unauthorized user with repository write access would be able to leak sensitive files from Argo CD's repo-server. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2081686[CVE-2022-24904]
+* Before this update, all unpatched versions of Argo CD v0.7.0 and later were vulnerable to a symlink-following bug. As a result, an unauthorized user with repository write access would be able to leak sensitive files from Argo CD's repo-server. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2081686[CVE-2022-24904]

--- a/modules/gitops-release-notes-1-5-3.adoc
+++ b/modules/gitops-release-notes-1-5-3.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-5-3_{context}"]
+= Release notes for {gitops-title} 1.5.3
+
+{gitops-title} 1.5.3 is now available on {product-title} 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-5-3_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, all unpatched versions of Argo CD v1.0.0 and later were vulnerable to a cross-site scripting bug. As a result, an unauthorized user would be able to inject a javascript link in the UI. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2096278[CVE-2022-31035]
+
+* Before this update, all versions of Argo CD v0.11.0 and later were vulnerable to multiple attacks when SSO login was initiated from the Argo CD CLI or the UI. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2096282[CVE-2022-31034]
+
+* Before this update, all unpatched versions of Argo CD v0.7 and later were vulnerable to a memory consumption bug. As a result, an unauthorized user would be able to crash the Argo CD's repo-server. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2096283[CVE-2022-31016]
+
+* Before this update, all unpatched versions of Argo CD v1.3.0 and later were vulnerable to a symlink-following bug. As a result, an unauthorized user with repository write access would be able to leak sensitive YAML files from Argo CD's repo-server. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2096291[CVE-2022-31036]

--- a/modules/gitops-release-notes-1-5-4.adoc
+++ b/modules/gitops-release-notes-1-5-4.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-5-4_{context}"]
+= Release notes for {gitops-title} 1.5.4
+
+{gitops-title} 1.5.4 is now available on {product-title} 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-5-4_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, the {gitops-title} was using an older version of the *REDIS 5* image tag. This update fixes the issue and upgrades the `rhel8/redis-5` image tag. link:https://issues.redhat.com/browse/GITOPS-2037[GITOPS-2037]


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.10, 4.11

JIRA issue:
https://issues.redhat.com/browse/RHDEVDOCS-4208

Preview pages: No preview generated due to Netlify issues.

SME review: @wtam2018 @jannfis 
Peer-review:  @rolfedh 
QE review: @rjeczkow @varshab1210