### PR TITLE
troubleshooting portal build failure

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1234,7 +1234,7 @@ Topics:
   - Name: Installing the MetalLB Operator
     File: metallb-operator-install
   - Name: Upgrading the MetalLB Operator
-    File: metalb-upgrading-operator
+    File: metallb-upgrading-operator
   - Name: Configuring MetalLB address pools
     File: metallb-configure-address-pools
   - Name: Advertising the IP address pools

--- a/networking/metallb/metallb-upgrading-operator.adoc
+++ b/networking/metallb/metallb-upgrading-operator.adoc
@@ -1,8 +1,8 @@
 :_content-type: ASSEMBLY
-[id="metallb-operator-upgrade"]
+[id="metallb-upgrading-operator"]
 = Upgrading the MetalLB Operator
 include::_attributes/common-attributes.adoc[]
-:context: metallb-operator-upgrade
+:context: metallb-upgrading-operator
 
 toc::[]
 
@@ -33,5 +33,5 @@ include::modules/nw-metalLB-basic-upgrade-operator.adoc[leveloffset=+1]
 
 * xref:../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster]
 
-* xref:metallb-operator-install.adoc#metallb-operator-install[Installing the MetalLB Operator]
+* xref:../../networking/metallb/metallb-operator-install.adoc#metallb-operator-install[Installing the MetalLB Operator]
 


### PR DESCRIPTION
The 4.11 portal build was failing during the sync for the second localization drop. Moving the fixes that I added to 4.11 on https://github.com/openshift/openshift-docs/pull/48198 and https://github.com/openshift/openshift-docs/pull/48195 back to main.