### PR TITLE
OSSMDOC-639: move ossm-1668 back to known issue

### DIFF
--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -19,9 +19,6 @@ The following issues been resolved in the current release:
 [id="ossm-rn-fixed-issues-ossm_{context}"]
 == {SMProductShortName} fixed issues
 
-* https://issues.redhat.com/browse/OSSM-1668[OSSM-1668]
-`jwksResolverCA` field is missing in `SMCP`.
-
 * https://issues.redhat.com/browse/OSSM-1325[OSSM-1325] istiod pod crashes and displays the following error message: `fatal error: concurrent map iteration and map write`.
 
 * https://issues.redhat.com/browse/OSSM-1211[OSSM-1211]

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -34,6 +34,13 @@ These are the known issues in {SMProductName}:
 
 * link:https://github.com/istio/istio/issues/14743[Istio-14743] Due to limitations in the version of Istio that this release of {SMProductName} is based on, there may be applications that are currently incompatible with {SMProductShortName}. See the linked community issue for details.
 
+* https://issues.redhat.com/browse/OSSM-1668[OSSM-1668]
+`jwksResolverCA` field is missing in `SMCP`.
++
+If you upgrade from Service Mesh operator 2.1.3 to Service Mesh operator 2.2, then the `jwksResolverCA` field is not supported.
++
+Workaround: Use the `techPreview` `jwksResolverExtraRootCA` field to enable additional JWKS CA certificates.
+
 //Keep OSSM-1655 in RN, closed as "explained" error is expected.
 * https://issues.redhat.com/browse/OSSM-1655[OSSM-1655] Kiali dashboard shows error after enabling mTLS in `SMCP`.
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.6-4.11
<!--- Specify the version or versions of OpenShift your PR applies to.

Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: https://issues.redhat.com/browse/OSSMDOC-639
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.bos.redhat.com/tokeefe/OSSMDOC-639/service_mesh/v2x/servicemesh-release-notes.html#ossm-rn-known-issues_ossm-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
Eng review: yxun
QE review: mattmahoneyrh
Peer review: jstickler
