### PR TITLE
OSSMDOC-551: Migrating from ServiceMeshExtension to WasmPlugin.

### DIFF
--- a/modules/ossm-extensions-migrating-to-wasmplugin.adoc
+++ b/modules/ossm-extensions-migrating-to-wasmplugin.adoc
@@ -1,0 +1,30 @@
+////
+This module included in the following assemblies:
+*service_mesh_/v2x/ossm-extensions.adoc
+////
+:_content-type: PROCEDURE
+[id="ossm-extensions-migrating-to-wasmplugin_{context}"]
+= Migrating to `WasmPlugin` resources
+
+To upgrade your WebAssembly extensions from the `ServiceMeshExtension` API to the `WasmPlugin` API, you rename your plug-in file.
+
+.Prerequisites
+
+* `ServiceMeshControlPlane` is upgraded to version 2.2 or later.
+
+[CAUTION]
+====
+Because both plug-ins will be called for every request, you might want to remove your existing `ServiceMeshExtension` resource before creating the new `WasmPlugin` resource. You might get undesired results having two plug-ins active at the same time.
+====
+
+.Procedure
+
+. Update your container image. If the plug-in is already in `/plugin.wasm` inside the container, skip to the next step.  If not:
+
+.. Ensure the plug-in file is named `plugin.wasm`. You must name the extension file `plugin.wasm`.
+
+.. Ensure the plug-in file is located in the root (/) directory. You must store extension files in the root of the container filesystem..
+
+.. Rebuild your container image and push it to a container registry.
+
+. Remove the `ServiceMeshExtension` resource and create a `WasmPlugin` resource that refers to the new container image you built.

--- a/modules/ossm-extensions-migration-overview.adoc
+++ b/modules/ossm-extensions-migration-overview.adoc
@@ -1,0 +1,90 @@
+////
+This module included in the following assemblies:
+*service_mesh_/v2x/ossm-extensions.adoc
+////
+:_content-type: CONCEPT
+[id="ossm-extensions-migration-overview_{context}"]
+= Migrating from `ServiceMeshExtension` to `WasmPlugin` resources
+
+The `ServiceMeshExtension` API is deprecated as of {SMProductName} version 2.2 and will be removed in a future release. If you are using the `ServiceMeshExtention` API, you must migrate to the `WasmPlugin` API to continue using your WebAssembly extensions.
+
+The APIs are very similar. The migration consists of two steps:
+
+. Renaming your plug-in file and updating the module packaging.
+
+. Creating a `WasmPlugin` resource that references the updated container image.
+
+[id="ossm-extensions-migration-api-changes_{context}"]
+== API changes
+
+The new `WasmPlugin` API is similar to the `ServiceMeshExtension`, but with a few differences, especially in the field names:
+
+
+.Field changes between `ServiceMeshExtensions` and `WasmPlugin`
+[options="header"]
+[cols="a, a"]
+|===
+|ServiceMeshExtension |WasmPlugin
+|`spec.config`
+|`spec.pluginConfig`
+
+|`spec.workloadSelector`
+|`spec.selector`
+
+|`spec.image`
+|`spec.url`
+
+//Question about the case here, is WasmPlugin app caps?
+|`spec.phase` valid values: PreAuthN, PostAuthN, PreAuthZ, PostAuthZ, PreStats, PostStats
+|`spec.phase` valid values: <empty>, AUTHN, AUTHZ, STATS
+|===
+
+The following is an example of how a `ServiceMeshExtension` resource could be converted into a `WasmPlugin` resource.
+
+.ServiceMeshExtension resource
+[source,yaml]
+----
+apiVersion: maistra.io/v1
+kind: ServiceMeshExtension
+metadata:
+  name: header-append
+  namespace: istio-system
+spec:
+  workloadSelector:
+    labels:
+      app: httpbin
+  config:
+    first-header: some-value
+    another-header: another-value
+  image: quay.io/maistra-dev/header-append-filter:2.2
+  phase: PostAuthZ
+  priority: 100
+----
+
+.New WasmPlugin resource equivalent to the ServiceMeshExtension above
+[source,yaml]
+----
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: header-append
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  url: oci://quay.io/maistra-dev/header-append-filter:2.2
+  phase: STATS
+  pluginConfig:
+    first-header: some-value
+    another-header: another-value
+----
+
+[id="ossm-extensions-migration-format-changes_{context}"]
+== Container image format changes
+
+The new `WasmPlugin` container image format is similar to the `ServiceMeshExtensions`, with the following differences:
+
+* The `ServiceMeshExtension` container format required a metadata file named `manifest.yaml` in the root directory of the container filesystem. The `WasmPlugin` container format does not require a `manifest.yaml` file.
+
+* The `.wasm` file (the actual plug-in) that previously could have any filename now must be named `plugin.wasm` and must be located in the root directory of the container filesystem.

