### PR TITLE
BZ-2100612: Updated ASH install doc in support of premium_LRS and standardSSD_LRS disk types

### DIFF
--- a/modules/installation-azure-stack-hub-config-yaml.adoc
+++ b/modules/installation-azure-stack-hub-config-yaml.adoc
@@ -30,13 +30,22 @@ apiVersion: v1
 baseDomain: example.com
 controlPlane: <1>
   name: master
+  platform:
+    azure:
+      osDisk:
+        diskSizeGB: 1024 <2>
+        diskType: premium_LRS
   replicas: 3
 compute: <1>
 - name: worker
-  platform: {}
+  platform:
+    azure:
+      osDisk:
+        diskSizeGB: 512 <2>
+        diskType: premium_LRS
   replicas: 0
 metadata:
-  name: test-cluster <2>
+  name: test-cluster <3>
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
@@ -53,50 +62,51 @@ endif::openshift-origin[]
   - 172.30.0.0/16
 platform:
   azure:
-    armEndpoint: azurestack_arm_endpoint <3>
-    baseDomainResourceGroupName: resource_group <4>
-    region: azure_stack_local_region <5>
-    resourceGroupName: existing_resource_group <6>
+    armEndpoint: azurestack_arm_endpoint <4>
+    baseDomainResourceGroupName: resource_group <5>
+    region: azure_stack_local_region <6>
+    resourceGroupName: existing_resource_group <7>
     outboundType: Loadbalancer
-    cloudName: AzureStackCloud <7>
-pullSecret: '{"auths": ...}' <8>
+    cloudName: AzureStackCloud <8>
+pullSecret: '{"auths": ...}' <9>
 ifndef::openshift-origin[]
-fips: false <9>
+fips: false <10>
+additionalTrustBundle: | <11>
+    -----BEGIN CERTIFICATE-----
+    <MY_TRUSTED_CA_CERT>
+    -----END CERTIFICATE-----
+sshKey: ssh-ed25519 AAAA... <12>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
 additionalTrustBundle: | <10>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
 sshKey: ssh-ed25519 AAAA... <11>
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-additionalTrustBundle: | <9>
-    -----BEGIN CERTIFICATE-----
-    <MY_TRUSTED_CA_CERT>
-    -----END CERTIFICATE-----
-sshKey: ssh-ed25519 AAAA... <10>
-endif::openshift-origin[]
 ----
 <1> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
-<2> Specify the name of the cluster.
-<3> Specify the Azure Resource Manager endpoint that your Azure Stack Hub operator provides.
-<4> Specify the name of the resource group that contains the DNS zone for your base domain.
-<5> Specify the name of your Azure Stack Hub local region.
-<6> Specify the name of an already existing resource group to install your cluster to. If undefined, a new resource group is created for the cluster.
-<7> Specify the Azure Stack Hub environment as your target platform.
-<8> Specify the pull secret required to authenticate your cluster.
+<2> You can specify the size of the disk to use in GB. Minimum recommendation for control plane nodes is 1024 GB.
+<3> Specify the name of the cluster.
+<4> Specify the Azure Resource Manager endpoint that your Azure Stack Hub operator provides.
+<5> Specify the name of the resource group that contains the DNS zone for your base domain.
+<6> Specify the name of your Azure Stack Hub local region.
+<7> Specify the name of an already existing resource group to install your cluster to. If undefined, a new resource group is created for the cluster.
+<8> Specify the Azure Stack Hub environment as your target platform.
+<9> Specify the pull secret required to authenticate your cluster.
 ifndef::openshift-origin[]
-<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<10> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
-<10> If your Azure Stack Hub environment uses an internal certificate authority (CA), add the necessary certificate bundle in `.pem` format.
-<11> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<11> If your Azure Stack Hub environment uses an internal certificate authority (CA), add the necessary certificate bundle in `.pem` format.
+<12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<9> If your Azure Stack Hub environment uses an internal certificate authority (CA), add the necessary certificate bundle in `.pem` format.
-<10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<10> If your Azure Stack Hub environment uses an internal certificate authority (CA), add the necessary certificate bundle in `.pem` format.
+<11> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 +
 [NOTE]
@@ -113,13 +123,22 @@ baseDomain: example.com <1>
 credentialsMode: Manual
 controlPlane: <2> <3>
   name: master
+  platform:
+    azure:
+      osDisk:
+        diskSizeGB: 1024 <4>
+        diskType: premium_LRS
   replicas: 3
 compute: <2>
 - name: worker
-  platform: {}
+  platform:
+    azure:
+      osDisk:
+        diskSizeGB: 512 <4>
+        diskType: premium_LRS
   replicas: 3
 metadata:
-  name: test-cluster <1> <4>
+  name: test-cluster <1> <5>
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
@@ -136,26 +155,26 @@ endif::openshift-origin[]
   - 172.30.0.0/16
 platform:
   azure:
-    armEndpoint: azurestack_arm_endpoint <1> <5>
-    baseDomainResourceGroupName: resource_group <1> <6>
-    region: azure_stack_local_region <1> <7>
-    resourceGroupName: existing_resource_group <8>
+    armEndpoint: azurestack_arm_endpoint <1> <6>
+    baseDomainResourceGroupName: resource_group <1> <7>
+    region: azure_stack_local_region <1> <8>
+    resourceGroupName: existing_resource_group <9>
     outboundType: Loadbalancer
     cloudName: AzureStackCloud <1>
