### PR TITLE
OADP-483: Warn about too frequent backup schedule

### DIFF
--- a/modules/oadp-scheduling-backups.adoc
+++ b/modules/oadp-scheduling-backups.adoc
@@ -8,6 +8,13 @@
 
 You schedule backups by creating a `Schedule` custom resource (CR) instead of a `Backup` CR.
 
+[WARNING]
+====
+Leave enough time in your backup schedule for a backup to finish before another backup is created.
+
+For example, if a backup of a namespace typically takes 10 minutes, do not schedule backups more frequently than every 15 minutes.
+====
+
 .Prerequisites
 
 * You must install the OpenShift API for Data Protection (OADP) Operator.


### PR DESCRIPTION
OADP 1.1.0, OCP 4.6+

Resolves https://issues.redhat.com/browse/OADP-483 by adding a short warning text to https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html-single/backup_and_restore/index#oadp-scheduling-backups_backing-up-applications.

Preview: http://file.emea.redhat.com/rhoch/backup_sched_warn/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-scheduling-backups_backing-up-applications

