### PR TITLE
RHDEVDOCS-2587 Bug 1810904 - [DOC]Should document how to configure pu…

### DIFF
--- a/modules/builds-image-source.adoc
+++ b/modules/builds-image-source.adoc
@@ -2,6 +2,8 @@
 //
 // * builds/creating-build-inputs.adoc
 
+:_content-type: CONCEPT
+
 [id="builds-image-source_{context}"]
 = Image source
 
@@ -46,7 +48,9 @@ source:
 If your cluster uses an `ImageContentSourcePolicy` object to configure repository mirroring, you can use only global pull secrets for mirrored registries. You cannot add a pull secret to a project.
 ====
 
-Optionally, if an input image requires a pull secret, you can link the pull secret to the service account used by the build. By default, builds use the `builder` service account. The pull secret is automatically added to the build if the secret contains a credential that matches the repository hosting the input image. To link a pull secret to the service account used by the build, run:
+.Images that require pull secrets
+
+When using an input image that requires a pull secret, you can link the pull secret to the service account used by the build. By default, builds use the `builder` service account. The pull secret is automatically added to the build if the secret contains a credential that matches the repository hosting the input image. To link a pull secret to the service account used by the build, run:
 
 [source,terminal]
 ----
@@ -60,12 +64,9 @@ This feature is not supported for builds using the custom strategy.
 ====
 endif::[]
 
-/////
-[role="_additional-resources"]
-.Additional resources
+.Images on mirrored registries that require pull secrets
 
-* Custom Strategy
-ifndef::openshift-online[]
-* ImageStreamTags
-endif::[]
-/////
+When using an input image from a mirrored registry, if you get a `build error: failed to pull image` message, you can resolve the error by using either of the following methods:
+
+* Create an input secret that contains the authentication credentials for the builder image’s repository and all known mirrors. In this case, create a pull secret for credentials to the image registry and its mirrors.
+* Use the input secret as the pull secret on the `BuildConfig` object.


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-2587
- Direct link to doc preview: Scroll down to the **Images on mirrored registries that require pull secrets** heading near the bottom of the the [Image source](https://rolfedh.github.io/previews/RHDEVDOCS-2587/cicd/builds/creating-build-inputs.html#builds-image-source_creating-build-inputs) section.
- SME review: @coreydaley  (completed)
- QE review: @jitendar-singh  (completed)
- Peer review: @Srivaralakshmi (completed)
- All reviews complete. Please merge now.