### PR TITLE
Remove obsolete RHV workaround

### DIFF
--- a/virt/virt-4-11-release-notes.adoc
+++ b/virt/virt-4-11-release-notes.adoc
@@ -206,15 +206,6 @@ $ oc annotate --overwrite -n openshift-cnv hyperconverged kubevirt-hyperconverge
 ----
 <1> Replace `<cpu_model>` with the actual CPU model value. You can determine this value by running `oc describe node <node>` for all nodes and looking at the `cpu-model-<name>` labels. Select the CPU model that is present on all of your nodes.
 
-* If you enter the wrong credentials for the RHV Manager while importing a RHV VM, the Manager might lock the admin user account because the `vm-import-operator` tries repeatedly to connect to the RHV API. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1887140[*BZ#1887140*])
-+
-** To unlock the account, log in to the Manager and enter the following command:
-+
-[source,terminal]
-----
-$ ovirt-aaa-jdbc-tool user unlock admin
-----
-
 * If you run {VirtProductName} 2.6.5 with {product-title} 4.8 or later, various issues occur. You can avoid these issues by upgrading {VirtProductName} to version 4.8 or later.
 +
 ** In the web console, if you navigate to the *Virtualization* page and select *Create* -> *With YAML* the following error message is displayed:


### PR DESCRIPTION
No Jira or BZ. 

Removing obsolete RHV workaround from CNV 4.11 RN.