### PR TITLE
[RHACS] Upgrade instructions for Scanner in RHACS 3.71

### DIFF
--- a/modules/upgrade-scanner-roxctl-371.adoc
+++ b/modules/upgrade-scanner-roxctl-371.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// */upgrading/upgrade-scanner.adoc
+:_module-type: PROCEDURE
+[id="upgrade-scanner-roxctl-371_{context}"]
+= Upgrading to RHACS version 3.71 
+
+If you are upgrading to RHACS 3.71 using the `roxctl` CLI and YAML files, you need to perform some additional steps. The Scanner DB image no longer mounts the `scanner-db-password` Kubernetes Secret into the `db` Scanner DB container. Instead, `scanner-db-password` is only used in the init container, `init-db`. Therefore, you must add the `POSTGRES_PASSWORD_FILE` environment variable to the init container configuration. The init container must also mount the `scanner-db-tls-volume` and `scanner-db-password` volumes. The following section provides the upgrade steps for {product-title-short} if you are using {ocp} or Kubernetes. For more information about init containers, see the link:https://kubernetes.io/docs/concepts/workloads/pods/init-containers/[Kubernetes documentation].
+
+.Prerequisites
+
+* This procedure assumes the `db` container in the Scanner DB configuration is at `index 0`, which is the first entry in the `containers` list; and the `scanner-db-password` volume mount is at `index 2`, which is the third entry. 
+
+While this scenario applies to most deployments, check the configuration for Scanner DB before entering these commands. If your values differ, you must adjust the `.../containers/x/volumeMounts/y` value in the following commands. 
+
+.Procedure
+
+. Apply the patch:
+* If you use {ocp}, enter the following command:
++
+[source,terminal]
+----
+$ oc -n stackrox patch deployment.apps/scanner-db --patch '{"spec":{"template":{"spec":{"initContainers":[{"name":"init-db","env":[{"name":"POSTGRES_PASSWORD_FILE","value":"/run/secrets/stackrox.io/secrets/password"}],"command":["/usr/local/bin/docker-entrypoint.sh","postgres","-c","config_file=/etc/postgresql.conf"],"volumeMounts":[{"name":"db-data","mountPath":"/var/lib/postgresql/data"},{"name":"scanner-db-tls-volume","mountPath":"/run/secrets/stackrox.io/certs","readOnly":true},{"name":"scanner-db-password","mountPath":"/run/secrets/stackrox.io/secrets","readOnly":true}],"securityContext":{"runAsGroup":70,"runAsNonRoot":true,"runAsUser":70}}]}}}}'
+----
+* If you use Kubernetes, enter the following command:
++
+[source,terminal]
+----
+$ kubectl -n stackrox patch deployment.apps/scanner-db --patch '{"spec":{"template":{"spec":{"initContainers":[{"name":"init-db","env":[{"name":"POSTGRES_PASSWORD_FILE","value":"/run/secrets/stackrox.io/secrets/password"}],"command":["/usr/local/bin/docker-entrypoint.sh","postgres","-c","config_file=/etc/postgresql.conf"],"volumeMounts":[{"name":"db-data","mountPath":"/var/lib/postgresql/data"},{"name":"scanner-db-tls-volume","mountPath":"/run/secrets/stackrox.io/certs","readOnly":true},{"name":"scanner-db-password","mountPath":"/run/secrets/stackrox.io/secrets","readOnly":true}],"securityContext":{"runAsGroup":70,"runAsNonRoot":true,"runAsUser":70}}]}}}}'
+----
+. Remove the path:
+* If you use {ocp}, enter the following command:
++
+[source,terminal]
+----
+$ oc -n stackrox patch deployment.apps/scanner-db --type json --patch '{"op":"remove","path":"/spec/template/spec/containers/0/volumeMounts/2"}'
+----
+* If you use Kubernetes, enter the following command:
++
+[source,terminal]
+----
+$ kubectl -n stackrox patch deployment.apps/scanner-db --type json --patch '{"op":"remove","path":"/spec/template/spec/containers/0/volumeMounts/2"}'
+----

--- a/modules/upgrade-scanner.adoc
+++ b/modules/upgrade-scanner.adoc
@@ -8,57 +8,84 @@
 You can update Scanner to the latest version by using the `roxctl` CLI.
 
 .Prerequisites
+* If you deploy images from a private image registry, you must first push the new image into your private registry, then edit the commands in the following section to use the name of your private image registry.
 
