### PR TITLE
OSDOCS-3819: Update AWS VPC endpoint guidance for restricted installations

### DIFF
--- a/modules/installation-aws-user-infra-requirements.adoc
+++ b/modules/installation-aws-user-infra-requirements.adoc
@@ -32,11 +32,35 @@ Alternatively, you can manually create the components or you can reuse existing 
 * IAM roles
 * S3 buckets
 
-If you are working in a disconnected environment or use a proxy, you cannot reach the public IP addresses for EC2 and ELB endpoints. To reach these endpoints, you must create a VPC endpoint and attach it to the subnet that the clusters are using. Create the following endpoints:
+If you are working in a disconnected environment, you are unable to reach the public IP addresses for EC2, ELB, and S3 endpoints. Depending on the level to which you want to restrict internet traffic during the installation, the following configuration options are available:
+
+[discrete]
+[id="create-vpc-endpoints_{context}"]
+=== Option 1: Create VPC endpoints
+
+Create a VPC endpoint and attach it to the subnets that the clusters are using. Name the endpoints as follows:
 
 * `ec2.<region>.amazonaws.com`
 * `elasticloadbalancing.<region>.amazonaws.com`
 * `s3.<region>.amazonaws.com`
+
+With this option, network traffic remains private between your VPC and the required AWS services.
+
+[discrete]
+[id="create-proxy-without-vpc-endpoints_{context}"]
+=== Option 2: Create a proxy without VPC endpoints
+As part of the installation process, you can configure an HTTP or HTTPS proxy. With this option, internet traffic goes through the proxy to reach the required AWS services.
+
+[discrete]
+[id="create-proxy-with-vpc-endpoints_{context}"]
+=== Option 3: Create a proxy with VPC endpoints
+As part of the installation process, you can configure an HTTP or HTTPS proxy with VPC endpoints. Create a VPC endpoint and attach it to the subnets that the clusters are using. Name the endpoints as follows:
+
+* `ec2.<region>.amazonaws.com`
+* `elasticloadbalancing.<region>.amazonaws.com`
+* `s3.<region>.amazonaws.com`
+
+When configuring the proxy in the `install-config.yaml` file, add these endpoints to the `noProxy` field. With this option, the proxy prevents the cluster from accessing the internet directly. However, network traffic remains private between your VPC and the required AWS services.
 
 .Required VPC components
 

--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -84,6 +84,9 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-aws"]
 :aws:
 endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:aws:
+endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :bare-metal:
 endif::[]
