### PR TITLE
OSSMDOC-640: [DDF]Clarify versioning of doc set.

### DIFF
--- a/modules/ossm-config-enabling-controlplane.adoc
+++ b/modules/ossm-config-enabling-controlplane.adoc
@@ -7,12 +7,12 @@
 
 Secure connections are always used when proxies communicate with the control plane regardless of the `spec.security.controlPlane.mtls` setting. If Mixer telemetry or policies are part of your configuration, set `spec.security.controlPlane.mtls` to `true` in your `ServiceMeshControlPlane` resource to enable strict mTLS.
 
-[source,yaml]
+[source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   security:
     controlPlane:
       mtls: true

--- a/modules/ossm-config-sec-mtls-mesh.adoc
+++ b/modules/ossm-config-sec-mtls-mesh.adoc
@@ -8,12 +8,12 @@
 
 If your workloads do not communicate with outside services, you can quickly enable mTLS across your mesh without communication interruptions. You can enable it by setting `spec.security.dataPlane.mtls` to `true` in the `ServiceMeshControlPlane` resource. The Operator creates the required resources.
 
-[source,yaml]
+[source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   security:
     dataPlane:
       mtls: true

--- a/modules/ossm-control-plane-cli.adoc
+++ b/modules/ossm-control-plane-cli.adoc
@@ -31,8 +31,8 @@ $ oc new-project istio-system
 +
 . Create a `ServiceMeshControlPlane` file named `istio-installation.yaml` using the following example. The version of the control plane determines the features available regardless of the version of the Operator.
 +
-.Example version 2.1 istio-installation.yaml
-[source,yaml]
+.Example version {MaistraVersion} istio-installation.yaml
+[source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
@@ -40,7 +40,7 @@ metadata:
   name: basic
   namespace: istio-system
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   tracing:
     type: Jaeger
     sampling: 10000

--- a/modules/ossm-cr-example.adoc
+++ b/modules/ossm-cr-example.adoc
@@ -138,13 +138,14 @@ The following table lists the specifications for the `ServiceMeshControlPlane` r
 This example `ServiceMeshControlPlane` definition contains all of the supported parameters.
 
 .Example `ServiceMeshControlPlane` resource
-[source,yaml]
+[source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
   name: basic
 spec:
+  version: v{MaistraVersion}
   proxy:
     runtime:
       container:

--- a/modules/ossm-cr-tracing.adoc
+++ b/modules/ossm-cr-tracing.adoc
@@ -8,14 +8,14 @@
 The following example illustrates the `spec.tracing` parameters for the `ServiceMeshControlPlane` object, and a description of the available parameters with appropriate values.
 
 .Example tracing parameters
-[source,yaml]
+[source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
   name: basic
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   tracing:
     sampling: 100
     type: Jaeger

--- a/modules/ossm-deploying-jaeger.adoc
+++ b/modules/ossm-deploying-jaeger.adoc
@@ -31,14 +31,14 @@ The streaming strategy requires an additional Red Hat subscription for AMQ Strea
 If you do not specify Jaeger configuration options, the `ServiceMeshControlPlane` resource will use the `allInOne` Jaeger deployment strategy by default. When using the default `allInOne` deployment strategy, set `spec.addons.jaeger.install.storage.type` to `Memory`. You can accept the defaults or specify additional configuration options under `install`.
 
 .Control plane default Jaeger parameters (Memory)
-[source,yaml]
+[source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
   name: basic
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   tracing:
     sampling: 10000
     type: Jaeger
@@ -56,14 +56,14 @@ spec:
 To use the default settings for the `production` deployment strategy, set `spec.addons.jaeger.install.storage.type` to `Elasticsearch` and specify additional configuration options under `install`. Note that the SMCP only supports configuring Elasticsearch resources and image name.
 
 .Control plane default Jaeger parameters (Elasticsearch)
-[source,yaml]
+[source,yaml, subs="attributes"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
   name: basic
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   tracing:
     sampling: 10000
     type: Jaeger
@@ -91,14 +91,14 @@ The SMCP supports only minimal Elasticsearch parameters. To fully customize your
 Create and configure your Jaeger instance and set `spec.addons.jaeger.name` to the name of the Jaeger instance, in this example: `MyJaegerInstance`.
 
 .Control plane with linked Jaeger production CR
-[source,yaml]
+[source,yaml, subs="attributes"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
   name: basic
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   tracing:
     sampling: 1000
     type: Jaeger
@@ -118,14 +118,14 @@ spec:
 To use the `streaming` deployment strategy, you create and configure your Jaeger instance first, then set `spec.addons.jaeger.name` to the name of the Jaeger instance, in this example: `MyJaegerInstance`.
 
 .Control plane with linked Jaeger streaming CR
-[source,yaml]
+[source,yaml, subs="attributes"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
   name: basic
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   tracing:
     sampling: 1000
     type: Jaeger

--- a/modules/ossm-enabling-jaeger.adoc
+++ b/modules/ossm-enabling-jaeger.adoc
@@ -9,14 +9,14 @@
 You enable distributed tracing by specifying a tracing type and a sampling rate in the `ServiceMeshControlPlane` resource.
 
 .Default `all-in-one` Jaeger parameters
-[source,yaml]
+[source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
   name: basic
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   tracing:
     sampling: 100
     type: Jaeger

--- a/modules/ossm-federation-config-smcp.adoc
+++ b/modules/ossm-federation-config-smcp.adoc
@@ -12,7 +12,7 @@ Before a mesh can be federated, you must configure the `ServiceMeshControlPlane`
 In the following example, the administrator for the `red-mesh` is configuring the SMCP for federation with both the `green-mesh` and the `blue-mesh`.
 
 .Sample SMCP for red-mesh
-[source,yaml]
+[source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
@@ -20,7 +20,7 @@ metadata:
   name: red-mesh
   namespace: red-mesh-system
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   runtime:
     defaults:
       container:

--- a/modules/ossm-install-rosa.adoc
+++ b/modules/ossm-install-rosa.adoc
@@ -20,7 +20,7 @@ You must create a new namespace, for example `istio-system`, when installing {SM
 The default configuration in the `ServiceMeshControlPlane` file does not work on a ROSA cluster. You must modify the default SMCP and set `spec.security.identity.type=ThirdParty` when installing on Red Hat OpenShift Service on AWS.
 
 .Example `ServiceMeshControlPlane` resource for ROSA
-[source,yaml]
+[source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
@@ -28,7 +28,7 @@ metadata:
   name: basic
   namespace: istio-system
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   security:
     identity:
       type: ThirdParty  #required setting for ROSA

--- a/modules/ossm-recommended-resources.adoc
+++ b/modules/ossm-recommended-resources.adoc
@@ -25,8 +25,8 @@ The settings in the following example are based on 1,000 services and 1,000 requ
 +
 .. Set the values for `spec.proxy.runtime.container.resources.requests.cpu` and `spec.proxy.runtime.container.resources.requests.memory` in your `ServiceMeshControlPlane` resource.
 +
-.Example version 2.1 ServiceMeshControlPlane
-[source,yaml]
+.Example version {MaistraVersion} ServiceMeshControlPlane
+[source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
@@ -34,7 +34,7 @@ metadata:
   name: basic
   namespace: istio-system
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   proxy:
     runtime:
       container:

--- a/modules/ossm-smcp-prod.adoc
+++ b/modules/ossm-smcp-prod.adoc
@@ -17,14 +17,14 @@ You cannot change the `metadata.name` field of an existing `ServiceMeshControlPl
 .. Edit the `ServiceMeshControlPlane` resource to use the `production` deployment strategy, by setting `spec.addons.jaeger.install.storage.type` to `Elasticsearch` and specify additional configuration options under `install`. You can create and configure your Jaeger instance and set `spec.addons.jaeger.name` to the name of the Jaeger instance.
 +
 .Default Jaeger parameters including Elasticsearch
-[source,yaml]
+[source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
   name: basic
 spec:
-  version: v2.1
+  version: v{MaistraVersion}
   tracing:
     sampling: 100
     type: Jaeger

--- a/modules/ossm-upgrading-from-20-to-21.adoc
+++ b/modules/ossm-upgrading-from-20-to-21.adoc
@@ -48,7 +48,7 @@ admission webhook smcp.validation.maistra.io denied the request: [support for po
 +
 For example:
 +
-[source,terminal]
+[source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
@@ -57,7 +57,7 @@ spec:
     type: Istiod
   telemetry:
     type: Istiod
-  version: v2.1
+  version: v{MaistraVersion}
 ----
 +
 Alternatively, instead of using the command line, you can use the web console to edit the control plane. In the {product-title} web console, click *Project* and select the project name you just entered.

--- a/service_mesh/v2x/ossm-about.adoc
+++ b/service_mesh/v2x/ossm-about.adoc
@@ -6,6 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[NOTE]
+====
+Because {SMProductName} releases on a different cadence from {product-title} and because the {SMProductName} Operator supports deploying multiple versions of the `ServiceMeshControlPlane`, the {SMProductShortName} documentation does not maintain separate documentation sets for minor versions of the product.  The current documentation set applies to all currently supported versions of {SMProductShortName} unless version-specific limitations are called out in a particular topic or for a particular feature.
+
+For additional information about the {SMProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift#ossm[Platform Life Cycle Policy].
+====
+
 include::modules/ossm-servicemesh-overview.adoc[leveloffset=+1]
 
 include::modules/ossm-core-features.adoc[leveloffset=+1]


### PR DESCRIPTION
In response to customer confusion around whether or not our docs have been updated for the recent 2.2 minor release, this PR:

* adds a note to the "About" assembly to explain that the Service Mesh documentation set is not versioned.
* adds version attributes to the example YAML files 

Note that there will be separate PRs to address the "2.x" in the left navigation in the various release branches.

Version(s): 4.6 - 4.12

Issue: [OSSMDOC-640](https://issues.redhat.com/browse/OSSMDOC-640)

Link to docs preview:
About section
http://file.bos.redhat.com/jstickle/OSSMDOC-640/service_mesh/v2x/ossm-about.html 

Also example control plane references with variables (two SCMP changes in this assembly)
http://file.bos.redhat.com/jstickle/OSSMDOC-640/service_mesh/v2x/ossm-create-smcp.html

http://file.bos.redhat.com/jstickle/OSSMDOC-640/service_mesh/v2x/ossm-reference-smcp.html 


Additional information: 
PM/Eng review: longmuir, rcernich
QE review: skondkar
Peer review:  jldohmann 