### PR TITLE
OSDOCS-3849 updated maxUnavailable field

### DIFF
--- a/modules/modify-unavailable-workers.adoc
+++ b/modules/modify-unavailable-workers.adoc
@@ -18,7 +18,7 @@ By default, only one machine is allowed to be unavailable when applying the kube
 $ oc edit machineconfigpool worker
 ----
 
-. Set `maxUnavailable` to the value that you want:
+. Add the `maxUnavailable` field and set the value:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-3849

Link to docs preview:
[Modifying the number of unavailable worker nodes](http://file.rdu.redhat.com/antaylor/osdocs-3849/scalability_and_performance/recommended-host-practices.html#modify-unavailable-workers_recommended-host-practices)