### PR TITLE
TELCODOCS-808: Reinstate changes from previously merged Poison Pill PRs to updated SNR files

### DIFF
--- a/modules/eco-self-node-remediation-operator-about.adoc
+++ b/modules/eco-self-node-remediation-operator-about.adoc
@@ -8,6 +8,22 @@
 
 The Self Node Remediation Operator runs on the cluster nodes and reboots nodes that are identified as unhealthy. The Operator uses the `MachineHealthCheck` or `NodeHealthCheck` controller to detect the health of a node in the cluster. When a node is identified as unhealthy, the `MachineHealthCheck` or the `NodeHealthCheck` resource creates the `SelfNodeRemediation` custom resource (CR), which triggers the Self Node Remediation Operator.
 
+The `SelfNodeRemediation` CR resembles the following YAML file:
+
+[source,yaml]
+----
+apiVersion: self-node-remediation.medik8s.io/v1alpha1
+kind: SelfNodeRemediation
+metadata:
+  name: selfnoderemediation-sample
+  namespace: openshift-operators
+spec:
+status:
+  lastError: <last_error_message> <1>
+----
+
+<1> Displays the last error that occurred during remediation. When remediation succeeds or if no errors occur, the field is left empty.
+
 The Self Node Remediation Operator minimizes downtime for stateful applications and restores compute capacity if transient failures occur. You can use this Operator regardless of the management interface, such as IPMI or an API to provision a node, and regardless of the cluster installation type, such as installer-provisioned infrastructure or user-provisioned infrastructure.
 
 [id="understanding-self-node-remediation-operator-config_{context}"]
@@ -28,7 +44,7 @@ metadata:
   namespace: openshift-operators
 spec:
   safeTimeToAssumeNodeRebootedSeconds: 180 <1>
-  watchdogFilePath: /dev/watchdog1 <2>
+  watchdogFilePath: /dev/watchdog <2>
   isSoftwareRebootEnabled: true <3>
   apiServerTimeout: 15s <4>
   apiCheckInterval: 5s <5>
@@ -44,13 +60,13 @@ spec:
 +
 If a watchdog device is unavailable, the `SelfNodeRemediationConfig` CR uses a software reboot.
 <3> Specify if you want to enable software reboot of the unhealthy nodes. By default, the value of `isSoftwareRebootEnabled` is set to `true`. To disable the software reboot, set the parameter value to `false`.
-<4> Specify the timeout duration to check connectivity with each API server. When this duration elapses, the Operator starts remediation.
-<5> Specify the frequency to check connectivity with each API server.
-<6> Specify a threshold value. After reaching this threshold, the node starts contacting its peers.
-<7> Specify the timeout duration for the peer to connect the API server.
-<8> Specify the timeout duration for establishing connection with the peer.
-<9> Specify the timeout duration to get a response from the peer.
-<10> Specify the frequency to update peer information, such as IP address.
+<4> Specify the timeout duration to check connectivity with each API server. When this duration elapses, the Operator starts remediation. The timeout duration must be more than or equal to 10 milliseconds.
+<5> Specify the frequency to check connectivity with each API server. The timeout duration must be more than or equal to 1 second.
+<6> Specify a threshold value. After reaching this threshold, the node starts contacting its peers. The threshold value must be more than or equal to 1 second.
+<7> Specify the duration of the timeout for the peer to connect the API server. The timeout duration must be more than or equal to 10 milliseconds.
+<8> Specify the duration of the timeout for establishing connection with the peer. The timeout duration must be more than or equal to 10 milliseconds.
+<9> Specify the duration of the timeout to get a response from the peer. The timeout duration must be more than or equal to 10 milliseconds.
+<10> Specify the frequency to update peer information, such as IP address. The timeout duration must be more than or equal to 10 seconds.
 
 [NOTE]
 ====


### PR DESCRIPTION
[TELCODOCS-808](https://issues.redhat.com//browse/TELCODOCS-808): This PR reinstates changes from the following two previously merged Poison Pill PRs that did not get ported onto the updated Self Node Remediation files.

- https://github.com/openshift/openshift-docs/pull/47389 ([TELCODOCS-330](https://issues.redhat.com//browse/TELCODOCS-330))
- https://github.com/openshift/openshift-docs/pull/46467 ([TELCODOCS-497](https://issues.redhat.com//browse/TELCODOCS-497))

Version(s): OpenShift 4.11+

Issues: 
https://issues.redhat.com/browse/TELCODOCS-808
https://issues.redhat.com/browse/TELCODOCS-330
https://issues.redhat.com/browse/TELCODOCS-497

Link to docs preview: 

- [Preview for [TELCODOCS-330](https://issues.redhat.com//browse/TELCODOCS-330)](http://file.rdu.redhat.com/avbhatt/TD808/nodes/nodes/eco-self-node-remediation-operator.html#about-self-node-remediation-operator_self-node-remediation-operator-remediate-nodes)
- [Preview for [TELCODOCS-497](https://issues.redhat.com//browse/TELCODOCS-497)](http://file.rdu.redhat.com/avbhatt/TD808/nodes/nodes/eco-self-node-remediation-operator.html#understanding-self-node-remediation-operator-config_self-node-remediation-operator-remediate-nodes)

Additional information:
There are no changes in this PR that are aside from the changes that went into the merged PR. Therefore, the content is SME, QE and Peer reviewed. 