### PR TITLE
TELCODOCS#809: Reworking any remaining references of PAO with references to NTO, including IDs and file names

### DIFF
--- a/modules/cnf-about-the-profile-creator-tool.adoc
+++ b/modules/cnf-about-the-profile-creator-tool.adoc
@@ -6,7 +6,7 @@
 [id="cnf-about-the-profile-creator-tool_{context}"]
 = About the Performance Profile Creator
 
-The Performance Profile Creator (PPC) is a command-line tool, delivered with the Performance Addon Operator, used to create the performance profile.
+The Performance Profile Creator (PPC) is a command-line tool, delivered with the Node Tuning Operator, used to create the performance profile.
 The tool consumes `must-gather` data from the cluster and several user-supplied profile arguments. The PPC generates a performance profile that is appropriate for your hardware and topology.
 
 The tool is run by one of the following methods:

--- a/modules/cnf-about_hyperthreading_for_low_latency_and_real_time_applications.adoc
+++ b/modules/cnf-about_hyperthreading_for_low_latency_and_real_time_applications.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// scalability_and_performance/cnf-low-latency-tuning.adoc
 
 :_content-type: CONCEPT
 [id="about_hyperthreading_for_low_latency_and_real_time_applications_{context}"]

--- a/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
+++ b/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //CNF-1483 (4.8)
-// * scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// * scalability_and_performance/low-latency-tuning.adoc
 
 :_content-type: PROCEDURE
 [id="adjusting-nic-queues-with-the-performance-profile_{context}"]
@@ -29,7 +29,7 @@ Unsupported network devices:
 
 .Procedure
 
-. Log in to the {product-title} cluster running the Performance Addon Operator as a user with `cluster-admin` privileges.
+. Log in to the {product-title} cluster running the Node Tuning Operator as a user with `cluster-admin` privileges.
 
 . Create and apply a performance profile appropriate for your hardware and topology. For guidance on creating a profile, see the "Creating a performance profile" section.
 

--- a/modules/cnf-allocating-multiple-huge-page-sizes.adoc
+++ b/modules/cnf-allocating-multiple-huge-page-sizes.adoc
@@ -1,14 +1,14 @@
 // CNF-538 Promote Multiple Huge Pages Sizes for Pods and Containers to beta
 // Module included in the following assemblies:
 //
-// *scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// *scalability_and_performance/cnf-low-latency-tuning.adoc
 
 [id="cnf-allocating-multiple-huge-page-sizes_{context}"]
 = Allocating multiple huge page sizes
 
 You can request huge pages with different sizes under the same container. This allows you to define more complicated pods consisting of containers with different huge page size needs.
 
-For example, you can define sizes `1G` and `2M` and the Performance Addon Operator will configure both sizes on the node, as shown here:
+For example, you can define sizes `1G` and `2M` and the Node Tuning Operator will configure both sizes on the node, as shown here:
 
 [source,yaml]
 ----

--- a/modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc
+++ b/modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc
@@ -1,7 +1,7 @@
 // CNF-643 Support and debugging tools for CNF
 // Module included in the following assemblies:
 //
-// *scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// *scalability_and_performance/cnf-low-latency-tuning.adoc
 
 :_content-type: PROCEDURE
 [id="cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support_{context}"]
@@ -29,19 +29,24 @@ You can specify one or more images when you run the command by including the `--
 
 Use the `oc adm must-gather` CLI command to collect information about your cluster, including features and objects associated with low latency tuning, including:
 
-* The Performance Addon Operator namespaces and child objects.
+* The Node Tuning Operator namespaces and child objects.
 * `MachineConfigPool` and associated `MachineConfig` objects.
 * The Node Tuning Operator and associated Tuned objects.
 * Linux Kernel command line options.
 * CPU and NUMA topology
 * Basic PCI device information and NUMA locality.
 
-To collect Performance Addon Operator debugging information with `must-gather`, you must specify the Performance Addon Operator `must-gather` image:
+To collect debugging information with `must-gather`, you must specify the Performance Addon Operator `must-gather` image:
 
 [source,terminal,subs="attributes+"]
 ----
 --image=registry.redhat.io/openshift4/performance-addon-operator-must-gather-rhel8:v{product-version}.
 ----
+
+[NOTE]
+====
+In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. However, you must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command.
+====
 
 [id="cnf-about-gathering-data_{context}"]
 == Gathering data about specific features
@@ -53,6 +58,11 @@ You can gather debugging information about specific features by using the `oc ad
 To collect the default `must-gather` data in addition to specific feature data, add the `--image-stream=openshift/must-gather` argument.
 ====
 
+[NOTE]
+====
+In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. However, you must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command.
+====
+
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
@@ -62,7 +72,7 @@ To collect the default `must-gather` data in addition to specific feature data, 
 
 . Navigate to the directory where you want to store the `must-gather` data.
 
-. Run the `oc adm must-gather` command with one or more `--image` or `--image-stream` arguments. For example, the following command gathers both the default cluster data and information specific to the Performance Addon Operator:
+. Run the `oc adm must-gather` command with one or more `--image` or `--image-stream` arguments. For example, the following command gathers both the default cluster data and information specific to the Node Tuning Operator:
 +
 [source,terminal,subs="attributes+"]
 ----

--- a/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
+++ b/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// scalability_and_performance/cnf-low-latency-tuning.adoc
 
 [id="configuring_for_irq_dynamic_load_balancing_{context}"]
 = Configuring a node for IRQ dynamic load balancing

--- a/modules/cnf-configuring-huge-pages.adoc
+++ b/modules/cnf-configuring-huge-pages.adoc
@@ -1,13 +1,13 @@
 // Module included in the following assemblies:
 //CNF-78 (4.4)
-// * scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// * scalability_and_performance/cnf-low-latency-tuning.adoc
 
 [id="cnf-configuring-huge-pages_{context}"]
 = Configuring huge pages
 
-Nodes must pre-allocate huge pages used in an {product-title} cluster. Use the Performance Addon Operator to allocate huge pages on a specific node.
+Nodes must pre-allocate huge pages used in an {product-title} cluster. Use the Node Tuning Operator to allocate huge pages on a specific node.
 
