### PR TITLE
OADP#395: Velero plug-in configuration

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
@@ -12,4 +12,5 @@ OpenShift API for Data Protection (OADP) features provide options for backing up
 The default plug-ins enable Velero to integrate with certain cloud providers and to back up and restore {product-title} resources.
 
 include::modules/oadp-features.adoc[leveloffset=+1]
-include::modules/oadp-plugins.adoc[leveloffset=+1]
+include::modules/oadp-plugins.adoc[leveloffset=+1
+include::modules/oadp-configuring-velero-plugins.adoc[leveloffset=+1]

--- a/modules/oadp-configuring-velero-plugins.adoc
+++ b/modules/oadp-configuring-velero-plugins.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+
+:_content-type: CONCEPT
+[id="oadp-configuring-velero-plugins_{context}"]
+= About OADP Velero plug-ins
+
+You can configure two types of plug-ins when you install Velero:
+
+* Default cloud provider plug-ins
+* Custom plug-ins
+
+Both types of plug-in are optional, but most users configure at least one cloud provider plug-in.
+
+== Default Velero cloud provider plug-ins
+
+You can install any of the following default Velero cloud provider plug-ins when you configure the `oadp_v1alpha1_dpa.yaml` file during deployment:
+
+* `aws` (Amazon Web Services)
+* `gcp` (Google Cloud Platform)
+* `azure` (Microsoft Azure)
+* `openshift` (OpenShift Velero plug-in)
+* `csi` (Container Storage Interface)
+* `kubevirt` (KubeVirt)
+
+You specify the desired default plug-ins in the `oadp_v1alpha1_dpa.yaml` file during deployment.
+
+.Example file
+
+The following `.yaml` file installs the `openshift`, `aws`, `azure`, and `gcp` plug-ins:
+
+[source,yaml]
+----
+ apiVersion: oadp.openshift.io/v1alpha1
+ kind: DataProtectionApplication
+ metadata:
+   name: dpa-sample
+ spec:
+   configuration:
+     velero:
+       defaultPlugins:
+       - openshift
+       - aws
+       - azure
+       - gcp
+----
+
+== Custom Velero plug-ins
+
+You can install a custom Velero plug-in by specifying the plug-in `image` and `name` when you configure the `oadp_v1alpha1_dpa.yaml` file during deployment.
+
+You specify the desired custom plug-ins in the `oadp_v1alpha1_dpa.yaml` file during deployment.
+
+.Example file
+
+The following `.yaml` file installs the default `openshift`, `azure`, and `gcp` plug-ins and a custom plug-in that has the name `custom-plugin-example` and the image `quay.io/example-repo/custom-velero-plugin`:
+
+[source,yaml]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+ name: dpa-sample
+spec:
+ configuration:
+   velero:
+     defaultPlugins:
+     - openshift
+     - azure
+     - gcp
+     customPlugins:
+     - name: custom-plugin-example
+       image: quay.io/example-repo/custom-velero-plugin
+----


### PR DESCRIPTION
OADP 1.1.0, OCP 4.6+

Resolves https://issues.redhat.com/browse/OADP-395 by adding configuration procedures for Velero plug-ins.

Preview:  http://file.emea.redhat.com/rhoch/velero_plugin_congig/backup_and_restore/application_backup_and_restore/oadp-features-plugins.html#oadp-configuring-velero-plugins_oadp-features-plugins