### PR TITLE
TELCODOCS-753: preview of variable changes for 4.11

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
+++ b/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
@@ -69,7 +69,7 @@ You can use the `ROLE_WORKER_CNF` variable to override the worker pool name:
 [source,terminal]
 ----
 $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e
-ROLE_WORKER_CNF=custom-worker-pool registry.redhat.io/openshift4/cnf-tests-rhel8:v4.10 /usr/bin/test-run.sh
+ROLE_WORKER_CNF=custom-worker-pool registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh
 ----
 +
 [NOTE]
@@ -84,7 +84,7 @@ Use this command to run in dry-run mode. This is useful for checking what is in 
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.10 /usr/bin/test-run.sh -ginkgo.dryRun -ginkgo.v
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh -ginkgo.dryRun -ginkgo.v
 ----
 
 [id="cnf-performing-end-to-end-tests-disconnected-mode_{context}"]
@@ -105,7 +105,7 @@ Run this command from an intermediate machine that has access both to the cluste
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.10 /usr/bin/mirror -registry my.local.registry:5000/ |  oc image mirror -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/mirror -registry my.local.registry:5000/ |  oc image mirror -f -
 ----
 
 Then, follow the instructions in the following section about overriding the registry used to fetch the images.
@@ -117,7 +117,7 @@ This is done by setting the `IMAGE_REGISTRY` environment variable:
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY="my.local.registry:5000/" -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.10 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY="my.local.registry:5000/" -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh
 ----
 
 [id="cnf-performing-end-to-end-tests-mirroring-to-cluster-internal-registry_{context}"]
@@ -214,7 +214,7 @@ echo "{\"auths\": { \"$REGISTRY\": { \"auth\": $TOKEN } }}" > dockerauth.json
 +
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.10 /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true -a=$(pwd)/dockerauth.json -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true -a=$(pwd)/dockerauth.json -f -
 ----
 
 . Run the tests:
@@ -236,11 +236,11 @@ $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAG
 [
     {
         "registry": "public.registry.io:5000",
-        "image": "imageforcnftests:4.10"
+        "image": "imageforcnftests:4.11"
     },
     {
         "registry": "public.registry.io:5000",
-        "image": "imagefordpdk:4.10"
+        "image": "imagefordpdk:4.11"
     }
 ]
 ----
@@ -249,7 +249,7 @@ $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAG
 +
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.10 /usr/bin/mirror --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" |  oc image mirror -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/mirror --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" |  oc image mirror -f -
 ----
 
 [id="cnf-performing-end-to-end-tests-running-in-single-node-cluster_{context}"]
@@ -343,7 +343,7 @@ For example, to change the `CNF_TESTS_IMAGE` with a custom registry run the foll
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.10 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh
 ----
 
 [id="cnf-performing-end-to-end-tests-ginkgo-parameters_{context}"]
@@ -355,7 +355,7 @@ You can use the `-ginkgo.focus` parameter to filter a set of tests:
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.10 /usr/bin/test-run.sh -ginkgo.focus="performance|sctp"
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh -ginkgo.focus="performance|sctp"
 ----
 
 You can run only the latency test using the `-ginkgo.focus` parameter.
@@ -364,7 +364,7 @@ To run only the latency test, you must provide the `-ginkgo.focus` parameter and
 
 [source,terminal]
 ----
-$ docker run --rm -v $KUBECONFIG:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 -e PERF_TEST_PROFILE=<performance_profile_name> registry.redhat.io/openshift4/cnf-tests-rhel8:v4.10 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\[config\]|\[performance\]\ Latency\ Test"
+$ docker run --rm -v $KUBECONFIG:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 -e PERF_TEST_PROFILE=<performance_profile_name> registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\[config\]|\[performance\]\ Latency\ Test"
 ----
 
 [NOTE]
@@ -637,7 +637,7 @@ Will run 1 of 151 specs
 
 SSSSSSS
 ------------------------------
