### PR TITLE
Adds doc text for oc bugs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1206,8 +1206,7 @@ With this update, the CMO now waits until deployments are deleted before recreat
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2069068[*BZ#2069068*])
 
 * Before this update, for user workload monitoring, if you configured external labels for metrics in Prometheus, the CMO did not correctly propagate these labels to Thanos Ruler.
-Thus, for user-defined projects, if you queried external metrics not provided by the user workload monitoring instance of Prometheus, you would sometimes not see external labels for these metrics even though you had configured Prometheus to add them.
-With this update, the CMO now properly propagates the external labels that you configured in Prometheus to Thanos Ruler, and you can see the labels when you query external metrics.
+If you queried external metrics for user-defined projects, not provided by the user workload monitoring instance of Prometheus, you would sometimes not see external labels for these metrics even though you had configured Prometheus to add them. With this update, the CMO now properly propagates the external labels that you configured in Prometheus to Thanos Ruler, and you can see the labels when you query external metrics.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2073112[*BZ#2073112*])
 
 * Before this update, the `tunbr` interface incorrectly triggered the `NodeNetworkInterfaceFlapping` alert.
@@ -1235,6 +1234,32 @@ With this update, the `tunbr` interface is now included in the list of interface
 [discrete]
 [id="ocp-4-11-openshift-cli-bug-fixes"]
 ==== OpenShift CLI (oc)
+
+* Previously, `oc` catalog mirroring failed if an older, deprecated image version was used as the source. Now, the image manifest version is detected automatically and mirroring works successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049133[*BZ#2049133*])
+
+* Previously, it was hard to understand from the logs when fallback inspect occured. The logs are now improved to make this more explicit. As a result, the output of `must-gather run` is much more clear. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2035717[*BZ#2035717*])
+
+* Previously, if you ran `must-gather` with invalid arguments, it did not consistently report the error and instead might attempt to collect data even when that is not possible. Now if `must-gather` is called with invalid options, it provides useful error output. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1999891[BZ#1999891])
+
+* Previously, if the `oc adm catalog mirror` command resulted in errors, it still continued and returned a `0` exit code. A `--continue-on-error` flag is now available that allows users to determine whether the command should continue if there are errors, or exit with a non-zero exit code. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2088483[*BZ#2088483*])
+
+* With this update, a `--subresource` flag was added to the `oc adm policy who-can` command to check who can perform a specified action on a subresource. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1905850[*BZ#1905850*])
+
+* Previously, users were unable to use tab completion for the `oc project` command. Now, hitting tab after `oc project` properly lists projects. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1905850[*BZ#1905850*])
+
+* Previously, startup probes were not removed from debug pods, which could cause issues with the debug pods if the startup probe failed. The `--keep-startup` flag has been added, which is `false` by default, meaning that startup probes are removed by default from debug pods. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2056122[*BZ#2056122*])
+
+* Previously, there was no timeout specified after invoking `oc debug node`, so users were never logged out of the cluster. A `TMOUT` environment variable has been added, so that after the specified time of inactivity, the session is automatically terminated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2043314[*BZ#2043314*])
+
+* With this update, `oc login` now shows the URL for the web console even when users are logged out. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957668[*BZ#1957668*])
+
+* Previously, the `oc rsync` command displayed a wrong error output when the container was not found. With this release, the `oc rsync` command displays the correct error message when the specific container is not running. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057633[*BZ#2057633*])
+
+* Previously, large images could not be pruned if they were new to the cluster. This caused recent images to be omitted when filtering the over sized images. With this release, you can now prune images that exceed the given size. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2083999[*BZ#2083999*])
+
+* Previously, there was a typo in the `gather` script. As a result, insights data was not collected properly. With this release, the typo is corrected and Insights data is now properly collected through the `must-gather`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2106543[*BZ#2106543*])
+
+* Previously, you could not apply the `EgressNetworkPolicy` resource type in your cluster through the `oc` CLI. With this release, you can now create, update, and delete an `EgressNetworkPolicy` resource. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2071614[*BZ#2071614*])
 
 [discrete]
 [id="ocp-4-11-container-bug-fixes"]


### PR DESCRIPTION
Adds bug doc text for `oc` bugs.

Link to docs preview- see the `oc` section.
http://file.rdu.redhat.com/opayne/RN-batch-3/release_notes/ocp-4-11-release-notes.html#ocp-4-11-bug-fixes




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
