### PR TITLE
OSDOCS-3870: Ported the Ingress content to OSD/ROSA

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -186,6 +186,8 @@ Name: Networking
 Dir: networking
 Distros: openshift-dedicated
 Topics:
+- Name: Understanding the Ingress Operator
+  File: ingress-operator
 - Name: OpenShift SDN default CNI network provider
   Dir: openshift_sdn
   Topics:

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -290,6 +290,8 @@ Name: Networking
 Dir: networking
 Distros: openshift-rosa
 Topics:
+- Name: Understanding the Ingress Operator
+  File: ingress-operator
 - Name: OpenShift SDN default CNI network provider
   Dir: openshift_sdn
   Topics:

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -1,12 +1,18 @@
 :_content-type: ASSEMBLY
 [id="configuring-ingress"]
 = Ingress Operator in {product-title}
+ifdef::openshift-enterprise[]
 include::_attributes/common-attributes.adoc[]
+endif::[]
+ifdef::openshift-rosa,openshift-dedicated[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+endif::[]
 :context: configuring-ingress
 
 toc::[]
 include::modules/nw-ne-openshift-ingress.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/nw-installation-ingress-config-asset.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-controller-configuration-parameters.adoc[leveloffset=+1]
@@ -23,6 +29,7 @@ include::modules/tls-profiles-understanding.adoc[leveloffset=+3]
 include::modules/tls-profiles-ingress-configuring.adoc[leveloffset=+3]
 
 include::modules/nw-mutual-tls-auth.adoc[leveloffset=+3]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/nw-ingress-view.adoc[leveloffset=+1]
 
@@ -32,6 +39,7 @@ include::modules/nw-ingress-operator-logs.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-controller-status.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [id="configuring-ingress-controller"]
 == Configuring the Ingress Controller
 
@@ -84,3 +92,4 @@ include::modules/nw-ingress-setting-max-connections.adoc[leveloffset=+2]
 == Additional resources
 
 * xref:../networking/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI]
+endif::openshift-rosa,openshift-dedicated[]


### PR DESCRIPTION
Version(s):
Enterprise 4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-3870

Link to docs preview:

- OCP is unchanged
    - [Ingress Operator in OpenShift Container Platform](http://file.rdu.redhat.com/eponvell/OSDOCS-3870_IngressPort/enterprise/networking/ingress-operator.html)
    - [Configuring the Ingress Controller endpoint publishing strategy](http://file.rdu.redhat.com/eponvell/OSDOCS-3870_IngressPort/enterprise/networking/nw-ingress-controller-endpoint-publishing-strategies.html)
    - Configuring ingress cluster traffic:
        - [Overview](http://file.rdu.redhat.com/eponvell/OSDOCS-3870_IngressPort/enterprise/networking/configuring_ingress_cluster_traffic/overview-traffic.html)
        - [Configuring ExternalIPs for services](http://file.rdu.redhat.com/eponvell/OSDOCS-3870_IngressPort/enterprise/networking/configuring_ingress_cluster_traffic/configuring-externalip.html)
        - [Configuring ingress cluster traffic using an Ingress Controller](http://file.rdu.redhat.com/eponvell/OSDOCS-3870_IngressPort/enterprise/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html)
        - [Configuring ingress cluster traffic using a load balancer](http://file.rdu.redhat.com/eponvell/OSDOCS-3870_IngressPort/enterprise/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.html)
        - [Configuring ingress cluster traffic on AWS](http://file.rdu.redhat.com/eponvell/OSDOCS-3870_IngressPort/enterprise/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-aws.html)
        - [Configuring ingress cluster traffic using a service external IP](http://file.rdu.redhat.com/eponvell/OSDOCS-3870_IngressPort/enterprise/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-service-external-ip.html)
        - [Configuring ingress cluster traffic using a NodePort](http://file.rdu.redhat.com/eponvell/OSDOCS-3870_IngressPort/enterprise/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.html)
- ROSA:
    - [Ingress Operator in Red Hat OpenShift Service on AWS](http://file.rdu.redhat.com/eponvell/OSDOCS-3870_IngressPort/rosa/networking/ingress-operator.html)
    - ~~Configuring the Ingress Controller endpoint publishing~~
    - ~~Configuring ingress cluster traffic~~:
        - ~~Overview~~
        - ~~Configuring ExternalIPs for services~~
        - ~~Configuring ingress cluster traffic using an Ingress Controller~~
        - ~~Configuring ingress cluster traffic using a load balancer~~
        - ~~Configuring ingress cluster traffic on AWS~~
        - ~~Configuring ingress cluster traffic using a service external IP~~
        - ~~Configuring ingress cluster traffic using a NodePort~~
- OSD:
    - [Ingress Operator in OpenShift Dedicated](http://file.rdu.redhat.com/eponvell/OSDOCS-3870_IngressPort/dedicated/networking/ingress-operator.html)
    - ~~Configuring the Ingress Controller endpoint publishing strategy~~
    - ~~Configuring ingress cluster traffic~~:
        - ~~Overview~~
        - ~~Configuring ExternalIPs for services~~
        - ~~Configuring ingress cluster traffic using an Ingress Controller~~
        - ~~Configuring ingress cluster traffic using a load balancer~~
        - ~~Configuring ingress cluster traffic on AWS~~
        - ~~Configuring ingress cluster traffic using a service external IP~~
        - ~~Configuring ingress cluster traffic using a NodePort~~
    

Additional information:
Ported the Ingress information from OCP to OSD/ROSA. This information hasn't been curated.