### PR TITLE
[OSDOCS] Adding the web console overview and Administrator perspective

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -76,7 +76,7 @@ Topics:
 - Name: Installation and update
   Distros: openshift-enterprise,openshift-origin
   File: architecture-installation
-- Name: Red Hat OpenShift Cluster Manager 
+- Name: Red Hat OpenShift Cluster Manager
   Distros: openshift-enterprise
   File: ocm-overview-ocp
 - Name: Control plane architecture
@@ -600,6 +600,8 @@ Name: Web console
 Dir: web_console
 Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
+- Name: Web Console Overview
+  File: web-console-overview
 - Name: Accessing the web console
   File: web-console
 - Name: Viewing cluster information
@@ -616,8 +618,6 @@ Topics:
 - Name: Dynamic plug-ins
   File: dynamic-plug-ins
   Distros: openshift-enterprise,openshift-origin
-- Name: Developer perspective
-  File: odc-about-developer-perspective
 - Name: Web terminal
   File: odc-about-web-terminal
   Distros: openshift-enterprise,openshift-online

--- a/applications/application-health.adoc
+++ b/applications/application-health.adoc
@@ -29,5 +29,5 @@ include::modules/odc-monitoring-health-checks.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* For details on switching to the *Developer* perspective in the web console, see xref:../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[About *Developer* perspective].
+* For details on switching to the *Developer* perspective in the web console, see xref:../web_console/about-developer-perspective.adoc#about-developer-perspective_web-console-overview[About *Developer* perspective].
 * For details on adding health checks while creating and deploying an application, see *Advanced Options* in the xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating applications using the Developer perspective] section.

--- a/applications/application-health.adoc
+++ b/applications/application-health.adoc
@@ -29,5 +29,5 @@ include::modules/odc-monitoring-health-checks.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* For details on switching to the *Developer* perspective in the web console, see xref:../web_console/about-developer-perspective.adoc#about-developer-perspective_web-console-overview[About *Developer* perspective].
+* For details on switching to the *Developer* perspective in the web console, see xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[About *Developer* perspective].
 * For details on adding health checks while creating and deploying an application, see *Advanced Options* in the xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating applications using the Developer perspective] section.

--- a/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
+++ b/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
@@ -51,7 +51,7 @@ endif::[]
 To create applications using the *Developer* perspective ensure that:
 
 * You have xref:../../web_console/web-console.adoc#web-console[logged in to the web console].
-* You are in the xref:../web_console/about-developer-perspective.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
+* You are in the xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 * You have created a project or have access to a project with the appropriate xref:../../authentication/using-rbac.adoc#default-roles_using-rbac[roles and permissions] to create applications and other workloads in {product-title}.
 
 ifdef::openshift-enterprise,openshift-webscale[]

--- a/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
+++ b/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
@@ -51,7 +51,7 @@ endif::[]
 To create applications using the *Developer* perspective ensure that:
 
 * You have xref:../../web_console/web-console.adoc#web-console[logged in to the web console].
-* You are in the xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
+* You are in the xref:../web_console/web-console-overview.adoc#about-developer-perspective[*Developer* perspective].
 * You have created a project or have access to a project with the appropriate xref:../../authentication/using-rbac.adoc#default-roles_using-rbac[roles and permissions] to create applications and other workloads in {product-title}.
 
 ifdef::openshift-enterprise,openshift-webscale[]

--- a/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
+++ b/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
@@ -51,7 +51,7 @@ endif::[]
 To create applications using the *Developer* perspective ensure that:
 
 * You have xref:../../web_console/web-console.adoc#web-console[logged in to the web console].
-* You are in the xref:../web_console/web-console-overview.adoc#about-developer-perspective[*Developer* perspective].
+* You are in the xref:../web_console/about-developer-perspective.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 * You have created a project or have access to a project with the appropriate xref:../../authentication/using-rbac.adoc#default-roles_using-rbac[roles and permissions] to create applications and other workloads in {product-title}.
 
 ifdef::openshift-enterprise,openshift-webscale[]

