### PR TITLE
OSDOCS-3196 - Updating SCC content for OSD and ROSA

### DIFF
--- a/authentication/managing-security-context-constraints.adoc
+++ b/authentication/managing-security-context-constraints.adoc
@@ -6,15 +6,50 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+In {product-title}, you can use security context constraints (SCCs) to control permissions for the pods in your cluster.
+
+Default SCCs are created during installation and when you install some Operators or other components. As a cluster administrator, you can also create your own SCCs by using the OpenShift CLI (`oc`).
+
+[IMPORTANT]
+====
+Do not modify the default SCCs. Customizing the default SCCs can lead to issues when some of the platform pods deploy or 
+ifndef::openshift-rosa[]
+{product-title} 
+endif::[]
+ifdef::openshift-rosa[]
+ROSA 
+endif::openshift-rosa[]
+is upgraded. Additionally, the default SCC values are reset to the defaults during some cluster upgrades, which discards all customizations to those SCCs.
+ifdef::openshift-origin,openshift-enterprise,openshift-webscale,openshift-dedicated,openshift-rosa[]
+
+Instead of modifying the default SCCs, create and modify your own SCCs as needed. For detailed steps, see xref:../authentication/managing-security-context-constraints.adoc#security-context-constraints-creating_configuring-internal-oauth[Creating security context constraints].
+endif::[]
+====
+
+ifdef::openshift-dedicated[]
+[NOTE]
+====
+In {product-title} deployments, you can create your own SCCs only for clusters that use the Customer Cloud Subscription (CCS) model. You cannot create SCCs for {product-title} clusters that use a Red Hat cloud account, because SCC resource creation requires `cluster-admin` privileges.
+====
+endif::openshift-dedicated[]
+
 include::modules/security-context-constraints-about.adoc[leveloffset=+1]
 include::modules/security-context-constraints-pre-allocated-values.adoc[leveloffset=+1]
 include::modules/security-context-constraints-example.adoc[leveloffset=+1]
-
-// This section shouldn't show on OSD
-ifndef::openshift-dedicated[]
 include::modules/security-context-constraints-creating.adoc[leveloffset=+1]
-endif::[]
-// End Exclusion
-
 include::modules/security-context-constraints-rbac.adoc[leveloffset=+1]
 include::modules/security-context-constraints-command-reference.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_configuring-internal-oauth"]
+== Additional resources
+
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../support/getting-support.adoc#getting-support[Getting support]
+endif::[]
+ifdef::openshift-dedicated[]
+* xref:../osd_architecture/osd-support.adoc#osd-getting-support[Getting support]
+endif::[]
+ifdef::openshift-rosa[]
+* xref:../rosa_architecture/rosa-getting-support.adoc#rosa-getting-support[Getting support]
+endif::[]

--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -6,12 +6,12 @@
 [id="security-context-constraints-about_{context}"]
 = About security context constraints
 
-Similar to the way that RBAC resources control user access, administrators can use _security context constraints_ (SCCs) to control permissions for pods. These permissions include actions that a pod can perform and what resources it can access. You can use SCCs to define a set of conditions that a pod must run with to be accepted into the system.
+Similar to the way that RBAC resources control user access, administrators can use security context constraints (SCCs) to control permissions for pods. These permissions determine the actions that a pod can perform and what resources it can access. You can use SCCs to define a set of conditions that a pod must run with to be accepted into the system.
 
 Security context constraints allow an administrator to control:
 
-* Whether a pod can run privileged containers with the `allowPrivilegedContainer` flag.
-* Whether a pod is constrained with the `allowPrivilegeEscalation` flag.
+* Whether a pod can run privileged containers with the `allowPrivilegedContainer` flag
+* Whether a pod is constrained with the `allowPrivilegeEscalation` flag
 * The capabilities that a container can request
 * The use of host directories as volumes
 * The SELinux context of the container
@@ -35,10 +35,17 @@ The cluster contains several default security context constraints (SCCs) as desc
 
 [IMPORTANT]
 ====
-Do not modify the default SCCs. Customizing the default SCCs can lead to issues when some of the platform pods deploy or {product-title} is upgraded. During upgrades between some versions of {product-title}, the values of the default SCCs are reset to the default values, which discards all customizations to those SCCs.
+Do not modify the default SCCs. Customizing the default SCCs can lead to issues when some of the platform pods deploy or 
+ifndef::openshift-rosa[]
+{product-title} 
+endif::[]
+ifdef::openshift-rosa[]
+ROSA 
+endif::openshift-rosa[]
+is upgraded. Additionally, the default SCC values are reset to the defaults during some cluster upgrades, which discards all customizations to those SCCs.
+ifdef::openshift-origin,openshift-enterprise,openshift-webscale,openshift-dedicated,openshift-rosa[]
 
-ifdef::openshift-origin,openshift-enterprise,openshift-webscale[]
-Instead, create new SCCs as needed.
+Instead of modifying the default SCCs, create and modify your own SCCs as needed. For detailed steps, see _Creating security context constraints_.
 endif::[]
 ====
 
@@ -243,12 +250,22 @@ pre-allocated values. Uses the minimum value of the first range as the default.
 Validates against the first ID in the first range.
 * `RunAsAny` - No default provided. Allows any `fsGroup` ID to be specified.
 
-ifndef::openshift-dedicated[]
 [id="authorization-controlling-volumes_{context}"]
+ifndef::openshift-dedicated[]
 == Controlling volumes