-* If you deploy images from a private image registry, first push the new image into your private registry, and then replace your image registry for the commands in this section.
-* If you used Red Hat UBI-based images when you installed {product-title}, replace the image names for the commands in this section with the following UBI-based image names:
-* If you have created custom scanner configurations, you must apply those changes before updating the scanner configuration file:
+.Procedure
+. If you have created custom scanner configurations, you must apply those changes before updating the scanner configuration file. 
+.. Generate Scanner using the following `roxctl` command:
 +
 [source,terminal]
 ----
 $ roxctl -e "$ROX_CENTRAL_ADDRESS" scanner generate
 ----
+.. Apply the TLS secrets YAML file:
+* If you use {ocp}, enter the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f scanner-bundle/scanner/02-scanner-03-tls-secret.yaml <1>
+$ oc apply -f scanner-bundle/scanner/02-scanner-03-tls-secret.yaml 
 ----
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+* If you use Kubernetes, enter the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f scanner-bundle/scanner/02-scanner-04-scanner-config.yaml <1>
+$ kubectl apply -f scanner-bundle/scanner/02-scanner-03-tls-secret.yaml 
 ----
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
-
-.Procedure
-
+.. Apply the Scanner configuration YAML file:
+* If you use {ocp}, enter the following command:
++
+[source,terminal]
+----
+$ oc apply -f scanner-bundle/scanner/02-scanner-04-scanner-config.yaml
+----
+* If you use Kubernetes, enter the following command:
++
+[source,terminal]
+----
+$ kubectl apply -f scanner-bundle/scanner/02-scanner-04-scanner-config.yaml
+----
 . Update the Scanner image:
+* If you use {ocp}, enter the following command:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner scanner=registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:{rhacs-version} <1>
+$ oc -n stackrox set image deploy/scanner scanner=registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:{rhacs-version} 
 ----
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+* If you use Kubernetes, enter the following command:
++
+[source,terminal,subs=attributes+]
+----
+$ kubectl -n stackrox set image deploy/scanner scanner=registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:{rhacs-version} 
+----
+
 . Update the Scanner database image:
+* If you use {ocp}, enter the following command:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner-db db=registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:{rhacs-version} <1>
+$ oc -n stackrox set image deploy/scanner-db db=registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:3.68.2
 ----
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+* If you use Kubernetes, enter the following command:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner-db init-db=registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:{rhacs-version} <1>
+$ kubectl -n stackrox set image deploy/scanner-db db=registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:{rhacs-version}
 ----
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 
 .Verification
 
 * Check that the new pods have deployed successfully:
+
+** If you use {ocp}, enter the following command:
 +
 [source,terminal]
 ----
-$ oc get pod -n stackrox --watch <1>
+$ oc get pod -n stackrox --watch 
 ----
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+
+** If you use Kubernetes, enter the following command:
++
+[source,terminal]
+----
+$ kubectl get pod -n stackrox --watch 
+----

--- a/modules/verify-central-cluster-upgrade.adoc
+++ b/modules/verify-central-cluster-upgrade.adoc
@@ -11,15 +11,23 @@ After you have upgraded both Central and Scanner, verify that the Central cluste
 .Procedure
 
 * Check the Central logs:
+
++ 
+If you are using {ocp}, enter the following command:
 +
 [source,terminal]
 ----
-$ oc logs -n stackrox deploy/central -c central <1>
+$ oc logs -n stackrox deploy/central -c central 
 ----
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 +
-If the upgrade is successful, you will see output similar to the following:
+If you are using Kubernetes, enter the following command:
 +
+[source,terminal]
+----
+$ kubectl logs -n stackrox deploy/central -c central 
+----
+
+.Sample output of a successful upgrade
 [source,terminal]
 ----
 No database restore directory found (this is not an error).

--- a/upgrading/upgrade-roxctl.adoc
+++ b/upgrading/upgrade-roxctl.adoc
@@ -43,6 +43,7 @@ include::modules/install-roxctl-cli-windows.adoc[leveloffset=+3]
 After you upgrade the `roxctl` CLI you can upgrade Scanner.
 
 include::modules/upgrade-scanner.adoc[leveloffset=+2]
+include::modules/upgrade-scanner-roxctl-371.adoc[leveloffset=+3]
 
 include::modules/verify-central-cluster-upgrade.adoc[leveloffset=+2]
 


### PR DESCRIPTION
This PR:

1. Adds instructions for upgrading for roxctl customers
2. Fixes confusing documentation experience by offering both `oc` and `kubectl` versions of commands ([as requested by SMEs](https://srox.slack.com/archives/CGDK78KRV/p1657133578043569))

Version: `rhacs-docs-3.71`
Label: `RHACS/next`
Issue: none
[Preview](https://openshift-docs-qckjbhdxs-kcarmichael08.vercel.app/openshift-acs/master/upgrading/upgrade-roxctl.html#upgrade-scanner_upgrade-roxctl)
