### PR TITLE
OSSMDOC-592: Updated federation failover example.

### DIFF
--- a/modules/ossm-federation-checklist.adoc
+++ b/modules/ossm-federation-checklist.adoc
@@ -24,6 +24,6 @@ Federating services meshes involves the following activities:
 
 * [ ] Federate two or more meshes by creating a `ServiceMeshPeer` resource for each mesh pair.
 
-* [ ] Export services by creating an `ExportServiceSet` resource to make services available from one mesh to a peer mesh.
+* [ ] Export services by creating an `ExportedServiceSet` resource to make services available from one mesh to a peer mesh.
 
-* [ ] Import services by creating an `ImportServiceSet` resource to import services shared by a mesh peer.
+* [ ] Import services by creating an `ImportedServiceSet` resource to import services shared by a mesh peer.

--- a/modules/ossm-federation-config-destinationrule-failover.adoc
+++ b/modules/ossm-federation-config-destinationrule-failover.adoc
@@ -40,13 +40,13 @@ $ oc project green-mesh-system
 .Example `DestinationRule`
 [source,yaml]
 ----
-apiVersion: networking.istio.io/v1beta
+apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
-  name: default
-  namespace: green-mesh-system
+  name: default-failover
+  namespace: bookinfo
 spec:
-  host: "*.green-mesh-system.svc.cluster.local"
+  host: "ratings.bookinfo.svc.cluster.local"
   trafficPolicy:
     loadBalancer:
       localityLbSetting:
@@ -55,8 +55,8 @@ spec:
           - from: us-east
             to: us-west
     outlierDetection:
-      consecutive5xxErrors: 1
-      interval: 5m
+      consecutive5xxErrors: 3
+      interval: 10s
       baseEjectionTime: 1m
 ----
 +
@@ -64,12 +64,12 @@ spec:
 +
 [source,terminal]
 ----
-$ oc create -n <smcp-system> -f <DestinationRule.yaml>
+$ oc create -n <application namespace> -f <DestinationRule.yaml>
 ----
 +
 For example:
 +
 [source,terminal]
 ----
-$ oc create -n green-mesh-system -f green-mesh-usWestDestinationRule.yaml
+$ oc create -n bookinfo -f green-mesh-us-west-DestinationRule.yaml
 ----

--- a/modules/ossm-federation-config-export.adoc
+++ b/modules/ossm-federation-config-export.adoc
@@ -21,7 +21,7 @@ You use an `ExportedServiceSet` resource to declare the services from one mesh t
 
 The following example is for services that `red-mesh` is exporting to `green-mesh`.
 
-.Example ExportServiceSet resource
+.Example ExportedServiceSet resource
 [source,yaml]
 ----
 kind: ExportedServiceSet
@@ -53,7 +53,7 @@ spec:
           namespace: bookinfo
 ----
 
-.ExportServiceSet parameters
+.ExportedServiceSet parameters
 [options="header"]
 [cols="l, a, a"]
 |===

--- a/modules/ossm-federation-config-failover-overview.adoc
+++ b/modules/ossm-federation-config-failover-overview.adoc
@@ -8,11 +8,11 @@ This module included in the following assemblies:
 
 Failover is the ability to switch automatically and seamlessly to a reliable backup system, for example another server. In the case of a federated mesh, you can configure a service in one mesh to failover to a service in another mesh.
 
-You configure Federation for failover by setting the `importAsLocal` and `locality` settings in a `ServiceImportSet` resource and then configuring a `DestinationRule` that configures failover for the service to the locality specified in the `ServiceImportSet`.
+You configure Federation for failover by setting the `importAsLocal` and `locality` settings in an `ImportedServiceSet` resource and then configuring a `DestinationRule` that configures failover for the service to the locality specified in the `ImportedServiceSet`.
 
 .Prerequisites
 
 * Two or more {product-title} 4.6 or above clusters already networked and federated.
-* `ExportServiceSet` resources already created for each mesh peer in the federated mesh.
-* `ImportServiceSet` resources already created for each mesh peer in the federated mesh.
-* An account with the cluster-admin role.
+* `ExportedServiceSet` resources already created for each mesh peer in the federated mesh.
+* `ImportedServiceSet` resources already created for each mesh peer in the federated mesh.
+* An account with the `cluster-admin` role.

