### PR TITLE
added flag to the sample install-config yaml file

### DIFF
--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -150,15 +150,19 @@ platform:
   aws:
 ifndef::gov,china,secret[]
     region: us-west-2 <1>
+    propagateUserTags: false <3> 
 endif::gov,china,secret[]
 ifdef::china[]
     region: cn-north-1 <1>
+    propagateUserTags: false <3>
 endif::china[]
 ifdef::gov[]
     region: us-gov-west-1 <1>
+    propagateUserTags: false <3>
 endif::gov[]
 ifdef::secret[]
     region: us-iso-east-1 <1>
+    propagateUserTags: false <3>
 endif::secret[]
     userTags:
       adminContact: jdoe


### PR DESCRIPTION
- Applies to 4.12 
- [Jira](https://issues.redhat.com/browse/CFE-524)
- [Preview](http://file.del.redhat.com/asakthiv/CFE509-524/installing/installing_aws/installing-aws-customizations.html#installation-aws-config-yaml_installing-aws-customizations)
Questions>> I have not added the `ExperimentalPropagateUserTags` , I think it is deprecated or are we still using it? My understanding is this is an optional parameter with a default boolean value of `false`.   @TrilokGeer 