### PR TITLE
[RHACS] Update variable for release 3.71.0

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -44,11 +44,11 @@ endif::[]
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 3.68.2
+:rhacs-version: 3.71.0
 :ocp-supported-version: 4.5
 // Following are used in modules/configure-policy-notifications.adoc
 :toolname: PagerDuty
 // Following variables are required for publishing using PV2
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
-:product-version: 3.70
+:product-version: 3.71
 :product-title-short: RHACS


### PR DESCRIPTION
Versions:
`rhacs-docs-3.71.0`

Label: `RHACS/next`

Issue: none

[Preview link](https://openshift-docs-my92odhvy-kcarmichael08.vercel.app/openshift-acs/master/installing/install-quick-roxctl.html#installing-cli-on-linux_install-quick-roxctl) (example of doc where this variable shows up) 
