### PR TITLE
CNV-16785 and CNV-19602: Storage-related RNs for 4.11

### DIFF
--- a/virt/virt-4-11-release-notes.adoc
+++ b/virt/virt-4-11-release-notes.adoc
@@ -77,6 +77,10 @@ The SVVP Certification applies to:
 === Storage
 
 //CNV-16785 Snapshot metrics
+* New metrics are available that provide information about xref:../virt/logging_events_monitoring/virt-prometheus-queries.adoc#virt-storage-snapshot-data_virt-prometheus-queries[virtual machine snapshots].
+
+//CNV-19602 Automatic boot source configuration
+* You can reduce the number of logs on disconnected environments or reduce resource usage by xref:../virt/virtual_machines/advanced_vm_management/virt-automatic-bootsource-updates.adoc#virt-disable-individual-bootsource-update_virt-automatic-bootsource-updates[disabling the automatic imports and updates for a boot source].
 
 [id="virt-4-11-web-new"]
 === Web console


### PR DESCRIPTION
For 4.11 only.

Jiras: https://issues.redhat.com/browse/CNV-16785 and https://issues.redhat.com/browse/CNV-19602

Direct doc preview link: http://file.rdu.redhat.com/bgaydos/CNV-16785/virt/virt-4-11-release-notes.html#virt-4-11-storage-new

These are both storage-related RNs and go in the same section of the RN file. Even though the feature topics live in the table of contents in virt or logging areas, I think they should be listed as storage-related due to their content (snapshots and boot sources).

Tagging  @tiraboschi ([CNV-16785](https://issues.redhat.com//browse/CNV-16785)) and @nunnatsa ([CNV-19602](https://issues.redhat.com//browse/CNV-19602)) for code review.
--- Nahshon, I am creating another PR today to correct the feature doc for CNV-15737. As you have indicated, the disabling is for a predefined boot source, so I am simply calling this "boot source" to avoid confusion. I think we should go for boot source/custom boot source in the feature doc, for simplicity, and will ensure that's clear with the new PR.
Tagging @duyanyan for QE review on both notes.

Thanks
Bob