### PR TITLE
BZ2090176: Updates OpenShift Data Foundation version to 4.10 in OCP 4.10 doc

### DIFF
--- a/storage/persistent_storage/persistent-storage-ocs.adoc
+++ b/storage/persistent_storage/persistent-storage-ocs.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 {rh-storage-first} is a provider of agnostic persistent storage for {product-title} supporting file, block, and object storage, either in-house or in hybrid clouds. As a Red Hat storage solution, {rh-storage-first} is completely integrated with {product-title} for deployment, management, and monitoring.
 
-{rh-storage-first} provides its own documentation library. The complete set of {rh-storage-first} documentation identified below is available at https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9.
+{rh-storage-first} provides its own documentation library. The complete set of {rh-storage-first} documentation identified below is available in the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10[Product Documentation for Red Hat OpenShift Data Foundation 4.10].
 
 [IMPORTANT]
 ====
@@ -24,70 +24,70 @@ toc::[]
 2+^| *Planning*
 
 |What's new, known issues, notable bug fixes, and Technology Previews
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/4.9_release_notes[Red Hat OpenShift Data Foundation 4.9 Release Notes]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/4.10_release_notes[Red Hat OpenShift Data Foundation 4.10 Release Notes]
 
 |Supported workloads, layouts, hardware and software requirements, sizing and scaling recommendations
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/planning_your_deployment[Planning your Red Hat OpenShift Data Foundation 4.9 deployment]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/planning_your_deployment[Planning your Red Hat OpenShift Data Foundation 4.10 deployment]
 
 2+^| *Deploying*
 
 |Deploying {rh-storage-first} using Amazon Web Services for local or cloud storage
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/deploying_openshift_data_foundation_using_amazon_web_services[Deploying OpenShift Data Foundation 4.9 using Amazon Web Services]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_data_foundation_using_amazon_web_services[Deploying OpenShift Data Foundation 4.10 using Amazon Web Services]
 
 |Deploying {rh-storage-first} to local storage on bare metal infrastructure
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/deploying_openshift_data_foundation_using_bare_metal_infrastructure[Deploying OpenShift Data Foundation 4.9 using bare metal infrastructure]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_data_foundation_using_bare_metal_infrastructure[Deploying OpenShift Data Foundation 4.10 using bare metal infrastructure]
 
 |Deploying {rh-storage-first} to use an external Red Hat Ceph Storage cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/deploying_openshift_data_foundation_in_external_mode[Deploying OpenShift Data Foundation 4.9 in external mode]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_data_foundation_in_external_mode[Deploying OpenShift Data Foundation 4.10 in external mode]
 
 |Deploying and managing {rh-storage-first} on existing Google Cloud clusters
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/deploying_and_managing_openshift_data_foundation_using_google_cloud[Deploying and managing OpenShift Data Foundation 4.9 using Google Cloud]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_and_managing_openshift_data_foundation_using_google_cloud[Deploying and managing OpenShift Data Foundation 4.10 using Google Cloud]
 
 |Deploying {rh-storage-first} to use local storage on IBM Z infrastructure
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/deploying_openshift_data_foundation_using_ibm_z_infrastructure[Deploying OpenShift Data Foundation using IBM Z]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_data_foundation_using_ibm_z_infrastructure[Deploying OpenShift Data Foundation using IBM Z]
 
 |Deploying {rh-storage-first} on IBM Power
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/deploying_openshift_data_foundation_using_ibm_power_systems[Deploying OpenShift Data Foundation using IBM Power]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_data_foundation_using_ibm_power[Deploying OpenShift Data Foundation using IBM Power]
 
 |Deploying {rh-storage-first} on IBM Cloud
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/deploying_openshift_data_foundation_using_ibm_cloud[Deploying OpenShift Data Foundation using IBM Cloud]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_data_foundation_using_ibm_cloud[Deploying OpenShift Data Foundation using IBM Cloud]
 
 |Deploying and managing {rh-storage-first} on {rh-openstack-first}
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/deploying_and_managing_openshift_data_foundation_using_red_hat_openstack_platform[Deploying and managing OpenShift Data Foundation 4.9 using Red Hat OpenStack Platform]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_and_managing_openshift_data_foundation_using_red_hat_openstack_platform[Deploying and managing OpenShift Data Foundation 4.10 using Red Hat OpenStack Platform]
 
 |Deploying and managing {rh-storage-first} on {rh-virtualization-first}
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/deploying_openshift_data_foundation_using_red_hat_virtualization_platform[Deploying and managing OpenShift Data Foundation 4.9 using Red Hat Virtualization Platform]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_data_foundation_using_red_hat_virtualization_platform[Deploying and managing OpenShift Data Foundation 4.10 using Red Hat Virtualization Platform]
 
 |Deploying {rh-storage-first} on VMware vSphere clusters
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/deploying_openshift_data_foundation_on_vmware_vsphere[Deploying OpenShift Data Foundation 4.9 on VMware vSphere]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_data_foundation_on_vmware_vsphere[Deploying OpenShift Data Foundation 4.10 on VMware vSphere]
 
 |Updating {rh-storage-first} to the latest version
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/upgrading_to_openshift_data_foundation[Updating OpenShift Data Foundation]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/updating_openshift_data_foundation[Updating OpenShift Data Foundation]
 
 2+^| *Managing*
 
 |Allocating storage to core services and hosted applications in {rh-storage-first}, including snapshot and clone
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/managing_and_allocating_storage_resources[Managing and allocating resources]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/managing_and_allocating_storage_resources[Managing and allocating resources]
 
 |Managing storage resources across a hybrid cloud or multicloud environment using the Multicloud Object Gateway (NooBaa)
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/managing_hybrid_and_multicloud_resources[Managing hybrid and multicloud resources]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/managing_hybrid_and_multicloud_resources[Managing hybrid and multicloud resources]
 
 |Safely replacing storage devices for {rh-storage-first}
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/replacing_devices[Replacing devices]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/replacing_devices[Replacing devices]
 
 |Safely replacing a node in a {rh-storage-first} cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/replacing_nodes[Replacing nodes]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/replacing_nodes[Replacing nodes]
 
 |Scaling operations in {rh-storage-first}
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/scaling_storage[Scaling storage]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/scaling_storage[Scaling storage]
 
 |Monitoring a {rh-storage-first} 4.9 cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/monitoring_openshift_data_foundation[Monitoring OpenShift Data Foundation 4.9]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/monitoring_openshift_data_foundation[Monitoring OpenShift Data Foundation 4.10]
 
 |Troubleshooting errors and issues
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/troubleshooting_openshift_data_foundation[Troubleshooting OpenShift Data Foundation 4.9]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/troubleshooting_openshift_data_foundation[Troubleshooting OpenShift Data Foundation 4.10]
 
 |Migrating your {product-title} cluster from version 3 to version 4
-|link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/migration_toolkit_for_containers/[Migration Toolkit for Containers]
+|link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/migration_toolkit_for_containers/[Migration Toolkit for Containers]
 
 |===


### PR DESCRIPTION
Updates OpenShift Data Foundation version to 4.10 in OCP 4.10 doc

Version(s): 4.10 only

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2090176

Link to docs preview: http://file.rdu.redhat.com/sdudhgao/update-links/storage/persistent_storage/persistent-storage-ocs.html

Additional information: