### PR TITLE
[OSDOCS-3320] removed inline from policy table descriptions

### DIFF
--- a/modules/rosa-deleting-account-wide-iam-roles-and-policies.adoc
+++ b/modules/rosa-deleting-account-wide-iam-roles-and-policies.adoc
@@ -11,7 +11,7 @@ endif::[]
 [id="rosa-deleting-account-wide-iam-roles-and-policies_{context}"]
 = Deleting the account-wide IAM roles and policies
 
-This section provides steps to delete the account-wide IAM roles and inline policies that you created for ROSA with STS deployments, along with the account-wide Operator policies. You can delete the account-wide AWS Identity and Access Management (IAM) roles and policies only after deleting all of the {product-title} (ROSA) with AWS Security Token Services (STS) clusters that depend on them.
+This section provides steps to delete the account-wide IAM roles and policies that you created for ROSA with STS deployments, along with the account-wide Operator policies. You can delete the account-wide AWS Identity and Access Management (IAM) roles and policies only after deleting all of the {product-title} (ROSA) with AWS Security Token Services (STS) clusters that depend on them.
 
 [IMPORTANT]
 ====

--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -45,7 +45,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
 |An IAM role used by the ROSA installer.
 
 |`ManagedOpenShift-Installer-Role-Policy`
-|An inline IAM policy that provides the ROSA installer with the permissions required to complete cluster installation tasks.
+|An IAM policy that provides the ROSA installer with the permissions required to complete cluster installation tasks.
 
 |===
 
@@ -150,6 +150,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
                 "ec2:DescribeVpcs",
                 "ec2:DetachInternetGateway",
                 "ec2:DisassociateRouteTable",
+                "ec2:GetConsoleOutput",
                 "ec2:GetEbsDefaultKmsKeyId",
                 "ec2:ModifyInstanceAttribute",
                 "ec2:ModifyNetworkInterfaceAttribute",
@@ -228,6 +229,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
                 "s3:GetBucketLocation",
                 "s3:GetBucketLogging",
                 "s3:GetBucketObjectLockConfiguration",
+                "s3:GetBucketReplication",
                 "s3:GetBucketRequestPayment",
                 "s3:GetBucketTagging",
                 "s3:GetBucketVersioning",
@@ -247,6 +249,8 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
                 "s3:PutObject",
                 "s3:PutObjectAcl",
                 "s3:PutObjectTagging",
+                "servicequotas:GetServiceQuota",
+                "servicequotas:ListAWSDefaultServiceQuotas",
                 "sts:AssumeRole",
                 "sts:AssumeRoleWithWebIdentity",
                 "sts:GetCallerIdentity",
@@ -258,6 +262,8 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
                 "ec2:DescribeVpcEndpointServicePermissions",
                 "ec2:DescribeVpcEndpointServices",
                 "ec2:ModifyVpcEndpointServicePermissions"
+                "kms:DescribeKey",
+                "cloudwatch:GetMetricData"
             ],
             "Resource": "*"
         }
@@ -276,7 +282,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
 |An IAM role used by the ROSA control plane.
 
 |`ManagedOpenShift-ControlPlane-Role-Policy`
-|An inline IAM policy that provides the ROSA control plane with the permissions required to manage its components.
+|An IAM policy that provides the ROSA control plane with the permissions required to manage its components.
 
 |===
 
@@ -371,7 +377,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
 |An IAM role used by the ROSA compute instances.
 
 |`ManagedOpenShift-Worker-Role-Policy`
-|An inline IAM policy that provides the ROSA compute instances with the permissions required to manage their components.
+|An IAM policy that provides the ROSA compute instances with the permissions required to manage their components.
 
 |===
 
@@ -411,6 +417,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
             "Effect": "Allow",
             "Action": [
                 "ec2:DescribeInstances"
+                "ec2:DescribeRegions"
             ],
             "Resource": "*"
         }
@@ -429,7 +436,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
 |An IAM role used by the Red Hat Site Reliability Engineering (SRE) support team.
 
 |`ManagedOpenShift-Support-Role-Policy`
-|An inline IAM policy that provides the Red Hat SRE support team with the permissions required to support ROSA clusters.
+|An IAM policy that provides the Red Hat SRE support team with the permissions required to support ROSA clusters.
 
 |===
 
@@ -473,9 +480,15 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
                 "cloudwatch:GetMetricData",
                 "cloudwatch:GetMetricStatistics",
                 "cloudwatch:ListMetrics",
