### PR TITLE
Removing space in shutdown command

### DIFF
--- a/modules/graceful-shutdown.adoc
+++ b/modules/graceful-shutdown.adoc
@@ -42,7 +42,7 @@ $ oc -n openshift-kube-apiserver-operator get secret kube-apiserver-to-kubelet-s
 +
 [source,terminal]
 ----
-$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1 ; done <1>
+$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1; done <1>
 ----
 <1> `-h 1` indicates how long, in minutes, this process lasts before the control-plane nodes are shut down. For large-scale clusters with 10 nodes or more, set to 10 minutes or longer to make sure all the compute nodes have time to shut down first.
 +


### PR DESCRIPTION
This applies to `main`, `enterprise-4.11`, `enterprise-4.10`, `enterprise-4.9`, `enterprise-4.8` and `enterprise-4.7`.

The same change was applied to `enterprise-4.6` in https://github.com/openshift/openshift-docs/pull/46814. This PR updates the 4.7+ documentation to provide consistency between the releases.

The preview is [here](http://file.fab.redhat.com/~pneedle/pr47241/graceful-cluster-shutdown.html#graceful-shutdown_graceful-shutdown-cluster).