### PR TITLE
OSSMDOC-629: add note to supported configurations topic.

### DIFF
--- a/modules/ossm-supported-configurations.adoc
+++ b/modules/ossm-supported-configurations.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// 
+//
 // * service_mesh/v2x/preparing-ossm-install.adoc
 // * service_mesh/v2x/servicemesh-release-notes.adoc
 // * post_installation_configuration/network-configuration.adoc
@@ -12,12 +12,12 @@ The following configurations are supported for the current release of {SMProduct
 [id="ossm-supported-platforms_{context}"]
 == Supported platforms
 
+The {SMProductName} Operator supports multiple versions of the `ServiceMeshControlPlane` resource. Version {MaistraVersion} service mesh control planes are supported on the following platform versions:
+
 * Red Hat {product-title} version 4.9 or later.
 * {product-dedicated} version 4.
 * Azure Red Hat OpenShift (ARO) version 4.
 * Red Hat OpenShift Service on AWS (ROSA).
-
-For additional information about {SMProductName} lifecycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift#ossm[Support Policy].
 
 [id="ossm-unsupported-configurations_{context}"]
 == Unsupported configurations

--- a/service_mesh/v2x/preparing-ossm-installation.adoc
+++ b/service_mesh/v2x/preparing-ossm-installation.adoc
@@ -23,6 +23,8 @@ Before you can install {SMProductName}, you must subscribe to {product-title} an
 * Install the version of the {product-title} command line utility (the `oc` client tool) that matches your {product-title} version and add it to your path.
 ** If you are using {product-title} {product-version}, see xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-about-cli_cli-developer-commands[About the OpenShift CLI].
 
+For additional information about {SMProductName} lifecycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift#ossm[Support Policy].
+
 include::modules/ossm-supported-configurations.adoc[leveloffset=+1]
 
 == Next steps


### PR DESCRIPTION
[OSSMDOC-629](https://issues.redhat.com/browse/OSSMDOC-629)

Version(s): 4.6 - 4.11

This PR adds a sentence to clarify that the supported versions applies to the SMCP and not the Operator.
Also moves an XREF out of the module and into the Assembly file.

Link to docs preview: http://file.bos.redhat.com/jstickle/OSSMDOC-629/service_mesh/v2x/preparing-ossm-installation.html#ossm-supported-platforms_preparing-ossm-installation

QE review - pbajjuri20
Peer review - rolfedh