### PR TITLE
CMP-1432 File Integrity Operator v0.1.30 release notes

### DIFF
--- a/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
@@ -13,6 +13,26 @@ These release notes track the development of the File Integrity Operator in the 
 
 For an overview of the File Integrity Operator, see xref:../../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-operator[Understanding the File Integrity Operator].
 
+[id="file-integrity-operator-release-notes-0-1-30"]
+== OpenShift File Integrity Operator 0.1.30
+
+The following advisory is available for the OpenShift File Integrity Operator 0.1.30:
+
+* link:https://access.redhat.com/errata/RHBA-2022:5538[RHBA-2022:5538 OpenShift File Integrity Operator Bug Fix and Enhancement Update]
+
+[id="file-integrity-operator-0-1-30-new-features-and-enhancements"]
+=== New features and enhancements
+
+* The File Integrity Operator is now supported on the following architectures:
++
+** IBM Power
+** IBM Z and LinuxONE
+
+[id="file-integrity-operator-0-1-30-bug-fixes"]
+=== Bug fixes
+
+* Previously, alerts issued by the File Integrity Operator did not set a namespace, making it difficult to understand where the alert originated. Now, the Operator sets the appropriate namespace, increasing understanding of the alert. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2101393[*BZ#2101393*])
+
 [id="file-integrity-operator-release-notes-0-1-24"]
 == OpenShift File Integrity Operator 0.1.24
 
@@ -27,6 +47,7 @@ The following advisory is available for the OpenShift File Integrity Operator 0.
 
 [id="openshift-file-integrity-operator-0-1-24-bug-fixes"]
 === Bug fixes
+
 * Previously, upgrading the Operator from versions older than 0.1.21 to 0.1.22 could cause the `re-init` feature to fail. This was a result of the Operator failing to update `configMap` resource labels. Now, upgrading to the latest version fixes the resource labels. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049206[*BZ#2049206*])
 
 * Previously, when enforcing the default `configMap` script contents, the wrong data keys were compared. This resulted in the `aide-reinit` script not being updated properly after an Operator upgrade, and caused the `re-init` process to fail. Now,`daemonSets` run to completion and the AIDE database `re-init` process executes successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2072058[*BZ#2072058*])
@@ -40,6 +61,7 @@ The following advisory is available for the OpenShift File Integrity Operator 0.
 
 [id="openshift-file-integrity-operator-0-1-22-bug-fixes"]
 === Bug fixes
+
 * Previously, a system with a File Integrity Operator installed might interrupt the {product-title} update, due to the  `/etc/kubernetes/aide.reinit` file.  This occurred if the `/etc/kubernetes/aide.reinit` file was present, but later removed prior to the `ostree` validation. With this update, `/etc/kubernetes/aide.reinit` is moved to the `/run` directory so that it does not conflict with the {product-title} update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033311[*BZ#2033311*])
 
 [id="file-integrity-operator-release-notes-0-1-21"]


### PR DESCRIPTION
Version(s):
4.6+

Issue:
[CMP-1432](https://issues.redhat.com/browse/CMP-1432)

Link to docs preview (VPN required):
[OpenShift File Integrity Operator 0.1.30](http://file.rdu.redhat.com/antaylor/CMP-1432/security/file_integrity_operator/file-integrity-operator-release-notes.html)

Additional information:
Peer review only at this time; PR will be merged upon release of the errata. The errata link provided in the build preview will not work until that time. 