-[performance] Latency Test with the hwlatdetect image 
+[performance] Latency Test with the hwlatdetect image
   should succeed
   /remote-source/app/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:221
 STEP: Waiting two minutes to download the latencyTest image
@@ -669,7 +669,7 @@ Feb 10 17:11:56.825: [ERROR]: timed out waiting for the condition
             Sample width:      950000us
          Non-sampling period:  9050000us
             Output File:       None
-    
+
     Starting test
     test finished
     Max Latency: 24us <3>
@@ -688,13 +688,13 @@ Feb 10 17:11:56.825: [ERROR]: timed out waiting for the condition
     	/remote-source/app/vendor/k8s.io/klog/klog.go:1276
     main.main()
     	/remote-source/app/cnf-tests/pod-utils/hwlatdetect-runner/main.go:53 +0x897
-    
+
     goroutine 6 [chan receive]:
     k8s.io/klog.(*loggingT).flushDaemon(0x5bed00)
     	/remote-source/app/vendor/k8s.io/klog/klog.go:1010 +0x8b
     created by k8s.io/klog.init.0
     	/remote-source/app/vendor/k8s.io/klog/klog.go:411 +0xd8
-    
+
     goroutine 7 [chan receive]:
     k8s.io/klog/v2.(*loggingT).flushDaemon(0x5bede0)
     	/remote-source/app/vendor/k8s.io/klog/v2/klog.go:1169 +0x8b
@@ -715,7 +715,7 @@ JUnit report was created: /junit.xml/cnftests-junit.xml
 
 Summarizing 1 Failure:
 
-[Fail] [performance] Latency Test with the hwlatdetect image [It] should succeed 
+[Fail] [performance] Latency Test with the hwlatdetect image [It] should succeed
 /remote-source/app/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:433
 
 Ran 1 of 151 Specs in 222.254 seconds
@@ -731,7 +731,7 @@ FAIL
 [id="cnf-performing-end-to-end-tests-capturing-results-hwlatdetect"]
 ==== Capturing the results
 
-You can capture the following types of results: 
+You can capture the following types of results:
 
 * Rough results that are gathered after each run to create a history of impact on any changes made throughout the test
 * The combined set of the rough tests with the best results and configuration settings
@@ -915,7 +915,7 @@ The same output can indicate different results for different workloads. For exam
 
 [source, terminal]
 ----
-running cmd: cyclictest -q -D 10m -p 1 -t 16 -a 2,4,6,8,10,12,14,16,54,56,58,60,62,64,66,68 -h 30 -i 1000 -m 
+running cmd: cyclictest -q -D 10m -p 1 -t 16 -a 2,4,6,8,10,12,14,16,54,56,58,60,62,64,66,68 -h 30 -i 1000 -m
 # Histogram
 000000 000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000
 000001 000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000
@@ -949,7 +949,7 @@ More histogram entries ...
 
 [source, terminal]
 ----
-running cmd: cyclictest -q -D 10m -p 1 -t 16 -a 2,4,6,8,10,12,14,16,54,56,58,60,62,64,66,68 -h 30 -i 1000 -m 
+running cmd: cyclictest -q -D 10m -p 1 -t 16 -a 2,4,6,8,10,12,14,16,54,56,58,60,62,64,66,68 -h 30 -i 1000 -m
 # Histogram
 000000 000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000
 000001 000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000	000000
@@ -989,7 +989,7 @@ More histogram entries ...
 
 .Procedure
 
-* To perform the `oslat`, run the following command: 
+* To perform the `oslat`, run the following command:
 
 [source,terminal,subs="attributes+"]
 ----
@@ -1119,7 +1119,7 @@ A JUnit-compliant XML is produced by passing the `--junit` parameter together wi
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.10 /usr/bin/test-run.sh --junit /path/to/junit
+$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh --junit /path/to/junit
 ----
 
 [id="cnf-performing-end-to-end-tests-test-failure-report_{context}"]
@@ -1129,7 +1129,7 @@ A report with information about the cluster state and resources for troubleshoot
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/reportdest:/path/to/report -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.10 /usr/bin/test-run.sh --report /path/to/report
+$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/reportdest:/path/to/report -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh --report /path/to/report
 ----
 
 [id="cnf-performing-end-to-end-tests-podman_{context}"]
