### PR TITLE
PTP events with OC is GA in OCP 4.10

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2174,8 +2174,8 @@ In the table below, features are marked with the following statuses:
 
 |PTP events with ordinary clock
 |-
-|-
 |TP
+|GA
 
 |`oc` CLI plug-ins
 |GA


### PR DESCRIPTION
PTP events with OC is GA in OCP 4.10

Merge to enterprise-4.10

Preview: http://file.emea.redhat.com/aireilly/fix-ptp-tp-note/release_notes/ocp-4-10-release-notes.html#ocp-4-10-technology-preview