### PR TITLE
[Enterprise-4.7] Added .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ dev_guide/builds/images/chained-build.png.cache
 .gem
 bin
 commercial_package
-openshift-install
+.vscode


### PR DESCRIPTION
Version(s):
4.7

Additional information:
Adds `.vscode` to `.gitignore`