### PR TITLE
OSDOCS-3625: Add support for user-provisioned IPv6 on metal

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -283,11 +283,7 @@ You can customize your installation configuration based on the requirements of y
 // But only for installer-provisioned
 // https://bugzilla.redhat.com/show_bug.cgi?id=2020416
 // Once BM UPI supports dual-stack, uncomment all the following conditionals and blocks
-//ifndef::bare[]
-Only IPv4 addresses are supported.
-////
-endif::bare[]
-ifdef::bare[]
+
 If you use the OVN-Kubernetes cluster network provider, both IPv4 and IPv6 address families are supported.
 
 If you use the OpenShift SDN cluster network provider, only the IPv4 address family is supported.
@@ -304,14 +300,12 @@ networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  - cidr: fd00:10:128::/56
+  - cidr: fd01::/48
     hostPrefix: 64
   serviceNetwork:
   - 172.30.0.0/16
   - fd00:172:16::/112
 ----
-endif::bare[]
-////
 
 .Network parameters
 [cols=".^2,.^3a,.^3a",options="header"]
@@ -348,51 +342,31 @@ If you specify multiple IP address blocks, the blocks must not overlap.
 
 [source,yaml]
 ----
-//ifndef::bare[]
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-//endif::bare[]
-//ifdef::bare[]
-//networking:
-//  clusterNetwork:
-//  - cidr: 10.128.0.0/14
-//    hostPrefix: 23
-//  - cidr: fd01::/48
-//    hostPrefix: 64
-//endif::bare[]
+  - cidr: fd01::/48
+    hostPrefix: 64
 ----
 
 |`networking.clusterNetwork.cidr`
 |
 Required if you use `networking.clusterNetwork`. An IP address block.
 
-//ifndef::bare[]
-An IPv4 network.
-//endif::bare[]
-//ifdef::bare[]
-//If you use the OpenShift SDN network provider, specify an IPv4 network. If you use the OVN-Kubernetes network provider, you can specify IPv4 and IPv6 networks.
-//endif::bare[]
+If you use the OpenShift SDN network provider, specify an IPv4 network. If you use the OVN-Kubernetes network provider, you can specify IPv4 and IPv6 networks.
 |
 An IP address block in Classless Inter-Domain Routing (CIDR) notation.
 The prefix length for an IPv4 block is between `0` and `32`.
-//ifdef::bare[]
-//The prefix length for an IPv6 block is between `0` and `128`. For example, `10.128.0.0/14` or `fd01::/48`.
-//endif::bare[]
+The prefix length for an IPv6 block is between `0` and `128`. For example, `10.128.0.0/14` or `fd01::/48`.
 
 |`networking.clusterNetwork.hostPrefix`
 |The subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23` then each node is assigned a `/23` subnet out of the given `cidr`. A `hostPrefix` value of `23` provides 510 (2^(32 - 23) - 2) pod IP addresses.
 |
 A subnet prefix.
 
-//ifndef::bare[]
-The default value is `23`.
-//endif::bare[]
-//ifdef::bare[]
-//For an IPv4 network the default value is `23`.
-//For an IPv6 network the default value is `64`. The default value is also the minimum value for IPv6.
-//endif::bare[]
+For an IPv4 network the default value is `23`.
+For an IPv6 network the default value is `64`. The default value is also the minimum value for IPv6.
 
 |`networking.serviceNetwork`
 |
@@ -400,26 +374,17 @@ The IP address block for services. The default value is `172.30.0.0/16`.
 
 The OpenShift SDN and OVN-Kubernetes network providers support only a single IP address block for the service network.
 
-//ifdef::bare[]
-//If you use the OVN-Kubernetes network provider, you can specify an IP address block for both of the IPv4 and IPv6 address families.
-//endif::bare[]
+If you use the OVN-Kubernetes network provider, you can specify an IP address block for both of the IPv4 and IPv6 address families.
 
 |
 An array with an IP address block in CIDR format. For example:
 
 [source,yaml]
 ----
-//ifndef::bare[]
 networking:
   serviceNetwork:
    - 172.30.0.0/16
-//endif::bare[]
-//ifdef::bare[]
-//networking:
-//  serviceNetwork:
-//   - 172.30.0.0/16
-//   - fd02::/112
-//endif::bare[]
+   - fd02::/112
 ----
 
 |`networking.machineNetwork`
@@ -446,12 +411,7 @@ Required if you use `networking.machineNetwork`. An IP address block. The defaul
 |
 An IP network block in CIDR notation.
 
-//ifndef::bare[]
-For example, `10.0.0.0/16`.
-//endif::bare[]
-//ifdef::bare[]
-//For example, `10.0.0.0/16` or `fd00::/48`.
-//endif::bare[]
+For example, `10.0.0.0/16` or `fd00::/48`.
 
 [NOTE]
 ====


### PR DESCRIPTION
This support was always intended for user-provisioned,
but was initially added for installer-provisioned which
was documented by a different team. So this adds it back
in here now that it is supported officially on user-provisioned.

- https://issues.redhat.com/browse/OSDOCS-3625

Preview: [Installing a user-provisioned bare metal cluster with network customizations -> Network configuration parameters](http://shell.lab.bos.redhat.com/~jboxman/OSDOCS-3625/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-configuration-parameters-network_installing-bare-metal-network-customizations)