### PR TITLE
CNV-17982: Correct HotPlug UI Docs

### DIFF
--- a/modules/virt-hot-plugging-a-virtual-disk-using-the-web-console.adoc
+++ b/modules/virt-hot-plugging-a-virtual-disk-using-the-web-console.adoc
@@ -6,7 +6,7 @@
 [id="virt-hot-plugging-a-virtual-disk-using-the-web-console{context}"]
 = Hot-plugging a virtual disk using the web console
 
-Hot-plug virtual disks that you want to attach to a virtual machine instance (VMI) while a virtual machine is running.
+Hot-plug virtual disks that you want to attach to a virtual machine instance (VMI) while a virtual machine is running. When you hot-plug a virtual disk, it remains attached to the VMI until you hot-unplug it.
 
 .Prerequisites
 * You must have a running virtual machine to hot-plug a virtual disk.
@@ -15,10 +15,12 @@ Hot-plug virtual disks that you want to attach to a virtual machine instance (VM
 
 . Click *Virtualization* -> *VirtualMachines* from the side menu.
 
-. Select a running virtual machine to open the *VirtualMachine details* page.
+. Select the running virtual machine to which you want to hot-plug a virtual disk.
 
-. On the *Disks* tab, click *Add disk*.
+. On the *VirtualMachine details* page, click the *Disks* tab.
 
-. In the *Add disk* window, fill in the information for the virtual disk that you want to hot-plug.
+. Click *Add disk*.
 
-. Click *Add*.
+. In the *Add disk (hot plugged)* window, fill in the information for the virtual disk that you want to hot-plug.
+
+. Click *Save*.

--- a/modules/virt-hot-unplugging-a-virtual-disk-using-the-web-console.adoc
+++ b/modules/virt-hot-unplugging-a-virtual-disk-using-the-web-console.adoc
@@ -6,7 +6,7 @@
 [id="virt-hot-unplugging-a-virtual-disk-using-the-web-console{context}"]
 = Hot-unplugging a virtual disk using the web console
 
-Hot-unplug virtual disks that you want to attach to a virtual machine instance (VMI) while a virtual machine is running.
+Hot-unplug virtual disks that you want to detach from a virtual machine instance (VMI) while a virtual machine is running.
 
 .Prerequisites
 * Your virtual machine must be running with a hot-plugged disk attached.
@@ -19,4 +19,4 @@ Hot-unplug virtual disks that you want to attach to a virtual machine instance (
 
 . On the *Disks* tab, click the Options menu {kebab} of the virtual disk that you want to hot-unplug.
 
-. Click *Delete*.
+. Click *Detach*.

--- a/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc
@@ -14,6 +14,8 @@ When you _hot-unplug_ a virtual disk, you detach a virtual disk from a virtual m
 
 Only data volumes and persistent volume claims (PVCs) can be hot-plugged and hot-unplugged. You cannot hot-plug or hot-unplug container disks.
 
+After you hot-plug a virtual disk, it remains hot-plugged until you detach (unplug) it, even if you restart the virtual machine.
+
 include::modules/virt-hot-plugging-a-virtual-disk-using-the-cli.adoc[leveloffset=+1]
 include::modules/virt-hot-unplugging-a-virtual-disk-using-the-cli.adoc[leveloffset=+1]
 include::modules/virt-hot-plugging-a-virtual-disk-using-the-web-console.adoc[leveloffset=+1]


### PR DESCRIPTION
For 4.11 only.

Jira: https://issues.redhat.com/browse/CNV-17982
BZs: https://bugzilla.redhat.com/show_bug.cgi?id=2109202
        https://bugzilla.redhat.com/show_bug.cgi?id=2110178

Direct doc preview link: http://file.rdu.redhat.com/bgaydos/CNV-17982/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.html

Hi @aglitke - It's been awhile since we talked about this. IN your original email from May 5 you say:

 _it seems that we are pretty thin regarding docs for the UI hotplug flows.  I think we should have a small section to explain the hotplug behavior in the UI._   

Here is the hot-plug topic in 4.10: https://docs.openshift.com/container-platform/4.10/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.html

My understanding is that the current behavior is that a disk remains hot-plugged until you explicitly detach it. I added that info in this PR and also fixed the label for UI un-plug to read Detach rather than Delete. Are you thinking we need further changes for the UI? 

@awels - Should this change be ported back to the 4.10 docs?

Thanks,
Bob