--- a/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
+++ b/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
@@ -51,7 +51,7 @@ endif::[]
 To create applications using the *Developer* perspective ensure that:
 
 * You have xref:../../web_console/web-console.adoc#web-console[logged in to the web console].
-* You are in the xref:../../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
+* You are in the xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 * You have created a project or have access to a project with the appropriate xref:../../authentication/using-rbac.adoc#default-roles_using-rbac[roles and permissions] to create applications and other workloads in {product-title}.
 
 ifdef::openshift-enterprise,openshift-webscale[]

--- a/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
+++ b/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
@@ -51,7 +51,7 @@ endif::[]
 To create applications using the *Developer* perspective ensure that:
 
 * You have xref:../../web_console/web-console.adoc#web-console[logged in to the web console].
-* You are in the xref:../../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[*Developer* perspective].
+* You are in the xref:../../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 * You have created a project or have access to a project with the appropriate xref:../../authentication/using-rbac.adoc#default-roles_using-rbac[roles and permissions] to create applications and other workloads in {product-title}.
 
 ifdef::openshift-enterprise,openshift-webscale[]

--- a/applications/odc-editing-applications.adoc
+++ b/applications/odc-editing-applications.adoc
@@ -10,7 +10,7 @@ You can edit the configuration and the source code of the application you create
 
 == Prerequisites
 
-* You have xref:../web_console/web-console.adoc#web-console[logged in to the web console] and have switched to the xref:../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[*Developer* perspective].
+* You have xref:../web_console/web-console.adoc#web-console[logged in to the web console] and have switched to the xref:../../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 * You have the appropriate xref:../authentication/using-rbac.adoc#default-roles_using-rbac[roles and permissions] in a project to create and modify applications in {product-title}.
 * You have xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[created and deployed an application on {product-title} using the *Developer* perspective].
 

--- a/applications/odc-editing-applications.adoc
+++ b/applications/odc-editing-applications.adoc
@@ -10,7 +10,7 @@ You can edit the configuration and the source code of the application you create
 
 == Prerequisites
 
-* You have xref:../web_console/web-console.adoc#web-console[logged in to the web console] and have switched to the xref:../../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
+* You have xref:../web_console/web-console.adoc#web-console[logged in to the web console] and have switched to the xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 * You have the appropriate xref:../authentication/using-rbac.adoc#default-roles_using-rbac[roles and permissions] in a project to create and modify applications in {product-title}.
 * You have xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[created and deployed an application on {product-title} using the *Developer* perspective].
 

--- a/applications/odc-monitoring-project-and-application-metrics-using-developer-perspective.adoc
+++ b/applications/odc-monitoring-project-and-application-metrics-using-developer-perspective.adoc
@@ -11,7 +11,7 @@ The *Observe* view in the *Developer* perspective provides options to monitor yo
 
 == Prerequisites
 
-* You have xref:../web_console/web-console.adoc#web-console-overview[logged in to the web console] and have switched to the xref:../../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
+* You have xref:../web_console/web-console.adoc#web-console-overview[logged in to the web console] and have switched to the xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 * You have xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[created and deployed applications on {product-title}].
 
 include::modules/odc-monitoring-your-project-metrics.adoc[leveloffset=+1]

--- a/applications/odc-monitoring-project-and-application-metrics-using-developer-perspective.adoc
+++ b/applications/odc-monitoring-project-and-application-metrics-using-developer-perspective.adoc
@@ -11,7 +11,7 @@ The *Observe* view in the *Developer* perspective provides options to monitor yo
 
 == Prerequisites
 
-* You have xref:../web_console/web-console.adoc#web-console-overview[logged in to the web console] and have switched to the xref:../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[*Developer* perspective].
+* You have xref:../web_console/web-console.adoc#web-console-overview[logged in to the web console] and have switched to the xref:../../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 * You have xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[created and deployed applications on {product-title}].
 
 include::modules/odc-monitoring-your-project-metrics.adoc[leveloffset=+1]

