### PR TITLE
RHDEVDOCS-4146 - 4.10 backport of federation for UWM metrics

### DIFF
--- a/modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc
+++ b/modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * monitoring/accessing-third-party-monitoring-apis.adoc
+
+:_content-type: PROCEDURE
+[id="monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus_{context}"]
+= Querying metrics by using the federation endpoint for Prometheus
+
+From {product-title} 4.10.17, you can use the federation endpoint to scrape platform and user-defined metrics from a network location outside the cluster.
+To do so, access the Prometheus `/federate` endpoint for the cluster via an {product-title} route. 
+
+[WARNING]
+====
+A delay in retrieving metrics data occurs when you use federation. 
+This delay can affect the accuracy and timeliness of the scraped metrics.
+
+Using the federation endpoint can also degrade the performance and scalability of your cluster, especially if you use the federation endpoint to retrieve large amounts of metrics data.
+To avoid these issues, follow these recommendations:
+
+* Do not try to retrieve all metrics data via the federation endpoint.
+Query it only when you want to retrieve a limited, aggregated data set. 
+For example, retrieving fewer than 1,000 samples for each request helps minimize the risk of performance degradation. 
+
+* Avoid querying the federation endpoint frequently. 
+Limit queries to a maximum of one every 30 seconds.
+
+If you need to forward large amounts of data outside the cluster, use remote write instead. For more information, see the _Configuring remote write storage_ section.
+====
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You have obtained the host URL for the {product-title} route.
+* You have access to the cluster as a user with the `cluster-monitoring-view` role or have obtained a bearer token with `get` permission on the `namespaces` resource.
++
+[NOTE]
+====
+You can only use bearer token authentication to access the federation endpoint.
+====
+
+.Procedure
+
+. Retrieve the bearer token:
++
+[source,terminal]
+----
+$ token=`oc whoami -t`
+----
+
+. Query metrics from the `/federate` route. 
+The following example queries `up` metrics:
++
+[source,terminal]
+----
+$ curl -G -s -k -H "Authorization: Bearer $token" \
+    'https:/<federation_host>/federate' \ <1>
+    --data-urlencode 'match[]=up'
+----
++
+<1> For <federation_host>, substitute the host URL for the federation route.
++
+.Example output
++
+[source,terminal]
+----
+# TYPE up untyped
+up{apiserver="kube-apiserver",endpoint="https",instance="10.0.143.148:6443",job="apiserver",namespace="default",service="kubernetes",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-0"} 1 1657035322214
+up{apiserver="kube-apiserver",endpoint="https",instance="10.0.148.166:6443",job="apiserver",namespace="default",service="kubernetes",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-0"} 1 1657035338597
+up{apiserver="kube-apiserver",endpoint="https",instance="10.0.173.16:6443",job="apiserver",namespace="default",service="kubernetes",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-0"} 1 1657035343834
+...
+----

--- a/monitoring/accessing-third-party-monitoring-uis-and-apis.adoc
+++ b/monitoring/accessing-third-party-monitoring-uis-and-apis.adoc
@@ -2,7 +2,7 @@
 [id="accessing-third-party-monitoring-uis-and-apis"]
 = Accessing third-party monitoring UIs and APIs
 include::_attributes/common-attributes.adoc[]
-:context: accessing-third-party-monitoring-uis-and-apis
+:context: accessing-third-party-monitoring-apis
 
 toc::[]
 
@@ -17,10 +17,13 @@ include::modules/monitoring-accessing-third-party-monitoring-uis.adoc[leveloffse
 // Accessing service APIs for third-party monitoring components
 include::modules/monitoring-accessing-third-party-monitoring-web-service-apis.adoc[leveloffset=+1]
 
+// Querying metrics by using the federation endpoint for Prometheus
+include::modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
-[id="additional-resources_accessing-third-party-monitoring-uis-and-apis"]
+[id="additional-resources_accessing-third-party-monitoring-apis"]
 == Additional resources
 
+* xref:../monitoring/configuring-the-monitoring-stack.adoc#configuring_remote_write_storage_configuring-the-monitoring-stack[Configuring remote write storage]
 * xref:../monitoring/managing-metrics.adoc#managing-metrics[Managing metrics]
 * xref:../monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]
-* xref:../monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards[Reviewing monitoring dashboards]

--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2952,6 +2952,12 @@ Space precluded documenting all of the container images for this release in the 
 
 link:https://access.redhat.com/solutions/6962052[{product-title} 4.10.17 container image list]
 
+[id="ocp-4-10-17-bug-fixes"]
+==== Bug fixes
+* Previously, the federation endpoint for Prometheus that stored user-defined metrics was not exposed. Thus, you could not access it to scrape these metrics from a network location outside the cluster.
+With this update, you can now use the federation endpoint to scrape user-defined metrics from a network location outside the cluster.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2090602[*BZ#2090602*])
+
 [id="ocp-4-10-17-updating"]
 ==== Updating
 


### PR DESCRIPTION
Summary: This PR adds release notes text as well as cherry-picked content from the completed 4.11 documentation to the 4.10 doc set for a feature that has already been backported to OCP 4.10 in the 4.10.17 z-stream release. This feature enables users  to use the federation endpoint to scrape user workload monitoring metrics. 

**Reviews are only needed for the new release notes text.** No SME or peer review is needed for the feature docs since the content is identical to the 4.11 content that was already approved and merged in the following PR: https://github.com/openshift/openshift-docs/pull/47335.

- Aligned team: DevTools
- For branches: 4.10 ONLY
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4146 and https://issues.redhat.com/browse/RHDEVDOCS-4147
- Direct link to doc previews (RH VPN access required): 
- - Release Notes: http://file.rdu.redhat.com/bburt/RHDEVDOCS-4146-backport-federation-for-uwm-metrics/release_notes/ocp-4-10-release-notes.html#ocp-4-10-17
- - Feature docs: http://file.rdu.redhat.com/bburt/RHDEVDOCS-4146-backport-federation-for-uwm-metrics/monitoring/accessing-third-party-monitoring-uis-and-apis.html#monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus_accessing-third-party-monitoring-apis
- SME review: @jan--f  (approved)
- QE review:  @lihongyan1 (approved)
- Peer review: @rolfedh (approved)

**Change Management**
ACK from Eng: Provided in https://issues.redhat.com/browse/MON-2484
ACK from PM: Provided in https://issues.redhat.com/browse/MON-2484
Need an ACK from Product Experience: @Senthamilarasu-STA  
ACK from QE: Provided in https://issues.redhat.com/browse/MON-2484
ACK from DPM: Provided in https://issues.redhat.com/browse/RHDEVDOCS-4146
ACK from CS: Provided in https://issues.redhat.com/browse/RHDEVDOCS-4146