### PR TITLE
[RHACS] ROX-11078: Add Alpine 3.16 support for scanner

### DIFF
--- a/modules/scanning-images.adoc
+++ b/modules/scanning-images.adoc
@@ -30,12 +30,12 @@ Scanner can check for vulnerabilities in images that use the following package f
 * apt
 * apk
 * dpkg
-* rpm
+* RPM
 
 [discrete]
 == Supported programming languages
 
-Scanner can check for vulnerabilities in depnendencies for the following programming languages:
+Scanner can check for vulnerabilities in dependencies for the following programming languages:
 
 * Java
 * JavaScript
@@ -61,7 +61,7 @@ Scanner identifies vulnerabilities in images that contain the following Linux di
 | Distribution | Version
 
 | link:https://www.alpinelinux.org/[Alpine Linux]
-| `alpine:v3.2`, `alpine:v3.3`, `alpine:v3.4`, `alpine:v3.5`, `alpine:v3.6`, `alpine:v3.7`, `alpine:v3.8`, `alpine:v3.9`, `alpine:v3.10`, `alpine:v3.11`, `alpine:v3.12`, `alpine:v3.13`, `alpine:v3.14`, `alpine:edge`
+| `alpine:v3.2`, `alpine:v3.3`, `alpine:v3.4`, `alpine:v3.5`, `alpine:v3.6`, `alpine:v3.7`, `alpine:v3.8`, `alpine:v3.9`, `alpine:v3.10`, `alpine:v3.11`, `alpine:v3.12`, `alpine:v3.13`, `alpine:v3.14`, `alpine:v3.15`, `alpine:v3.16`, `alpine:edge`
 
 | link:https://aws.amazon.com/amazon-linux-ami[Amazon Linux]
 | `amzn:2018.03`, `amzn:2`


### PR DESCRIPTION
Version(s):
`rhacs-docs-3.71.0`

Labels:
`RHACS/next`

[Issue](https://issues.redhat.com/browse/ROX-11078)

[Link to docs preview](https://openshift-docs-aksjr1cvx-kcarmichael08.vercel.app/openshift-acs/master/operating/examine-images-for-vulnerabilities.html)