--- a/applications/odc-viewing-application-composition-using-topology-view.adoc
+++ b/applications/odc-viewing-application-composition-using-topology-view.adoc
@@ -12,7 +12,7 @@ The *Topology* view in the *Developer* perspective of the web console provides a
 To view your applications in the *Topology* view and interact with them, ensure that:
 
 * You have xref:../web_console/web-console.adoc#web-console[logged in to the web console].
-* You are in the xref:../../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
+* You are in the xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 * You have the appropriate xref:../authentication/using-rbac.adoc#default-roles_using-rbac[roles and permissions] in a project to create applications and other workloads in {product-title}.
 * You have xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[created and deployed an application on {product-title} using the *Developer* perspective].
 

--- a/applications/odc-viewing-application-composition-using-topology-view.adoc
+++ b/applications/odc-viewing-application-composition-using-topology-view.adoc
@@ -12,7 +12,7 @@ The *Topology* view in the *Developer* perspective of the web console provides a
 To view your applications in the *Topology* view and interact with them, ensure that:
 
 * You have xref:../web_console/web-console.adoc#web-console[logged in to the web console].
-* You are in the xref:../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[*Developer* perspective].
+* You are in the xref:../../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 * You have the appropriate xref:../authentication/using-rbac.adoc#default-roles_using-rbac[roles and permissions] in a project to create applications and other workloads in {product-title}.
 * You have xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[created and deployed an application on {product-title} using the *Developer* perspective].
 

--- a/applications/working_with_helm_charts/odc-working-with-helm-releases.adoc
+++ b/applications/working_with_helm_charts/odc-working-with-helm-releases.adoc
@@ -12,7 +12,7 @@ You can use the *Developer* perspective in the web console to upgrade, rollback,
 
 == Prerequisites
 
-* You have logged in to the web console and have switched to the xref:../../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
+* You have logged in to the web console and have switched to the xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 
 include::modules/odc-upgrading-helm-release.adoc[leveloffset=+1]
 

--- a/applications/working_with_helm_charts/odc-working-with-helm-releases.adoc
+++ b/applications/working_with_helm_charts/odc-working-with-helm-releases.adoc
@@ -12,7 +12,7 @@ You can use the *Developer* perspective in the web console to upgrade, rollback,
 
 == Prerequisites
 
-* You have logged in to the web console and have switched to the xref:../../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[*Developer* perspective].
+* You have logged in to the web console and have switched to the xref:../../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 
 include::modules/odc-upgrading-helm-release.adoc[leveloffset=+1]
 

--- a/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.adoc
+++ b/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.adoc
@@ -19,7 +19,8 @@ After you create the pipelines for your application, you can view and visually i
 [discrete]
 == Prerequisites
 
-* You have access to an {product-title} cluster and have switched to the xref:../../web_console/odc-about-developer-perspective.adoc[*Developer* perspective] in the web console.
+* You have access to an {product-title} cluster and have switched to the xref:../web_console/about-developer-perspective.adoc#about-developer-perspective_web-console-overview
+[*Developer* perspective] in the web console.
 * You have the xref:../../cicd/pipelines/installing-pipelines.adoc#installing-pipelines[OpenShift Pipelines Operator installed] in your cluster.
 * You are a cluster administrator or a user with create and edit permissions.
 * You have created a project.
@@ -29,7 +30,7 @@ include::modules/op-constructing-pipelines-using-pipeline-builder.adoc[leveloffs
 
 == Creating OpenShift Pipelines along with applications
 
-To create pipelines along with applications, use the *From Git* option in the *Add+* view of the *Developer* perspective. You can view all of your available pipelines and select the pipelines you want to use to create applications while importing your code or deploying an image. 
+To create pipelines along with applications, use the *From Git* option in the *Add+* view of the *Developer* perspective. You can view all of your available pipelines and select the pipelines you want to use to create applications while importing your code or deploying an image.
 
 The Tekton Hub Integration is enabled by default and you can see tasks from the Tekton Hub that are supported by your cluster. Administrators can opt out of the Tekton Hub Integration and the Tekton Hub tasks will no longer be displayed. You can also check whether a webhook URL exists for a generated pipeline. Default webhooks are added for the pipelines that are created using the *+Add* flow and the URL is visible in the side panel of the selected resources in the Topology view.
 

--- a/getting_started/openshift-overview.adoc
+++ b/getting_started/openshift-overview.adoc
@@ -41,7 +41,7 @@ Develop and deploy containerized applications with {product-title}. {product-tit
 * **xref:../applications/projects/working-with-projects.adoc#working-with-projects[Work with projects]**: Create projects from the {product-title} web console or OpenShift CLI (`oc`) to organize and share the software you develop.
 
 * **xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Work with applications]**:
-Use the xref:../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[*Developer* perspective] in the {product-title} web console to
+Use the xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective] in the {product-title} web console to
 xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[create and deploy applications].
 Use the
 xref:../applications/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[*Topology* view]

