### PR TITLE
Release notes for Self Node Remediation Operator

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -465,6 +465,18 @@ For more information, see xref:../updating/update-using-custom-machine-config-po
 [id="ocp-4-11-nodes"]
 === Nodes
 
+[id="ocp-4-11-nodes-self-node-remediation"]
+==== Self Node Remediation Operator replaces the Poison Pill Operator
+{product-title} 4.11 introduces the Self Node Remediation Operator that replaces the Poison Pill Operator.
+
+The Self Node Remediation Operator provides the following enhancements:
+
+* Introduces separate remediation templates based on the remediation strategy.
+* Captures last error message if remediation is unsuccessful.
+* Improves metrics for Self Node Remediation Operator's configuration parameters by providing minimum values for the parameters.
+
+For more information, see xref:../nodes/nodes/eco-self-node-remediation-operator.adoc#self-node-remediation-operator-remediate-nodes[Remediating nodes with the Self Node Remediation Operator].
+
 [id="ocp-4-11-nodes-descheduler-simulate"]
 ==== Descheduler now defaults to simulating pod evictions
 


### PR DESCRIPTION
This PR documents the release notes for Self Node Remediation Operator for OpenShift 4.11

Version(s): OpenShift 4.11 (enterprise-4.11 only)

Issue:
https://issues.redhat.com/browse/TELCODOCS-581
https://issues.redhat.com/browse/TELCODOCS-330
https://issues.redhat.com/browse/TELCODOCS-497
https://issues.redhat.com/browse/TELCODOCS-790

Link to docs preview:
http://file.rdu.redhat.com/avbhatt/rn-td-581/release_notes/ocp-4-11-release-notes.html#ocp-4-11-nodes-self-node-remediation

Additional information:
