### PR TITLE
TELCODOCS-663: Add information about RHWA must-gather images

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -60,6 +60,11 @@ endif::openshift-dedicated[]
 |`registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:1.2.0`
 |Data collection for {sandboxed-containers-first}.
 
+|`registry.redhat.io/workload-availability/self-node-remediation-must-gather-rhel8:v0.4.0`
+|Data collection for the Self Node Remediation Operator and the Node Health Check Operator.
+
+|`registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v4.11.0`
+|Data collection for the Node Maintenance Operator.
 |===
 
 endif::openshift-origin[]

--- a/nodes/nodes/eco-node-health-check-operator.adoc
+++ b/nodes/nodes/eco-node-health-check-operator.adoc
@@ -23,6 +23,10 @@ include::modules/eco-node-health-check-operator-installation-web-console.adoc[le
 
 include::modules/eco-node-health-check-operator-installation-cli.adoc[leveloffset=+1]
 
+[id="gather-data-nhc"]
+== Gathering data about the Node Health Check Operator
+To collect debugging information about the Node Health Check Operator, use the `must-gather` tool. For information about the `must-gather` image for the Node Health Check Operator, see xref:../../support/gathering-cluster-data.adoc#gathering-data-specific-features_gathering-cluster-data[Gathering data about specific features].
+
 [id="additional-resources-nhc-operator-installation"]
 == Additional resources
 * xref:../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Changing the update channel for an Operator]

--- a/nodes/nodes/eco-node-maintenance-operator.adoc
+++ b/nodes/nodes/eco-node-maintenance-operator.adoc
@@ -46,6 +46,10 @@ include::modules/eco-resuming-node-maintenance-cr-web-console.adoc[leveloffset=+
 
 include::modules/eco-resuming-node-maintenance-cr-cli.adoc[leveloffset=+2]
 
+[id="gather-data-nmo"]
+== Gathering data about the Node Maintenance Operator
+To collect debugging information about the Node Maintenance Operator, use the `must-gather` tool. For information about the `must-gather` image for the Node Maintenance Operator, see xref:../../support/gathering-cluster-data.adoc#gathering-data-specific-features_gathering-cluster-data[Gathering data about specific features].
+
 [role="_additional-resources"]
 [id="additional-resources-node-maintenance-operator-installation"]
 == Additional resources

--- a/nodes/nodes/eco-self-node-remediation-operator.adoc
+++ b/nodes/nodes/eco-self-node-remediation-operator.adoc
@@ -23,6 +23,10 @@ include::modules/eco-configuring-machine-health-check-with-self-node-remediation
 
 include::modules/eco-self-node-remediation-operator-troubleshooting.adoc[leveloffset=+1]
 
+[id="gather-data-self-node-remediation"]
+== Gathering data about the Self Node Remediation Operator
+To collect debugging information about the Self Node Remediation Operator, use the `must-gather` tool. For information about the `must-gather` image for the Self Node Remediation Operator, see xref:../../support/gathering-cluster-data.adoc#gathering-data-specific-features_gathering-cluster-data[Gathering data about specific features].
+
 [role="_additional-resources"]
 [id="additional-resources-self-node-remediation-operator-installation"]
 == Additional resources


### PR DESCRIPTION
[TELCODOCS-663](https://issues.redhat.com//browse/TELCODOCS-663): This PR adds information about `must-gather` images for the following Red Hat Workload Availability (RHWA) Operators:

- Self Node Remediation
- Node Health Check
- Node Maintenance

Version(s): OpenShift 4.11+

Issue:
https://issues.redhat.com/browse/TELCODOCS-663

Previews:
- [Gathering data about specific features](http://file.rdu.redhat.com/avbhatt/TD663/support/gathering-cluster-data.html#gathering-data-specific-features_gathering-cluster-data)
- Self Node Remediation: http://file.rdu.redhat.com/avbhatt/TD663/nodes/nodes/eco-self-node-remediation-operator.html#about-collecting-data-snr
- Node Health Check: http://file.rdu.redhat.com/avbhatt/TD663/nodes/nodes/eco-node-health-check-operator.html#about-collecting-data-nhc
- Node Maintenance: http://file.rdu.redhat.com/avbhatt/TD663/nodes/nodes/eco-node-maintenance-operator.html#about-collecting-data-nmo

Additional information:
Prior to OpenShift 4.11, the Self Node Remediation Operator was known as the Poison Pill Operator. Relevant changes for Poison Pill Operator are applicable for version 4.10 and they are addressed in a separate PR (https://github.com/openshift/openshift-docs/pull/48210)