### PR TITLE
BZ#2110059: Fix inaccuracies in ingress dest CA cert docs

### DIFF
--- a/modules/nw-ingress-creating-a-route-via-an-ingress.adoc
+++ b/modules/nw-ingress-creating-a-route-via-an-ingress.adoc
@@ -10,7 +10,7 @@ Some ecosystem components have an integration with Ingress resources but not wit
 
 .Procedure
 
-. Define an Ingress object in the {product-title} console or by entering the oc `create` command:
+. Define an Ingress object in the {product-title} console or by entering the `oc create` command:
 +
 .YAML Definition of an Ingress
 [source,yaml]

--- a/modules/nw-ingress-reencrypt-route-custom-cert.adoc
+++ b/modules/nw-ingress-reencrypt-route-custom-cert.adoc
@@ -6,10 +6,10 @@
 [id="creating-re-encrypt-route-with-custom-certificate_{context}"]
 = Creating a route using the destination CA certificate in the Ingress annotation
 
-The `route.openshift.io/destination-ca-certificate-secret` annotation can be used on an Ingress object to define an route with a custom certificate (CA).
+The `route.openshift.io/destination-ca-certificate-secret` annotation can be used on an Ingress object to define a route with a custom destination CA certificate.
 
 .Prerequisites
-* You must have a certificate/key pair in PEM-encoded files, where the certificate is valid for the route host.
+* You may have a certificate/key pair in PEM-encoded files, where the certificate is valid for the route host.
 * You may have a separate CA certificate in a PEM-encoded file that completes the certificate chain.
 * You must have a separate destination CA certificate in a PEM-encoded file.
 * You must have a service that you want to expose.
@@ -42,7 +42,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: frontend
-  Annotations:
+  annotations:
     route.openshift.io/termination: reencrypt
     route.openshift.io/destination-ca-certificate-secret: secret-ca-cert
 spec:


### PR DESCRIPTION
* `modules/nw-ingress-creating-a-route-via-an-ingress.adoc`: Change "oc `create`" to "`oc create`".
* `modules/nw-ingress-reencrypt-route-custom-cert.adoc`: Change "an route" to "a route".  Replace "certificate (CA)" with "destination CA certificate".  State that the user *may* (not *must*) specify a certificate/key pair.  Change "Annotations:" to "annotations:" in the example yaml.

-------

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):

<!--- Specify the version or versions of OpenShift your PR applies to.

Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->
4.11+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://bugzilla.redhat.com/show_bug.cgi?id=2110059

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
The option to configure a destination CA certificate on an ingress object was added in OpenShift 4.11: https://issues.redhat.com/browse/NE-729