### PR TITLE
[WIP] RHDEVDOCS-4143-better-docs-for-CMO-config-maps-410

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2161,6 +2161,8 @@ Topics:
   File: accessing-third-party-monitoring-uis-and-apis
 - Name: Troubleshooting monitoring issues
   File: troubleshooting-monitoring-issues
+- Name: Config map reference for the cluster monitoring operator
+  File: config-map-reference-for-the-cluster-monitoring-operator  
 ---
 Name: Scalability and performance
 Dir: scalability_and_performance

--- a/modules/monitoring-about-configuring-core-platform-monitoring.adoc
+++ b/modules/monitoring-about-configuring-core-platform-monitoring.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: CONCEPT
+[id="about-configuring-core-platform-monitoring_{context}"]
+= About configuring core platform monitoring
+
+Edit the `cluster-monitoring-config` config map in the `openshift-monitoring` namespace to configure the following core platform monitoring components: 
+
+[source,yaml]
+----
+# Holds configuration related with the main Alertmanager instance.
+alertmanagerMain: <struct>
+# Boolean flag to enable monitoring for user-defined projects.
+# Default: false
+enableUserWorkload: <bool>
+# Holds configuration settings for the Grafana component
+grafanaConfig: <struct>
+# Holds configuration related to the prometheus-adapter
+k8sPrometheusAdapter: <struct>
+# Holds configuration related with kube-state-metrics agent
+kubeStateMetrics: <struct>
+# Holds configuration related with the prometheus component that will be managed by
+# the prometheus-operator
+prometheusK8s: <struct>
+# Holds configuration related with prometheus-operator
+prometheusOperator: <struct>
+# Holds configuration related with openshift-state-metrics agent
+openshiftStateMetrics: <struct>
+# Holds configuration related with the Thanos Querier component
+thanosQuerier: <struct>
+----

--- a/modules/monitoring-about-configuring-user-workload-monitoring.adoc
+++ b/modules/monitoring-about-configuring-user-workload-monitoring.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: CONCEPT
+[id="about-configuring-user-workload-monitoring_{context}"]
+= About configuring user workload monitoring
+
+Edit the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace to configure the following   components that monitor user-defined projects: 
+
+[source,yaml]
+----
+# Holds configuration for the Alertmanager component for user-defined projects.
+alertmanager: <struct>
+# Holds configuration related to the Prometheus component that will be managed by
+# the prometheus-operator from configuring nodeSelector to RemoteWrite
+prometheus: <struct>
+# Holds configuration related with prometheus-operator, nodeSelector, tolerations
+# and logLevel
+prometheusOperator: <struct>
+# Holds configuration for the Thanos Ruler component
+thanosRuler: <struct>
+----

--- a/modules/monitoring-additionalalertmanagerconfig-reference.adoc
+++ b/modules/monitoring-additionalalertmanagerconfig-reference.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="additionalalertmanagerconfig-reference_{context}"]
+= AdditionalAlertmanagerConfig reference
+
+These settings configure the ways in which monitoring components communicate with additional Alertmanager instances.  
+Configuration settings include configuring the URL scheme, the connection timeout for alerts, the authentication method, and so forth.
+
+.Configuration options
+
+[source,yaml]
+----
+additionalAlertmanagerConfigs:
+  # The api version of Alertmanager.
+  apiVersion: <string>
+  # The bearer token to use when authenticating to Alertmanager.
+  bearerToken: v1.SecretKeySelector
+  # Path prefix to add in front of the push endpoint path.
+  pathPrefix: <string>
+  # The URL scheme to use when communicating with Alertmanager instances.
+  scheme: <string>
+  # List of statically configured Alertmanager instances.
+  staticConfigs: <[]string>
+  # The timeout used when sending alerts.
+  timeout: <string>
+  # TLS Config to use for alertmanager connection.
+  tlsConfig: TLSConfig
+----