-{product-title} provides a method for creating and allocating huge pages. Performance Addon Operator provides an easier method for doing  this using the performance profile.
+{product-title} provides a method for creating and allocating huge pages. Node Tuning Operator provides an easier method for doing  this using the performance profile.
 
 For example, in the `hugepages` `pages` section of the performance profile, you can specify multiple blocks of `size`, `count`, and, optionally, `node`:
 

--- a/modules/cnf-configuring-workload-hints.adoc
+++ b/modules/cnf-configuring-workload-hints.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// scalability_and_performance/cnf-low-latency-tuning.adoc
 
 :_content-type: CONCEPT
 [id="configuring-workload-hints_{context}"]

--- a/modules/cnf-cpu-infra-container.adoc
+++ b/modules/cnf-cpu-infra-container.adoc
@@ -1,12 +1,12 @@
 // Module included in the following assemblies:
 //
-// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// scalability_and_performance/cnf-low-latency-tuning.adoc
 
 :_content-type: PROCEDURE
 [id="cnf-cpu-infra-container_{context}"]
 = Restricting CPUs for infra and application containers
 
-Generic housekeeping and workload tasks use CPUs in a way that may impact latency-sensitive processes. By default, the container runtime uses all online CPUs to run all containers together, which can result in context switches and spikes in latency. Partitioning the CPUs prevents noisy processes from interfering with latency-sensitive processes by separating them from each other. The following table describes how processes run on a CPU after you have tuned the node using the Performance Add-On Operator:
+Generic housekeeping and workload tasks use CPUs in a way that may impact latency-sensitive processes. By default, the container runtime uses all online CPUs to run all containers together, which can result in context switches and spikes in latency. Partitioning the CPUs prevents noisy processes from interfering with latency-sensitive processes by separating them from each other. The following table describes how processes run on a CPU after you have tuned the node using the Node Tuning Operator:
 
 .Process' CPU assignments
 [%header,cols=2*]

--- a/modules/cnf-creating-the-performance-profile-object.adoc
+++ b/modules/cnf-creating-the-performance-profile-object.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 // Epic CNF-78
-// * scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// * scalability_and_performance/cnf-low-latency-tuning.adoc
 
 [id="cnf-creating-the-performance-profile-object_{context}"]
 = Creating the PerformanceProfile object

--- a/modules/cnf-debugging-low-latency-cnf-tuning-status.adoc
+++ b/modules/cnf-debugging-low-latency-cnf-tuning-status.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 // Epic CNF-303 (4.5)
-// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// scalability_and_performance/cnf-low-latency-tuning.adoc
 //CNF-303 Performance add-ons status CNF-372
 //Performance Addon Operator Detailed Status
 //See: https://issues.redhat.com/browse/CNF-379  (Yanir Quinn)
@@ -12,7 +12,7 @@ The `PerformanceProfile` custom resource (CR) contains status fields for reporti
 
 A typical issue can arise when the status of machine config pools that are attached to the performance profile are in a degraded state, causing the `PerformanceProfile` status to degrade. In this case, the machine config pool issues a failure message.
 
-The Performance Addon Operator contains the `performanceProfile.spec.status.Conditions` status field:
+The Node Tuning Operator contains the `performanceProfile.spec.status.Conditions` status field:
 
 [source,bash]
 ----
@@ -59,7 +59,7 @@ Each of these types contain the following fields:
 [id="cnf-debugging-low-latency-cnf-tuning-status-machineconfigpools_{context}"]
 == Machine config pools
 
-A performance profile and its created products are applied to a node according to an associated machine config pool (MCP). The MCP holds valuable information about the progress of applying the machine configurations created by performance addons that encompass kernel args, kube config, huge pages allocation, and deployment of rt-kernel. The performance addons controller monitors changes in the MCP and updates the performance profile status accordingly.
+A performance profile and its created products are applied to a node according to an associated machine config pool (MCP). The MCP holds valuable information about the progress of applying the machine configurations created by performance profiles that encompass kernel args, kube config, huge pages allocation, and deployment of rt-kernel. The Performance Profile controller monitors changes in the MCP and updates the performance profile status accordingly.
 
 The only conditions returned by the MCP to the performance profile status is when the MCP is `Degraded`, which leads to `performaceProfile.status.condition.Degraded = true`.
 

--- a/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
+++ b/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
@@ -8,6 +8,11 @@
 
 The Performance Profile Creator (PPC) tool requires `must-gather` data. As a cluster administrator, run `must-gather` to capture information about your cluster.
 
+[NOTE]
+====
+In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. However, you must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command.
+====
+
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.

--- a/modules/cnf-logging-associated-with-adjusting-nic-queues.adoc
+++ b/modules/cnf-logging-associated-with-adjusting-nic-queues.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //CNF-1483 (4.8)
-// * scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// * scalability_and_performance/cnf-low-latency-tuning.adoc
 
 [id="logging-associated-with-adjusting-nic-queues_{context}"]
 = Logging associated with adjusting NIC queues

--- a/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
+++ b/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
@@ -1,16 +1,16 @@
 // CNF-802 Infrastructure-provided interrupt processing for guaranteed pod CPUs
 // Module included in the following assemblies:
 //
-// *cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// *cnf-low-latency-tuning.adoc
 
 [id="managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus_{context}"]
 = Managing device interrupt processing for guaranteed pod isolated CPUs
 
-The Performance Addon Operator can manage host CPUs by dividing them into reserved CPUs for cluster and operating system housekeeping duties, including pod infra containers, and isolated CPUs for application containers to run the workloads. This allows you to set CPUs for low latency workloads as isolated.
+The Node Tuning Operator can manage host CPUs by dividing them into reserved CPUs for cluster and operating system housekeeping duties, including pod infra containers, and isolated CPUs for application containers to run the workloads. This allows you to set CPUs for low latency workloads as isolated.
 
 Device interrupts are load balanced between all isolated and reserved CPUs to avoid CPUs being overloaded, with the exception of CPUs where there is a guaranteed pod running. Guaranteed pod CPUs are prevented from processing device interrupts when the relevant annotations are set for the pod.
 
