### PR TITLE
Adds RNs for the Dev Perspective

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -180,6 +180,19 @@ For more information, see xref:../post_installation_configuration/cluster-capabi
 [id="ocp-4-11-web-console"]
 === Web console
 
+[id="ocp-4-111-developer-perspective"]
+==== Developer Perspective
+
+* With this update, in the developer perspective, you can add your GitHub repository containing pipelines to the Openshift Container Platform cluster. You can now run pipelines and tasks from your GitHub repository on the cluster when relevant Git events, such as push or pull requests are triggered.
+
+** In the administrator perspective, you can configure your GitHub application with the OpenShift cluster to use a pipeline as code. With this configuration, you can execute a set of tasks required for build deployment.
+
+* With this update, you can create a customized pipeline using your own set of curated tasks. You can search, install, and upgrade your tasks directly from the developer console.
+
+* With this update, in the web terminal you can now have multiple tabs, view bash history, and the web terminal remains open until you close the browser window or tab.
+
+* With this update, in the *Add+* page of the developer perspective, a new menu added to share project and Helm Chart repositories that allows to add or remove users to the project.
+
 [id="ocp-4-11-oc"]
 === OpenShift CLI (oc)
 
@@ -1035,7 +1048,7 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 
 * Before this update, invalid subscription labels were created when a resource name exceeded 63 characters. Truncating labels that exceed the 63-character limit resolves the issue, and the subscription resource no longer rejects the Kubernetes API. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2016425[*BZ#2016425*])
 
-* Before this update, catalog source pods for the Marketplace Operator prevented nodes from draining. As a result, the Cluster Autoscaler could not scale down effectively. With this update, adding the `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation to the catalog source pods fixes the issue, and the Cluster Autoscaler can scale down effectively.(link:https://bugzilla.redhat.com/show_bug.cgi?id=2053343[*BZ#2053343*])
+* Before this update, catalog source pods for the Marketplace Operator prevented nodes from draining. As a result, the Cluster Autoscaler could not scale down effectively. With this update, adding the `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation to the catalog source pods fixes the issue, and the Cluster Autoscaler can scale down effectively. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2053343[*BZ#2053343*])
 
 * Before this update, the `collect-profiles` job could take a long time to complete in certain circumstances, such as when a pod could not be scheduled. As a result, if enough jobs were scheduled but unable to run, the number of scheduled jobs exceeded pod quota limits. With this update, only one `collect-profiles` pod exists at a time, and the `collect-profiles` job does not exceed pod quota limits. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2055861[*BZ#2055861*])
 
@@ -1045,7 +1058,7 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 
 * Previously, info-level logs were generated during `operator-marketplace` project polling, which caused log spam. This update uses the command line flag to reduce the log line to the debug level, and adds more control of the log levels for the user. As a result, this reduces log spam. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057558[*BZ#2057558*])
 
-* Previously, each component managed by the CVO consisted of YAML files defined in the `/manifest` directory in the root of a project's repo. When removing a YYAML file from the `/manifest` directory, you needed to add the `release.openshift.io/delete: “true”` annotation, otherwise the CVO would not delete the resources from the cluster. This update reintroduces any resources that were removed from the `/manifest` directory and adds the `release.openshift.io/delete: “true”` annotation so that the CVO cleans up the resources. As a result, resources that are no longer required for the OLM component are removed from the cluster.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1975543[*BZ#1975543*])
+* Previously, each component managed by the Cluster Version Operator (CVO) consisted of YAML files defined in the `/manifest` directory in the root of a project's repo. When removing a YYAML file from the `/manifest` directory, you needed to add the `release.openshift.io/delete: “true”` annotation, otherwise the CVO would not delete the resources from the cluster. This update reintroduces any resources that were removed from the `/manifest` directory and adds the `release.openshift.io/delete: “true”` annotation so that the CVO cleans up the resources. As a result, resources that are no longer required for the OLM component are removed from the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975543[*BZ#1975543*])
 
 * Previously, the CheckRegistryServer function used by GRPC catalog sources did not confirm the existence of the service account associated with the catalog source. This caused the existence of an unhealthy catalog source with no service account. With this update, the GRPC `CheckRegistryServer` function checks if the service account exists and recreates the service if it is not found. As a result, the OLM recreates service accounts owned by GRPC catalog souces if they do not exist. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975543[*BZ#1975543*])
 
@@ -1095,17 +1108,35 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-4-11-web-console-developer-perspective-bug-fixes"]
 ==== Web console (Developer perspective)
 
-* Before this update, the *Git Import* form displayed an error message when an invalid devfile repository (older than devfile v2.2) is entered. With this update, the error message states that devfiles older than v2.2 are not supported.(link:https://bugzilla.redhat.com/show_bug.cgi?id=2046435[*BZ#2046435*])
+* Before this update, the *Git Import* form displayed an error message when an invalid devfile repository (older than devfile v2.2) is entered. With this update, the error message states that devfiles older than v2.2 are not supported. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2046435[*BZ#2046435*])
 
-* Before this update, if the *ConsoleLink CR* (openshift-blog) was not available in the cluster, the blog link was undefined. Clicking on the blog link did not redirect to the OpenShift blog. With this update, a fall back link to https://developers.redhat.com/products/openshift/whats-new is added even if the *ConsoleLink CR* (openshift-blog) is not present in the cluster.(link:https://bugzilla.redhat.com/show_bug.cgi?id=2050637[BZ#2050637])
+* Before this update, if the *ConsoleLink CR* (openshift-blog) was not available in the cluster, the blog link was undefined. Clicking on the blog link did not redirect to the OpenShift blog. With this update, a fall back link to https://developers.redhat.com/products/openshift/whats-new is added even if the *ConsoleLink CR* (openshift-blog) is not present in the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2050637[*BZ#2050637*])
 
-* Before this update, the API version for the kafka CR was updated. This version did not support the old version, so an empty *Bootstrap server* was displayed on *Create Event Source - KafkaSource* even if it was created. With this update, the updated APIs for the Kafka CR support the old versions and renders the *Bootstrap server* list in *Create Event Source - KafkaSource* form.(link:https://bugzilla.redhat.com/show_bug.cgi?id=2058623[BZ#2058623])
+* Before this update, the API version for the kafka CR was updated. This version did not support the old version, so an empty *Bootstrap server* was displayed on *Create Event Source - KafkaSource* even if it was created. With this update, the updated APIs for the Kafka CR support the old versions and renders the *Bootstrap server* list in *Create Event Source - KafkaSource* form. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2058623[*BZ#2058623*])
 
-* Before this update, when you used the *Import from Git* form to import a private Git repository, the correct import type and a builder image were not identified because the secret to fetch the private repository details was not decoded. With this update, the *Import from Git* form decodes the secret to fetch the private repository details.(link:https://bugzilla.redhat.com/show_bug.cgi?id=2053501[BZ#2053501])
+* Before this update, when you used the *Import from Git* form to import a private Git repository, the correct import type and a builder image were not identified because the secret to fetch the private repository details was not decoded. With this update, the *Import from Git* form decodes the secret to fetch the private repository details. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2053501[*BZ#2053501*])
 
-* Before this update, from the developer perspective, the *Observe* dashboard opened for the most recently viewed workload rather than the one you selected in the *Topology* view. This issue happens because the session prefers the redux store instead of the query parameters in the URL. With this update, the *Observe* dashboard renders components based on the query parameters in the URL.(link:https://bugzilla.redhat.com/show_bug.cgi?id=2052953[BZ#2052953])
+* Before this update, from the developer perspective, the *Observe* dashboard opened for the most recently viewed workload rather than the one you selected in the *Topology* view. This issue happens because the session prefers the redux store instead of the query parameters in the URL. With this update, the *Observe* dashboard renders components based on the query parameters in the URL. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2052953[*BZ#2052953*])
 
-* Before this update, the *Pipeline* used to start with the hardcoded value `gp2` as the default storage class even if it did not exist on the cluster. With this update, you can use the default specified storage class name instead of a hardcoded value.(link:https://bugzilla.redhat.com/show_bug.cgi?id=2084635[BZ#2084635])
+* Before this update, the *Pipeline* used to start with the hardcoded value `gp2` as the default storage class even if it did not exist on the cluster. With this update, you can use the default specified storage class name instead of a hardcoded value. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2084635[*BZ#2084635*])
+
+* Before this update, while running high-volume pipeline logs, the auto-scroll functionality does not work and logs display older messages. Running high-volume pipeline logs generates a large number of calls to the `scrollIntoView` method. With this update, high-volume pipeline logs do not generate any calls to the `scrollIntoView` method and gives a smooth auto-scroll functionality. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2014161[*BZ#2014161*])
+
+* Before this update, when creating a *RoleBinding* using the *Create RoleBinding* form, the subject name was mandatory. A missing subject name fails to load the *Project Access* tab. With this update, the *RoleBinding* without the *Subject Name* property is not listed in the *Project Access* tab. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2051558[*BZ#2051558*])
+
+* Before this update, the sink and trigger for event sources showed all the resources, even though those are standalone or part of backing the `k-native service`, `Broker`, or `KameletBinding`. The addressed resources used to show in the sink dropdown list. With this update, a filter has been added to show only standalone resources as sink. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054285[*BZ#2054285*])
+
+* Before this update, the empty tabs in the sidebar of the topology view were not filtered out before rendering. This displayed invalid tabs for *Workloads* in the topology view. With this update, the empty tabs are filtered properly before rendering. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049483[*BZ#2049483*])
+
+* Before this update, when a pipeline is started using the *Start Last Run* button, the `started-by` annotation of the created `PipelineRun` was not updated to the correct username so the triggered by section did not show the correct username. With this update, the `started-by` annotation value is updated to the correct username and the triggered by section shows the username of the correct user that started the pipeline. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2046618[*BZ#2046618*])
+
+* Before this update, the `ProjectHelmChartRepository` CR does not show up in the cluster. Consequently, the API schema for this CR has not been initialized in the cluster yet. With this update the `ProjectHelmChartRepository` shows up in the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054197[*BZ#2054197*])
+
+* Before this update, when you navigate using a keyboard in the topology, the selected items were not highlighted. With this update, navigation using a keyboard highlights and updates styles to the selected items. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039277[*BZ#2039277*])
+
+* Before this update, the layout of the web terminal opened outside of the default view and could not be resized. With this update, the web terminal opens inside the default view and resizes properly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2022253[*BZ#2022253*])
+
+* Before this update, some of the sidebar items did not contain namespace context. Consequently, when links were opened from another browser, or opening links from a different active namespace, the web console does not switch to the correct namespace. With this update, the correct namespace is selected when opening the URL. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039647[*BZ#2039647*])
 
 [id="ocp-4-11-technology-preview"]
 == Technology Preview features
@@ -1599,6 +1630,8 @@ As a workaround, remove the previous version of the MetalLB Operator. Do not del
 For more information, see xref:../networking/metallb/metallb-upgrading-operator.adoc#metallb-upgrading-operator[Upgrading the MetalLB Operator]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2100180[*BZ#2100180*])
 
 * The OpenShift CLI (`oc`) for {product-title} 4.11 does not work properly on macOS due to a change in error handling of untrusted certificates in Go 1.18 libraries. Due to this change, `oc login` and other `oc` commands can fail with a `certificate is not trusted` error without proceeding further when running on macOS. Until the error handling is properly fixed in Go 1.18 (tracked by link:https://github.com/golang/go/issues/52010[Go issue #52010]), the workaround is to use the {product-title} 4.10 `oc` CLI instead. Note that when using the {product-title} 4.10 `oc` CLI with an {product-title} 4.11 cluster, it is no longer possible to get a token by using the `oc serviceaccounts get-token <service_account>` command. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097830[*BZ#2097830*]) (link:https://bugzilla.redhat.com/show_bug.cgi?id=2109799[*BZ#2109799*])
+
+* There is currently a known issue in the *Add Helm Chart Repositories* form to extend the Developer Catalog of a project. The *Quick Start* guides shows that you can add the `ProjectHelmChartRepository` CR in the desired namespace whereas it does not mention that to perform this you need permission from the kubeadmin. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054197[BZ#2054197])
 
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Adds RNs for the developer perspective.

Version(s):
`enterprise-4.11` only

https://issues.redhat.com/browse/RHDEVDOCS-4022 

Link to docs preview:
Developer perspective features: http://file.rdu.redhat.com/opayne/dev-console-RNs/release_notes/ocp-4-11-release-notes.html#ocp-4-111-developer-perspective
Bug fixes: http://file.rdu.redhat.com/opayne/dev-console-RNs/release_notes/ocp-4-11-release-notes.html#ocp-4-11-bug-fixes (Note that some of these were merged, but looks like bolding the link text missed peer review. I have fixed those.)
Known issue: http://file.rdu.redhat.com/opayne/dev-console-RNs/release_notes/ocp-4-11-release-notes.html#ocp-4-11-bug-fixes (last bullet)



