### PR TITLE
OSDOCS-3029: Added Azure Marketplace install content

### DIFF
--- a/installing/installing_azure/installing-azure-account.adoc
+++ b/installing/installing_azure/installing-azure-account.adoc
@@ -33,6 +33,8 @@ include::modules/installation-azure-service-principal.adoc[leveloffset=+1]
 
 * For more information about CCO modes, see xref:../../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator-modes[About the Cloud Credential Operator].
 
+include::modules/installation-azure-marketplace.adoc[leveloffset=+1]
+
 include::modules/installation-azure-regions.adoc[leveloffset=+1]
 
 == Next steps

--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -24,6 +24,8 @@ include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
+include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+1]
+
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]

--- a/installing/installing_azure/installing-azure-user-infra.adoc
+++ b/installing/installing_azure/installing-azure-user-infra.adoc
@@ -72,6 +72,8 @@ include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+1]
+
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/modules/installation-azure-marketplace-subscribe.adoc
+++ b/modules/installation-azure-marketplace-subscribe.adoc
@@ -1,0 +1,142 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-azure-customizations.adoc
+// * installing/installing_aws/installing-azure-user-infra.adoc
+
+ifeval::["{context}" == "installing-azure-customizations"]
+:ipi:
+endif::[]
+ifeval::["{context}" == "installing-azure-user-infra"]
+:upi:
+endif::[]
+
+//mpytlak: The procedure differs depending on whether this module is used in an IPI or UPI assembly.
+
+:_content-type: PROCEDURE
+[id="installation-azure-marketplace-subscribe_{context}"]
+= Selecting an Azure Marketplace image
+If you are deploying an {product-title} cluster using the Azure Marketplace offering, you must first obtain the Azure Marketplace image. The installation program uses this image to deploy worker nodes. When obtaining your image, consider the following:
+
+* While the images are the same, the Azure Marketplace publisher is different depending on your region. If you are located in North America, specify `redhat` as the publisher. If you are located in EMEA, specify `redhat-limited` as the publisher.
+* The offer includes a `rh-ocp-worker` SKU and a `rh-ocp-worker-gen1` SKU. The `rh-ocp-worker` SKU represents a Hyper-V generation version 2 VM image. The default instance types used in {product-title} are version 2 compatible. If you are going to use an instance type that is only version 1 compatible, use the image associated with the `rh-ocp-worker-gen1` SKU. The `rh-ocp-worker-gen1` SKU represents a Hyper-V version 1 VM image.
+
+.Prerequisites
+
+* You have installed the Azure CLI client `(az)`.
+* Your Azure account is entitled for the offer and you have logged into this account with the Azure CLI client.
+
+.Procedure
+
+. Display all of the available {product-title} images by running one of the following commands:
+** North America:
++
+--
+[source,terminal]
+----
+$  az vm image list --all --offer rh-ocp-worker --publisher redhat -o table
+----
+.Example output
+[source,terminal]
+----
+Offer          Publisher       Sku                 Urn                                                             Version
+-------------  --------------  ------------------  --------------------------------------------------------------  --------------
+rh-ocp-worker  RedHat          rh-ocp-worker       RedHat:rh-ocp-worker:rh-ocpworker:4.8.2021122100               4.8.2021122100
+rh-ocp-worker  RedHat          rh-ocp-worker-gen1  RedHat:rh-ocp-worker:rh-ocp-worker-gen1:4.8.2021122100         4.8.2021122100
+----
+--
+** EMEA:
++
+--
+[source,terminal]
+----
+$  az vm image list --all --offer rh-ocp-worker --publisher redhat-limited -o table
+----
+.Example output
+[source,terminal]
+----
+Offer          Publisher       Sku                 Urn                                                             Version
+-------------  --------------  ------------------  --------------------------------------------------------------  --------------
+rh-ocp-worker  redhat-limited  rh-ocp-worker       redhat-limited:rh-ocp-worker:rh-ocp-worker:4.8.2021122100       4.8.2021122100
+rh-ocp-worker  redhat-limited  rh-ocp-worker-gen1  redhat-limited:rh-ocp-worker:rh-ocp-worker-gen1:4.8.2021122100  4.8.2021122100
+----
+--
+
++
+[NOTE]
+====
+Regardless of the version of {product-title} you are installing, the correct version of the Azure Marketplace image to use is 4.8.x. If required, as part of the installation process, your VMs are automatically upgraded.
+====
+. Inspect the image for your offer by running one of the following commands:
+** North America:
++
+[source,terminal]
+----
+$ az vm image show --urn redhat:rh-ocp-worker:rh-ocp-worker:<version>
+----
+** EMEA:
++
+[source,terminal]
+----
+$ az vm image show --urn redhat-limited:rh-ocp-worker:rh-ocp-worker:<version>
+----
+. Review the terms of the offer by running one of the following commands:
+** North America:
++
+[source,terminal]
+----
+$ az vm image terms show --urn redhat:rh-ocp-worker:rh-ocp-worker:<version>
+----
+** EMEA:
++
+[source,terminal]
+----
+$ az vm image terms show --urn redhat-limited:rh-ocp-worker:rh-ocp-worker:<version>
+----
+. Accept the terms of the offering by running one of the following commands:
+** North America:
++
+[source,terminal]
+----
+$ az vm image terms accept --urn redhat:rh-ocp-worker:rh-ocp-worker:<version>
+----
+** EMEA:
++
+[source,terminal]
+----
+$ az vm image terms accept --urn redhat-limited:rh-ocp-worker:rh-ocp-worker:<version>
+----
+ifdef::ipi[]
+. Record the image details of your offer. You must update the `compute` section in the `install-config.yaml` file with values for `publisher`, `offer`, `sku`, and `version` before deploying the cluster.
+endif::ipi[]
+ifdef::upi[]
+. Record the image details of your offer. If you use the Azure Resource Manager (ARM) template to deploy your worker nodes, you can update `storageProfile.imageReference` by deleting the `id` parameter and adding the `offer`, `publisher`, `sku`, and `version` parameters using the values from your offer.
+endif::upi[]
+
+ifdef::ipi[]
+.Sample `install-config.yaml` file with the Azure Marketplace worker nodes
+
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com
+compute:
+- hyperthreading: Enabled
+  name: worker
+  platform:
+    azure:
+      type: Standard_D4s_v5
+      osImage:
+        publisher: redhat
+        offer: rh-ocp-worker
+        sku: rh-ocp-worker
+        version: 4.8.2021122100
+  replicas: 3
+----
+endif::ipi[]
+
+ifeval::["{context}" == "installing-azure-customizations"]
+:!ipi:
+endif::[]
+ifeval::["{context}" == "installing-azure-user-infra"]
+:!upi:
+endif::[]

