### PR TITLE
OSDOCS-3741: Fixed an old variable showing in documentation.

### DIFF
--- a/modules/upgrade-auto.adoc
+++ b/modules/upgrade-auto.adoc
@@ -13,7 +13,7 @@ You can use {cluster-manager} to schedule recurring, automatic upgrades for z-st
 
 .Procedure
 
-. From {console-red-hat}, select your cluster from the clusters list.
+. From {cluster-manager-url}, select your cluster from the clusters list.
 
 . Click the *Upgrade settings* tab to access the upgrade operator.
 

--- a/modules/upgrade-manual.adoc
+++ b/modules/upgrade-manual.adoc
@@ -14,7 +14,7 @@ You can use {cluster-manager} to manually upgrade your {product-title} cluster o
 
 .Procedure
 
-. From {console-red-hat}, select your cluster from the clusters list.
+. From {cluster-manager-url}, select your cluster from the clusters list.
 
 . Click the *Upgrade settings* tab to access the upgrade operator. You can also update your cluster from the *Overview* tab by clicking *Update* next to the cluster version under the *Details* heading.
 


### PR DESCRIPTION
Version(s):
Enterprise-4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-3741

Link to docs preview:
* Auto Mode: https://people.redhat.com/eponvell/062922/OSDOCS-3741_Variable-Fix/upgrading/osd-upgrades.html#upgrade-auto_osd-upgrades
* Manual Mode: https://people.redhat.com/eponvell/062922/OSDOCS-3741_Variable-Fix/upgrading/osd-upgrades.html#upgrade-manual_osd-upgrades

Additional information:
Replaced an old variable so that it displays correctly.