### PR TITLE
OSDOCS-3567: Removing TP notice

### DIFF
--- a/installing/disconnected_install/index.adoc
+++ b/installing/disconnected_install/index.adoc
@@ -19,4 +19,4 @@ If you already have a container image registry, such as Red Hat Quay, you can us
 You can use one of the following procedures to mirror your {product-title} image repository to your mirror registry:
 
 * xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
-* xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in] (Technology Preview)
+* xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in]

--- a/installing/disconnected_install/installing-mirroring-disconnected.adoc
+++ b/installing/disconnected_install/installing-mirroring-disconnected.adoc
@@ -22,7 +22,7 @@ The following steps outline the high-level workflow on how to use the oc-mirror 
 // About the oc-mirror plug-in
 include::modules/oc-mirror-about.adoc[leveloffset=+1]
 
-// TODO: Check the content of this module to make sure it's accurate for oc-mirror
+// About the mirror registry
 include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -30,7 +30,6 @@ include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 
 * For information about viewing the CRI-O logs to view the image source, see xref:../../installing/validating-an-installation.adoc#viewing-the-image-pull-source_validating-an-installation[Viewing the image pull source].
 
-// TODO: Copied this prereq section + about mirror registry from the orig section. Review/update as necessary
 [id="prerequisites_installing-mirroring-disconnected"]
 == Prerequisites
 
@@ -97,9 +96,6 @@ include::modules/oc-mirror-disk-to-mirror.adoc[leveloffset=+3]
 
 // Installing the ImageContentSourcePolicy and CatalogSource resources into the cluster
 include::modules/oc-mirror-updating-cluster-manifests.adoc[leveloffset=+1]
-
-// TODO: Consider whether we want any sort of reference module on how to use `oc mirror` (the 3 ways etc)
-// Maybe consider adding the blurb just to the beginning of the procedure modules (the combo of params?)
 
 [id="updating-mirror-registry-content"]
 == Keeping your mirror registry content updated


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3567

Link to docs preview: http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3567-tp-removal/installing/disconnected_install/