-    clusterOSimage: https://vhdsa.blob.example.example.com/vhd/rhcos-410.84.202112040202-0-azurestack.x86_64.vhd <1> <9>
-pullSecret: '{"auths": ...}' <1> <10>
+    clusterOSimage: https://vhdsa.blob.example.example.com/vhd/rhcos-410.84.202112040202-0-azurestack.x86_64.vhd <1> <10>
+pullSecret: '{"auths": ...}' <1> <11>
 ifndef::openshift-origin[]
-fips: false <11>
-sshKey: ssh-ed25519 AAAA... <12>
+fips: false <12>
+sshKey: ssh-ed25519 AAAA... <13>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA...<11>
+sshKey: ssh-ed25519 AAAA...<12>
 endif::openshift-origin[]
 ifndef::openshift-origin[]
+additionalTrustBundle: | <14>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
 additionalTrustBundle: | <13>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-additionalTrustBundle: | <12>
 endif::openshift-origin[]
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
@@ -164,24 +183,25 @@ endif::openshift-origin[]
 <1> Required.
 <2> If you do not provide these parameters and values, the installation program provides the default value.
 <3> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
-<4> The name of the cluster.
-<5> The Azure Resource Manager endpoint that your Azure Stack Hub operator provides.
-<6> The name of the resource group that contains the DNS zone for your base domain.
-<7> The name of your Azure Stack Hub local region.
-<8> The name of an existing resource group to install your cluster to. If undefined, a new resource group is created for the cluster.
-<9> The URL of a storage blob in the Azure Stack environment that contains an {op-system} VHD.
-<10> The pull secret required to authenticate your cluster.
+<4> You can specify the size of the disk to use in GB. Minimum recommendation for control plane nodes is 1024 GB.
+<5> The name of the cluster.
+<6> The Azure Resource Manager endpoint that your Azure Stack Hub operator provides.
+<7> The name of the resource group that contains the DNS zone for your base domain.
+<8> The name of your Azure Stack Hub local region.
+<9> The name of an existing resource group to install your cluster to. If undefined, a new resource group is created for the cluster.
+<10> The URL of a storage blob in the Azure Stack environment that contains an {op-system} VHD.
+<11> The pull secret required to authenticate your cluster.
 ifndef::openshift-origin[]
-<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<12> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
-<12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<13> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<11> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 +
 [NOTE]
@@ -189,10 +209,10 @@ endif::openshift-origin[]
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 ifndef::openshift-origin[]
-<13> If the Azure Stack Hub environment is using an internal Certificate Authority (CA), adding the CA certificate is required.
+<14> If the Azure Stack Hub environment is using an internal Certificate Authority (CA), adding the CA certificate is required.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<12> If the Azure Stack Hub environment is using an internal Certificate Authority (CA), adding the CA certificate is required.
+<13> If the Azure Stack Hub environment is using an internal Certificate Authority (CA), adding the CA certificate is required.
 endif::openshift-origin[]
 
 endif::ash-default,ash-network[]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1429,6 +1429,22 @@ Additional Azure configuration parameters are described in the following table:
 |====
 |Parameter|Description|Values
 
+|`compute.platform.azure.osDisk.diskSizeGB`
+|The Azure disk size for the VM.
+|Integer that represents the size of the disk in GB. The default is `128`.
+
+|`compute.platform.azure.osDisk.diskType`
+|Defines the type of disk.
+|`standard_LRS`, `premium_LRS`, or `standardSSD_LRS`. The default is `premium_LRS`.
+
+|`controlPlane.platform.azure.osDisk.diskSizeGB`
+|The Azure disk size for the VM.
+|Integer that represents the size of the disk in GB. The default is `1024`.
+
+|`controlPlane.platform.azure.osDisk.diskType`
+|Defines the type of disk.
+|`premium_LRS` or `standardSSD_LRS`. The default is `premium_LRS`.
+
 |`platform.azure.armEndpoint`
 |The URL of the Azure Resource Manager endpoint that your Azure Stack Hub operator provides.
 |String


### PR DESCRIPTION
Version(s):
CP to 4.10 and 4.11

Issue:
This is the second of two PRs[1] that address BZ [2100616](https://bugzilla.redhat.com/show_bug.cgi?id=2100612). This PR updates the Azure Stack Hub installation doc in support of premium_LRS and standardSSD_LRS disk types that was introduced in 4.10.14

Link to docs preview:

- [Additional Azure Stack Hub configuration parameters](http://file.rdu.redhat.com/mpytlak/bz2100612/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.html#installation-configuration-parameters-additional-azure-stack-hub_installing-azure-stack-hub-default)
- [Sample customized install-config.yaml file for Azure Stack Hub](http://file.rdu.redhat.com/mpytlak/bz2100612/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.html#installation-azure-stack-hub-config-yaml_installing-azure-stack-hub-default)

Additional information:
4.10 release note: https://github.com/openshift/openshift-docs/pull/47207
