### PR TITLE
Rename disable-language-specific-vulneribility-scanning.adoc to disab…

### DIFF
--- a/modules/disable-language-specific-vulnerability-scanning.adoc
+++ b/modules/disable-language-specific-vulnerability-scanning.adoc
@@ -2,8 +2,8 @@
 //
 // * ooperating/examine-images-for-vulnerabilities.adoc
 :_module-type: PROCEDURE
-[id="disable-language-specific-vulneribility-scanning_{context}"]
-= Disabling language-specific vulneribility scanning
+[id="disable-language-specific-vulnerability-scanning_{context}"]
+= Disabling language-specific vulnerability scanning
 
 Scanner identifies the vulnerabilities in the programming language-specific dependencies by defalut. You can disable the language-specific dependency scanning.
 

--- a/operating/examine-images-for-vulnerabilities.adoc
+++ b/operating/examine-images-for-vulnerabilities.adoc
@@ -69,7 +69,7 @@ include::modules/identify-container-image-layer-that-introduces-vulnerabilities.
 
 include::modules/identify-operating-system-of-the-base-image.adoc[leveloffset=+1]
 
-include::modules/disable-language-specific-vulneribility-scanning.adoc[leveloffset=+1]
+include::modules/disable-language-specific-vulnerability-scanning.adoc[leveloffset=+1]
 
 [id="additional-resources_examine-images-for-vulnerabilities"]
 [role="_additional-resources"]


### PR DESCRIPTION
…le-language-specific-vulnerability-scanning.adoc

Typo in title

Applies to:
- `rhacs-docs-3.65`
- `rhacs-docs-3.66`
- `rhacs-docs-3.67`
- `rhacs-docs-3.68`
- `rhacs-docs-3.69`
- `rhacs-docs-3.70`

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
