### PR TITLE
[GH47273]: Fix utilizationThreshold example and clarify parameter requirements

### DIFF
--- a/modules/cluster-autoscaler-cr.adoc
+++ b/modules/cluster-autoscaler-cr.adoc
@@ -39,7 +39,7 @@ spec:
     delayAfterDelete: 5m <13>
     delayAfterFailure: 30s <14>
     unneededTime: 5m <15>
-    utilizationThreshold: 0.4 <16>
+    utilizationThreshold: "0.4" <16>
 ----
 <1> Specify the priority that a pod must exceed to cause the cluster autoscaler to deploy additional nodes. Enter a 32-bit integer value. The `podPriorityThreshold` value is compared to the value of the `PriorityClass` that you assign to each pod.
 <2> Specify the maximum number of nodes to deploy. This value is the total number of machines that are deployed in your cluster, not just the ones that the autoscaler controls. Ensure that this value is large enough to account for all of your control plane and compute machines and the total number of replicas that you specify in your `MachineAutoscaler` resources.
@@ -56,7 +56,7 @@ spec:
 <13> Optional: Specify the period to wait before deleting a node after a node has recently been _deleted_. If you do not specify a value, the default value of `0s` is used.
 <14> Optional: Specify the period to wait before deleting a node after a scale down failure occurred. If you do not specify a value, the default value of `3m` is used.
 <15> Optional: Specify the period before an unnecessary node is eligible for deletion. If you do not specify a value, the default value of `10m` is used.
-<16> Optional: Specify the _node utilization level_ below which an unnecessary node is eligible for deletion. The node utilization level is the sum of the requested resources divided by the allocated resources for the node, and must be a value greater than `0` but less than `1`. If you do not specify a value, the cluster autoscaler uses a default value of `0.5`, which corresponds to 50% utilization.
+<16> Optional: Specify the _node utilization level_ below which an unnecessary node is eligible for deletion. The node utilization level is the sum of the requested resources divided by the allocated resources for the node, and must be a value greater than `"0"` but less than `"1"`. If you do not specify a value, the cluster autoscaler uses a default value of `"0.5"`, which corresponds to 50% utilization. This value must be expressed as a string.
 // Might be able to add a formula to show this visually, but need to look into asciidoc math formatting and what our tooling supports.
 
 [NOTE]


### PR DESCRIPTION
Version(s):
4.10+

Issue:
#47273

Link to docs preview:
[ClusterAutoscaler resource definition](http://file.rdu.redhat.com/jrouth/GH47273/machine_management/applying-autoscaling.html#cluster-autoscaler-cr_applying-autoscaling) (requires VPN)

/cc @mtulio 