### PR TITLE
OLM file-based catalog release notes stub

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -508,6 +508,13 @@ For clusters on user-provisioned xref:../installing/installing_bare_metal/instal
 [id="ocp-4-11-olm"]
 === Operator lifecycle
 
+[id="ocp-4-11-olm-fbc"]
+==== File-based catalog format
+
+The default Red Hat-provided Operator catalogs for {product-title} 4.11 releases in the file-based catalog format. {product-title} 4.6 through 4.10 released in the SQLite database format. File-based catalogs are the latest iteration of the catalog format in Operator Lifecycle Manager (OLM). It is a plain text-based file in JSON or YAML and is a declarative configuration evolution of the earlier SQLite database format. Cluster administrators and users will not see any change to their install workflows and Operator consumption with the new catalog format.
+
+For more information, see xref:../operators/understanding/olm-packaging-format.html#olm-file-based-catalogs_olm-packaging-format[File-based catalogs].
+
 [id="ocp-4-11-osdk"]
 === Operator development
 
@@ -692,7 +699,7 @@ The `haproxy.router.openshift.io/balance` variable, which sets the router load-b
 [id="ocp-4-11-legacy-service-account"]
 ==== LegacyServiceAccountTokenNoAutoGeneration is on by default
 
-To align with upstream link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes-1[Kubernetes having moved] the `LegacyServiceAccountTokenNoAutoGeneration` feature gate to beta and enabling it by default, {product-title} now also follows this security feature and ships with the feature enabled. As a result, when creating new service accounts (SA), a service account token secret is no longer automatically generated. Previously, {product-title} automatically added a service account token to a secret for each new SA.
+To align with upstream link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes-1[Kubernetes having moved] the `LegacyServiceAccountTokenNoAutoGeneration` feature gate to beta and enabling it by default, {product-title} now also follows this security feature and releasess with the feature enabled. As a result, when creating new service accounts (SA), a service account token secret is no longer automatically generated. Previously, {product-title} automatically added a service account token to a secret for each new SA.
 
 If you need a service account token secret, you must manually use the TokenRequest API to request bound service account tokens or create a service account token secret.
 


### PR DESCRIPTION
Version(s):
4.11 release notes

Link to docs preview:
[File-based catalog format](http://file.rdu.redhat.com/antaylor/olm-fbc-rns/release_notes/ocp-4-11-release-notes.html#ocp-4-11-olm)

Additional information:
Describes the new file-based catalog system for Operator Lifecycle Manager (OLM).