### PR TITLE
Java-based Operator release notes stub

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -500,17 +500,12 @@ See xref:../networking/routes/route-configuration.adoc#nw-ingress-creating-a-rou
 [id="ocp-4-11-osdk"]
 === Operator development
 
-[id="ocp-4-11-PAO-to-NTO"]
-==== Performance Addon Operator functions moved to the Node Tuning Operator
+[id="ocp-4-11-java-osdk"]
+==== Java-based Operators (Technology Preview)
 
-In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. The Node Tuning Operator is part of the standard installation for {product-title} 4.11. If you upgrade to {product-title} 4.11, the Node Tuning Operator removes the Performance Addon Operator and all related artifacts on startup.
+Starting in {product-title} {product-version} as a Technology Preview feature, the Operator SDK includes the tools and libraries to develop a Java-based Operator. Operator developers can take advantage of Java programming language support in the Operator SDK to build a Java-based Operator and manage its lifecycle.
 
-For more information, see xref:../operators/operator-reference.adoc#about-node-tuning-operator_platform-operators-ref[Node Tuning Operator].
-
-[NOTE]
-====
-You must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command with the Performance Profile Creator. For more information, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#gathering-data-about-your-cluster-using-must-gather_cnf-create-performance-profiles[Gathering data about your cluster using must-gather]
-====
+For more information, see xref:../operators/operator_sdk/java/osdk-java-quickstart.adoc[Getting started with Operator SDK for Java-based Operators].
 
 [id="ocp-4-11-builds"]
 === Builds
@@ -611,6 +606,18 @@ The Node Observability Operator provides the ability to:
 * Make the profiling data files available for further analysis.
 
 For more information, see xref:../scalability_and_performance/node-observability-operator.adoc#node-observability-operator[Requesting CRI-O and Kubelet profiling data using the Node Observability Operator].
+
+[id="ocp-4-11-PAO-to-NTO"]
+==== Performance Addon Operator functions moved to the Node Tuning Operator
+
+In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. The Node Tuning Operator is part of the standard installation for {product-title} 4.11. If you upgrade to {product-title} 4.11, the Node Tuning Operator removes the Performance Addon Operator and all related artifacts on startup.
+
+For more information, see xref:../operators/operator-reference.adoc#about-node-tuning-operator_platform-operators-ref[Node Tuning Operator].
+
+[NOTE]
+====
+You must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command with the Performance Profile Creator. For more information, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#gathering-data-about-your-cluster-using-must-gather_cnf-create-performance-profiles[Gathering data about your cluster using must-gather]
+====
 
 [id="ocp-4-11-backup-and-restore"]
 === Backup and restore
@@ -1420,6 +1427,11 @@ In the table below, features are marked with the following statuses:
 |TP
 
 |Node Observability Operator
+|-
+|-
+|TP
+
+|Java-based Operator
 |-
 |-
 |TP


### PR DESCRIPTION
Version(s):
4.11

Link to docs preview:
[Java-based Operators (Technology Preview)](http://file.rdu.redhat.com/antaylor/java-osdk-rns/release_notes/ocp-4-11-release-notes.html#ocp-4-11-java-osdk)
[Technology Preview (see the last row of the table)](http://file.rdu.redhat.com/antaylor/java-osdk-rns/release_notes/ocp-4-11-release-notes.html#ocp-4-11-technology-preview)

Additional information:
Release notes stub for Java OSDK. Includes new features and enhancements note as well as Tech Preview table entry.  Moved the NTO enhancement to the Scalability and Performance subsection.