### PR TITLE
[RHACS] ROX-11713: Remove stackrox.io repo for images

### DIFF
--- a/modules/acs-requirements.adoc
+++ b/modules/acs-requirements.adoc
@@ -20,7 +20,7 @@ For example, Intel processors older than _Sandy Bridge_ and AMD processors older
 ====
 
 * Cluster nodes with a supported operating system.
-See the link:https://access.redhat.com/node/5822721[{product-title} Support Policy] for additional information.
+For more information, see the link:https://access.redhat.com/node/5822721[{product-title} Support Policy].
 ** *Operating system*: Amazon Linux, CentOS, Container-Optimized OS from Google, {op-system-first}, Debian, {op-system-base-full}, or Ubuntu.
 ** *Processor and memory*: 2 CPU cores and at least 3GiB of RAM.
 +
@@ -42,9 +42,4 @@ However, you can use another storage type if you do not have SSDs available.
 Use the `helm version` command to verify the version of Helm you have installed.
 * The {ocp} CLI (`oc`).
 * You must have the required permissions to configure deployments in the Central cluster.
-* You must have access to the Red Hat Container Registry. See link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication] for information about downloading images from `registry.redhat.io`.
-+
-[NOTE]
-====
-If you are not a Red Hat customer and purchased the StackRox Kubernetes Security Platform before the acquisition, you can use StackRox’s container registry at `stackrox.io`. Contact mailto:support@stackrox.com[support@stackrox.com] to enable access to the registry.
-====
+* You must have access to the Red Hat Container Registry. For information about downloading images from `registry.redhat.io`, see link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication].

--- a/modules/central-services-private-config.adoc
+++ b/modules/central-services-private-config.adoc
@@ -10,32 +10,33 @@ There are no default values for these parameters.
 
 [id="central-services-private-configuration-file-image-pull-secrets_{context}"]
 == Image pull secrets
-The credentials required for pulling images from your registry.
+The credentials that are required for pulling images from the registry depend on the following factors:
 
-[NOTE]
-====
-* If you are using the `stackrox.io` registry, you must specify the `imagePullSecrets.username` and `imagePullSecrets.password` parameters.
-* If you are using a custom registry, you must also specify the `image.registry` parameter.
-* If you do not use a username and password to log in to your custom registry, you must specify one of the following parameters:
+* If you are using a custom registry, you must specify these parameters:
+** `imagePullSecrets.username`
+** `imagePullSecrets.password`
+** `image.registry` 
+
+* If you do not use a username and password to log in to the custom registry, you must specify one of the following parameters:
 ** `imagePullSecrets.allowNone`
 ** `imagePullSecrets.useExisting`
 ** `imagePullSecrets.useFromDefaultServiceAccount`
-====
+
 
 |===
 | Parameter | Description
 
 | `imagePullSecrets.username`
-| The username for your registry.
+| The username of the account that is used to log in to the registry.
 
 | `imagePullSecrets.password`
-| The password (for the selected username) of your registry.
+| The password of the account that is used to log in to the registry.
 
 | `imagePullSecrets.allowNone`
 | Use `true` if you are using a custom registry and it allows pulling images without credentials.
 
 | `imagePullSecrets.useExisting`
-| A comma-seprated list of secrets as values.
+| A comma-separated list of secrets as values.
 For example, `secret1, secret2, secretN`. Use this option if you have already created pre-existing image pull secrets with the given name in the target namespace.
 
 | `imagePullSecrets.useFromDefaultServiceAccount`
@@ -45,7 +46,7 @@ For example, `secret1, secret2, secretN`. Use this option if you have already cr
 [id="central-services-private-configuration-file-proxy-config_{context}"]
 == Proxy configuration
 
-If you are installing {product-title} in a cluster that requires a proxy  to connect to external services, you must specify your proxy configuration by using the `proxyConfig` parameter.
+If you are installing {product-title} in a cluster that requires a proxy to connect to external services, you must specify your proxy configuration by using the `proxyConfig` parameter.
 For example:
 
 [source,yaml]


### PR DESCRIPTION
Version(s): 
Merge to:

- `rhacs-docs`

Cherry pick to:
- `rhacs-docs-3.69`
- `rhacs-docs-3.70`
- `rhacs-docs-3.71`
- `rhacs-docs-3.72.0`

Labels:
`RHACS` 
`RHACS/next`

[Issue](https://issues.redhat.com/browse/ROX-11713)

Link to docs preview:

- [Prerequisites](https://openshift-docs-9igqprvgi-kcarmichael08.vercel.app/openshift-acs/master/installing/prerequisites.html#acs-general-requirements_acs-prerequisites)
- [Private configuration file](https://openshift-docs-9igqprvgi-kcarmichael08.vercel.app/openshift-acs/master/installing/installing_helm/install-helm-customization.html#configure-central-services-helm-chart)