### PR TITLE
OSSMDOC-586: Service Mesh 2.2.1 Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -122,7 +122,7 @@ endif::[]
 :product-dedicated: Red Hat OpenShift Dedicated
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.2
+:SMProductVersion: 2.2.1
 :MaistraVersion: 2.2
 //Service Mesh v1
 :SMProductVersion1x: 1.1.18.2

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -19,6 +19,17 @@ The following issues been resolved in the current release:
 [id="ossm-rn-fixed-issues-ossm_{context}"]
 == {SMProductShortName} fixed issues
 
+* https://issues.redhat.com/browse/OSSM-1668[OSSM-1668]
+`jwksResolverCA` field is missing in `SMCP`.
+
+* https://issues.redhat.com/browse/OSSM-1325[OSSM-1325] istiod pod crashes and displays the following error message: `fatal error: concurrent map iteration and map write`.
+
+* https://issues.redhat.com/browse/OSSM-1211[OSSM-1211]
+Configuring Federated service meshes for failover does not work as expected.
++
+The Istiod pilot log displays the following error: `envoy connection [C289] TLS error: 337047686:SSL routines:tls_process_server_certificate:certificate verify failed`
++
+
 * https://issues.redhat.com/browse/OSSM-1099[OSSM-1099]
 The Kiali console displayed the message `Sorry, there was a problem. Try a refresh or navigate to a different page.`
 

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -34,23 +34,12 @@ These are the known issues in {SMProductName}:
 
 * link:https://github.com/istio/istio/issues/14743[Istio-14743] Due to limitations in the version of Istio that this release of {SMProductName} is based on, there may be applications that are currently incompatible with {SMProductShortName}. See the linked community issue for details.
 
-* https://issues.redhat.com/browse/OSSM-1668[OSSM-1668]
-`jwksResolverCA` field is missing in `SMCP`.
-+
-If you upgrade from Service Mesh operator 2.1.3 to Service Mesh operator 2.2, then the `jwksResolverCA` field is not supported. You must use the `techPreview` `jwksResolverExtraRootCA` field to enable additional JWKS CA certificates.
 //Keep OSSM-1655 in RN, closed as "explained" error is expected.
 * https://issues.redhat.com/browse/OSSM-1655[OSSM-1655] Kiali dashboard shows error after enabling mTLS in `SMCP`.
 +
 After enabling the `spec.security.controlPlane.mtls` setting in the SMCP, the Kiali console displays the following error message `No subsets defined`.
 
 * https://issues.redhat.com/browse/OSSM-1396[OSSM-1396] If a gateway resource contains the `spec.externalIPs` setting, instead of being recreated when the `ServiceMeshControlPlane` is updated, the gateway is removed and never recreated.
-
-* https://issues.redhat.com/browse/OSSM-1211[OSSM-1211]
-Configuring Federated service meshes for failover does not work as expected.
-+
-The Istiod pilot log displays the following error: `envoy connection [C289] TLS error: 337047686:SSL routines:tls_process_server_certificate:certificate verify failed`
-+
-There is no workaround at this time.
 
 * https://issues.redhat.com/browse/OSSM-1168[OSSM-1168] When service mesh resources are created as a single YAML file, the Envoy proxy sidecar is not reliably injected into pods. When the SMCP, SMMR, and Deployment resources are created individually, the deployment works as expected.
 //Keep OSSM-1052 in RN - Closed as documented.

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -19,11 +19,33 @@ Module included in the following assemblies:
 * *Policy Enforcement* - Apply organizational policy to the interaction between services, ensure access policies are enforced and resources are fairly distributed among consumers. Policy changes are made by configuring the mesh, not by changing application code.
 * *Telemetry* - Gain understanding of the dependencies between services and the nature and flow of traffic between them, providing the ability to quickly identify issues.
 
+== New features {SMProductName} version {SMProductVersion}
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), bug fixes, and is supported on OpenShift Container Platform 4.9 and 4.10.
+
+=== Component versions included in {SMProductName} version {SMProductVersion}
+
+|===
+|Component |Version
+
+|Istio
+|1.12.7
+
+|Envoy Proxy
+|1.20.6
+
+|Jaeger
+|1.34.1
+
+|Kiali
+|1.48.1
+|===
+
 == New features {SMProductName} 2.2
 
 This release of {SMProductName} adds new features and enhancements, and is supported on OpenShift Container Platform 4.9 and 4.10.
 
-=== Component versions included in {SMProductName} version {SMProductVersion}
+=== Component versions included in {SMProductName} version 2.2
 
 |===
 |Component |Version
@@ -86,6 +108,28 @@ spec:
             PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER: true
 ----
 Restricting route attachment on Gateway API listeners is possible using the `SameNamespace` or `All` settings. Istio ignores usage of label selectors in `listeners.allowedRoutes.namespaces` and reverts to the default behavior (`SameNamespace`).
+
+== New features {SMProductName} 2.1.4
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
+
+=== Component versions included in {SMProductName} version 2.1.4
+
+|===
+|Component |Version
+
+|Istio
+|1.9.9
+
+|Envoy Proxy
+|1.17.1
+
+|Jaeger
+|1.29.1
+
+|Kiali
+|1.36.11
+|===
 
 == New features {SMProductName} 2.1.3
 
@@ -309,10 +353,10 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 |1.14.5
 
 |Jaeger
-|1.24.1
+|1.28.0
 
 |Kiali
-|1.24.14-1
+|1.24.15-1
 |===
 
 == New features {SMProductName} 2.0.9


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.6-4.11
<!--- Specify the version or versions of OpenShift your PR applies to.

Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: https://issues.redhat.com/browse/OSSMDOC-586
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to 2.2.1 docs preview: http://file.bos.redhat.com/tokeefe/OSSMDOC-586/service_mesh/v2x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-version-2-2-1

Link to 2.1.4 docs preview: http://file.bos.redhat.com/tokeefe/OSSMDOC-586/service_mesh/v2x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-2-1-4

Link to 2.0.10 docs preview: http://file.bos.redhat.com/tokeefe/OSSMDOC-586/service_mesh/v2x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-2-0-10

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
Eng review: jwendell
QE review: pbajjuri20
Peer review: jstickler