### PR TITLE
[enterprise-4.8] GitHub-43205: Fixing example callback URL

### DIFF
--- a/modules/identity-provider-registering-github.adoc
+++ b/modules/identity-provider-registering-github.adoc
@@ -32,7 +32,7 @@ https://oauth-openshift.apps.<cluster-name>.<cluster-domain>/oauth2callback/<idp
 For example:
 +
 ----
-https://oauth-openshift.apps.example-openshift-cluster.com/oauth2callback/github/
+https://oauth-openshift.apps.openshift-cluster.example.com/oauth2callback/github
 ----
 . Click *Register application*. GitHub provides a client ID and a client secret.
 You need these values to complete the identity provider configuration.


### PR DESCRIPTION
Manual CP of #47421.