### PR TITLE
[TELCODOCS-443] PTP 4.11 tech preview note - PTP dual NIC as boundary clock feature

### DIFF
--- a/modules/ptp-configuring-linuxptp-services-as-boundary-clock-dual-nic.adoc
+++ b/modules/ptp-configuring-linuxptp-services-as-boundary-clock-dual-nic.adoc
@@ -6,6 +6,9 @@
 [id="ptp-configuring-linuxptp-services-as-bc-for-dual-nic_{context}"]
 = Configuring linuxptp services as boundary clocks for dual NIC hardware
 
+:FeatureName: Precision Time Protocol (PTP) hardware with dual NIC configured as boundary clocks
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
 You can configure the `linuxptp` services (`ptp4l`, `phc2sys`) as boundary clocks for dual NIC hardware by creating a `PtpConfig` custom resource (CR) object for each NIC.
 
 Dual NIC hardware allows you to connect each NIC to the same upstream leader clock with separate `ptp4l` instances for each NIC feeding the downstream clocks.

--- a/networking/using-ptp.adoc
+++ b/networking/using-ptp.adoc
@@ -6,18 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Precision Time Protocol (PTP) hardware with single NIC configured as boundary clock
-include::snippets/technology-preview.adoc[leveloffset=+1]
+You can configure `linuxptp` services and use PTP-capable hardware in {product-title} cluster nodes.
 
 [id="about-using-ptp-hardware"]
 == About PTP hardware
-
-You can configure `linuxptp` services and use PTP-capable hardware in {product-title} cluster nodes.
-
-[NOTE]
-====
-The PTP Operator works with PTP-capable devices on clusters provisioned only on bare-metal infrastructure.
-====
 
 You can use the {product-title} console or OpenShift CLI (`oc`) to install PTP by deploying the PTP Operator. The PTP Operator creates and manages the `linuxptp` services and provides the following features:
 
@@ -26,6 +18,11 @@ You can use the {product-title} console or OpenShift CLI (`oc`) to install PTP b
 * Management of the configuration of `linuxptp` services.
 
 * Notification of PTP clock events that negatively affect the performance and reliability of your application with the PTP Operator `cloud-event-proxy` sidecar.
+
+[NOTE]
+====
+The PTP Operator works with PTP-capable devices on clusters provisioned only on bare-metal infrastructure.
+====
 
 include::modules/nw-ptp-introduction.adoc[leveloffset=+1]
 
@@ -66,9 +63,6 @@ include::modules/cnf-configuring-fifo-priority-scheduling-for-ptp.adoc[leveloffs
 include::modules/cnf-troubleshooting-common-ptp-operator-issues.adoc[leveloffset=+1]
 
 == PTP hardware fast event notifications framework
-
-:FeatureName: PTP events with ordinary clock
-include::snippets/technology-preview.adoc[leveloffset=+2]
 
 include::modules/cnf-about-ptp-and-clock-synchronization.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Updates PTP tech preview notes for PTP 4.11. Adding a TP note for dual NIC as boundary clock feature.

Version(s):
main, enterprise-4.11

Preview: http://file.emea.redhat.com/aireilly/update-ptp-tp-notes/networking/using-ptp.html#ptp-configuring-linuxptp-services-as-bc-for-dual-nic_using-ptp
