### PR TITLE
guidance on commenting out callouts in multi-line commands

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1039,6 +1039,24 @@ $ oc adm create-error-template > errors.html
 ----
 ....
 
+* If your command contains multiple lines and uses callout annotations, you must comment out the callout(s) in the codeblock, as shown in the following example:
++
+....
+To scale based on the percent of CPU utilization, create a `HorizontalPodAutoscaler` object for an existing object:
+
+[source,terminal]
+----
+$ oc autoscale <object_type>/<name> \// <1>
+  --min <number> \// <2>
+  --max <number> \// <3>
+  --cpu-percent=<percent> <4>
+----
+<1> Specify the type and name of the object to autoscale.
+<2> Optional: Specify the minimum number of replicas when scaling down.
+<3> Specify the maximum number of replicas when scaling up.
+<4> Specify the target average CPU utilization over all the pods, represented as a percent of requested CPU.
+....
+
 * Separate a command and its related example output into individual code blocks.
 This allows the command to be easily copied using the button on
 +++docs.openshift.com+++.


### PR DESCRIPTION
This came up in Slack. [Here's](https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/#copy-and-paste-friendly-callouts ) the reasoning behind it.