### PR TITLE
clarifying the context variable in module headings

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -277,19 +277,26 @@ Do not include line spaces between the anchor ID and the section title.
 
 === Anchoring in module files
 
-You must add the `{context}` variable to the end of anchor IDs in module files. When called, the `{context}` variable is resolved into the value declared in the `:context:` attribute in the corresponding assembly file. This enables cross-referencing to module IDs in context to a specific assembly and is useful when a module is included in multiple assemblies.
+You must add the `{context}` variable to the end of each anchor ID in module files. When called, the `{context}` variable is resolved into the value declared in the `:context:` attribute in the corresponding assembly file. This enables cross-referencing to module IDs in context to a specific assembly and is useful when a module is included in multiple assemblies.
 
-The following is an example of an anchor ID in a module file:
+[NOTE]
+====
+The `{context}` variable must be preceded by an underscore (`_`) when declared in an anchor ID.
+====
+
+The following is an example of an anchor ID for a module file title:
 
 ----
 [id="sending-notifications-to-external-systems_{context}"]
 = Sending notifications to external systems
 ----
 
-[NOTE]
-====
-The `{context}` variable must be preceded by an underscore (`_`) when declared in an anchor ID.
-====
+The following is an example of an anchor ID for a second level (`==`) heading:
+
+----
+[id="deployment-scaling-benefits_{context}"]
+== Deployment and scaling benefits
+----
 
 === Anchoring "Prerequisites", "Additional resources", and "Next steps" titles in assemblies
 


### PR DESCRIPTION
We had a discussion about a build error that was caused by a missing `_{context}` element in a secondary heading, so I'm proposing a clarification. (So many modules have a single anchor that it's easy to forget that _all_ anchors in modules need the `_{context}` element.)