-In the performance profile, `globallyDisableIrqLoadBalancing` is used to manage whether device interrupts are processed or not. For certain workloads the reserved CPUs are not always sufficient for dealing with device interrupts, and for this reason, device interrupts are not globally disabled on the isolated CPUs. By default, Performance Addon Operator does not disable device interrupts on isolated CPUs.
+In the performance profile, `globallyDisableIrqLoadBalancing` is used to manage whether device interrupts are processed or not. For certain workloads, the reserved CPUs are not always sufficient for dealing with device interrupts, and for this reason, device interrupts are not globally disabled on the isolated CPUs. By default, Node Tuning Operator does not disable device interrupts on isolated CPUs.
 
 To achieve low latency for workloads, some (but not all) pods require the CPUs they are running on to not process device interrupts. A pod annotation, `irq-load-balancing.crio.io`, is used to define whether device interrupts are processed or not. When configured, CRI-O disables device interrupts only as long as the pod is running.
 
@@ -37,9 +37,9 @@ Only disable CPU CFS quota when the CPU manager static policy is enabled and for
 ====
 
 [id="configuring-global-device-interrupts-handling-for-isolated-cpus_{context}"]
-== Disabling global device interrupts handling in Performance Addon Operator
+== Disabling global device interrupts handling in Node Tuning Operator
 
-To configure Performance Addon Operator to disable global device interrupts for the isolated CPU set, set the `globallyDisableIrqLoadBalancing` field in the performance profile to `true`. When `true`, conflicting pod annotations are ignored. When `false`, IRQ loads are balanced across all CPUs.
+To configure Node Tuning Operator to disable global device interrupts for the isolated CPU set, set the `globallyDisableIrqLoadBalancing` field in the performance profile to `true`. When `true`, conflicting pod annotations are ignored. When `false`, IRQ loads are balanced across all CPUs.
 
 A performance profile snippet illustrates this setting:
 

--- a/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
+++ b/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 // Epic CNF-290 (4.5)
-// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// scalability_and_performance/low-latency-tuning.adoc
 
 :_content-type: PROCEDURE
 [id="cnf-performing-end-to-end-tests-for-platform-verification_{context}"]
@@ -21,7 +21,6 @@ Validations include:
 * Targeting a machine config pool that belong to the machines to be tested
 * Enabling SCTP on the nodes
 * Enabling xt_u32 kernel module via machine config
-* Having the Performance Addon Operator installed
 * Having the SR-IOV Operator installed
 * Having the PTP Operator installed
 * Enabling the `contain-mount-namespace` mode via machine config
@@ -199,7 +198,7 @@ $ oc policy add-role-to-user system:image-puller system:serviceaccount:ovs-qos-t
 +
 [source,bash]
 ----
