### PR TITLE
CNV-18642: Adding general QS note to Boot Sources

### DIFF
--- a/virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.adoc
@@ -10,6 +10,8 @@ A boot source contains a bootable operating system (OS) and all of the configura
 
 You use a boot source to create virtual machine templates with specific configurations. These templates can be used to create any number of available virtual machines.
 
+Quick Start tours are available in the {product-title} web console to assist you in creating a custom boot source, uploading a boot source, and other tasks. Select *Quick Starts* from the *Help* menu to view the Quick Start tours.
+
 include::modules/virt-about-vms-and-boot-sources.adoc[leveloffset=+1]
 
 include::modules/virt-importing-rhel-image-boot-source-web.adoc[leveloffset=+1]


### PR DESCRIPTION
Revision/replacement of PR https://github.com/openshift/openshift-docs/pull/47210
See https://github.com/openshift/openshift-docs/pull/47361 for removal of specific Quick Start titles in Create VM assembly.

This PR only updates the boot sources assembly to add a general promotion for the Quick Starts.

For 4.7, 4.8, 4.9, 4.10, and 4.11.

@apinnick See this Jira for details on the two PR for this story:
Jira: https://issues.redhat.com/browse/CNV-18642

Direct doc preview link: http://file.rdu.redhat.com/bgaydos/CNV-18642_3/virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.html
