### PR TITLE
Adding redirect rule for 404'd external DNS page

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -163,6 +163,9 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.8|4\.9)/updating/installing-update-service.html /container-platform/$1/updating/updating-restricted-network-cluster.html [NE,R=301]
     RewriteRule ^container-platform/(4\.8|4\.9)/updating/understanding-the-update-service.html /container-platform/$1/updating/updating-restricted-network-cluster.html [NE,R=301]
 
+    # Redirect for renamed external DNS page
+    RewriteRule ^container-platform/4\.10/networking/external_dns_operator/nw-installing-external-dns-operator.html /container-platform/4.10/networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.html [NE,R=302]
+
     # CNV scenarios based redirect
     RewriteRule ^container-platform/4\.8/virt/learn_more_about_ov.html /container-platform/4.8/virt/virt-learn-more-about-openshift-virtualization.html [NE,R=301]
 


### PR DESCRIPTION
Adding a redirect rule to resolve https://github.com/openshift/openshift-docs/issues/46809. Setting directly to 301 to resolve the 404 as soon as it is merged

For main only