### PR TITLE
TELCODOCS-490: Updated release note to indicate docs aren't available for disabling BMO.

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -168,6 +168,11 @@ For more information, see xref:../installing/installing_aws/installing-restricte
 
 For more information, see the "Installation configuration parameters" section of the installation documentation for your platform.
 
+[NOTE]
+====
+The documentation for disabling the Bare Metal Operator is currently unavailable.
+====
+
 [id="ocp-4-11-post-installation"]
 === Post-installation configuration
 


### PR DESCRIPTION
Documentation for disabling the Bare Metal Operator was deferred in favor of work on Assisted Installer SaaS. This addition to the release note indicates that documentation for disabling the BMO is not yet available. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>

Version(s): 4.11

Issue: https://issues.redhat.com/browse/TELCODOCS-490

Link to docs preview: http://157.131.167.205/TELCODOCS-490-rn/release_notes/ocp-4-11-release-notes.html#ocp-4-11-capabilities