### PR TITLE
BZ#2093247 - adding details for workload partitioning

### DIFF
--- a/modules/sno-du-enabling-workload-partitioning.adoc
+++ b/modules/sno-du-enabling-workload-partitioning.adoc
@@ -10,7 +10,7 @@ A key feature to enable as part of a {sno} installation is workload partitioning
 
 [NOTE]
 ====
-Workload partitioning must be applied during installation.
+You can enable workload partitioning during the cluster installation process only. You cannot disable workload partitioning post-installation. However, you can reconfigure workload partitioning by updating the `cpu` value that you define in the `performanceprofile`, and in the MachineConfig CR in the following procedure. 
 ====
 
 .Procedure
@@ -34,7 +34,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKcmVzb3VyY2VzID0geyAiY3B1c2hhcmVzIiA9IDAsICJjcHVzZXQiID0gIjAtMSw1Mi01MyIgfQo=
+          source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKW2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudC5yZXNvdXJjZXNdCmNwdXNoYXJlcyA9IDAKQ1BVcyA9ICIwLTEsIDUyLTUzIgo=
         mode: 420
         overwrite: true
         path: /etc/crio/crio.conf.d/01-workload-partitioning
@@ -56,11 +56,13 @@ spec:
 [crio.runtime.workloads.management]
 activation_annotation = "target.workload.openshift.io/management"
 annotation_prefix = "resources.workload.openshift.io"
-resources = { "cpushares" = 0, "cpuset" = "0-1,52-53" } <1>
+[crio.runtime.workloads.management.resources]
+cpushares = 0
+CPUs = "0-1, 52-53" <1>
 ----
-<1> The `cpuset` value will vary based on the installation.
+<1> The `CPUs` value varies based on the installation.
 
-If Hyper-Threading is enabled, specify both threads of each core. The `cpuset` must match the reserved CPU set specified in the performance profile.
+If Hyper-Threading is enabled, specify both threads of each core. The `CPUs` value must match the reserved CPU set specified in the performance profile.
 
 
 This content should be base64 encoded and provided in the `01-workload-partitioning-content` in the manifest above.
@@ -75,6 +77,6 @@ This content should be base64 encoded and provided in the `01-workload-partition
   }
 }
 ----
-<1> The `cpuset` must match the value in `/etc/crio/crio.conf.d/01-workload-partitioning`.
+<1> The `cpuset` must match the `CPUs` value in `/etc/crio/crio.conf.d/01-workload-partitioning`.
 
 This content should be base64 encoded and provided in the `openshift-workload-pinning-content` in the preceding manifest.


### PR DESCRIPTION
BZ#2093247: Adding some detail that workload partitioning can only be applied at install time, cannot be disabled post-install, but can be reconfigured post-install.

Version(s):
4.9+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2093247

Link to docs preview:
http://file.emea.redhat.com/rohennes/BZ2093247/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.html#sno-du-enabling-workload-partitioning_sno-du-enabling-workload-partitioning-on-single-node-openshift
