### PR TITLE
[SDN-2585]: Configure multiple worker and controller for initial configurations

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -48,6 +48,8 @@ include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-
 
 * xref:../../release_notes/ocp-4-11-release-notes.adoc#ocp-4-11-known-issues[OpenShift Container Platform 4.11 release notes]
 
+include::modules/ipi-install-configure-multiple-cluster-nodes.adoc[leveloffset=+2]
+
 include::modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc[leveloffset=+2]
 
 [id="ipi-install-manifest-configuration-files"]

--- a/modules/ipi-install-configure-multiple-cluster-nodes.adoc
+++ b/modules/ipi-install-configure-multiple-cluster-nodes.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+
+:_content-type: CONCEPT
+[id="ipi-install-configure-multiple-cluster-nodes_{context}"]
+= Configuring multiple cluster nodes
+
+You can simultaneously configure {product-title} cluster nodes with identical settings. Configuring multiple cluster nodes avoids adding redundant information for each node to the `install-config.yaml` file. This file contains specific parameters to apply an identical configuration to multiple nodes in the cluster.
+
+Compute nodes are configured separately from the controller node. However, configurations for both node types use the highlighted parameters in the `install-config.yaml` file to enable multi-node configuration. Set the `networkConfig` parameters to `BOND`, as shown in the following example:
+
+[source,yaml]
+----
+hosts:
+- name: ostest-master-0
+ [...]
+ networkConfig: &BOND
+   interfaces:
+   - name: bond0
+     type: bond
+     state: up
+     ipv4:
+       dhcp: true
+       enabled: true
+     link-aggregation:
+       mode: active-backup
+       port:
+       - enp2s0
+       - enp3s0
+- name: ostest-master-1
+ [...]
+ networkConfig: *BOND
+- name: ostest-master-2
+ [...]
+ networkConfig: *BOND
+----
+
+NOTE: Configuration of multiple cluster nodes is only available for initial deployments on installer-provisioned infrastructure.


### PR DESCRIPTION
Epic: [SDN-2585](https://issues.redhat.com/browse/SDN-2585)
[OSDOCS-3824](https://issues.redhat.com/browse/OSDOCS-3824)

Version(s): 4.10 +

(Updated 7/26) Link to docs preview: http://file.rdu.redhat.com/tlove/sdn2585-411-doc-update/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-configure-multiple-cluster-nodes_ipi-install-installation-workflow


  

