### PR TITLE
TELCODOCS:604 - Updated variable versions and fixed variables in star…

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -45,8 +45,9 @@ endif::openshift-origin[]
 :rh-rhacm: RHACM
 :sandboxed-containers-first: OpenShift sandboxed containers
 :sandboxed-containers-operator: OpenShift sandboxed containers Operator
-:sandboxed-containers-version: 1.1
-:sandboxed-containers-legacy-version: 1.0.2
+:sandboxed-containers-version: 1.3
+:sandboxed-containers-version-z: 1.3.0
+:sandboxed-containers-legacy-version: 1.2.2
 :cert-manager-operator: cert-manager Operator for Red Hat OpenShift
 :secondary-scheduler-operator-full: Secondary Scheduler Operator for Red Hat OpenShift
 :secondary-scheduler-operator: Secondary Scheduler Operator

--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -57,7 +57,7 @@ ifndef::openshift-dedicated[]
 |Data collection for Local Storage Operator.
 endif::openshift-dedicated[]
 
-|`registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:1.2.0`
+|`registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:{sandboxed-containers-version}.0`
 |Data collection for {sandboxed-containers-first}.
 
 |`registry.redhat.io/workload-availability/self-node-remediation-must-gather-rhel8:v0.4.0`

--- a/modules/sandboxed-containers-create-kata-config-resource-cli.adoc
+++ b/modules/sandboxed-containers-create-kata-config-resource-cli.adoc
@@ -28,26 +28,26 @@ Kata is installed on all worker nodes by default. If you want to install `kata` 
 
 . Create a YAML file with the following manifest:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: kataconfiguration.openshift.io/v1
 kind: KataConfig
 metadata:
   name: cluster-kataconfig
 spec:
-  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:1.2.0
+  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:{sandboxed-containers-version}.0
 ----
 
 . (Optional) If you want to install `kata` as a `RuntimeClass` only on selected nodes, create a YAML file that includes the label in the manifest:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: kataconfiguration.openshift.io/v1
 kind: KataConfig
 metadata:
   name: cluster-kataconfig
 spec:
-  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:1.2.0
+  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:{sandboxed-containers-version}.0
   kataConfigPoolSelector:
     matchLabels:
       <label_key>: '<label_value>'

--- a/modules/sandboxed-containers-create-kataconfig-resource-web-console.adoc
+++ b/modules/sandboxed-containers-create-kataconfig-resource-web-console.adoc
@@ -32,27 +32,27 @@ Kata is installed on all worker nodes by default. If you want to install `kata` 
 . Copy and paste the following manifest into the *YAML view*:
 
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: kataconfiguration.openshift.io/v1
 kind: KataConfig
 metadata:
   name: cluster-kataconfig
 spec:
-  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:1.2.0
+  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:{sandboxed-containers-version}.0
 ----
 +
 If you want to install `kata` as a `RuntimeClass` only on selected nodes, include the label in the manifest:
 
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: kataconfiguration.openshift.io/v1
 kind: KataConfig
 metadata:
   name: cluster-kataconfig
 spec:
-  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:1.2.0
+  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:{sandboxed-containers-version}.0
   kataConfigPoolSelector:
     matchLabels:
       <label_key>: '<label_value>'

--- a/modules/sandboxed-containers-installing-operator-cli.adoc
+++ b/modules/sandboxed-containers-installing-operator-cli.adoc
@@ -81,7 +81,7 @@ spec:
   name: sandboxed-containers-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: sandboxed-containers-operator.v1.2.0
+  startingCSV: sandboxed-containers-operator.v{sandboxed-containers-version-z}
 ----
 
 .. Create the `Subscription` object:
@@ -109,7 +109,8 @@ $ oc get csv -n openshift-sandboxed-containers-operator
 +
 .Example output
 +
+[source,terminal,subs="attributes+"]
 ----
-NAME                             DISPLAY                                  VERSION  REPLACES                    PHASE
-openshift-sandboxed-containers   openshift-sandboxed-containers-operator  {sandboxed-containers-version}.0   {sandboxed-containers-legacy-version}   Succeeded
+NAME                             DISPLAY                                  VERSION  REPLACES     PHASE
+openshift-sandboxed-containers   openshift-sandboxed-containers-operator  {sandboxed-containers-version-z}    {sandboxed-containers-legacy-version}        Succeeded
 ----

--- a/sandboxed_containers/troubleshooting-sandboxed-containers.adoc
+++ b/sandboxed_containers/troubleshooting-sandboxed-containers.adoc
@@ -17,9 +17,9 @@ include::modules/about-must-gather.adoc[leveloffset=+2]
 
 To collect {sandboxed-containers-first} data with `must-gather`, you must specify the
 {sandboxed-containers-first} image:
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
---image=registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:1.2.0
+--image=registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:{sandboxed-containers-version}.0
 ----
 
 include::modules/sandboxed-containers-collecting-data.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): Main, 4.12

Issue:
[TELCODOCS-604](https://issues.redhat.com/browse/TELCODOCS-604)
Also tracks work for [BZ-2111447](https://bugzilla.redhat.com/show_bug.cgi?id=2111447) and [TELCODOCS-632](https://issues.redhat.com/browse/TELCODOCS-632).

[Link to docs preview](http://file.emea.redhat.com/miweiss/TELCODOCS-604/sandboxed_containers/deploying-sandboxed-container-workloads.html#sandboxed-containers-installing-operator-cli_deploying-sandboxed-containers)

This PR tracks OSC variable updates, including updates to the OSC must-gather and kataMonitor images.