### PR TITLE
OSSMDOC-626: Check known issues file for fixed issues.

### DIFF
--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -2,7 +2,7 @@
 Module included in the following assemblies:
 * service_mesh/v2x/servicemesh-release-notes.adoc
 ////
-
+:_content-type: REFERENCE
 [id="ossm-rn-fixed-issues_{context}"]
 = Fixed issues
 
@@ -49,6 +49,15 @@ Namespace starting with `kube` is hidden from Kiali.
 
 * link:https://issues.redhat.com/browse/OSSM-285[OSSM-285] When trying to access the Kiali console, receive the following error message "Error trying to get OAuth Metadata". The workaround is to restart the Kiali pod.
 
+* link:https://issues.redhat.com/browse/MAISTRA-2735[MAISTRA-2735] The resources that the Service Mesh Operator deletes when reconciling the SMCP changed in {SMProductName} version 2.1. Previously, the Operator deleted a resource with the following labels:
+
+** `maistra.io/owner`
+** `app.kubernetes.io/version`
+
++
+Now, the Operator ignores resources that does not also include the `app.kubernetes.io/managed-by=maistra-istio-operator` label. If you create your own resources, you should not add the `app.kubernetes.io/managed-by=maistra-istio-operator` label to them.
+
+
 * link:https://issues.jboss.org/browse/MAISTRA-2687[MAISTRA-2687] {SMProductName} 2.1 federation gateway does not send the full certificate chain when using external certificates. The {SMProductShortName} federation egress gateway only sends the client certificate. Because the federation ingress gateway only knows about the root certificate, it cannot verify the client certificate unless you add the root certificate to the federation import `ConfigMap`.
 
 * link:https://issues.redhat.com/browse/MAISTRA-2635[MAISTRA-2635] Replace deprecated Kubernetes API. To remain compatible with {product-title} 4.8, the `apiextensions.k8s.io/v1beta1` API was deprecated as of {SMProductName} 2.0.8.
@@ -56,6 +65,8 @@ Namespace starting with `kube` is hidden from Kiali.
 * link:https://issues.redhat.com/browse/MAISTRA-2631[MAISTRA-2631] The WASM feature is not working because podman is failing due to nsenter binary not being present. {SMProductName} generates the following error message: `Error: error configuring CNI network plugin exec: "nsenter": executable file not found in $PATH`. The container image now contains nsenter and WASM works as expected.
 
 * link:https://issues.redhat.com/browse/MAISTRA-2534[MAISTRA-2534] When istiod attempted to fetch the JWKS for an issuer specified in a JWT rule, the issuer service responded with a 502.  This prevented the proxy container from becoming ready and caused deployments to hang. The fix for the link:https://github.com/istio/istio/issues/24629[community bug] has been included in the  {SMProductShortName} 2.0.7 release.
+
+* link:https://issues.jboss.org/browse/MAISTRA-2411[MAISTRA-2411] When the Operator creates a new ingress gateway using `spec.gateways.additionaIngress` in the `ServiceMeshControlPlane`, Operator is not creating a `NetworkPolicy` for the additional ingress gateway like it does for the default istio-ingressgateway. This is causing a 503 response from the route of the new gateway. The workaround for this issue is to manually create the `NetworkPolicy` in the <istio-system> namespace.
 
 * link:https://issues.redhat.com/browse/MAISTRA-2401[MAISTRA-2401] CVE-2021-3586 servicemesh-operator: NetworkPolicy resources incorrectly specified ports for ingress resources. The NetworkPolicy resources installed for {SMProductName} did not properly specify which ports could be accessed. This allowed access to all ports on these resources from any pod. Network policies applied to the following resources are affected:
 
@@ -88,9 +99,11 @@ Upgrading the operator to 2.0 might break client tools that read the SMCP status
 +
 This also causes the READY and STATUS columns to be empty when you run `oc get servicemeshcontrolplanes.v1.maistra.io`.
 
