### PR TITLE
BZ2092346 - rearranged info to avoid 2 admonitions close together

### DIFF
--- a/modules/virt-creating-storage-class.adoc
+++ b/modules/virt-creating-storage-class.adoc
@@ -7,14 +7,9 @@
 = Creating a storage class
 
 When you create a storage class, you set parameters that affect the
-dynamic provisioning of persistent volumes (PVs) that belong to that storage class.
+dynamic provisioning of persistent volumes (PVs) that belong to that storage class. You cannot update a `StorageClass` object's parameters after you create it.
 
 In order to use the host path provisioner (HPP) you must create an associated storage class for the CSI driver with the `storagePools` stanza.
-
-[NOTE]
-====
-You cannot update a `StorageClass` object's parameters after you create it.
-====
 
 [NOTE]
 ====


### PR DESCRIPTION
BZ2092346 - Two "Note" admonitions in succession. 

Corrected this issue by rolling the less important note into the first paragraph. 

Version(s):
PR applies to 4.6 onwards

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2092346

NOTE:
Automatic preview functionality is currently not available.
http://file.rdu.redhat.com/~ddacosta/BZ2092346/virt-configuring-local-storage-for-vms.html

<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
