### PR TITLE
ECOPROJECT-411: Add info about the SNR CR and lastError field

### DIFF
--- a/modules/eco-poison-pill-operator-about.adoc
+++ b/modules/eco-poison-pill-operator-about.adoc
@@ -8,6 +8,22 @@
 
 The Poison Pill Operator runs on the cluster nodes and reboots nodes that are identified as unhealthy. The Operator uses the `MachineHealthCheck` controller to detect the health of a node in the cluster. When a node is identified as unhealthy, the `MachineHealthCheck` resource creates the `PoisonPillRemediation` custom resource (CR), which triggers the Poison Pill Operator.
 
+The `SelfNodeRemediation` CR resembles the following YAML file:
+
+[source,yaml]
+----
+apiVersion: self-node-remediation.medik8s.io/v1alpha1
+kind: SelfNodeRemediation
+metadata:
+  name: selfnoderemediation-sample
+  namespace: openshift-operators
+spec:
+status:
+  lastError: <last_error_message> <1>
+----
+
+<1> Displays the last error that occurred during remediation. When remediation succeeds or if no errors occur, the field is left empty.
+
 The Poison Pill Operator minimizes downtime for stateful applications and restores compute capacity if transient failures occur. You can use this Operator regardless of the management interface, such as IPMI or an API to provision a node, and regardless of the cluster installation type, such as installer-provisioned infrastructure or user-provisioned infrastructure.
 
 [id="understanding-poison-pill-operator-config_{context}"]


### PR DESCRIPTION
[TELCODOCS-330](https://issues.redhat.com//browse/TELCODOCS-330) adds the `lastError` field to the `SelfNodeRemediation` CR

Version(s): OpenShift 4.11+

Issue: https://issues.redhat.com/browse/TELCODOCS-330

Link to docs preview: http://file.emea.redhat.com/avbhatt/td-330/nodes/nodes/eco-poison-pill-operator.html#about-poison-pill-operator_poison-pill-operator-remediate-nodes

Additional information:
This PR uses the updated name for `PoisonPillRemediation` CR (which is `SelfNodeRemediation` CR). The Operator and related components name change is addressed in a separate PR. 
