### PR TITLE
troubleshooting portal build failure

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1235,7 +1235,7 @@ Topics:
   - Name: Installing the MetalLB Operator
     File: metallb-operator-install
   - Name: Upgrading the MetalLB Operator
-    File: metalb-upgrading-operator
+    File: metallb-upgrading-operator
   - Name: Configuring MetalLB address pools
     File: metallb-configure-address-pools
   - Name: Advertising the IP address pools

--- a/networking/metallb/metallb-upgrading-operator.adoc
+++ b/networking/metallb/metallb-upgrading-operator.adoc
@@ -1,8 +1,8 @@
 :_content-type: ASSEMBLY
-[id="metallb-operator-upgrade"]
+[id="metallb-upgrading-operator"]
 = Upgrading the MetalLB Operator
 include::_attributes/common-attributes.adoc[]
-:context: metallb-operator-upgrade
+:context: metallb-upgrading-operator
 
 toc::[]
 

--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1546,7 +1546,7 @@ This script removes unauthenticated subjects from the following cluster role bin
 +
 As a workaround, remove the previous version of the MetalLB Operator. Do not delete the namespace or the instance of the MetalLB custom resource, and deploy the new Operator version. This keeps MetalLB running and configured.
 +
-For more information, see xref:../networking/metallb/metalb-upgrading-operator.adoc#metallb-operator-upgrade[Upgrading the MetalLB Operator]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2100180[*BZ#2100180*])
+For more information, see xref:../networking/metallb/metallb-upgrading-operator.adoc#metallb-upgrading-operator[Upgrading the MetalLB Operator]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2100180[*BZ#2100180*])
 
 * The OpenShift CLI (`oc`) for {product-title} 4.11 does not work properly on macOS due to a change in error handling of untrusted certificates in Go 1.18 libraries. Due to this change, `oc login` and other `oc` commands can fail with a `certificate is not trusted` error without proceeding further when running on macOS. Until the error handling is properly fixed in Go 1.18 (tracked by link:https://github.com/golang/go/issues/52010[Go issue #52010]), the workaround is to use the {product-title} 4.10 `oc` CLI instead. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097830[*BZ#2097830*])
 


### PR DESCRIPTION
This file is empty after sync.sh runs for reasons that are not apparent. IIRC, the file name, id, and context statement need to match. 