### PR TITLE
[TELCODOCS-793] - Telco RAN 4.11 GA preview known issues

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1396,6 +1396,55 @@ This script removes unauthenticated subjects from the following cluster role bin
 
 * The oc-mirror CLI plug-in can fail to upload an image set to the target mirror registry if the `archiveSize` value in the image set configuration is smaller than the container image size, causing the catalog directory to span multiple archives. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2106461[*BZ#2106461*])
 
+[id="ocp-4-11-ran-ga-known-issues"]
+* When a master NIC interface in a node with a dual NIC PTP configuration is shut down, all the NIC interfaces are incorrectly set as faulty. A faulty event is generated for all interfaces.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2091599[*BZ#2091599*])
+
+* For RAN vDU deployments, when the PTP Operator is deployed by the ZTP pipeline, the `network-transport` field in the `PtpConfig` CR is incorrectly set to `UDPv4`. The correct value is `L2`.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2060492[*BZ#2060492*])
+
+* In RAN vDU deployments, PTP is used instead of NTP. In order to use PTP in the cluster, you must disable NTP. Currently, this is done using an additional `MachineConfig` CR to disable `chronyd` in the cluster.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2058231[*BZ#2058231*])
+
+* In a node with a dual NIC PTP configuration, the PTP events framework reports an incorrect status of `HANDOVER` or `FREERUN` instead of a `LOCKED` state for a PTP clock in a `LOCKED` state. As a result, consumer applications using PTP events get an incorrect status for the PTP clock.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2092275[*BZ#2092275*])
+
+* In a node with a single NIC boundary clock PTP configuration, the PTP events framework reports an incorrect status of `FREERUN` instead of a `LOCKED` state for a PTP clock in a `LOCKED` state. As a result, consumer applications using PTP events get an incorrect status for the PTP clock.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2091441[*BZ#2091441*])
+
+* When you reset a network interface that is configured as a PTP ordinary clock, only the PTP `class-change` event is recorded in the PTP events log. `status-change` or `sync-status` events are not recorded in the PTP events log. The failure of the PTP events framework to capture these events does not impact PTP network timekeeping.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2091437[*BZ#2091437*])
+
+* When you apply a `PTPConfig` CR in the cluster that configures two slave interfaces, PTP metrics and events list the network interfaces with a `SLAVE` and `MASTER` status instead of `SLAVE` and `PASSIVE` respectively. To diagnose problems with network interfaces configured with PTP, use the PTP Management Client (`pmc`) tool.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2091434[*BZ#2091434*])
+
+* In a cluster configured for PTP, `phc2sys` reports offset values for master ports. PTP events are generated for the offsets. For example:
++
+[source,terminal]
+----
+phc2sys[859300.541]: [ptp4l.0.config] ens3f1 rms 52 max 52 freq 3081 +/ 0 delay 2542 +/- 0
+----
++
+Offset metrics and events should not be reported for master ports.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2047308[*BZ#2047308*])
+
+* In {product-title} 4.11, PTP events publisher and subscriber resource addresses are not implemented as per O-RAN specifications.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2037991[*BZ#2037991*])
+
+* When using the {product-title} v4.11 brew bundle build to deploy SRO in a disconnected environment, the following error is reported when building the index image using the SRO bundle image.
++
+[source,terminal]
+----
+Error: index image registry-proxy.engineering.redhat.com/rh-osbs/iib:224698 missing label operators.operatorframework.io.index.database.v1
+----
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2081487[*BZ#2081487*])
+
+* When a {sno} cluster is installed with `kernel-rt`, default performance profile, and `nohz_full` enabled on isolated CPUs, the cluster does not finish installing. If workload partitioning is disabled, the cluster pods float across the entire CPU set. Control plane pods are started, but they consume an entire CPU. If workload partitioning is enabled, cluster pods are pinned to non-isolated cores, and the cluster reports as `READY`. However, additional pods that land on isolated cores do not function properly.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2045902[*BZ#2045902*])
+
+* Currently, the Kubelet service monitor scrape interval is hardcoded in {product-title}. This reduces the potential CPU resources that are available for production workloads.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2035046[*BZ#2035046*])
+
 * In {product-title} 4.11, the MetalLB Operator scope has changed from namespace to cluster and this results in upgrading from a prior version failing.
 +
 As a workaround, remove the previous version of the MetalLB Operator. Do not delete the namespace or the instance of the MetalLB custom resource, and deploy the new Operator version. This keeps MetalLB running and configured.


### PR DESCRIPTION
Known issues for Telco RAN 4.11 GA. Required for Nokia preview. 

https://issues.redhat.com/browse/TELCODOCS-793

Version(s):
enterprise-4.11

Preview: http://file.emea.redhat.com/aireilly/nokia-411-preview-known-issues/release_notes/ocp-4-11-release-notes.html#ocp-4-11-ran-ga-known-issues