### PR TITLE
CNV-15737: Corrections to boot source autoupdate assembly

### DIFF
--- a/modules/virt-autoupdate-custom-bootsource.adoc
+++ b/modules/virt-autoupdate-custom-bootsource.adoc
@@ -5,9 +5,9 @@
 
 :_content-type: PROCEDURE
 [id="virt-autoupdate-custom-bootsource_{context}"]
-= Enabling automatic updates on custom boot sources
+= Enabling automatic updates for user-defined boot sources
 
-{VirtProductName} automatically updates pre-defined boot sources by default, but does not automatically update custom boot sources. You must manually enable automatic imports and updates on any custom boot sources by editing the `HyperConverged` custom resource (CR).
+{VirtProductName} automatically updates system-defined boot sources by default, but does not automatically update user-defined boot sources. You must manually enable automatic imports and updates on a user-defined boot sources by editing the `HyperConverged` custom resource (CR).
 
 .Procedure
 
@@ -18,7 +18,7 @@
 $ oc edit -n openshift-cnv HyperConverged
 ----
 
-. Edit the `HyperConverged` CR, specifying the appropriate template and boot source in the `dataImportCronTemplates` section. For example:
+. Edit the `HyperConverged` CR, adding the appropriate template and boot source in the `dataImportCronTemplates` section. For example:
 +
 .Example in CentOS 7
 [source,yaml]

--- a/modules/virt-configuring-storage-class-bootsource-update.adoc
+++ b/modules/virt-configuring-storage-class-bootsource-update.adoc
@@ -5,14 +5,13 @@
 
 :_content-type: PROCEDURE
 [id="virt-configuring-storage-class-bootsource-update_{context}"]
-= Configuring a storage class for custom boot source updates
+= Configuring a storage class for user-defined boot source updates
 
-You must configure a storage class that allows automatic updating for custom boot sources.
+You can configure a storage class that allows automatic importing and updating for user-defined boot sources.
 
 .Procedure
 
-* Choose the appropriate method to configure a storage class:
-**  Edit the `HyperConverged` custom resource (CR) and define a `storageClassName`.
+. Define a new `storageClassName` by editing the `HyperConverged` custom resource (CR).
 +
 [source,yaml]
 ----
@@ -27,17 +26,17 @@ spec:
     spec:
       template:
         spec:
-          storageClassName: <storage_class_name>
+          storageClassName: <appropriate_class_name>
 ...
 ----
-**  Set a default storage class by running the following commands:
+. Set the new default storage class by running the following commands:
 +
 [source,terminal]
 ----
-oc patch storageclass <current_default_storage_class> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+$ oc patch storageclass <current_default_storage_class> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 ----
 +
 [source,terminal]
 ----
-oc patch storageclass <appropriate_storage_class> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+$ oc patch storageclass <appropriate_storage_class> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 ----

--- a/modules/virt-disable-bootsource-update.adoc
+++ b/modules/virt-disable-bootsource-update.adoc
@@ -7,18 +7,22 @@
 [id="virt-disabling-bootsource-update_{context}"]
 = Disabling automatic boot source updates
 
-You can reduce the number of logs on disconnected environments or reduce resource usage by disabling the automatic imports and updates of pre-defined boot sources. Set the `spec.featureGates.enableCommonBootImageImport` field in the `HyperConverged` custom resource (CR) to `false`.
+Disabling automatic boot source imports and updates can be helpful to reduce the number of logs in disconnected environments or to reduce resource usage.
+
+To disable automatic boot source imports and updates, set the `spec.featureGates.enableCommonBootImageImport` field in the `HyperConverged` custom resource (CR) to `false`.
 
 [NOTE]
 ====
-Custom boot sources are not affected by this setting.
+User-defined boot sources are not affected by this setting.
 ====
 
 .Procedure
 
-* Use the following command to disable automatic updates:
+* Use the following command to disable automatic boot source updates:
 +
 [source,terminal]
 ----
