### PR TITLE
Release note for LegacyServiceAccountTokenNoAutoGeneration

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -314,13 +314,18 @@ The `haproxy.router.openshift.io/balance` variable, which sets the router load-b
 [discrete]
 [id="ocp-4-11-legacy-service-account"]
 ==== LegacyServiceAccountTokenNoAutoGeneration is on by default
-To align with upstream Kubernetes moving the `LegacyServiceAccountTokenNoAutoGeneration` feature gate to beta and enabling it by default, {product-title} now also follows this security feature and ships with the feature enabled.
 
-This feature removes automatic generation of Service Account token secrets, meaning that a Service Account no longer receives an  automatically generated token upon its creation.
+To align with upstream link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes-1[Kubernetes having moved] the `LegacyServiceAccountTokenNoAutoGeneration` feature gate to beta and enabling it by default, {product-title} now also follows this security feature and ships with the feature enabled. As a result, when creating new service accounts (SA), a service account token secret is no longer automatically generated. Previously, {product-title} automatically added a service account token to a secret for each new SA.
 
-However, OpenShift Controller Manager still requires Service Account tokens to appear in secrets in order to function properly, and it will continue to request these tokens in secrets in {product-title} 4.11. In a future release, the `TokenRequest` API will be used instead.
+If you need a service account token secret, you must manually use the TokenRequest API to request bound service account tokens or create a service account token secret. 
 
-Service Account token secrets will still appear as auto-generated in {product-title} 4.11. However, instead of two secrets per Service Account, there will now be only one, which will be further reduced to zero in a future release. For now, dockercfg secrets will still be generated as secrets and no secrets will be deleted during upgrades.
+After updating to {product-version}, existing service account token secrets are not deleted and continue to function as expected.
+
+Service Account token secrets still appear as auto-generated in {product-title} 4.11. However, instead of two secrets per Service Account, there will now be only one, which will be further reduced to zero in a future release. These tokens do not work. For now, dockercfg secrets are still being generated as secrets and no secrets will be deleted during upgrades.
+
+* For information about using the TokenRequest API, see xref:../authentication/bound-service-account-tokens.html#bound-sa-tokens-configuring_bound-service-account-tokens[Using bound service account tokens]
+
+* For information about creating a service account token secret, see xref:../nodes/pods/nodes-pods-secrets.html#nodes-pods-secrets-creating-sa_nodes-pods-secrets[Creating a service account token secret].
 
 [id="ocp-4-11-deprecated-removed-features"]
 == Deprecated and removed features
@@ -452,6 +457,10 @@ In the table, features are marked with the following statuses:
 |
 |
 
+|Automatic generation of service account token secrets
+|GA
+|GA
+|REM
 
 |====
 


### PR DESCRIPTION
Release note for LegacyServiceAccountTokenNoAutoGeneration. Slight re-wording at the [request](https://bugzilla.redhat.com/show_bug.cgi?id=2093995#c32) of support

https://github.com/openshift/openshift-docs/pull/47150

Preview: [LegacyServiceAccountTokenNoAutoGeneration is on by default](http://file.rdu.redhat.com/~mburke/BZ-2093995-release-note/release_notes/ocp-4-11-release-notes.html#ocp-4-11-notable-technical-changes)