--- a/modules/monitoring-alertmanagermain-reference.adoc
+++ b/modules/monitoring-alertmanagermain-reference.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="alertmanagermain-reference_{context}"]
+= alertmanagerMain reference
+
+These settings configure the Alertmanager component for core platform monitoring.
+
+.Configuration options
+
+[source,yaml]
+----
+alertmanagerMain:
+  # Boolean flag that enables or disables the main Alertmanager instance under
+  # openshift-monitoring
+  # default: true
+  enabled: <bool>
+  # Boolean flag that enables or disables user-defined project namespaces to be selected
+  # for AlertmanagerConfig lookup. By default, Alertmanager only looks for a configuration
+  # in the namespace to which it was deployed. This setting only works if the UWM Alertmanager
+  # instance is not enabled
+  # default: false
+  enableUserAlertmanagerConfig: <bool>
+  # The log level for Alertmanager.
+  # Possible values are: error, warn, info, debug.
+  # default: info
+  logLevel: <string>
+  # Defines the nodes on which the pods are scheduled.
+  nodeSelector: v1.NodeSelector
+  # Defines resource requests and limits for single pods.
+  resources: v1.ResourceRequirements
+  # Defines tolerations for pods.
+  tolerations: v1.Toleration
+  # Allow a user to configure persistent storage for the Alertmanager pods.
+  # A user can configure storageClass and size of volume.
+  volumeClaimTemplate: v1.PersistentVolumeClaim
+----
+
+.Example
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    alertmanagerMain:
+      enabled: true
+      enableUserAlertmanagerConfig: true
+      logLevel: "debug"
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      resources:
+        requests:
+          cpu: 5m
+          memory: 30Mi
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: 15Gb
+----

--- a/modules/monitoring-basicauth-reference.adoc
+++ b/modules/monitoring-basicauth-reference.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="basicauth-reference_{context}"]
+= BasicAuth reference
+
+These settings configure basic authentication for monitoring components.  
+
+[source,yaml]
+----
+basicAuth:
+  # The secret in the service monitor namespace that contains the username
+  # for authentication.
+  username: v1.SecretKeySelector
+  # The secret in the service monitor namespace that contains the password
+  # for authentication.
+  password: v1.SecretKeySelector
+----

--- a/modules/monitoring-common-data-types-for-monitoring-configuration.adoc
+++ b/modules/monitoring-common-data-types-for-monitoring-configuration.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: CONCEPT
+[id="common-data-types-for-monitoring-configuration_{context}"]
+= Common data types for monitoring configuration
+
+This section describes a set of common data types common for configuring both core platform monitoring components and components that monitor user-defined projects.

--- a/modules/monitoring-enableuserWorkload-reference.adoc
+++ b/modules/monitoring-enableuserWorkload-reference.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="enableuserworkload-reference_{context}"]
+= enableUserWorkload reference
+
+When set to `true`, this setting enables monitoring for user-defined projects.
+By default, this setting is set to `false`.
+
+If you enable this setting, the Cluster Monitoring Operator creates a new namespace called `openshift-user-workload-monitoring` to which it deploys the following components:
+
+* prometheus-operator
+* prometheus
+* thanos-ruler
+
+These components monitor all namespaces not monitored by the {product-title} core platform monitoring stack.
+
+.Configuration options
+
+[source,yaml]
+----
+# default: false
+enableUserWorkload: <bool>
+----
+
+.Example
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+----

--- a/modules/monitoring-grafanaconfig-reference.adoc
+++ b/modules/monitoring-grafanaconfig-reference.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="grafanaconfig-reference_{context}"]
+= grafanaConfig reference
+
+These settings configure the Grafana component.
+
+
+.Configuration options
+
+[source,yaml]
+----
+# enable or disable Grafana on the cluster
+enabled: <bool>
+# defines which nodes on which the pods are scheduled
+nodeSelector: v1.NodeSelector
+# defines tolerations for the pods
+tolerations: v1.Toleration
+----
+
+.Example
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    grafanaConfig:
+      enabled: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+----

