### PR TITLE
OSDK 4.11 release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -548,6 +548,20 @@ Starting in {product-title} {product-version} as a Technology Preview feature, t
 
 For more information, see xref:../operators/operator_sdk/java/osdk-java-quickstart.adoc[Getting started with Operator SDK for Java-based Operators].
 
+[id="ocp-4-11-run-bundle-fbc-osdk"]
+==== Operator SDK support for file-based catalogs
+
+As of {product-title} {product-version}, the `run bundle` command supports the file-based catalog format for Operator catalogs by default. The deprecated SQLite database format for Operator catalogs continues to be supported; however, it will be removed in a future release.
+
+For more information, see xref:../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-working-bundle-images[Working with bundle images].
+
+[id="ocp-4-11-bundle-validators-osdk"]
+==== Validating Operator bundles
+
+As an Operator author, you can run the `bundle validate` command in the Operator SDK to validate the content and format of an Operator bundle. In addition to the default test, you can run optional validators to test for issues in your bundle, such as an empty CRD description or unsupported Operator Lifecycle Manager (OLM) resources.
+
+For more information, see xref:../operators/operator_sdk/osdk-bundle-validate.adoc#osdk-bundle-validate[Validating Operator bundles].
+
 [id="ocp-4-11-builds"]
 === Builds
 
@@ -740,6 +754,27 @@ Service Account token secrets still appear as auto-generated in {product-title} 
 * For information about using the TokenRequest API, see xref:../authentication/bound-service-account-tokens.html#bound-sa-tokens-configuring_bound-service-account-tokens[Using bound service account tokens]
 
 * For information about creating a service account token secret, see xref:../nodes/pods/nodes-pods-secrets.html#nodes-pods-secrets-creating-sa_nodes-pods-secrets[Creating a service account token secret].
+
+[discrete]
+[id="ocp-4-11-operator-sdk-1-22-0"]
+==== Operator SDK 1.22.0
+
+{product-title} 4.11 supports Operator SDK 1.22.0. See xref:../cli_reference/osdk/cli-osdk-install.adoc#cli-osdk-install[Installing the Operator SDK CLI] to install or update to this latest version.
+
+[NOTE]
+====
+Operator SDK 1.22.0 supports Kubernetes 1.24.
+====
+
+If you have Operator projects that were previously created or maintained with Operator SDK 1.16.0, update your projects to keep compatibility with Operator SDK 1.22.0.
+
+* xref:../operators/operator_sdk/golang/osdk-golang-updating-projects.adoc#osdk-upgrading-projects_osdk-golang-updating-projects[Updating Go-based Operator projects]
+
+* xref:../operators/operator_sdk/ansible/osdk-ansible-updating-projects.adoc#osdk-upgrading-projects_osdk-ansible-updating-projects[Updating Ansible-based Operator projects]
+
+* xref:../operators/operator_sdk/helm/osdk-helm-updating-projects.adoc#osdk-upgrading-projects_osdk-helm-updating-projects[Updating Helm-based Operator projects]
+
+* xref:../operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.adoc#osdk-upgrading-projects_osdk-hybrid-helm-updating-projects[Updating Hybrid Helm-based Operator projects]
 
 [id="ocp-4-11-deprecated-removed-features"]
 == Deprecated and removed features


### PR DESCRIPTION
Version(s): 4.11 release note and notable technical change

Issue: Release notes for the following tickets:

- [OSDOCS-3746](https://issues.redhat.com//browse/OSDOCS-3746)
- [OSDOCS-3531](https://issues.redhat.com//browse/OSDOCS-3531)
- [OSDOCS-3429](https://issues.redhat.com//browse/OSDOCS-3429)

Link to docs preview:

- [Notable technical change](http://file.rdu.redhat.com/mipeter/osdk-4.11-release-notes/release_notes/ocp-4-11-release-notes.html#ocp-4-11-notable-technical-changes) (OSDK 1.22.0 and Kubernetes 1.24 support)
- [OSDK support for file-based catalogs](http://file.rdu.redhat.com/mipeter/osdk-4.11-release-notes/release_notes/ocp-4-11-release-notes.html#ocp-4-11-run-bundle-fbc-osdk) (`run bundle`)
- [Validating Operator bundles](http://file.rdu.redhat.com/mipeter/osdk-4.11-release-notes/release_notes/ocp-4-11-release-notes.html#ocp-4-11-bundle-validators-osdk) (built in validator tests and `bundle validate` command) 