-$ oc patch hco kubevirt-hyperconverged -n openshift-cnv --type json -p '[{"op": "replace", "path": "/spec/featureGates/enableCommonBootImageImport", "value": false}]'
+$ oc patch hco kubevirt-hyperconverged -n openshift-cnv \
+ --type json -p '[{"op": "replace", "path": "/spec/featureGates/enableCommonBootImageImport", \
+ "value": false}]'
 ----

--- a/modules/virt-disable-individual-bootsource-update.adoc
+++ b/modules/virt-disable-individual-bootsource-update.adoc
@@ -5,13 +5,18 @@
 
 :_content-type: PROCEDURE
 [id="virt-disable-individual-bootsource-update_{context}"]
-= Disabling an automatic update for a custom boot source
+= Disabling an automatic update for a system-defined or user-defined boot source
 
-You can reduce the number of logs on disconnected environments or reduce resource usage by disabling the automatic imports and updates for an individual custom boot source.
+You can disable automatic imports and updates for a user-defined boot source and for a system-defined boot source.
+
+Because system-defined boot sources are not listed by default in the `spec.dataImportCronTemplates` of the `HyperConverged` custom resource (CR), you must add the boot source and disable auto imports and updates.
 
 .Procedure
 
-* Edit the `HyperConverged` custom resource (CR) and disable updates for a custom boot source by setting the `dataimportcrontemplate.kubevirt.io/enable` annotation in the CR to `false`.
+* To disable automatic imports and updates for a user-defined boot source, remove the boot source from the `spec.dataImportCronTemplates` field in the custom resource list.
+* To disable automatic imports and updates for a system-defined boot source:
+** Edit the `HyperConverged` CR and add the boot source to `spec.dataImportCronTemplates`.
+** Disable automatic imports and updates by setting the `dataimportcrontemplate.kubevirt.io/enable` annotation to `false`. For example:
 +
 [source,yaml]
 ----

--- a/modules/virt-enabling-bootsource-update.adoc
+++ b/modules/virt-enabling-bootsource-update.adoc
@@ -7,13 +7,16 @@
 [id="virt-enabling-bootsource-update_{context}"]
 = Enabling automatic boot source updates
 
-If you have pre-defined boot sources from {VirtProductName} 4.9, then you must manually opt them in to the automatic boot source updates. All pre-defined boot sources from {VirtProductName} 4.10 and later are automatically updated by default.
+If you have boot sources from {VirtProductName} 4.9 or earlier, you must manually turn on automatic updates for these boot sources. All boot sources in {VirtProductName} 4.10 and later are automatically updated by default.
+
+To enable automatic boot source imports and updates, set the `cdi.kubevirt.io/dataImportCron` field to `true` for each boot source you want to update automatically.
 
 .Procedure
 
-* Use the following command to apply the `dataImportCron` label to the data source:
+* To turn on automatic updates for a boot source, use the following command to apply the `dataImportCron` label to the data source:
 +
 [source,terminal]
 ----
-$ oc label --overwrite DataSource rhel8 -n openshift-virtualization-os-images cdi.kubevirt.io/dataImportCron=true
+$ oc label --overwrite DataSource rhel8 -n openshift-virtualization-os-images cdi.kubevirt.io/dataImportCron=true <1>
 ----
+<1> Specifying `true` turns on automatic updates for the `rhel8` boot source.