--- a/modules/monitoring-k8sprometheusadapter-reference.adoc
+++ b/modules/monitoring-k8sprometheusadapter-reference.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="k8sprometheusadapter-reference_{context}"]
+= k8sPrometheusAdapter reference
+
+These settings configure the Prometheus Adapter component for core platform monitoring.
+
+.Configuration options
+
+[source,yaml]
+----
+k8sPrometheusAdapter:
+  # The audit configuration to be used by the Prometheus Adapter instance.
+  # Possible profile values are: "metadata, request, requestresponse, none".
+  # default: metadata
+  audit: <struct>
+  # Defines the nodes on which the pods are scheduled.
+  nodeSelector: v1.NodeSelector
+  # Defines the tolerations for the pods.
+  tolerations: v1.Toleration
+----
+
+.Example
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    k8sPrometheusAdapter:
+      audit:
+        profile: request
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+----

--- a/modules/monitoring-kubestatemetrics-reference.adoc
+++ b/modules/monitoring-kubestatemetrics-reference.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="kubestatemetrics-reference_{context}"]
+= kubeStateMetrics reference
+
+These settings configure the `kube-state-metrics` agent.
+
+.Configuration options
+
+[source,yaml]
+----
+kubeStateMetrics:
+  # Defines the nodes on which the pods are scheduled.
+  nodeSelector: v1.NodeSelector
+  # Defines the tolerations for the pods.
+  tolerations: v1.Toleration
+----
+
+.Example
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    kubeStateMetrics:
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+----

--- a/modules/monitoring-metadataconfig-reference.adoc
+++ b/modules/monitoring-metadataconfig-reference.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="metadataconfig-reference_{context}"]
+= MetadataConfig reference
+
+These settings configure metrics metadata for monitoring components.  
+
+.Configuration options
+
+[source,yaml]
+----
+metadataConfig:
+  # Configures whether or not metric metadata is sent to remote storage.
+  send: <bool>
+  # Configures how frequently metric metadata is sent to remote storage.
+  sendInterval: <string>
+----
+

--- a/modules/monitoring-openshiftstatemetrics-reference.adoc
+++ b/modules/monitoring-openshiftstatemetrics-reference.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="openshiftstatemetrics-reference_{context}"]
+= openshiftStateMetrics reference
+
+These settings configure the `openshift-state-metrics` agent.
+
+.Configuration options
+
+[source,yaml]
+----
+openshiftStateMetrics:
+  # Defines the nodes on which the pods are scheduled.
+  nodeSelector: v1.NodeSelector
+  # Defines tolerations for the pods.
+  tolerations: v1.Toleration
+----
+
+.Example
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    openshiftStateMetrics:
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+----

