### PR TITLE
TELCODOCS-658: Added a release note

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -493,6 +493,11 @@ The following OpenShift CLI (`oc`) commands were removed with this release:
 
 Support for deploying custom schedulers manually has been removed with this release. Use the xref:../nodes/scheduling/secondary_scheduler/index.adoc#nodes-secondary-scheduler-about_nodes-secondary-scheduler-about[{secondary-scheduler-operator-full}] instead to deploy a custom secondary scheduler in {product-title}.
 
+[id="ocp-4-11-openshiftsdn-sno-not-supported"]
+==== Support for deploying {sno} with OpenShiftSDN has been removed
+
+Support for deploying {sno} clusters with OpenShiftSDN has been removed with this release. OVN-Kubernetes is the default networking solution for {sno} deployments.
+
 [id="ocp-4-11-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
Added a release note for https://issues.redhat.com/browse/TELCODOCS-658. 

Issue: https://issues.redhat.com/browse/TELCODOCS-658

Version(s): 4.11

Preview URL: http://157.131.167.205/TELCODOCS-658-rn/release_notes/ocp-4-11-release-notes.html#ocp-4-11-openshiftsdn-sno-not-supported

Signed-off-by: John Wilkins <jowilkin@redhat.com>