### PR TITLE
[enterprise-4.10]TELCODOCS-663:Add information about must-gather images for Poison Pill, NHC, and NMO

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -57,6 +57,12 @@ endif::openshift-dedicated[]
 |`registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:1.2.0`
 |Data collection for {sandboxed-containers-first}.
 
+|`registry.redhat.io/openshift4/poison-pill-must-gather-rhel8:v4.10`
+|Data collection for the Poison Pill Operator and the Node Health Check Operator.
+
+|`registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v4.10.0`
+|Data collection for the Node Maintenance Operator.
+
 |===
 
 endif::openshift-origin[]

--- a/nodes/nodes/eco-node-health-check-operator.adoc
+++ b/nodes/nodes/eco-node-health-check-operator.adoc
@@ -23,6 +23,10 @@ include::modules/eco-node-health-check-operator-installation-web-console.adoc[le
 
 include::modules/eco-node-health-check-operator-installation-cli.adoc[leveloffset=+1]
 
+[id="gather-data-nhc"]
+== Gathering data about the Node Health Check Operator
+To collect debugging information about the Node Health Check Operator, use the `must-gather` tool. For information about the `must-gather` image for the Node Health Check Operator, see xref:../../support/gathering-cluster-data.adoc#gathering-data-specific-features_gathering-cluster-data[Gathering data about specific features].
+
 [id="additional-resources-nhc-operator-installation"]
 == Additional resources
 * xref:../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Changing the update channel for an Operator]

--- a/nodes/nodes/eco-node-maintenance-operator.adoc
+++ b/nodes/nodes/eco-node-maintenance-operator.adoc
@@ -46,6 +46,10 @@ include::modules/eco-resuming-node-maintenance-cr-web-console.adoc[leveloffset=+
 
 include::modules/eco-resuming-node-maintenance-cr-cli.adoc[leveloffset=+2]
 
+[id="gather-data-nmo"]
+== Gathering data about the Node Maintenance Operator
+To collect debugging information about the Node Maintenance Operator, use the `must-gather` tool. For information about the `must-gather` image for the Node Maintenance Operator, see xref:../../support/gathering-cluster-data.adoc#gathering-data-specific-features_gathering-cluster-data[Gathering data about specific features].
+
 [role="_additional-resources"]
 [id="additional-resources-node-maintenance-operator-installation"]
 == Additional resources

--- a/nodes/nodes/eco-poison-pill-operator.adoc
+++ b/nodes/nodes/eco-poison-pill-operator.adoc
@@ -23,6 +23,10 @@ include::modules/eco-configuring-machine-health-check-with-poison-pill.adoc[leve
 
 include::modules/eco-poison-pill-operator-troubleshooting.adoc[leveloffset=+1]
 
+[id="gather-data-poison-pill"]
+== Gathering data about the Poison Pill Operator
+To collect debugging information about the Poison Pill Operator, use the `must-gather` tool. For information about the `must-gather` image for the Poison Pill Operator, see xref:../../support/gathering-cluster-data.adoc#gathering-data-specific-features_gathering-cluster-data[Gathering data about specific features].
+
 [role="_additional-resources"]
 [id="additional-resources-poison-pill-operator-installation"]
 == Additional resources


### PR DESCRIPTION
[TELCODOCS): This PR adds information about must-gather images for the following Operators:

- Poison Pill
- Node Health Check
- Node Maintenance

Version(s): OpenShift 4.10 only (enterprise-4.10)

Issue:
https://issues.redhat.com/browse/TELCODOCS

Previews:

- [Gathering data about specific features](http://file.rdu.redhat.com/avbhatt/ent-TD-663/support/gathering-cluster-data.html#gathering-data-specific-features_gathering-cluster-data)
- Poison Pill: http://file.rdu.redhat.com/avbhatt/ent-TD-663/nodes/nodes/eco-poison-pill-operator.html#gather-data-poison-pill
- Node Health Check: http://file.rdu.redhat.com/avbhatt/ent-TD-663/nodes/nodes/eco-node-health-check-operator.html#gather-data-nhc
- Node Maintenance: http://file.rdu.redhat.com/avbhatt/ent-TD-663/nodes/nodes/eco-node-maintenance-operator.html#gather-data-nmo
