### PR TITLE
GH#47998: Remove SR-IOV from the live migration requirements

### DIFF
--- a/modules/virt-about-live-migration.adoc
+++ b/modules/virt-about-live-migration.adoc
@@ -11,10 +11,6 @@ Live migration is the process of moving a running virtual machine instance (VMI)
 
 You can use live migration if the following conditions are met:
 
-* Virtual machines must have a persistent volume claim (PVC) with a shared `ReadWriteMany` (RWX) access mode to be live migrated.
-
-* The pod network binding must not be of the bridge interface type `()`.
-
-* Live migration is supported for virtual machines that are attached to an SR-IOV network interface.
-
-* If the virtual machine uses a host model CPU, live migration is supported only between nodes that support the virtual machine's host model CPU.
+* Shared storage with `ReadWriteMany` (RWX) access mode.
+* Sufficient RAM and network bandwidth.
+* If the virtual machine uses a host model CPU, the nodes must support the virtual machine's host model CPU.

--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -32,9 +32,9 @@ include::modules/virt-hardware-os-requirements.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../architecture/architecture-rhcos.adoc#rhcos-about_architecture-rhcos[About RHCOS]
-* link:https://catalog.redhat.com[Red Hat Ecosystem Catalog] for supported CPUs
-* xref:../../storage/index.adoc#storage-overview[Supported storage]
+* xref:../../architecture/architecture-rhcos.adoc#rhcos-about_architecture-rhcos[About RHCOS].
+* link:https://catalog.redhat.com[Red Hat Ecosystem Catalog] for supported CPUs.
+* xref:../../storage/index.adoc#storage-overview[Supported storage].
 
 include::modules/virt-cluster-resource-requirements.adoc[leveloffset=+1]
 
@@ -43,8 +43,8 @@ include::modules/virt-cluster-resource-requirements.adoc[leveloffset=+1]
 
 You must consider the following tested object maximums when planning your cluster:
 
-* xref:../../scalability_and_performance/planning-your-environment-according-to-object-maximums.html#planning-your-environment-according-to-object-maximums[{product-title} object maximums]
-* link:https://access.redhat.com/articles/6571671[{VirtProductName} object maximums]
+* xref:../../scalability_and_performance/planning-your-environment-according-to-object-maximums.html#planning-your-environment-according-to-object-maximums[{product-title} object maximums].
+* link:https://access.redhat.com/articles/6571671[{VirtProductName} object maximums].
 
 [id="restricted-networks-environments_{context}"]
 == Restricted network environments
@@ -58,9 +58,9 @@ If you have limited internet connectivity, you can xref:../../operators/admin/ol
 
 Live migration has the following requirements:
 
-* Shared storage with `ReadWriteMany` (RWX) access mode
-* Sufficient RAM and network bandwidth
-* Appropriate CPUs with sufficient capacity on the worker nodes. If the CPUs have different capacities, live migration might be very slow or fail.
+* Shared storage with `ReadWriteMany` (RWX) access mode.
+* Sufficient RAM and network bandwidth.
+* If the virtual machine uses a host model CPU, the nodes must support the virtual machine's host model CPU.
 
 [id="snapshots-and-cloning_{context}"]
 == Snapshots and cloning


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to.

Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: [GH#47998](https://github.com/openshift/openshift-docs/issues/47998)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

* [Preparing your cluster: Live migration](http://file.tlv.redhat.com/apinnick/issue47998-remove-sriov-live-migration/virt/install/preparing-cluster-for-virt.html#live-migration_preparing-cluster-for-virt)

* [About live migration](http://file.tlv.redhat.com/apinnick/issue47998-remove-sriov-live-migration/virt/live_migration/virt-live-migration.html#virt-about-live-migration_virt-live-migration)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