-SECRET=$(oc -n cnftests get secret | grep builder-docker | awk {'print $1'}
+SECRET=$(oc -n cnftests get secret | grep builder-docker | awk {'print $1'})
 TOKEN=$(oc -n cnftests get secret $SECRET -o jsonpath="{.data['\.dockercfg']}" | base64 --decode | jq '.["image-registry.openshift-image-registry.svc:5000"].auth')
 ----
 
@@ -803,7 +802,7 @@ The `cyclictest` tool measures the real-time kernel scheduler latency on the spe
 
 * You logged into registry.redhat.io with your Customer Portal credentials
 * You installed the real-time kernel
-* You installed the Performance Add-on Operator and you applied performance profile
+* You applied the performance profile by using the Node Tuning Operator
 
 .Procedure
 
@@ -985,7 +984,7 @@ More histogram entries ...
 .Prerequisites
 
 * You logged into registry.redhat.io with your Customer Portal credentials
-* You installed the Performance Add-on Operator and you applied a performance profile
+* You applied the performance profile by using the Node Tuning Operator
 
 .Procedure
 

--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -1,7 +1,7 @@
 // CNF-489 Real time and low latency workload provisioning
 // Module included in the following assemblies:
 //
-// *cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// *cnf-low-latency-tuning.adoc
 
 :_content-type: PROCEDURE
 [id="cnf-provisioning-real-time-and-low-latency-workloads_{context}"]
@@ -21,7 +21,7 @@ The usage of execution probes in conjunction with applications that require guar
 In earlier versions of {product-title}, the Performance Addon Operator was used to implement automatic tuning to achieve low latency performance for OpenShift applications. In {product-title} 4.11 and later, these functions are part of the Node Tuning Operator.
 ====
 
-[id="performance-addon-operator-known-limitations-for-real-time_{context}"]
+[id="node-tuning-operator-known-limitations-for-real-time_{context}"]
 == Known limitations for real-time
 
 [NOTE]
@@ -41,7 +41,7 @@ This procedure is fully supported with bare metal installations using {op-system
 
 Establishing the right performance expectations refers to the fact that the real-time kernel is not a panacea. Its objective is consistent, low-latency determinism offering predictable response times. There is some additional kernel overhead associated with the real-time kernel. This is due primarily to handling hardware interruptions in separately scheduled threads. The increased overhead in some workloads results in some degradation in overall throughput. The exact amount of degradation is very workload dependent, ranging from 0% to 30%. However, it is the cost of determinism.
 
-[id="performance-addon-operator-provisioning-worker-with-real-time-capabilities_{context}"]
+[id="node-tuning-operator-provisioning-worker-with-real-time-capabilities_{context}"]
 == Provisioning a worker with real-time capabilities
 
 . Optional: Add a node to the {product-title} cluster.
@@ -118,7 +118,7 @@ Labels:       machineconfiguration.openshift.io/role=worker-rt
 
 . Verify everything is working as expected.
 
-[id="performance-addon-operator-verifying-real-time-kernel-installation_{context}"]
+[id="node-tuning-operator-verifying-real-time-kernel-installation_{context}"]
 == Verifying the real-time kernel installation
 
 Use this command to verify that the real-time kernel is installed:
@@ -141,7 +141,7 @@ rt-worker-0.example.com	          Ready	 worker,worker-rt   5d17h   v1.24.0
 [...]
 ----
 
-[id="performance-addon-operator-creating-workload-that-works-in-real-time_{context}"]
+[id="node-tuning-operator-creating-workload-that-works-in-real-time_{context}"]
 == Creating a workload that works in real-time
 
 Use the following procedures for preparing a workload that will use real-time capabilities.
@@ -155,7 +155,7 @@ Use the following procedures for preparing a workload that will use real-time ca
 When writing your applications, follow the general recommendations described in
 link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/8/html-single/tuning_guide/index#chap-Application_Tuning_and_Deployment[Application tuning and deployment].
 
-[id="performance-addon-operator-creating-pod-with-guaranteed-qos-class_{context}"]
+[id="node-tuning-operator-creating-pod-with-guaranteed-qos-class_{context}"]
 == Creating a pod with a QoS class of `Guaranteed`
 
 Keep the following in mind when you create a pod that is given a QoS class of `Guaranteed`:
@@ -214,7 +214,7 @@ status:
 If a container specifies its own memory limit, but does not specify a memory request, {product-title} automatically assigns a memory request that matches the limit. Similarly, if a container specifies its own CPU limit, but does not specify a CPU request, {product-title} automatically assigns a CPU request that matches the limit.
 ====
 
-[id="performance-addon-operator-disabling-cpu-load-balancing-for-dpdk_{context}"]
+[id="node-tuning-operator-disabling-cpu-load-balancing-for-dpdk_{context}"]
 == Optional: Disabling CPU load balancing for DPDK
 
 Functionality to disable or enable CPU load balancing is implemented on the CRI-O level. The code under the CRI-O disables or enables CPU load balancing only when the following requirements are met.
@@ -259,7 +259,7 @@ spec:
 Only disable CPU load balancing when the CPU manager static policy is enabled and for pods with guaranteed QoS that use whole CPUs. Otherwise, disabling CPU load balancing can affect the performance of other containers in the cluster.
 ====
 
-[id="performance-addon-operator-assigning-proper-node-selector_{context}"]
+[id="node-tuning-operator-assigning-proper-node-selector_{context}"]
 == Assigning a proper node selector
 
 The preferred way to assign a pod to nodes is to use the same node selector the performance profile used, as shown here:
@@ -278,7 +278,7 @@ spec:
 
 For more information, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/nodes/index#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors].
 
-[id="performance-addon-operator-scheduling-workload-onto-worker-with-real-time-capabilities_{context}"]
+[id="node-tuning-operator-scheduling-workload-onto-worker-with-real-time-capabilities_{context}"]
 == Scheduling a workload onto a worker with real-time capabilities
 
 Use label selectors that match the nodes attached to the machine config pool that was configured for low latency by the Node Tuning Operator. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[Assigning pods to nodes].

--- a/modules/cnf-reducing-netqueues-using-nto.adoc
+++ b/modules/cnf-reducing-netqueues-using-nto.adoc
@@ -1,14 +1,19 @@
 // Module included in the following assemblies:
 //CNF-1483 (4.8)
-// * scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// * scalability_and_performance/low-latency-tuning.adoc
 
-[id="reducing-nic-queues-using-the-performance-addon-operator_{context}"]
-= Reducing NIC queues using the Performance Addon Operator
+[id="reducing-nic-queues-using-the-node-tuning-operator_{context}"]
+= Reducing NIC queues using the Node Tuning Operator
 
-The Performance Addon Operator allows you to adjust the network interface controller (NIC) queue count for each network device by configuring the performance profile. Device network queues allows the distribution of packets among different physical queues and each queue gets a separate thread for packet processing.
+The Node Tuning Operator allows you to adjust the network interface controller (NIC) queue count for each network device by configuring the performance profile. Device network queues allows the distribution of packets among different physical queues and each queue gets a separate thread for packet processing.
 
 In real-time or low latency systems, all the unnecessary interrupt request lines (IRQs) pinned to the isolated CPUs must be moved to reserved or housekeeping CPUs.
 
 In deployments with applications that require system, {product-title} networking or in mixed deployments with Data Plane Development Kit (DPDK) workloads, multiple queues are needed to achieve good throughput and the number of NIC queues should be adjusted or remain unchanged. For example, to achieve low latency the number of NIC queues for DPDK based workloads should be reduced to just the number of reserved or housekeeping CPUs.
 
 Too many queues are created by default for each CPU and these do not fit into the interrupt tables for housekeeping CPUs when tuning for low latency. Reducing the number of queues makes proper tuning possible. Smaller number of queues means a smaller number of interrupts that then fit in the IRQ table.
+
+[NOTE]
+====
+In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. 
+====

--- a/modules/cnf-running-the-performance-creator-profile-offline.adoc
+++ b/modules/cnf-running-the-performance-creator-profile-offline.adoc
@@ -252,7 +252,7 @@ spec:
 +
 [NOTE]
 ====
-Install the Performance Addon Operator before applying the profile.
+Install the Node Tuning Operator before applying the profile.
 ====
 
 +

--- a/modules/cnf-topology-aware-lifecycle-manager-about-cgu-crs.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-about-cgu-crs.adoc
@@ -76,7 +76,7 @@ spec:
   enable: false
   managedPolicies: <2>
   - policy1-common-cluster-version-policy
-  - policy2-common-pao-sub-policy
+  - policy2-common-nto-sub-policy
   remediationStrategy: <3>
     canaries: <4>
       - spoke1
@@ -90,18 +90,18 @@ status: <6>
     type: Ready
   copiedPolicies:
   - cgu-upgrade-complete-policy1-common-cluster-version-policy
-  - cgu-upgrade-complete-policy2-common-pao-sub-policy
+  - cgu-upgrade-complete-policy2-common-nto-sub-policy
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy
     namespace: default
-  - name: policy2-common-pao-sub-policy
+  - name: policy2-common-nto-sub-policy
     namespace: default
   placementBindings:
   - cgu-upgrade-complete-policy1-common-cluster-version-policy
-  - cgu-upgrade-complete-policy2-common-pao-sub-policy
+  - cgu-upgrade-complete-policy2-common-nto-sub-policy
   placementRules:
   - cgu-upgrade-complete-policy1-common-cluster-version-policy
-  - cgu-upgrade-complete-policy2-common-pao-sub-policy
+  - cgu-upgrade-complete-policy2-common-nto-sub-policy
   remediationPlan:
   - - spoke1
 ----
@@ -147,7 +147,7 @@ spec:
   enable: true <1>
   managedPolicies:
   - policy1-common-cluster-version-policy
-  - policy2-common-pao-sub-policy
+  - policy2-common-nto-sub-policy
   remediationStrategy:
     maxConcurrency: 1
     timeout: 240
@@ -159,18 +159,18 @@ status: <2>
     type: Ready
   copiedPolicies:
   - cgu-upgrade-complete-policy1-common-cluster-version-policy
-  - cgu-upgrade-complete-policy2-common-pao-sub-policy
+  - cgu-upgrade-complete-policy2-common-nto-sub-policy
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy
     namespace: default
-  - name: policy2-common-pao-sub-policy
+  - name: policy2-common-nto-sub-policy
     namespace: default
   placementBindings:
   - cgu-upgrade-complete-policy1-common-cluster-version-policy
-  - cgu-upgrade-complete-policy2-common-pao-sub-policy
+  - cgu-upgrade-complete-policy2-common-nto-sub-policy
   placementRules:
   - cgu-upgrade-complete-policy1-common-cluster-version-policy
-  - cgu-upgrade-complete-policy2-common-pao-sub-policy
+  - cgu-upgrade-complete-policy2-common-nto-sub-policy
   remediationPlan:
   - - spoke1
   status:
@@ -218,7 +218,7 @@ spec:
   enable: true
   managedPolicies:
   - policy1-common-cluster-version-policy
-  - policy2-common-pao-sub-policy
+  - policy2-common-nto-sub-policy
   remediationStrategy:
     maxConcurrency: 1
     timeout: 240
@@ -231,7 +231,7 @@ status: <2>
   managedPoliciesForUpgrade:
   - name: policy1-common-cluster-version-policy
     namespace: default
-  - name: policy2-common-pao-sub-policy
+  - name: policy2-common-nto-sub-policy
     namespace: default
   remediationPlan:
   - - spoke1

--- a/modules/cnf-topology-aware-lifecycle-manager-apply-policies.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-apply-policies.adoc
@@ -29,7 +29,7 @@ metadata:
 spec:
   managedPolicies: <1>
     - policy1-common-cluster-version-policy
-    - policy2-common-pao-sub-policy
+    - policy2-common-nto-sub-policy
     - policy3-common-ptp-sub-policy
     - policy4-common-sriov-sub-policy
   enable: false
@@ -93,13 +93,13 @@ $ oc get cgu -n default cgu-1 -ojsonpath='{.status}' | jq
   ],
   "copiedPolicies": [
     "cgu-policy1-common-cluster-version-policy",
-    "cgu-policy2-common-pao-sub-policy",
+    "cgu-policy2-common-nto-sub-policy",
     "cgu-policy3-common-ptp-sub-policy",
     "cgu-policy4-common-sriov-sub-policy"
   ],
   "managedPoliciesContent": {
     "policy1-common-cluster-version-policy": "null",
-    "policy2-common-pao-sub-policy": "[{\"kind\":\"Subscription\",\"name\":\"performance-addon-operator\",\"namespace\":\"openshift-performance-addon-operator\"}]",
+    "policy2-common-nto-sub-policy": "[{\"kind\":\"Subscription\",\"name\":\"node-tuning-operator\",\"namespace\":\"openshift-cluster-node-tuning-operator\"}]",
     "policy3-common-ptp-sub-policy": "[{\"kind\":\"Subscription\",\"name\":\"ptp-operator-subscription\",\"namespace\":\"openshift-ptp\"}]",
     "policy4-common-sriov-sub-policy": "[{\"kind\":\"Subscription\",\"name\":\"sriov-network-operator-subscription\",\"namespace\":\"openshift-sriov-network-operator\"}]"
   },
@@ -109,7 +109,7 @@ $ oc get cgu -n default cgu-1 -ojsonpath='{.status}' | jq
       "namespace": "default"
     },
     {
-      "name": "policy2-common-pao-sub-policy",
+      "name": "policy2-common-nto-sub-policy",
       "namespace": "default"
     },
     {
@@ -123,19 +123,19 @@ $ oc get cgu -n default cgu-1 -ojsonpath='{.status}' | jq
   ],
   "managedPoliciesNs": {
     "policy1-common-cluster-version-policy": "default",
-    "policy2-common-pao-sub-policy": "default",
+    "policy2-common-nto-sub-policy": "default",
     "policy3-common-ptp-sub-policy": "default",
     "policy4-common-sriov-sub-policy": "default"
   },
   "placementBindings": [
     "cgu-policy1-common-cluster-version-policy",
-    "cgu-policy2-common-pao-sub-policy",
+    "cgu-policy2-common-nto-sub-policy",
     "cgu-policy3-common-ptp-sub-policy",
     "cgu-policy4-common-sriov-sub-policy"
   ],
   "placementRules": [
     "cgu-policy1-common-cluster-version-policy",
-    "cgu-policy2-common-pao-sub-policy",
+    "cgu-policy2-common-nto-sub-policy",
     "cgu-policy3-common-ptp-sub-policy",
     "cgu-policy4-common-sriov-sub-policy"
   ],