--- a/modules/ossm-federation-config-import.adoc
+++ b/modules/ossm-federation-config-import.adoc
@@ -21,7 +21,7 @@ You use an `ImportedServiceSet` resource to select services for import. Only ser
 
 The following example is for the `green-mesh` importing a service that was exported by `red-mesh`.
 
-.Example ImportServiceSet
+.Example ImportedServiceSet
 [source,yaml]
 ----
 kind: ImportedServiceSet
@@ -43,7 +43,7 @@ spec:
         name: ratings
 ----
 
-.ImportServiceSet parameters
+.ImportedServiceSet parameters
 [options="header"]
 [cols="l, a, a"]
 |===

--- a/modules/ossm-federation-config-importedserviceset-failover.adoc
+++ b/modules/ossm-federation-config-importedserviceset-failover.adoc
@@ -3,14 +3,14 @@ This module included in the following assemblies:
 * service_mesh/v2x/ossm-federation.adoc
 ////
 :_content-type: PROCEDURE
-[id="ossm-federation-config-importserviceset-failover_{context}"]
-= Configuring an ImportServiceSet for failover
+[id="ossm-federation-config-importedserviceset-failover_{context}"]
+= Configuring an ImportedServiceSet for failover
 
 Locality-weighted load balancing allows administrators to control the distribution of traffic to endpoints based on the localities of where the traffic originates and where it will terminate. These localities are specified using arbitrary labels that designate a hierarchy of localities in {region}/{zone}/{sub-zone} form.
 
 In the examples in this section, the `green-mesh` is located in the `us-east` region, and the `red-mesh` is located in the `us-west` region.
 
-.Example `ImportServiceSet` resource from red-mesh to green-mesh
+.Example `ImportedServiceSet` resource from red-mesh to green-mesh
 [source,yaml]
 ----
 kind: ImportedServiceSet
@@ -76,14 +76,14 @@ For example, `green-mesh-system`.
 $ oc project green-mesh-system
 ----
 +
-.  Edit the `ImportServiceSet` file, where `<ImportServiceSet.yaml>` includes a full path to the file you want to edit, enter the following command:
+.  Edit the `ImportedServiceSet` file, where `<ImportedServiceSet.yaml>` includes a full path to the file you want to edit, enter the following command:
 +
 [source,terminal]
 ----
-$ oc edit -n <smcp-system> -f <ImportServiceSet.yaml>
+$ oc edit -n <smcp-system> -f <ImportedServiceSet.yaml>
 ----
 +
-For example, if you want to modify the file that imports from the red-mesh-system to the green-mesh-system as shown in the previous `ImportServiceSet` example.
+For example, if you want to modify the file that imports from the red-mesh-system to the green-mesh-system as shown in the previous `ImportedServiceSet` example.
 +
 [source,terminal]
 ----

--- a/modules/ossm-federation-create-export.adoc
+++ b/modules/ossm-federation-create-export.adoc
@@ -25,7 +25,7 @@ You can configure services for export even if they don't exist yet. When a servi
 .Procedure from the Console
 This is conjecture about what the flow might look like.
 
-Follow this procedure to create an `ExportServiceSet` with the web console. This example shows the red-mesh exporting the ratings service from the bookinfo application to the green-mesh.
+Follow this procedure to create an `ExportedServiceSet` with the web console. This example shows the red-mesh exporting the ratings service from the bookinfo application to the green-mesh.
 
 . Log in to the {product-title} web console as a user with the cluster-admin role.
 . Navigate to *Operators* → *Installed Operators*.
@@ -42,7 +42,7 @@ Follow this procedure to create an `ExportServiceSet` with the web console. This
 
 .Procedure from the CLI
 
-Follow this procedure to create an `ExportServiceSet` from the command line.
+Follow this procedure to create an `ExportedServiceSet` from the command line.
 
 . Log in to the {product-title} CLI as a user with the `cluster-admin` role. Enter the following command. Then, enter your username and password when prompted.
 +
