### PR TITLE
GitHub-43205: Fixing example callback URL

### DIFF
--- a/modules/config-github-idp.adoc
+++ b/modules/config-github-idp.adoc
@@ -45,7 +45,7 @@ https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp
 For example:
 +
 ----
-https://oauth-openshift.apps.example-openshift-cluster.com/oauth2callback/github/
+https://oauth-openshift.apps.openshift-cluster.example.com/oauth2callback/github
 ----
 
 . link:https://docs.github.com/en/developers/apps/creating-an-oauth-app[Register an application on GitHub].

--- a/modules/config-gitlab-idp.adoc
+++ b/modules/config-gitlab-idp.adoc
@@ -38,7 +38,7 @@ https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp
 For example:
 +
 ----
-https://oauth-openshift.apps.example-openshift-cluster.com/oauth2callback/gitlab/
+https://oauth-openshift.apps.openshift-cluster.example.com/oauth2callback/gitlab
 ----
 
 . link:https://docs.gitlab.com/ee/integration/oauth_provider.html[Add a new application in GitLab].

--- a/modules/config-google-idp.adoc
+++ b/modules/config-google-idp.adoc
@@ -41,7 +41,7 @@ https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp
 For example:
 +
 ----
-https://oauth-openshift.apps.example-openshift-cluster.com/oauth2callback/github/
+https://oauth-openshift.apps.openshift-cluster.example.com/oauth2callback/github
 ----
 
 . Configure a Google identity provider using link:https://developers.google.com/identity/protocols/OpenIDConnect[Google's OpenID Connect integration].

--- a/modules/config-idp.adoc
+++ b/modules/config-idp.adoc
@@ -52,7 +52,7 @@ You must register the OAuth app under your GitHub organization. If you register 
 The following is an example of a homepage URL for a GitHub identity provider:
 +
 ----
-https://oauth-openshift.apps.example-openshift-cluster.com
+https://oauth-openshift.apps.openshift-cluster.example.com
 ----
 
 * For the authorization callback URL in your GitHub OAuth app configuration, specify the full *OAuth callback URL* that is automatically generated in the *Add a GitHub identity provider* page on {cluster-manager}. The full URL has the following syntax:

--- a/modules/config-openid-idp.adoc
+++ b/modules/config-openid-idp.adoc
@@ -78,7 +78,7 @@ https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp
 For example:
 +
 ----
-https://oauth-openshift.apps.example-openshift-cluster.com/oauth2callback/openid/
+https://oauth-openshift.apps.openshift-cluster.example.com/oauth2callback/openid
 ----
 
 . link:https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest[Create an authorization request using an Authorization Code Flow].

--- a/modules/identity-provider-registering-github.adoc
+++ b/modules/identity-provider-registering-github.adoc
@@ -32,7 +32,7 @@ https://oauth-openshift.apps.<cluster-name>.<cluster-domain>/oauth2callback/<idp
 For example:
 +
 ----
-https://oauth-openshift.apps.example-openshift-cluster.com/oauth2callback/github/
+https://oauth-openshift.apps.openshift-cluster.example.com/oauth2callback/github
 ----
 . Click *Register application*. GitHub provides a client ID and a client secret.
 You need these values to complete the identity provider configuration.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.6+

Issue:
#43205

Link to docs preview:
* OCP (single page): http://file.rdu.redhat.com/~ahoffer/2022/configuring-github-identity-provider.html#identity-provider-registering-github_configuring-github-identity-provider
* ROSA: (single page): http://file.rdu.redhat.com/~ahoffer/2022/rosa-sts-config-identity-providers.html
* Dedicated (single page): http://file.rdu.redhat.com/~ahoffer/2022/config-identity-providers.html

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
