### PR TITLE
BZ-2109524: Update troubleshooting steps for SNR resource removal

### DIFF
--- a/modules/eco-self-node-remediation-operator-troubleshooting.adoc
+++ b/modules/eco-self-node-remediation-operator-troubleshooting.adoc
@@ -2,6 +2,7 @@
 //
 // * nodes/nodes/eco-self-node-remediation-operator.adoc
 
+:_content-type: REFERENCE
 [id="troubleshooting-self-node-remediation-operator_{context}"]
 = Troubleshooting the Self Node Remediation Operator
 
@@ -36,12 +37,22 @@ If the `MachineHealthCheck` controller did not create the `SelfNodeRemediation` 
 If the `SelfNodeRemediation` CR was created, ensure that its name matches the unhealthy node or the machine object.
 
 [id="daemon-set-exists_{context}"]
-== Daemon set exists even after uninstalling the Self Node Remediation Operator
-Issue:: The self node remediation daemon set exists even after after uninstalling the Operator.
+== Daemon set and other Self Node Remediation Operator resources exist even after uninstalling the Operator
+Issue:: The Self Node Remediation Operator resources, such as the daemon set, configuration CR, and the remediation template CR, exist even after after uninstalling the Operator.
 
-Resolution:: To remove the self node remediation daemon set, manually delete the `SelfNodeRemediationConfig` CR. Run the following command:
+Resolution:: To remove the Self Node Remediation Operator resources, delete the resources by running the following commands for each resource type:
 +
 [source,terminal]
 ----
-$ oc delete ds <self-node-remediation-ds> -n self-node-remediation
+$ oc delete ds <self-node-remediation-ds> -n <namespace>
+----
++
+[source,terminal]
+----
+$ oc delete snrc <self-node-remediation-config> -n <namespace>
+----
++
+[source,terminal]
+----
+$ oc delete snrt <self-node-remediation-template> -n <namespace>
 ----

--- a/nodes/nodes/eco-self-node-remediation-operator.adoc
+++ b/nodes/nodes/eco-self-node-remediation-operator.adoc
@@ -28,3 +28,4 @@ include::modules/eco-self-node-remediation-operator-troubleshooting.adoc[levelof
 == Additional resources
 
 * The Self Node Remediation Operator is supported in a restricted network environment. For more information, see xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+* xref:../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster]


### PR DESCRIPTION
BZ-2109524: This PR updates information about removing Self Node Remediation resources after uninstalling the Operator

Version(s): OpenShift 4.11+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2109524

Preview:
http://file.rdu.redhat.com/avbhatt/bz-2109524/nodes/nodes/eco-self-node-remediation-operator.html#daemon-set-exists_self-node-remediation-operator-remediate-nodes

Additional information:
Prior to OpenShift 4.11, the Self Node Remediation Operator was known as the Poison Pill Operator. Relevant changes for Poison Pill Operator are applicable from versions 4.8-4.10 and they are addressed in a separate PR (https://github.com/openshift/openshift-docs/pull/48157).

