### PR TITLE
CNV-16554: Moving TP note in enterprise-4.11 to match MAIN

### DIFF
--- a/virt/backup_restore/virt-backup-restore-overview.adoc
+++ b/virt/backup_restore/virt-backup-restore-overview.adoc
@@ -6,10 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You back up and restore virtual machines by using the xref:../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[OpenShift API for Data Protection (OADP)].
-
 :FeatureName: OADP for {VirtProductName}
 include::snippets/technology-preview.adoc[]
+
+You back up and restore virtual machines by using the xref:../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[OpenShift API for Data Protection (OADP)].
 
 .Prerequisites
 


### PR DESCRIPTION
For 4.11 ONLY.

Jira: https://issues.redhat.com/browse/CNV-16554
Doc preview: http://file.rdu.redhat.com/bgaydos/CNV-16554_r/virt/backup_restore/virt-backup-restore-overview.html

Per @bergerhoffer - Moving the Tech Preview note in 4.11 to match the location of the note in the MAIN.

cc: @apinnick for awareness. Avital, Andrea spotted the note was in a different place in 4.11 than in MAIN, so we're correcting this. Andrea will handle the merge and pick.

Thanks,
Bob
