### PR TITLE
RN RHEL9 openshift-install support

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -73,6 +73,12 @@ The redirector hostname for downloading {op-system} boot images is now `rhcos.mi
 [id="ocp-4-11-installation-and-upgrade"]
 === Installation and upgrade
 
+[id="ocp-4-11-rhel-9-openshift-installer"]
+==== RHEL 9 support for the OpenShift installer
+Using Red Hat Enterprise Linux (RHEL) 9 with the OpenShift installer (openshift-install) is now supported.
+
+For more information, see the "Obtaining the installation program" section of the installation documentation for your platform.
+
 ==== New minimum system requirements for installing {product-title} on a single node
 This release updates the minimum system requirements for installing {product-title} on a single node. When installing {product-title} on a single node, you should configure a minimum of 16 GB of RAM. Specific workload requirements can require additional RAM. The complete list of supported platforms has been updated to include bare metal, vSphere, {rh-openstack-first}, and Red Hat Virtualization platforms. In all cases, you must specify the `platform.none: {}` parameter in the `install-config.yaml` configuration file when the `openshift-installer` binary is being used to install {sno}.
 
@@ -1337,8 +1343,7 @@ With this update, the `user-workload-monitoring-config` config map is now automa
 With this update, the CMO now waits until deployments are deleted before recreating them, which resolves this issue.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2069068[*BZ#2069068*])
 
-* Before this update, for user workload monitoring, if you configured external labels for metrics in Prometheus, the CMO did not correctly propagate these labels to Thanos Ruler.
-If you queried external metrics for user-defined projects, not provided by the user workload monitoring instance of Prometheus, you would sometimes not see external labels for these metrics even though you had configured Prometheus to add them. With this update, the CMO now properly propagates the external labels that you configured in Prometheus to Thanos Ruler, and you can see the labels when you query external metrics. Thus, for user-defined projects, if you queried external metrics not provided by the user workload monitoring instance of Prometheus, you would sometimes not see external labels for these metrics even though you had configured Prometheus to add them. With this update, the CMO now properly propagates the external labels that you configured in Prometheus to Thanos Ruler, and you can see the labels when you query external metrics.
+* Before this update, for user workload monitoring, if you configured external labels for metrics in Prometheus, the CMO did not correctly propagate these labels to Thanos Ruler. If you queried external metrics for user-defined projects, not provided by the user workload monitoring instance of Prometheus, you would sometimes not see external labels for these metrics even though you had configured Prometheus to add them. With this update, the CMO now properly propagates the external labels that you configured in Prometheus to Thanos Ruler, and you can see the labels when you query external metrics. Therefore, for user-defined projects, if you queried external metrics not provided by the user workload monitoring instance of Prometheus, you would sometimes not see external labels for these metrics even though you had configured Prometheus to add them. With this update, the CMO now properly propagates the external labels that you configured in Prometheus to Thanos Ruler, and you can see the labels when you query external metrics.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2073112[*BZ#2073112*])
 
 * Before this update, the `tunbr` interface incorrectly triggered the `NodeNetworkInterfaceFlapping` alert.


### PR DESCRIPTION
RN for adding RHEL9 openshift-install support.
4.11 only
Doc preview: https://bscott-rh.github.io/openshift-docs/RN-RHEL9-openshift-installer/release_notes/ocp-4-11-release-notes.html#ocp-4-11-rhel-9-openshift-installer