### PR TITLE
BZ#2086986 remove references to deprecated instance_type_id

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1275,14 +1275,6 @@ Additional {rh-virtualization} configuration parameters for machine pools are de
 |Optional. Memory of the VM in MiB.
 |Integer
 
-|`<machine-pool>.platform.ovirt.instanceTypeID`
-|Optional. An instance type UUID, such as `00000009-0009-0009-0009-0000000000f1`, which you can get from the `https://<engine-fqdn>/ovirt-engine/api/instancetypes` endpoint.
-[WARNING]
-====
-The `instance_type_id` field is deprecated and will be removed in a future release.
-====
-|String of UUID
-
 |`<machine-pool>.platform.ovirt.osDisk`
 |Optional. Defines the first and bootable disk of the VM.
 |String

--- a/modules/machineset-yaml-rhv.adoc
+++ b/modules/machineset-yaml-rhv.adoc
@@ -43,28 +43,27 @@ spec:
           apiVersion: ovirtproviderconfig.machine.openshift.io/v1beta1
           cluster_id: <ovirt_cluster_id> <6>
           template_name: <ovirt_template_name> <7>
-          instance_type_id: <instance_type_id> <8>
-          sparse: <boolean_value> <9>
-          format: <raw_or_cow> <10>
-          cpu: <11>
-            sockets: <number_of_sockets> <12>
-            cores: <number_of_cores> <13>
-            threads: <number_of_threads> <14>
-          memory_mb: <memory_size> <15>
-          guaranteed_memory_mb:  <memory_size> <16>
-          os_disk: <17>
-            size_gb: <disk_size> <18>
-            storage_domain_id: <storage_domain_UUID> <19>
-          network_interfaces: <20>
-            vnic_profile_id:  <vnic_profile_id> <21>
+          sparse: <boolean_value> <8>
+          format: <raw_or_cow> <9>
+          cpu: <10>
+            sockets: <number_of_sockets> <11>
+            cores: <number_of_cores> <12>
+            threads: <number_of_threads> <13>
+          memory_mb: <memory_size> <14>
+          guaranteed_memory_mb:  <memory_size> <15>
+          os_disk: <16>
+            size_gb: <disk_size> <17>
+            storage_domain_id: <storage_domain_UUID> <18>
+          network_interfaces: <19>
+            vnic_profile_id:  <vnic_profile_id> <20>
           credentialsSecret:
-            name: ovirt-credentials <22>
+            name: ovirt-credentials <21>
           kind: OvirtMachineProviderSpec
-          type: <workload_type> <23>
-          auto_pinning_policy: <auto_pinning_policy> <24>
-          hugepages: <hugepages> <25>
+          type: <workload_type> <22>
+          auto_pinning_policy: <auto_pinning_policy> <23>
+          hugepages: <hugepages> <24>
           affinityGroupsNames:
-            - compute <26>
+            - compute <25>
           userDataSecret:
             name: worker-user-data
 ----
@@ -87,53 +86,46 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 
 <7> Specify the {rh-virtualization} VM template to use to create the machine.
 
-<8> Optional: Specify the VM instance type.
-+
-[WARNING]
-====
-The `instance_type_id` field is deprecated and will be removed in a future release.
-====
-+
-If you include this parameter, you do not need to specify the hardware parameters of the VM including CPU and memory because this parameter overrides all hardware parameters.
-<9> Setting this option to `false` enables preallocation of disks. The default is `true`. Setting `sparse` to `true` with `format` set to `raw` is not available for block storage domains. The `raw` format writes the entire virtual disk to the underlying physical disk.
-<10> Can be set to `cow` or `raw`. The default is `cow`. The `cow` format is optimized for virtual machines.
+<8> Setting this option to `false` enables preallocation of disks. The default is `true`. Setting `sparse` to `true` with `format` set to `raw` is not available for block storage domains. The `raw` format writes the entire virtual disk to the underlying physical disk.
+
+<9> Can be set to `cow` or `raw`. The default is `cow`. The `cow` format is optimized for virtual machines.
 +
 [NOTE]
 ====
 Preallocating disks on file storage domains writes zeroes to the file. This might not actually preallocate disks depending on the underlying storage.
 ====
-<11> Optional: The CPU field contains the CPU configuration, including sockets, cores, and threads.
+<10> Optional: The CPU field contains the CPU configuration, including sockets, cores, and threads.
 
-<12> Optional: Specify the number of sockets for a VM.
+<11> Optional: Specify the number of sockets for a VM.
 
-<13> Optional: Specify the number of cores per socket.
+<12> Optional: Specify the number of cores per socket.
 
-<14> Optional: Specify the number of threads per core.
+<13> Optional: Specify the number of threads per core.
 
-<15> Optional: Specify the size of a VM's memory in MiB.
+<14> Optional: Specify the size of a VM's memory in MiB.
 
