### PR TITLE
New heading for MCO release note

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -436,10 +436,10 @@ The Machine Config Operator (MCO) now updates the affected nodes alphabetically 
 
 For more information, see xref:../post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks[Machine config overview].
 
-[id="ocp-4-11-mco-signer-ca-alert"]
-==== New alert if MCO cannot update the signer CA on a paused node
+[id="ocp-4-11-mco-enhanced-notification"]
+==== Enhanced notification for paused Machine Config Pools upon certificate renewal
 
-You will now receive alerts in the Alerting UI of the {product-title} web console if the MCO attempts to renew an expired `kube-apiserver-to-kubelet-signer` CA certificate on a Machine Config Pool (MCP) that is paused. If the MCPs are paused, the MCO cannot push the newly rotated certificates to those nodes, which can result in failures.
+You will now receive alerts in the Alerting UI of the {product-title} web console if the MCO attempts to renew an expired `kube-apiserver-to-kubelet-signer` CA certificate on a machine config pool (MCP) that is paused. If the MCPs are paused, the MCO cannot push the newly rotated certificates to those nodes, which can result in failures.
 
 For more information, see xref:../updating/update-using-custom-machine-config-pools.html#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools[Pausing the machine config pools].
 


### PR DESCRIPTION
I noticed that I wrote the [release note for this feature previously](https://github.com/openshift/openshift-docs/pull/45855/files#diff-c77c0cbc134fbd6d7bfb05509f65f4077fbbe88a6ce62ddafb44edc35e479f26R132) but forgot. I just merged a [different PR for this relase note](https://github.com/openshift/openshift-docs/pull/47929/files#diff-c77c0cbc134fbd6d7bfb05509f65f4077fbbe88a6ce62ddafb44edc35e479f26R440). 

I like the previous heading better. 