### PR TITLE
OSDOCS-3825 Azure Accelerated Networking enabled in OCP 4.11

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -168,6 +168,12 @@ For more information, see xref:../installing/disconnected_install/installing-mir
 
 For more information, see xref:../installing/installing_azure/enabling-user-managed-encryption-azure.adoc#enabling-user-managed-encryption-azure[Enabling user-managed encryption for Azure].
 
+[id="ocp-4-11-azure-network-accel"]
+==== Accelerated Networking for Azure enabled by default
+{product-title} 4.11 on Azure provides accelerated networking for control plane and compute nodes. Accelerated networking is enabled by default for supported instance types in an installer-provisioned infrastructure installation. 
+
+For more information, see link:https://access.redhat.com/solutions/6007341[Openshift 4 on Azure - accelerated networking].
+
 [id="ocp-4-11-aws-vpc-endpoints"]
 ==== AWS VPC endpoints and restricted installations
 You are no longer required to configure AWS VPC endpoints when installing a restricted {product-title} cluster on AWS. While configuring VPC endpoints remains an option, you can also choose to configure a proxy without VPC endpoints or configure a proxy with VPC endpoints.


### PR DESCRIPTION
[OSDOCS-3825](https://issues.redhat.com//browse/OSDOCS-3825) Azure Accelerated Networking enabled by default in 4.11

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3825

Link to docs preview:
http://file.rdu.redhat.com/jbrigman/azure-accelnet/release_notes/ocp-4-11-release-notes.html#ocp-4-11-azure-network-accel
