### PR TITLE
OADP-567: Document VolSync as a prerequisite for Tech Preview use of DataMover

### DIFF
--- a/modules/data-mover-prerequisites.adoc
+++ b/modules/data-mover-prerequisites.adoc
@@ -1,0 +1,11 @@
+// This is a small bit of text that will need to be copy-pasted into the procedure installing the DataMover feature into OADP 1.1.0.
+
+
+.Prerequisite
+
+* VolSync Operator installed using the Operator Lifecycle Manager (OLM). Administrators can link:https://docs.openshift.com/container-platform/4.10/operators/admin/olm-adding-operators-to-cluster.html[install Operators on clusters]. Non-administrators can link:https://docs.openshift.com/container-platform/4.10/operators/user/olm-installing-operators-in-namespace.html[install Operators in namespaces].
+
+[NOTE]
+====
+The VolSync Operator is required only for use with the Technology Preview Data Mover. The Operator is not required for using OADP GA features.
+====


### PR DESCRIPTION
OADP 1.1.0 

Resolves: https://issues.redhat.com/browse/OADP-567

This bit of text will be added to the prerequisites for DataMover. The documentation for DataMover is being written by another writer, so this text will be added to that section. 