### PR TITLE
ECOPROJECT 615: Updating references to Poison Pill Operator with Self Node Remediation Operator in NHC files

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1962,8 +1962,8 @@ Topics:
     File: nodes-nodes-managing-max-pods
   - Name: Using the Node Tuning Operator
     File: nodes-node-tuning-operator
-  - Name: Remediating nodes with the Poison Pill Operator
-    File: eco-poison-pill-operator
+  - Name: Remediating nodes with the Self Node Remediation Operator
+    File: eco-self-node-remediation-operator
   - Name: Deploying node health checks by using the Node Health Check Operator
     File: eco-node-health-check-operator
   - Name: Using the Node Maintenance Operator to place nodes in maintenance mode

--- a/modules/eco-node-health-check-operator-about.adoc
+++ b/modules/eco-node-health-check-operator-about.adoc
@@ -6,11 +6,11 @@
 [id="about-node-health-check-operator_{context}"]
 = About the Node Health Check Operator
 
-The Node Health Check Operator deploys the `NodeHealthCheck` controller to detect the health of a node in the cluster. The `NodeHealthCheck` controller creates the `NodeHealthCheck` custom resource (CR), which defines a set of criteria and thresholds to determine the node's health. 
+The Node Health Check Operator deploys the `NodeHealthCheck` controller to detect the health of a node in the cluster. The `NodeHealthCheck` controller creates the `NodeHealthCheck` custom resource (CR), which defines a set of criteria and thresholds to determine the node's health.
 
-The Node Health Check Operator also installs the Poison Pill Operator as a default remediation provider.
+The Node Health Check Operator also installs the Self Node Remediation Operator as a default remediation provider.
 
-When the Node Health Check Operator detects an unhealthy node, it creates a remediation CR that triggers the remediation provider. For example, the controller creates the `PoisonPillRemediation` CR, which triggers the Poison Pill Operator to remediate the unhealthy node. 
+When the Node Health Check Operator detects an unhealthy node, it creates a remediation CR that triggers the remediation provider. For example, the controller creates the `SelfNodeRemediation` CR, which triggers the Self Node Remediation Operator to remediate the unhealthy node.
 
 The `NodeHealthCheck` CR resembles the following YAML file:
 
@@ -24,12 +24,12 @@ metadata:
 spec:
   minHealthy: 51% <1>
   pauseRequests: <2>
-    - <pause-test-cluster> 
+    - <pause-test-cluster>
   remediationTemplate: <3>
-    apiVersion: poison-pill.medik8s.io/v1alpha1
-    name: group-x
+    apiVersion: self-node-remediation.medik8s.io/v1alpha1
+    name: self-node-remediation-resource-deletion-template
     namespace: openshift-operators
-    kind: PoisonPillRemediationTemplate
+    kind: SelfNodeRemediationTemplate
   selector: <4>
     matchExpressions:
       - key: node-role.kubernetes.io/worker
@@ -50,9 +50,9 @@ spec:
 ====
 During the upgrade process, nodes in the cluster might become temporarily unavailable and get identified as unhealthy. In the case of worker nodes, when the Operator detects that the cluster is upgrading, it stops remediating new unhealthy nodes to prevent such nodes from rebooting.
 ====
-<3> Specifies a remediation template from the remediation provider. For example, from the Poison Pill Operator. 
+<3> Specifies a remediation template from the remediation provider. For example, from the Self Node Remediation Operator.
 <4> Specifies a `selector` that matches labels or expressions that you want to check. The default value is empty, which selects all nodes.
-<5> Specifies a list of the conditions that determine whether a node is considered unhealthy. 	
+<5> Specifies a list of the conditions that determine whether a node is considered unhealthy.
 <6> Specifies the timeout duration for a node condition. If a condition is met for the duration of the timeout, the node will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy node.
 
 [id="understanding-nhc-operator-workflow_{context}"]
@@ -63,7 +63,7 @@ When a node is identified as unhealthy, the Node Health Check Operator checks ho
 When the node turns healthy, the controller deletes the external remediation template.
 
 [id="how-nhc-prevent-conflict-with-mhc_{context}"]
-== About how node health checks prevent conflicts with machine health checks 
+== About how node health checks prevent conflicts with machine health checks
 
 When both, node health checks and machine health checks are deployed, the node health check avoids conflict with the machine health check.
 

--- a/nodes/nodes/eco-node-health-check-operator.adoc
+++ b/nodes/nodes/eco-node-health-check-operator.adoc
@@ -6,12 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Use the Node Health Check Operator to deploy the `NodeHealthCheck` controller. The controller identifies unhealthy nodes and uses the Poison Pill Operator to remediate the unhealthy nodes.
+Use the Node Health Check Operator to deploy the `NodeHealthCheck` controller. The controller identifies unhealthy nodes and uses the Self Node Remediation Operator to remediate the unhealthy nodes.
 
 [role="_additional-resources"]
 .Additional resources
 
-xref:../../nodes/nodes/eco-poison-pill-operator.adoc#poison-pill-operator-remediate-nodes[Remediating nodes with the Poison Pill Operator]
+xref:../../nodes/nodes/eco-self-node-remediation-operator.adoc#self-node-remediation-operator-remediate-nodes[Remediating nodes with the Self Node Remediation Operator]
 
 :FeatureName: Node Health Check Operator
 


### PR DESCRIPTION
Version(s): OpenShift 4.11+

Issue: https://issues.redhat.com/browse/TELCODOCS-619

Link to docs preview: http://file.emea.redhat.com/avbhatt/td-619/nodes/nodes/eco-node-health-check-operator.html

Additional information:
This PR addresses the doc changes required in the Node Health Check Operator to accommodate the Poison Pill Operator name change (now renamed as Self Node Remediation Operator). Along with the Operator name, this PR also updates references to CRs, namespaces, kind, APIs, and any other updates that are related to the name change.