### PR TITLE
Red Hat Virtualization (RHV) in {product-title} will be deprecated an…

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1023,6 +1023,11 @@ The following `oc` commands and flags for requesting tokens are now deprecated:
 
 Use the `oc create token` command instead to request tokens.
 
+[id="ocp-4-11-rhv-deprecations"]
+==== Red Hat Virtualization (RHV) as a host platform for {product-title} will be deprecated
+
+Red Hat Virtualization (RHV) will be deprecated in an upcoming release of {product-title}. Support for {product-title} on RHV will be removed from a future {product-title} release, currently planned as {product-title} 4.14.
+
 [id="ocp-4-11-removed-features"]
 === Removed features
 


### PR DESCRIPTION
From @emarcusRH and @ctomasko: RHV on OCP dep. announcement.

Version(s):
`enterprise-4.11` only

Issue:
[OCPRHV-772](https://issues.redhat.com/browse/OCPRHV-772)

Link to docs preview:
http://file.rdu.redhat.com/opayne/rhv-dep-announce/release_notes/ocp-4-11-release-notes.html#ocp-4-11-rhv-deprecations



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
