### PR TITLE
TELCODOCS:601 - Document fixed issues for release notes for OSC 1.3

### DIFF
--- a/sandboxed_containers/sandboxed-containers-4.11-release-notes.adoc
+++ b/sandboxed_containers/sandboxed-containers-4.11-release-notes.adoc
@@ -21,7 +21,13 @@ This product is fully supported and enabled by default as of {product-title} 4.1
 [id="sandboxed-containers-1-3-bug-fixes"]
 == Bug fixes
 
+* Previously, when creating the `KataConfig` CR and observing the pod status under the `openshift-sandboxed-containers-operator` namespace, a huge number of restarts for monitor pods was shown. The monitor pods use a specific SELinux policy that was installed as part of the `sandboxed-containers` extension installation. The monitor pod was created immediately. However, the SELinux policy was not yet available, which resulted in a pod creation error, followed by a pod restart.
++
+With this release, the SELinux policy is available when the monitor pod is created, and the monitor pod transitions to a `Running` state immediately. (https://issues.redhat.com/browse/KATA-1338[*KATA-1338*])
 
+* Previously, {sandboxed-containers-first} deployed a security context constraint (SCC) on startup which enforced a custom SELinux policy that was not available on Machine Config Operator (MCO) pods. This caused the MCO pod to change to a `CrashLoopBackOff` state and cluster upgrades to fail. With this release, {sandboxed-containers-first} deploys the SCC when creating the `KataConfig` CR and no longer enforces using the custom SELinux policy. (https://issues.redhat.com/browse/KATA-1373[*KATA-1373*])
+
+* Previously, when uninstalling the {sandboxed-containers-operator}, the `sandboxed-containers-operator-scc` custom resource was not deleted. With this release, the `sandboxed-containers-operator-scc` custom resource is deleted when uninstalling the {sandboxed-containers-operator}. (https://issues.redhat.com/browse/KATA-1569[*KATA-1569*])
 
 [id="sandboxed-containers-1-3-known-issues"]
 == Known issues


### PR DESCRIPTION
Version(s): 4.11

Issue:
[TELCODOCS-601](https://issues.redhat.com/browse/TELCODOCS-601)


[Link to docs preview](http://file.emea.redhat.com/miweiss/TELCODOCS-601/sandboxed_containers/sandboxed-containers-4.11-release-notes.html)

Reviewed and approved by SME and QE.