### PR TITLE
adds a batch of installer bugs to RNs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1386,6 +1386,30 @@ sourceStrategy:
 
 * Previously, there was an eventual consistency issue in the AWS Terraform provider when updating new load balancers. Therefore, the installation would fail when trying to access the new load balancers. With this fix, the installer is now updated to an upstream Terraform provider, which ensures eventual consistency. As a result, the installation does not fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1898265[*BZ#1898265*])
 
+* Previously, the installation program had a list of required APIs that check for quota and permissions, and the list contained some unnecessary APIs that failed if the user did not provide the permissions. With this update, The list of APIs is split into `required` and `optional` where the `optional` APIs are not accessible. A warning message is displayed for the `optional` APIs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2084280[*BZ#2084280*])
+
+* Previously, the `.apps` entry did not have the tag `kubernetes.io_cluster<infraID>` that was used by the installation program to delete code from the database that would isolate all the resources created for a given cluster and delete them. With this update, a tag was added to the cluster Ingress Operator during creation time which makes the entry visible to delete. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2055601[*BZ#2055601*])
+
+* Previously, the `openshift-install` command would fail when using the internal publishing strategy. With this update, the `openshift-install` command no longer fails. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2047670[*BZ#2047670*])
+
+* Previously, there was an eventual consistency issue in the AWS Terraform provider when updating to newly created Virtual Private Clouds (VPCs). Consequently, the installation program would fail when attempting to access VPCs. With this update, the installation program is updated to the upstream Terraform provider and the install does not fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2043080[*BZ#2043080*])
+
+* Previously, there was an eventual consistency issue in the AWS Terraform provider when updating to newly created network interfaces. Consequently, installs would fail to access the network interfaces. With this update, the Terraform provider is updated to accept eventual consistency and installation does not fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2047741[*BZ#2047741*])
+
+* Previously, the `corespersocket` value could be higher than the `numCores` value when installing a VMware cluster using installer-provisioned infrastructure. This could cause unexpected results during installation. With this update, users recieve a warning to correct these values before the cluster is created. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2034147[*BZ#2034147*])
+
+* Previously, a rare bug caused inconsistency during AWS cluster installations. The installation program has been updated to avoid this scenario. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2046277[*BZ#2046277*])
+
+* Previously, the bootstrap machine used a default size and instance type when installing on Azure using installer-provisioned infrastructure. With this update, the bootstrap machine uses the size and instance type of the control plane machines. You can now control the size and instance type of the bootstrap machine by modifying the control plane settings in your installation configuration. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2026356[*BZ#2026356*])
+
+* Previously, the installation program provided Terraform with an ambiguous network name. This could lead to Terraform being unable to determine the correct network to use. With this update, the installation program provides Terraform with a unique network ID so that the installation succeeds. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918005[*BZ#1918005*])
+
+* Previously, control plane machines could be created before the dependent NAT gateway was created when installing a cluster on AWS, causing the installation to fail. With this update, Terraform ensures that the NAT gateway has been created before the control plane machines are created. This ensures that the installation will succeed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049108[*BZ#2049108*])
+
+* Previously, if you used an OVN network rather than the default OSN network, the scale-up task failed because it took longer than the maximum amount of time required. This update doubles the amount of retries during the scale-up task so that the task can be completed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2090151[*BZ#2090151*])
+
+* Previously, when you tried to delete multiple clusters from the database in parallel, the deletion process failed because of a bug in the `vmware` and `govmomi` libraries. The bug caused one of the cluster's tags to be deleted, which resulted in a 404 error when the deletion process could not find the tag. This update ignores tags that aren't found and continues the deletion process so that it finishes without error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2021041[*BZ#2021041*])
+
 [discrete]
 [id="ocp-4-11-kube-api-server-bug-fixes"]
 ==== Kubernetes API server


### PR DESCRIPTION
Adds a batch of installer bugs to RNs

Preview
https://joealdinger.github.io/openshift-docs/RN-preview2/release_notes/ocp-4-11-release-notes.html#ocp-4-11-bug-fixes



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
