### PR TITLE
[OSDOCS-3595]: pd-balanced disks for GCP

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-gcp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-gcp.adoc
@@ -8,18 +8,31 @@ toc::[]
 
 You can create a different machine set to serve a specific purpose in your {product-title} cluster on Google Cloud Platform (GCP). For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
+//[IMPORTANT] admonition for UPI
 include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
+//Machine API overview
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 
+//Sample YAML for a machine set custom resource on GCP
 include::modules/machineset-yaml-gcp.adoc[leveloffset=+1]
 
+//Creating a machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 
+//Configuring persistent disk types by using machine sets
+include::modules/machineset-gcp-pd-disk-types.adoc[leveloffset=+1]
+
+//Machine sets that deploy machines as preemptible VM instances
 include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
 
-include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+1]
+//Creating preemptible VM instances by using machine sets
+include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+2]
 
+//Enabling customer-managed encryption keys for a machine set
 include::modules/machineset-enabling-customer-managed-encryption.adoc[leveloffset=+1]
+//TODO break out procedure as a L2
 
+//Enabling GPU support for a machine set
 include::modules/machineset-gcp-enabling-gpu-support.adoc[leveloffset=+1]
+//TODO break out procedure as a L2

--- a/modules/machineset-gcp-pd-disk-types.adoc
+++ b/modules/machineset-gcp-pd-disk-types.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-gcp.adoc
+
+:_content-type: PROCEDURE
+[id="machineset-gcp-pd-disk-types_{context}"]
+= Configuring persistent disk types by using machine sets
+
+You can configure the type of persistent disk that a machine set deploys machines on by editing the machine set YAML file. 
+
+For more information about persistent disk types, compatibility, regional availability, and limitations, see the GCP Compute Engine documentation about link:https://cloud.google.com/compute/docs/disks#pdspecs[persistent disks].
+
+.Procedure
+
+. In a text editor, open the YAML file for an existing machine set or create a new one.
+
+. Edit the following line under the `providerSpec` field:
++
+[source,yaml]
+----
+providerSpec:
+  value:
+    disks:
+      type: <pd-disk-type> <1>
+----
+<1> Specify the disk persistent type. Valid values are `pd-ssd`, `pd-standard`, and `pd-balanced`. The default value is `pd-standard`.
+
+.Verification
+
+* On the Google Cloud console, review the details for a machine deployed by the machine set and verify that the `Type` field matches the configured disk type.


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OSDOCS-3595](https://issues.redhat.com//browse/OSDOCS-3595)

Link to docs preview:
[Configuring persistent disk types by using machine sets](http://file.rdu.redhat.com/jrouth/OSDOCS-3595-gcp-pd-balanced-disks/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-gcp-pd-disk-types_creating-machineset-gcp) (VPN required)

Additional information:
- This does not call out `pd-balanced` specifically, but rather shows how to set the disk type via machine set. The `pd-balanced` type support can be announced in the release notes.
- This PR is for 4.11+ because it includes `pd-balanced`, but I think this should be backported with the other two supported disk types (I assume through 4.6 but will check with SMEs).
- Did some housekeeping in the "Creating a machine set on GCP" assembly