### PR TITLE
Samples Operator Doc updates for RHDEVDOCS-4230

### DIFF
--- a/modules/samples-operator-overview.adoc
+++ b/modules/samples-operator-overview.adoc
@@ -65,7 +65,7 @@ ifdef::openshift-origin[]
 endif::[]
 ====
 
-However, if the Cluster Samples Operator also detects an {product-title} global proxy is configured, it bypasses those checks.
+However, if the Cluster Samples Operator detects that it is on an IPv6 network and an {product-title} global proxy is configured, then IPv6 check supersedes all the checks. As a result, the Cluster Samples Operator bootstraps itself as `Removed`.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
[RHDEVDOCS-4230](https://issues.redhat.com//browse/RHDEVDOCS-4230): Tracker for Bug 2100390 - Docs - Samples operator should bootstrap to managed when set global proxy

- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: enterprise-`4.6`, enterprise-`4.7`, enterprise-`4.8`, enterprise-`4.9`, enterprise-`4.10`, and enterprise-`4.11`
- **JIRA issues**: [RHDEVDOCS-4230](https://issues.redhat.com/browse/RHDEVDOCS-4230)
- **Preview pages**: [Download to see the preview in your browser](https://drive.google.com/file/d/1FJzQa_FJkKAq0N1Sya4VBqOnjzu2oYQj/view?usp=sharing)
- **SME Review**: Completed by @dperaza4dustbit, @fbm3307 
- **QE review**: Completed by @tisutisu
- **Peer-review**: Completed by @jc-berger 