### PR TITLE
RN for vSphere CSI version requirements

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -198,6 +198,18 @@ For more information, see link:https://access.redhat.com/articles/6484031[Instal
 
 For more information, see link:https://access.redhat.com/articles/6675791[Installing OpenShift using AWS Marketplace].
 
+[id="ocp-4-11-installation-vsphere-csi"]
+==== CSI driver installation on vSphere clusters
+To install a CSI driver on a cluster running on vSphere, you must have the following components installed:
+
+* Virtual hardware version 15 or later
+* vSphere version 7.0 Update 2 or later
+* VMware ESXi version 7.0 Update 2 or later
+
+Components with versions earlier than those above are deprecated or removed. Deprecated versions are still fully supported, but Red Hat recommends that you use vSphere 7.0 Update 2 or later and ESXi 7.0 Update 2 or later.
+
+For more information, see xref:../release_notes/ocp-4-11-release-notes.adoc#ocp-4-11-deprecated-removed-features[Deprecated and removed features].
+
 [id="ocp-4-11-post-installation"]
 === Post-installation configuration
 


### PR DESCRIPTION
4.11 Release note updating the vSphere version requirements for installing CSI drivers.
[Doc preview](https://bscott-rh.github.io/openshift-docs/RN-411-esxi-prereqs/release_notes/ocp-4-11-release-notes.html#ocp-4-11-installation-vsphere-csi)
Corresponding install PR https://github.com/openshift/openshift-docs/pull/48386