### PR TITLE
Adjusting start/end of comments in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,9 +3,9 @@
 <!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->
 
 Version(s):
-<!--- Specify the version or versions of OpenShift your PR applies to.
+<!--- Specify the version or versions of OpenShift your PR applies to. -->
 
-Examples:
+<!-- Version examples:
   * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
   * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
   * PR applies only to a specific single version (e.g. 4.10): 4.10
@@ -15,9 +15,9 @@ Issue:
 <!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
 
 Link to docs preview:
-<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.
+<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. -->
 
-NOTE:
+<!-- NOTE:
 Automatic preview functionality is currently not available.
   * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
   * External contributors can request a generated preview from the OpenShift documentation team. --->


### PR DESCRIPTION
Version(s):
main only

Issue:
None

Adjusted the start and end of a few comments, so that it's easier to just select that single comment line to replace with the version and/or doc preview, instead of having to scroll down to find the ending comment and delete multiple lines.