### PR TITLE
BZ:2110915 - Added asynchronous update for OSC 1.2.1 to release notes…

### DIFF
--- a/sandboxed_containers/sandboxed-containers-release-notes.adoc
+++ b/sandboxed_containers/sandboxed-containers-release-notes.adoc
@@ -161,6 +161,15 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 
 This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {sandboxed-containers-first} {sandboxed-containers-version}.
 
+[id="sandboxed-containers-1-2-1"]
+=== RHSA-2022:1508 - {sandboxed-containers-first} {sandboxed-containers-version}.1 bug fix advisory.
+
+Issued: 2022-04-21
+
+{sandboxed-containers-first} release {sandboxed-containers-version}.1 is now available. This advisory contains an update for {sandboxed-containers-first} with bug fixes.
+
+The list of bug fixes included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2022:1508[RHSA-2022:1508] advisory.
+
 [id="sandboxed-containers-1-2-0"]
 === RHSA-2022:0855 - {sandboxed-containers-first} {sandboxed-containers-version}.0 image release, security update, bug fix, and enhancement advisory.
 


### PR DESCRIPTION
Version(s): 4.10

Issue:
[BZ-2110915](https://bugzilla.redhat.com/show_bug.cgi?id=2110915)

[Link to docs preview](http://file.emea.redhat.com/miweiss/BZ-2110915/sandboxed_containers/sandboxed-containers-release-notes.html#sandboxed-containers-1-2-asynchronous-errata-updates)

Reviewed and approved by QE.