### PR TITLE
updating the directory guidance

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -187,7 +187,7 @@ If you create a directory with a multiple-word name, separate each word with an 
 Do not italicize user-replaced values. This guideline is an exception to the link:https://redhat-documentation.github.io/supplementary-style-guide/#user-replaced-values[Red Hat supplementary style guide].
 ====
 
-Do not create a top-level directory in the repository without checking with the docs team. In the main OpenShift docs, you can create one level of subdirectories. In the docs for features that are designed to be used with OpenShift, such as Service Mesh and OpenShift Virtualization, you can create two levels of subdirectories.
+Do not create or rename a top-level directory in the repository without checking with the docs program manager first. In the main OpenShift docs, you can create one level of subdirectories. In the docs for features that are designed to be used with OpenShift, such as Service Mesh and OpenShift Virtualization, you can create two levels of subdirectories.
 
 When creating a new directory or subdirectory, you must create four symbolic links in it:
 


### PR DESCRIPTION
I ran into some issues with the 4.11 translation drop because of a directory name mismatch, so I'm updating the guidance about directories