### PR TITLE
BZ:2011790 - Baremetal ipi installation fails when using ipv6 and pro…

### DIFF
--- a/modules/ipi-install-setting-proxy-settings-within-install-config.adoc
+++ b/modules/ipi-install-setting-proxy-settings-within-install-config.adoc
@@ -32,3 +32,8 @@ Key considerations:
 * If the proxy does not have an HTTPS proxy, change the value of `httpsProxy` from `https://` to `http://`.
 * If using a provisioning network, include it in the `noProxy` setting, otherwise the installer will fail.
 * Set all of the proxy settings as environment variables within the provisioner node. For example, `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
+
+[NOTE]
+====
+When provisioning with IPv6, you cannot define a CIDR address block in the `noProxy` settings. You must define each address separately.
+====


### PR DESCRIPTION
Version(s): Main, 4.6-4.11

Issue:
[BZ-2011790](https://bugzilla.redhat.com/show_bug.cgi?id=2011790)

[Link to docs preview](http://file.emea.redhat.com/miweiss/BZ-2011790/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-setting-proxy-settings-within-install-config_ipi-install-installation-workflow)

Reviewed and approved by SME ( @derekhiggins ) and QE ( @vvoronkov )