@@ -183,14 +186,6 @@ The `Proxy` object `status.noProxy` field is populated with the values of the `n
 For installations on Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, and {rh-openstack-first}, the `Proxy` object `status.noProxy` field is also populated with the instance metadata endpoint (`169.254.169.254`).
 ====
 
-ifdef::aws[]
-* You have added the
-ifdef::aws-china[`ec2.<region>.amazonaws.com.cn`, ]
-ifndef::aws-china[`ec2.<region>.amazonaws.com`, ]
-`elasticloadbalancing.<region>.amazonaws.com`, and `s3.<region>.amazonaws.com` endpoints to your VPC endpoint. These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works on the container level, not the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not sufficient.
-endif::aws[]
-// TODO: xref installation-aws-user-infra-requirements.adoc#installation-aws-user-infra-other-infrastructure_{context} as a relative link
-
 .Procedure
 
 . Edit your `install-config.yaml` file and add the proxy settings. For example:
@@ -202,18 +197,24 @@ baseDomain: my.domain.com
 proxy:
   httpProxy: http://<username>:<pswd>@<ip>:<port> <1>
   httpsProxy: https://<username>:<pswd>@<ip>:<port> <2>
+ifndef::aws[]
   noProxy: example.com <3>
+endif::aws[]
+ifdef::aws[]
+  noProxy: ec2.<region>.amazonaws.com,elasticloadbalancing.<region>.amazonaws.com,s3.<region>.amazonaws.com <3>
+endif::aws[]
 additionalTrustBundle: | <4>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-...
 ----
 <1> A proxy URL to use for creating HTTP connections outside the cluster. The
 URL scheme must be `http`.
 <2> A proxy URL to use for creating HTTPS connections outside the cluster.
-<3> A comma-separated list of destination domain names, IP addresses, or
-other network CIDRs to exclude from proxying. Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass the proxy for all destinations.
+<3> A comma-separated list of destination domain names, IP addresses, or other network CIDRs to exclude from proxying. Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass the proxy for all destinations.
+ifdef::aws[]
+If you have added the Amazon `EC2`,`Elastic Load Balancing`, and `S3` VPC endpoints to your VPC, you must add these endpoints to the `noProxy` field.
+endif::aws[]
 ifdef::vsphere,vmc[]
 You must include vCenter's IP address and the IP range that you use for its machines.
 endif::vsphere,vmc[]
@@ -269,6 +270,9 @@ ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisione
 :!aws:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-aws"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
 :!aws:
 endif::[]
 ifeval::["{context}" == "installing-bare-metal"]

--- a/modules/installation-creating-aws-bootstrap.adoc
+++ b/modules/installation-creating-aws-bootstrap.adoc
@@ -7,9 +7,10 @@
 [id="installation-creating-aws-bootstrap_{context}"]
 = Creating the bootstrap node in AWS
 
-You must create the bootstrap node in Amazon Web Services (AWS) to use during {product-title} cluster initialization.
+You must create the bootstrap node in Amazon Web Services (AWS) to use during {product-title} cluster initialization. You do this by:
 
-You can use the provided CloudFormation template and a custom parameter file to create a stack of AWS resources. The stack represents the bootstrap node that your {product-title} installation requires.
+* Providing a location to serve the `bootstrap.ign` Ignition config file to your cluster. This file is located in your installation directory. The provided CloudFormation Template assumes that the Ignition config files for your cluster are served from an S3 bucket. If you choose to serve the files from another location, you must modify the templates.
+* Using the provided CloudFormation template and a custom parameter file to create a stack of AWS resources. The stack represents the bootstrap node that your {product-title} installation requires.
 
 [NOTE]
 ====
@@ -30,42 +31,20 @@ have to contact Red Hat support with your installation logs.
 
 .Procedure
 
-. Provide a location to serve the `bootstrap.ign` Ignition config file to your
-cluster. This file is located in your installation directory. One way to do this
-is to create an S3 bucket in your cluster's region and upload the Ignition
-config file to it.
-+
-[IMPORTANT]
-====
-The provided CloudFormation Template assumes that the
-Ignition config files for your cluster are served from an S3 bucket. If you
-choose to serve the files from another location, you must modify the templates.
-====
-+
-[IMPORTANT]
-====
-If you are deploying to a region that has endpoints that differ from the AWS SDK, or you are providing your own custom endpoints, you must use a presigned URL for your S3 bucket instead of the `s3://` schema.
-====
-+
-[NOTE]
-====
-The bootstrap Ignition config file does contain secrets, like X.509 keys. The
-following steps provide basic security for the S3 bucket. To provide additional
-security, you can enable an S3 bucket policy to allow only certain users, such
-as the OpenShift IAM user, to access objects that the bucket contains. You
-can avoid S3 entirely and serve your bootstrap Ignition config file from any
-address that the bootstrap machine can reach.
-====
-
-.. Create the bucket:
+. Create the bucket by running the following command:
 +
 [source,terminal]
 ----
 $ aws s3 mb s3://<cluster-name>-infra <1>
 ----
 <1> `<cluster-name>-infra` is the bucket name. When creating the `install-config.yaml` file, replace `<cluster-name>` with the name specified for the cluster.
++
+You must use a presigned URL for your S3 bucket, instead of the `s3://` schema, if you are:
+** Deploying to a region that has endpoints that differ from the AWS SDK.
+** Deploying a proxy.
+** Providing your own custom endpoints.
 
-.. Upload the `bootstrap.ign` Ignition config file to the bucket:
+. Upload the `bootstrap.ign` Ignition config file to the bucket by running the following command:
 +
 [source,terminal]
 ----
