### PR TITLE
OSDOCS-3435: Updated Nutanix RN to include link to IPI topic

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -116,7 +116,7 @@ For more information, see xref:../installing/installing_aws/installing-aws-secre
 ==== Installing a cluster on Nutanix using installer-provisioned infrastructure
 {product-title} 4.11 introduces support for installing a cluster on Nutanix using installer-provisioned infrastructure. This type of installation lets you use the installation program to deploy a cluster on infrastructure that the installation program provisions and the cluster maintains.
 
-//For more information, see ../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#installing-nutanix-installer-provisioned[Installing a cluster on Nutanix].
+For more information, see xref:../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#installing-nutanix-installer-provisioned[Installing a cluster on Nutanix].
 
 [id="ocp-4-11-azure-ultrassd"]
 ==== Installing {product-title} using Azure Ultra SSD


### PR DESCRIPTION
Version(s):
CP to 4.11

Issue:
This PR is a continuation of https://github.com/openshift/openshift-docs/pull/46302. Updated the Nutanix release note to include a link to Installing a cluster on Nutanix.

Link to docs preview:
[Installing a cluster on Nutanix using installer-provisioned infrastructure](http://file.rdu.redhat.com/mpytlak/NutanixRN/release_notes/ocp-4-11-release-notes.html#ocp-4-11-nutanix)