### PR TITLE
OSDOCS-3463 OLM file-based catalog update

### DIFF
--- a/cli_reference/opm/cli-opm-ref.adoc
+++ b/cli_reference/opm/cli-opm-ref.adoc
@@ -27,8 +27,15 @@ $ opm <command> [<subcommand>] [<argument>] [<flags>]
 :FeatureName: The SQLite-based catalog format, including the related CLI commands,
 include::modules/deprecated-feature.adoc[]
 
-include::modules/opm-cli-ref-index.adoc[leveloffset=+1]
 include::modules/opm-cli-ref-init.adoc[leveloffset=+1]
 include::modules/opm-cli-ref-render.adoc[leveloffset=+1]
 include::modules/opm-cli-ref-validate.adoc[leveloffset=+1]
 include::modules/opm-cli-ref-serve.adoc[leveloffset=+1]
+include::modules/opm-cli-ref-index.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format]
+* xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs]
+* xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in]

--- a/modules/olm-about-catalogs.adoc
+++ b/modules/olm-about-catalogs.adoc
@@ -6,7 +6,7 @@
 [id="olm-about-catalogs_{context}"]
 = About Operator catalogs
 
-An Operator catalog is a repository of metadata that Operator Lifecycle Manager (OLM) can query to discover and install Operators and their dependencies on a cluster. OLM always installs Operators from the latest version of a catalog. As of {product-title} 4.6, Red Hat-provided catalogs are distributed using _index images_.
+An Operator catalog is a repository of metadata that Operator Lifecycle Manager (OLM) can query to discover and install Operators and their dependencies on a cluster. OLM always installs Operators from the latest version of a catalog.
 
 An index image, based on the Operator bundle format, is a containerized snapshot of a catalog. It is an immutable artifact that contains the database of pointers to a set of Operator manifest content. A catalog can reference an index image to source its content for OLM on the cluster.
 

--- a/modules/olm-fb-catalogs.adoc
+++ b/modules/olm-fb-catalogs.adoc
@@ -2,15 +2,11 @@
 //
 // * operators/understanding/olm-packaging-format.adoc
 
+:_content-type: CONCEPT
 [id="olm-file-based-catalogs_{context}"]
 = File-based catalogs
 
 _File-based catalogs_ are the latest iteration of the catalog format in Operator Lifecycle Manager (OLM). It is a plain text-based (JSON or YAML) and declarative config evolution of the earlier SQLite database format, and it is fully backwards compatible. The goal of this format is to enable Operator catalog editing, composability, and extensibility.
-
-[NOTE]
-====
-The default Red Hat-provided Operator catalogs for {product-title} 4.6 and later are currently still shipped in the SQLite database format.
-====
 
 Editing::
 With file-based catalogs, users interacting with the contents of a catalog are able to make direct changes to the format and verify that their changes are valid. Because this format is plain text JSON or YAML, catalog maintainers can easily manipulate catalog metadata by hand or with widely known and supported JSON or YAML tooling, such as the `jq` CLI.

--- a/modules/opm-cli-ref-index.adoc
+++ b/modules/opm-cli-ref-index.adoc
@@ -5,7 +5,16 @@
 [id="opm-cli-ref-index_{context}"]
 = index
 
-Generate Operator index container images from pre-existing Operator bundles.
+Generate Operator index for SQLite database format container images from pre-existing Operator bundles.
+
+[IMPORTANT]
+====
+As of {product-title} 4.11, the default Red Hat-provided Operator catalog releases in the file-based catalog format. The default Red Hat-provided Operator catalogs for {product-title} 4.6 through 4.10 released in the deprecated SQLite database format.
+
+The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
+
+Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format. For more information about working with file-based catalogs, see "Additional resources".
+====
 
 .Command syntax
 [source,terminal]

--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -30,7 +30,14 @@ If your cluster is using custom catalogs, see xref:../../operators/operator_sdk/
 
 _File-based catalogs_ are the latest iteration of the catalog format in Operator Lifecycle Manager (OLM). It is a plain text-based (JSON or YAML) and declarative config evolution of the earlier SQLite database format, and it is fully backwards compatible.
 
-For more details about the file-based catalog specification, see xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format].
+[IMPORTANT]
+====
+As of {product-title} 4.11, the default Red Hat-provided Operator catalog releases in the file-based catalog format. The default Red Hat-provided Operator catalogs for {product-title} 4.6 through 4.10 released in the deprecated SQLite database format.
+
+The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
+
+Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format. For more information about working with file-based catalogs, see xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format] and xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in].
+====
 
 include::modules/olm-creating-fb-catalog-image.adoc[leveloffset=+2]
 

--- a/operators/admin/olm-restricted-networks.adoc
+++ b/operators/admin/olm-restricted-networks.adoc
@@ -57,6 +57,15 @@ include::modules/olm-pruning-index-image.adoc[leveloffset=+1]
 
 For instructions about mirroring Operator catalogs for use with disconnected clusters, see xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#olm-mirroring-catalog_installing-mirroring-installation-images[Installing -> Mirroring images for a disconnected installation].
 
