### PR TITLE
BZ2039509: Adds the instruction to read the pod logs

### DIFF
--- a/modules/nw-metallb-software-components.adoc
+++ b/modules/nw-metallb-software-components.adoc
@@ -5,31 +5,28 @@
 [id="nw-metallb-software-components_{context}"]
 = MetalLB software components
 
-When you install the MetalLB Operator, the `metallb-operator-controller-manager` deployment starts a pod.
-The pod is the implementation of the Operator.
-The pod monitors for changes to all the relevant resources.
+When you install the MetalLB Operator, the `metallb-operator-controller-manager` deployment starts a pod. The pod is the implementation of the Operator. The pod monitors for changes to all the relevant resources.
 
 When the Operator starts an instance of MetalLB, it starts a `controller` deployment and a `speaker` daemon set.
 
 `controller`::
-The Operator starts the deployment and a single pod.
-When you add a service of type `LoadBalancer`, Kubernetes uses the `controller` to allocate an IP address from an address pool.
+The Operator starts the deployment and a single pod. When you add a service of type `LoadBalancer`, Kubernetes uses the `controller` to allocate an IP address from an address pool.
+In case of a service failure, verify you have the following entry in your `controller` pod logs:
++
+.Example output
+[source,terminal]
+----
+"event":"ipAllocated","ip":"172.22.0.201","msg":"IP address assigned by controller
+----
 
 `speaker`::
-The Operator starts a daemon set for `speaker` pods.
-By default, a pod is started on each node in your cluster.
-You can limit the pods to specific nodes by specifying a node selector in the `MetalLB` custom resource when you start MetalLB.
+The Operator starts a daemon set for `speaker` pods. By default, a pod is started on each node in your cluster. You can limit the pods to specific nodes by specifying a node selector in the `MetalLB` custom resource when you start MetalLB. If the `controller` allocated the IP address to the service and service is still unavailable, read the `speaker` pod logs. If the `speaker` pod is unavailable, run the `oc describe pod -n` command.
 +
 For layer 2 mode, after the `controller` allocates an IP address for the service, the `speaker` pods use an algorithm to determine which `speaker` pod on which node will announce the load balancer IP address.
-The algorithm involves hashing the node name and the load balancer IP address.
-See the section about external traffic policy for more information.
+The algorithm involves hashing the node name and the load balancer IP address. For more information, see "MetalLB and external traffic policy".
 // IETF treats protocol names as proper nouns.
 The `speaker` uses Address Resolution Protocol (ARP) to announce IPv4 addresses and Neighbor Discovery Protocol (NDP) to announce IPv6 addresses.
 
-For BGP mode, after the `controller` allocates an IP address for the service, each `speaker` pod advertises the load balancer IP address with its BGP peers.
-You can configure which nodes start BGP sessions with BGP peers.
+For Border Gateway Protocol (BGP) mode, after the `controller` allocates an IP address for the service, each `speaker` pod advertises the load balancer IP address with its BGP peers. You can configure which nodes start BGP sessions with BGP peers.
 
-Requests for the load balancer IP address are routed to the node with the `speaker` that announces the IP address.
-After the node receives the packets, the service proxy routes the packets to an endpoint for the service.
-The endpoint can be on the same node in the optimal case, or it can be on another node.
-The service proxy chooses an endpoint each time a connection is established.
+Requests for the load balancer IP address are routed to the node with the `speaker` that announces the IP address. After the node receives the packets, the service proxy routes the packets to an endpoint for the service. The endpoint can be on the same node in the optimal case, or it can be on another node. The service proxy chooses an endpoint each time a connection is established.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. ---> Adds the instruction to read the `speaker` and `controller` pod logs
Also removed the hard wraps

Version(s): 4.9+
<!--- Specify the version or versions of OpenShift your PR applies to.

Examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2039509
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/sdudhgao/event-logs/networking/metallb/about-metallb.html#nw-metallb-software-components_about-metallb-and-metallb-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build.

NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
