### PR TITLE
TELCODOCS:602 - Documenting known issues for OSC release notes 1.3

### DIFF
--- a/sandboxed_containers/sandboxed-containers-4.11-release-notes.adoc
+++ b/sandboxed_containers/sandboxed-containers-4.11-release-notes.adoc
@@ -26,7 +26,80 @@ This product is fully supported and enabled by default as of {product-title} 4.1
 [id="sandboxed-containers-1-3-known-issues"]
 == Known issues
 
+* If you are using {sandboxed-containers-first}, you might receive SELinux denials when accessing files or directories mounted from the `hostPath` volume in an {product-title} cluster. These denials can occur even when running privileged sandboxed containers because privileged sandboxed containers do not disable SELinux checks.
++
+Following SELinux policy on the host guarantees full isolation of the host file system from the sandboxed workload by default. This also provides stronger protection against potential security flaws in the `virtiofsd` daemon or QEMU.
++
+If the mounted files or directories do not have specific SELinux requirements on the host, you can use local persistent volumes as an alternative. Files are automatically relabeled to `container_file_t`, following SELinux policy for container runtimes. See xref:../storage/persistent_storage/persistent-storage-local.adoc#persistent-storage-local[Persistent storage using local volumes] for more information.
++
+Automatic relabeling is not an option when mounted files or directories are expected to have specific SELinux labels on the host. Instead, you can set custom SELinux rules on the host to allow the `virtiofsd` daemon to access these specific labels. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904609[*BZ#1904609*])
 
+* Some {sandboxed-containers-operator} pods use container CPU resource limits to increase the number of available CPUs for the pod. These pods might receive fewer CPUs than requested. If the functionality is available inside the container, you can diagnose CPU resource issues by using `oc rsh <pod>` to access a pod and running the `lscpu` command:
++
+[source,terminal]
+----
+$ lscpu
+----
++
+.Example output
++
+[source,terminal]
+----
+CPU(s):                          16
+On-line CPU(s) list:             0-12,14,15
+Off-line CPU(s) list:            13
+----
++
+The list of offline CPUs will likely change unpredictably from run to run.
++
+As a workaround, you can use a pod annotation to request additional CPUs rather than setting a CPU limit. CPU requests that use pod annotation are not affected by this issue, because the processor allocation method is different. Rather than setting a CPU limit, the following `annotation` must be added to the metadata of the pod:
++
+[source,yaml]
+----
+metadata:
+  annotations:
+    io.katacontainers.config.hypervisor.default_vcpus: "16"
+----
++
+(link:https://issues.redhat.com/browse/KATA-1376[*KATA-1376*])
+
+* The progress of the runtime installation is shown in the `status` section of the `kataConfig` custom resource (CR). However, the progress is not shown if all of the following conditions are true:
+
+** There are no worker nodes defined. You can run `oc get machineconfigpool` to check the number of worker nodes in the machine config pool.
+** No `kataConfigPoolSelector` is specified to select nodes for installation.
+
++
+In this case, the installation starts on the control plane nodes because the Operator assumes it is a converged cluster where nodes have both control plane and worker roles. The `status` section of the `kataConfig` CR is not updated during the installation. (link:https://issues.redhat.com/browse/KATA-1017[*KATA-1017*])
+
+* When using older versions of the Buildah tool in {sandboxed-containers-first}, the build fails with the following error:
++
+[source,text]
+----
+process exited with error: fork/exec /bin/sh: no such file or directory
+
+subprocess exited with status 1
+----
++
+You must use the latest version of Buildah, available at link:https://quay.io/buildah/stable:latest[quay.io].
++
+(link:https://issues.redhat.com/browse/KATA-1278[*KATA-1278*])
+
+* In the *KataConfig* tab in the web console, if you click *Create KataConfig* while in the *YAML view*, the `KataConfig` YAML is missing the `spec` fields. Toggling to the *Form view* and then back to the *YAML view* fixes this issue and displays the full YAML. (link:https://issues.redhat.com/browse/KATA-1372[*KATA-1372*])
+
+* In the *KataConfig* tab in the web console, a `404: Not found` error message appears whether a `KataConfig` CR already exists or not. To access an existing `KataConfig` CR, go to *Home* > *Search*. From the *Resources* list, select *KataConfig*. (link:https://issues.redhat.com/browse/KATA-1605[*KATA-1605*])
+
+* Upgrading {sandboxed-containers-first} does not automatically update the existing `KataConfig` CR. As a result, monitor pods from previous deployments are not restarted and continue to run with an outdated `kataMonitor` image.
++
+Upgrade the `kataMonitor` image with the following command:
++
+[source,terminal]
+----
+$ oc patch kataconfig example-kataconfig --type merge --patch '{"spec":{"kataMonitorImage":"registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:1.3.0"}}'
+----
++
+You can also upgrade the `kataMonitor` image by editing the `KataConfig` YAML in the web console.
++
+(link:https://issues.redhat.com/browse/KATA-1650[*KATA-1650*])
 
 [id="sandboxed-containers-1-3-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Version(s): 4.11

Issue:
[TELCODOCS-602](https://issues.redhat.com/browse/TELCODOCS-602)

[Link to docs preview](http://file.emea.redhat.com/miweiss/TELCODOCS-602/sandboxed_containers/sandboxed-containers-4.11-release-notes.html)

Reviewed and approved by SME and QE.