### PR TITLE
BZ#2105351 Installation instructions for aws-load-balancer-operator

### DIFF
--- a/modules/installing-aws-load-balancer-operator.adoc
+++ b/modules/installing-aws-load-balancer-operator.adoc
@@ -17,7 +17,7 @@ You can install the AWS Load Balancer Operator from the OperatorHub by using the
 . Navigate to *Operators* → *OperatorHub* in the {product-title} web console.
 . Select the *AWS Load Balancer Operator*. You can use the *Filter by keyword* text box or use the filter list to search for the AWS Load Balancer Operator from the list of Operators.
 . Select the `aws-load-balancer-operator` namespace.
-. Follow the instructions to prepare the Operator for installation.
+. Follow the instructions to prepare the cluster VPC and subnets for the Operator installation.
 . On the *AWS Load Balancer Operator* page, click *Install*.
 . On the *Install Operator* page, select the following options:
 .. *Update the channel* as *stable-v0.1*.


### PR DESCRIPTION
Clarify that the VPC and subnets need to be prepared for installing the
aws-load-balancer-operator.

Version(s):
4.11+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2105351