### PR TITLE
OCPNODE-638: Kubelet-Controller Manager communication Profiles (WorkerLatencyProfiles) Installation module

### DIFF
--- a/modules/nodes-cluster-worker-latency-profiles-install.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-install.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * nodes/clusters/nodes-cluster-worker-latency-profiles
+
+:_content-type: PROCEDURE
+[id="nodes-cluster-worker-latency-profiles-install_{context}"]
+= Configuring a worker latency profile on installation
+
+If you anticipate that your cluster network might experience latency issues that could benefit from a worker latency profile, you can configure the policy at the time you install a cluster.
+
+The installation process adds the specified policy to the `node.config` object, which you can edit at any time to change the profile as needed.
+
+.Procedure
+
+. Before executing the `openshift-install create cluster` task, create the `node.config` object:
+
+.. Create a YAML file similar to the following:
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+ name: cluster
+spec:
+ workerLatencyProfile: "MediumUpdateAverageReaction" <1>
+----
+<1> Specifies the worker latency policy to deploy upon installation, either `MediumUpdateAverageReaction` `LowUpdateSlowReaction`,
+
+.. Create the object:
++
+[source,terminal]
+----
+$ oc create -f <filename>.yaml
+----
+
+.Verification 
+
+. Check that the correct worker latency policy was configured by looking in the `nodes.config` object:
++
+[source,terminal]
+----
+$ oc get nodes.config/cluster -o yaml|grep spec -A2
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Node
+ ...
+spec:  
+  workerLatencyProfile: LowUpdateSlowReaction
+ ...
+----
+

--- a/nodes/clusters/nodes-cluster-worker-latency-profiles.adoc
+++ b/nodes/clusters/nodes-cluster-worker-latency-profiles.adoc
@@ -24,3 +24,5 @@ include::modules/nodes-cluster-worker-latency-profiles-about.adoc[leveloffset=+1
 
 include::modules/nodes-cluster-worker-latency-profiles-using.adoc[leveloffset=+1]
 
+include::modules/nodes-cluster-worker-latency-profiles-install.adoc[leveloffset=+1]
+


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/pull/47973

Adding a new module for configuring a worker latency profile during installation.  Final location and logistics TBD.

[Configuring a worker latency profile when installing a cluster](http://file.rdu.redhat.com/~mburke/clusters/nodes-cluster-worker-latency-profiles.html#nodes-cluster-worker-latency-profiles-install_nodes-cluster-worker-latency-profiles) Topic not present