--- a/modules/monitoring-prometheus-reference.adoc
+++ b/modules/monitoring-prometheus-reference.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="prometheus-reference_{context}"]
+= prometheus reference
+
+These settings configure the Prometheus component for user-defined projects.
+
+.Configuration options
+
+[source,yaml]
+----
+prometheus:
+  # Contains the configuration for how the Prometheus component communicates 
+  # with additional Alertmanager instances, including such settings as 
+  # configuring the URL scheme, connection timeout, and authentication method.
+  # default: nil
+  additionalAlertmanagerConfigs: AdditionalAlertmanagerConfig
+  # Defines a global limit on the number of scraped samples that will be 
+  # accepted. This setting overrides any SampleLimit set per ServiceMonitor 
+  # and/or PodMonitor. Admins can use this setting to enforce the SampleLimit 
+  # and thus keep the overall number of samples/series under the
+  # desired limit. 
+  # Note that if SampleLimit is lower that value will be taken instead.
+  # default: 0
+  enforcedSampleLimit: <integer>
+  # Defines a global limit on the number of scraped targets. This setting 
+  # overrides any TargetLimit set per ServiceMonitor and/or PodMonitor.
+  # Admins can use it to enforce the TargetLimit to keep the overall number of 
+  # targets under the desired limit. 
+  # Note that if TargetLimit is lower, that value will be taken instead, 
+  # except if either value is zero, in which case the non-zero value will be 
+  # used. If both values are zero, no limit is enforced.
+  # default: 0
+  enforcedTargetLimit: <integer>
+  # The labels to add to any time series or alerts when communicating with 
+  # external systems (federation, remote storage, Alertmanager).
+  externalLabels: <map[string]string>
+  # Defines the log level for Prometheus.
+  # Possible values are: error, warn, info, debug.
+  # default: info
+  logLevel: <string>
+  # Defines the nodes on which the pods are scheduled.
+  nodeSelector: v1.NodeSelector
+  # QueryLogFile specifies the file to which PromQL queries are logged. 
+  # This setting supports either or a file name or a full path.
+  # If a file name is specified, queries are saved to an emptyDir volume at 
+  # /var/log/prometheus. If a full path is specified, an emptyDir volume is 
+  # mounted at that location. Relative paths not supported.
+  # default: ""
+  queryLogFile: <string>
+  # Contains the remote write configuration, including the URL, authorization, and relabeling settings.
+  remoteWrite: RemoteWriteSpec
+  # Defines resource requests and limits for single pods.
+  resources: v1.ResourceRequirements
+  # Defines how long Prometheus retains data. 
+  # The default is '24h'. The setting must match the regular expression 
+  # [0-9]+(ms|s|m|h|d|w|y) (milliseconds seconds minutes
+  # hours days weeks years).
+  retention: <string>
+  # Defines tolerations for the pods.
+  tolerations: v1.Toleration
+  # Allows a user to configure persistent storage for the Prometheus pods.
+  # If enabled, a user can configure storageClass and size of volume.
+  volumeClaimTemplate: v1.PersistentVolumeClaim
+----
+
+.Example
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    prometheus:
+      additionalAlertmanagerConfigs:
+      - apiVersion: v2
+        scheme: https
+        bearerToken:
+          name: alertmanager1-bearer-token
+          key: token
+        staticConfigs:
+        - alertmanager1-remote.com
+      enforcedLabelLimit: 500
+      enforcedLabelNameLengthLimit: 50
+      enforcedLabelValueLengthLimit: 600
+      enforcedSampleLimit: 100
+      enforcedTargetLimit: 10
+      externalLabels:
+        datacenter: eu-west
+      logLevel: debug
+      nodeSelector:
+        kubernetes.io/os: linux
+      queryLogFile: /tmp/test.log
+      retention: 10h
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      remoteWrite:
+      - url: "https://test.remotewrite.com/api/write"
+      retention: 24h
+      retentionSize: 15GB
+      tolerations:
+        - operator: "Exists"
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: 15Gb
+----

--- a/modules/monitoring-prometheusk8s-reference.adoc
+++ b/modules/monitoring-prometheusk8s-reference.adoc
@@ -1,0 +1,101 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="prometheusk8s-reference_{context}"]
+= prometheusK8s reference
+
+These settings configure the Prometheus component for core platform monitoring.
+
+.Configuration options
+
+[source,yaml]
+----
+prometheusK8s:
+  # Configures how the Prometheus component should communicate with additional
+  # Alertmanager instances, including configuring URL scheme, connection
+  # timeout, and authentication method
+  # default: nil
+  additionalAlertmanagerConfigs: AdditionalAlertmanagerConfig
+  # The labels that will be used to add to any time series or alerts when 
+  # communicating with external systems 
+  # (federation, remote storage, Alertmanager).
+  # default: nil
+  externalLabels: <map[string]string>
+  # The log level for Prometheus.
+  # Possible values are: error, warn, info, debug.
+  # default: info
+  logLevel: <string>
+  # Defines the nodes on which the pods are scheduled.
+  nodeSelector: v1.NodeSelector
+  # Specifies the file to which PromQL queries are logged. 
+  # You can specify either a file name or a full path. If a file name
+  # is specified, the queries will be saved to an emptyDir volume
+  # located at /var/log/prometheus. If a full path is specified,
+  # an emptyDir volume will be mounted at that location. 
+  # Relative paths are not supported.
+  # Writing to linux std streams is also not supported.
+  # default: ""
+  queryLogFile: <string>
+  # Contains the remote write configuration, including setting such as
+  # URL, authorization, and relabeling.
+  remoteWrite: RemoteWriteSpec
+  # Defines resource requests and limits for single pods.
+  resources: v1.ResourceRequirements
+  # Defines how long Prometheus retains data. 
+  # The default is '15d'. The setting must match the regular expression 
+  # [0-9]+(ms|s|m|h|d|w|y) (milliseconds seconds minutes
+  # hours days weeks years).
+  retention: <string>
+  # Defines tolerations for the pods.
+  tolerations: v1.Toleration
+  # Allows a user to configure persistent storage for the Prometheus pods.
+  # If enabled, a user can configure storageClass and size of volume.
+  volumeClaimTemplate: v1.PersistentVolumeClaim
+----
+
+.Example
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      additionalAlertmanagerConfigs:
+      - apiVersion: v2
+        scheme: https
+        bearerToken:
+          name: alertmanager1-bearer-token
+          key: token
+        staticConfigs:
+        - alertmanager1-remote.com
+      enforcedBodySizeLimit: 64MB
+      externalLabels:
+        datacenter: eu-west
+      logLevel: debug
+      nodeSelector:
+        kubernetes.io/os: linux
+      queryLogFile: /tmp/test.log
+      retention: 10h
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      remoteWrite:
+      - url: "https://test.remotewrite.com/api/write"
+      retention: 24h
+      retentionSize: 15GB
+      tolerations:
+        - operator: "Exists"
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: 15Gb
+----

