### PR TITLE
OSDOCS-3842: Adding deprecation for RHEL 7 support with oc

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1475,6 +1475,11 @@ As an alternative, users can navigate to the *Observe* section of the {product-t
 In {product-title} 4.10, persistent storage using FlexVolume is deprecated. This feature is still fully supported, but only important bugs will be fixed. However, it may be removed in a future {product-title} release.
 Out-of-tree Container Storage Interface (CSI) driver is the recommended way to write volume drivers in {product-title}. Maintainers of FlexVolume drivers should implement a CSI driver and move users of FlexVolume to CSI. Users of FlexVolume should move their workloads to CSI driver.
 
+[id="ocp-4-10-deprecated-oc-rhel7"]
+==== {op-system-base} 7 support for the OpenShift CLI (oc) is deprecated
+
+Support for using {op-system-base-full} 7 with the OpenShift CLI (`oc`) is deprecated and will be removed in a future {product-title} release.
+
 [id="ocp-4-10-removed-features"]
 === Removed features
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OSDOCS-3842

Link to docs preview:
http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3842/release_notes/ocp-4-10-release-notes.html#ocp-4-10-deprecated-oc-rhel7


