### PR TITLE
modules/enabling-baseline-capability-set: Fix "none" -> "None"

### DIFF
--- a/modules/enabling-baseline-capability-set.adoc
+++ b/modules/enabling-baseline-capability-set.adoc
@@ -20,7 +20,7 @@ As a cluster administrator, you can enable the capabilities by setting `baseline
 $ oc patch clusterversion version --type merge -p '{"spec":{"capabilities":{"baselineCapabilitySet":"vCurrent"}}}' <1>
 ----
 +
-<1> For `baselineCapabilitySet` you can specify `vCurrent`, `v4.11`, or `none`.
+<1> For `baselineCapabilitySet` you can specify `vCurrent`, `v4.11`, or `None`.
 +
 The following table describes the `baselineCapabilitySet` values.
 +
@@ -35,7 +35,7 @@ The following table describes the `baselineCapabilitySet` values.
 |`v4.11`
 |Specify when you want the capabilities defined in {product-title} 4.11 and not automatically enable capabilities, which might be introduced in later versions.
 
-|`none`
+|`None`
 |Specify when the other sets are too large, and you do not need any capabilities or want to fine-tune via `additionalEnabledCapabilities`.
 
 |===


### PR DESCRIPTION
Match [the casing used in the API enum][1], fixing a typo from 52da949f96 (#47915, CC @darshan-nagaraj)

[1]: https://github.com/openshift/api/blob/d2198688dc209e0ed3a6ab1c74ec02cf36b64cf3/config/v1/types_cluster_version.go#L258-L264
