### PR TITLE
ECOPROJECT-883: Documentation for updated remediation templates

### DIFF
--- a/modules/eco-configuring-machine-health-check-with-self-node-remediation.adoc
+++ b/modules/eco-configuring-machine-health-check-with-self-node-remediation.adoc
@@ -28,8 +28,10 @@ metadata:
   name: selfnoderemediationtemplate-sample
 spec:
   template:
-    spec: {}
+    spec:
+      remediationStrategy: ResourceDeletion <1>
 ----
+<1> Specifies the remediation strategy. The default strategy is `ResourceDeletion`.
 
 .. To create the `SelfNodeRemediationTemplate` CR, run the following command:
 +

--- a/modules/eco-self-node-remediation-operator-about.adoc
+++ b/modules/eco-self-node-remediation-operator-about.adoc
@@ -55,10 +55,16 @@ If a watchdog device is unavailable, the `SelfNodeRemediationConfig` CR uses a s
 [id="understanding-self-node-remediation-remediation-template-config_{context}"]
 == Understanding the Self Node Remediation Template configuration
 
-The Self Node Remediation Operator also creates the `SelfNodeRemediationTemplate` CR with the name `self-node-remediation-default-template` in the Self Node Remediation Operator's namespace. This CR defines the remediation strategy for the nodes.
+The Self Node Remediation Operator also creates the `SelfNodeRemediationTemplate` Custom Resource Definition (CRD). This CRD defines the remediation strategy for the nodes. The following remediation strategies are available:
 
-The default remediation strategy is `NodeDeletion` that removes the `node` object.
-In {product-title} 4.10, the Self Node Remediation Operator introduced a new remediation strategy called `ResourceDeletion`. The `ResourceDeletion` remediation strategy removes the pods and associated volume attachments on the node rather than the `node` object. This strategy helps to recover workloads faster.
+`ResourceDeletion`:: This remediation strategy removes the pods and associated volume attachments on the node rather than the node object. This strategy helps to recover workloads faster. `ResourceDeletion` is the default remediation strategy.
+
+`NodeDeletion`:: This remediation strategy removes the node object.
+
+The Self Node Remediation Operator creates the following `SelfNodeRemediationTemplate` CRs for each strategy:
+
+* `self-node-remediation-resource-deletion-template`, which the `ResourceDeletion` remediation strategy uses
+* `self-node-remediation-node-deletion-template`, which the `NodeDeletion` remediation strategy uses
 
 The `SelfNodeRemediationTemplate` CR resembles the following YAML file:
 
@@ -67,15 +73,13 @@ The `SelfNodeRemediationTemplate` CR resembles the following YAML file:
 apiVersion: self-node-remediation.medik8s.io/v1alpha1
 kind: SelfNodeRemediationTemplate
 metadata:
-creationTimestamp: "2022-03-02T08:02:40Z"
-generation: 1
-name: self-node-remediation-default-template
-namespace: openshift-operators
-resourceVersion: "596469"
-uid: 5d29e437-c485-48fa-ba9e-0354649afd31
+  creationTimestamp: "2022-03-02T08:02:40Z"
+  name: self-node-remediation-<remediation_object>-deletion-template <1>
+  namespace: openshift-operators
 spec:
-template:
-spec:
-remediationStrategy: NodeDeletion <1>
+  template:
+    spec:
+      remediationStrategy: <remediation_strategy>  <2>
 ----
-<1> Specifies the remediation strategy. The default remediation strategy is `NodeDeletion`.
+<1> Specifies the type of remediation template based on the remediation strategy. Replace `<remediation_object>` with either `resource` or `node`, for example, `self-node-remediation-resource-deletion-template`.
+<2> Specifies the remediation strategy. The remediation strategy can either be `ResourceDeletion` or `NodeDeletion`.


### PR DESCRIPTION
[TELCODOCS-790](https://issues.redhat.com//browse/TELCODOCS-790): This PR adds information about the two remediation templates for the Self Node Remediation Operator (formerly Poison Pill Operator).

Version(s): OpenShift 4.11+

Issue:
https://issues.redhat.com/browse/TELCODOCS-790

Preview:
http://file.rdu.redhat.com/avbhatt/TD790/nodes/nodes/eco-self-node-remediation-operator.html#understanding-self-node-remediation-remediation-template-config_self-node-remediation-operator-remediate-nodes