--- a/modules/monitoring-prometheusoperator-reference.adoc
+++ b/modules/monitoring-prometheusoperator-reference.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="prometheusoperator-reference_{context}"]
+= prometheusOperator reference
+
+These settings configure the `prometheus-operator`.
+
+.Configuration options
+
+[source,yaml]
+----
+prometheusOperator:
+  # Defines the log level for the Prometheus Operator.
+  # Possible values are: error, warn, info, debug.
+  # default: info
+  logLevel: <string>
+  # Defines the nodes on which the pods are scheduled.
+  nodeSelector: v1.NodeSelector
+  # Defines tolerations for the pods.
+  tolerations: v1.Toleration
+----
+
+.Example
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+   prometheusOperator:
+      logLevel: debug
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+----

--- a/modules/monitoring-prometheusoperator-uwm-reference.adoc
+++ b/modules/monitoring-prometheusoperator-uwm-reference.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="prometheusoperator-uwm-reference_{context}"]
+= prometheusOperator UWM reference
+
+These settings configure the `prometheus-operator` for user workload monitoring (UWM). 
+
+.Configuration options
+
+[source,yaml]
+----
+prometheusOperator:
+  # Defines the log level for the Prometheus Operator.
+  # Possible values are: error, warn, info, debug.
+  # default: info
+  logLevel: <string>
+  # Defines the nodes on which the pods are scheduled.
+  nodeSelector: v1.NodeSelector
+  # Defines tolerations for the pods.
+  tolerations: v1.Toleration
+----
+
+.Example
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+   prometheusOperator:
+      logLevel: debug
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+----

--- a/modules/monitoring-queueconfig-reference.adoc
+++ b/modules/monitoring-queueconfig-reference.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="queueconfig-reference_{context}"]
+= QueueConfig reference
+
+These settings configure parameters for the remote write queue.
+
+.Configuration options
+
+[source,yaml]
+----
+queueConfig:
+  # BatchSendDeadline is the maximum time a sample will wait in buffer.
+  batchSendDeadline: <string>
+  # Capacity is the number of samples to buffer per shard before shards will 
+  # start to be dropped.
+  capacity: <integer>
+  # MaxBackoff is the maximum retry delay.
+  maxBackoff: <string>
+  # MaxRetries is the maximum number of times to retry a batch on recoverable errors.
+  maxRetries: <integer>
+  # MaxShards is the maximum number of shards, that is, the amount of 
+  # concurrency.
+  maxShards: <integer>
+  # MaxSamplesPerSend is the maximum number of samples per send.
+  maxSamplesPerSend: <integer>
+  # MinBackoff is the initial retry delay. This value is doubled 
+  # for every retry.
+  minBackoff: <string>
+  # MinShards is the minimum number of shards, that is, the  amount of
+  # concurrency.
+  minShards: <integer>
+  # Retry connection when receiving a 429 status code from the remote-write 
+  # storage endpoint.
+  # This is an experimental feature and might change in the future.
+  retryOnRateLimit: <bool>
+----

