### PR TITLE
Adds another batch of bug doc text to RNs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -170,7 +170,7 @@ For more information, see xref:../installing/installing_azure/enabling-user-mana
 
 [id="ocp-4-11-azure-network-accel"]
 ==== Accelerated Networking for Azure enabled by default
-{product-title} 4.11 on Azure provides accelerated networking for control plane and compute nodes. Accelerated networking is enabled by default for supported instance types in an installer-provisioned infrastructure installation. 
+{product-title} 4.11 on Azure provides accelerated networking for control plane and compute nodes. Accelerated networking is enabled by default for supported instance types in an installer-provisioned infrastructure installation.
 
 For more information, see link:https://access.redhat.com/solutions/6007341[Openshift 4 on Azure - accelerated networking].
 
@@ -954,7 +954,7 @@ In {product-title} {product-version}, the Insights Operator collects the followi
 
 * The `images.config.openshift.io` resource definition
 * `kube-controller-manager` container logs when the `"Internal error occurred: error resolving resource"` or `"syncing garbage collector with updated resources from discovery"` error messages are present
-* `storageclusters.ocs.openshift.io/v1` resources 
+* `storageclusters.ocs.openshift.io/v1` resources
 
 With this additional information, Red Hat improves {product-title} functionality and enhances Insights Advisor recommendations.
 
@@ -1359,6 +1359,8 @@ sourceStrategy:
 [id="ocp-4-11-cluster-version-operator-bug-fixes"]
 ==== Cluster Version Operator
 
+* Previously, the Cluster Version Operator (CVO) when it encountered an error during an upgrade would stop reconciling current release manifests. With this update, release loading is separated from reconciling so the latter does not block the former and a new condition `ReleaseAccepted` has been added to clarify the status of the release load. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822752#[*BZ#1822752*])
+
 [discrete]
 [id="ocp-4-11-console-storage-bug-fixes"]
 ==== Console Storage Plug-in
@@ -1367,11 +1369,21 @@ sourceStrategy:
 [id="ocp-4-11-dns-bug-fixes"]
 ==== Domain Name System (DNS)
 
