### PR TITLE
OSDOCS-3318: Modified the note around worker node labels

### DIFF
--- a/modules/rosa-adding-node-labels.adoc
+++ b/modules/rosa-adding-node-labels.adoc
@@ -10,11 +10,6 @@ Add or edit labels for compute (also known as worker) nodes at any time to manag
 
 Labels are assigned as key-value pairs. Each key must be unique to the object it is assigned to.
 
-[NOTE]
-====
-Adding node labels to an existing machine pool adds the labels to only new nodes that are created in that pool. The labels are not applied to the existing nodes. If you need nodes with the labels, you can scale down the nodes in the machine pool to zero, add the node labels, and then scale back up to the desired amount. Alternatively, you can create a new machine pool and define the node labels at creation time. You cannot scale the default machine pool to zero.
-====
-
 .Prerequisites
 
 ifdef::openshift-rosa[]

--- a/modules/rosa-adding-taints.adoc
+++ b/modules/rosa-adding-taints.adoc
@@ -8,11 +8,6 @@
 
 You can add taints for compute (also known as worker) nodes in a machine pool to control which pods are scheduled to them. When you apply a taint to a machine pool, the scheduler cannot place a pod on the nodes in the pool unless the pod specification includes a toleration for the taint.
 
-[NOTE]
-====
-Adding taints to an existing machine pool adds the taints to only new nodes that are created in that pool. The taints are not applied to the existing nodes. If you need nodes with the taint, you can scale down the nodes in the machine pool to zero, add the taints, and then scale back up to the desired amount. Alternatively, you can create a new machine pool and define the taints at creation time. You cannot scale the default machine pool to zero.
-====
-
 .Prerequisites
 
 ifdef::openshift-rosa[]


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-3318

Link to docs preview:

1. [Adding Labels](http://file.rdu.redhat.com/eponvell/OSDOCS-3318_Worker-Nodes/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#rosa-adding-node-labels_rosa-managing-worker-nodes) 
2. [Adding Taints](http://file.rdu.redhat.com/eponvell/OSDOCS-3318_Worker-Nodes/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#rosa-adding-taints_rosa-managing-worker-nodes)

Additional information:
Changed the language of the note for worker nodes and adding a label.