### PR TITLE
{OSDOCS-3805]: Add concept module for etcd vertical scaling

### DIFF
--- a/modules/vertical-scaling-etcd-members.adoc
+++ b/modules/vertical-scaling-etcd-members.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/recommended-host-practices.adoc
+
+:_content-type: CONCEPT
+[id="vertical-scaling-etcd-members_{context}"]
+= Vertical scaling etcd members in a cluster
+
+For large and dense clusters, etcd can suffer from poor performance if the keyspace grows too large and exceeds the space quota. Periodically maintain and defragment etcd to free up space in the data store. Monitor Prometheus for etcd metrics and defragment it when required; otherwise, etcd can raise a cluster-wide alarm that puts the cluster into a maintenance mode that accepts only key reads and deletes.
+
+
+
+
++
+----
+$ sudo docker run --volume /var/lib/etcd:/var/lib/etcd:Z quay.io/openshift-scale/etcd-perf
+----
+--
+
+The output reports whether the disk is fast enough to host etcd by comparing the 99th percentile of the fsync metric captured from the run to see if it is less than 10 ms.
+
+Because etcd replicates the requests among all the members, its performance strongly depends on network input/output (I/O) latency. High network latencies result in etcd heartbeats taking longer than the election timeout, which results in leader elections that are disruptive to the cluster. A key metric to monitor on a deployed {product-title} cluster is the 99th percentile of etcd network peer latency on each etcd cluster member. Use Prometheus to track the metric.
+
+The `histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[2m]))` metric reports the round trip time for etcd to finish replicating the client requests between the members. Ensure that it is less than 50 ms.

--- a/modules/vertical-scaling-etcd-members.adoc
+++ b/modules/vertical-scaling-etcd-members.adoc
@@ -4,21 +4,12 @@
 
 :_content-type: CONCEPT
 [id="vertical-scaling-etcd-members_{context}"]
-= Vertical scaling etcd members in a cluster
+= Vertical scaling etcd cluster members
 
-For large and dense clusters, etcd can suffer from poor performance if the keyspace grows too large and exceeds the space quota. Periodically maintain and defragment etcd to free up space in the data store. Monitor Prometheus for etcd metrics and defragment it when required; otherwise, etcd can raise a cluster-wide alarm that puts the cluster into a maintenance mode that accepts only key reads and deletes.
+Vertical scaling adds and removes etcd members in a cluster. This process maintains the quorum stability and prevents data loss and cluster unavailability.
 
+Scale up an etcd cluster by adding a member, which becomes a non-voting member called a _learner_. The _learner_ is promoted to a voting member only when it receives a complete snapshot from the leader.
 
+Scale down an etcd cluster by removing an active member, which is then scheduled for removal. The member is only removed when a replacement member is available. This action protects the etcd quorum and the cluster operation is maintained.
 
-
-+
-----
-$ sudo docker run --volume /var/lib/etcd:/var/lib/etcd:Z quay.io/openshift-scale/etcd-perf
-----
---
-
-The output reports whether the disk is fast enough to host etcd by comparing the 99th percentile of the fsync metric captured from the run to see if it is less than 10 ms.
-
-Because etcd replicates the requests among all the members, its performance strongly depends on network input/output (I/O) latency. High network latencies result in etcd heartbeats taking longer than the election timeout, which results in leader elections that are disruptive to the cluster. A key metric to monitor on a deployed {product-title} cluster is the 99th percentile of etcd network peer latency on each etcd cluster member. Use Prometheus to track the metric.
-
-The `histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[2m]))` metric reports the round trip time for etcd to finish replicating the client requests between the members. Ensure that it is less than 50 ms.
+NOTE: New members cannot be added or removed from an etcd cluster if they are unhealthy. See _Replacing an unhealthy etcd member_ for more information.

--- a/modules/vertical-scaling-etcd-members.adoc
+++ b/modules/vertical-scaling-etcd-members.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: CONCEPT
 [id="vertical-scaling-etcd-members_{context}"]
-= Vertical scaling etcd cluster members
+= Vertical scaling etcd cluster members 
 
 Vertical scaling adds and removes etcd members in a cluster. This process maintains the quorum stability and prevents data loss and cluster unavailability.
 

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -33,7 +33,7 @@ include::modules/vertical-scaling-etcd-members.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../scalability_and_performance/vertical-scaling-etcd-members.adoc#vertical-scaling-etcd-members[Vertical scaling etcd members in a cluster]
+* xref:../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-unhealthy-member[Replacing an unhealthy etcd member]
 
 include::modules/etcd-defrag.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -29,6 +29,12 @@ include::modules/increasing-aws-flavor-size.adoc[leveloffset=+2]
 
 include::modules/recommended-etcd-practices.adoc[leveloffset=+1]
 
+include::modules/vertical-scaling-etcd-members.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../scalability_and_performance/vertical-scaling-etcd-members.adoc#vertical-scaling-etcd-members[Vertical scaling etcd members in a cluster]
+
 include::modules/etcd-defrag.adoc[leveloffset=+1]
 
 include::modules/infrastructure-components.adoc[leveloffset=+1]

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -31,7 +31,7 @@ include::modules/recommended-etcd-practices.adoc[leveloffset=+1]
 
 include::modules/vertical-scaling-etcd-members.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
+[role="_additional-resources"]  
 .Additional resources
 * xref:../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-unhealthy-member[Replacing an unhealthy etcd member]
 


### PR DESCRIPTION
Version(s): 4.11 +
Issue: [OSDOCS-3805](https://issues.redhat.com/browse/OSDOCS-3805)

Link to docs preview: http://file.rdu.redhat.com/tlove/etcd-3805-vertical-scaling/scalability_and_performance/recommended-host-practices.html#vertical-scaling-etcd-members_recommended-host-practices

Additional information: Added a concept module for 'Vertical scaling of etcd cluster members'


