### PR TITLE
[OSDOCS-3688]: 4.11 Rel Notes for Cloud team features

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -628,6 +628,41 @@ For more information, see xref:../operators/operator_sdk/osdk-bundle-validate.ad
 [id="ocp-4-11-machine-api"]
 === Machine API
 
+[id="ocp-4-11-mapi-aws-imdsv2"]
+==== Configuration options for the Amazon EC2 Instance Metadata Service
+
+You can now use machine sets to create compute machines that use a specific version of the Amazon EC2 Instance Metadata Service (IMDS). Machine sets can create compute machines that allow the use of both IMDSv1 and IMDSv2 or compute machines that require the use of IMDSv2.
+
+For more information, see xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-imds-options_creating-machineset-aws[Machine set options for the Amazon EC2 Instance Metadata Service].
+
+[id="ocp-4-11-mapi-ultra-disks"]
+==== Machine API support for Azure ultra disks
+
+You can now create a machine set running on Azure that deploys machines with ultra disks. You can either deploy machines with ultra disks as data disks, or by using persistent volume claims (PVCs) that use in-tree or Container Storage Interface (CSI) PVCs.
+
+For more information, see the following topics:
+
+* xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-azure-ultra-disk_creating-machineset-azure[Machine sets that deploy machines with ultra disks as data disks]
+
+* xref:../storage/container_storage_interface/persistent-storage-csi-azure.adoc#machineset-azure-ultra-disk_persistent-storage-csi-azure[Machine sets that deploy machines with ultra disks using CSI PVCs]
+
+* xref:../storage/persistent_storage/persistent-storage-azure.adoc#machineset-azure-ultra-disk_persistent-storage-azure[Machine sets that deploy machines with ultra disks using in-tree PVCs]
+
+[id="ocp-4-11-mapi-pd-balanced"]
+==== Configuration options for Google Cloud Platform persistent disk types
+
+The `pd-balanced` persistent disk type for the Google Cloud Platform (GCP) Compute Engine is now supported. For more information, see xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-gcp-pd-disk-types_creating-machineset-gcp[Configuring persistent disk types by using machine sets].
+
+[id="ocp-4-11-mapi-nutanix-new-platform"]
+==== Machine API support for Nutanix clusters
+
+The new platform support for Nutanix clusters includes the ability to manage machines using Machine API machine sets. For more information, see xref:../machine_management/creating_machinesets/creating-machineset-nutanix.adoc[Creating a machine set on Nutanix].
+
+[id="ocp-4-11-capi-tp-aws-gcp"]
+==== Managing machines with the Cluster API (Technology Preview)
+
+{product-title} 4.11 introduces the ability to manage machines by using the upstream Cluster API, integrated into {product-title}, as a Technology Preview for AWS and GCP clusters. This capability is in addition or an alternative to managing machines with the Machine API. For more information, see xref:../machine_management/capi-machine-management.adoc[Managing machines with the Cluster API].
+
 [id="ocp-4-11-machine-config-operator"]
 === Machine Config Operator
 
@@ -1904,6 +1939,11 @@ In the table below, features are marked with the following statuses:
 |TP
 
 |Hosted control planes for {product-title}
+|-
+|-
+|TP
+
+|Managing machines with the Cluster API
 |-
 |-
 |TP


### PR DESCRIPTION
Version(s):
4.11

Issue:
[OSDOCS-3688](https://issues.redhat.com//browse/OSDOCS-3688) and subtasks ([OSDOCS-3690](https://issues.redhat.com//browse/OSDOCS-3690) [OSDOCS-3837](https://issues.redhat.com//browse/OSDOCS-3837) [OSDOCS-3827](https://issues.redhat.com//browse/OSDOCS-3827) [OSDOCS-3834](https://issues.redhat.com//browse/OSDOCS-3834) [OSDOCS-3838](https://issues.redhat.com//browse/OSDOCS-3838))

Link to docs preview:
- [New features and enhancements > Machine API](http://file.rdu.redhat.com/jrouth/OSDOCS-3688-cloud-rel-notes/release_notes/ocp-4-11-release-notes.html#ocp-4-11-machine-api)
- [Technology Preview features](http://file.rdu.redhat.com/jrouth/OSDOCS-3688-cloud-rel-notes/release_notes/ocp-4-11-release-notes.html#ocp-4-11-technology-preview) (end of table)

Additional information:
~The CAPI TP docs are still in progress, so the link from *Managing machines with the Cluster API (Technology Preview)* is broken (and I expect the build to fail) until #48121 is merged)~
CAPI TP docs are merged, and the build is resolved :tada: 