### PR TITLE
Fixing a command in the 4.7 branch so that it uses fluentd and not co…

### DIFF
--- a/modules/cluster-logging-forwarding-json-logs-to-the-default-elasticsearch.adoc
+++ b/modules/cluster-logging-forwarding-json-logs-to-the-default-elasticsearch.adoc
@@ -52,5 +52,5 @@ The Red Hat OpenShift Logging Operator redeploys the Fluentd pods. However, if t
 +
 [source,terminal]
 ----
-$ oc delete pod --selector logging-infra=collector
+$ oc delete pod --selector logging-infra=fluentd
 ----


### PR DESCRIPTION
Reverts 4.7 instance of https://github.com/openshift/openshift-docs/pull/46618. 

For 4.7 only. 

QE approved.

Preview:

![image](https://user-images.githubusercontent.com/77019920/176446827-1d72980b-76ee-4795-9baf-01bdebf83ef1.png)


Can be merged upon approval. 