### PR TITLE
OADP-461: Document known issue: Restore of resources with Admission Webhooks

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -28,10 +28,34 @@ include::modules/velero-obtaining-by-accessing-binary.adoc[leveloffset=+1]
 include::modules/oadp-debugging-oc-cli.adoc[leveloffset=+1]
 include::modules/migration-debugging-velero-resources.adoc[leveloffset=+1]
 
+[id="issues-with-velero-and-admission-workbooks"]
+== Issues with Velero and admission webhooks
+
+Velero has limited abilities to resolve admission webhook issues during a restore. If you have workloads with admission webhooks, you might need to use an additional Velero plug-in or make changes to how you restore the workload.
+
+Typically, workloads with admission webhooks require you to create a resource of a specific kind first. This is especially true if your workload has child resources because admission webhooks typically block child resources.
+
+For example, creating or restoring a top-level object such as `service.serving.knative.dev` typically creates child resources automatically. If you do this first, you will not need to use Velero to create and restore these resources. This avoids the problem of child resources being blocked by an admission webhook that Velero might use.
+
+[id="velero-restore-workarounds-for-workloads-with-admission-webhooks"]
+=== Restoring workarounds for Velero backups that use admission webhooks
+
+This section describes the additional steps required to restore resources for several types of Velero backups that use admission webhooks.
+
+include::modules/migration-debugging-velero-admission-webhooks-knative.adoc[leveloffset=+3]
+include::modules/migration-debugging-velero-admission-webhooks-ibm-appconnect.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/admission-plug-ins.adoc[Admission plug-ins]
+* xref:../../architecture/admission-plug-ins.adoc#admission-webhooks-about_admission-plug-ins[Webhook admission plug-ins]
+* xref:../../architecture/admission-plug-ins.adoc#admission-webhook-types_admission-plug-ins[Types of webhook admission plug-ins]
+
 include::modules/oadp-installation-issues.adoc[leveloffset=+1]
 include::modules/oadp-backup-restore-cr-issues.adoc[leveloffset=+1]
 include::modules/oadp-restic-issues.adoc[leveloffset=+1]
 
 include::modules/migration-using-must-gather.adoc[leveloffset=+1]
 
-:oadp-troubleshooting!:
+:!oadp-troubleshooting:

--- a/modules/migration-debugging-velero-admission-webhooks-ibm-appconnect.adoc
+++ b/modules/migration-debugging-velero-admission-webhooks-ibm-appconnect.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+:_content-type: PROCEDURE
+[id="migration-debugging-velero-admission-webhooks-ibm-appconnect_{context}"]
+= Restoring IBM AppConnect resources
+
+If you experience issues when you use Velero to a restore an IBM AppConnect resource that has an admission webhook, you can run the checks in this procedure.
+
+.Procedure
+
+. Check if you have any mutating admission plug-ins of `kind: MutatingWebhookConfiguration` in the cluster:
++
+[source,terminal]
+----
+$ oc get mutatingwebhookconfigurations
+----
+
+. Examine the YAML file of each `kind: MutatingWebhookConfiguration` to ensure that none of its rules block creation of the objects that are experiencing issues. For more information, see link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#rulewithoperations-v1-admissionregistration-k8s-io[the official Kuberbetes documentation].
+
+. Check that any `spec.version` in `type: Configuration.appconnect.ibm.com/v1beta1` used at backup time is supported by the installed Operator.

--- a/modules/migration-debugging-velero-admission-webhooks-knative.adoc
+++ b/modules/migration-debugging-velero-admission-webhooks-knative.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+:_content-type: PROCEDURE
+[id="migration-debugging-velero-admission-webhooks-knative_{context}"]
+= Restoring Knative resources
+
+You might encounter problems using Velero to back up Knative resources that use admission webhooks.
+
+You can avoid such problems by restoring the top level `Service` resource first whenever you back up and restore Knative resources that use admission webhooks.
+
+.Procedure
+
+* Restore the top level `service.serving.knavtive.dev Service` resource:
++
+[source,terminal]
+----
+$ velero restore <restore_name> \
+  --from-backup=<backup_name> --include-resources \
+  service.serving.knavtive.dev
+----


### PR DESCRIPTION
OADP 1.1.0, OCP 4.9+

Resolves: https://issues.redhat.com/browse/OADP-461 by adding a new section to the "Troubleshooting" section. 

Preview:  http://file.emea.redhat.com/rhoch/vel_admin_whook/backup_and_restore/application_backup_and_restore/troubleshooting.html#issues-with-velero-and-admission-workbooks

Please do not merge before Sept. 1.
