### PR TITLE
[OSDOCS-3832]: Fix structure of osdk-control-compat

### DIFF
--- a/modules/osdk-control-compat.adoc
+++ b/modules/osdk-control-compat.adoc
@@ -50,7 +50,7 @@ Operators that use deprecated APIs can adversely impact critical workloads when 
 You must use `olm.maxOpenShiftVersion` annotation only if your Operator bundle version cannot work in later versions. Be aware that cluster admins cannot upgrade their clusters with your solution installed. If you do not provide later version and a valid upgrade path,
 cluster admins may uninstall your Operator and can upgrade the cluster version.
 ====
-
++
 .Example CSV with `olm.maxOpenShiftVersion` annotation
 [source,yaml]
 ----
@@ -61,14 +61,14 @@ metadata:
     "olm.properties": '[{"type": "olm.maxOpenShiftVersion", "value": "<cluster_version>"}]' <1>
 ----
 <1> Specify the maximum cluster version of {product-title} that your Operator is compatible with. For example, setting `value` to `4.9` prevents cluster upgrades to {product-title} versions later than 4.9 when this bundle is installed on a cluster.
-
++
 . If your bundle is intended for distribution in a Red Hat-provided Operator catalog, configure the compatible versions of {product-title} for your Operator by setting the following properties. This configuration ensures your Operator is only included in catalogs that target compatible versions of {product-title}:
 +
 [NOTE]
 ====
 This step is only valid when publishing Operators in Red Hat-provided catalogs. If your bundle is only intended for distribution in a custom catalog, you can skip this step. For more details, see "Red Hat-provided Operator catalogs".
 ====
-
++
 .. Set the `com.redhat.openshift.versions` annotation in your project's `bundle/metadata/annotations.yaml` file:
 +
 .Example `bundle/metadata/annotations.yaml` file with compatible versions
@@ -77,7 +77,7 @@ This step is only valid when publishing Operators in Red Hat-provided catalogs. 
 com.redhat.openshift.versions: "v4.7-v4.9" <1>
 ----
 <1> Set to a range or single version.
-
++
 .. To prevent your bundle from being carried on to an incompatible version of {product-title}, ensure that the index image is generated with the proper `com.redhat.openshift.versions` label in your Operator's bundle image. For example, if your project was generated using the Operator SDK, update the `bundle.Dockerfile` file:
 +
 .Example `bundle.Dockerfile` with compatible versions


### PR DESCRIPTION
Version(s):
4.8+
(This patch cherry-picks cleanly back to 4.9, but 4.8 requires a backport.  This section does not exist in earlier versions.)

Issue:
https://issues.redhat.com/browse/OSDOCS-3832

Link to docs preview:
http://shell.lab.bos.redhat.com/~yselkowi/openshift-docs/osdocs-3832/operators/operator_sdk/osdk-working-bundle-images.html#osdk-control-compat_osdk-working-bundle-images
(compare to [current state](https://docs.openshift.com/container-platform/4.10/operators/operator_sdk/osdk-working-bundle-images.html#osdk-control-compat_osdk-working-bundle-images))

Additional information:
This fixes the Procedure subsection of the "Controlling Operator compatibility with OpenShift Container Platform versions" section of the "Operators->Developing Operators->Working with bundle images" page, as well as some resulting build warnings.
