### PR TITLE
[OSDOCS-3285] added sentence to scaling worker nodes section

### DIFF
--- a/modules/rosa-scaling-worker-nodes.adoc
+++ b/modules/rosa-scaling-worker-nodes.adoc
@@ -8,6 +8,8 @@
 
 If you have not enabled autoscaling for your machine pool, you can manually scale the number of compute (also known as worker) nodes in the pool to meet your deployment needs.
 
+You must scale each machine pool separately.
+
 .Prerequisites
 
 ifdef::openshift-rosa[]


### PR DESCRIPTION
[OSDOCS-3285] added sentence to scaling worker nodes section

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-3285

Link to docs preview:
http://file.rdu.redhat.com/aldiaz/OSDOCS-3285/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#rosa-scaling-worker-nodes_rosa-managing-worker-nodes
