### PR TITLE
Adding clarification for step 2 of virtual media procedure

### DIFF
--- a/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
+++ b/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
@@ -63,7 +63,7 @@ oc edit provisioning
 <1> Add `virtualMediaViaExternalNetwork: true` to the `provisioning` CR.
 
 
-. Edit the machineset to use the API VIP address:
+. If the image URL exists, edit the `machineset` to use the API VIP address. This step only applies to clusters installed in versions 4.9 or earlier.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
For versions 4.10+

Description: Step 2 of this procedure is still necessary for versions 4.9 and earlier, but not needed for versions 4.10+. 
Issue referenced in https://github.com/openshift/openshift-docs/pull/46455#issuecomment-1175199507

Preview: 
[Expanding the cluster -> Preparing to deploy with Virtual Media on the baremetal network](https://kelbrown20.github.io/openshift-docs/metal-ipi-updating-virtual-media/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-to-deploy-with-virtual-media-on-the-baremetal-network_ipi-install-expanding) 