+[IMPORTANT]
+====
+As of {product-title} 4.11, the default Red Hat-provided Operator catalog releases in the file-based catalog format. The default Red Hat-provided Operator catalogs for {product-title} 4.6 through 4.10 released in the deprecated SQLite database format.
+
+The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
+
+Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format. For more information about working with file-based catalogs, see xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format], xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs], and xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in].
+====
+
 include::modules/olm-creating-catalog-from-index.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/operators/understanding/olm-packaging-format.adoc
+++ b/operators/understanding/olm-packaging-format.adoc
@@ -23,6 +23,7 @@ include::modules/olm-dependencies.adoc[leveloffset=+2]
 * xref:../../operators/understanding/olm/olm-understanding-dependency-resolution.adoc#olm-understanding-dependency-resolution[Operator Lifecycle Manager dependency resolution]
 
 include::modules/olm-about-opm.adoc[leveloffset=+2]
+
 * See xref:../../cli_reference/opm/cli-opm-install.adoc#cli-opm-install[CLI tools] for steps on installing the `opm` CLI.
 
 ifdef::openshift-origin[]
@@ -38,6 +39,15 @@ ifdef::openshift-origin[]
 endif::[]
 
 include::modules/olm-fb-catalogs.adoc[leveloffset=+1]
+[IMPORTANT]
+====
+As of {product-title} 4.11, the default Red Hat-provided Operator catalog releases in the file-based catalog format. The default Red Hat-provided Operator catalogs for {product-title} 4.6 through 4.10 released in the deprecated SQLite database format.
+
+The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
+
+Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format. For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs] and xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in].
+====
+
 include::modules/olm-fb-catalogs-structure.adoc[leveloffset=+2]
 include::modules/olm-fb-catalogs-schemas.adoc[leveloffset=+2]
 include::modules/olm-fb-catalogs-prop.adoc[leveloffset=+2]

--- a/operators/understanding/olm-rh-catalogs.adoc
+++ b/operators/understanding/olm-rh-catalogs.adoc
@@ -6,12 +6,25 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+Red Hat provides several Operator catalogs that are included with {product-title} by default.
+
+[IMPORTANT]
+====
+As of {product-title} 4.11, the default Red Hat-provided Operator catalog releases in the file-based catalog format. The default Red Hat-provided Operator catalogs for {product-title} 4.6 through 4.10 released in the deprecated SQLite database format.
+
+The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
+
+Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format. For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Managing custom catalogs], 
+xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format], and xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in].
+====
+
 include::modules/olm-about-catalogs.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Managing custom catalogs]
+* xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Packaging format]
 * xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
 
 include::modules/olm-rh-catalogs.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.11

Issue: [OSDOCS-3463](https://issues.redhat.com//browse/OSDOCS-3463)

If you notice documentation gaps that need to be addressed after 4.11 GA, please make a comment in this ticket: https://issues.redhat.com/browse/OSDOCS-3863

Link to docs preview (VPN required):

- [OPM CLI reference](http://file.rdu.redhat.com/mipeter/osdocs-3463--olm-fbc-refs-for-operator-catalogs/cli_reference/opm/cli-opm-ref.html#opm-cli-ref-index_cli-opm-ref)
  - [cli_reference/opm/cli-opm-ref.adoc](https://github.com/openshift/openshift-docs/pull/48113/files#diff-8755958357d9ac32e019f88f88ea8d968015cc77f8f808954272d5bf766f9ef4)
  - [modules/opm-cli-ref-index.adoc](https://github.com/openshift/openshift-docs/pull/48113/files#diff-b73fc8fa70cc981a4d1876c65da94ec01b18fb146c07f691e4e3a3d387512c50)
- [Red Hat-provided Operator catalogs](http://file.rdu.redhat.com/mipeter/osdocs-3463--olm-fbc-refs-for-operator-catalogs/operators/understanding/olm-rh-catalogs.html)
  - [modules/olm-about-catalogs.adoc](https://github.com/openshift/openshift-docs/pull/48113/files#diff-b0f7c90f0fb7d5f8048547b14db72475f6faa9e3d3ae018df9cd0c2c365add10)
- [Operator Framework packaging format ](http://file.rdu.redhat.com/mipeter/osdocs-3463--olm-fbc-refs-for-operator-catalogs/operators/understanding/olm-packaging-format.html#olm-file-based-catalogs_olm-packaging-format)
  - [modules/olm-fb-catalogs.adoc](https://github.com/openshift/openshift-docs/pull/48113/files#diff-92054fc86db6e46a843b60373c6c2c7085ab2a4a512a6a397776bf2a7cbb8856)
- [Managing custom catalogs](http://file.rdu.redhat.com/mipeter/osdocs-3463--olm-fbc-refs-for-operator-catalogs/operators/admin/olm-managing-custom-catalogs.html#olm-managing-custom-catalogs-fb)
- [Using OLM on restricted networks](http://file.rdu.redhat.com/mipeter/osdocs-3463--olm-fbc-refs-for-operator-catalogs/operators/admin/olm-restricted-networks.html#olm-mirror-catalog_olm-restricted-networks)

Additional information: Adds an admonition that the RH Operator catalog releases in the file-based catalog format in OCP 4.11 and clarifies that the `opm index` command is deprecated along with the SQLite database format. 