### PR TITLE
corrected wrong instances of subcommand

### DIFF
--- a/modules/installation-aws-ami-stream-metadata.adoc
+++ b/modules/installation-aws-ami-stream-metadata.adoc
@@ -12,7 +12,7 @@
 
 In {product-title}, _stream metadata_ provides standardized metadata about {op-system} in the JSON format and injects the metadata into the cluster. Stream metadata is a stable format that supports multiple architectures and is intended to be self-documenting for maintaining automation.
 
-You can use the `coreos print-stream-json` sub-command of `openshift-install` to access information about the boot images in the stream metadata format. This command provides a method for printing stream metadata in a scriptable, machine-readable format.
+You can use the `coreos print-stream-json` subcommand of `openshift-install` to access information about the boot images in the stream metadata format. This command provides a method for printing stream metadata in a scriptable, machine-readable format.
 
 For user-provisioned installations, the `openshift-install` binary contains references to the version of {op-system} boot images that are tested for use with {product-title}, such as the AWS AMI.
 
@@ -51,7 +51,7 @@ ifndef::openshift-origin[]
 $ openshift-install coreos print-stream-json | jq -r '.architectures.aarch64.images.aws.regions["us-west-1"].image'
 ----
 +
-.Example output 
+.Example output
 [source,terminal]
 ----
 ami-0af1d3b7fa5be2131

--- a/modules/manual-configuration-of-cli-profiles.adoc
+++ b/modules/manual-configuration-of-cli-profiles.adoc
@@ -11,7 +11,7 @@
 This section covers more advanced usage of CLI configurations. In most situations, you can use the `oc login` and `oc project` commands to log in and switch between contexts and projects.
 ====
 
-If you want to manually configure your CLI config files, you can use the `oc config` command instead of directly modifying the files. The `oc config` command includes a number of helpful sub-commands for this purpose:
+If you want to manually configure your CLI config files, you can use the `oc config` command instead of directly modifying the files. The `oc config` command includes a number of helpful subcommands for this purpose:
 
 .CLI configuration subcommands
 [cols="1,8",options="header"]

--- a/modules/op-tkn-hub-interaction.adoc
+++ b/modules/op-tkn-hub-interaction.adoc
@@ -24,7 +24,7 @@ $ tkn hub --api-server https://api.hub.tekton.dev
 
 [NOTE]
 ====
-For each example, to get the corresponding sub-commands and flags, run `tkn hub <command> --help`.
+For each example, to get the corresponding subcommands and flags, run `tkn hub <command> --help`.
 ====
 
 == hub downgrade

--- a/modules/virt-about-libguestfs-tools-virtctl-guestfs.adoc
+++ b/modules/virt-about-libguestfs-tools-virtctl-guestfs.adoc
@@ -7,7 +7,7 @@
 
 `Libguestfs` tools help you access and modify virtual machine (VM) disk images. You can use `libguestfs` tools to view and edit files in a guest, clone and build virtual machines, and format and resize disks.
 
-You can also use the `virtctl guestfs` command and its sub-commands to modify, inspect, and debug VM disks on a PVC. To see a complete list of possible sub-commands, enter `virt-` on the command line and press the Tab key. For example:
+You can also use the `virtctl guestfs` command and its subcommands to modify, inspect, and debug VM disks on a PVC. To see a complete list of possible subcommands, enter `virt-` on the command line and press the Tab key. For example:
 
 [width="100%",cols="42%,58%",options="header",]
 |===


### PR DESCRIPTION
- This PR rectifies wrong instances of subcommand ref https://redhat-documentation.github.io/supplementary-style-guide/#glossary-terms-conventions
- Applies to main, 4.11,4.10,4.9.  Note : 4.8/4.7/4.6 all have different numbers of the instance. (would need to create separate PRs)
- [managing-cli-profiles](http://file.del.redhat.com/asakthiv/grammaredits/cli_reference/openshift_cli/managing-cli-profiles.html#manual-configuration-of-cli-profiles_managing-cli-profiles)
- [using-cli-tools](http://file.del.redhat.com/asakthiv/grammaredits/virt/virt-using-the-cli-tools.html)
- [tkn ref](http://file.del.redhat.com/asakthiv/grammaredits/cli_reference/tkn_cli/op-tkn-reference.html)
- [aws cloudformations](http://file.del.redhat.com/asakthiv/grammaredits/installing/installing_aws/installing-aws-user-infra.html)
- QE not required