### PR TITLE
OSDOCS-3834: Adding ap-southeast-3 to support AWS regions

### DIFF
--- a/modules/installation-aws-regions.adoc
+++ b/modules/installation-aws-regions.adoc
@@ -25,6 +25,7 @@ The following AWS public regions are supported:
 * `ap-south-1` (Mumbai)
 * `ap-southeast-1` (Singapore)
 * `ap-southeast-2` (Sydney)
+* `ap-southeast-3` (Jakarta)
 * `ca-central-1` (Central)
 * `eu-central-1` (Frankfurt)
 * `eu-north-1` (Stockholm)


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR addresses [osdocs-3834](https://issues.redhat.com/browse/OSDOCS-3844)

Link to docs preview:
[AWS public regions](http://file.rdu.redhat.com/mpytlak/AWSRegion/installing/installing_aws/installing-aws-account.html#installation-aws-public_installing-aws-account)
