### PR TITLE
RHDEVDOCS-4142: Adds Monitoring ConfigMap ref.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2229,6 +2229,8 @@ Topics:
   File: accessing-third-party-monitoring-apis
 - Name: Troubleshooting monitoring issues
   File: troubleshooting-monitoring-issues
+- Name: ConfigMap reference for Cluster Monitoring Operator
+  File: configmap-reference-for-cluster-monitoring-operator
 ---
 Name: Scalability and performance
 Dir: scalability_and_performance

--- a/monitoring/configmap-reference-for-cluster-monitoring-operator.adoc
+++ b/monitoring/configmap-reference-for-cluster-monitoring-operator.adoc
@@ -1,0 +1,589 @@
+:_content-type: ASSEMBLY
+[id="configmap-reference-for-cluster-monitoring-operator"]
+= ConfigMap reference for Cluster Monitoring Operator
+include::_attributes/common-attributes.adoc[]
+:context: configmap-reference-for-cluster-monitoring-operator
+
+toc::[]
+
+[id="cluster-monitoring-configuration-reference"]
+== Cluster Monitoring configuration reference
+
+[role="_abstract"]
+Parts of Cluster Monitoring are configurable. The API is accessible through parameters defined in various ConfigMaps.
+
+Depending on which part of the stack you want to configure, edit the following:
+
+* The configuration of OpenShift Container Platform monitoring components in a ConfigMap called `cluster-monitoring-config` in the `openshift-monitoring` namespace. Defined by link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration].
+
+* The configuration of components that monitor user-defined projects in a ConfigMap called `user-workload-monitoring-config` in the `openshift-user-workload-monitoring` namespace. Defined by link:#userworkloadconfiguration[UserWorkloadConfiguration].
+
+The configuration file itself is always defined under the `config.yaml` key within the ConfigMap data.
+
+NOTE: Not all configuration parameters are exposed. Configuring Cluster Monitoring is optional. If the configuration does not exist or is empty or malformed, defaults are used.
+
+
+== AdditionalAlertmanagerConfig
+
+=== Description
+
+`AdditionalAlertmanagerConfig` defines configuration on how a component should communicate with aditional Alertmanager instances.
+
+=== Required
+
+* `apiVersion`
+
+Appears in: link:#prometheusk8sconfig[PrometheusK8sConfig],
+link:#prometheusrestrictedconfig[PrometheusRestrictedConfig],
+link:#thanosrulerconfig[ThanosRulerConfig]
+
+[options="header"]
+|===
+|Property |Type |Description
+|apiVersion |string |APIVersion defines the api version of Alertmanager.
+
+|bearerToken
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretkeyselector-v1-core[v1.SecretKeySelector]
+|BearerToken defines the bearer token to use when authenticating to
+Alertmanager.
+
+|pathPrefix |string |PathPrefix defines the path prefix to add in front
+of the push endpoint path.
+
+|scheme |string |Scheme the URL scheme to use when talking to
+Alertmanagers.
+
+|staticConfigs |array(string) |StaticConfigs a list of statically configured
+Alertmanagers.
+
+|timeout |string |Timeout defines the timeout used when sending alerts.
+
+|tlsConfig |link:#tlsconfig[TLSConfig] |TLSConfig defines the TLS Config
+to use for alertmanager connection.
+|===
+
+
+== AlertmanagerMainConfig
+
+=== Description
+
+`AlertmanagerMainConfig` defines configuration related with the main Alertmanager instance.
+
+Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
+
+[options="header"]
+|===
+|Property |Type |Description
+|enabled |bool |Enabled a boolean flag to enable or disable the main
+Alertmanager instance under openshift-monitoring default: true
+
+|enableUserAlertmanagerConfig |bool |EnableUserAlertManagerConfig
+boolean flag to enable or disable user-defined namespaces to be selected
+for AlertmanagerConfig lookup, by default Alertmanager only looks for
+configuration in the namespace where it was deployed to. This will only
+work if the UWM Alertmanager instance is not enabled. default: false
+
+|logLevel |string |LogLevel defines the log level for Alertmanager.
+Possible values are: error, warn, info, debug. default: info
+
+|nodeSelector |map[string]string |NodeSelector defines which Nodes the
+Pods are scheduled on.
+
+|resources
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core[v1.ResourceRequirements]
+|Resources define resources requests and limits for single Pods.
+
+|tolerations
+|array(link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#toleration-v1-core[v1.Toleration])
+|Tolerations defines the Pods tolerations.
+
+|volumeClaimTemplate
+|link:https://github.com/prometheus-operator/prometheus-operator/blob/v0.57.0/Documentation/api.md#embeddedpersistentvolumeclaim[monv1.EmbeddedPersistentVolumeClaim]
+|VolumeClaimTemplate defines persistent storage for Alertmanager. It’s
+possible to configure storageClass and size of volume.
+|===
+
+
+== ClusterMonitoringConfiguration
+
+=== Description
+
+`ClusterMonitoringConfiguration` defines configuration that allows users to customise the platform monitoring stack through the cluster-monitoring-config ConfigMap in the openshift-monitoring namespace
+
+[options="header"]
+|===
+|Property |Type |Description
+|alertmanagerMain |link:#alertmanagermainconfig[AlertmanagerMainConfig]
+|AlertmanagerMainConfig defines configuration related with the main
+Alertmanager instance.
+
+|enableUserWorkload |bool |UserWorkloadEnabled boolean flag to enable
+monitoring for user-defined projects.
+
+|k8sPrometheusAdapter |link:#k8sprometheusadapter[K8sPrometheusAdapter]
+|K8sPrometheusAdapter defines configuration related with
+prometheus-adapter
+
+|kubeStateMetrics |link:#kubestatemetricsconfig[KubeStateMetricsConfig]
+|KubeStateMetricsConfig defines configuration related with
+kube-state-metrics agent
+
+|prometheusK8s |link:#prometheusk8sconfig[PrometheusK8sConfig]
+|PrometheusK8sConfig defines configuration related with prometheus
+
+|prometheusOperator
+|link:#prometheusoperatorconfig[PrometheusOperatorConfig]
+|PrometheusOperatorConfig defines configuration related with
+prometheus-operator
+
+|openshiftStateMetrics
+|link:#openshiftstatemetricsconfig[OpenShiftStateMetricsConfig]
+|OpenShiftMetricsConfig defines configuration related with
+openshift-state-metrics agent
+
+|thanosQuerier |link:#thanosquerierconfig[ThanosQuerierConfig]
+|ThanosQuerierConfig defines configuration related with the Thanos
+Querier component
+|===
+
+
+== K8sPrometheusAdapter
+
+=== Description
+
+`K8sPrometheusAdapter` defines configuration related with Prometheus Adapater
+
+Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
+
+[options="header"]
+|===
+|Property |Type |Description
+|audit |Audit |Audit defines the audit configuration to be used by the
+prometheus adapter instance. Possible profile values are: "metadata,
+request, requestresponse, none". default: metadata
+
+|nodeSelector |map[string]string |NodeSelector defines which Nodes the
+Pods are scheduled on.
+
+|tolerations
+|array(link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#toleration-v1-core[v1.Toleration])
+|Tolerations defines the Pods tolerations.
+|===
+
+
+== KubeStateMetricsConfig
+
+=== Description
+
+`KubeStateMetricsConfig` defines configuration related with the kube-state-metrics agent.
+
+Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
+
+[options="header"]
+|===
+|Property |Type |Description
+|nodeSelector |map[string]string |NodeSelector defines which Nodes the
+Pods are scheduled on.
+
+|tolerations
+|array(link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#toleration-v1-core[v1.Toleration])
+|Tolerations defines the Pods tolerations.
+|===
+
+
+== OpenShiftStateMetricsConfig
+
+=== Description
+
+`OpenShiftStateMetricsConfig` holds configuration related to openshift-state-metrics agent.
+
+Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
+
+[options="header"]
+|===
+|Property |Type |Description
+|nodeSelector |map[string]string |NodeSelector defines which Nodes the
+Pods are scheduled on.
+
+|tolerations
+|array(link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#toleration-v1-core[v1.Toleration])
+|Tolerations defines the Pods tolerations.
+|===
+
+
+== PrometheusK8sConfig
+
+=== Description
+
+`PrometheusK8sConfig` holds configuration related to the Prometheus component.
+
+Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
+
+[options="header"]
+|===
+|Property |Type |Description
+|additionalAlertmanagerConfigs
+|array(xref:#additionalalertmanagerconfig[AdditionalAlertmanagerConfig])
+|AlertmanagerConfigs holds configuration about how the Prometheus
+component should communicate with aditional Alertmanager instances.
+default: nil
+
+// not present in 4.10
+//|enforcedBodySizeLimit |string |EnforcedBodySizeLimit enforces body size limit of Prometheus scrapes, if a scrape is bigger than the limit it will fail. 3 kinds of values are accepted:. empty value: no limit. a value in Prometheus size format, e.g. "64MB". string "automatic", which means the limit will be automatically calculated based oncluster capacity.: 64MB
+
+|externalLabels |map[string]string |ExternalLabels defines labels to be
+added to any time series or alerts when communicating with external
+systems (federation, remote storage, Alertmanager). default: nil
+
+|logLevel |string |LogLevel defines the log level for Prometheus.
+Possible values are: error, warn, info, debug. default: info
+
+|nodeSelector |map[string]string |NodeSelector defines which Nodes the
+Pods are scheduled on.
+
+|queryLogFile |string |QueryLogFile specifies the file to which PromQL
+queries are logged. Suports both just a filename in which case they will
+be saved to an emptyDir volume at `/var/log/prometheus`, if a full path is
+given an emptyDir volume will be mounted at that location. Relative
+paths not supported, also not supported writing to linux std streams.
+default: ""
+
+|remoteWrite |array(xref:#remotewritespec[remotewritespec]) |RemoteWrite
+Holds the remote write configuration, everything from url, authorization
+to relabeling
+
+|resources
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core[v1.ResourceRequirements]
+|Resources define resources requests and limits for single Pods.
+
+|retention |string |Retention defines the Time duration Prometheus shall
+retain data for. Must match the regular expression
+[0-9]+(ms\|s\|m\|h\|d\|w\|y) (milliseconds seconds minutes hours days weeks
+years). default: 15d
+
+// not present in 4.10
+//|retentionSize |string |RetentionSize defines the maximum amount of disk space used by blocks + WAL. default: nil
+
+|tolerations
+|array(link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#toleration-v1-core[v1.Toleration])
+|Tolerations defines the Pods tolerations.
+
+|volumeClaimTemplate
+|link:https://github.com/prometheus-operator/prometheus-operator/blob/v0.57.0/Documentation/api.md#embeddedpersistentvolumeclaim[monv1.EmbeddedPersistentVolumeClaim]
+|VolumeClaimTemplate defines persistent storage for Prometheus. It’s
+possible to configure storageClass and size of volume.
+|===
+
+
+== PrometheusOperatorConfig
+
+=== Description
+
+`PrometheusOperatorConfig` holds configuration related to Prometheus Operator.
+
+Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration],
+link:#userworkloadconfiguration[UserWorkloadConfiguration]
+
+[options="header"]
+|===
+|Property |Type |Description
+|logLevel |string |LogLevel defines the log level for Prometheus
+Operator. Possible values are: error, warn, info, debug. default: info
+
+|nodeSelector |map[string]string |NodeSelector defines which Nodes the
+Pods are scheduled on.
+
+|tolerations
+|array(link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#toleration-v1-core[v1.Toleration])
+|Tolerations defines the Pods tolerations.
+|===
+
+
+== PrometheusRestrictedConfig
+
+=== Description
+
+`PrometheusRestrictedConfig` defines configuration related to the Prometheus component that will monitor user-defined projects.
+
+Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
+
+[options="header"]
+|===
+|Property |Type |Description
+|additionalAlertmanagerConfigs
+|array(xref:#additionalalertmanagerconfig[additionalalertmanagerconfig])
+|AlertmanagerConfigs holds configuration about how the Prometheus
+component should communicate with aditional Alertmanager instances.
+default: nil
+
+// not present in 4.10
+//|enforcedLabelLimit |uint64 |EnforcedLabelLimit per-scrape limit on the number of labels accepted for a sample. If more than this number of labels are present post metric-relabeling, the entire scrape will be treated as failed. 0 means no limit. default: 0
+
+// not present in 4.10
+//|enforcedLabelNameLengthLimit |uint64 |EnforcedLabelNameLengthLimit per-scrape limit on the length of labels name that will be accepted for a sample. If a label name is longer than this number post metric-relabeling, the entire scrape will be treated as failed. 0 means no limit. default: 0
+
+// not present in 4.10
+//|enforcedLabelValueLengthLimit |uint64 |EnforcedLabelValueLengthLimit per-scrape limit on the length of labels value that will be accepted for a sample. If a label value is longer than this number post metric-relabeling, the entire scrape will be treated as failed. 0 means no limit. default: 0
+
+|enforcedSampleLimit |uint64 |EnforcedSampleLimit defines a global
+limit on the number of scraped samples that will be accepted. This
+overrides any SampleLimit set per ServiceMonitor or/and PodMonitor. It
+is meant to be used by admins to enforce the SampleLimit to keep the
+overall number of samples/series under the desired limit. Note that if
+SampleLimit is lower that value will be taken instead. default: 0
+
+|enforcedTargetLimit |uint64 |EnforcedTargetLimit defines a global
+limit on the number of scraped targets. This overrides any TargetLimit
+set per ServiceMonitor or/and PodMonitor. It is meant to be used by
+admins to enforce the TargetLimit to keep the overall number of targets
+under the desired limit. Note that if TargetLimit is lower, that value
+will be taken instead, except if either value is zero, in which case the
+non-zero value will be used. If both values are zero, no limit is
+enforced. default: 0
+
+|externalLabels |map[string]string |ExternalLabels defines labels to be
+added to any time series or alerts when communicating with external
+systems (federation, remote storage, Alertmanager). default: nil
+
+|logLevel |string |LogLevel defines the log level for Prometheus.
+Possible values are: error, warn, info, debug. default: info
+
+|nodeSelector |map[string]string |NodeSelector defines which Nodes the
+Pods are scheduled on.
+
+|queryLogFile |string |QueryLogFile specifies the file to which PromQL
+queries are logged. Suports both just a filename in which case they will
+be saved to an emptyDir volume at /var/log/prometheus, if a full path is
+given an emptyDir volume will be mounted at that location. Relative
+paths not supported, also not supported writing to linux std streams.
+default: ""
+
+|remoteWrite |array(xref:#remotewritespec[remotewritespec]) |RemoteWrite
+Holds the remote write configuration, everything from url, authorization
+to relabeling
+
+|resources
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core[v1.ResourceRequirements]
+|Resources define resources requests and limits for single Pods.
+
+|retention |string |Retention defines the Time duration Prometheus shall
+retain data for. Must match the regular expression
+[0-9]+(ms\|s\|m\|h\|d\|w\|y) (milliseconds seconds minutes hours days weeks
+years). default: 15d
+
+// not present in 4.10
+//|retentionSize |string |RetentionSize defines the maximum amount of disk space used by blocks + WAL. default: nil
+
+|tolerations
+|array(link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#toleration-v1-core[v1.Toleration])
+|Tolerations defines the Pods tolerations.
+
+|volumeClaimTemplate
+|link:https://github.com/prometheus-operator/prometheus-operator/blob/v0.57.0/Documentation/api.md#embeddedpersistentvolumeclaim[monv1.EmbeddedPersistentVolumeClaim]
+|VolumeClaimTemplate defines persistent storage for Prometheus. It’s
+possible to configure storageClass and size of volume.
+|===
+
+
+== RemoteWriteSpec
+
+=== Description
+
+`RemoteWriteSpec` is an almost identical copy of `monv1.RemoteWriteSpec` but with the `BearerToken` field removed. In the future other fields might be added here.
+
+=== Required
+
+* `url`
+
+Appears in: link:#prometheusk8sconfig[PrometheusK8sConfig],
+link:#prometheusrestrictedconfig[PrometheusRestrictedConfig]
+
+[options="header"]
+|===
+|Property |Type |Description
+|authorization |monv1.SafeAuthorization |Authorization defines the
+authorization section for remote write
+
+|basicAuth
+|link:https://github.com/prometheus-operator/prometheus-operator/blob/v0.57.0/Documentation/api.md#basicauth[monv1.BasicAuth]
+|BasicAuth defines configuration for basic authentication for the URL.
+
+|bearerTokenFile |string |BearerTokenFile defines the file where the
+bearer token for remote write resides.
+
+|headers |map[string]string |Headers custom HTTP headers to be sent
+along with each remote write request. Be aware that headers that are set
+by Prometheus itself can’t be overwritten.
+
+|metadataConfig
+|link:https://github.com/prometheus-operator/prometheus-operator/blob/v0.57.0/Documentation/api.md#metadataconfig[monv1.MetadataConfig]
+|MetadataConfig configures the sending of series metadata to remote
+storage.
+
+|name |string |Name defines the name of the remote write queue, must be
+unique if specified. The name is used in metrics and logging in order to
+differentiate queues.
+
+|oauth2 |monv1.OAuth2 |OAuth2 configures OAuth2 authentication for
+remote write.
+
+|proxyUrl |string |ProxyURL defines an optional proxy URL
+
+|queueConfig
+|link:https://github.com/prometheus-operator/prometheus-operator/blob/v0.57.0/Documentation/api.md#queueconfig[monv1.QueueConfig]
+|QueueConfig allows tuning of the remote write queue parameters.
+
+|remoteTimeout |string |RemoteTimeout defines the timeout for requests
+to the remote write endpoint.
+
+|sigv4 |monv1.Sigv4 |Sigv4 allows to configures AWS’s Signature
+Verification 4
+
+|tlsConfig
+|link:https://github.com/prometheus-operator/prometheus-operator/blob/v0.57.0/Documentation/api.md#safetlsconfig[monv1.SafeTLSConfig]
+|TLSConfig defines the TLS configuration to use for remote write.
+
+|url |string |URL defines the URL of the endpoint to send samples to.
+
+|writeRelabelConfigs
+|array(link:https://github.com/prometheus-operator/prometheus-operator/blob/v0.57.0/Documentation/api.md#relabelconfig[monv1.RelabelConfig])
+|WriteRelabelConfigs defines the list of remote write relabel
+configurations.
+|===
+
+
+== TLSConfig
+
+=== Description
+
+`TLSConfig` configures the options for TLS connections.
+
+=== Required
+
+* `insecureSkipVerify`
+
+Appears in: link:#additionalalertmanagerconfig[AdditionalAlertmanagerConfig]
+
+[options="header"]
+|===
+|Property |Type |Description
+|ca
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretkeyselector-v1-core[v1.SecretKeySelector]
+|CA defines the CA cert in the Prometheus container to use for the
+targets.
+
+|cert
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretkeyselector-v1-core[v1.SecretKeySelector]
+|Cert defines the client cert in the Prometheus container to use for the
+targets.
+
+|key
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretkeyselector-v1-core[v1.SecretKeySelector]
+|Key defines the client key in the Prometheus container to use for the
+targets.
+
+|serverName |string |ServerName used to verify the hostname for the
+targets.
+
+|insecureSkipVerify |bool |InsecureSkipVerify disable target certificate
+validation.
+|===
+
+
+== ThanosQuerierConfig
+
+=== Description
+
+`ThanosQuerierConfig` holds configuration related to Thanos Querier component.
+
+Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
+
+[options="header"]
+|===
+|Property |Type |Description
+|enableRequestLogging |bool |EnableRequestLogging boolean flag to enable
+or disable request logging default: false
+
+|logLevel |string |LogLevel defines the log level for Thanos Querier.
+Possible values are: error, warn, info, debug. default: info
+
+|nodeSelector |map[string]string |NodeSelector defines which Nodes the
+Pods are scheduled on.
+
+|resources
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core[v1.ResourceRequirements]
+|Resources define resources requests and limits for single Pods.
+
+|tolerations
+|array(link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#toleration-v1-core[v1.Toleration])
+|Tolerations defines the Pods tolerations.
+|===
+
+
+== ThanosRulerConfig
+
+=== Description
+
+`ThanosRulerConfig` defines configuration for the Thanos Ruler instance for user-defined projects.
+
+Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
+
+[options="header"]
+|===
+|Property |Type |Description
+|additionalAlertmanagerConfigs
+|array(xref:#additionalalertmanagerconfig[additionalalertmanagerconfig])
+|AlertmanagerConfigs holds configuration about how the Thanos Ruler
+component should communicate with aditional Alertmanager instances.
+default: nil
+
+|logLevel |string |LogLevel defines the log level for Thanos Ruler.
+Possible values are: error, warn, info, debug. default: info
+
+|nodeSelector |map[string]string |NodeSelector defines which Nodes the
+Pods are scheduled on.
+
+|resources
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core[v1.ResourceRequirements]
+|Resources define resources requests and limits for single Pods.
+
+|retention |string |Retention defines the time duration Thanos Ruler
+shall retain data for. Must match the regular expression
+[0-9]+(ms\|s\|m\|h\|d\|w\|y) (milliseconds seconds minutes hours days weeks
+years). default: 15d
+
+|tolerations
+|array(link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#toleration-v1-core[v1.Toleration])
+|Tolerations defines the Pods tolerations.
+
+|volumeClaimTemplate
+|link:https://github.com/prometheus-operator/prometheus-operator/blob/v0.57.0/Documentation/api.md#embeddedpersistentvolumeclaim[monv1.EmbeddedPersistentVolumeClaim]
+|VolumeClaimTemplate defines persistent storage for Thanos Ruler. It’s
+possible to configure storageClass and size of volume.
+|===
+
+
+== UserWorkloadConfiguration
+
+=== Description
+
+`UserWorkloadConfiguration` defines configuration that allows users to customise the monitoring stack responsible for user-defined projects through the user-workload-monitoring-config ConfigMap in the openshift-user-workload-monitoring namespace
+
+[options="header"]
+|===
+|Property |Type |Description
+// not present in 4.10
+//|alertmanager |link:#alertmanageruserworkloadconfig[AlertmanagerUserWorkloadConfig] |Alertmanager defines configuration for Alertmanager component.
+
+|prometheus
+|link:#prometheusrestrictedconfig[PrometheusRestrictedConfig]
+|Prometheus defines configuration for Prometheus component.
+
+|prometheusOperator
+|link:#prometheusoperatorconfig[PrometheusOperatorConfig]
+|PrometheusOperator defines configuration for prometheus-operator
+component.
+
+|thanosRuler |link:#thanosrulerconfig[ThanosRulerConfig] |ThanosRuler
+defines configuration for the Thanos Ruler component
+|===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.10
<!--- Specify the version or versions of OpenShift your PR applies to.

Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: [RHDEVDOCS-4142](https://issues.redhat.com/browse/RHDEVDOCS-4142)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.brq.redhat.com/rkratky/RHDEVDOCS-4142/monitoring/configmap-reference-for-cluster-monitoring-operator.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information: This is a temporary stop-gap fix for a customer-reported deficiency. The language has not been properly reviewed. Given this is reference material, we consider it OK for the time being. The entire reference content will be reviewed and updated ASAP.
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