--- a/modules/about-administrator-perspective.adoc
+++ b/modules/about-administrator-perspective.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// web_console/web-console-overview.adoc
+
+:_content-type: CONCEPT
+[id="about-administrator-perspective_{context}"]
+= About the Administrator perspective in the web console
+
+The {product-title} web console provides two perspectives; the *Administrator* perspective and the *Developer* perspective. The *Administrator* perspective enables you to view logging, metrics, and high-status information about the cluster. You can view the cluster inventory, capacity, general and specific utilization information, and the stream of important events, all of which help you to simplify planning and troubleshooting tasks. You can also view and manage a wide variety of settings that are of particular interest to the cluster administrators, such as cluster updates, cluster operators, CRDs, role bindings, and resource quotas. Both project administrators and cluster administrators can view the *Administrator* perspective.
+
+
+[NOTE]
+====
+The default web console perspective that is shown depends on the role of the user. The *Administrator* perspective is displayed by default if the user is recognized as an administrator.
+====
+
+The *Administrator* perspective provides workflows specific to administrator use cases, such as the ability to:
+
+* Manage workload storage, networking, and cluster settings.
+* Add users and groups with different levels of permissions to use or modify clusters.
+* View and manage a variety of advanced settings such as cluster updates, partial cluster updates, cluster Operators, custom resource definitions (CRDs), role bindings, and resource quotas.
+* Access and manage monitoring features such as metrics, alerts, and monitoring dashboards.
+* Visually interact with applications, components, and services associated with *Administrator* perspective in the OpenShift platform.
+
+
+Cluster administrators can also launch an embedded command line terminal instance in the web console in {product-title} 4.7 and later. The terminal instance is preinstalled with common CLI tools for interacting with the cluster, such as `oc`, `kubectl`,`odo`, `kn`, `tkn`, `helm`, `kubens`, and `kubectx`. It also has the context of the project you are working on and automatically logs you in using your credentials.

--- a/modules/about-developer-perspective.adoc
+++ b/modules/about-developer-perspective.adoc
@@ -1,12 +1,13 @@
-:_content-type: ASSEMBLY
-[id="odc-about-developer-perspective"]
+// Module included in the following assemblies:
+//
+// web_console/web-console-overview.adoc
+
+:_content-type: CONCEPT
+[id="about-developer-perspective_{context}"]
 = About the Developer perspective in the web console
-include::_attributes/common-attributes.adoc[]
-:context: odc-about-developer-perspective
 
-toc::[]
+The {product-title} web console provides two perspectives; the *Administrator* perspective and the *Developer* perspective. The *Developer* perspective offers several built-in ways to deploy applications, services, and databases. You can view real-time virtualization of rolling and recreating rollouts on the component. You can also view the application status, resource utilization, project event streaming, and quota consumption. You can also share your project with others. You can also troubleshoot problems with your applications by running Prometheus Query Language (PromQL) queries on your project and examining the metrics visualized on a plot. The metrics provide information about the state of a cluster and any user-defined workloads that you are monitoring.
 
-The {product-title} web console provides two perspectives; the *Administrator* perspective and the *Developer* perspective.
 [NOTE]
 ====
 The default web console perspective that is shown depends on the role of the user. The *Developer* perspective is displayed by default if the user is recognised as a developer.
