### PR TITLE
Removes 4.10 doc updates from 4.11 RN draft

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -42,27 +42,6 @@ The scope of support for layered and dependent components of {product-title} cha
 
 This release adds improvements related to the following components and concepts.
 
-[id="ocp-4-11-documentation"]
-=== Documentation
-
-[id="ocp-4-11-getting-started"]
-==== Getting started with {product-title}
-
-{product-title} 4.11 now includes a getting started guide. Getting Started with {product-title} defines basic terminology and provides role-based next steps for developers and administrators.
-
-The tutorials walk new users through the web console and the OpenShift CLI (`oc`) interfaces. New users can accomplish the following tasks through the Getting Started:
-
-* Create a project
-* Grant view permissions
-* Deploy a container image from Quay
-* Examine and scale an application
-* Deploy a Python application from GitHub
-* Connect to a database from Quay
-* Create a secret
-* Load and view your application
-
-For more information, see xref:../getting_started/openshift-overview.adoc[Getting Started with {product-title}].
-
 [id="ocp-4-11-rhcos"]
 === {op-system-first}
 


### PR DESCRIPTION
Removes a missed feature/enhancement that was in 4.10 from the 4.11 RNs draft

Version(s):
`enterprise-4.11`

Issue:
cc @bergerhoffer 

Link to docs preview:
http://file.rdu.redhat.com/opayne/updates-RN-draft/release_notes/ocp-4-11-release-notes.html#ocp-4-11-new-features-and-enhancements 




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
