### PR TITLE
OADP-481: Document supported volume types

### DIFF
--- a/modules/oadp-backing-up-applications-restic.adoc
+++ b/modules/oadp-backing-up-applications-restic.adoc
@@ -10,6 +10,11 @@ You back up Kubernetes resources, internal images, and persistent volumes with R
 
 You do not need to specify a snapshot location in the `DataProtectionApplication` CR.
 
+[IMPORTANT]
+====
+Restic does not support backing up `hostPath` volumes. For more information, see link:https://{velero-domain}/docs/v{velero-version}/restic/#limitations[additional Rustic limitations].
+====
+
 .Prerequisites
 
 * You must install the OpenShift API for Data Protection (OADP) Operator.


### PR DESCRIPTION
OADP 1.1.0; OCP 4.9+

Resolves: https://issues.redhat.com/browse/OADP-481 by listing the volume types that Restic does not support.

Preview: http://file.emea.redhat.com/rhoch/restic_lim/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-backing-up-applications-restic_backing-up-applications

NOTE: Please merge PR https://github.com/openshift/openshift-docs/pull/47670 before you merge this PR -- otherwise a link in the proposed text will not work! Thanks. 