### PR TITLE
OSSMDOC-597: Document support for ROSA.

### DIFF
--- a/modules/ossm-federation-limitations.adoc
+++ b/modules/ossm-federation-limitations.adoc
@@ -10,4 +10,3 @@ The {SMProductName} federated approach to joining meshes has the following limit
 
 * Federation of meshes is not supported on OpenShift Dedicated.
 * Federation of meshes is not supported on Microsoft Azure Red Hat OpenShift (ARO).
-* Federation of meshes is not supported on Red Hat OpenShift Service on AWS (ROSA).

--- a/modules/ossm-supported-configurations.adoc
+++ b/modules/ossm-supported-configurations.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-//
+// 
 // * service_mesh/v2x/preparing-ossm-install.adoc
 // * service_mesh/v2x/servicemesh-release-notes.adoc
 // * post_installation_configuration/network-configuration.adoc
@@ -14,7 +14,8 @@ The following configurations are supported for the current release of {SMProduct
 
 * Red Hat {product-title} version 4.9 or later.
 * {product-dedicated} version 4.
-* Azure Red Hat OpenShift version 4.
+* Azure Red Hat OpenShift (ARO) version 4.
+* Red Hat OpenShift Service on AWS (ROSA).
 
 For additional information about {SMProductName} lifecycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift#ossm[Support Policy].
 


### PR DESCRIPTION
Version(s): 4.6 - 4.11

Issue:[OSSMDOC-597](https://issues.redhat.com/browse/OSSMDOC-597)

Update the docs to document ROSA as a fully supported platform.

Link to docs preview:
http://file.bos.redhat.com/jstickle/OSSMDOC-597/service_mesh/v2x/preparing-ossm-installation.html#ossm-supported-configurations_preparing-ossm-installation
http://file.bos.redhat.com/jstickle/OSSMDOC-597/service_mesh/v2x/ossm-federation.html#ossm-federation-limitations_federation

QE review -  pbajjuri20
Peer review - jc-berger