### PR TITLE
addressing some portal build issues

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -104,5 +104,5 @@ include::modules/ipi-preparing-reinstall-cluster-bare-metal.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_creating_manifest_ignition"]
 == Additional resources
-* xref:../..//installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-generate-k8s-manifest-ignition_installing-bare-metal.adoc#installation-user-infra-generate-k8s-manifest-ignition_installing-bare-metal[{product-title} Creating the Kubernetes manifest and Ignition config files]
+* xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-generate-k8s-manifest-ignition_installing-bare-metal[{product-title} Creating the Kubernetes manifest and Ignition config files]
 * xref:../../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[{product-title} upgrade channels and releases]

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -178,7 +178,7 @@ $  ssh -i <ssh-key-path> core@<master-hostname>
 ----
 +
 .Sample `pki` directory
-[sample,terminal]
+[source,terminal]
 ----
 sh-4.4# pwd
 /var/lib/kubelet/pki

--- a/modules/enabling-multi-cluster-console.adoc
+++ b/modules/enabling-multi-cluster-console.adoc
@@ -32,7 +32,7 @@ Do not set this feature gate on production clusters. You will not be able to upg
 
 . A pop-up window that states that a web console update is available will appear a few moments after you enable. Click *Refresh the web console* in the pop-up window to update.
 +
-[Note]
+[NOTE]
 ====
 You might see the pop-up window to refresh the web console twice if the second redeployment has not occurred by the time you click *Refresh the web console*.
 ====

--- a/modules/networking-osp-enabling-metadata.adoc
+++ b/modules/networking-osp-enabling-metadata.adoc
@@ -9,7 +9,7 @@
 
 You can apply a machine config to your machine pool that makes the {rh-openstack-first} metadata service available as a mountable drive.
 
-[INFO]
+[NOTE]
 ====
 The following machine config enables the display of {rh-openstack} network UUIDs from within the SR-IOV Network Operator. This configuration simplifies the association of SR-IOV resources to cluster SR-IOV resources.
 ====

--- a/modules/nodes-nodes-viewing-listing.adoc
+++ b/modules/nodes-nodes-viewing-listing.adoc
@@ -208,7 +208,6 @@ Events:     <11>
 
 Among the information shown for nodes, the following node conditions appear in the output of the commands shown in this section:
 
-[discrete]
 [id="machine-health-checks-resource-conditions"]
 .Node Conditions
 [cols="3a,8a",options="header"]

--- a/modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc
+++ b/modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc
@@ -15,7 +15,6 @@ To verify signatures of task runs using {tekton-chains} with any additional auth
 * Retrieve the signature and payload from the signed task run.
 * Verify the signature of the task run.
 
-[discrete]
 .Prerequisites
 Ensure that the following are installed on the cluster:
 
@@ -23,7 +22,6 @@ Ensure that the following are installed on the cluster:
 * {tekton-chains}
 * link:https://docs.sigstore.dev/cosign/installation/[Cosign]
 
-[discrete]
 .Procedure
 
 . Create an encrypted x509 key pair and save it as a Kubernetes secret:

--- a/modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc
+++ b/modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc
@@ -15,7 +15,6 @@ Cluster administrators can use {tekton-chains} to sign and verify images and pro
 * Create an image with Kaniko in a task run.
 * Verify the signed image and the signed provenance.
 
-[discrete]
 .Prerequisites
 Ensure that the following are installed on the cluster:
 
@@ -25,7 +24,6 @@ Ensure that the following are installed on the cluster:
 * link:https://docs.sigstore.dev/rekor/installation/[Rekor]
 * link:https://stedolan.github.io/jq/[jq]
 
-[discrete]
 .Procedure
 
 . Create an encrypted x509 key pair and save it as a Kubernetes secret:

--- a/modules/persistent-storage-csi-vsphere-install-issues.adoc
+++ b/modules/persistent-storage-csi-vsphere-install-issues.adoc
@@ -21,12 +21,12 @@ To uninstall the third-party vSphere CSI Driver:
 . Delete the configmap and secret objects that were installed previously with the third-party vSphere CSI Driver.
 . Delete the third-party vSphere CSI driver `CSIDriver` object:
 +
-[output, terminal]
+[source,terminal]
 ----
 ~ $ oc delete CSIDriver csi.vsphere.vmware.com
 ----
 +
-[output, terminal]
+[source,terminal]
 ----
 csidriver.storage.k8s.io "csi.vsphere.vmware.com" deleted
 ----

--- a/modules/persistent-storage-csi-vsphere-stor-policy.adoc
+++ b/modules/persistent-storage-csi-vsphere-stor-policy.adoc
@@ -7,7 +7,7 @@
 = vSphere storage policy
 
 The vSphere CSI Operator Driver storage class uses vSphere's storage policy. {product-title} automatically creates a storage policy that targets datastore configured in cloud configuration:
-[output, yaml]
+[source,yaml]
 ----
 kind: StorageClass
 apiVersion: storage.k8s.io/v1

--- a/modules/security-deploy-image-sources.adoc
+++ b/modules/security-deploy-image-sources.adoc
@@ -24,7 +24,7 @@ applied uniformly across all nodes or targeted for different node workloads (for
 example, build, zone, or environment).
 
 .Example image signature policy file
-[json]
+[source,json]
 ----
 {
     "default": [{"type": "reject"}],

--- a/modules/storage-persistent-storage-reclaim.adoc
+++ b/modules/storage-persistent-storage-reclaim.adoc
@@ -15,7 +15,7 @@ $ oc get pv
 ----
 +
 .Example output
-[source-terminal]
+[source,terminal]
 ----
 NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM             STORAGECLASS     REASON    AGE
  pvc-b6efd8da-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim1    manual                     10s
@@ -39,7 +39,7 @@ $ oc get pv
 ----
 +
 .Example output
-[source-terminal]
+[source,terminal]
 ----
 NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM             STORAGECLASS     REASON    AGE
  pvc-b6efd8da-b7b5-11e6-9d58-0ed433a7dd94   4Gi        RWO           Delete          Bound     default/claim1    manual                     10s


### PR DESCRIPTION
I'm syncing 4.11 to the portal to prepare for GA and encountered some warnings and errors.

Sample previews: http://file.rdu.redhat.com/kalexand/portal_build_fixes/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#additional-resources_creating_manifest_ignition

http://file.rdu.redhat.com/kalexand/portal_build_fixes/post_installation_configuration/cluster-tasks.html#dr-scenario-2-restoring-cluster-state_post-install-cluster-tasks

http://file.rdu.redhat.com/kalexand/portal_build_fixes/storage/understanding-persistent-storage.html#reclaim-policy_understanding-persistent-storage