### PR TITLE
BZ-2100180 Adding known issue for metallb upgrade

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1334,6 +1334,12 @@ This script removes unauthenticated subjects from the following cluster role bin
 
 * The oc-mirror CLI plug-in can fail to upload an image set to the target mirror registry if the `archiveSize` value in the image set configuration is smaller than the container image size, causing the catalog directory to span multiple archives. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2106461[*BZ#2106461*])
 
+* In {product-title} 4.11, the MetalLB Operator scope has changed from namespace to cluster and this results in upgrading from a prior version failing. 
++
+As a workaround, remove the previous version of the MetalLB Operator. Do not delete the namespace or the instance of the MetalLB custom resource, and deploy the new Operator version. This keeps MetalLB running and configured.
++
+For more information, see xref:../networking/metallb/metalb-upgrading-operator.adoc#metallb-operator-upgrade[Upgrading the MetalLB Operator]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2100180[*BZ#2100180*])
+
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
[BZ#2100180]: Upgrading the MetalLB Operator to 4.11 version fails.

Version(s):
Known issue for 4.11 RN

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2100180

Link to docs preview: http://file.emea.redhat.com/kquinn/BZ-2100180/release_notes/ocp-4-11-release-notes.html#ocp-4-11-known-issues
NOTE:
Cross ref dependency on https://github.com/openshift/openshift-docs/pull/45516 merged. 