@@ -169,11 +169,11 @@ $ oc get policies -A
 ----
 NAMESPACE   NAME                                                 REMEDIATION ACTION   COMPLIANCE STATE   AGE
 default     cgu-policy1-common-cluster-version-policy            enforce                                 17m <1>
-default     cgu-policy2-common-pao-sub-policy                    enforce                                 17m
+default     cgu-policy2-common-nto-sub-policy                    enforce                                 17m
 default     cgu-policy3-common-ptp-sub-policy                    enforce                                 17m
 default     cgu-policy4-common-sriov-sub-policy                  enforce                                 17m
 default     policy1-common-cluster-version-policy                inform               NonCompliant       15h
-default     policy2-common-pao-sub-policy                        inform               NonCompliant       15h
+default     policy2-common-nto-sub-policy                        inform               NonCompliant       15h
 default     policy3-common-ptp-sub-policy                        inform               NonCompliant       18m
 default     policy4-common-sriov-sub-policy                      inform               NonCompliant       18m
 ----
@@ -213,13 +213,13 @@ $ oc get cgu -n default cgu-1 -ojsonpath='{.status}' | jq
   ],
   "copiedPolicies": [
     "cgu-policy1-common-cluster-version-policy",
-    "cgu-policy2-common-pao-sub-policy",
+    "cgu-policy2-common-nto-sub-policy",
     "cgu-policy3-common-ptp-sub-policy",
     "cgu-policy4-common-sriov-sub-policy"
   ],
   "managedPoliciesContent": {
     "policy1-common-cluster-version-policy": "null",
-    "policy2-common-pao-sub-policy": "[{\"kind\":\"Subscription\",\"name\":\"performance-addon-operator\",\"namespace\":\"openshift-performance-addon-operator\"}]",
+    "policy2-common-nto-sub-policy": "[{\"kind\":\"Subscription\",\"name\":\"node-tuning-operator\",\"namespace\":\"openshift-cluster-node-tuning-operator\"}]",
     "policy3-common-ptp-sub-policy": "[{\"kind\":\"Subscription\",\"name\":\"ptp-operator-subscription\",\"namespace\":\"openshift-ptp\"}]",
     "policy4-common-sriov-sub-policy": "[{\"kind\":\"Subscription\",\"name\":\"sriov-network-operator-subscription\",\"namespace\":\"openshift-sriov-network-operator\"}]"
   },
