### PR TITLE
RHDEVDOCS-4229 Release Notes Pipelines 1.7.2

### DIFF
--- a/modules/op-release-notes-1-7.adoc
+++ b/modules/op-release-notes-1-7.adoc
@@ -362,3 +362,51 @@ With this update, {pipelines-title} General Availability (GA) 1.7.1 is available
 * Before this update, for each namespace the resource pruner job created a separate container to prune resources. With this update, the resource pruner job runs commands for all namespaces as a loop in one container.
 // https://issues.redhat.com/browse/SRVKP-2160
 
+
+[id="release-notes-1-7-2_{context}"]
+== Release notes for {pipelines-title} General Availability 1.7.2
+
+With this update, {pipelines-title} General Availability (GA) 1.7.2 is available on {product-title} 4.9, 4.10, and the upcoming version.
+
+[id="known-issues-1-7-2_{context}"]
+=== Known issues
+
+* The `chains-config` config map for {tekton-chains} in the `openshift-pipelines` namespace is automatically reset to default after upgrading the {pipelines-title} Operator. Currently, there is no workaround for this issue.
+// https://issues.redhat.com/browse/SRVKP-2349
+
+[id="fixed-issues-1-7-2_{context}"]
+=== Fixed issues
+
+* Before this update, tasks on {pipelines-shortname} 1.7.1 failed on using `init` as the first argument, followed by two or more arguments. With this update, the flags are parsed correctly and the task runs are successful.
+// https://issues.redhat.com/browse/SRVKP-2340
+
+* Before this update, installation of the {pipelines-title} Operator on {product-title} 4.9 and 4.10 failed due to invalid role binding, with the following error message:
++
+[source,terminal]
+----
+error updating rolebinding openshift-operators-prometheus-k8s-read-binding: RoleBinding.rbac.authorization.k8s.io "openshift-operators-prometheus-k8s-read-binding" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:"rbac.authorization.k8s.io", Kind:"Role", Name:"openshift-operator-read"}: cannot change roleRef
+----
++
+With this update, the {pipelines-title} Operator installs with distinct role binding namespaces to avoid conflict with installation of other Operators. 
+// https://issues.redhat.com/browse/SRVKP-2327
+
+* Before this update, upgrading the Operator triggered a reset of the `signing-secrets` secret key for {tekton-chains} to its default value. With this update, the custom secret key persists after you upgrade the Operator.
++
+[NOTE]
+====
+Upgrading to {pipelines-title} 1.7.2 resets the key. However, when you upgrade to future releases, the key is expected to persist.
+====
++ 
+// https://issues.redhat.com/browse/SRVKP-2304
+
+* Before this update, all S2I build tasks failed with an error similar to the following message:
++
+[source,terminal]
+----
+Error: error writing "0 0 4294967295\n" to /proc/22/uid_map: write /proc/22/uid_map: operation not permitted
+time="2022-03-04T09:47:57Z" level=error msg="error writing \"0 0 4294967295\\n\" to /proc/22/uid_map: write /proc/22/uid_map: operation not permitted"
+time="2022-03-04T09:47:57Z" level=error msg="(unable to determine exit status)"
+----
++
+With this update, the `pipelines-scc` security context constraint (SCC) is compatible with the `SETFCAP` capability necessary for S2I and Buildah clustertasks. As a result, the S2I build tasks run successfully.
+// https://issues.redhat.com/browse/SRVKP-2091


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`
- **JIRA issues**: [RHDEVDOCS-4229 Release Notes Pipelines 1.7.2](https://issues.redhat.com/browse/RHDEVDOCS-4229)
- **Preview pages**: Unavailable due to issues with Netlify. However, you can download this [generated HTML page](https://drive.google.com/file/d/13Q-dQUA4xZ6AYf4SsIL-eO286G9a8QtW/view?usp=sharing) and view it using your browser.
- **SME review**: @concaf       
- **Peer-review**: @Preeticp     

Manual cherry-pick for `enterprise-4.9`: https://github.com/openshift/openshift-docs/pull/47893 