### PR TITLE
TELCODOCS:600 - document new features for OSC release notes

### DIFF
--- a/sandboxed_containers/sandboxed-containers-4.11-release-notes.adoc
+++ b/sandboxed_containers/sandboxed-containers-4.11-release-notes.adoc
@@ -16,7 +16,24 @@ This product is fully supported and enabled by default as of {product-title} 4.1
 [id="sandboxed-containers-1-3-new-features-and-enhancements"]
 == New features and enhancements
 
+[id="refined-kata-metrics"]
+=== Container ID in metrics list
 
+The `sandbox_id` with the ID of the relevant sandboxed container now appears in the metrics list on the *Metrics* page in the web console.
+
+In addition, the `kata-monitor` process now adds three new labels to kata-specific metrics: `cri_uid`, `cri_name`, and `cri_namespace`. These labels enable kata-specific metrics to relate to corresponding kubernetes workloads.
+
+For more information about kata-specific metrics, see xref:../sandboxed_containers/monitoring-sandboxed-containers.adoc#sandboxed-containers-metrics-list_monitoring-sandboxed-containers[About {sandboxed-containers-first} metrics].
+
+[id="osc-baremetal-fully-supported-on-aws"]
+=== {sandboxed-containers-first} availability on AWS bare metal
+
+Previously, {sandboxed-containers-first} availability on AWS bare metal was in Technology Preview. With this release, installing {sandboxed-containers-first} on AWS bare-metal clusters is fully supported.
+
+[id="osc-with-sno-topology"]
+=== Support for {sandboxed-containers-first} on {sno}
+
+{sandboxed-containers-first} now work on {sno} clusters when the {sandboxed-containers-operator} is installed by {rh-rhacm-first}.
 
 [id="sandboxed-containers-1-3-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
Version(s): Just 4.11

Issue:
[TELCODOCS-600](https://issues.redhat.com/browse/TELCODOCS-600)

[Link to docs preview](http://file.emea.redhat.com/miweiss/TELCODOCS-600/sandboxed_containers/sandboxed-containers-4.11-release-notes.html)

Acked by SMEs and QE.