-<16> Optional: Specify the size of a virtual machine's guaranteed memory in MiB. This is the amount of memory that is guaranteed not to be drained by the ballooning mechanism. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/administration_guide#memory_ballooning[Memory Ballooning] and link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/administration_guide#Cluster_Optimization_Settings_Explained[Optimization Settings Explained].
+<15> Optional: Specify the size of a virtual machine's guaranteed memory in MiB. This is the amount of memory that is guaranteed not to be drained by the ballooning mechanism. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/administration_guide#memory_ballooning[Memory Ballooning] and link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/administration_guide#Cluster_Optimization_Settings_Explained[Optimization Settings Explained].
 +
 [NOTE]
 ====
 If you are using a version earlier than {rh-virtualization} 4.4.8, see link:https://access.redhat.com/articles/6454811[Guaranteed memory requirements for OpenShift on Red Hat Virtualization clusters].
 ====
-<17> Optional: Root disk of the node.
+<16> Optional: Root disk of the node.
 
-<18> Optional: Specify the size of the bootable disk in GiB.
+<17> Optional: Specify the size of the bootable disk in GiB.
 
-<19> Optional: Specify the UUID of the storage domain for the compute node's disks. If none is provided, the compute node is created on the same storage domain as the control nodes. (default)
+<18> Optional: Specify the UUID of the storage domain for the compute node's disks. If none is provided, the compute node is created on the same storage domain as the control nodes. (default)
 
-<20> Optional: List of the network interfaces of the VM. If you include this parameter, {product-title} discards all network interfaces from the template and creates new ones.
+<19> Optional: List of the network interfaces of the VM. If you include this parameter, {product-title} discards all network interfaces from the template and creates new ones.
 
-<21> Optional: Specify the vNIC profile ID.
+<20> Optional: Specify the vNIC profile ID.
 
-<22> Specify the name of the secret object that holds the {rh-virtualization} credentials.
+<21> Specify the name of the secret object that holds the {rh-virtualization} credentials.
 
-<23> Optional: Specify the workload type for which the instance is optimized. This value affects the `{rh-virtualization} VM` parameter. Supported values: `desktop`, `server` (default), `high_performance`. `high_performance` improves performance on the VM. Limitations exist, for example, you cannot access the VM with a graphical console. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Configuring_High_Performance_Virtual_Machines_Templates_and_Pools[Configuring High Performance Virtual Machines, Templates, and Pools] in the _Virtual Machine Management Guide_.
-<24> Optional: AutoPinningPolicy defines the policy that automatically sets CPU and NUMA settings, including pinning to the host for this instance. Supported values: `none`, `resize_and_pin`. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Setting_NUMA_Nodes[Setting NUMA Nodes] in the _Virtual Machine Management Guide_.
-<25> Optional: Hugepages is the size in KiB for defining hugepages in a VM. Supported values: `2048` or `1048576`. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Configuring_Huge_Pages[Configuring Huge Pages] in the _Virtual Machine Management Guide_.
-<26> Optional: A list of affinity group names to be applied to the VMs. The affinity groups must exist in oVirt.
+<22> Optional: Specify the workload type for which the instance is optimized. This value affects the `{rh-virtualization} VM` parameter. Supported values: `desktop`, `server` (default), `high_performance`. `high_performance` improves performance on the VM. Limitations exist, for example, you cannot access the VM with a graphical console. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Configuring_High_Performance_Virtual_Machines_Templates_and_Pools[Configuring High Performance Virtual Machines, Templates, and Pools] in the _Virtual Machine Management Guide_.
+<23> Optional: AutoPinningPolicy defines the policy that automatically sets CPU and NUMA settings, including pinning to the host for this instance. Supported values: `none`, `resize_and_pin`. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Setting_NUMA_Nodes[Setting NUMA Nodes] in the _Virtual Machine Management Guide_.
+<24> Optional: Hugepages is the size in KiB for defining hugepages in a VM. Supported values: `2048` or `1048576`. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Configuring_Huge_Pages[Configuring Huge Pages] in the _Virtual Machine Management Guide_.
+<25> Optional: A list of affinity group names to be applied to the VMs. The affinity groups must exist in oVirt.
 
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

[BZ#2086986](https://bugzilla.redhat.com/show_bug.cgi?id=2086986)
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->
**NEW PR  for REVIEW**

previous comments can be viewed in: 
https://github.com/openshift/openshift-docs/pull/47948

Version(s):
PR applies to enterprise-4.11 or later
<!--- Specify the version or versions of OpenShift your PR applies to.
Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue:

Remove references to "instance_type_id" parameter from the documentation 
This applies specifically to  

- sample YAML for creating a machineset on RHV, 

and to 
- example installation config YAML example for installing on RHV with customizations

<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
http://file.tlv.redhat.com/emarcus/2086986/installing/installing_rhv/installing-rhv-customizations.html#installation-configuration-parameters-additional-machine_installing-rhv-customizations

http://file.tlv.redhat.com/emarcus/2086986/machine_management/creating_machinesets/creating-machineset-rhv.html#machineset-yaml-rhv_creating-machineset-rhv



<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:


<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
