### PR TITLE
OSDOCS-3558: Addded asia-south2 to supported GCP regions

### DIFF
--- a/modules/installation-gcp-regions.adoc
+++ b/modules/installation-gcp-regions.adoc
@@ -16,6 +16,7 @@ regions:
 * `asia-northeast2` (Osaka, Japan)
 * `asia-northeast3` (Seoul, South Korea)
 * `asia-south1` (Mumbai, India)
+* `asia-south2` (Delhi, India)
 * `asia-southeast1` (Jurong West, Singapore)
 * `asia-southeast2` (Jakarta, Indonesia)
 * `australia-southeast1` (Sydney, Australia)


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR address [osdocs-3558](https://issues.redhat.com/browse/OSDOCS-3558).

Link to docs preview:
[Supported GCP regions](http://file.rdu.redhat.com/mpytlak/osdocs-3558/installing/installing_gcp/installing-gcp-account.html#installation-gcp-regions_installing-gcp-account)