--- a/modules/installation-azure-marketplace.adoc
+++ b/modules/installation-azure-marketplace.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-azure-account.adoc
+
+:_content-type: CONCEPT
+[id="installation-azure-marketplace_{context}"]
+= Supported Azure Marketplace regions
+
+Installing a cluster using the Azure Marketplace image is available to customers who purchase the offer in North America and EMEA.
+
+While the offer must be purchased in North America or EMEA, you can deploy the cluster to any of the Azure public partitions that {product-title} supports.
+
+[NOTE]
+====
+Deploying a cluster using the Azure Marketplace image is not supported for the Azure Government regions.
+====


### PR DESCRIPTION
Version(s):
CP to 4.11 and 4.12

Issue:
This PR addresses [osdocs-3029](https://issues.redhat.com/browse/OSDOCS-3029).

Link to docs preview:

- [Supported Azure Marketplace regions](http://file.rdu.redhat.com/mpytlak/osdocs-3029/installing/installing_azure/installing-azure-account.html#installation-azure-marketplace_installing-azure-account)
- Installing a cluster on Azure with customizations > [Selecting an Azure Marketplace image](http://file.rdu.redhat.com/mpytlak/osdocs-3029/installing/installing_azure/installing-azure-customizations.html#installation-azure-marketplace-subscribe_installing-azure-customizations)
- Installing a cluster on Azure using ARM templates > [Selecting an Azure Marketplace image](http://file.rdu.redhat.com/mpytlak/osdocs-3029/installing/installing_azure/installing-azure-user-infra.html#installation-azure-marketplace-subscribe_installing-azure-user-infra)