### PR TITLE
TELCODOCS-659: NHC is GA in 4.11 so the TP snippet was removed

### DIFF
--- a/nodes/nodes/eco-node-health-check-operator.adoc
+++ b/nodes/nodes/eco-node-health-check-operator.adoc
@@ -13,10 +13,6 @@ Use the Node Health Check Operator to identify unhealthy nodes. The Operator use
 
 xref:../../nodes/nodes/eco-self-node-remediation-operator.adoc#self-node-remediation-operator-remediate-nodes[Remediating nodes with the Self Node Remediation Operator]
 
-:FeatureName: Node Health Check Operator
-
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 include::modules/eco-node-health-check-operator-about.adoc[leveloffset=+1]
 
 include::modules/eco-node-health-check-operator-installation-web-console.adoc[leveloffset=+1]


### PR DESCRIPTION
[https://issues.redhat.com/browse/TELCODOCS-659](https://issues.redhat.com/browse/TELCODOCS-659) Change support status of NHC for the 4.11 docs

Applies to OpenShift version : 4.11 +

Preview: [Deploying node health checks by using the Node Health Check Operator](http://file.emea.redhat.com/pogrady/TELCODOCS-659/nodes/nodes/eco-node-health-check-operator.html)

@slintes @anna-savina @prabinovRedhat can you please review/approve.

Thank you.