### PR TITLE
OSDOCS-3866 updated vSphere version requirements for installation

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -45,23 +45,23 @@ endif::[]
 [id="installation-vsphere-infrastructure_{context}"]
 = VMware vSphere infrastructure requirements
 
-You must install the {product-title} cluster on a VMware vSphere version 6 or 7 instance that meets the requirements for the components that you use.
+You must install the {product-title} cluster on a VMware vSphere version 7 instance that meets the requirements for the components that you use.
 
 
 .Version requirements for vSphere virtual environments
 [cols=2, options="header"]
 |===
 |Virtual environment product |Required version
-|VM hardware version | 13 or later
-|vSphere ESXi hosts | 6.5 or later
-|vCenter host   | 6.5 or later
+|VM hardware version | 15 or later
+|vSphere ESXi hosts | 7.0.2 or later
+|vCenter host   | 7.0.2 or later
 |===
 
 [IMPORTANT]
 ====
-Installing a cluster on VMware vSphere version 6.7U3 or earlier and virtual hardware version 13 is now deprecated. These versions are still fully supported, but version 4.11 of {product-title} will require vSphere virtual hardware version 15 or later. Hardware version 15 is now the default for vSphere virtual machines in {product-title}. To update the hardware version for your vSphere nodes, see the "Updating hardware on nodes running in vSphere" article.
+Installing a cluster on VMware vSphere version 7.0.1 or earlier is now deprecated. These versions are still fully supported, but version 4.11 of {product-title} requires vSphere virtual hardware version 15 or later. Hardware version 15 is now the default for vSphere virtual machines in {product-title}. To update the hardware version for your vSphere nodes, see the "Updating hardware on nodes running in vSphere" article.
 
-If your vSphere nodes are below hardware version 15 or your VMware vSphere version is earlier than 6.7U3, upgrading from {product-title} 4.10 to {product-title} 4.11 is not available.
+If your vSphere nodes are below hardware version 15 or your VMware vSphere version is earlier than 6.7.3, upgrading from {product-title} 4.10 to {product-title} 4.11 is not available.
 ====
 
 .Minimum supported vSphere version for VMware components
@@ -69,22 +69,19 @@ If your vSphere nodes are below hardware version 15 or your VMware vSphere versi
 |Component | Minimum supported versions |Description
 
 |Hypervisor
-|vSphere 6.5 and later with HW version 13
+|vSphere 6.7u3 and later with HW version 15
 |This version is the minimum version that {op-system-first} supports. See the link:https://access.redhat.com/ecosystem/search/#/ecosystem/Red%20Hat%20Enterprise%20Linux?sort=sortTitle%20asc&vendors=VMware&category=Server[Red Hat Enterprise Linux 8 supported hypervisors list].
 
 |Storage with in-tree drivers
-|vSphere 6.5 and later
+|vSphere 6.7u3 and later
 |This plug-in creates vSphere storage by using the in-tree storage drivers for vSphere included in {product-title}.
 
 ifndef::vmc[]
 |Optional: Networking (NSX-T)
-|vSphere 6.5U3 or vSphere 6.7U2 and later
-|vSphere 6.5U3 or vSphere 6.7U2+ are required for {product-title}. VMware's NSX Container Plug-in (NCP) is certified with {product-title} 4.6 and NSX-T 3.x+.
+|vSphere 7.0.1 and later
+|vSphere 7.0.1 is required for {product-title}. VMware's NSX Container Plug-in (NCP) is certified with {product-title} 4.6 and NSX-T 3.x+.
 endif::vmc[]
 |===
-
-If you use a vSphere version 6.5 instance, consider upgrading to 6.7U3 or 7.0 before
-you install {product-title}.
 
 [IMPORTANT]
 ====

--- a/modules/vmware-csi-driver-reqs.adoc
+++ b/modules/vmware-csi-driver-reqs.adoc
@@ -24,7 +24,7 @@
 
 The following requirements must be met in order to install the CSI Driver Operator:
 
-* VMware vSphere version 6.7U3 or later
+* VMware vSphere version 7.0.1 or later
 * Virtual machines of hardware version 15 or later
 * No third-party CSI driver already installed in the cluster
 


### PR DESCRIPTION
[OSDOCS-3866](https://issues.redhat.com//browse/OSDOCS-3866) updated vSphere version requirements for installation

Applies to 4.11+

https://issues.redhat.com/browse/OSDOCS-3866

Doc preview: https://bscott-rh.github.io/openshift-docs/OSDOCS-3866/installing/installing_vsphere/preparing-to-install-on-vsphere.html#installation-vsphere-infrastructure_preparing-to-install-on-vsphere