### PR TITLE
RNs-4.9.41 Added with bug fix update

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2941,3 +2941,26 @@ link:https://access.redhat.com/solutions/6964719[{product-title} 4.9.40 containe
 ==== Updating
 
 To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-9-41"]
+=== RHBA-2022:5434 - {product-title} 4.9.41 bug fix update
+
+Issued: 2022-07-05
+
+{product-title} release 4.9.41, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5434[RHBA-2022:5434] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5433[RHBA-2022:5433] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6965553[{product-title} 4.9.41 container image list]
+
+[id="ocp-4-9-41-bug-fixes"]
+==== Bug fixes
+
+* Previously, when a `PipelineRun` was created with a `volumeClaimTemplate`, the pipelines used the hardcoded value of `gp2` rather than the assigned storage class name. With this fix, the appropriate storage class name is assigned when starting a `PipelineRun` with a `volumeClaimTemplate`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097618#[*BZ#2097618*])
+
+* Previously, HAProxy redirected to the wrong HTTPS route. As a result, applications were not redirected to HTTPS and were not validated. This fix sets a flag on the redirect map to ensure the HAProxy redirects to the correct HTTPS route. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2010227#[*BZ#2010227*])
+
+[id="ocp-4-9-41-updating"]
+==== Updating
+
+To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
**RNs-4.9.41**
Added with bug fix update

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

**Version(s):**
PR applies only to enterprise-4.9

**Issue:**
https://issues.redhat.com/browse/OCPPLAN-9498

**Link to docs preview:**
https://wiharris.github.io/openshift-docs/RNs-4.9.41/release_notes/ocp-4-9-release-notes.html#ocp-4-9-41


**Additional information:**



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
