### PR TITLE
OCPNODE-638: Kubelet-Controller Manager communication Profiles (WorkerLatencyProfiles) Add to Edge docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2257,6 +2257,9 @@ Topics:
 - Name: Low latency tuning
   File: cnf-low-latency-tuning
   Distros: openshift-origin,openshift-enterprise
+- Name: Improving cluster stability in high latency environments using worker latency profiles
+  File: scaling-worker-latency-profiles
+  Distros: openshift-origin,openshift-enterprise
 - Name: Creating a performance profile
   File: cnf-create-performance-profiles
   Distros: openshift-origin,openshift-enterprise

--- a/nodes/edge/nodes-edge-remote-workers.adoc
+++ b/nodes/edge/nodes-edge-remote-workers.adoc
@@ -17,7 +17,7 @@ However, having remote worker nodes can introduce higher latency, intermittent l
 
 * *Power outage*: Because the control plane and remote worker nodes are in separate locations, a power outage at the remote location or at any point between the two can negatively impact your cluster. See xref:../../nodes/edge/nodes-edge-remote-workers.adoc#nodes-edge-remote-workers-power_nodes-edge-remote-workers[Power loss on remote worker nodes] for information on how {product-title} responds to a node losing power and for methods to diminish the impact to your cluster.
 
-* *Latency spikes or temporary reduction in throughput*: As with any network, any changes in network conditions between your cluster and the remote worker nodes can negatively impact your cluster. These types of situations are beyond the scope of this documentation.
+* *Latency spikes or temporary reduction in throughput*: As with any network, any changes in network conditions between your cluster and the remote worker nodes can negatively impact your cluster. {product-title} offers multiple _worker latency profiles_ that let you control the reaction of the cluster to latency issues. 
 
 Note the following limitations when planning a cluster with remote worker nodes:
 
@@ -36,6 +36,15 @@ For more information on using these objects in a cluster with remote worker node
 include::modules/nodes-edge-remote-workers-power.adoc[leveloffset=+1]
 
 For more information on using these objects in a cluster with remote worker nodes, see xref:../../nodes/edge/nodes-edge-remote-workers.html#nodes-edge-remote-workers-strategies_nodes-edge-remote-workers[About remote worker node strategies].
+
+[id="nodes-edge-remote-workers-latency"]
+== Latency spikes or temporary reduction in throughput to remote workers
+
+include::snippets/worker-latency-profile-intro.adoc[]
+
+.Additional resources
+
+* xref:../../nodes/clusters/nodes-cluster-worker-latency-profiles.adoc#nodes-cluster-worker-latency-profiles[Improving cluster stability in high latency environments using worker latency profiles ]
 
 include::modules/nodes-edge-remote-workers-strategies.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/optimizing-networking.adoc
+++ b/scalability_and_performance/optimizing-networking.adoc
@@ -32,8 +32,10 @@ include::modules/recommended-install-practices.adoc[leveloffset=+1]
 include::modules/ipsec-impact-networking.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="optimizing-networking-additional-resources"]
+== Additional resources
 
 * xref:../installing/installing_aws/installing-aws-network-customizations.adoc#modifying-nwoperator-config-startup_installing-aws-network-customizations[Modifying advanced network configuration parameters]
 * xref:../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes default CNI network provider]
 * xref:../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-openshift-sdn_cluster-network-operator[Configuration parameters for the OpenShift SDN default CNI network provider]
+* xref:../scalability_and_performance/scaling-worker-latency-profiles.adoc#scaling-worker-latency-profiles[Improving cluster stability in high latency environments using worker latency profiles]

--- a/scalability_and_performance/scaling-worker-latency-profiles.adoc
+++ b/scalability_and_performance/scaling-worker-latency-profiles.adoc
@@ -1,0 +1,26 @@
+:_content-type: ASSEMBLY
+:context: scaling-worker-latency-profiles
+[id="scaling-worker-latency-profiles"]
+= Improving cluster stability in high latency environments using worker latency profiles  
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+
+
+// The following include statements pull in the module files that comprise
+// the assembly. Include any combination of concept, procedure, or reference
+// modules required to cover the user story. You can also include other
+// assemblies.
+
+
+include::snippets/worker-latency-profile-intro.adoc[]
+
+These worker latency profiles are three sets of parameters that are pre-defined with carefully tuned values that control the reaction of the cluster to latency issues  without your needing to determine the best values manually.  
+
+You can configure worker latency profiles when installing a cluster or at any time you notice increased latency in your cluster network.
+
+include::modules/nodes-cluster-worker-latency-profiles-about.adoc[leveloffset=+1]
+
+include::modules/nodes-cluster-worker-latency-profiles-using.adoc[leveloffset=+1]
+


### PR DESCRIPTION
Add [Worker Latency Profiles](https://github.com/openshift/openshift-docs/pull/47612) to other assemblies.

Network edge -> [Latency spikes or temporary reduction in throughput to remote workers](http://file.rdu.redhat.com/mburke/nodes-workerlatencyprofile-edge/nodes/edge/nodes-edge-remote-workers.html#nodes-edge-remote-workers-latency). Editied an existing module and linked to _Nodes_ -> _Clusters_ ->_Improving cluster stability in high latency environments using worker latency profiles_

Scalability and Performance -> [Improving cluster stability in high latency environments using worker latency profiles](http://file.rdu.redhat.com/~mburke/nodes-workerlatencyprofile-edge/scalability_and_performance/scaling-worker-latency-profiles.html). New module that  is identical to the one in Nodes


