### PR TITLE
OSSMDOC-641 Update federation for OSSM 2.2.

### DIFF
--- a/modules/ossm-federation-checklist.adoc
+++ b/modules/ossm-federation-checklist.adoc
@@ -12,15 +12,15 @@ Federating services meshes involves the following activities:
 
 ** [ ] Configure the load balancers supporting the services associated with the federation gateways to support raw TLS traffic.
 
-* [ ] Installing the {SMProductName} version 2.1 Operator in each of your clusters.
+* [ ] Installing the {SMProductName} version 2.1 or later Operator in each of your clusters.
 
-* [ ] Deploying a version 2.1 `ServiceMeshControlPlane` to each of your clusters.
+* [ ] Deploying a version 2.1 or later `ServiceMeshControlPlane` to each of your clusters.
 
 * [ ] Configuring the SMCP for federation for each mesh that you want to federate:
 
-** [ ] Create a federation egress gateway for each mesh you are going to federate with
-** [ ] Create a federation ingress gateway for each mesh you are going to federate with
-** [ ] Configure a unique trust domain
+** [ ] Create a federation egress gateway for each mesh you are going to federate with.
+** [ ] Create a federation ingress gateway for each mesh you are going to federate with.
+** [ ] Configure a unique trust domain.
 
 * [ ] Federate two or more meshes by creating a `ServiceMeshPeer` resource for each mesh pair.
 

--- a/virt/upgrading-virt.adoc
+++ b/virt/upgrading-virt.adoc
@@ -8,6 +8,16 @@ toc::[]
 
 Learn how Operator Lifecycle Manager (OLM) delivers z-stream and minor version updates for {VirtProductName}.
 
+[NOTE]
+====
+* The Node Maintenance Operator (NMO) is no longer shipped with {VirtProductName}. You can xref:../nodes/nodes/eco-node-maintenance-operator.adoc#node-maintenance-operator[install the NMO] from the *OperatorHub* in the {product-title} web console, or by using the OpenShift CLI (`oc`).
++
+You must perform one of the following tasks before updating to {VirtProductName} 4.11 from {VirtProductName} 4.10.2 and later releases:
+
+** Move all nodes out of maintenance mode.
+** Install the standalone NMO and replace the `nodemaintenances.nodemaintenance.kubevirt.io` custom resource (CR) with a `nodemaintenances.nodemaintenance.medik8s.io` CR.
+====
+
 include::modules/virt-about-upgrading-virt.adoc[leveloffset=+1]
 
 [id="configuring-workload-updates_upgrading-virt"]


### PR DESCRIPTION
This PR updates the federation docs for OSSM 2.2.  (updates references to 2.1 to read "2.1 or later" now that we have more than one release that supports federation)
ALSO fixes typos ExportServiceSet -> ExportedServiceSet  and ImportServiceSet -> ImportedServiceSet

Version(s): 4.6 - 4.11

Issue: [OSSMDOC - 641](https://issues.redhat.com/browse/OSSMDOC-641)

Link to docs preview: http://file.bos.redhat.com/jstickle/OSSMDOC-641/service_mesh/v2x/ossm-federation.html#ossm-federation-prerequisites_federation

Additional information:
QE Review: skondkar
Peer Review: 