@@ -23,11 +24,3 @@ The *Developer* perspective provides workflows specific to developer use cases, 
 == Prerequisites
 
 To access the *Developer* perspective, ensure that you have logged in to the web console.
-
-include::modules/odc-accessing-developer-perspective.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating and deploying applications on {product-title} using the *Developer* perspective]
-* xref:../applications/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[Viewing the applications in your project, verifying their deployment status, and interacting with them in the *Topology* view]

--- a/modules/accessing-the-administrator-perspective.adoc
+++ b/modules/accessing-the-administrator-perspective.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// web_console/about-administrator-perspective.adoc
+
+:_content-type: PROCEDURE
+[id="accessing-the-administrator-perspective_{context}"]
+= Accessing the Administrator perspective
+
+.Prerequisites
+To access the Administrator perspective, ensure that you have logged in to the web console and have the administrator role privileges.
+
+The *Administrator* perspective in the {product-title} web console provides workflows specific to administrator use cases.
+
+You can access the *Administrator* perspective from the web console as follows:
+
+.Procedure
+
+. Log in to the {product-title} web console using your login credentials.
+. Use the menu bar to display available menu items and applications for *Administrators*.

--- a/modules/odc-installing-helm-charts-using-developer-perspective.adoc
+++ b/modules/odc-installing-helm-charts-using-developer-perspective.adoc
@@ -5,7 +5,7 @@
 You can use either the *Developer* perspective in the web console or the CLI to select and install a chart from the Helm charts listed in the *Developer Catalog*. You can create Helm releases by installing Helm charts and see them in the *Developer* perspective of the web console.
 
 .Prerequisites
-* You have logged in to the web console and have switched to the xref:../../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[*Developer* perspective].
+* You have logged in to the web console and have switched to the xref:../../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 
 .Procedure
 To create Helm releases from the Helm charts provided in the *Developer Catalog*:

--- a/modules/odc-installing-helm-charts-using-developer-perspective.adoc
+++ b/modules/odc-installing-helm-charts-using-developer-perspective.adoc
@@ -5,7 +5,7 @@
 You can use either the *Developer* perspective in the web console or the CLI to select and install a chart from the Helm charts listed in the *Developer Catalog*. You can create Helm releases by installing Helm charts and see them in the *Developer* perspective of the web console.
 
 .Prerequisites
-* You have logged in to the web console and have switched to the xref:../../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
+* You have logged in to the web console and have switched to the xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective].
 
 .Procedure
 To create Helm releases from the Helm charts provided in the *Developer Catalog*:

--- a/web_console/about-administrator-perspective.adoc
+++ b/web_console/about-administrator-perspective.adoc
@@ -1,0 +1,30 @@
+:_content-type: ASSEMBLY
+[id="about-administrator-perspective"]
+= About the Administrator perspective in the web console
+include::_attributes/common-attributes.adoc[]
+:context: about-administrator-perspective
+
+toc::[]
+
+The {product-title} web console provides two perspectives; the *Administrator* perspective and the *Developer* perspective.
+
+[NOTE]
+====
+The default web console perspective that is shown depends on the role of the user. The *Administrator* perspective is displayed by default if the user is recognized as an administrator.
+====
+
+The *Administrator* perspective provides workflows specific to administrator use cases, such as the ability to:
+
+* Manage workload storage, networking, and cluster settings.
+* Add users and groups with different levels of permissions to use or modify clusters.
+* View and manage a variety of advanced settings such as cluster updates, partial cluster updates, cluster Operators, custom resource definitions (CRDs), role bindings, and resource quotas.
+* Access and manage monitoring features such as metrics, alerts, and monitoring dashboards.
+* Visually interact with applications, components, and services associated with *Administrator* perspective in the OpenShift platform.
+
+include::modules/accessing-the-administrator-perspective.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../welcome/learn_more_about_openshift.adoc#cluster-administrator[Learn more about Cluster Administrator]
+* xref:../getting_started/openshift-overview.adoc#for-administrators[Overview of the *Administrator* perspective]