@@ -229,7 +229,7 @@ $ oc get cgu -n default cgu-1 -ojsonpath='{.status}' | jq
       "namespace": "default"
     },
     {
-      "name": "policy2-common-pao-sub-policy",
+      "name": "policy2-common-nto-sub-policy",
       "namespace": "default"
     },
     {
@@ -243,19 +243,19 @@ $ oc get cgu -n default cgu-1 -ojsonpath='{.status}' | jq
   ],
   "managedPoliciesNs": {
     "policy1-common-cluster-version-policy": "default",
-    "policy2-common-pao-sub-policy": "default",
+    "policy2-common-nto-sub-policy": "default",
     "policy3-common-ptp-sub-policy": "default",
     "policy4-common-sriov-sub-policy": "default"
   },
   "placementBindings": [
     "cgu-policy1-common-cluster-version-policy",
-    "cgu-policy2-common-pao-sub-policy",
+    "cgu-policy2-common-nto-sub-policy",
     "cgu-policy3-common-ptp-sub-policy",
     "cgu-policy4-common-sriov-sub-policy"
   ],
   "placementRules": [
     "cgu-policy1-common-cluster-version-policy",
-    "cgu-policy2-common-pao-sub-policy",
+    "cgu-policy2-common-nto-sub-policy",
     "cgu-policy3-common-ptp-sub-policy",
     "cgu-policy4-common-sriov-sub-policy"
   ],

--- a/modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc
@@ -96,11 +96,6 @@ spec:
 ----
 
 .. Remove the specified subscriptions channels in the common `PolicyGenTemplate` CR, if they exist. The default subscriptions channels from the ZTP image are used for the update.
-+
-[NOTE]
-====
-The default channel for the Operators applied through ZTP 4.10 is `stable`, except for the `performance-addon-operator`. The default channel for PAO is `4.10`. You can also specify the default channels in the common `PolicyGenTemplate` CR.
-====
 
 .. Push the `PolicyGenTemplate` CRs updates to the ZTP Git repository.
 +

--- a/modules/cnf-topology-aware-lifecycle-manager-troubleshooting.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-troubleshooting.adoc
@@ -88,7 +88,7 @@ $ oc get cgu lab-upgrade -ojsonpath='{.spec.managedPolicies}'
 +
 [source,json]
 ----
-["group-du-sno-validator-du-validator-policy", "policy2-common-pao-sub-policy", "policy3-common-ptp-sub-policy"]
+["group-du-sno-validator-du-validator-policy", "policy2-common-nto-sub-policy", "policy3-common-ptp-sub-policy"]
 ----
 
 [discrete]
@@ -109,7 +109,7 @@ $ oc get policies --all-namespaces
 ----
 NAMESPACE   NAME                                                 REMEDIATION ACTION   COMPLIANCE STATE   AGE
 default     policy1-common-cluster-version-policy                inform               NonCompliant       5d21h
-default     policy2-common-pao-sub-policy                        inform               Compliant          5d21h
+default     policy2-common-nto-sub-policy                        inform               Compliant          5d21h
 default     policy3-common-ptp-sub-policy                        inform               NonCompliant       5d21h
 default     policy4-common-sriov-sub-policy                      inform               NonCompliant       5d21h
 ----
@@ -132,7 +132,7 @@ $ oc get policies --all-namespaces
 ----
 NAMESPACE   NAME                                                 REMEDIATION ACTION   COMPLIANCE STATE   AGE
 default     policy1-common-cluster-version-policy                inform               NonCompliant       5d21h
-default     policy2-common-pao-sub-policy                        inform               Compliant          5d21h
+default     policy2-common-nto-sub-policy                        inform               Compliant          5d21h
 default     policy3-common-ptp-sub-policy                        inform               NonCompliant       5d21h
 default     policy4-common-sriov-sub-policy                      inform               NonCompliant       5d21h
 ----

--- a/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
+++ b/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // Epic CNF-78 (4.4)
 // Epic CNF-422 (4.5)
-// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// scalability_and_performance/cnf-low-latency-tuning.adoc
 
 [id="cnf-tuning-nodes-for-low-latency-via-performanceprofile_{context}"]
 = Tuning nodes for low latency with the performance profile

