### PR TITLE
BZ-2109524:Update troubleshooting steps for Poison Pill Operator resource removal

### DIFF
--- a/modules/eco-poison-pill-operator-troubleshooting.adoc
+++ b/modules/eco-poison-pill-operator-troubleshooting.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * nodes/nodes/eco-poison-pill-operator.adoc
-
+:_content-type: REFERENCE
 [id="troubleshooting-poison-pill-operator_{context}"]
 = Troubleshooting the Poison Pill Operator
 
@@ -36,12 +36,22 @@ If the `MachineHealthCheck` controller did not create the `PoisonPillRemediation
 If the `PoisonPillRemediation` CR was created, ensure that its name matches the unhealthy node or the machine object.
 
 [id="daemon-set-exists_{context}"]
-== Daemon set exists even after uninstalling the Poison Pill Operator 
-Issue:: The Poison Pill daemon set exists even after after uninstalling the Operator.
+== Daemon set and other Poison Pill Operator resources exist even after uninstalling the Poison Pill Operator 
+Issue:: The Poison Pill Operator resources, such as the daemon set, configuration CR, and the remediation template CR, exist even after after uninstalling the Operator.
 
-Resolution:: To remove the Poison Pill daemon set, manually delete the `PoisonPillConfig` CR. Run the following command:  
+Resolution:: To remove the Poison Pill Operator resources, delete the resources by running the following commands for each resource type:
 +
 [source,terminal]
 ----
-$ oc delete ds <poison-pill-daemonset> -n <namespace>
+$ oc delete ds <poison-pill-ds> -n <namespace>
+----
++
+[source,terminal]
+----
+$ oc delete ppc <poison-pill-config> -n <namespace>
+----
++
+[source,terminal]
+----
+$ oc delete pprt <poison-pill-remediation-template> -n <namespace>
 ----

--- a/nodes/nodes/eco-poison-pill-operator.adoc
+++ b/nodes/nodes/eco-poison-pill-operator.adoc
@@ -28,3 +28,4 @@ include::modules/eco-poison-pill-operator-troubleshooting.adoc[leveloffset=+1]
 == Additional resources
 
 * The Poison Pill Operator is supported in a restricted network environment. For more information, see xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+* xref:../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster]


### PR DESCRIPTION
BZ-2109524: This PR updates information about removing Poison Pill Operator resources after uninstalling the Operator

Version(s): OpenShift 4.8-4.10 (Needs a `merge` to enterprise-4.10, `cherrypick` to enterprise-4.9 and enterprise-4.8)

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2109524

Preview:
http://file.rdu.redhat.com/avbhatt/ent-bz-2109524/nodes/nodes/eco-poison-pill-operator.html#daemon-set-exists_poison-pill-operator-remediate-nodes

Additional information:
Starting with OpenShift 4.11, the Poison Pill Operator is replaced by the Self Node Remediation Operator. Relevant changes for Self Node Remediation Operator are applicable from version 4.11+ and they are addressed in a separate PR (https://github.com/openshift/openshift-docs/pull/48151).