--- a/modules/ossm-extensions-ref-wasmplugin.adoc
+++ b/modules/ossm-extensions-ref-wasmplugin.adoc
@@ -137,7 +137,7 @@ The `PullPolicy` object specifies the pull behavior to be applied when fetching 
 |If an existing version of the image has been pulled before, that will be used. If no version of the image is present locally, we will pull the latest version.
 
 |Always
-|We will always pull the latest version of an image when applying this plugin.
+|Always pull the latest version of an image when applying this plug-in.
 |===
 
 `Struct` represents a structured data value, consisting of fields which map to dynamically typed values. In some languages, Struct might be supported by a native representation. For example, in scripting languages like JavaScript a struct is represented as an object.
@@ -152,7 +152,7 @@ The `PullPolicy` object specifies the pull behavior to be applied when fetching 
 |Map of dynamically typed values.
 |===
 
-`PluginPhase` specifies the phase in the filter chain where the plugin will be injected.
+`PluginPhase` specifies the phase in the filter chain where the plug-in will be injected.
 
 .PluginPhase
 [options="header"]
@@ -160,14 +160,14 @@ The `PullPolicy` object specifies the pull behavior to be applied when fetching 
 |===
 | Field | Description
 |<empty>
-|Control plane decides where to insert the plugin. This will generally be at the end of the filter chain, right before the Router. Do not specify PluginPhase if the plugin is independent of others.
+|Control plane decides where to insert the plug-in. This will generally be at the end of the filter chain, right before the Router. Do not specify PluginPhase if the plug-in is independent of others.
 
 |AUTHN
-|Insert plugin before Istio authentication filters.
+|Insert plug-in before Istio authentication filters.
 
 |AUTHZ
-|Insert plugin before Istio authorization filters and after Istio authentication filters.
+|Insert plug-in before Istio authorization filters and after Istio authentication filters.
 
 |STATS
-|Insert plugin before Istio stats filters and after Istio authorization filters.
+|Insert plug-in before Istio stats filters and after Istio authorization filters.
 |===

--- a/service_mesh/v2x/ossm-extensions.adoc
+++ b/service_mesh/v2x/ossm-extensions.adoc
@@ -26,3 +26,7 @@ include::modules/ossm-extensions-smextension-format.adoc[leveloffset=+1]
 include::modules/ossm-extensions-ref-smextension.adoc[leveloffset=+1]
 
 include::modules/ossm-extensions-smextension-deploy.adoc[leveloffset=+2]
+
+include::modules/ossm-extensions-migration-overview.adoc[leveloffset=+1]
+
+include::modules/ossm-extensions-migrating-to-wasmplugin.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): 4.6 - 4.11

Issue: [OSSMDOC-551](https://issues.redhat.com/browse/OSSMDOC-551)  Document the migration from the ServiceMeshExtension API to the WasmPlugin API.

Link to docs preview: http://file.bos.redhat.com/jstickle/OSSMDOC-551/service_mesh/v2x/ossm-extensions.html#ossm-extensions-migration-overview_ossm-extensions

Eng review - jwendell
QE review -  skondkar
Peer review - sayjadha, stevsmit