### PR TITLE
OSDOCS-3554: Updating migration content for 4.11

### DIFF
--- a/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
@@ -122,6 +122,18 @@ If you used one of these in {product-title} 3.11, you must choose a different pe
 
 For more information, see xref:../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
 
+[discrete]
+==== Migration of in-tree volumes to CSI drivers
+
+{product-title} 4 is migrating in-tree volume plug-ins to their Container Storage Interface (CSI) counterparts. In {product-title} {product-version}, CSI drivers are the new default for the following in-tree volume types:
+
+* Azure Disk
+* OpenStack Cinder
+
+All aspects of volume lifecycle, such as creation, deletion, mounting, and unmounting, is handled by the CSI driver.
+
+For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
+
 [id="migration-preparing-networking"]
 === Networking considerations
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3554

Link to docs preview:
(single page) http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3554/migrating_from_ocp_3_to_4/planning-migration-3-4.html#migration-preparing-storage

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