+endif::openshift-dedicated[]
+ifdef::openshift-dedicated[]
+== Controlling volumes for CCS clusters
+endif::openshift-dedicated[]
 
-The usage of specific volume types can be controlled by setting the `volumes`
-field of the SCC. The allowable values of this field correspond to the volume
+The usage of specific volume types 
+ifdef::openshift-dedicated[]
+for {product-title} with Customer Cloud Subscription (CCS) clusters 
+endif::openshift-dedicated[]
+can be controlled by setting the `volumes`
+field of the SCC.
+
+The allowable values of this field correspond to the volume
 sources that are defined when creating a volume:
 
 * link:https://kubernetes.io/docs/concepts/storage/volumes/#awselasticblockstore[`awsElasticBlockStore`]
@@ -297,8 +314,6 @@ settings in the `volumes` field. For example, if `allowHostDirVolumePlugin`
 is set to false but allowed in the `volumes` field, then the `hostPath`
 value will be removed from `volumes`.
 ====
-endif::[]
-
 
 [id="admission_{context}"]
 == Admission control

--- a/modules/security-context-constraints-creating.adoc
+++ b/modules/security-context-constraints-creating.adoc
@@ -4,9 +4,26 @@
 
 :_content-type: PROCEDURE
 [id="security-context-constraints-creating_{context}"]
+ifndef::openshift-dedicated[]
 = Creating security context constraints
+endif::[]
+ifdef::openshift-dedicated[]
+= Creating security context constraints for CCS clusters
+endif::[]
 
 You can create security context constraints (SCCs) by using the OpenShift CLI (`oc`).
+
+[IMPORTANT]
+====
+Creating and modifying your own SCCs are advanced operations that might cause instability to your cluster. If you have questions about using your own SCCs, contact Red Hat Support. For information about contacting Red Hat support, see _Getting support_.
+====
+
+ifdef::openshift-dedicated[]
+[NOTE]
+====
+In {product-title} deployments, you can create your own SCCs only for clusters that use the Customer Cloud Subscription (CCS) model. You cannot create SCCs for {product-title} clusters that use a Red Hat cloud account, because SCC resource creation requires `cluster-admin` privileges.
+====
+endif::openshift-dedicated[]
 
 .Prerequisites
 
@@ -15,9 +32,8 @@ You can create security context constraints (SCCs) by using the OpenShift CLI (`
 
 .Procedure
 
-. Define the SCC in a YAML file named `scc_admin.yaml`:
+. Define the SCC in a YAML file named `scc-admin.yaml`:
 +
-.`SecurityContextConstraints` object definition
 [source,yaml]
 ----
 kind: SecurityContextConstraints
@@ -39,11 +55,7 @@ groups:
 - my-admin-group
 ----
 +
-Optionally, you can drop specific capabilities for an SCC by setting the
-`requiredDropCapabilities` field with the desired values. Any specified
-capabilities are dropped from the container. To drop all capabilities, specify `ALL`. For example, to create an SCC
-that drops the `KILL`, `MKNOD`, and `SYS_CHROOT` capabilities, add
-the following to the SCC object:
+Optionally, you can drop specific capabilities for an SCC by setting the `requiredDropCapabilities` field with the desired values. Any specified capabilities are dropped from the container. To drop all capabilities, specify `ALL`. For example, to create an SCC that drops the `KILL`, `MKNOD`, and `SYS_CHROOT` capabilities, add the following to the SCC object:
 +
 [source,yaml]
 ----
@@ -65,7 +77,7 @@ CRI-O supports the same list of capability values that are found in the link:htt
 +
 [source,terminal]
 ----
-$ oc create -f scc_admin.yaml
+$ oc create -f scc-admin.yaml
 ----
 +
 .Example output

--- a/modules/security-context-constraints-example.adoc
+++ b/modules/security-context-constraints-example.adoc
@@ -54,7 +54,7 @@ users: <9>
 - system:serviceaccount:default:registry
 - system:serviceaccount:default:router
 - system:serviceaccount:openshift-infra:build-controller
-volumes:
+volumes: <10>
 - '*'
 ----
 
@@ -68,13 +68,14 @@ security context.
 <5> A list of capabilities to drop from a pod. Or, specify `ALL` to drop all
 capabilities.
 <6> The `runAsUser` strategy type, which dictates the allowable values for the
-Security Context.
+security context.
 //could use the available strategies
 <7> The `seLinuxContext` strategy type, which dictates the allowable values for
-the Security Context.
+the security context.
 <8> The `supplementalGroups` strategy, which dictates the allowable supplemental
-groups for the Security Context.
+groups for the security context.
 <9> The users who can access this SCC.
+<10> The allowable volume types for the security context. In the example, `*` allows the use of all volume types.
 
 The `users` and `groups` fields on the SCC control which users can access the
 SCC.


### PR DESCRIPTION
**This PR is a work in progress. Do not merge.**

This applies to `main`, `enterprise-4.11` and `enterprise-4.10`.

This PR relates to https://issues.redhat.com/browse/OSDOCS-3196. The PR updates the "Managing security context constraints" page in the OSD and ROSA libraries. The PR also includes some minor updates to the OCP SCC content, because the three distributions use the same assembly and module files for this page.

The previews are as follows:

* OCP: http://file.fab.redhat.com/pneedle/pr48451/ocp/managing-security-context-constraints.html
* OSD: http://file.fab.redhat.com/pneedle/pr48451/osd/managing-security-context-constraints.html
* ROSA: http://file.fab.redhat.com/pneedle/pr48451/rosa/managing-security-context-constraints.html