+                "ec2-instance-connect:SendSerialConsoleSSHPublicKey",
                 "ec2:CopySnapshot",
+                "ec2:CreateNetworkInsightsPath",
                 "ec2:CreateSnapshot",
                 "ec2:CreateSnapshots",
+                "ec2:CreateTags",
+                "ec2:DeleteNetworkInsightsAnalysis",
+                "ec2:DeleteNetworkInsightsPath",
+                "ec2:DeleteTags",
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAddresses",
                 "ec2:DescribeAddressesAttribute",
@@ -495,27 +508,30 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
                 "ec2:DescribeDhcpOptions",
                 "ec2:DescribeEgressOnlyInternetGateways",
                 "ec2:DescribeIamInstanceProfileAssociations",
-                "ec2:DescribeIdFormat",
                 "ec2:DescribeIdentityIdFormat",
+                "ec2:DescribeIdFormat",
                 "ec2:DescribeImageAttribute",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstanceAttribute",
+                "ec2:DescribeInstances",
                 "ec2:DescribeInstanceStatus",
                 "ec2:DescribeInstanceTypeOfferings",
                 "ec2:DescribeInstanceTypes",
-                "ec2:DescribeInstances",
                 "ec2:DescribeInternetGateways",
                 "ec2:DescribeIpv6Pools",
                 "ec2:DescribeKeyPairs",
                 "ec2:DescribeLaunchTemplates",
+                "ec2:DescribeLocalGatewayRouteTables",
                 "ec2:DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations",
                 "ec2:DescribeLocalGatewayRouteTableVpcAssociations",
-                "ec2:DescribeLocalGatewayRouteTables",
+                "ec2:DescribeLocalGateways",
                 "ec2:DescribeLocalGatewayVirtualInterfaceGroups",
                 "ec2:DescribeLocalGatewayVirtualInterfaces",
-                "ec2:DescribeLocalGateways",
+                "ec2:DescribeManagedPrefixLists",
                 "ec2:DescribeNatGateways",
                 "ec2:DescribeNetworkAcls",
+                "ec2:DescribeNetworkInsightsAnalyses",
+                "ec2:DescribeNetworkInsightsPaths",
                 "ec2:DescribeNetworkInterfaces",
                 "ec2:DescribePlacementGroups",
                 "ec2:DescribePrefixLists",
@@ -526,6 +542,7 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
                 "ec2:DescribeRouteTables",
                 "ec2:DescribeScheduledInstances",
                 "ec2:DescribeSecurityGroupReferences",
+                "ec2:DescribeSecurityGroupRules",
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeSnapshotAttribute",
                 "ec2:DescribeSnapshots",
@@ -539,8 +556,8 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
                 "ec2:DescribeTransitGatewayMulticastDomains",
                 "ec2:DescribeTransitGatewayPeeringAttachments",
                 "ec2:DescribeTransitGatewayRouteTables",
-                "ec2:DescribeTransitGatewayVpcAttachments",
                 "ec2:DescribeTransitGateways",
+                "ec2:DescribeTransitGatewayVpcAttachments",
                 "ec2:DescribeVolumeAttribute",
                 "ec2:DescribeVolumeStatus",
                 "ec2:DescribeVolumes",
@@ -559,17 +576,22 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
                 "ec2:DescribeVpnConnections",
                 "ec2:DescribeVpnGateways",
                 "ec2:GetAssociatedIpv6PoolCidrs",
+                "ec2:GetConsoleOutput",
+                "ec2:GetManagedPrefixListEntries",
+                "ec2:GetSerialConsoleAccessStatus",
                 "ec2:GetTransitGatewayAttachmentPropagations",
                 "ec2:GetTransitGatewayMulticastDomainAssociations",
                 "ec2:GetTransitGatewayPrefixListReferences",
                 "ec2:GetTransitGatewayRouteTableAssociations",
                 "ec2:GetTransitGatewayRouteTablePropagations",
+                "ec2:ModifyInstanceAttribute",
                 "ec2:RebootInstances",
+                "ec2:RunInstances",
                 "ec2:SearchLocalGatewayRoutes",
                 "ec2:SearchTransitGatewayMulticastGroups",
                 "ec2:SearchTransitGatewayRoutes",
-                "ec2:RunInstances",
                 "ec2:StartInstances",
+                "ec2:StartNetworkInsightsAnalysis",
                 "ec2:StopInstances",
                 "ec2:TerminateInstances",
                 "elasticloadbalancing:ConfigureHealthCheck",