--- a/modules/virt-verify-status-bootsource-update.adoc
+++ b/modules/virt-verify-status-bootsource-update.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assembly:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-automatic-bootsource-updates.adoc
+//
+
+:_content-type: PROCEDURE
+[id="virt-verify-status-bootsource-update_{context}"]
+= Verifying the status of a boot source
+
+You can verify whether a boot source is system-defined or user-defined.
+
+The `status` section of each boot source listed in the `status.dataImportChronTemplates` field of the `HyperConverged` CR indicates the type of boot source. For example, `commonTemplate: true` indicates a system-defined (`commonTemplate`) boot source and `status: {}` indicates a user-defined boot source.
+
+.Procedure
+
+. Use the `oc get` command to list the `dataImportChronTemplates` in the `HyperConverged` CR.
+
+. Verify the status of the boot source.
++
+.Example output
+
+[source,yaml]
+----
+...
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+...
+spec:
+  ...
+status: <1>
+  ...
+  dataImportCronTemplates: <2>
+  - metadata:
+      annotations:
+        cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+      name: centos-7-image-cron
+    spec:
+      garbageCollect: Outdated
+      managedDataSource: centos7
+      schedule: 55 8/12 * * *
+      template:
+        metadata: {}
+        spec:
+          source:
+            registry:
+              url: docker://quay.io/containerdisks/centos:7-2009
+          storage:
+            resources:
+              requests:
+                storage: 30Gi
+        status: {}
+    status:
+      commonTemplate: true <3>
+    ...
+  - metadata:
+      annotations:
+        cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+      name: user-defined-dic
+    spec:
+      garbageCollect: Outdated
+      managedDataSource: user-defined-centos-stream8
+      schedule: 55 8/12 * * *
+      template:
+        metadata: {}
+        spec:
+          source:
+            registry:
+              pullMethod: node
+              url: docker://quay.io/containerdisks/centos-stream:8
+          storage:
+            resources:
+              requests:
+                storage: 30Gi
+        status: {}
+    status: {} <4>
+...
+----
+<1> The `status` field for the `HyperConverged` CR.
+<2> The `dataImportCronTemplates` field, which lists all defined boot sources.
+<3> Indicates a system-defined boot source.
+<4> Indicates a user-defined boot source.

--- a/virt/virtual_machines/advanced_vm_management/virt-automatic-bootsource-updates.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-automatic-bootsource-updates.adoc
@@ -6,7 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As of version 4.10, {VirtProductName} automatically imports and updates pre-defined boot sources, unless you manually opt-out. If you upgrade to version {VirtProductName} 4.10 from version 4.9 or earlier and have pre-defined boot sources from the earlier version, you must manually opt-in to automatic imports and updates for those pre-defined boot sources.
+You can use boot sources that are _system-defined_ and included with {VirtProductName} or _user-defined_, which you create. System-defined boot source imports and updates are controlled by the product feature gate. You can enable, disable, or re-enable updates using the feature gate. User-defined boot sources are not controlled by the product feature gate and must be individually managed to opt in or opt out of automatic imports and updates.
+
+[IMPORTANT]
+====
+As of version 4.10, {VirtProductName} automatically imports and updates boot sources, unless you manually opt out. If you upgrade to version 4.10, you must manually enable automatic imports and updates for boot sources from version 4.9 or earlier.
+====
 
 include::modules/virt-enabling-bootsource-update.adoc[leveloffset=+1]
 
@@ -19,3 +24,5 @@ include::modules/virt-configuring-storage-class-bootsource-update.adoc[leveloffs
 include::modules/virt-autoupdate-custom-bootsource.adoc[leveloffset=+1]
 
 include::modules/virt-disable-individual-bootsource-update.adoc[leveloffset=+1]
+
+include::modules/virt-verify-status-bootsource-update.adoc[leveloffset=+1]


### PR DESCRIPTION
For 4.11 only.

Jira: https://issues.redhat.com/browse/CNV-15737

Direct doc preview link: http://file.rdu.redhat.com/bgaydos/CNV-15737_2/virt/virtual_machines/advanced_vm_management/virt-automatic-bootsource-updates.html

This PR aims to correct errors and make the terminology clearer in PR https://github.com/openshift/openshift-docs/pull/47939.

To that end, we have eliminated the term "pre-defined boot source" and instead talk only of boot sources and custom boot sources. We also have added that in `virt-disable-bootsource-update` we are only referring to disabling a SINGLE boot source update rather than all updates.

@nunnatsa - Please have a look at the **entire** topic preview linked above. I want to make sure all the modules are correct, especially the two that talk specifically about custom boot sources.... boot sources that have been modified by the user:
- Configuring a storage class for custom boot source updates
- Enabling automatic updates on custom boot sources

If this version still has problems, let's set up a meeting to correct it. 

Tagging @duyanyan for QE Review after @nunnatsa has signed off.

Thanks
Bob
