### PR TITLE
OSSMDOC-625: Preliminary work, moving Core Features topic out of Release Notes

### DIFF
--- a/modules/ossm-core-features.adoc
+++ b/modules/ossm-core-features.adoc
@@ -1,0 +1,15 @@
+////
+Module included in the following assemblies:
+* service_mesh/v2x/servicemesh-release-notes.adoc
+////
+
+:_content-type: CONCEPT
+[id="ossm-core-features_{context}"]
+= Core features
+
+{SMProductName} provides a number of key capabilities uniformly across a network of services:
+
+* *Traffic Management* - Control the flow of traffic and API calls between services, make calls more reliable, and make the network more robust in the face of adverse conditions.
+* *Service Identity and Security* - Provide services in the mesh with a verifiable identity and provide the ability to protect service traffic as it flows over networks of varying degrees of trustworthiness.
+* *Policy Enforcement* - Apply organizational policy to the interaction between services, ensure access policies are enforced and resources are fairly distributed among consumers. Policy changes are made by configuring the mesh, not by changing application code.
+* *Telemetry* - Gain understanding of the dependencies between services and the nature and flow of traffic between them, providing the ability to quickly identify issues.

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -5,19 +5,15 @@ Module included in the following assemblies:
 
 :_content-type: PROCEDURE
 [id="ossm-rn-new-features_{context}"]
-= Core features
+= New features and enhancements
 
 ////
 *Feature* – Describe the new functionality available to the customer. For enhancements, try to describe as specifically as possible where the customer will see changes.
 *Reason* – If known, include why has the enhancement been implemented (use case, performance, technology, etc.). For example, showcases integration of X with Y, demonstrates Z API feature, includes latest framework bug fixes. There may not have been a 'problem' previously, but system behavior may have changed.
 *Result* – If changed, describe the current user experience
 ////
-{SMProductName} provides a number of key capabilities uniformly across a network of services:
 
-* *Traffic Management* - Control the flow of traffic and API calls between services, make calls more reliable, and make the network more robust in the face of adverse conditions.
-* *Service Identity and Security* - Provide services in the mesh with a verifiable identity and provide the ability to protect service traffic as it flows over networks of varying degrees of trustworthiness.
-* *Policy Enforcement* - Apply organizational policy to the interaction between services, ensure access policies are enforced and resources are fairly distributed among consumers. Policy changes are made by configuring the mesh, not by changing application code.
-* *Telemetry* - Gain understanding of the dependencies between services and the nature and flow of traffic between them, providing the ability to quickly identify issues.
+This release adds improvements related to the following components and concepts.
 
 == New features {SMProductName} version {SMProductVersion}
 

--- a/service_mesh/v2x/ossm-about.adoc
+++ b/service_mesh/v2x/ossm-about.adoc
@@ -7,3 +7,5 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 include::modules/ossm-servicemesh-overview.adoc[leveloffset=+1]
+
+include::modules/ossm-core-features.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.6 - 4.11

Issue: [OSSMDOC-625 ](https://issues.redhat.com/browse/OSSMDOC-625)
Note that this PR does not address the entire ask in this issue, just the one part that now that it's been pointed out I just can't unsee.  Core Features topic removed from Release Notes and added to About assembly.

Link to docs preview:   http://file.bos.redhat.com/jstickle/OSSMDOC-625/service_mesh/v2x/servicemesh-release-notes.html 

http://file.bos.redhat.com/jstickle/OSSMDOC-625/service_mesh/v2x/ossm-about.html 

Additional information:
Peer review: stevsmit