--- a/modules/monitoring-relabelconfig-reference.adoc
+++ b/modules/monitoring-relabelconfig-reference.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="relabelconfig-reference_{context}"]
+= RelabelConfig reference
+
+These settings configure remote write relabeling.
+
+.Configuration options
+
+[source,yaml]
+----
+relabelConfig:
+  # Action to perform based on regex matching. Default is 'replace'.
+  action: <string>
+  # Modulus to take of the hash of the source label values.
+  modulus: <integer>
+  # Regular expression against which the extracted value is matched.  
+  # Default is '(.*)'
+  regex: <string>
+  # Replacement value against which a regex replace is performed if the
+  # regular expression matches. Regex capture groups are available. 
+  # Default is '$1'
+  replacement: <string>
+  # Separator placed between concatenated source label values. 
+  # Default is ';'.
+  separator: <string>
+  #The source labels select values from existing labels. Their content is 
+  # concatenated using the configured separator and matched against the 
+  # configured regular expression for the replace, keep, and drop actions.
+  sourceLabels: <[]string>
+  # Label to which the resulting value is written in a replace action.
+  # It is mandatory for replace actions. Regex capture groups are available.
+  targetLabel: <string>
+----

--- a/modules/monitoring-remotewritespec-reference.adoc
+++ b/modules/monitoring-remotewritespec-reference.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="remotewritespec-reference_{context}"]
+= RemoteWriteSpec reference
+
+These settings configure remote write for monitoring components.
+
+.Configuration options
+
+[source,yaml]
+----
+remoteWrite:
+  # The URL of the endpoint to send samples to.
+  url: <string>
+  # The name of the remote write queue, which must be unique if specified. The
+  # name is used in metrics and logging in order to differentiate queues.
+  # Only valid in Prometheus versions 2.15.0 and newer.
+  name: <string>
+  # Timeout setting for requests to the remote write endpoint.
+  remoteTimeout: <string>
+  # Custom HTTP headers to be sent along with each remote write request.
+  # Headers set by Prometheus itself cannot be overwritten.
+  # Only valid in Prometheus versions 2.25.0 and newer.
+  headers: <map[string]string>
+  # The list of remote write relabel configurations.
+  writeRelabelConfigs: RelabelConfig
+  # BasicAuth settings for the URL.
+  basicAuth: BasicAuth
+  # Bearer token file for remote write.
+  bearerTokenFile: <string>
+  # TLS Config settings to use for remote write.
+  tlsConfig: SafeTLSConfig
+  # Optional ProxyURL
+  proxyUrl: <string>
+  # QueueConfig settings, which allow tuning of the remote write queue
+  # parameters.
+  queueConfig: QueueConfig
+  # MetadataConfig setting to configure how series metadata is sent to remote 
+  # storage.
+  metadataConfig: MetadataConfig
+----

--- a/modules/monitoring-safetlsconfig-reference.adoc
+++ b/modules/monitoring-safetlsconfig-reference.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="safetlsconfig-reference_{context}"]
+= SafeTLSConfig reference
+
+These settings configure TLS authentication for monitoring components.  
+
+[source,yaml]
+----
+tlsConfig:
+  # Struct containing the CA cert to use for the targets.
+  ca: SecretOrConfigMap
+  # Struct containing the client cert file for the targets.
+  cert: SecretOrConfigMap
+  # Disable target certificate validation.
+  insecureSkipVerify: <bool>
+  # Secret containing the client key file for the targets.
+  keySecret: v1.SecretKeySelector
+  # Server name used to verify the hostname for the targets.
+  serverName: <string>
+----

