### PR TITLE
OSSMDOC-549: Update upstream/downstream differences

### DIFF
--- a/modules/ossm-multitenant.adoc
+++ b/modules/ossm-multitenant.adoc
@@ -13,7 +13,7 @@ Whereas upstream Istio takes a single tenant approach, {SMProductName} supports 
 [id="ossm-mt-vs-clusterwide_{context}"]
 == Multitenancy versus cluster-wide installations
 
-The main difference between a multitenant installation and a cluster-wide installation is the scope of privileges used by the control plane deployments, for example, Galley and Pilot. The components no longer use cluster-scoped Role Based Access Control (RBAC) resource `ClusterRoleBinding`.
+The main difference between a multitenant installation and a cluster-wide installation is the scope of privileges used by istod. The components no longer use cluster-scoped Role Based Access Control (RBAC) resource `ClusterRoleBinding`.
 
 Every project in the `ServiceMeshMemberRoll` `members` list will have a `RoleBinding` for each service account associated with the control plane deployment and each control plane deployment will only watch those member projects. Each member project has a `maistra.io/member-of` label added to it, where the `member-of` value is the project containing the control plane installation.
 

--- a/modules/ossm-vs-istio.adoc
+++ b/modules/ossm-vs-istio.adoc
@@ -85,11 +85,15 @@ spec:
 
 {SMProductName} replaces BoringSSL with OpenSSL. OpenSSL is a software library that contains an open source implementation of the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols. The {SMProductName} Proxy binary dynamically links the OpenSSL libraries (libssl and libcrypto) from the underlying Red Hat Enterprise Linux operating system.
 
-
 [id="ossm-external-workloads_{context}"]
 == External workloads
 
-{SMProductName} does not support external workloads (virtual machines).
+{SMProductName} does not support external workloads, such as virtual machines running outside OpenShift on bare metal servers.
+
+[id="ossm-virtual-machine-support_{context}"]
+== Virtual Machine Support
+
+You can deploy virtual machines to OpenShift using OpenShift Virtualization. Then, you can apply a mesh policy, such as mTLS or AuthorizationPolicy, to these virtual machines, just like any other pod that is part of a mesh.
 
 [id="ossm-component-modifications_{context}"]
 == Component modifications
@@ -114,6 +118,25 @@ spec:
 == Istio Container Network Interface (CNI) plug-in
 
 {SMProductName} includes CNI plug-in, which provides you with an alternate way to configure application pod networking. The CNI plug-in replaces the `init-container` network configuration eliminating the need to grant service accounts and projects access to security context constraints (SCCs) with elevated privileges.
+
+[id="ossm-global-mtls_{context}"]
+== Global mTLS settings
+{SMProductName} creates a `PeerAuthentication` resource that enables or disables Mutual TLS authentication (mTLS) within the mesh.
+
+[id="ossm-gateways_{context}"]
+== Gateways
+
+{SMProductName} installs ingress and egress gateways by default. You can disable this in the SMCP using `spec.gateways.ingress.enabled=false` or `spec.gateways.egress.enabled=false`.
+
+[id="ossm-multicluster-configuration_{context}"]
+== Multicluster configurations
+
+{SMProductName} does not provide support for multicluster configurations.
+
+[id="ossm-certificate-signing-request_{context}"]
+== Custom Certificate Signing Requests (CSR)
+
+You cannot configure {SMProductName} to process CSRs through the Kubernetes certificate authority (CA).
 
 [id="ossm-routes-gateways_{context}"]
 == Routes for Istio Gateways


### PR DESCRIPTION
Version(s): 4.6 - 4.11

Issue: https://issues.redhat.com/browse/OSSMDOC-549

Link to docs preview: http://file.bos.redhat.com/tokeefe/OSSMDOC-549/service_mesh/v2x/ossm-vs-community.html#ossm-vs-istio_ossm-vs-istio

Additional information:

@rcernich and @longmuir please review

Eng Review: rcernich, jwendell
QE Review: skondkar
Peer Review: jstickler