### PR TITLE
Removing example numbering from module headings

### DIFF
--- a/modules/nw-metallb-advertise-address-pool-with-bgp-advanced.adoc
+++ b/modules/nw-metallb-advertise-address-pool-with-bgp-advanced.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="nw-metallb-advertise-an-advanced-address-pool-configuration-bgp_{context}"]
-= Example 2: Advertise an advanced address pool configuration with BGP
+= Example: Advertise an advanced address pool configuration with BGP
 
 Configure MetalLB as follows so that the `IPAddressPool` is advertised with the BGP protocol.
 

--- a/modules/nw-metallb-advertise-address-pool-with-bgp.adoc
+++ b/modules/nw-metallb-advertise-address-pool-with-bgp.adoc
@@ -5,7 +5,7 @@
 :_content-type: PROCEDURE
 
 [id="nw-metallb-advertise-a-basic-address-pool-configuration-bgp_{context}"]
-= Example 1: Advertise a basic address pool configuration with BGP
+= Example: Advertise a basic address pool configuration with BGP
 
 Configure MetalLB as follows so that the `IPAddressPool` is advertised with the BGP protocol.
 


### PR DESCRIPTION
This applies to `main` and `enterprise-4.11` only.

The PR relates to https://github.com/openshift/openshift-docs/pull/45516/. I thought of one small nit after I reviewed and merged that PR. The "Example 1:" and "Example 2:" headings could become just "Example:", in case the modules are used elsewhere in the future and to be consistent with example headings in one of the other assemblies previewed in PR 45516.

The preview is [here](http://file.fab.redhat.com/pneedle/pr47990/about-advertising-ipaddresspool.html).