### PR TITLE
[RHACS] ROX-11710 - Make EBPF the default collection method

### DIFF
--- a/configuration/configure-proxy.adoc
+++ b/configuration/configure-proxy.adoc
@@ -13,7 +13,7 @@ When you use a proxy with {product-title}:
 * All outgoing HTTP, HTTPS, and other TCP traffic from Central and Scanner goes through the proxy.
 * Traffic between Central and Scanner does not go through the proxy.
 * The proxy configuration does not affect the other {product-title} components.
-* When you are not using the offline mode, and a Collector running in a secured cluster needs to download an additional kernel module or eBPF probe at runtime:
+* When you are not using the offline mode, and a Collector running in a secured cluster needs to download an additional eBPF probe or kernel module at runtime:
 ** The collector attempts to download them by contacting Sensor.
 ** The Sensor then forwards this request to Central.
 ** Central uses the proxy to locate the module or probe at `\https://collector-modules.stackrox.io`.

--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -167,9 +167,11 @@ These components are Collector and Compliance.
 | Parameter | Description
 
 | `perNode.collector.collection`
-| The method for system-level data collection. The default value is `EBPF`. Red Hat recommend using `EBPF` as the value for this parameter.
-If you select `NoCollection`, you will not be able to see any information about network activity and process executions.
-Options include `NoCollection`, `EBPF`, and `KernelModule`.
+| The method for system-level data collection.
+The default value is `EBPF`.
+Red Hat recommends using `EBPF` for data collection.
+If you select NoCollection, Collector does not report any information about the network activity and the process executions.
+Available options are `NoCollection`, `EBPF`, and `KernelModule`.
 
 | `perNode.collector.imageFlavor`
 | The image type to use for Collector. You can specify it as `Regular` or `Slim`.

--- a/modules/secured-cluster-services-config.adoc
+++ b/modules/secured-cluster-services-config.adoc
@@ -189,7 +189,7 @@ If you do not create this account, you must complete future upgrades manually if
 
 | `collector.slimMode`
 | Specify `true` if you want to use a slim Collector image for deploying Collector.
-Using slim Collector images requires Central to provide the matching kernel module or eBPF probe.
+Using slim Collector images requires Central to provide the matching eBPF probe or kernel module.
 If you are running {product-title} in offline mode, you must download a kernel support package from link:https://install.stackrox.io/collector/support-packages/index.html[stackrox.io] and upload it to Central for slim Collectors to function.
 Otherwise, you must ensure that Central can access the online probe repository hosted at link:https://collector-modules.stackrox.io/[https://collector-modules.stackrox.io/].
 //TODO: Change these links when new links are alive.

--- a/modules/update-kernel-support-packages.adoc
+++ b/modules/update-kernel-support-packages.adoc
@@ -7,7 +7,7 @@
 
 Collector monitors the runtime activity for each node in your secured clusters.
 To monitor the activities, Collector requires probes.
-These probes are kernel modules or eBPF programs specific to the Linux kernel version installed on the host.
+These probes are eBPF programs or kernel modules specific to the Linux kernel version installed on the host.
 The Collector image contains a set of built-in probes.
 
 When {product-title} runs in normal mode (connected to the internet), Collector automatically downloads a new probe if the required probe is not built in.


### PR DESCRIPTION
Document updates for [ROX-11710](https://issues.redhat.com/browse/ROX-11710)

- Preview: https://openshift-docs-git-rox-11710-updates-gnelson.vercel.app/openshift-acs/master/installing/install-ocp-operator.html#per-node-settings_install-ocp-operator

Applies to:
- `rhacs-docs-3.71`


---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
