### PR TITLE
WIP- Release note for TELCODOCS-780 moving TP to GA

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -519,6 +519,12 @@ Open Virtual Network (OVN) was redesigned to host its control plane and data sto
 
 For clusters on user-provisioned xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-configuration-parameters-network_installing-bare-metal-network-customizations[bare metal infrastructure], the OVN-Kubernetes cluster network provider supports both IPv4 and IPv6 address families.
 
+[id="ocp-4-11-pod-level-bonding"]
+==== Pod-level bonding for secondary networks
+Bonding at the pod level is vital to assist workloads inside pods that require high availability and more throughput. With pod-level bonding, you can create a bond interface from many single root I/O virtualization (SR-IOV) virtual function interfaces in kernel mode interface. The SR-IOV virtual functions are passed into the pod and attached to a kernel driver. This feature was previously introduced as a Technology Preview feature in {product-title} 4.10 and is now generally available in {product-title} 4.11. 
+
+Scenarios where you require pod-level bonding include creating a bond interface from many SR-IOV virtual functions on different physical functions. Create a bond interface from two different physical functions on the host to achieve high availability at pod level.
+
 [id="ocp-4-11-hardware"]
 === Hardware
 
@@ -1433,8 +1439,8 @@ In the table below, features are marked with the following statuses:
 
 |Pod-level bonding for secondary networks
 |-
-|TP
-|
+|GA
+|GA
 
 |IPv6 dual stack
 |GA


### PR DESCRIPTION
[TELCODOCS-780](https://issues.redhat.com//browse/TELCODOCS-780): Release note for [TELCODOCS-780](https://issues.redhat.com//browse/TELCODOCS-780)

Version(s):
4.11

Issue:
https://github.com/openshift/openshift-docs/pull/48271

Link to docs preview:
http://file.emea.redhat.com/rohennes/RN-[TELCODOCS-780](https://issues.redhat.com//browse/TELCODOCS-780)/release_notes/ocp-4-11-release-notes.html#ocp-4-11-pod-level-bonding

Additional information:
This was originally Tech Preview for 4.10. Support is now available for 4.11 and also support is backported to 4.10.

