### PR TITLE
Removed release notes admonition about docs not being available. Ben Scott wrote them.

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -180,11 +180,6 @@ For more information, see xref:../installing/installing_aws/installing-restricte
 
 For more information, see the "Installation configuration parameters" section of the installation documentation for your platform.
 
-[NOTE]
-====
-The documentation for disabling the Bare Metal Operator is currently unavailable.
-====
-
 [id="ocp-4-11-azure-marketplace"]
 ==== Azure Marketplace offering
 {product-title} is now available on the Azure Marketplace. The Azure Marketplace offering is available to customers who procure {product-title} in North America and EMEA.


### PR DESCRIPTION
I was originally assigned to write docs about disabling the BMO operator. The ticket was deferred, but apparently picked up and completed in another JIRA ticket by Ben Scott. So my addition of the note in this PR https://github.com/openshift/openshift-docs/pull/48304 is getting removed. In fact, the documentation is available. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>

Version(s): 4.11

Link to docs preview: http://157.131.167.205/TELCODOCS-742.2-rn/release_notes/ocp-4-11-release-notes.html#ocp-4-11-capabilities