### PR TITLE
BZ2100534 added AWS route 53 to restricted installation note

### DIFF
--- a/modules/installation-about-restricted-network.adoc
+++ b/modules/installation-about-restricted-network.adoc
@@ -48,8 +48,7 @@ require an active connection to the internet to obtain software components. Rest
 ifndef::ibm-power[]
 If you choose to perform a restricted network installation on a cloud platform, you
 still require access to its cloud APIs. Some cloud functions, like
-Amazon Web Service's IAM service, require internet access, so you might still
-require internet access.
+Amazon Web Service's Route 53 DNS and IAM services, require internet access.
 //behind a proxy
 Depending on your network, you might require less internet
 access for an installation on bare metal hardware or on VMware vSphere.


### PR DESCRIPTION
[BZ#2100534:](https://bugzilla.redhat.com/show_bug.cgi?id=2100534) Added AWS Route 53 to the note about internet access for restricted installations.
 
Version(s):
4.6+

Doc preview:
[About installations in restricted networks](https://bscott-rh.github.io/openshift-docs/BZ2100534/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.html#installation-about-restricted-networks_installing-restricted-networks-aws-installer-provisioned)