### PR TITLE
adds batch 5 of bugs to RNs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1203,6 +1203,10 @@ sourceStrategy:
 
 * Previously, the procedural name generator for Azure availability sets exceeded the 80 character maximum limit. This might cause the Machine API to reuse the same sets during the name truncation, rather than creating multiple availability sets. With this release, the procedural name generator is updated to ensure that the name is no longer than 80 characters and the cluster name is not duplicated in the set name. As a result, Azure availability sets are no longer truncated in unexpected ways by the procedural name generator. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2093044[*BZ#2093044*])
 
+* Because the Cluster Autoscaler Operator was deploying the cluster autoscaler without setting any leader election parameters, the cluster autoscaler could unexpectedly fail and restart after a cluster restart. With this fix, the Cluster Autoscaler Operator now deploys the cluster autoscaler with well-defined leader election flags. As a result, the cluster autoscaler operates as expected after restarts. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2063194[*BZ#2063194*])"
+
+* Previously, certificate signing request (CSR) renewal was handled by `kube-controller-manager` and correctly left pending by the machine approver, which increased `mapi_current_pending_csr` to `1`. Afterwards, the `kube-controller-manager` approved the CSR, but the machine approver would ignore it, which left the metric unchanged. Consequently, the `mapi_current_pending_csr` was stuck at `1` until another machine approver reconciled it. With this update, CSR approvals are reconciled from other controllers to update metrics properly. As a result, `mapi_current_pending_csr` is always up-to-date after every reconcile. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2072195[*BZ#2072195*])
+
 [discrete]
 [id="ocp-4-11-cloud-credential-operator-bug-fixes"]
 ==== Cloud Credential Operator
@@ -1222,6 +1226,8 @@ sourceStrategy:
 [discrete]
 [id="ocp-4-11-image-registry-bug-fixes"]
 ==== Image Registry
+
+* Previously, the image registry used an `ImageContentSourcePolicy` (ICSP) as a source only when it was an exact match. The same source file was expected to be pulled through for any subrepositories. The ICSP name and path did not match for subrepositories. As a result, the image was not used. Now, the ICSP is applied successfully to the subrepositories, which can use the mirrored images. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2014240[*BZ#2014240*])
 
 [discrete]
 [id="ocp-4-11-image-streams-bug-fixes"]
@@ -1393,6 +1399,10 @@ In this update, `systemd` service only sets the default RPS mask for virtual int
 [id="ocp-4-11-openshift-api-server-bug-fixes"]
 ==== OpenShift API server
 
+* Because multiple Authentication Operator controllers were synchronizing at the same time, the Authentication Operator was taking too long to react to changes to its configuration. This feature adds jitter to the regular synchronization periods so that the Authentication Operator controllers do not race for resources. As a result, it now takes less time for the Authentication Operator to react to configuration changes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1958198[*BZ#1958198*])"
+
+* With {product-title} 4.11, authentication attempts from external identity providers are now logged to the audit logs. As a result, you can view successful, failed, and errored login attempts from external identity providers in the audit logs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2086465[*BZ#2086465*])"
+
 [discrete]
 [id="ocp-4-11-openshift-update-service-bug-fixes"]
 ==== OpenShift Update Service
@@ -1404,6 +1414,8 @@ In this update, `systemd` service only sets the default RPS mask for virtual int
 * Before this update, if a machine was booted through PXE and the `BOOTIF` argument was on the kernel command line, the machine would boot with DHCP enabled on only a single interface. With this update, the machine boots with DHCP enabled on all interfaces even if the `BOOTIF` argument is provided. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2032717[BZ#2032717])
 
 * Previously, nodes that were provisioned from VMware OVA images did not delete the Ignition config after initial provisioning. Consequently, this created security issues when secrets are stored within the Ignition config. With this update, the Ignition config is now deleted from the VMware hypervisor after initial provisioning on new nodes and when upgrading from a previous {product-title} release on existing nodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2082274[BZ#2082274])
+
+* Previously, any arguments provided to the `toolbox` command were ignored when the command wasfirst invoked. This fix updates the toolbox script to initiate the `podman container create` command followed by the `podman start` and `podman exec` commands. It also modifies the script to handle multiple arguments and whitespaces as an array. As a result, the arguments passed to the `toolbox` command are executed every time as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039589[*BZ#2039589*])
 
 [discrete]
 [id="ocp-4-11-performance-bug-fixes"]
@@ -1975,7 +1987,10 @@ For more information, see xref:../networking/metallb/metallb-upgrading-operator.
 * The OpenShift CLI (`oc`) for {product-title} 4.11 does not work properly on macOS due to a change in error handling of untrusted certificates in Go 1.18 libraries. Due to this change, `oc login` and other `oc` commands can fail with a `certificate is not trusted` error without proceeding further when running on macOS. Until the error handling is properly fixed in Go 1.18 (tracked by link:https://github.com/golang/go/issues/52010[Go issue #52010]), the workaround is to use the {product-title} 4.10 `oc` CLI instead. Note that when using the {product-title} 4.10 `oc` CLI with an {product-title} 4.11 cluster, it is no longer possible to get a token by using the `oc serviceaccounts get-token <service_account>` command. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097830[*BZ#2097830*]) (link:https://bugzilla.redhat.com/show_bug.cgi?id=2109799[*BZ#2109799*])
 
 * There is currently a known issue in the *Add Helm Chart Repositories* form to extend the Developer Catalog of a project. The *Quick Start* guides shows that you can add the `ProjectHelmChartRepository` CR in the desired namespace whereas it does not mention that to perform this you need permission from the kubeadmin. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054197[BZ#2054197])
+
 * There is currently a known issue. If you create an instance of `ProjectHelmChartRepository` custom resource (CR) that uses TLS verification, you cannot list the repositories and perform Helm-related operations. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/HELM-343[*HELM-343*])
+
+* If the pruner fails, the Image Registry Operator is degraded until the pruner successfully runs. By default, the pruner runs once a day. As a workaround, you can give it more opportunities to run successfully by configuring it to run more often. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1990125[*BZ#1990125*])
 
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Adds a batch of bugs to the RNs (I think this might be batch 6 but who's counting 😅 

Link to docs preview:
http://file.rdu.redhat.com/opayne/RN-batch-6/release_notes/ocp-4-11-release-notes.html#ocp-4-11-bug-fixes



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
