### PR TITLE
OSDOCS-2920 - Updating statement about monitoring for user-defined projects

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -130,10 +130,10 @@ Topics:
   Topics:
     - Name: Understanding the monitoring stack
       File: osd-understanding-the-monitoring-stack
-    - Name: Configuring the monitoring stack
-      File: osd-configuring-the-monitoring-stack
     - Name: Accessing monitoring for user-defined projects
       File: osd-accessing-monitoring-for-user-defined-projects
+    - Name: Configuring the monitoring stack
+      File: osd-configuring-the-monitoring-stack
     - Name: Managing metrics
       File: osd-managing-metrics
     - Name: Managing alerts

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -219,10 +219,10 @@ Topics:
   Topics:
   - Name: Understanding the monitoring stack
     File: rosa-understanding-the-monitoring-stack
-  - Name: Configuring the monitoring stack
-    File: rosa-configuring-the-monitoring-stack
   - Name: Accessing monitoring for user-defined projects
     File: rosa-accessing-monitoring-for-user-defined-projects
+  - Name: Configuring the monitoring stack
+    File: rosa-configuring-the-monitoring-stack
   - Name: Managing metrics
     File: rosa-managing-metrics
   - Name: Managing alerts

--- a/modules/osd-monitoring-understanding-the-monitoring-stack.adoc
+++ b/modules/osd-monitoring-understanding-the-monitoring-stack.adoc
@@ -6,9 +6,20 @@
 [id="understanding-the-monitoring-stack_{context}"]
 = Understanding the monitoring stack
 
-The {product-title} monitoring stack is based on the link:https://prometheus.io/[Prometheus] open source project and its wider ecosystem. The monitoring stack includes the following:
+The {product-title} 
+ifdef::openshift-rosa[]
+(ROSA) 
+endif::openshift-rosa[]
+monitoring stack is based on the link:https://prometheus.io/[Prometheus] open source project and its wider ecosystem. The monitoring stack includes the following:
 
-* *Default platform monitoring components*. A set of platform monitoring components are installed in the `openshift-monitoring` project by default during an {product-title} installation. This provides monitoring for core {product-title}. The default monitoring stack also enables remote health monitoring for clusters. Critical metrics, such as CPU and memory, are collected from all of the workloads in every namespace and are made available for your use.
+* *Default platform monitoring components*. A set of platform monitoring components are installed in the `openshift-monitoring` project and enabled by default during 
+ifdef::openshift-dedicated[]
+an {product-title} 
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+a ROSA 
+endif::openshift-rosa[]
+installation. This provides monitoring for core cluster components. The default monitoring stack also enables remote health monitoring for clusters. Critical metrics, such as CPU and memory, are collected from all of the workloads in every namespace and are made available for your use.
 +
 These components are illustrated in the *Installed by default* section in the following diagram.
 

--- a/osd_cluster_admin/osd_monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc
+++ b/osd_cluster_admin/osd_monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc
@@ -6,9 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-By default, centralized monitoring for user-defined projects and platform monitoring are enabled. You can monitor your own projects in {product-title} without the need for an additional monitoring solution.
-
-The monitoring of user-defined projects cannot be disabled.
+When you install an {product-title} cluster, monitoring for user-defined projects is enabled by default. With monitoring for user-defined projects enabled, you can monitor your own {product-title} projects without the need for an additional monitoring solution.
 
 The `dedicated-admin` user has default permissions to configure and access monitoring for user-defined projects.
 
@@ -17,7 +15,9 @@ The `dedicated-admin` user has default permissions to configure and access monit
 Custom Prometheus instances and the Prometheus Operator installed through Operator Lifecycle Manager (OLM) can cause issues with user-defined project monitoring if it is enabled. Custom Prometheus instances are not supported.
 ====
 
+Optionally, you can disable monitoring for user-defined projects during or after a cluster installation.
+
 [id="accessing-user-defined-monitoring-next-steps"]
 == Next steps
 
-* xref:../../osd_cluster_admin/osd_monitoring/osd-managing-metrics.adoc#osd-managing-metrics[Managing metrics]
+* xref:../../osd_cluster_admin/osd_monitoring/osd-configuring-the-monitoring-stack.adoc#osd-configuring-the-monitoring-stack[Configuring the monitoring stack]

--- a/osd_cluster_admin/osd_monitoring/osd-configuring-the-monitoring-stack.adoc
+++ b/osd_cluster_admin/osd_monitoring/osd-configuring-the-monitoring-stack.adoc
@@ -79,4 +79,4 @@ include::modules/osd-monitoring-setting-log-levels-for-monitoring-components.ado
 [id="configuring-the-monitoring-stack-next-steps"]
 == Next steps
 
-* xref:../../osd_cluster_admin/osd_monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc#osd-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]
+* xref:../../osd_cluster_admin/osd_monitoring/osd-managing-metrics.adoc#osd-managing-metrics[Managing metrics]