--- a/modules/cnf-understanding-low-latency.adoc
+++ b/modules/cnf-understanding-low-latency.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 // Epic CNF-78 (4.4)
-// * scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// * scalability_and_performance/cnf-low-latency-tuning.adoc
 
 :_content-type: CONCEPT
 [id="cnf-understanding-low-latency_{context}"]

--- a/modules/cnf-understanding-workload-hints.adoc
+++ b/modules/cnf-understanding-workload-hints.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// scalability_and_performance/cnf-low-latency-tuning.adoc
 
 :_content-type: CONCEPT
 [id="cnf-understanding-workload-hints_{context}"]

--- a/modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc
+++ b/modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc
@@ -1,29 +1,29 @@
 // CNF-802 Infrastructure-provided interrupt processing for guaranteed pod CPUs
 // Module included in the following assemblies:
 //
-// *cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// *cnf-low-latency-tuning.adoc
 
 [id="use-device-interrupt-processing-for-isolated-cpus_{context}"]
 = Upgrading the performance profile to use device interrupt processing
 
-When you upgrade the Performance Addon Operator performance profile custom resource definition (CRD) from v1 or v1alpha1 to v2, `globallyDisableIrqLoadBalancing` is set to `true` on existing profiles.
+When you upgrade the Node Tuning Operator performance profile custom resource definition (CRD) from v1 or v1alpha1 to v2, `globallyDisableIrqLoadBalancing` is set to `true` on existing profiles.
 
 [NOTE]
 ====
 `globallyDisableIrqLoadBalancing` toggles whether IRQ load balancing will be disabled for the Isolated CPU set. When the option is set to `true` it disables IRQ load balancing for the Isolated CPU set. Setting the option to `false` allows the IRQs to be balanced across all CPUs.
 ====
 
-[id="pao_supported_api_versions_{context}"]
+[id="nto_supported_api_versions_{context}"]
 == Supported API Versions
 
-The Performance Addon Operator supports `v2`, `v1`, and `v1alpha1` for the performance profile `apiVersion` field. The v1 and v1alpha1 APIs are identical. The v2 API includes an optional boolean field `globallyDisableIrqLoadBalancing` with a default value of `false`.
+The Node Tuning Operator supports `v2`, `v1`, and `v1alpha1` for the performance profile `apiVersion` field. The v1 and v1alpha1 APIs are identical. The v2 API includes an optional boolean field `globallyDisableIrqLoadBalancing` with a default value of `false`.
 
-[id="upgrading_pao_api_from_v1alpha1_to_v1_{context}"]
-=== Upgrading Performance Addon Operator API from v1alpha1 to v1
+[id="upgrading_nto_api_from_v1alpha1_to_v1_{context}"]
+=== Upgrading Node Tuning Operator API from v1alpha1 to v1
 
-When upgrading Performance Addon Operator API version from v1alpha1 to v1, the v1alpha1 performance profiles are converted on-the-fly using a "None" Conversion strategy and served to the Performance Addon Operator with API version v1.
+When upgrading Node Tuning Operator API version from v1alpha1 to v1, the v1alpha1 performance profiles are converted on-the-fly using a "None" Conversion strategy and served to the Node Tuning Operator with API version v1.
 
-[id="upgrading_pao_api_from_v1alpha1_to_v1_or_v2_{context}"]
-=== Upgrading Performance Addon Operator API from v1alpha1 or v1 to v2
+[id="upgrading_nto_api_from_v1alpha1_to_v1_or_v2_{context}"]
+=== Upgrading Node Tuning Operator API from v1alpha1 or v1 to v2
 
-When upgrading from an older Performance Addon Operator API version, the existing v1 and v1alpha1 performance profiles are converted using a conversion webhook that injects the `globallyDisableIrqLoadBalancing` field with a value of `true`.
+When upgrading from an older Node Tuning Operator API version, the existing v1 and v1alpha1 performance profiles are converted using a conversion webhook that injects the `globallyDisableIrqLoadBalancing` field with a value of `true`.

--- a/modules/cnf-verifying-queue-status.adoc
+++ b/modules/cnf-verifying-queue-status.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //CNF-1483 (4.8)
-// * scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// * scalability_and_performance/cnf-low-latency-tuning.adoc
 
 [id="verifying-queue-status_{context}"]
 = Verifying the queue status

--- a/modules/configuring_hyperthreading_for_a_cluster.adoc
+++ b/modules/configuring_hyperthreading_for_a_cluster.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+// scalability_and_performance/cnf-low-latency-tuning.adoc
 
 :_content-type: PROCEDURE
 [id="configuring_hyperthreading_for_a_cluster_{context}"]

--- a/modules/ztp-generating-ran-policies.adoc
+++ b/modules/ztp-generating-ran-policies.adoc
@@ -55,10 +55,10 @@ out
 │   ├── common-log-sub-ns-policy.yaml
 │   ├── common-log-sub-oper-policy.yaml
 │   ├── common-log-sub-policy.yaml
-│   ├── common-pao-sub-catalog-policy.yaml
-│   ├── common-pao-sub-ns-policy.yaml
-│   ├── common-pao-sub-oper-policy.yaml
-│   ├── common-pao-sub-policy.yaml
+│   ├── common-nto-sub-catalog-policy.yaml
+│   ├── common-nto-sub-ns-policy.yaml
+│   ├── common-nto-sub-oper-policy.yaml
+│   ├── common-nto-sub-policy.yaml
 │   ├── common-policies-placementbinding.yaml
 │   ├── common-policies-placementrule.yaml
 │   ├── common-ptp-sub-ns-policy.yaml

--- a/networking/hardware_networks/using-dpdk-and-rdma.adoc
+++ b/networking/hardware_networks/using-dpdk-and-rdma.adoc
@@ -45,7 +45,7 @@ include::modules/nw-openstack-hw-offload-testpmd-pod.adoc[leveloffset=+1]
 
 * xref:../../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-about-the-profile-creator-tool_cnf-create-performance-profiles[Creating a performance profile]
 * xref:../../scalability_and_performance/cnf-low-latency-tuning.adoc#adjusting-nic-queues-with-the-performance-profile_cnf-master[Reducing NIC queues using the Node Tuning Operator]