+* link:https://issues.jboss.org/browse/MAISTRA-1947[MAISTRA-1947] _Technology Preview_ Updates to ServiceMeshExtensions are not applied. The workaround is to remove and recreate the ServiceMeshExtensions.
+
 * link:https://issues.redhat.com/browse/MAISTRA-1983[MAISTRA-1983] _Migration to 2.0_ Upgrading to 2.0.0 with an existing invalid `ServiceMeshControlPlane` cannot easily be repaired. The invalid items in the `ServiceMeshControlPlane` resource caused an unrecoverable error. The fix makes the errors recoverable. You can delete the invalid resource and replace it with a new one or edit the resource to fix the errors. For more information about editing your resource, see [Configuring the Red Hat OpenShift Service Mesh installation].
 
-* link:https://issues.redhat.com/browse/MAISTRA-1502[Maistra-1502] As a result of CVEs fixes in version 1.0.10, the Istio dashboards are not available from the *Home Dashboard* menu in Grafana. The Istio dashboards still exist. To access them, click the *Dashboard* menu in the navigation panel and select the *Manage* tab.
+* link:https://issues.redhat.com/browse/MAISTRA-1502[MAISTRA-1502] As a result of CVEs fixes in version 1.0.10, the Istio dashboards are not available from the *Home Dashboard* menu in Grafana. To access the Istio dashboards, click the *Dashboard* menu in the navigation panel and select the *Manage* tab.
 
 * link:https://issues.redhat.com/browse/MAISTRA-1399[MAISTRA-1399] {SMProductName} no longer prevents you from installing unsupported CNI protocols. The supported network configurations has not changed.
 
@@ -101,6 +114,12 @@ This also causes the READY and STATUS columns to be empty when you run `oc get s
 ** [2019-06-03 07:03:28.943][19][warning][misc] [external/envoy/source/common/protobuf/utility.cc:129] Using deprecated option 'envoy.api.v2.listener.Filter.config'. This configuration will be removed from Envoy soon.
 ** [2019-08-12 22:12:59.001][13][warning][misc] [external/envoy/source/common/protobuf/utility.cc:174] Using deprecated option 'envoy.api.v2.Listener.use_original_dst' from file lds.proto. This configuration will be removed from Envoy soon.
 
+* link:https://issues.jboss.org/browse/MAISTRA-806[MAISTRA-806] Evicted Istio Operator Pod causes mesh and CNI not to deploy.
++
+If the `istio-operator` pod is evicted while deploying the control pane, delete the evicted `istio-operator` pod.
++
+* link:https://issues.jboss.org/browse/MAISTRA-681[MAISTRA-681] When the control plane has many namespaces, it can lead to performance issues.
+
 * link:https://issues.jboss.org/browse/MAISTRA-193[MAISTRA-193] Unexpected console info messages are visible when health checking is enabled for citadel.
 
-* link:https://bugzilla.redhat.com/show_bug.cgi?id=1821432[Bug 1821432] Toggle controls in {product-title} Control Resource details page do not update the CR correctly. UI Toggle controls in the Service Mesh Control Plane (SMCP) Overview page in the {product-title} web console sometimes update the wrong field in the resource. To update a SMCP, edit the YAML content directly or update the resource from the command line instead of clicking the toggle controls.
+* link:https://bugzilla.redhat.com/show_bug.cgi?id=1821432[Bugzilla 1821432] The toggle controls in {product-title} Custom Resource details page does not update the CR correctly. UI Toggle controls in the Service Mesh Control Plane (SMCP) Overview page in the {product-title} web console sometimes updates the wrong field in the resource. To update a SMCP, edit the YAML content directly or update the resource from the command line instead of clicking the toggle controls.

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -2,7 +2,7 @@
 Module included in the following assemblies:
 * service_mesh/v2x/servicemesh-release-notes.adoc
 ////
-
+:_content-type: REFERENCE
 [id="ossm-rn-known-issues_{context}"]
 = Known issues
 
@@ -32,14 +32,18 @@ These limitations exist in {SMProductName}:
 
 These are the known issues in {SMProductName}:
 
+* link:https://github.com/istio/istio/issues/14743[Istio-14743] Due to limitations in the version of Istio that this release of {SMProductName} is based on, there may be applications that are currently incompatible with {SMProductShortName}. See the linked community issue for details.
+
 * https://issues.redhat.com/browse/OSSM-1668[OSSM-1668]
 `jwksResolverCA` field is missing in `SMCP`.
 +
 If you upgrade from Service Mesh operator 2.1.3 to Service Mesh operator 2.2, then the `jwksResolverCA` field is not supported. You must use the `techPreview` `jwksResolverExtraRootCA` field to enable additional JWKS CA certificates.
-
+//Keep OSSM-1655 in RN, closed as "explained" error is expected.
 * https://issues.redhat.com/browse/OSSM-1655[OSSM-1655] Kiali dashboard shows error after enabling mTLS in `SMCP`.
 +
-After enabling the `spec.security.controlPlane.mtls` setting in the SMCP, the Kiali console displays the following error message `"No subsets defined"`.
+After enabling the `spec.security.controlPlane.mtls` setting in the SMCP, the Kiali console displays the following error message `No subsets defined`.
+
+* https://issues.redhat.com/browse/OSSM-1396[OSSM-1396] If a gateway resource contains the `spec.externalIPs` setting, instead of being recreated when the `ServiceMeshControlPlane` is updated, the gateway is removed and never recreated.
 
 * https://issues.redhat.com/browse/OSSM-1211[OSSM-1211]
 Configuring Federated service meshes for failover does not work as expected.
@@ -48,14 +52,10 @@ The Istiod pilot log displays the following error: `envoy connection [C289] TLS 
 +
 There is no workaround at this time.
 