--- a/web_console/web-console-overview.adoc
+++ b/web_console/web-console-overview.adoc
@@ -1,0 +1,35 @@
+:_content-type: ASSEMBLY
+[id="web-console-overview"]
+= Web Console Overview
+include::_attributes/common-attributes.adoc[]
+:context: web-console-overview
+
+toc::[]
+
+The Red Hat {product-title} web console provides a graphical user interface to visualize your project data and perform administrative, management, and troubleshooting tasks. The web console supports both *Administrator* and *Developer* perspectives.
+
+The web console runs as pods on the control plane nodes in the openshift-console project. It is managed by an operator pod.
+
+Both *Administrator* and *Developer* perspectives enable you to create quick start tutorials for the OpenShift Container Platform. A quick start is a guided tutorial with user tasks and is useful for getting oriented with an application, operator, or other product offering.
+
+
+include::modules/about-administrator-perspective.adoc[leveloffset=+1]
+include::modules/accessing-the-administrator-perspective.adoc[leveloffset=+2]
+
+include::modules/about-developer-perspective.adoc[leveloffset=+1]
+include::modules/odc-accessing-developer-perspective.adoc[leveloffset=+2]
+
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../welcome/learn_more_about_openshift.adoc#cluster-administrator[Learn more about Cluster Administrator]
+* xref:../getting_started/openshift-overview.adoc#for-administrators[Overview of the *Administrator* perspective]
+* xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating and deploying applications on {product-title} using the *Developer* perspective]
+* xref:../applications/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[Viewing the applications in your project, verifying their deployment status, and interacting with them in the *Topology* view]
+* xref:../web_console/using-dashboard-to-get-cluster-information.adoc#viewing-cluster-information[Viewing cluster information]
+* xref:../web_console/configuring-web-console.adoc#configuring-the-web-console[Configuring the web console]
+* xref:../web_console/customizing-the-web-console.adoc#customizing-the-web-console[Customizing the web console]
+* xref:../web_console/odc-about-web-terminal.adoc#web-terminal[Launching an embedded command line terminal inst in the web console]
+* xref:../web_console/creating-quick-start-tutorials.adoc#creating-quick-start-tutorials[Creating quick start tutorials]
+* xref:../web_console/disabling-web-console.adoc#disabling-the-web-console[Disabling the web console]

--- a/web_console/web-console-overview.adoc
+++ b/web_console/web-console-overview.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 The Red Hat {product-title} web console provides a graphical user interface to visualize your project data and perform administrative, management, and troubleshooting tasks. The web console supports both *Administrator* and *Developer* perspectives.
 
-The web console runs as pods on the control plane nodes in the openshift-console project. It is managed by an operator pod.
+The web console runs as pods on the control plane nodes in the openshift-console project. It is managed by an operator pod
 
 Both *Administrator* and *Developer* perspectives enable you to create quick start tutorials for the OpenShift Container Platform. A quick start is a guided tutorial with user tasks and is useful for getting oriented with an application, operator, or other product offering.
 

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -159,7 +159,7 @@ Develop and deploy containerized applications with {product-title}. {product-tit
 - **xref:../applications/projects/working-with-projects.adoc#working-with-projects[Work with projects]**: Create projects from the {product-title} web console or OpenShift CLI (`oc`) to organize and share the software you develop.
 
 - **xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Work with applications]**:
-Use the xref:../web_console/odc-about-developer-perspective.adoc#odc-about-developer-perspective[*Developer* perspective] in the {product-title} web console to
+Use the xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[*Developer* perspective] in the {product-title} web console to
 xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[create and deploy applications].
 Use the
 xref:../applications/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[*Topology* view]


### PR DESCRIPTION
Version(s): 4.6+

Issue: https://issues.redhat.com/browse/OSDOCS-2719 

Link to docs preview: 

Additional information: This PR adds a section about the Administrator perspective in the web console (which serves as a parallel section to the Developer perspective). This PR also rearranges the sections so that the Administrator and Developer perspectives appear right after "Accessing the web console." 
