### PR TITLE
OSDOCS-3439: Updated the PID limits

### DIFF
--- a/osd_architecture/osd_policy/osd-service-definition.adoc
+++ b/osd_architecture/osd_policy/osd-service-definition.adoc
@@ -12,7 +12,7 @@ include::modules/sdpolicy-am-billing.adoc[leveloffset=+2]
 include::modules/sdpolicy-am-cluster-self-service.adoc[leveloffset=+2]
 include::modules/sdpolicy-am-cloud-providers.adoc[leveloffset=+2]
 include::modules/sdpolicy-am-compute.adoc[leveloffset=+2]
-
+include::snippets/pid-limits.adoc[]
 .Additional Resources
 * xref:../../osd_architecture/osd_policy/osd-service-definition.adoc#sdpolicy-red-hat-operator_osd-service-definition[Red Hat Operator Support]
 

--- a/osd_cluster_admin/osd_nodes/osd-nodes-machinepools-about.adoc
+++ b/osd_cluster_admin/osd_nodes/osd-nodes-machinepools-about.adoc
@@ -9,6 +9,8 @@ toc::[]
 
 The primary resources are machines, machine sets, and machine pools.
 
+include::snippets/pid-limits.adoc[]
+
 == Machines
 A machine is a fundamental unit that describes the host for a worker node.
 

--- a/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
@@ -16,7 +16,7 @@ This section provides information about the service definition for {product-titl
 include::modules/rosa-sdpolicy-am-billing.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-cluster-self-service.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-compute.adoc[leveloffset=+2]
-
+include::snippets/pid-limits.adoc[]
 .Additional Resources
 * xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-red-hat-operator_rosa-service-definition[Red Hat Operator Support]
 

--- a/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
@@ -10,6 +10,8 @@ toc::[]
 
 The primary resources are machines, machine sets, and machine pools.
 
+include::snippets/pid-limits.adoc[]
+
 == Machines
 A machine is a fundamental unit that describes the host for a worker node.
 

--- a/snippets/pid-limits.adoc
+++ b/snippets/pid-limits.adoc
@@ -1,0 +1,23 @@
+// Text snippet included in the following assemblies:
+//
+// SERVICE DEFINITION REFERENCES
+//
+// * /osd_architecture/osd-service-definition.adoc
+//
+// * /rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+//
+// MACHINE POOL REFERENCES
+//
+// * /osd_cluster_admin/osd_nodes/osd-nodes-machinepools-about.adoc
+//
+// * /rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
+//
+
+:_content-type: SNIPPET
+
+[IMPORTANT]
+====
+As of the {product-title} versions 4.8.35, 4.9.26, 4.10.6, the {product-title} default per-pod pid limit is `4096`. If you want to enable this PID limit, you must upgrade your {product-title} clusters to these versions or later. {product-title} clusters with prior versions use a default PID limit of `1024`.
+
+You cannot configure the per-pod PID limit on any {product-title} cluster.
+====


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/OSDOCS-3439

Link to docs preview:

- ROSA snippet instances:
    - [Service Definition](http://file.rdu.redhat.com/eponvell/OSDOCS-3439_pidLimit/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-support_rosa-service-definition)
    - [About Machinepools](http://file.rdu.redhat.com/eponvell/OSDOCS-3439_pidLimit/rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.html)
- OSD snippet instances:
    - [Service Definition](http://file.rdu.redhat.com/eponvell/OSDOCS-3439_pidLimit/dedicated/osd_architecture/osd_policy/osd-service-definition.html#support_osd-service-definition)
    - [About Machinepools](http://file.rdu.redhat.com/eponvell/OSDOCS-3439_pidLimit/dedicated/osd_cluster_admin/osd_nodes/osd-nodes-machinepools-about.html)

NOTE: The OSD and ROSA service definition topic instances are placeholder until #47934 restructure is merged.

Additional information:
Updated the PID limits reference from `1024` to `4096`