### PR TITLE
Added a RN for Creating a route using the destination CA certificate in the Ingress annotation

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -370,9 +370,9 @@ For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-co
 
 [id="ocp-4-11-configuring-interface-level-safe-network-sysclts"]
 ==== Support for configuring interface-level safe network sysctls
-Use the new `tuning-cni` meta plug-in to set an interface level safe network sysctls that only applies to a specific interface. For example, you can change the behavior of `accept_redirects` on a particular network interface by configuring the `tuning-cni` plug-in. A complete list of the interface-specific safe sysclts that can be set is available in the documentation. 
+Use the new `tuning-cni` meta plug-in to set an interface level safe network sysctls that only applies to a specific interface. For example, you can change the behavior of `accept_redirects` on a particular network interface by configuring the `tuning-cni` plug-in. A complete list of the interface-specific safe sysclts that can be set is available in the documentation.
 
-In addition to this enhancement the set of system-wide safe sysctls that can be set has increased to support `net.ipv4.ping_group_range` and `net.ipv4.ip_unprivileged_port_start`. 
+In addition to this enhancement the set of system-wide safe sysctls that can be set has increased to support `net.ipv4.ping_group_range` and `net.ipv4.ip_unprivileged_port_start`.
 
 For more information about configuring the `tuning-cni` plugin, see xref:../networking/setting-interface-level-network-sysctls.adoc#nodes-setting-interface-level-network-sysctls[Setting interface level network sysctls].
 
@@ -434,7 +434,7 @@ If you are using the OVN-Kubernetes cluster network provider, you can now enable
 
 Additional MetalLB custom resource defintions (CRDs) have been added to support more complex configurations.
 
-The following CRDs have been added: 
+The following CRDs have been added:
 
 * `IPAddressPools`
 * `L2Advertisement`
@@ -445,12 +445,19 @@ With these enhancements, you can use the Operator for more complex configuration
 
 [NOTE]
 ====
-The CRDs documented for {product-title} 4.10 and the existing ways to configure MetalLB as described in link:https://docs.openshift.com/container-platform/4.10/networking/metallb/about-metallb.html[About MetalLB and the MetalLB Operator] are still supported but deprecated. The `AddressPool` configuration is deprecated. 
+The CRDs documented for {product-title} 4.10 and the existing ways to configure MetalLB as described in link:https://docs.openshift.com/container-platform/4.10/networking/metallb/about-metallb.html[About MetalLB and the MetalLB Operator] are still supported but deprecated. The `AddressPool` configuration is deprecated.
 
 In 4.10, layer 2 and BGP IP addresses using the `AddressPool` were assigned from different address pools. In {product-title} 4.11, layer 2 and BGP IP addresses can be assigned from the same address pool.
 ====
 
 For more information, see xref:../networking/metallb/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator].
+
+[id="ocp-4-11-create-route-using-destination-ca-certificate"]
+==== Ability to create a route using the destination CA certificate in the Ingress annotation
+
+The `route.openshift.io/destination-ca-certificate-secret` annotation can now be used on an Ingress object to define a route with a custom certificate (CA).
+
+See xref:../networking/routes/route-configuration.adoc#nw-ingress-creating-a-route-via-an-ingress_route-configuration[Creating a route using the destination CA certificate in the Ingress annotation] for more information.
 
 [id="ocp-4-11-hardware"]
 === Hardware
@@ -494,7 +501,7 @@ You must still use the `performance-addon-operator-must-gather` image when runni
 [id="ocp-4-11-mco-update-zone"]
 ==== MCO now updates nodes by zone and age
 
-The Machine Config Operator (MCO) now updates the affected nodes alphabetically by zone, based on the `topology.kubernetes.io/zone` label. If a zone has more than one node, the oldest nodes are updated first. For nodes that do not use zones, such as in bare metal deployments, the nodes are upgraded by age, with the oldest nodes updated first. Previously, the MCO did not consider zones or node age.  
+The Machine Config Operator (MCO) now updates the affected nodes alphabetically by zone, based on the `topology.kubernetes.io/zone` label. If a zone has more than one node, the oldest nodes are updated first. For nodes that do not use zones, such as in bare metal deployments, the nodes are upgraded by age, with the oldest nodes updated first. Previously, the MCO did not consider zones or node age.
 
 For more information, see xref:../post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks[Machine config overview].
 
@@ -610,7 +617,7 @@ The `haproxy.router.openshift.io/balance` variable, which sets the router load-b
 
 To align with upstream link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes-1[Kubernetes having moved] the `LegacyServiceAccountTokenNoAutoGeneration` feature gate to beta and enabling it by default, {product-title} now also follows this security feature and ships with the feature enabled. As a result, when creating new service accounts (SA), a service account token secret is no longer automatically generated. Previously, {product-title} automatically added a service account token to a secret for each new SA.
 
-If you need a service account token secret, you must manually use the TokenRequest API to request bound service account tokens or create a service account token secret. 
+If you need a service account token secret, you must manually use the TokenRequest API to request bound service account tokens or create a service account token secret.
 
 After updating to {product-version}, existing service account token secrets are not deleted and continue to function as expected.
 
@@ -1389,7 +1396,7 @@ This script removes unauthenticated subjects from the following cluster role bin
 
 * The oc-mirror CLI plug-in can fail to upload an image set to the target mirror registry if the `archiveSize` value in the image set configuration is smaller than the container image size, causing the catalog directory to span multiple archives. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2106461[*BZ#2106461*])
 
-* In {product-title} 4.11, the MetalLB Operator scope has changed from namespace to cluster and this results in upgrading from a prior version failing. 
+* In {product-title} 4.11, the MetalLB Operator scope has changed from namespace to cluster and this results in upgrading from a prior version failing.
 +
 As a workaround, remove the previous version of the MetalLB Operator. Do not delete the namespace or the instance of the MetalLB custom resource, and deploy the new Operator version. This keeps MetalLB running and configured.
 +


### PR DESCRIPTION
Adding a release note for https://issues.redhat.com/browse/NE-729 / https://issues.redhat.com/browse/OSDOCS-3628 / https://github.com/openshift/openshift-docs/pull/46275

Version(s):
4.11

Preview build: 
http://file.rdu.redhat.com/~ahardin/July-2022/route-destination-ca-cert/release_notes/ocp-4-11-release-notes.html#ocp-4-11-create-route-using-destination-ca-certificate