@@ -58,9 +58,9 @@ $ oc login --username=<NAMEOFUSER> <API token> https://<HOSTNAME>:6443
 $ oc project red-mesh-system
 ----
 +
-. Create an `ExportServiceSet` file based on the following example where `red-mesh` is exporting services to `green-mesh`.
+. Create an `ExportedServiceSet` file based on the following example where `red-mesh` is exporting services to `green-mesh`.
 +
-.Example ExportServiceSet resource from red-mesh to green-mesh
+.Example ExportedServiceSet resource from red-mesh to green-mesh
 [source,yaml]
 ----
 apiVersion: federation.maistra.io/v1
@@ -83,11 +83,11 @@ spec:
       name: reviews
 ----
 +
-. Run the following command to upload and create the `ExportServiceSet` resource in the red-mesh-system namespace.
+. Run the following command to upload and create the `ExportedServiceSet` resource in the red-mesh-system namespace.
 +
 [source,terminal]
 ----
-$ oc create -n <ControlPlaneNamespace> -f <ExportServiceSet.yaml>
+$ oc create -n <ControlPlaneNamespace> -f <ExportedServiceSet.yaml>
 ----
 +
 For example:
@@ -97,7 +97,7 @@ For example:
 $ oc create -n red-mesh-system -f export-to-green-mesh.yaml
 ----
 +
-. Create additional `ExportServiceSets` as needed for each mesh peer in your federated mesh.
+. Create additional `ExportedServiceSets` as needed for each mesh peer in your federated mesh.
 //TODO - Add sample output after the validation
 . To validate the services you've exported from `red-mesh` to share with `green-mesh`, run the following command:
 +

--- a/modules/ossm-federation-create-import.adoc
+++ b/modules/ossm-federation-create-import.adoc
@@ -7,7 +7,7 @@ This module included in the following assemblies:
 [id="ossm-federation-create-import_{context}"]
 = Creating an ImportedServiceSet
 
-You create an `ImportServiceSet` resource to explicitly declare the services that you want to import into your mesh.
+You create an `ImportedServiceSet` resource to explicitly declare the services that you want to import into your mesh.
 
 Services are imported with the name `<exported-name>.<exported-namespace>.svc.<ServiceMeshPeer.name>.remote` which is a "hidden" service, visible only within the egress gateway namespace and is associated with the exported service's hostname. The service will be available locally as `<export-name>.<export-namespace>.<domainSuffix>`, where `domainSuffix` is `svc.<ServiceMeshPeer.name>-imports.local` by default, unless `importAsLocal` is set to `true`, in which case `domainSuffix` is `svc.cluster.local`.  If `importAsLocal` is set to `false`, the domain suffix in the import rule will be applied.  You can treat the local import just like any other service in the mesh. It automatically routes through the egress gateway, where it is redirected to the exported service's remote name.
 
