### PR TITLE
TELCODOCS-742: Metal Platform Release Checklist (OCP 4.11 GA)

### DIFF
--- a/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -8,11 +8,6 @@
 
 During installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState. To use the `networkConfig` configuration setting, you must provide an NMState YAML configuration.
 
-[IMPORTANT]
-====
-Before configuring host network interfaces, review the OpenShift Container Platform 4.10 release notes.
-====
-
 See link:https://nmstate.io/examples.html#interfaces-ethernet[NMState] for additional examples of the NMState syntax.
 
 .Example


### PR DESCRIPTION
Removed a reference to see 4.10 release notes in a 4.11 doc.

Fixes: [TELCODOCS-742](https://issues.redhat.com//browse/TELCODOCS-742)

See https://issues.redhat.com/browse/TELCODOCS-742 for additional details.

Preview URL: http://157.131.167.205/TELCODOCS-742/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow

For release(s): 4.11
Signed-off-by: John Wilkins <jowilkin@redhat.com>
