### PR TITLE
BZ-2099319: Adding option to perform rolling node restart

### DIFF
--- a/authentication/bound-service-account-tokens.adoc
+++ b/authentication/bound-service-account-tokens.adoc
@@ -14,4 +14,9 @@ include::modules/bound-sa-tokens-about.adoc[leveloffset=+1]
 // Configuring bound service account tokens using volume projection
 include::modules/bound-sa-tokens-configuring.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../nodes/nodes/nodes-nodes-rebooting.adoc#nodes-nodes-rebooting-gracefully_nodes-nodes-rebooting[Rebooting a node gracefully]
+
 // TODO: Verify distros: openshift-enterprise,openshift-webscale,openshift-origin

--- a/modules/bound-sa-tokens-configuring.adoc
+++ b/modules/bound-sa-tokens-configuring.adoc
@@ -23,7 +23,7 @@ This step is typically not required if the bound tokens are used only within the
 ====
 If you change the service account issuer to a custom one, the previous service account issuer is still trusted for the next 24 hours.
 
-If necessary, you can manually restart all pods in the cluster so that the holder will request a new bound token. Before doing this, wait for a new revision of the Kubernetes API server pods to roll out with your service account issuer changes.
+You can force all holders to request a new bound token either by manually restarting all pods in the cluster or by performing a rolling node restart. Before performing either action, wait for a new revision of the Kubernetes API server pods to roll out with your service account issuer changes.
 ====
 
 .. Edit the `cluster` `Authentication` object:
@@ -44,9 +44,7 @@ spec:
 
 .. Save the file to apply the changes.
 
-.. Optional: Manually restart all pods in the cluster so that the holder will request a new bound token.
-
-... Wait for a new revision of the Kubernetes API server pods to roll out. It can take several minutes for all nodes to update to the new revision. Run the following command:
+.. Wait for a new revision of the Kubernetes API server pods to roll out. It can take several minutes for all nodes to update to the new revision. Run the following command:
 +
 [source,terminal]
 ----
@@ -67,12 +65,25 @@ If the output shows a message similar to one of the following messages, the upda
 ** `3 nodes are at revision 11; 0 nodes have achieved new revision 12`
 ** `2 nodes are at revision 11; 1 nodes are at revision 12`
 
-... Manually restart all pods in the cluster:
+.. Optional: Force the holder to request a new bound token either by performing a rolling node restart or by manually restarting all pods in the cluster.
+
+*** Perform a rolling node restart:
++
+[WARNING]
+====
+It is not recommended to perform a rolling node restart if you have custom workloads running on your cluster, because it can cause a service interruption. Instead, manually restart all pods in the cluster.
+====
++
+Restart nodes sequentially. Wait for the node to become fully available before restarting the next node. See _Rebooting a node gracefully_ for instructions on how to drain, restart, and mark a node as schedulable again.
+
+*** Manually restart all pods in the cluster:
 +
 [WARNING]
 ====
 Be aware that running this command causes a service interruption, because it deletes every running pod in every namespace. These pods will automatically restart after they are deleted.
 ====
++
+Run the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.8+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2099319

Link to docs preview:
[* (single page): http://file.rdu.redhat.com/~ahoffer/2022/BZ-2099319/authentication/bound-service-account-tokens.html#bound-sa-tokens-configuring_bound-service-account-tokens](https://47461--docspreview.netlify.app/openshift-enterprise/latest/authentication/bound-service-account-tokens.html#bound-sa-tokens-configuring_bound-service-account-tokens)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