--- a/osd_cluster_admin/osd_monitoring/osd-understanding-the-monitoring-stack.adoc
+++ b/osd_cluster_admin/osd_monitoring/osd-understanding-the-monitoring-stack.adoc
@@ -30,4 +30,4 @@ include::modules/osd-monitoring-targets-for-user-defined-projects.adoc[leveloffs
 [id="understanding-the-monitoring-stack-next-steps"]
 == Next steps
 
-* xref:../../osd_cluster_admin/osd_monitoring/osd-configuring-the-monitoring-stack.adoc#osd-configuring-the-monitoring-stack[Configuring the monitoring stack]
+* xref:../../osd_cluster_admin/osd_monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc#osd-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]

--- a/rosa_cluster_admin/rosa_monitoring/rosa-accessing-monitoring-for-user-defined-projects.adoc
+++ b/rosa_cluster_admin/rosa_monitoring/rosa-accessing-monitoring-for-user-defined-projects.adoc
@@ -6,9 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-By default, centralized monitoring for user-defined projects and platform monitoring are enabled. You can monitor your own projects in {product-title} without the need for an additional monitoring solution.
-
-The monitoring of user-defined projects cannot be disabled.
+When you install a {product-title} (ROSA) cluster, monitoring for user-defined projects is enabled by default. With monitoring for user-defined projects enabled, you can monitor your own ROSA projects without the need for an additional monitoring solution.
 
 The `dedicated-admin` user has default permissions to configure and access monitoring for user-defined projects.
 
@@ -17,7 +15,9 @@ The `dedicated-admin` user has default permissions to configure and access monit
 Custom Prometheus instances and the Prometheus Operator installed through Operator Lifecycle Manager (OLM) can cause issues with user-defined project monitoring if it is enabled. Custom Prometheus instances are not supported.
 ====
 
+Optionally, you can disable monitoring for user-defined projects during or after a cluster installation.
+
 [id="accessing-user-defined-monitoring-next-steps"]
 == Next steps
 
-* xref:../../rosa_cluster_admin/rosa_monitoring/rosa-managing-metrics.adoc#rosa-managing-metrics[Managing metrics]
+* xref:../../rosa_cluster_admin/rosa_monitoring/rosa-configuring-the-monitoring-stack.adoc#rosa-configuring-the-monitoring-stack[Configuring the monitoring stack]

--- a/rosa_cluster_admin/rosa_monitoring/rosa-configuring-the-monitoring-stack.adoc
+++ b/rosa_cluster_admin/rosa_monitoring/rosa-configuring-the-monitoring-stack.adoc
@@ -80,4 +80,4 @@ include::modules/osd-monitoring-setting-log-levels-for-monitoring-components.ado
 [id="configuring-the-monitoring-stack-next-steps"]
 == Next steps
 
-* xref:../../rosa_cluster_admin/rosa_monitoring/rosa-accessing-monitoring-for-user-defined-projects.adoc#rosa-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]
+* xref:../../rosa_cluster_admin/rosa_monitoring/rosa-managing-metrics.adoc#rosa-managing-metrics[Managing metrics]

--- a/rosa_cluster_admin/rosa_monitoring/rosa-understanding-the-monitoring-stack.adoc
+++ b/rosa_cluster_admin/rosa_monitoring/rosa-understanding-the-monitoring-stack.adoc
@@ -31,4 +31,4 @@ include::modules/osd-monitoring-targets-for-user-defined-projects.adoc[leveloffs
 [id="understanding-the-monitoring-stack-next-steps"]
 == Next steps
 
-* xref:../../rosa_cluster_admin/rosa_monitoring/rosa-configuring-the-monitoring-stack.adoc#rosa-configuring-the-monitoring-stack[Configuring the monitoring stack]
+* xref:../../rosa_cluster_admin/rosa_monitoring/rosa-accessing-monitoring-for-user-defined-projects.adoc#rosa-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]


### PR DESCRIPTION
This applies to `main`, `enterprise-4.10` and `enterprise-4.11`.

This PR relates to https://issues.redhat.com/browse/OSDOCS-2920. The PR updates statements about disabling monitoring for user-defined projects in the OSD and ROSA libraries. It also moves the "Accessing monitoring for user-defined projects" assembly for each distro to be before the "Configuring the monitoring stack" assembly, because the content is relevant prior to the configuration stage in the user journey.

The previews are available on the following links:

#### OSD

* http://file.fab.redhat.com/pneedle/pr48340/osd/osd_cluster_admin/osd_monitoring/osd-accessing-monitoring-for-user-defined-projects.html
* http://file.fab.redhat.com/pneedle/pr48340/osd/osd_cluster_admin/osd_monitoring/osd-understanding-the-monitoring-stack.html#understanding-the-monitoring-stack_osd-understanding-the-monitoring-stack

#### ROSA

* http://file.fab.redhat.com/pneedle/pr48340/rosa/rosa_cluster_admin/rosa_monitoring/rosa-accessing-monitoring-for-user-defined-projects.html
* http://file.fab.redhat.com/pneedle/pr48340/rosa/rosa_cluster_admin/rosa_monitoring/rosa-understanding-the-monitoring-stack.html#understanding-the-monitoring-stack_rosa-understanding-the-monitoring-stack