### PR TITLE
TELCODOCS-325: Added a release note for CNF-2448, Move PAO under NTO as new controller

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -679,6 +679,11 @@ For more information, see xref:../operators/operator-reference.adoc#about-node-t
 You must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command with the Performance Profile Creator. For more information, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#gathering-data-about-your-cluster-using-must-gather_cnf-create-performance-profiles[Gathering data about your cluster using must-gather]
 ====
 
+[id="ocp-4-11-PAO-to-NTO-docs"]
+==== Low latency tuning documentation updates
+
+In earlier version of {product-title}, documentation for low latency tuning included references to the Performance Addon Operator. Since the Node Tuning Operator now provides low latency tuning, the documentation title changed from "Performance Addon Operator for low latency nodes" to "Low latency tuning", and multiple cross-references to this document were updated accordingly. For more information, see xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#cnf-low-latency-tuning[Low latency tuning].
+
 [id="ocp-4-11-backup-and-restore"]
 === Backup and restore
 


### PR DESCRIPTION
Documentation for low latency tuning was renamed. The release note indicate the title change and updates to cross-references.

Version(s): 4.11

Issue: https://issues.redhat.com/browse/TELCODOCS-325

Link to docs preview: http://157.131.167.205/TELCODOCS-325-rn/release_notes/ocp-4-11-release-notes.html#ocp-4-11-PAO-to-NTO-docs

Signed-off-by: John Wilkins <jowilkin@redhat.com>