### PR TITLE
[SRVKS-885] Add cost management integration docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3616,5 +3616,7 @@ Topics:
 - Name: Integrations
   Dir: integrations
   Topics:
+  - Name: Integrating Serverless with the cost management service
+    File: serverless-cost-management-integration
   - Name: Using NVIDIA GPU resources with serverless applications
     File: gpu-resources

--- a/modules/serverless-cost-management-labels.adoc
+++ b/modules/serverless-cost-management-labels.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * /serverless/integrations/serverless-cost-management-integration.adoc
+
+:_content-type: REFERENCE
+[id="serverless-cost-management-labels_{context}"]
+= Using labels for cost management queries
+
+Labels, also known as _tags_ in cost management, can be applied for nodes, namespaces or pods. Each label is a key and value pair. You can use a combination of multiple labels to generate reports. You can access reports about costs by using the link:https://console.redhat.com/openshift/cost-management/[Red Hat hybrid console].
+
+Labels are inherited from nodes to namespaces, and from namespaces to pods. However, labels are not overridden if they already exist on a resource. For example, Knative services have a default `app=<revision_name>` label:
+
+.Example Knative service default label
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: example-service
+spec:
+...
+      labels:
+        app: <revision_name>
+...
+----
+
+If you define a label for a namespace, such as `app=my-domain`, the cost management service does not take into account costs coming from a Knative service with the tag `app=<revision_name>` when querying the application using the `app=my-domain` tag. Costs for Knative services that have this tag must be queried under the `app=<revision_name>` tag.

--- a/serverless/integrations/serverless-cost-management-integration.adoc
+++ b/serverless/integrations/serverless-cost-management-integration.adoc
@@ -1,0 +1,24 @@
+:_content-type: ASSEMBLY
+[id="serverless-cost-management-integration"]
+= Integrating {ServerlessProductShortName} with the cost management service
+include::_attributes/common-attributes.adoc[]
+:context: serverless-cost-management-integration
+
+toc::[]
+
+link:https://access.redhat.com/documentation/en-us/cost_management_service/2022/html/getting_started_with_cost_management/assembly-introduction-cost-management#about-cost-management_getting-started[Cost management] is an {product-title} service that enables you to better understand and track costs for clouds and containers. It is based on the open source link:https://project-koku.github.io/[Koku] project.
+
+[id="prerequisites_serverless-cost-management-integration"]
+== Prerequisites
+
+* You have cluster administrator permissions.
+
+* You have set up cost management and added an link:https://access.redhat.com/documentation/en-us/cost_management_service/2022/html/adding_an_openshift_container_platform_source_to_cost_management/index[{product-title} source].
+
+include::modules/serverless-cost-management-labels.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_serverless-cost-management-integration"]
+== Additional resources
+* link:https://access.redhat.com/documentation/en-us/cost_management_service/2022/html/getting_started_with_cost_management/assembly-installing-cost-management#configure-tagging-next-step_configuring[Configure tagging for your sources]
+* link:https://access.redhat.com/documentation/en-us/cost_management_service/2022/html/getting_started_with_cost_management/assembly-using-cost-management#cost-explorer-next-step_using-cost-management[Use the Cost Explorer to visualize your costs]


### PR DESCRIPTION
Version(s):
OCP 4.6+
Does not apply for ROSA / OSD since the cost management docs are OCP-centric.

Issue:
https://issues.redhat.com/browse/SRVKS-885

Link to docs preview:
http://file.rdu.redhat.com/abrennan/300622/SRVKS-885/serverless/integrations/serverless-cost-management-integration.html