### PR TITLE
[OSDOCS-3865]: Update autoscaler delete annotation

### DIFF
--- a/modules/bmo-editing-the-hostfirmwaresettings-resource.adoc
+++ b/modules/bmo-editing-the-hostfirmwaresettings-resource.adoc
@@ -58,7 +58,7 @@ Where `<host_name>` is the name of the host. The machine name appears under the 
 +
 [source,terminal]
 ----
-$ oc annotate machine <machine_name> machine.openshift.io/cluster-api-delete-machine=yes -n openshift-machine-api
+$ oc annotate machine <machine_name> machine.openshift.io/delete-machine=true -n openshift-machine-api
 ----
 +
 Where `<machine_name>` is the name of the machine to delete.

--- a/modules/machineset-delete-policy.adoc
+++ b/modules/machineset-delete-policy.adoc
@@ -15,7 +15,7 @@ spec:
   replicas: <desired_replica_count>
 ----
 
-Specific machines can also be prioritized for deletion by adding the annotation `machine.openshift.io/cluster-api-delete-machine=true` to the machine of interest, regardless of the deletion policy.
+Specific machines can also be prioritized for deletion by adding the annotation `machine.openshift.io/delete-machine=true` to the machine of interest, regardless of the deletion policy.
 
 [IMPORTANT]
 ====

--- a/modules/machineset-manually-scaling.adoc
+++ b/modules/machineset-manually-scaling.adoc
@@ -39,7 +39,7 @@ $ oc get machine -n openshift-machine-api
 +
 [source,terminal]
 ----
-$ oc annotate machine/<machine_name> -n openshift-machine-api machine.openshift.io/cluster-api-delete-machine="true"
+$ oc annotate machine/<machine_name> -n openshift-machine-api machine.openshift.io/delete-machine="true"
 ----
 
 . Cordon and drain the node that you want to delete:


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-3865](https://issues.redhat.com//browse/OSDOCS-3865) for https://github.com/openshift/machine-api-operator/pull/1024

Link to docs preview:
- [Scaling a machine set manually](http://file.rdu.redhat.com/jrouth/OSDOCS-3865-update-cas-delete-annotation/machine_management/manually-scaling-machineset.html#machineset-manually-scaling_manually-scaling-machineset) (step 3)
- [The machine set deletion policy](http://file.rdu.redhat.com/jrouth/OSDOCS-3865-update-cas-delete-annotation/machine_management/manually-scaling-machineset.html#machineset-delete-policy_manually-scaling-machineset) (under the YAML snippet)
- [Editing the HostFirmwareSettings resource](http://file.rdu.redhat.com/jrouth/OSDOCS-3865-update-cas-delete-annotation/post_installation_configuration/bare-metal-configuration.html#editing-the-hostfirmwaresettings-resource_post-install-bare-metal-configuration) (step 6) Not sure about this one, but seems like it should match the other.

QE review:
- [x] QE has approved this change.

Additional information:
Cc: @johnwilkins since I'm poking your BMC stuff :slightly_smiling_face: 