### PR TITLE
BZ#2097051: Add info regarding credrequest directory - enteprise-4.9

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -30,8 +30,11 @@ By default, `ccoctl` creates objects in the directory in which the commands are 
 $ oc adm release extract \
 --credentials-requests \
 --cloud=aws \
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
+--to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
+--quay.io/<path_to>/ocp-release:<version>
 ----
++
+<1> `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
 
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 +

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -88,8 +88,11 @@ This command also creates a YAML configuration file in `/<path_to_ccoctl_output_
 $ oc adm release extract \
 --credentials-requests \
 --cloud=aws \
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
+--to=<path_to_directory_with_list_of_credentials_requests>/credrequests <1>
+--quay.io/<path_to>/ocp-release:<version>
 ----
++
+<1> `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
 
 .. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 +

--- a/modules/cco-ccoctl-upgrading.adoc
+++ b/modules/cco-ccoctl-upgrading.adoc
@@ -30,8 +30,11 @@ Some `ccoctl` commands make AWS API calls to create or modify AWS resources. You
 $ oc adm release extract \
 --credentials-requests \
 --cloud=aws \
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests quay.io/<path_to>/ocp-release:<version>
+--to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
+--quay.io/<path_to>/ocp-release:<version>
 ----
++
+<1> `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
 
 . For each `CredentialsRequest` CR in the release image, ensure that a namespace that matches the text in the `spec.secretRef.namespace` field exists in the cluster. This field is where the generated secrets that hold the credentials configuration are stored.
 +


### PR DESCRIPTION
Original PR: #47286
Version(s): 4.9

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2097051

Link to docs preview:
http://file.rdu.redhat.com/snarayan/BZ2097051_credrequest_directory_4_9/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-individually_cco-mode-sts

http://file.rdu.redhat.com/snarayan/BZ2097051_credrequest_directory_4_9/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-at-once_cco-mode-sts

http://file.rdu.redhat.com/snarayan/BZ2097051_credrequest_directory_4_9/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-upgrading_sts-mode-upgrading
