### PR TITLE
NE-989: Add nw-ingress-edge-route-default-certificate

### DIFF
--- a/modules/nw-ingress-edge-route-default-certificate.adoc
+++ b/modules/nw-ingress-edge-route-default-certificate.adoc
@@ -1,0 +1,71 @@
+// This is included in the following assemblies:
+//
+// networking/routes/route-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="creating-edge-route-with-default-certificate_{context}"]
+= Creating a route using the default certificate through an Ingress object
+
+If you create an Ingress object without specifying any TLS configuration, {product-title} generates an insecure route. To create an Ingress object that generates a secure, edge-terminated route using the default ingress certificate, you can specify an empty TLS configuration as follows.
+
+.Prerequisites
+
+* You have a service that you want to expose.
+* You have access to the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Create a YAML file for the Ingress object.  In this example, the file is called `example-ingress.yaml`:
++
+.YAML definition of an Ingress object
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+  ...
+spec:
+  rules:
+    ...
+  tls:
+  - {} <1>
+----
++
+<1> Use this exact syntax to specify TLS without specifying a custom certificate.
+
+. Create the Ingress object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f example-ingress.yaml
+----
+
+.Verification
+* Verify that {product-title} has created the expected route for the Ingress object by running the following command:
++
+[source,terminal]
+----
+$ oc get routes -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: v1
+items:
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: frontend-j9sdd <1>
+    ...
+  spec:
+  ...
+    tls: <2>
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge <3>
+  ...
+----
+<1> The name of the route includes the name of the Ingress object followed by a random suffix.
+<2> In order to use the default certificate, the route should not specify `spec.certificate`.
+<3> The route should specify the `edge` termination policy.

--- a/networking/routes/route-configuration.adoc
+++ b/networking/routes/route-configuration.adoc
@@ -46,6 +46,8 @@ include::modules/nw-route-admission-policy.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-creating-a-route-via-an-ingress.adoc[leveloffset=+1]
 
+include::modules/nw-ingress-edge-route-default-certificate.adoc[leveloffset=+1]
+
 include::modules/nw-ingress-reencrypt-route-custom-cert.adoc[leveloffset=+1]
 
 include::modules/nw-router-configuring-dual-stack.adoc[leveloffset=+1]


### PR DESCRIPTION
Add an example of creating an ingress object that uses the default certificate.  The required syntax to do this is subtle and non-obvious.

* `modules/nw-ingress-edge-route-default-certificate.adoc`: New file.
* `networking/routes/route-configuration.adoc`: Include the new module.

-------

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to.

Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->
4.6+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/NE-989

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->
https://48054--docspreview.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration#creating-edge-route-with-default-certificate_route-configuration

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
This functionality was added in OpenShift 4.6 with <https://github.com/openshift/openshift-controller-manager/pull/128/commits/19afa766b2a8a59dee015c710265471852664354>.


<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->