--- a/modules/monitoring-thanosquerier-reference.adoc
+++ b/modules/monitoring-thanosquerier-reference.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="thanosquerier-reference_{context}"]
+= thanosQuerier reference
+
+These settings configure the Thanos Querier component for core platform monitoring.
+
+.Configuration options
+
+[source,yaml]
+----
+thanosQuerier:
+  # Boolean flag to enable or disable request logging.
+  # default: false
+  enableRequestLogging: <bool>
+  # The log level for Thanos Querier.
+  # Possible values are: error, warn, info, debug.
+  # default: info
+  logLevel: <string>
+  # Defines the nodes on which the pods are scheduled.
+  nodeSelector: v1.NodeSelector
+  # Defines resource requests and limits for single pods.
+  resources: v1.ResourceRequirements
+  # Defines the tolerations for the pods.
+  tolerations: v1.Toleration
+----
+
+.Example
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    thanosQuerier:
+      enableRequestLogging: true
+      logLevel: debug
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+----

--- a/modules/monitoring-thanosruler-reference.adoc
+++ b/modules/monitoring-thanosruler-reference.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="thanosruler-reference_{context}"]
+= thanosRuler reference
+
+These settings configure the Thanos Ruler component for user-defined projects.
+
+.Configuration options
+
+[source,yaml]
+----
+thanosRuler:
+  # Contains configuration settings for how Thanos Ruler communicates 
+  # with additional Alertmanager instances, including configuring the URL scheme, the connection timeout, and the authentication method.
+  # default: nil
+  additionalAlertmanagerConfigs: AdditionalAlertmanagerConfig
+  # Defines the log level for Alertmanager.
+  # Possible values are: error, warn, info, debug.
+  # default: nil
+  logLevel: <string>
+  # Defines the nodes on which the pods are scheduled.
+  nodeSelector: v1.NodeSelector
+  # Defines resource requests and limits for single pods.
+  resources: v1.ResourceRequirements
+  # Defines how long Prometheus retains data. 
+  # Default is '24h'.
+  # The setting must match the regular expression 
+  # [0-9]+(ms|s|m|h|d|w|y) 
+  # (milliseconds seconds minutes hours days weeks years).
+  retention: <string>
+  # Defines tolerations for the pods.
+  tolerations: v1.Toleration
+  # Allows a user to configure persistent storage for the Alertmanager pods.
+  # If enabled, a user can configure storageClass and size of volume.
+  volumeClaimTemplate: v1.PersistentVolumeClaim
+----
+
+.Example
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    thanosRuler:
+      additionalAlertmanagerConfigs:
+      - apiVersion: v2
+        scheme: https
+        bearerToken:
+          name: alertmanager1-bearer-token
+          key: token
+        staticConfigs:
+        - alertmanager1-remote.com
+      logLevel: debug
+      nodeSelector:
+        kubernetes.io/os: linux
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+      retention: 24h
+      tolerations:
+        - operator: "Exists"
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: 15Gb
+----

--- a/modules/monitoring-tlsconfig-reference.adoc
+++ b/modules/monitoring-tlsconfig-reference.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+
+:_content-type: REFERENCE
+[id="tlsconfig-reference_{context}"]
+= TLSConfig reference
+
+These settings configure TLS authentication for monitoring components.  
+
+.Configuration options
+
+[source,yaml]
+----
+tlsConfig:
+  # The CA cert in the Prometheus container to use for the targets.
+  ca: v1.SecretKeySelector
+  # The client cert in the Prometheus container to use for the targets.
+  cert: v1.SecretKeySelector
+  # Disables target certificate validation.
+  insecureSkipVerify: <bool>
+  # The client key in the Prometheus container to use for the targets.
+  key: v1.SecretKeySelector
+  # The name of the server used to verify the hostname for the targets.
+  serverName: <string>
+----

