### PR TITLE
Fixes broken link in updating docs

### DIFF
--- a/updating/understanding-openshift-updates.adoc
+++ b/updating/understanding-openshift-updates.adoc
@@ -18,5 +18,7 @@ include::modules/update-common-terms.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-overview-post-install-machine-configuration-tasks[Machine config overview]
+ifdef::openshift-enterprise[]
 * xref:../updating/updating-restricted-network-cluster.adoc#update-service-overview_updating-restricted-network-cluster[About the OpenShift Update Service]
+endif::openshift-enterprise[]
 * xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Update channels and releases]


### PR DESCRIPTION
Fixing a link in upstream docs that goes to 404 page.

- Specifically the "About the OpenShift Update Service" in the Additional resources section.

Version(s):
okd and enterprise-4.11

Issue:
Discussed in slack with Console Team

Link to docs preview:
OKD
http://file.rdu.redhat.com/opayne/link-fix-updating-restricted/welcome/
Direct link: http://file.rdu.redhat.com/opayne/link-fix-updating-restricted/updating/understanding-openshift-updates.html

Enterprise
https://47272--docspreview.netlify.app/openshift-enterprise/latest/updating/understanding-openshift-updates.html


<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
