### PR TITLE
Java-based Operator code update

### DIFF
--- a/modules/osdk-java-controller-memcached-deployment.adoc
+++ b/modules/osdk-java-controller-memcached-deployment.adoc
@@ -11,18 +11,11 @@ The `createMemcachedDeployment` method uses the link:https://fabric8.io/[fabric8
 [source,java]
 ----
     private Deployment createMemcachedDeployment(Memcached m) {
-        return new DeploymentBuilder()
+        Deployment deployment = new DeploymentBuilder()
             .withMetadata(
                 new ObjectMetaBuilder()
                     .withName(m.getMetadata().getName())
                     .withNamespace(m.getMetadata().getNamespace())
-                    .withOwnerReferences(
-                        new OwnerReferenceBuilder()
-                            .withApiVersion("v1")
-                            .withKind("Memcached")
-                            .withName(m.getMetadata().getName())
-                            .withUid(m.getMetadata().getUid())
-                            .build())
                     .build())
             .withSpec(
                 new DeploymentSpecBuilder()
@@ -50,5 +43,7 @@ The `createMemcachedDeployment` method uses the link:https://fabric8.io/[fabric8
                             .build())
                     .build())
             .build();
+      deployment.addOwnerReference(m);
+      return deployment;
     }
 ----

--- a/modules/osdk-java-implement-controller.adoc
+++ b/modules/osdk-java-implement-controller.adoc
@@ -113,46 +113,41 @@ public class MemcachedReconciler implements Reconciler<Memcached> {
   }
 
   private Deployment createMemcachedDeployment(Memcached m) {
-    return new DeploymentBuilder()
-        .withMetadata(
-            new ObjectMetaBuilder()
-                .withName(m.getMetadata().getName())
-                .withNamespace(m.getMetadata().getNamespace())
-                .withOwnerReferences(
-                    new OwnerReferenceBuilder()
-                        .withApiVersion("v1")
-                        .withKind("Memcached")
-                        .withName(m.getMetadata().getName())
-                        .withUid(m.getMetadata().getUid())
-                        .build())
-                .build())
-        .withSpec(
-            new DeploymentSpecBuilder()
-                .withReplicas(m.getSpec().getSize())
-                .withSelector(
-                    new LabelSelectorBuilder().withMatchLabels(labelsForMemcached(m)).build())
-                .withTemplate(
-                    new PodTemplateSpecBuilder()
-                        .withMetadata(
-                            new ObjectMetaBuilder().withLabels(labelsForMemcached(m)).build())
-                        .withSpec(
-                            new PodSpecBuilder()
-                                .withContainers(
-                                    new ContainerBuilder()
-                                        .withImage("memcached:1.4.36-alpine")
-                                        .withName("memcached")
-                                        .withCommand("memcached", "-m=64", "-o", "modern", "-v")
-                                        .withPorts(
-                                            new ContainerPortBuilder()
-                                                .withContainerPort(11211)
-                                                .withName("memcached")
-                                                .build())
-                                        .build())
-                                .build())
-                        .build())
-                .build())
-        .build();
-}
+      Deployment deployment = new DeploymentBuilder()
+          .withMetadata(
+              new ObjectMetaBuilder()
+                  .withName(m.getMetadata().getName())
+                  .withNamespace(m.getMetadata().getNamespace())
+                  .build())
+          .withSpec(
+              new DeploymentSpecBuilder()
+                  .withReplicas(m.getSpec().getSize())
+                  .withSelector(
+                      new LabelSelectorBuilder().withMatchLabels(labelsForMemcached(m)).build())
+                  .withTemplate(
+                      new PodTemplateSpecBuilder()
+                          .withMetadata(
+                              new ObjectMetaBuilder().withLabels(labelsForMemcached(m)).build())
+                          .withSpec(
+                              new PodSpecBuilder()
+                                  .withContainers(
+                                      new ContainerBuilder()
+                                          .withImage("memcached:1.4.36-alpine")
+                                          .withName("memcached")
+                                          .withCommand("memcached", "-m=64", "-o", "modern", "-v")
+                                          .withPorts(
+                                              new ContainerPortBuilder()
+                                                  .withContainerPort(11211)
+                                                  .withName("memcached")
+                                                  .build())
+                                          .build())
+                                  .build())
+                          .build())
+                  .build())
+          .build();
+    deployment.addOwnerReference(m);
+    return deployment;
+  }
 }
 ----
 ====


### PR DESCRIPTION
Version(s):
4.11+

Link to docs preview:
[Implementing the controller](http://file.rdu.redhat.com/antaylor/osdocs-2933.3/operators/operator_sdk/java/osdk-java-tutorial.html#osdk-java-implement-controller_osdk-java-tutorial)
[Define the createMemcachedDeployment](https://docs.openshift.com/container-platform/4.11/operators/operator_sdk/java/osdk-java-tutorial.html#osdk-java-controller-memcached-deployment_osdk-java-tutorial)

Additional information:
Last minute edit to code. 