### PR TITLE
BZ#2095782 [enterprise-4.10] - Fix tx_timestamp_timeout Value in PTP Documentation for e810

### DIFF
--- a/modules/cnf-configuring-cvl-nic-as-oc.adoc
+++ b/modules/cnf-configuring-cvl-nic-as-oc.adoc
@@ -85,7 +85,7 @@ spec:
       inhibit_multicast_service 0
       net_sync_monitor 0
       tc_spanning_tree 0
-      tx_timestamp_timeout 10
+      tx_timestamp_timeout 50
       unicast_listen 0
       unicast_master_table 0
       unicast_req_duration 3600

--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -84,7 +84,7 @@ spec:
       inhibit_multicast_service  0
       net_sync_monitor           0
       tc_spanning_tree           0
-      tx_timestamp_timeout       10
+      tx_timestamp_timeout       50
       #was 1 (default !)
       unicast_listen          0
       unicast_master_table  0
@@ -132,7 +132,7 @@ spec:
       delay_filter_length  10
       egressLatency          0
       ingressLatency         0
-      boundary_clock_jbod  1
+      boundary_clock_jbod  0
       #
       # Clock description
       #

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -81,7 +81,7 @@ spec:
       inhibit_multicast_service 0
       net_sync_monitor 0
       tc_spanning_tree 0
-      tx_timestamp_timeout 1
+      tx_timestamp_timeout 50
       unicast_listen 0
       unicast_master_table 0
       unicast_req_duration 3600


### PR DESCRIPTION
Fixes tx_timestamp_timeout Value in PTP Documentation for e810

Version(s):
Merge to enterprise-4.10 only. 

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2095782

Link to docs preview:
http://file.emea.redhat.com/aireilly/BZ2095782/networking/using-ptp.html#cnf-configuring-cvl-nic-as-ptp-slave_using-ptp