### PR TITLE
enterprise-4.11 release notes: Fix {sno} var typo

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -74,8 +74,8 @@ The redirector hostname for downloading {op-system} boot images is now `rhcos.mi
 === Installation and upgrade
 
 ==== New minimum system requirements for installing {product-title} on a single node
-This release updates the minimum system requirements for installing {product-title} on a single node. When installing {product-title} on a single node, you should configure a minimum of 16 GB of RAM. Specific workload requirements can require additional RAM. The complete list of supported platforms has been updated to include bare metal, vSphere, {rh-openstack-first}, and Red Hat Virtualization platforms. In all cases, you must specify the `platform.none: {}` parameter in the `install-config.yaml` configuration file when the `openshift-installer` binary is being used to install :sno:.
-s
+This release updates the minimum system requirements for installing {product-title} on a single node. When installing {product-title} on a single node, you should configure a minimum of 16 GB of RAM. Specific workload requirements can require additional RAM. The complete list of supported platforms has been updated to include bare metal, vSphere, {rh-openstack-first}, and Red Hat Virtualization platforms. In all cases, you must specify the `platform.none: {}` parameter in the `install-config.yaml` configuration file when the `openshift-installer` binary is being used to install {sno}.
+
 [id="ocp-4-11-OCP-on-arm"]
 ==== {product-title} on ARM
 


### PR DESCRIPTION
Fixes a `{sno}` variable typo on the enterprise-4.11 release notes.

Merge to enterprise-4.11.

Preview: http://file.emea.redhat.com/aireilly/fix-sno-typo/release_notes/ocp-4-11-release-notes.html#new-minimum-system-requirements-for-installing-openshift-container-platform-on-a-single-node