### PR TITLE
Adds another batch of bug doc text to RNs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1455,6 +1455,18 @@ In this update, `systemd` service only sets the default RPS mask for virtual int
 
 * Previously, in an error message that occurred when users ran `opm index prune` against a file-based catalog image, imprecise language made it unclear that this command does not support that catalog format. This update clarifies the error message so users understand that the command `opm index prune` only supports SQLite-based images. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039135[*BZ#2039135*])
 
+* Previously, there was a broken thread safety around the Operator API. Consequently, Operator resources were not properly deleted. With this update, Operator resources are correctly deleted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2015023[*BZ#2015023*])
+
+* Previously, pod failures were artificially extending the validity period of certificates causing them to incorrectly rotate. With this update, the certificate validity period is correctly deterined and the certificates are correctly rotated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2020484[*BZ#2020484*])
+
+[discrete]
+[id="ocp-4-11-openshift-operator-sdk-bug-fixes"]
+==== Operator SDK
+
+* Before this update, the Operator SDK used upstream images rather than downstream supported images to scaffold Hybrid Helm-based Operators. With this update, the Operator SDK uses supported downstream images to scaffold Hybrid Helm-based Operators. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039135[*BZ#2039135*])
+
+* With {product-title} 4.11, Operator SDK allows for `arm64` Operator images to be built. As a result, Operator SDK now supports building Operator images that target `arm64`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2035899#[*BZ#2035899*])
+
 [discrete]
 [id="ocp-4-11-openshift-api-server-bug-fixes"]
 ==== OpenShift API server
@@ -1488,6 +1500,18 @@ In this update, `systemd` service only sets the default RPS mask for virtual int
 [discrete]
 [id="ocp-4-11-routing-bug-fixes"]
 ==== Routing
+
+* Previously, the Ingress Operator did not validate whether a Kubernetes service object in the OpenShift Ingress namespace was created or owned by the Ingress Controller it was trying to reconcile with. Therefore, the Ingress Operator would modify or remove Kubernetes services that had the same name and namespace, regardless of ownership, causing unexpected behavior. With this update, the Ingress Operator can now check the ownership of existing Kubernetes services before attempting to modify or remove services. If ownership does not match, the Ingress Operator shows an error and does not take any action. As a result, the Ingress Operator cannot cannot modify or delete a custom Kubernetes service with the same name as the OpenShift Ingress namespace that it wants to modify or remove. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054200[*BZ#2054200*])
+
+* Previously, {product-title} 4.8 added an API for customizing platform routes. This API includes status and spec fields in the cluster ingress configuration for reporting the current host names of customizable routes and the user's desired host names for these routes, respectively. The API also defined constraints for these values. These constraints were restrictive and excluded some valid potential host names. Consequently, the restrictive validation for the API prevented users from specifying custom host names that should have been permitted and prevented users from being able to install clusters with domains that should have been permitted. With this update, the constraints on host names were relaxed to allow all host names that are valid for routes and {product-title} allows users to use cluster domains with TLDs that contain decimal digits. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039256[*BZ#2039256*])
+
+* Previously, the Ingress Operator did not check whether Ingress Controllers configured with cluster `spec.domain` parameter matched the `spec.baseDomain` parameter. This caused the Operator to create DNS records and set `DNSManaged` conditions to `false`. With this fix, the Ingress Operator now checks whether the `spec.domain` parameter matches with the cluster `spec.baseDomain`. As a result, for custom Ingress Controllers, the Ingress Operator does not create DNS records and sets `DNSManaged` conditions to false . (link:https://bugzilla.redhat.com/show_bug.cgi?id=2041616#[*BZ#2041616*])
+
+* Previously, in OpenShift Container Platform 4.10, the HAProxy must-gather function could take up to an hour to run. This can happen when routers in the terminating state delay the `oc cp` comand. The delay lasts until the pod is terminated. With the new release, a 10 minute limit on the `oc op` command prevents longer delays.   (link:https://bugzilla.redhat.com/show_bug.cgi?id=2104701[*BZ#2104701*])
+
+* Previously, the Ingress Operator did not clear the route status when Ingress Controllers were deleted, showing that the route was still in the operator after its deletion. This fix clears the route status when an Ingress Controller is deleted, resulting in the route being cleared in the operator after its deletion. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1944851#[*BZ#1944851*])
+
+* Previously, the output for the `oc explain router.status.ingress.conditions` command explain route status showed `Currently only Ready` rather than `Admitted` due to incorrect wording in the Application Programming Interface (API). This fix corrects the wording in the API. As a result, the command output is correct. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2041133#[*BZ#2041133*])
 
 [discrete]
 [id="ocp-4-11-samples-bug-fixes"]
@@ -2078,6 +2102,12 @@ Identify the disk that holds the live image, in this example `nvme0n1p3`, and ru
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2107674[BZ#2107674])
 
 * In a disconnected environment, SRO does not try to fetch DTK from the main registry. It fetches from the mirror registry instead. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102724[*BZ#2102724*])
+
+* The process counter displays incorrect information for the `phc2sys` process on the interface where `phc2sys` is not running. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGSM-46005[*OCPBUGSM-46005*])
+
+* When a network interface controller (NIC) in a node with a dual NIC PTP configuration is shut down, a faulty event is generated for both PTP interfaces. There is curently no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGSM-46004[*OCPBUGSM-46004*])
+
+* In low-band systems, the system clock does not synchronize with the PTP ordinary clock after the grandmaster clock is disconnected for a few hours and recovered. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGSM-45173[*OCPBUGSM-45173*])
 
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Adds another batch of bug doc text

Link to docs preview:
http://file.rdu.redhat.com/opayne/RN-batch-7/release_notes/ocp-4-11-release-notes.html#ocp-4-11-bug-fixes
http://file.rdu.redhat.com/opayne/RN-batch-7/release_notes/ocp-4-11-release-notes.html#ocp-4-11-known-issues




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
