### PR TITLE
[OSDOCS-3592]: Note for Hyper-V gen2 images in machine set YAML

### DIFF
--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -74,9 +74,6 @@ ifndef::infra[]
 endif::infra[]
 ifdef::infra[]
           node-role.kubernetes.io/infra: "" <2>
-      taints: <5>
-      - key: node-role.kubernetes.io/infra
-        effect: NoSchedule
 endif::infra[]
       providerSpec:
         value:
@@ -87,17 +84,12 @@ endif::infra[]
           image:
             offer: ""
             publisher: ""
-            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/images/<infrastructure_id> <1>
+            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/images/<infrastructure_id> <5>
             sku: ""
             version: ""
           internalLoadBalancer: ""
           kind: AzureMachineProviderSpec
-ifndef::infra[]
-          location: <region> <5>
-endif::infra[]
-ifdef::infra[]
           location: <region> <6>
-endif::infra[]
           managedIdentity: <infrastructure_id>-identity <1>
           metadata:
             creationTimestamp: null
@@ -118,11 +110,11 @@ endif::infra[]
             name: worker-user-data <2>
           vmSize: Standard_D4s_v3
           vnet: <infrastructure_id>-vnet <1>
-ifndef::infra[]
-          zone: "1" <6>
-endif::infra[]
-ifdef::infra[]
           zone: "1" <7>
+ifdef::infra[]
+      taints: <8>
+      - key: node-role.kubernetes.io/infra
+        effect: NoSchedule
 endif::infra[]
 ----
 <1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
@@ -151,18 +143,17 @@ $  oc -n openshift-machine-api \
 ifndef::infra[]
 <2> Specify the node label to add.
 <3> Specify the infrastructure ID, node label, and region.
-<4> Optional: Specify the machine set name to enable the use of availability sets. This setting only applies to new compute machines.
-<5> Specify the region to place machines on.
-<6> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
 endif::infra[]
 ifdef::infra[]
 <2> Specify the `<infra>` node label.
 <3> Specify the infrastructure ID, `<infra>` node label, and region.
+endif::infra[]
 <4> Optional: Specify the machine set name to enable the use of availability sets. This setting only applies to new compute machines.
-<5> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<5> Specify an image that is compatible with your instance type. The Hyper-V generation V2 images created by the installation program have a `-gen2` suffix, while V1 images have the same name without the suffix.
 <6> Specify the region to place machines on.
 <7> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
-
+ifdef::infra[]
+<8> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 endif::infra[]
 
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OSDOCS-3592](https://issues.redhat.com//browse/OSDOCS-3592) for [CORS-1916](https://issues.redhat.com//browse/CORS-1916)

Link to docs preview:
- [Sample YAML for a machine set custom resource on Azure](http://file.rdu.redhat.com/jrouth/OSDOCS-3592-hypervgeneration-v2-azure/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-yaml-azure_creating-machineset-azure)
- [Sample YAML for a machine set custom resource on Azure](http://file.rdu.redhat.com/jrouth/OSDOCS-3592-hypervgeneration-v2-azure/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-azure_creating-infrastructure-machinesets) (infra)

Additional information:
This is just the machine set component of this effort. Moved the `taints` parameter to the end of the YAML to make the conditionals less horrifying (_and_ it's alphabetical :nerd_face:).