### PR TITLE
OADP-377: Update IAM policy for image uploads

### DIFF
--- a/modules/migration-configuring-aws-s3.adoc
+++ b/modules/migration-configuring-aws-s3.adoc
@@ -98,7 +98,9 @@ $ cat > velero-policy.json <<EOF
         {
             "Effect": "Allow",
             "Action": [
-                "s3:ListBucket"
+                "s3:ListBucket",
+                "s3:GetBucketLocation",
+                "s3:ListBucketMultipartUploads"
             ],
             "Resource": [
                 "arn:aws:s3:::${BUCKET}"


### PR DESCRIPTION
OADP 1.1.0, OCP 4.6+

Resolves https://issues.redhat.com/browse/OADP-377 by adding two IAM permissions missing from current documentation. 

Preview:  http://file.emea.redhat.com/rhoch/update_iam/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#migration-configuring-aws-s3_installing-oadp-aws , step 5. 