### PR TITLE
CNV-18642: Removing specific Quick Start titles in VM Quick Start

### DIFF
--- a/modules/virt-creating-vm-quick-start-web.adoc
+++ b/modules/virt-creating-vm-quick-start-web.adoc
@@ -10,12 +10,6 @@ The web console provides Quick Starts with instructional guided tours for creati
 
 Tasks in a Quick Start begin with selecting a Red Hat template. Then, you can add a boot source and import the operating system image. Finally, you can save the custom template and use it to create a virtual machine.
 
-Quick Start tours for creating virtual machines include the following:
-
-* Creating a Red Hat Enterprise Linux virtual machine
-* Creating a Windows 10 virtual machine
-* Importing a VMWare virtual machine
-
 .Prerequisites
 * Access to the website where you can download the URL link for the operating system image.
 


### PR DESCRIPTION
For 4.7, 4.8, 4.9, 4.10, and 4.11.

This PR removes specific titles of Quick Starts in the VM Quick Start module. The original request was to remove the Import VM QS title as it's no longer available. My thinking is that we shouldn't list specific Quick Start titles as they change frequently (as exemplified here :-) @apinnick WDYT?

See PR https://github.com/openshift/openshift-docs/pull/47362 for addition of general QS promotion for boot sources.

Jira: https://issues.redhat.com/browse/CNV-18642

Direct doc preview build: http://file.rdu.redhat.com/bgaydos/CNV-18642_2/virt/virtual_machines/virt-create-vms.html#virt-creating-vm-quick-start-web_virt-create-vms