@@ -578,18 +600,18 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
                 "elasticloadbalancing:DescribeListenerCertificates",
                 "elasticloadbalancing:DescribeListeners",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
-                "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeLoadBalancerPolicies",
                 "elasticloadbalancing:DescribeLoadBalancerPolicyTypes",
-                "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeRules",
                 "elasticloadbalancing:DescribeSSLPolicies",
                 "elasticloadbalancing:DescribeTags",
-                "elasticloadbalancing:DescribeTags",
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",
+                "iam:GetRole",
+                "iam:ListRoles",
+                "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",
                 "route53:ListHostedZones",
@@ -599,6 +621,10 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
                 "s3:GetObjectAcl",
                 "s3:GetObjectTagging",
                 "s3:ListAllMyBuckets"
+                "sts:DecodeAuthorizationMessage",
+                "tiros:CreateQuery",
+                "tiros:GetQueryAnswer",
+                "tiros:GetQueryExplanation"
             ],
             "Resource": "*"
         },
@@ -825,14 +851,19 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
         "s3:CreateBucket",
         "s3:DeleteBucket",
         "s3:PutBucketTagging",
+        "s3:GetBucketTagging",
         "s3:PutBucketPublicAccessBlock",
+        "s3:GetBucketPublicAccessBlock",
         "s3:PutEncryptionConfiguration",
+        "s3:GetEncryptionConfiguration",
         "s3:PutLifecycleConfiguration",
+        "s3:GetLifecycleConfiguration",
         "s3:GetBucketLocation",
         "s3:ListBucket",
         "s3:GetObject",
         "s3:PutObject",
         "s3:DeleteObject",
+        "s3:ListBucketMultipartUploads",
         "s3:AbortMultipartUpload",
         "s3:ListMultipartUploadParts"
       ],

--- a/modules/rosa-sts-creating-a-cluster-quickly-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-quickly-ocm.adoc
@@ -155,7 +155,7 @@ rosa create cluster --sts
 <1> Specifies the prefix to include in the account-wide role and policy names. The default is `ManagedOpenShift`.
 <2> Optional: Specifies a permissions boundary Amazon Resource Name (ARN) for the roles. For more information, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html[Permissions boundaries for IAM entities] in the AWS documentation.
 <3> Selects the role creation mode. You can use `auto` mode to automatically create the account wide roles and policies.
-<4> Creates the account-wide installer, control plane, worker and support roles and corresponding inline IAM policies. For more information, see _Account-wide IAM role and policy reference_.
+<4> Creates the account-wide installer, control plane, worker and support roles and corresponding IAM policies. For more information, see _Account-wide IAM role and policy reference_.
 <5> Creates the cluster-specific Operator IAM roles that permit the ROSA cluster Operators to carry out core OpenShift functionality. For more information, see _Account-wide IAM role and policy reference_.
 .. On the *Accounts and roles* page, click *Refresh ARNs* and verify that the installer, support, worker, and control plane account roles are detected.
 

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -181,7 +181,7 @@ rosa create cluster --sts
 <1> Specifies the prefix to include in the {cluster-manager} IAM role name. The default is `ManagedOpenShift`.
 <2> Optional: Specifies a permissions boundary Amazon Resource Name (ARN) for the role. For more information, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html[Permissions boundaries for IAM entities] in the AWS documentation.
 <3> Selects the role creation mode. You can use `auto` mode to automatically create the account wide roles and policies. In `manual` mode, the `rosa` CLI generates the `aws` commands needed to create the roles and policies. In `manual` mode, the corresponding policy JSON files are also saved to the current directory. `manual` mode enables you to review the details before running the `aws` commands manually.
-<4> Creates the account-wide installer, control plane, worker and support roles and corresponding inline IAM policies. For more information, see _Account-wide IAM role and policy reference_.
+<4> Creates the account-wide installer, control plane, worker and support roles and corresponding IAM policies. For more information, see _Account-wide IAM role and policy reference_.
 <5> Creates the cluster-specific Operator IAM roles that permit the ROSA cluster Operators to carry out core OpenShift functionality. For more information, see _Account-wide IAM role and policy reference_.
 .. On the *Accounts and roles* page, click *Refresh ARNs* and verify that the installer, support, worker, and control plane account roles are detected.
 


### PR DESCRIPTION
[OSDOCS-3320] removed inline from policy table descriptions

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-3320

Link to docs preview:
http://file.rdu.redhat.com/aldiaz/OSDOCS-3320/rosa_architecture/rosa-sts-about-iam-resources.html

