### PR TITLE
[Enterprise-4.6] Added .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dev_guide/builds/images/chained-build.png.cache
 .gem
 bin
 commercial_package
+.vscode


### PR DESCRIPTION
Version(s):
4.6

Additional information:
Added `.vscode` to `.gitignore`