### PR TITLE
[ENTERPRISE-4.9] Adds the .vscode directory to .gitignore for enterprise-4.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ dev_guide/builds/images/chained-build.png.cache
 .gem
 bin
 commercial_package
-
+.vscode


### PR DESCRIPTION
Version(s):
4.9

Link to docs preview:
No preview

Additional information:
This adds .vscode to the gitignore file for Enterprise-4.9