### PR TITLE
Correct capitalization for OpenShift in the sno attributes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -132,5 +132,5 @@ endif::[]
 :ibmzProductName: IBM Z
 // Red Hat Quay Container Security Operator
 :rhq-cso: Red Hat Quay Container Security Operator
-:sno: single-node Openshift
-:sno-caps: Single-node Openshift
+:sno: single-node OpenShift
+:sno-caps: Single-node OpenShift


### PR DESCRIPTION
No issue but it is related to https://github.com/openshift/openshift-docs/pull/47284

This PR corrects the capitalization for "OpenShift" in the recently added sno attributes

Versions: OpenShift 4.9+