### PR TITLE
[BZ2083843] IPv6 Dual-stack add prereq and further procedure

### DIFF
--- a/modules/nw-dual-stack-convert-back-single-stack.adoc
+++ b/modules/nw-dual-stack-convert-back-single-stack.adoc
@@ -1,0 +1,26 @@
+:_content-type: PROCEDURE
+[id="nw-dual-stack-convert-back-single-stack_{context}"]
+= Converting to a single-stack cluster network
+
+As a cluster administrator, you can convert your dual-stack cluster network to a single-stack cluster network.
+
+.Prerequisites
+
+* You installed the OpenShift CLI (`oc`).
+* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* Your cluster uses the OVN-Kubernetes cluster network provider.
+* The cluster nodes have IPv6 addresses.
+* You have enabled dual-stack networking.
+
+.Procedure
+
+. Edit the `Network.operator.openshift.io` custom resource (CR) by running the
+following command:
++
+[source,terminal]
+----
+$ oc edit networks.operator.openshift.io
+----
+
+. Remove the IPv6 specific configuration that you have added to the `cidr` and `hostPrefix` fields in the previous procedure.
+

--- a/modules/nw-dual-stack-convert.adoc
+++ b/modules/nw-dual-stack-convert.adoc
@@ -15,6 +15,7 @@ After converting to dual-stack networking only newly created pods are assigned I
 * You are logged in to the cluster with a user with `cluster-admin` privileges.
 * Your cluster uses the OVN-Kubernetes cluster network provider.
 * The cluster nodes have IPv6 addresses.
+* You have configured an IPv6-enabled router based on your infrastructure.
 
 .Procedure
 

--- a/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc
+++ b/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc
@@ -11,7 +11,8 @@ After converting to dual-stack, all newly created pods are dual-stack enabled.
 
 [NOTE]
 ====
-A dual-stack network is supported on clusters provisioned on bare metal infrastructure only.
+A dual-stack network is supported on clusters provisioned on bare metal and IBM Power infrastructure only.
 ====
 
 include::modules/nw-dual-stack-convert.adoc[leveloffset=+1]
+include::modules/nw-dual-stack-convert-back-single-stack.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to.

Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2083843
https://issues.redhat.com/browse/MULTIARCH-2116
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
Review doc: https://docs.google.com/document/d/1tGo8_FTmHg73tpPg4DziD4_d9Efo2DaGHT7jbh-XuvU/edit#

Link to docs preview: http://file.str.redhat.com/~sniemann/ipv6_router/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->
QE review: 
- x86: Anurag Saxena
- IBM Power: Mick Tarsel 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
