### PR TITLE
[SRVKE-1239] Add deployment override config docs for eventing

### DIFF
--- a/modules/knative-eventing-CR-system-deployments.adoc
+++ b/modules/knative-eventing-CR-system-deployments.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-configuration.adoc
+
+:_content-type: REFERENCE
+[id="knative-eventing-CR-system-deployments_{context}"]
+= Overriding Knative Eventing system deployment configurations
+
+You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeEventing` custom resource (CR). Currently, overriding default configuration settings is supported for the `eventing-controller`, `eventing-webhook`, and `imc-controller` fields.
+
+[IMPORTANT]
+====
+The `replicas` spec cannot override the number of replicas for deployments that use the Horizontal Pod Autoscaler (HPA), and does not work for the `eventing-webhook` deployment.
+====
+
+In the following example, a `KnativeEventing` CR overrides the `eventing-controller` deployment so that:
+
+* The deployment has specified CPU and memory resource limits.
+* The deployment has 3 replicas.
+* The `example-label: label` label is added.
+* The `example-annotation: annotation` annotation is added.
+* The `nodeSelector` field is set to select nodes with the `disktype: hdd` label.
+
+.KnativeEventing CR example
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  deployments:
+  - name: eventing-controller
+    resources:
+    - container: eventing-controller
+      requests:
+        cpu: 300m
+        memory: 100Mi
+      limits:
+        cpu: 1000m
+        memory: 250Mi
+    replicas: 3
+    labels:
+      example-label: label
+    annotations:
+      example-annotation: annotation
+    nodeSelector:
+      disktype: hdd
+----
+
+[NOTE]
+====
+The `KnativeEventing` CR label and annotation settings override the deployment's labels and annotations for both the deployment itself and the resulting pods.
+====

--- a/modules/knative-serving-CR-system-deployments.adoc
+++ b/modules/knative-serving-CR-system-deployments.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: REFERENCE
 [id="knative-serving-CR-system-deployments_{context}"]
-= Overriding system deployment configurations
+= Overriding Knative Serving system deployment configurations
 
 You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeServing` custom resource (CR). Currently, overriding default configuration settings is supported for the `resources`, `replicas`, `labels`, `annotations`, and `nodeSelector` fields.
 

--- a/serverless/admin_guide/serverless-configuration.adoc
+++ b/serverless/admin_guide/serverless-configuration.adoc
@@ -19,8 +19,16 @@ include::modules/serverless-channel-default.adoc[leveloffset=+1]
 //autoscaling
 include::modules/serverless-enable-scale-to-zero.adoc[leveloffset=+1]
 include::modules/serverless-scale-to-zero-grace-period.adoc[leveloffset=+1]
+
 // deployments
-include::modules/knative-serving-CR-system-deployments.adoc[leveloffset=+1]
+[id="serverless-configuration-CR-system-deployments"]
+== Overriding system deployment configurations
+
+You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeServing` and `KnativeEventing` custom resources (CRs).
+
+include::modules/knative-serving-CR-system-deployments.adoc[leveloffset=+2]
+include::modules/knative-eventing-CR-system-deployments.adoc[leveloffset=+2]
+
 // enable emptydirs
 include::modules/serverless-config-emptydir.adoc[leveloffset=+1]
 // global https redirect


### PR DESCRIPTION
Version(s):
OCP 4.6+

Issue:
https://issues.redhat.com/browse/SRVKE-1239

Link to docs preview:
http://file.rdu.redhat.com/abrennan/260722/SRVKE-1239/serverless/admin_guide/serverless-configuration.html#serverless-configuration-CR-system-deployments