### PR TITLE
OSDOCS-3819: Added RN for AWS VPC endpoint guidance for restricted installations

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -151,6 +151,12 @@ If you used the Technology Preview version of the oc-mirror plug-in for {product
 
 For more information, see xref:../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in].
 
+[id="ocp-4-11-aws-vpc-endpoints"]
+==== AWS VPC endpoints and restricted installations
+You are no longer required to configure AWS VPC endpoints when installing a restricted {product-title} cluster on AWS. While configuring VPC endpoints remains an option, you can also choose to configure a proxy without VPC endpoints or configure a proxy with VPC endpoints.
+
+For more information, see xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installation-custom-aws-vpc-requirements_installing-restricted-networks-aws-installer-provisioned[Requirements for using your VPC].
+
 [id="ocp-4-11-web-console"]
 === Web console
 


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR is the RN for [osdocs-3819](https://issues.redhat.com/browse/OSDOCS-3819).

Link to docs preview:
[AWS VPC endpoints and restricted installations](http://file.rdu.redhat.com/mpytlak/osdocs3819-rn/release_notes/ocp-4-11-release-notes.html#ocp-4-11-aws-vpc-endpoints)