### PR TITLE
TELCODOCS-628: Removing chronyd from extra manifests

### DIFF
--- a/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
+++ b/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
@@ -81,14 +81,7 @@ spec:
 ----
 <1> Must match the URLs of the HTTPD server.
 
-. For disconnected installations, you must deploy an NTP clock that is reachable through the disconnected network.
-You can do this by configuring chrony to act as server, editing the `/etc/chrony.conf` file, and adding the following allowed IPv6 range:
-+
-[source,text]
-----
-# Allow NTP client access from local network.
-#allow 192.168.0.0/16
-local stratum 10
-bindcmdaddress ::
-allow 2620:52:0:1310::/64
-----
+[IMPORTANT]
+====
+A valid NTP server is required during cluster installation. Ensure that a suitable NTP server is available and can be reached from the installed clusters through the disconnected network.
+====

--- a/modules/ztp-deploying-a-site.adoc
+++ b/modules/ztp-deploying-a-site.adoc
@@ -182,6 +182,6 @@ The `SiteConfig` CR creates the following CRs on the hub cluster:
 * `ClusterDeployment`
 * `InfraEnv`
 * `NMStateConfig` - One per node
-* `ExtraManifestsConfigMap` - Extra manifests. The additional manifests include workload partitioning, chronyd, mountpoint hiding, sctp enablement, and more.
+* `ExtraManifestsConfigMap` - Extra manifests. The extra manifests include workload partitioning, mountpoint hiding, sctp enablement, and more. To automatically merge the extra manifests into a single manifest per each `MachineConfigPool` role, which is named as `predefined-extra-manifests-<role>`, set the `.spec.clusters.mergeDefaultMachineConfigs` to `true` in the `SiteConfig.yaml` file.
 * `ManagedCluster`
 * `KlusterletAddonConfig`

--- a/modules/ztp-du-cluster-config-reference.adoc
+++ b/modules/ztp-du-cluster-config-reference.adoc
@@ -84,6 +84,7 @@ spec:
         group.ice-ptp=0:f:10:*:ice-ptp.*
         [service]
         service.stalld=start,enable
+        service.chronyd=stop,disable
 ----
 <1> Listed CPUs depend on the host hardware configuration, specifically the number of available CPUs in the system and the CPU topology.
 

--- a/modules/ztp-generating-ran-policies.adoc
+++ b/modules/ztp-generating-ran-policies.adoc
@@ -69,7 +69,6 @@ out
 │   └── common-sriov-sub-policy.yaml
 ├── groups
 │   ├── group-du
-│   │   ├── group-du-mc-chronyd-policy.yaml
 │   │   ├── group-du-mc-mount-ns-policy.yaml
 │   │   ├── group-du-mcp-du-policy.yaml
 │   │   ├── group-du-mc-sctp-policy.yaml


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.11, 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to.

Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue:
https://issues.redhat.com/browse/TELCODOCS-628
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://48093--docspreview.netlify.app/openshift-enterprise/latest//scalability_and_performance/ztp-deploying-disconnected.html#ztp-configuring-the-cluster-for-a-disconnected-environment_ztp-deploying-disconnected
https://48093--docspreview.netlify.app/openshift-enterprise/latest//scalability_and_performance/ztp-deploying-disconnected.html#ztp-deploying-a-site_ztp-deploying-disconnected
https://48093--docspreview.netlify.app/openshift-enterprise/latest//scalability_and_performance/ztp-deploying-disconnected.html#ztp-generating-ran-policies_ztp-deploying-disconnected
https://48093--docspreview.netlify.app/openshift-enterprise/latest//scalability_and_performance/ztp-vdu-validating-cluster-tuning.html#recommended-cluster-kernel-configuration
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information: Content backported to 4.10 and reviewed in https://github.com/openshift/openshift-docs/pull/49030
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