@@ -1190,5 +1190,5 @@ To override the performance profile, the manifest must be mounted inside the con
 
 [source,termal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift4/cnf-tests-rhel8:v4.10 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh
 ----

--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -224,7 +224,7 @@ For more information, see xref:../post_installation_configuration/cluster-capabi
 {product-title} 4.11 introduces heterogeneous architecture cluster support using Azure installer-provisioned infrastructure in Technology Preview. This feature offers, as a day-two operation, the ability to add `arm64` worker nodes to an existing `x86_64` Azure cluster that is installer provisioned with a heterogeneous installer binary. You can add `arm64` workers to your heterogeneous cluster by creating a custom Azure machine set that uses a manually generated `arm64` boot image. Control planes on `arm64` architectures are not currently supported. For more information, see xref:../post_installation_configuration/deploy-heterogeneous-configuration.adoc[Configuring a heterogeneous cluster].
 [IMPORTANT]
 ====
-The heterogeneous installer binary will not be updated in every {product-title} z-stream release. 
+The heterogeneous installer binary will not be updated in every {product-title} z-stream release.
 ====
 
 [id="ocp-4-11-web-console"]
@@ -1638,6 +1638,11 @@ With this update, the container requests `1m` of CPU and `10Mi` of memory. These
 * Before this update, for user workload monitoring, if you configured external labels for metrics in Prometheus, the CMO did not correctly propagate these labels to Thanos Ruler. If you queried external metrics for user-defined projects, not provided by the user workload monitoring instance of Prometheus, you would sometimes not see external labels for these metrics even though you had configured Prometheus to add them. With this update, the CMO now properly propagates the external labels that you configured in Prometheus to Thanos Ruler, and you can see the labels when you query external metrics. Therefore, for user-defined projects, if you queried external metrics not provided by the user workload monitoring instance of Prometheus, you would sometimes not see external labels for these metrics even though you had configured Prometheus to add them. With this update, the CMO now properly propagates the external labels that you configured in Prometheus to Thanos Ruler, and you can see the labels when you query external metrics. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2073112[*BZ#2073112*])
 
 * Before this update, the `tunbr` interface incorrectly triggered the `NodeNetworkInterfaceFlapping` alert. With this update, the `tunbr` interface is now included in the list of interfaces that the alert ignores and no longer causes the alert to trigger incorrectly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2090838[*BZ#2090838*])
+* Before this update, for user workload monitoring, if you configured external labels for metrics in Prometheus, the CMO did not correctly propagate these labels to Thanos Ruler.
+If you queried external metrics for user-defined projects, not provided by the user workload monitoring instance of Prometheus, you would sometimes not see external labels for these metrics even though you had configured Prometheus to add them. With this update, the CMO now properly propagates the external labels that you configured in Prometheus to Thanos Ruler, and you can see the labels when you query external metrics.
+Thus, for user-defined projects, if you queried external metrics not provided by the user workload monitoring instance of Prometheus, you would sometimes not see external labels for these metrics even though you had configured Prometheus to add them.
+With this update, the CMO now properly propagates the external labels that you configured in Prometheus to Thanos Ruler, and you can see the labels when you query external metrics.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2073112[*BZ#2073112*])
 
 * Previously, the Prometheus Operator allowed invalid re-label configurations. With this update, the Prometheus Operator validates re-labeled configurations. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2051407[*BZ#2051407*])
 


### PR DESCRIPTION
Update the same code base as https://github.com/openshift/openshift-docs/pull/39295 (Performance and scalability) to address code blocks and docker commands referencing 4.10 as a value. 

Version(s):
  * PR applies only to a specific single version  4.11
Issue:
https://issues.redhat.com/browse/TELCODOCS-753 

Link to docs preview: http://file.emea.redhat.com/tmulquee/TELCODOCS-753/scalability_and_performance/cnf-low-latency-tuning.html