@@ -73,7 +52,7 @@ $ aws s3 cp <installation_directory>/bootstrap.ign s3://<cluster-name>-infra/boo
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you stored the installation files in.
 
-.. Verify that the file uploaded:
+. Verify that the file uploaded by running the following command:
 +
 [source,terminal]
 ----
@@ -85,9 +64,13 @@ $ aws s3 ls s3://<cluster-name>-infra/
 ----
 2019-04-03 16:15:16     314878 bootstrap.ign
 ----
++
+[NOTE]
+====
+The bootstrap Ignition config file does contain secrets, like X.509 keys. The following steps provide basic security for the S3 bucket. To provide additional security, you can enable an S3 bucket policy to allow only certain users, such as the OpenShift IAM user, to access objects that the bucket contains. You can avoid S3 entirely and serve your bootstrap Ignition config file from any address that the bootstrap machine can reach.
+====
 
-. Create a JSON file that contains the parameter values that the template
-requires:
+. Create a JSON file that contains the parameter values that the template requires:
 +
 [source,json]
 ----
@@ -187,6 +170,8 @@ deploying the cluster to an AWS GovCloud region.
 . Copy the template from the *CloudFormation template for the bootstrap machine*
 section of this topic and save it as a YAML file on your computer. This template
 describes the bootstrap machine that your cluster requires.
+
+. Optional: If you are deploying the cluster with a proxy, you must update the ignition in the template to add the  `ignition.config.proxy` fields. Additionally, If you have added the Amazon EC2, Elastic Load Balancing, and S3 VPC endpoints to your VPC, you must add these endpoints to the `noProxy` field.
 
 . Launch the CloudFormation template to create a stack of AWS resources that represent the bootstrap node:
 +

