### PR TITLE
OSDOCS-3602: Document image registry distribution across availability zones

### DIFF
--- a/modules/registry-operator-distribution-across-availability-zones.adoc
+++ b/modules/registry-operator-distribution-across-availability-zones.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * openshift_images/configuring-registry-operator.adoc
+
+
+[id="registry-operator-distribution-across-availability-zones_{context}"]
+= Image Registry Operator distribution across availability zones
+
+The default configuration of the Image Registry Operator spreads image registry pods across topology zones to prevent delayed recovery times in case of a complete zone failure where all pods are impacted. 
+
+The Image Registry Operator defaults to the following when deployed with a zone-related topology constraint:
+
+.Image Registry Operator deployed with a zone related topology constraint
+[source,yaml]
+----
+  topologySpreadConstraints:
+  - labelSelector:
+      matchLabels:
+        docker-registry: default
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+  - labelSelector:
+      matchLabels:
+        docker-registry: default
+    maxSkew: 1
+    topologyKey: node-role.kubernetes.io/worker
+    whenUnsatisfiable: DoNotSchedule
+  - labelSelector:
+      matchLabels:
+        docker-registry: default
+    maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule
+----
+
+The Image Registry Operator defaults to the following when deployed without a zone-related topology constraint, which applies to bare metal and vSphere instances:
+
+.Image Registry Operator deployed without a zone related topology constraint
+[source,yaml]
+----
+ topologySpreadConstraints:
+  - labelSelector:
+      matchLabels:
+        docker-registry: default
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+  - labelSelector:
+      matchLabels:
+        docker-registry: default
+    maxSkew: 1
+    topologyKey: node-role.kubernetes.io/worker
+    whenUnsatisfiable: DoNotSchedule
+----
+
+A cluster administrator can override the default `topologySpreadConstraints` by configuring the `configs.imageregistry.operator.openshift.io/cluster` spec file. In that case, only the constraints you provide apply.

--- a/registry/configuring-registry-operator.adoc
+++ b/registry/configuring-registry-operator.adoc
@@ -9,31 +9,20 @@ toc::[]
 [id="image-registry-on-cloud"]
 == Image Registry on cloud platforms and OpenStack
 
-The Image Registry Operator installs a single instance of the {product-title}
-registry, and manages all registry configuration, including setting up
-registry storage.
+The Image Registry Operator installs a single instance of the {product-title} registry, and manages all registry configuration, including setting up registry storage.
 
 [NOTE]
 ====
-Storage is only automatically configured when you install an
-installer-provisioned infrastructure cluster on AWS, GCP, Azure, or OpenStack.
+Storage is only automatically configured when you install an installer-provisioned infrastructure cluster on AWS, GCP, Azure, or OpenStack.
 
 When you install or upgrade an installer-provisioned infrastructure cluster on AWS or Azure, the Image Registry Operator sets the `spec.storage.managementState` parameter to `Managed`. If the `spec.storage.managementState` parameter is set to `Unmanaged`, the Image Registry Operator takes no action related to storage.
 ====
 
-After the control plane deploys, the Operator will create a default
-`configs.imageregistry.operator.openshift.io` resource instance based on
-configuration detected in the cluster.
+After the control plane deploys, the Operator creates a default `configs.imageregistry.operator.openshift.io` resource instance based on configuration detected in the cluster.
 
-If insufficient information is available to define a complete
-`configs.imageregistry.operator.openshift.io` resource, the incomplete resource
-will be defined and the Operator will update the resource status with
-information about what is missing.
+If insufficient information is available to define a complete `configs.imageregistry.operator.openshift.io` resource, the incomplete resource is defined and the Operator updates the resource status with information about what is missing.
 
-The Image Registry Operator runs in the `openshift-image-registry` namespace,
-and manages the registry instance in that location as well. All configuration
-and workload resources for the registry reside in that namespace.
-
+The Image Registry Operator runs in the `openshift-image-registry` namespace, and manages the registry instance in that location as well. All configuration and workload resources for the registry reside in that namespace.
 
 [IMPORTANT]
 ====
@@ -50,6 +39,13 @@ However, the `managementState` of the Image Registry Operator alters the behavio
 == Image Registry on bare metal and vSphere
 
 include::modules/registry-removed.adoc[leveloffset=+2]
+
+include::modules/registry-operator-distribution-across-availability-zones.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints[Configuring pod topology spread constraints]
 
 include::modules/registry-operator-configuration-resource-overview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3602

Link to docs preview:
http://file.rdu.redhat.com/~bmcelvee/20221107/registry/configuring-registry-operator.html#registry-operator-distribution-across-availability-zones_configuring-registry-operator


Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