@@ -18,32 +18,32 @@ Services are imported with the name `<exported-name>.<exported-namespace>.svc.<S
 
 [NOTE]
 ====
-You can configure services for import even if they haven't been exported yet. When a service that matches the value specified in the ImportServiceSet is deployed and exported, it will be automatically imported.
+You can configure services for import even if they haven't been exported yet. When a service that matches the value specified in the ImportedServiceSet is deployed and exported, it will be automatically imported.
 ====
 
 ////
 .Procedure from the Console
 This is conjecture about what the flow might look like.
 
-Follow this procedure to create an `ImportServiceSet` with the web console. This example shows the green-mesh importing the ratings service that was exported by the red-mesh.
+Follow this procedure to create an `ImportedServiceSet` with the web console. This example shows the green-mesh importing the ratings service that was exported by the red-mesh.
 
 . Log in to the {product-title} web console as a user with the cluster-admin role.
 . Navigate to *Operators* → *Installed Operators*.
 . Click the *Project* menu and select the project where you installed the control plane for the mesh you want to import services into. For example, `green-mesh-system`.
-. Click the {SMProductName} Operator, then click *Istio Service Mesh ImportServiceSet*.
-. On the *Istio Service Mesh ImportServiceSet* tab, click *Create ImportServiceSet*.
-. On the *Create ImportServiceSet* page, click *YAML* to modify your configuration.
+. Click the {SMProductName} Operator, then click *Istio Service Mesh ImportedServiceSet*.
+. On the *Istio Service Mesh ImportedServiceSet* tab, click *Create ImportedServiceSet*.
+. On the *Create ImportedServiceSet* page, click *YAML* to modify your configuration.
 . Modify the default configuration with values for your import.
 . Click *Create*. The Operator creates the import the based on your configuration parameters.
-. To verify the `ImportServiceSet` resource was created, click the *Istio Service Mesh ImportServiceSet* tab.
-.. Click the name of the new `ImportServiceSet`; for example, `import-from-red-mesh`.
-.. Click the *Resources* tab to see the `ImportServiceSet` resource the Operator created and configured.
+. To verify the `ImportedServiceSet` resource was created, click the *Istio Service Mesh ImportedServiceSet* tab.
+.. Click the name of the new `ImportedServiceSet`; for example, `import-from-red-mesh`.
+.. Click the *Resources* tab to see the `ImportedServiceSet` resource the Operator created and configured.
 ////
 
 
 .Procedure from the CLI
 
-Follow this procedure to create an `ImportServiceSet` from the command line.
+Follow this procedure to create an `ImportedServiceSet` from the command line.
 
 . Log in to the {product-title} CLI as a user with the `cluster-admin` role. Enter the following command. Then, enter your username and password when prompted.
 +
@@ -59,9 +59,9 @@ $ oc login --username=<NAMEOFUSER> <API token> https://<HOSTNAME>:6443
 $ oc project green-mesh-system
 ----
 +
-. Create an `ImportServiceSet` file based on the following example where `green-mesh` is importing services previously exported by `red-mesh`.
+. Create an `ImportedServiceSet` file based on the following example where `green-mesh` is importing services previously exported by `red-mesh`.
 +
-.Example ImportServiceSet resource from red-mesh to green-mesh
+.Example ImportedServiceSet resource from red-mesh to green-mesh
 [source,yaml]
 ----
 kind: ImportedServiceSet
@@ -81,11 +81,11 @@ spec:
         name: ratings
 ----
 +
-. Run the following command to upload and create the `ImportServiceSet` resource in the green-mesh-system namespace.
+. Run the following command to upload and create the `ImportedServiceSet` resource in the green-mesh-system namespace.
 +
 [source,terminal]
 ----
-$ oc create -n <ControlPlaneNamespace> -f <ImportServiceSet.yaml>
+$ oc create -n <ControlPlaneNamespace> -f <ImportedServiceSet.yaml>
 ----
 +
 For example:
@@ -95,7 +95,7 @@ For example:
 $ oc create -n green-mesh-system -f import-from-red-mesh.yaml
 ----
 +
-. Create additional `ImportServiceSets` as needed for each mesh peer in your federated mesh.
+. Create additional `ImportedServiceSet` resources as needed for each mesh peer in your federated mesh.
 //TODO - Add sample output after the validation
 . To validate the services you've imported into `green-mesh`, run the following command:
 +

--- a/service_mesh/v2x/ossm-federation.adoc
+++ b/service_mesh/v2x/ossm-federation.adoc
@@ -42,7 +42,7 @@ include::modules/ossm-federation-create-import.adoc[leveloffset=+2]
 
 include::modules/ossm-federation-config-failover-overview.adoc[leveloffset=+1]
 
-include::modules/ossm-federation-config-importserviceset-failover.adoc[leveloffset=+2]
+include::modules/ossm-federation-config-importedserviceset-failover.adoc[leveloffset=+2]
 
 include::modules/ossm-federation-config-destinationrule-failover.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):  4.6 - 4.11

Issue: [OSSMDOC-592](https://issues.redhat.com/browse/OSSMDOC-592)

Link to docs preview: 
http://file.bos.redhat.com/jstickle/OSSMDOC-592/service_mesh/v2x/ossm-federation.html#ossm-federation-config-failover-overview_federation


Additional information:
Eng review: yxun
QE Review: skondkar
Peer Review: stevsmit