### PR TITLE
OSDOCS-3800: Clarifying that you can't install oc on RHEL 9 via RPM

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -140,6 +140,13 @@ For more information, see xref:../installing/installing_bare_metal_ipi/ipi-insta
 
 Using {op-system-base-full} 9 with the OpenShift CLI (`oc`) is now supported.
 
+[NOTE]
+====
+It is not supported to install the OpenShift CLI (`oc`) as an RPM for {op-system-base-full} 9. You must install the OpenShift CLI for {op-system-base} 9 by downloading the binary.
+====
+
+For more information, see xref:../cli_reference/openshift_cli/getting-started-cli.adoc#installing-openshift-cli[Installing the OpenShift CLI].
+
 [id="ocp-4-11-ibm-z"]
 === IBM Z and LinuxONE
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3800

Link to docs preview:
(single page) http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3800-rn-2/release_notes/ocp-4-11-release-notes.html#ocp-4-11-oc-rhel-9

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