+* Topology aware hints is a new feature in {product-title} {product-version} that allows the `EndpointSlice` controller to specify hints to the container network interface (CNI) for how it should route traffic to a service's endpoints. The DNS operator was not enabling topology aware hints for the cluster DNS service. Consequently, the CNI network providers did not keep DNS traffic local to the zone or node. With this fix, the DNS operator was updated to specify topology aware hints on the cluster DNS service. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2095941[*BZ#2095941*])
+
+* Previously, the kubelet created a default `/etc/resolv.conf` for pods based on the `/etc/resolv.conf` from the node host. Consequently, the malformed `resolv.conf` file could cause resolvers to fail to parse `resolv.conf`, therefore breaking DNS resolution in pods. With this update, the kubelet accepts a `resolv.conf` file and pods get a valid `resolv.conf` file. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2063414[*BZ#2063414*])
+
+* Previously, the DNS Operator did not set the `cluster-autoscaler.kubernetes.io/enable-ds-eviction` annotation on DNS pods. Consequently, the the cluster autoscaler did not remove the DNS pod from a node before removing the node. With this update, the DNS operator was changed to add the `cluster-autoscaler.kubernetes.io/enable-ds-eviction` annotation to DNS pods. The DNS pod can now be removed from a node before removing the node by the cluster autoscaler. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2061244[*BZ#2061244*])
+
 [discrete]
 [id="ocp-4-11-image-registry-bug-fixes"]
 ==== Image Registry
 
 * Previously, the image registry used an `ImageContentSourcePolicy` (ICSP) as a source only when it was an exact match. The same source file was expected to be pulled through for any subrepositories. The ICSP name and path did not match for subrepositories. As a result, the image was not used. Now, the ICSP is applied successfully to the subrepositories, which can use the mirrored images. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2014240[*BZ#2014240*])
+
+* Previously, if the pruner failed, the image registry Operator is reported as degraded until the pruner successfully runs. With this update, the Operator is more resilient to the pruner failures. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1990125[*BZ#1990125*])
+
+* Previously, the registry used exact match when applying `ImageContentSourcePo`(ICSP). With this update, ICSP is applied for subrepositories and mirrors now work as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2014240[*BZ#2014240*])
 
 [discrete]
 [id="ocp-4-11-image-streams-bug-fixes"]
@@ -1576,7 +1588,7 @@ In this update, `systemd` service only sets the default RPS mask for virtual int
 
 * Before this update, the package server was not aware of pod topology when defining its leader election duration, renewal deadline, and retry periods. As a result, the package server strained topologies with limited resources, such as single-node environments. This update introduces a `leaderElection` package that sets reasonable lease duration, renewal deadlines, and retry periods. This fix reduces strain on clusters with limited resources. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2048563[*BZ#2048563*])
 
-* Previously, there was a bad catalog source in the `openshift-marketplace` namespace. Because of this, all subscriptions were blocked. With this update, if there is a bad catalog source in the `openshift-marketplace` namespace, users can subscribe to an operator from a quality catalog source of their own namespace with the original annotation. As a result, if there is a bad catalog source in the local namespace, the user cannot subscribe to any operator in the namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2076323[*BZ2076323])
+* Previously, there was a bad catalog source in the `openshift-marketplace` namespace. Because of this, all subscriptions were blocked. With this update, if there is a bad catalog source in the `openshift-marketplace` namespace, users can subscribe to an operator from a quality catalog source of their own namespace with the original annotation. As a result, if there is a bad catalog source in the local namespace, the user cannot subscribe to any operator in the namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2076323[*BZ2076323*])
 
 * Previously, info-level logs were generated during `operator-marketplace` project polling, which caused log spam. This update uses the command line flag to reduce the log line to the debug level, and adds more control of the log levels for the user. As a result, this reduces log spam. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057558[*BZ#2057558*])
 
@@ -1657,6 +1669,12 @@ In this update, `systemd` service only sets the default RPS mask for virtual int
 [discrete]
 [id="ocp-4-11-storage-bug-fixes"]
 ==== Storage
+
+* Previously, the Alibaba Container Storage Interface (CS) driver that shipped with {product-title} returned errors when a user created a persistent volume claim (PVC) smaller than 20 GiB. This was due to Alibaba Cloud only supporting volumes larger than 20 GiB. With this update, Alibaba CSI driver automatically increases all volume sizes to at least 20 GiB and smaller PVCs are now dynamically provisioned. This can result in increased costs. Administrators can use quota on PVC count for each namespace in restricted environments to limit costs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057495[*BZ#2057495*])
+
+* In earlier versions, the Local Storage Operator (LSO) added an owner reference to the persistent volumes (PVs) it created, such that deletion of the node would also issue a delete request for the PV. This could result in the PV remaining in the `Terminating` state while still attached to a pod. LSO no longer creates that OwnerReference, which means cluster administrators must delete any unused PVs after a node is removed from the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2061447#[*BZ#2061447*]) For more information, see xref:../storage/persistent_storage/persistent-storage-local.adoc#persistent-storage-local[Persistent storage using local volumes].
+
+* This fix ensures that read-only-many volumes are provisioned appropriately by GCP CSI Driver as read-only. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1968253#[*BZ#1968253*])
 
 [discrete]
 [ids="ocp-4-11-telco-edge-bug-fixes"]
@@ -2239,6 +2257,8 @@ Identify the disk that holds the live image, in this example `nvme0n1p3`, and ru
 * When a network interface controller (NIC) in a node with a dual NIC PTP configuration is shut down, a faulty event is generated for both PTP interfaces. There is curently no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGSM-46004[*OCPBUGSM-46004*])
 
 * In low-band systems, the system clock does not synchronize with the PTP ordinary clock after the grandmaster clock is disconnected for a few hours and recovered. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGSM-45173[*OCPBUGSM-45173*])
+
+* Previously, if you were using the OVN-Kubernetes cluster network provider, if a service with `type=LoadBalancer` was configured with `internalTrafficPolicy=cluster` set, then all traffic was routed to the default gateway, even if the host routing table included better routes to use. Now the best route is used rather than always using the default gateway. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2060159[BZ#2060159])
 
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Adds another batch of bug doc text.

Link to docs preview:
http://file.rdu.redhat.com/opayne/RN-batch-8/release_notes/ocp-4-11-release-notes.html#ocp-4-11-bug-fixes




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
