### PR TITLE
OSDOCS-3551: Update AMIs for 4.11 GA

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -23,73 +23,76 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-0f3804f5a2f913dcc`
+|`ami-0067394b051d857f9`
 
 |`ap-east-1`
-|`ami-0de1febb30a83da66`
+|`ami-057f593cc29fd3e08`
 
 |`ap-northeast-1`
-|`ami-0183df96a3e002687`
+|`ami-0f5bfc3e39711a7d8`
 
 |`ap-northeast-2`
-|`ami-06b8798cd60242798`
+|`ami-07b8f6b801b49a0b7`
 
 |`ap-northeast-3`
-|`ami-00b16b33aa0951016`
+|`ami-0677b0ba9d47e5e3a`
 
 |`ap-south-1`
-|`ami-007243f8ff78e8294`
+|`ami-0755c7732de0421e7`
 
 |`ap-southeast-1`
-|`ami-079dfdacb5ab5a0d1`
+|`ami-07b2f18a01b8ddce4`
 
 |`ap-southeast-2`
-|`ami-03882e39cb7785c32`
+|`ami-075b1af2bc583944b`
+
+|`ap-southeast-3`
+|`ami-0b5a81f57762da2f4`
 
 |`ca-central-1`
-|`ami-05cba1f80cc8b1dbe`
+|`ami-0fda98e014e64d6c4`
 
 |`eu-central-1`
-|`ami-073c775bbe9cd434e`
+|`ami-0ba6fa5b3d81c5d56`
 
 |`eu-north-1`
-|`ami-0763e6e75b681acc5`
+|`ami-08aed4be0d4d11b0c`
 
 |`eu-south-1`
-|`ami-00d023f19775fb64b`
+|`ami-0349bc626dd021c7c`
 
 |`eu-west-1`
-|`ami-0033e3f2331a530c4`
+|`ami-0706a49df2a8357b6`
 
 |`eu-west-2`
-|`ami-00d8a741ebe74f0c4`
+|`ami-0681b7397b0ec9691`
 
 |`eu-west-3`
-|`ami-09b04e7f60e3374a7`
+|`ami-0919c4668782f35da`
 
 |`me-south-1`
-|`ami-0f8039330b6e54010`
+|`ami-07ef03ebf19799060`
 
 |`sa-east-1`
-|`ami-01af22f821b470ad1`
+|`ami-046a4e6f57aea3234`
 
 |`us-east-1`
-|`ami-0c72f473496a7b1c2`
+|`ami-0722eb0819717090f`
 
 |`us-east-2`
-|`ami-09e637fc5885c13cc`
+|`ami-026e5701f495c94a2`
 
 |`us-gov-east-1`
-|`ami-0c3b11bcccf6ec63c`
+|`ami-016dce87c45add851`
 
 |`us-gov-west-1`
-|`ami-084d95ff443d8bf99`
+|`ami-0c5bb1f0b393638a0`
 
 |`us-west-1`
-|`ami-0fa0f6fce7e63dd26`
+|`ami-021ef831672014a17`
 
 |`us-west-2`
-|`ami-084fb1316cd1ed4cc`
+|`ami-0bba4636ff1b1dc1c`
 
 |===
 
@@ -101,62 +104,62 @@ ifndef::openshift-origin[]
 |AWS zone
 |AWS AMI
 
-|`ap-east`
-|`ami-0f8195c36da4edbd7`
+|`ap-east-1`
+|`ami-083382a51b31f6bd1`
 
 |`ap-northeast-1`
-|`ami-000a86fa0a0b76144`
+|`ami-09b84fda1b7171183`
 
 |`ap-northeast-2`
-|`ami-0f772f5dc2347a954`
+|`ami-06404fbe4209e9557`
 
 |`ap-south-1`
-|`ami-02ab23e25b8e8af97`
+|`ami-0b9655b3c7c3525ba`
 
 |`ap-southeast-1`
-|`ami-085ae5a7dcbfb056d`
+|`ami-0a9b453d016e3dfde`
 
 |`ap-southeast-2`
-|`ami-085ff9f4e8d4d66e0`
+|`ami-0e7af060f6e927702`
 
 |`ca-central-1`
-|`ami-0050cdf32f76ba82c`
+|`ami-0c8293928c44b6bbd`
 
 |`eu-central-1`
-|`ami-092527fcf7c21fe42`
+|`ami-08a950d054a165e21`
 
 |`eu-north-1`
-|`ami-07d673450675ea033`
+|`ami-020dd619ad4f379dd`
 
 |`eu-south-1`
-|`ami-0f165ac29cc9d27bf`
+|`ami-0b915ff416b9aad24`
 
 |`eu-west-1`
-|`ami-0e0cd7d2eb949538d`
+|`ami-034df7689a87ce826`
 
 |`eu-west-2`
-|`ami-0790ba70a444fe74d`
+|`ami-02bf81e08b4b2f1ef`
 
 |`eu-west-3`
-|`ami-0d16af5bd22cc5227`
+|`ami-03878de77169a8599`
 
 |`me-south-1`
-|`ami-05e1ba911ce321052`
+|`ami-034b27bd530bac050`
 
 |`sa-east-1`
-|`ami-04b124534c7f05cd2`
+|`ami-06ab90bd7daf4dd8b`
 
 |`us-east-1`
-|`ami-09bbec91849ca85bc`
+|`ami-00d3196d06bc2a924`
 
 |`us-east-2`
-|`ami-048ac599f7315a0bc`
+|`ami-028a3d23312630036`
 
 |`us-west-1`
-|`ami-0af1d3b7fa5be2131`
+|`ami-05356b8fece665cf1`
 
 |`us-west-2`
-|`ami-0bd3bf54ee678e2a6`
+|`ami-0e6473997df31eb0f`
 
 |===
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR addresses [OSDOCS-3551](https://issues.redhat.com/browse/OSDOCS-3551).

Link to docs preview:
[RHCOS AMIs for the AWS Infrastructure](http://file.rdu.redhat.com/mpytlak/osdocs-3547/installing/installing_aws/installing-restricted-networks-aws.html#installation-aws-user-infra-rhcos-ami_installing-restricted-networks-aws)