### PR TITLE
TELCODOCS:820 - Added new erratum to release notes and updated versio…

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -46,7 +46,8 @@ endif::openshift-origin[]
 :sandboxed-containers-first: OpenShift sandboxed containers
 :sandboxed-containers-operator: OpenShift sandboxed containers Operator
 :sandboxed-containers-version: 1.2
-:sandboxed-containers-legacy-version: 1.1.0
+:sandboxed-containers-version-z: 1.2.2
+:sandboxed-containers-legacy-version: 1.2.1
 :cert-manager-operator: cert-manager Operator for Red Hat OpenShift
 :secondary-scheduler-operator-full: Secondary Scheduler Operator for Red Hat OpenShift
 :secondary-scheduler-operator: Secondary Scheduler Operator

--- a/modules/sandboxed-containers-installing-operator-cli.adoc
+++ b/modules/sandboxed-containers-installing-operator-cli.adoc
@@ -81,7 +81,7 @@ spec:
   name: sandboxed-containers-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.2.0
+  startingCSV: sandboxed-containers-operator.v{sandboxed-containers-version-z}
 ----
 
 .. Create the `Subscription` object:
@@ -109,7 +109,8 @@ $ oc get csv -n openshift-sandboxed-containers-operator
 +
 .Example output
 +
+[source,terminal,subs="attributes+"]
 ----
-NAME                             DISPLAY                                  VERSION  REPLACES                    PHASE
-openshift-sandboxed-containers   openshift-sandboxed-containers-operator  {sandboxed-containers-version}.0   {sandboxed-containers-legacy-version}   Succeeded
+NAME                             DISPLAY                                  VERSION  REPLACES   PHASE
+openshift-sandboxed-containers   openshift-sandboxed-containers-operator  {sandboxed-containers-version-z}    {sandboxed-containers-legacy-version}      Succeeded
 ----

--- a/sandboxed_containers/sandboxed-containers-release-notes.adoc
+++ b/sandboxed_containers/sandboxed-containers-release-notes.adoc
@@ -161,6 +161,15 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 
 This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {sandboxed-containers-first} {sandboxed-containers-version}.
 
+[id="sandboxed-containers-1-2-2"]
+=== RHSA-2022:1508 - {sandboxed-containers-first} {sandboxed-containers-version}.2 bug fix advisory.
+
+Issued: 2022-07-26
+
+{sandboxed-containers-first} release {sandboxed-containers-version}.2 is now available. This advisory contains an update for {sandboxed-containers-first} with bug fixes.
+
+The list of bug fixes included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2022:5725[RHSA-2022:5725] advisory.
+
 [id="sandboxed-containers-1-2-1"]
 === RHSA-2022:1508 - {sandboxed-containers-first} {sandboxed-containers-version}.1 bug fix advisory.
 


### PR DESCRIPTION
Version(s): Only 4.10

Issue:
[TELCODOCS-820](https://issues.redhat.com/browse/TELCODOCS-820)
Also tracks work for [BZ-2111447](https://bugzilla.redhat.com/show_bug.cgi?id=2111447)

[Link to docs preview](http://file.emea.redhat.com/miweiss/TELCODOCS-820/sandboxed_containers/sandboxed-containers-release-notes.html#sandboxed-containers-1-2-asynchronous-errata-updates)