-* link:https://github.com/istio/istio/issues/14743[Istio-14743] Due to limitations in the version of Istio that this release of {SMProductName} is based on, there are several applications that are currently incompatible with {SMProductShortName}. See the linked community issue for details.
-
-* https://issues.redhat.com/browse/OSSM-1396[OSSM-1396] If a gateway resource contains the `spec.externalIPs` setting, instead of being recreated when the `ServiceMeshControlPlane` is updated, the gateway is removed and never recreated.
-
 * https://issues.redhat.com/browse/OSSM-1168[OSSM-1168] When service mesh resources are created as a single YAML file, the Envoy proxy sidecar is not reliably injected into pods. When the SMCP, SMMR, and Deployment resources are created individually, the deployment works as expected.
-
+//Keep OSSM-1052 in RN - Closed as documented.
 * https://issues.redhat.com/browse/OSSM-1052[OSSM-1052] When configuring a Service `ExternalIP` for the ingressgateway in the service mesh control plane, the service is not created. The schema for the SMCP is missing the parameter for the service. The workaround for this issue is to disable the gateway creation in the SMCP spec and manage the gateway deployment entirely manually (including Service, Role and RoleBinding).
-
+//Keep OSSM-882 in RN to document the workaround
 * https://issues.redhat.com/browse/OSSM-882[OSSM-882] Namespace is in the accessible_namespace list but does not appear in Kiali UI. By default, Kiali will not show any namespaces that start with "kube" because these namespaces are typically internal-use only and not part of a mesh.
 +
 For example, if you create a namespace called 'akube-a' and add it to the Service Mesh member roll, then the Kiali UI does not display the namespace. For defined exclusion patterns, the software excludes namespaces that start with or contain the pattern.
@@ -74,19 +74,9 @@ api:
     - "^kiali-operator"
 ----
 +
-* link:https://issues.redhat.com/browse/MAISTRA-2735[MAISTRA-2735] The resources that the Service Mesh Operator deletes when reconciling the SMCP have changed. Previously, the Operator deleted a resource with the following labels:
-
-** `maistra.io/owner`
-** `app.kubernetes.io/version`
-
-+
-Now, the Operator ignores resources that don't also include the `app.kubernetes.io/managed-by=maistra-istio-operator` label. If you create your own resources, you should not add the `app.kubernetes.io/managed-by=maistra-istio-operator` label to them.
-
 * link:https://issues.redhat.com/browse/MAISTRA-2692[MAISTRA-2692] With Mixer removed, custom metrics that have been defined in {SMProductShortName} 2.0.x cannot be used in 2.1. Custom metrics can be configured using `EnvoyFilter`. Red Hat is unable to support `EnvoyFilter` configuration except where explicitly documented. This is due to tight coupling with the underlying Envoy APIs, meaning that backward compatibility cannot be maintained.
 
 * link:https://issues.redhat.com/browse/MAISTRA-2648[MAISTRA-2648] `ServiceMeshExtensions` are currently not compatible with meshes deployed on IBM Z Systems.
