### PR TITLE
Adding known issue of 4.11 oc with macOS

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1414,6 +1414,8 @@ As a workaround, remove the previous version of the MetalLB Operator. Do not del
 +
 For more information, see xref:../networking/metallb/metalb-upgrading-operator.adoc#metallb-operator-upgrade[Upgrading the MetalLB Operator]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2100180[*BZ#2100180*])
 
+* The OpenShift CLI (`oc`) for {product-title} 4.11 does not work properly on macOS due to a change in error handling of untrusted certificates in Go 1.18 libraries. Due to this change, `oc login` and other `oc` commands can fail with a `certificate is not trusted` error without proceeding further when running on macOS. Until the error handling is properly fixed in Go 1.18 (tracked by link:https://github.com/golang/go/issues/52010[Go issue #52010]), the workaround is to use the {product-title} 4.10 `oc` CLI instead. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097830[*BZ#2097830*])
+
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Version(s):
4.11

Issue:
From RN Tracker: https://github.com/openshift/openshift-docs/issues/43249#issuecomment-1191169097

Link to docs preview:
(single file): http://file.rdu.redhat.com/~ahoffer/2022/oc-known-issue-mac/release_notes/ocp-4-11-release-notes.html#ocp-4-11-known-issues