--- a/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -1,0 +1,118 @@
+:_content-type: ASSEMBLY
+[id="config-map-reference-for-the-cluster-monitoring-operator"]
+= Config map reference for the Cluster Monitoring Operator
+include::_attributes/common-attributes.adoc[]
+:context: config-map-reference-for-the-cluster-monitoring-operator
+
+toc::[]
+
+You can configure different components of the Cluster Monitoring Operator (CMO) by adjusting settings in config maps. 
+Depending on which part of the monitoring stack you want to configure, edit the `ConfigMap` object for one of the following:
+
+* For {product-title} core platform monitoring components, edit the `cluster-monitoring-config` config map in the `openshift-monitoring` namespace.
+* For components that monitor user-defined projects, edit the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace.
+
+The configuration file is always defined under the `config.yaml`
+key in the `ConfigMap` object data.
+
+[NOTE]
+====
+The following features and limitations apply to editing config map settings for the CMO:
+
+* Changing configuration settings is optional.
+* Not all configuration parameters are exposed for use.
+* If a configuration setting does not exist or is empty or malformed, default values will be applied.
+====
+
+// Configuring core platform monitoring
+
+include::modules/monitoring-about-configuring-core-platform-monitoring.adoc[leveloffset=+1]
+
+// alertmanagerMain
+
+include::modules/monitoring-alertmanagermain-reference.adoc[leveloffset=+2]
+
+// enableUserWorkload
+
+include::modules/monitoring-enableuserWorkload-reference.adoc[leveloffset=2]
+
+// enableUserWorkload
+
+include::modules/monitoring-grafanaconfig-reference.adoc[leveloffset=2]
+
+// k8sPrometheusAdapter
+
+include::modules/monitoring-k8sprometheusadapter-reference.adoc[leveloffset=2]
+
+// kubeStateMetrics
+
+include::modules/monitoring-kubestatemetrics-reference.adoc[leveloffset=2]
+
+// prometheusK8s
+
+include::modules/monitoring-prometheusk8s-reference.adoc[leveloffset=2]
+
+// prometheusOperator
+
+include::modules/monitoring-prometheusoperator-reference.adoc[leveloffset=2]
+
+// openshiftStateMetrics
+
+include::modules/monitoring-openshiftstatemetrics-reference.adoc[leveloffset=2]
+
+// thanosQuerier
+
+include::modules/monitoring-thanosquerier-reference.adoc[leveloffset=2]
+
+
+// Configuring user workload monitoring
+
+include::modules/monitoring-about-configuring-user-workload-monitoring.adoc[leveloffset=+1]
+
+// prometheus
+
+include::modules/monitoring-prometheus-reference.adoc[leveloffset=2]
+
+// prometheusOperator
+
+include::modules/monitoring-prometheusoperator-uwm-reference.adoc[leveloffset=2]
+
+// thanosRuler
+
+include::modules/monitoring-thanosruler-reference.adoc[leveloffset=2]
+
+// Common data types
+
+include::modules/monitoring-common-data-types-for-monitoring-configuration.adoc[leveloffset=+1]
+
+// AdditionalAlertmanagerConfig
+
+include::modules/monitoring-additionalalertmanagerconfig-reference.adoc[leveloffset=2]
+
+// TLSConfig
+
+include::modules/monitoring-tlsconfig-reference.adoc[leveloffset=2]
+
+// RemoteWriteSpec
+
+include::modules/monitoring-remotewritespec-reference.adoc[leveloffset=2]
+
+// BasicAuth
+
+include::modules/monitoring-basicauth-reference.adoc[leveloffset=2]
+
+// MetadataConfig
+
+include::modules/monitoring-metadataconfig-reference.adoc[leveloffset=2]
+
+// QueueConfig
+
+include::modules/monitoring-queueconfig-reference.adoc[leveloffset=2]
+
+// RelabelConfig
+
+include::modules/monitoring-relabelconfig-reference.adoc[leveloffset=2]
+
+// SafeTLSConfig
+
+include::modules/monitoring-safetlsconfig-reference.adoc[leveloffset=2]


### PR DESCRIPTION
[WIP]
Summary: This PR provides a config map reference for the Cluster Monitoring Operator that has been compiled from the source code.

- Aligned team: DevTools
- For branches: 4.10 ONLY
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4143
- Direct link to doc preview: http://file.rdu.redhat.com/bburt/RHDEVDOCS-4143-better-docs-for-CMO-config-maps-410/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html
- SME review: 
- QE review: @ tbd
- Peer review: @ tbd