--- a/modules/installation-custom-aws-vpc.adoc
+++ b/modules/installation-custom-aws-vpc.adoc
@@ -67,25 +67,33 @@ The installation program modifies your subnets to add the `kubernetes.io/cluster
 +
 If you prefer to use your own Route 53 hosted private zone, you must associate the existing hosted zone with your VPC prior to installing a cluster. You can define your hosted zone using the `platform.aws.hostedZone` field in the `install-config.yaml` file.
 
-ifndef::aws-china,aws-secret[]
-If you are working in a disconnected environment, you are unable to reach the public IP addresses for EC2 and ELB endpoints. To resolve this, you must create a VPC endpoint and attach it to the subnet that the clusters are using. The endpoints should be named as follows:
+ifndef::aws-secret[]
+If you are working in a disconnected environment, you are unable to reach the public IP addresses for EC2, ELB, and S3 endpoints. Depending on the level to which you want to restrict internet traffic during the installation, the following configuration options are available:
+endif::aws-secret[]
 
+ifdef::aws-secret[]
+A cluster in an SC2S or C2S Region is unable to reach the public IP addresses for the EC2, ELB, and S3 endpoints. Depending on the level to which you want to restrict internet traffic during the installation, the following configuration options are available:
+endif::aws-secret[]
+
+[discrete]
+[id="create-vpc-endpoints_{context}"]
+=== Option 1: Create VPC endpoints
+
+Create a VPC endpoint and attach it to the subnets that the clusters are using. Name the endpoints as follows:
+
+ifndef::aws-china,aws-secret[]
 * `ec2.<region>.amazonaws.com`
 * `elasticloadbalancing.<region>.amazonaws.com`
 * `s3.<region>.amazonaws.com`
 endif::aws-china,aws-secret[]
 
 ifdef::aws-china[]
-If you are working in a disconnected environment, you are unable to reach the public IP addresses for EC2 and ELB endpoints. To resolve this, you must create a VPC endpoint and attach it to the subnet that the clusters are using. The endpoints should be named as follows:
-
 * `ec2.<region>.amazonaws.com.cn`
 * `elasticloadbalancing.<region>.amazonaws.com`
 * `s3.<region>.amazonaws.com`
 endif::aws-china[]
 
 ifdef::aws-secret[]
-* A cluster in an SC2S or C2S Region is unable to reach the public IP addresses for the EC2 and ELB endpoints. You must create a VPC endpoint and attach it to the subnet that the clusters are using. Name the endpoints as follows:
-+
 SC2S::
 ** `elasticloadbalancing.<region>.sc2s.sgov.gov`
 ** `ec2.<region>.sc2s.sgov.gov`
@@ -95,6 +103,43 @@ C2S::
 ** `ec2.<region>.c2s.ic.gov`
 ** `s3.<region>.c2s.ic.gov`
 endif::aws-secret[]
+
+With this option, network traffic remains private between your VPC and the required AWS services.
+
+[discrete]
+[id="create-proxy-without-vpc-endpoints_{context}"]
+=== Option 2: Create a proxy without VPC endpoints
+As part of the installation process, you can configure an HTTP or HTTPS proxy. With this option, internet traffic goes through the proxy to reach the required AWS services.
+
+[discrete]
+[id="create-proxy-with-vpc-endpoints_{context}"]
+=== Option 3: Create a proxy with VPC endpoints
+As part of the installation process, you can configure an HTTP or HTTPS proxy with VPC endpoints. Create a VPC endpoint and attach it to the subnets that the clusters are using. Name the endpoints as follows:
+
+ifndef::aws-china,aws-secret[]
+* `ec2.<region>.amazonaws.com`
+* `elasticloadbalancing.<region>.amazonaws.com`
+* `s3.<region>.amazonaws.com`
+endif::aws-china,aws-secret[]
+
+ifdef::aws-china[]
+* `ec2.<region>.amazonaws.com.cn`
+* `elasticloadbalancing.<region>.amazonaws.com`
+* `s3.<region>.amazonaws.com`
+endif::aws-china[]
+
+ifdef::aws-secret[]
+SC2S::
+** `elasticloadbalancing.<region>.sc2s.sgov.gov`
+** `ec2.<region>.sc2s.sgov.gov`
+** `s3.<region>.sc2s.sgov.gov`
+C2S::
+** `elasticloadbalancing.<region>.c2s.ic.gov`
+** `ec2.<region>.c2s.ic.gov`
+** `s3.<region>.c2s.ic.gov`
+endif::aws-secret[]
+
+When configuring the proxy in the `install-config.yaml` file, add these endpoints to the `noProxy` field. With this option, the proxy prevents the cluster from accessing the internet directly. However, network traffic remains private between your VPC and the required AWS services.
 
 .Required VPC components
 


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR addresses [odsocs-3819](https://issues.redhat.com/browse/OSDOCS-3819).

Link to docs preview:

- Installing a cluster on AWS in a restricted network > [Requirements for using your VPC](http://file.rdu.redhat.com/mpytlak/osdocs3819/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.html#installation-custom-aws-vpc-requirements_installing-restricted-networks-aws-installer-provisioned)
- Installing a cluster on AWS into a Secret or Top Secret Region > [Requirements for using your VPC](http://file.rdu.redhat.com/mpytlak/osdocs3819/installing/installing_aws/installing-aws-secret-region.html#installation-custom-aws-vpc-requirements_installing-aws-secret-region)
- Installing a cluster on AWS into a China region > [Requirements for using your VPC](http://file.rdu.redhat.com/mpytlak/osdocs3819/installing/installing_aws/installing-aws-china.html#installation-custom-aws-vpc-requirements_installing-aws-china-region)
- [Configuring a cluster-wide proxy](http://file.rdu.redhat.com/mpytlak/osdocs3819/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.html#installation-configure-proxy_installing-restricted-networks-aws-installer-provisioned)
- Installing a cluster on AWS in a restricted network with user-provisioned infrastructure > [Other infrastructure components](http://file.rdu.redhat.com/mpytlak/osdocs3819/installing/installing_aws/installing-restricted-networks-aws.html#installation-aws-user-infra-other-infrastructure_installing-restricted-networks-aws)
- Installing a cluster on AWS in a restricted network with user-provisioned infrastructure > [Creating the bootstrap node in AWS](http://file.rdu.redhat.com/mpytlak/osdocs3819/installing/installing_aws/installing-restricted-networks-aws.html#installation-creating-aws-bootstrap_installing-restricted-networks-aws)