### PR TITLE
[SRVKE-1093] Update Kafka output

### DIFF
--- a/modules/serverless-install-kafka-odc.adoc
+++ b/modules/serverless-install-kafka-odc.adoc
@@ -104,9 +104,12 @@ $ oc get pods -n knative-eventing
 .Example output
 [source,terminal]
 ----
-NAME                                            READY   STATUS    RESTARTS   AGE
-kafka-ch-controller-85f879d577-xcbjh            1/1     Running   0          44s
-kafka-ch-dispatcher-55d76d7db8-ggqjl            1/1     Running   0          44s
-kafka-controller-manager-bc994c465-pt7qd        1/1     Running   0          40s
-kafka-webhook-54646f474f-wr7bb                  1/1     Running   0          42s
+NAME                                        READY   STATUS    RESTARTS   AGE
+kafka-broker-dispatcher-7769fbbcbb-xgffn    2/2     Running   0          44s
+kafka-broker-receiver-5fb56f7656-fhq8d      2/2     Running   0          44s
+kafka-channel-dispatcher-84fd6cb7f9-k2tjv   2/2     Running   0          44s
+kafka-channel-receiver-9b7f795d5-c76xr      2/2     Running   0          44s
+kafka-controller-6f95659bf6-trd6r           2/2     Running   0          44s
+kafka-source-dispatcher-6bf98bdfff-8bcsn    2/2     Running   0          44s
+kafka-webhook-eventing-68dc95d54b-825xs     2/2     Running   0          44s
 ----


### PR DESCRIPTION
Version(s):
Applies for OCP 4.6+

Issue:
https://issues.redhat.com/browse/SRVKE-1093

Link to preview:
http://file.rdu.redhat.com/abrennan/050722/kafkaoutput/serverless/admin_guide/serverless-kafka-admin.html#serverless-install-kafka-odc_serverless-kafka-admin