### PR TITLE
GH-45261: MCO 4.11 release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -429,6 +429,20 @@ You must still use the `performance-addon-operator-must-gather` image when runni
 [id="ocp-4-11-machine-config-operator"]
 === Machine Config Operator
 
+[id="ocp-4-11-mco-update-zone"]
+==== MCO now updates nodes by zone and age
+
+The Machine Config Operator (MCO) now updates the affected nodes alphabetically by zone, based on the `topology.kubernetes.io/zone` label. If a zone has more than one node, the oldest nodes are updated first. For nodes that do not use zones, such as in bare metal deployments, the nodes are upgraded by age, with the oldest nodes updated first. Previously, the MCO did not consider zones or node age.  
+
+For more information, see xref:../post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks[Machine config overview].
+
+[id="ocp-4-11-mco-signer-ca-alert"]
+==== New alert if MCO cannot update the signer CA on a paused node
+
+You will now receive alerts in the Alerting UI of the {product-title} web console if the MCO attempts to renew an expired `kube-apiserver-to-kubelet-signer` CA certificate on a Machine Config Pool (MCP) that is paused. If the MCPs are paused, the MCO cannot push the newly rotated certificates to those nodes, which can result in failures.
+
+For more information, see xref:../updating/update-using-custom-machine-config-pools.html#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools[Pausing the machine config pools].
+
 [id="ocp-4-11-nodes"]
 === Nodes
 


### PR DESCRIPTION
Release notes for https://issues.redhat.com/browse/OSDOCS-3451 and https://issues.redhat.com/browse/OSDOCS-3039

https://github.com/openshift/openshift-docs/pull/45261

Preview [Machine Config Operator](http://file.rdu.redhat.com/mburke/mco-411-release-notes/release_notes/ocp-4-11-release-notes.html#ocp-4-11-machine-config-operator)