-* xref:../../scalability_and_performance/cnf-low-latency-tuning.adoc#performance-addon-operator-provisioning-worker-with-real-time-capabilities_cnf-master[Provisioning a worker with real-time capabilities]
+* xref:../../scalability_and_performance/cnf-low-latency-tuning.adoc#node-tuning-operator-provisioning-worker-with-real-time-capabilities_cnf-master[Provisioning a worker with real-time capabilities]
 * xref:../../networking/hardware_networks/installing-sriov-operator.adoc#installing-sr-iov-operator_installing-sriov-operator[Installing the SR-IOV Network Operator]
 * xref:../../networking/hardware_networks/configuring-sriov-device.adoc#nw-sriov-networknodepolicy-object_configuring-sriov-device[Configuring an SR-IOV network device]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-whereabouts_configuring-additional-network[Dynamic IP address assignment configuration with Whereabouts]

--- a/scalability_and_performance/cnf-low-latency-tuning.adoc
+++ b/scalability_and_performance/cnf-low-latency-tuning.adoc
@@ -54,7 +54,7 @@ include::modules/cnf-cpu-infra-container.adoc[leveloffset=+2]
 
 * link:https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed[Create a pod that gets assigned a QoS class of Guaranteed]
 
-include::modules/cnf-reducing-netqueues-using-pao.adoc[leveloffset=+1]
+include::modules/cnf-reducing-netqueues-using-nto.adoc[leveloffset=+1]
 
 include::modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc[leveloffset=+2]
 

--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -253,7 +253,7 @@ The following table is a summary of the feature availability in {oke} and {produ
 | Kube Descheduler Operator provided by Red Hat | Included | Included | Kube Descheduler Operator
 | Local Storage provided by Red Hat | Included | Included | Local Storage Operator
 | Node Feature Discovery provided by Red Hat | Included | Included | Node Feature Discovery Operator
-| Performance Add-on Operator | Included | Included | Performance Add-on Operator
+| Performance Profile controller | Included | Included | N/A
 | PTP Operator provided by Red Hat | Included | Included | PTP Operator
 | Service Telemetry Operator provided by Red Hat | Included | Included | Service Telemetry Operator
 | SR-IOV Network Operator | Included | Included | SR-IOV Network Operator


### PR DESCRIPTION
TELCODOCS#809: Final sweep of the docs to remove any remaining references to Performance Addon Operator. The functions of this Operator is replaced by the Node Tuning Operator. Also renaming IDs, file names and comments relating to parent assemblies that reference PAO. 

FYI - a related PR: https://github.com/openshift/openshift-docs/pull/44823 Aidan Reilly reworking one of the sections with many references to PAO. My PR will most likely go first. 

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/TELCODOCS-809

Link to docs preview:
NOTE: I only added a preview link for changes to content in modules. I didn't add a preview link for changes to commented content at the beginning of modules that identifies in which assembly a module features, or for changes to IDs.

* modules/cnf-about-the-profile-creator-tool.adoc:
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-create-performance-profiles.html#cnf-about-the-profile-creator-tool_cnf-create-performance-profiles
* modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-low-latency-tuning.html#adjusting-nic-queues-with-the-performance-profile_cnf-master
* modules/cnf-allocating-multiple-huge-page-sizes.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-low-latency-tuning.html#cnf-allocating-multiple-huge-page-sizes_cnf-master
* modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-low-latency-tuning.html#cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support_cnf-master
* modules/cnf-configuring-huge-pages.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-low-latency-tuning.html#cnf-configuring-huge-pages_cnf-master
* modules/cnf-debugging-low-latency-cnf-tuning-status.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-low-latency-tuning.html#cnf-debugging-low-latency-cnf-tuning-status_cnf-master
* modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-create-performance-profiles.html#gathering-data-about-your-cluster-using-must-gather_cnf-create-performance-profiles
* modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-low-latency-tuning.html#managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus_cnf-master
* modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-low-latency-tuning.html#cnf-performing-end-to-end-tests-for-platform-verification_cnf-master
* modules/cnf-reducing-netqueues-using-nto.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-low-latency-tuning.html#reducing-nic-queues-using-the-node-tuning-operator_cnf-master
* modules/cnf-running-the-performance-creator-profile-offline.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-create-performance-profiles.html#running-the-performance-profile-creator-wrapper-script_cnf-create-performance-profiles
* modules/cnf-topology-aware-lifecycle-manager-about-cgu-crs.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-talm-for-cluster-upgrades.html#talo-about-cgu-crs_cnf-topology-aware-lifecycle-manager
* modules/cnf-topology-aware-lifecycle-manager-apply-policies.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-talm-for-cluster-upgrades.html#talo-apply-policies_cnf-topology-aware-lifecycle-manager
* modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/ztp-deploying-disconnected.html#talo-operator-update_ztp-deploying-disconnected
* modules/cnf-topology-aware-lifecycle-manager-troubleshooting.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-talm-for-cluster-upgrades.html#talo-troubleshooting-managed-policies_cnf-topology-aware-lifecycle-manager
* modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-low-latency-tuning.html#use-device-interrupt-processing-for-isolated-cpus_cnf-master
* modules/ztp-generating-ran-policies.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/ztp-deploying-disconnected.html#ztp-generating-ran-policies_ztp-deploying-disconnected
* networking/hardware_networks/using-dpdk-and-rdma.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/networking/hardware_networks/using-dpdk-and-rdma.html#additional-resources_using-dpdk-and-rdma
* openshift_images/cnf-building-and-deploying-a-dpdk-payload.adoc

* scalability_and_performance/cnf-low-latency-tuning.adoc
http://file.emea.redhat.com/rohennes/TELCODOCS-809-PAO-cleanup/scalability_and_performance/cnf-low-latency-tuning.html






