### PR TITLE
TELCODOCS:791b - added known issue about upgrading OCP cluster for us…

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2347,6 +2347,48 @@ Identify the disk that holds the live image, in this example `nvme0n1p3`, and ru
 
 * There is currently a known issue with OVN-Kubernetes that whenever the `NetworkManager` service restarts the node will lose network connectivity and must be recovered. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2074009[*BZ#2074009*])
 
+* If you have {sandboxed-containers-first}, when upgrading a cluster, you might encounter an issue where the Machine Config Operator (MCO) pod changes to a `CrashLoopBackOff` state and the `openshift.io/scc` annotation of the pod displays `sandboxed-containers-operator-scc` instead of the default `hostmount-anyuid` value.
++
+If this happens, temporarily change the `seLinuxOptions` strategy in the `sandboxed-containers-operator-scc` SCC to the less restrictive `RunAsAny`, so that the admission process does not prefer it over the `hostmount-anyuid` SCC.
++
+--
+. Change the `seLinuxOptions` strategy by running the following command:
++
+[source,terminal]
+----
+$ oc patch scc sandboxed-containers-operator-scc --type=merge --patch '{"seLinuxContext":{"type": "RunAsAny"}}'
+----
+
+. Restart the MCO pod by running the following commands:
++
+[source,terminal]
+----
+$ oc scale deployments/machine-config-operator -n openshift-machine-config-operator --replicas=0
+----
++
+[source,terminal]
+----
+$ oc scale deployments/machine-config-operator -n openshift-machine-config-operator --replicas=1
+----
+
+. Revert the `seLinuxOptions` strategy of the `sandboxed-containers-operator-scc` to its original value of `MustRunAs` by running the following command:
++
+[source,terminal]
+----
+$ oc patch scc sandboxed-containers-operator-scc --type=merge --patch '{"seLinuxContext":{"type": "MustRunAs"}}'
+----
+
+. Verify that the `hostmount-anyuid` SCC is applied to the MCO pod by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-machine-config-operator -l k8s-app=machine-config-operator -o yaml | grep scc
+openshift.io/scc: hostmount-anyuid
+----
+--
++
+(link:https://issues.redhat.com/browse/KATA-1373[*KATA-1373*])
+
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Version(s): Only 4.11

Issue:
[TELCODOCS-791](https://issues.redhat.com/browse/TELCODOCS-791)

[Link to docs preview](http://file.emea.redhat.com/miweiss/TELCODOCS-791b/release_notes/ocp-4-11-release-notes.html#ocp-4-11-known-issues)

The new known issue is the last one in the list.

Reviewed and approved by SME and QE.