### PR TITLE
TELCODOCS-750: Document bug fix descriptions

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -409,6 +409,7 @@ For more information, see xref:../security/audit-log-policy-config.adoc#about-au
 
 [id="ocp-4-11-networking"]
 === Networking
+
 ==== New option for Ingress Controllers with the hostnetwork endpoint
 
 This update introduces a new option for Ingress Controllers with the `hostnetwork` endpoint strategy. You can now host multiple Ingress Controllers on the same worker node using `httpPort`, `httpsPort`, and `statsPort` binding ports.
@@ -1148,7 +1149,7 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 
 [id="ocp-4-11-bug-fixes"]
 == Bug fixes
-
+//Bug fix work for TELCODOCS-750
 [discrete]
 [id="ocp-4-11-bare-metal-hardware-bug-fixes"]
 ==== Bare Metal Hardware Provisioning
@@ -1308,6 +1309,13 @@ With this update, the `tunbr` interface is now included in the list of interface
 ==== Networking
 
 [discrete]
+[id="ocp-4-11-ne-perf-improvements"]
+==== Networking performance improvements
+* Previously, a `systemd` service set a default RPS mask according to the reserved CPUs list in the performance profile for all network devices visible from udev excluding virtual devices. A `crio` hook script set the RPS mask of all network devices visible from /sys/devices for guaranteed pods. This resulted in multiple impacts to network performance.
+In this update, `systemd` service only sets the default RPS mask for virtual interfaces under /sys/devices/virtual. The `crio` hook script now also excludes physical devices. This configuration mitigates issues such as overloading of processes, lengthy polling intervals, and spikes in latency.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2081852[*BZ#2081852*])
+
+[discrete]
 [id="ocp-4-11-node-bug-fixes"]
 ==== Node
 
@@ -1396,6 +1404,10 @@ With this update, the `tunbr` interface is now included in the list of interface
 * Before this update, if a machine was booted through PXE and the `BOOTIF` argument was on the kernel command line, the machine would boot with DHCP enabled on only a single interface. With this update, the machine boots with DHCP enabled on all interfaces even if the `BOOTIF` argument is provided. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2032717[BZ#2032717])
 
 * Previously, nodes that were provisioned from VMware OVA images did not delete the Ignition config after initial provisioning. Consequently, this created security issues when secrets are stored within the Ignition config. With this update, the Ignition config is now deleted from the VMware hypervisor after initial provisioning on new nodes and when upgrading from a previous {product-title} release on existing nodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2082274[BZ#2082274])
+
+[discrete]
+[id="ocp-4-11-performance-bug-fixes"]
+==== Performance
 
 [discrete]
 [id="ocp-4-11-performance-addon-operator-bug-fixes"]


### PR DESCRIPTION
Version: PR applies to 4.11 only. 
Issue: https://issues.redhat.com/browse/TELCODOCS-750 
Link to docs preview:
http://file.emea.redhat.com/tmulquee/TELCODOCS-750/release_notes/ocp-4-11-release-notes.html#ocp-4-11-bug-fixes



Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