-
-* link:https://issues.jboss.org/browse/MAISTRA-2411[MAISTRA-2411] When the Operator creates a new ingress gateway using `spec.gateways.additionaIngress` in the `ServiceMeshControlPlane`, Operator is not creating a `NetworkPolicy` for the additional ingress gateway like it does for the default istio-ingressgateway. This is causing a 503 response from the route of the new gateway. The workaround for this issue is to manually create the `NetworkPolicy` in the <istio-system> namespace.
 
 * link:https://issues.jboss.org/browse/MAISTRA-1959[MAISTRA-1959] _Migration to 2.0_ Prometheus scraping (`spec.addons.prometheus.scrape` set to `true`) does not work when mTLS is enabled. Additionally, Kiali displays extraneous graph data when mTLS is disabled.
 +
@@ -103,22 +93,12 @@ spec:
           - 15020
 ----
 +
-* link:https://issues.jboss.org/browse/MAISTRA-1947[MAISTRA-1947] _Technology Preview_ Updates to ServiceMeshExtensions are not applied. The workaround is to remove and recreate the ServiceMeshExtensions.
-
+//Keep MAISTRA-1314 in RN until IPv6 is actually supported
 * link:https://issues.redhat.com/browse/MAISTRA-1314[MAISTRA-1314] {SMProductName} does not yet support IPv6.
-
-* link:https://issues.jboss.org/browse/MAISTRA-806[MAISTRA-806] Evicted Istio Operator Pod causes mesh and CNI not to deploy.
-+
-If the `istio-operator` pod is evicted while deploying the control pane, delete the evicted `istio-operator` pod.
-+
-* link:https://issues.jboss.org/browse/MAISTRA-681[MAISTRA-681] When the control plane has many namespaces, it can lead to performance issues.
-
-* link:https://issues.jboss.org/browse/MAISTRA-465[MAISTRA-465] The Maistra Operator fails to create a service for operator metrics.
 
 * link:https://issues.jboss.org/browse/MAISTRA-453[MAISTRA-453] If you create a new project and deploy pods immediately, sidecar injection does not occur. The operator fails to add the `maistra.io/member-of` before the pods are created, therefore the pods must be deleted and recreated for sidecar injection to occur.
 
 * link:https://issues.jboss.org/browse/MAISTRA-158[MAISTRA-158] Applying multiple gateways referencing the same hostname will cause all gateways to stop functioning.
-
 
 [id="ossm-rn-known-issues-kiali_{context}"]
 == Kiali known issues
@@ -130,6 +110,7 @@ New issues for Kiali should be created in the link:https://issues.redhat.com/pro
 
 These are the known issues in Kiali:
 
+//Keep KIALI-2206 in RN as this is for information purposes.
 * link:https://issues.jboss.org/browse/KIALI-2206[KIALI-2206] When you are accessing the Kiali console for the first time, and there is no cached browser data for Kiali, the “View in Grafana” link on the Metrics tab of the Kiali Service Details page redirects to the wrong location. The only way you would encounter this issue is if you are accessing Kiali for the first time.
-
+//Keep KIALI-507 in RN as this is for information purposes.
 * link:https://github.com/kiali/kiali/issues/507[KIALI-507] Kiali does not support Internet Explorer 11. This is because the underlying frameworks do not support Internet Explorer. To access the Kiali console, use one of the two most recent versions of the Chrome, Edge, Firefox or Safari browser.


### PR DESCRIPTION
Version(s):  OCP 4.6 - 4.11

Issue: [OSSMDOC-626](https://issues.redhat.com/browse/OSSMDOC-626)

Link to docs preview:
http://file.bos.redhat.com/jstickle/OSSMDOC-626/service_mesh/v2x/servicemesh-release-notes.html

This PR 
* Checks the Known Issues module for issues that have been fixed and moves them to the Fixed Issues module
* Adds comments for issues that have been closed in JIRA because they were documented (there were some questions about why some of these were still in the release notes if they were closed)
* Rearranges some of the issues in numerical order for easier reference/ findability

QE review: pbajjuri20
Peer review: nalhadef