### PR TITLE
RHDEVDOCS-3922 - metrics page UI improvements

### DIFF
--- a/modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc
+++ b/modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc
@@ -9,11 +9,6 @@
 
 As a cluster administrator or as a user with view permissions for all projects, you can access metrics for all default {product-title} and user-defined projects in the Metrics UI.
 
-[NOTE]
-====
-Only cluster administrators have access to the third-party UIs provided with {product-title} Monitoring.
-====
-
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role or with view permissions for all projects.
@@ -21,19 +16,33 @@ Only cluster administrators have access to the third-party UIs provided with {pr
 
 .Procedure
 
-. In the *Administrator* perspective within the {product-title} web console, select *Observe* -> *Metrics*.
+. Select the *Administrator* perspective in the {product-title} web console.
+
+. Select *Observe* -> *Metrics*.
 
 . Select *Insert Metric at Cursor* to view a list of predefined queries.
 
 . To create a custom query, add your Prometheus Query Language (PromQL) query to the *Expression* field.
++
+[NOTE]
+====
+As you type a PromQL expression, autocomplete suggestions appear in a drop-down list.
+These suggestions include functions, metrics, labels, and time tokens.
+You can use the keyboard arrows to select one of these suggested items and then press Enter to add the item to your expression.
+You can also move your mouse pointer over a suggested item to view a brief description of that item.
+====
 
 . To add multiple queries, select *Add Query*.
+
+. To duplicate an existing query, select {kebab} next to the query, then choose *Duplicate query*.
 
 . To delete a query, select {kebab} next to the query, then choose *Delete query*.
 
 . To disable a query from being run, select {kebab} next to the query and choose *Disable query*.
 
-. Select *Run Queries* to run the queries that you have created. The metrics from the queries are visualized on the plot. If a query is invalid, the UI shows an error message.
+. To run queries that you created, select *Run Queries*. 
+The metrics from the queries are visualized on the plot. 
+If a query is invalid, the UI shows an error message.
 +
 [NOTE]
 ====
@@ -41,8 +50,3 @@ Queries that operate on large amounts of data might time out or overload the bro
 ====
 
 . Optional: The page URL now contains the queries you ran. To use this set of queries again in the future, save this URL.
-
-[role="_additional-resources"]
-.Additional resources
-
-* See the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus query documentation] for more information about creating PromQL queries.

--- a/modules/monitoring-querying-metrics-for-user-defined-projects-as-a-developer.adoc
+++ b/modules/monitoring-querying-metrics-for-user-defined-projects-as-a-developer.adoc
@@ -13,7 +13,7 @@ In the *Developer* perspective, the Metrics UI includes some predefined CPU, mem
 
 [NOTE]
 ====
-Developers can only use the *Developer* perspective and not the *Administrator* perspective. As a developer, you can only query metrics for one project at a time. Developers cannot access the third-party UIs provided with {product-title} monitoring that are for core platform components. Instead, use the Metrics UI for your user-defined project.
+Developers can only use the *Developer* perspective and not the *Administrator* perspective. As a developer, you can only query metrics for one project at a time in the *Observe* --> *Metrics* page in the web console for your user-defined project.
 ====
 
 .Prerequisites
@@ -25,18 +25,20 @@ Developers can only use the *Developer* perspective and not the *Administrator* 
 
 .Procedure
 
-. From the *Developer* perspective in the {product-title} web console, select *Observe* -> *Metrics*.
+. Select the *Developer* perspective in the {product-title} web console.
+
+. Select *Observe* -> *Metrics*.
 
 . Select the project that you want to view metrics for in the *Project:* list.
 
-. Choose a query from the *Select Query* list, or run a custom PromQL query by selecting *Show PromQL*.
+. Select a query from the *Select query* list, or create a custom PromQL query based on the selected query by selecting *Show PromQL*.
+
+. Optional: Select *Custom query* from the *Select query* list to enter a new query. 
+As you type, autocomplete suggestions appear in a drop-down list.
+These suggestions include functions and metrics.
+Click a suggested item to select it.
 +
 [NOTE]
 ====
 In the *Developer* perspective, you can only run one query at a time.
 ====
-
-[role="_additional-resources"]
-.Additional resources
-
-* See the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus query documentation] for more information about creating PromQL queries.

--- a/monitoring/managing-metrics.adoc
+++ b/monitoring/managing-metrics.adoc
@@ -34,19 +34,27 @@ include::modules/monitoring-specifying-how-a-service-is-monitored.adoc[leveloffs
 include::modules/monitoring-querying-metrics.adoc[leveloffset=+1]
 //include::modules/monitoring-contents-of-the-metrics-ui.adoc[leveloffset=+2]
 include::modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about creating PromQL queries, see the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus query documentation].
+
 include::modules/monitoring-querying-metrics-for-user-defined-projects-as-a-developer.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
-* See the xref:../monitoring/managing-metrics.adoc#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics[Querying metrics for user-defined projects as a developer] for details on accessing non-cluster metrics as a developer or a privileged user
+* For more information about creating PromQL queries, see the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus query documentation]. 
 
 include::modules/monitoring-exploring-the-visualized-metrics.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
-* See the xref:../monitoring/managing-metrics.adoc#querying-metrics_managing-metrics[Querying metrics] section on using the PromQL interface
+* See xref:../monitoring/managing-metrics.adoc#querying-metrics_managing-metrics[Querying metrics] for details on using the PromQL interface
+* See xref:../monitoring/managing-metrics.adoc#querying-metrics-for-all-projects-as-an-administrator_managing-metrics[Querying metrics for all projects as an administrator] for details on accessing metrics for all projects as an administrator.
+* See xref:../monitoring/managing-metrics.adoc#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics[Querying metrics for user-defined projects as a developer] for details on accessing non-cluster metrics as a developer or a privileged user.
 
 == Next steps
 


### PR DESCRIPTION
Summary: This PR updates 2 existing procedures to add documentation for the Duplicate Query feature and autocomplete suggestions added to the PromQL Query Browser on the Observe > Metrics page in the OCP web console.

This PR also moves some "Additional resources" xref content that was incorrectly placed in proc modules and puts this content into the correct place in the assembly file.

- Aligned team: DevTools
- For branches: 4.11
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3922
- Direct link to doc preview (RH VPN access required): 
- - http://file.rdu.redhat.com/bburt/RHDEVDOCS-3922-observe-metrics-page-improvements/monitoring/managing-metrics.html#querying-metrics-for-all-projects-as-an-administrator_managing-metrics 
- - http://file.rdu.redhat.com/bburt/RHDEVDOCS-3922-observe-metrics-page-improvements/monitoring/managing-metrics.html#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics
- SME review:  @jgbernalp 
- QE review: @Tai-RedHat 
- Peer review: @ tbd