### PR TITLE
CNV-20074: placing redirects to prevent CNV from releasing with OCP

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -289,7 +289,7 @@ AddType text/vtt                            vtt
     # OpenShift Virtualization (CNV) catchall redirect; use when CNV releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `virt` directory traffic to the about-virt page.
     # To activate the redirects, uncomment the next line and update the version number to the pending release.
-    # RewriteRule container-platform/4\.10/virt/(?!about-virt\.html)(.+)$ /container-platform/4.10/virt/about-virt.html [NE,R=302]
+    RewriteRule container-platform/4\.11/virt/(?!about-virt\.html)(.+)$ /container-platform/4.11/virt/about-virt.html [NE,R=302]
 
     # Serverless Redirects
     RewriteRule container-platform/(4\.5|4\.6)/serverless/knative_eventing/(serverless-subscriptions\.html|serverless-channels\.html|serverless-subscriptions\.html) /container-platform/$1/serverless/event_workflows/serverless-channels.html [NE,R=301]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): No CP
<!--- Specify the version or versions of OpenShift your PR applies to.

Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: https://issues.redhat.com/browse/CNV-20074
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: N/A
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:


- CNV GA is scheduled for August 9
- Added rule to redirect all `/virt/*` content to the `about-virt.adoc` assembly to support asynchronous release from OCP
- To be reversed when CNV 4.11 GAs (after merging placeholder reversal)
- Reference: https://github.com/openshift/openshift-docs/pull/42597
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
