### PR TITLE
Adding the context to an additional resources ID

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
@@ -16,7 +16,7 @@ include::modules/dr-restoring-cluster-state.adoc[leveloffset=+1]
 include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources"]
+[id="additional-resources_dr-restoring-cluster-state"]
 == Additional resources
 
 * xref:../../../networking/accessing-hosts.adoc#accessing-hosts[Creating a bastion host to access {product-title} instances and the control plane nodes with SSH].


### PR DESCRIPTION
This applies to `main`, `enterprise-4.11` and `enterprise-4.10`.

This PR adds the context for an assembly to an additional resources ID. This relates to https://github.com/openshift/openshift-docs/pull/47040.