### PR TITLE
some small cleanup to the MachineAutoscaler resource definition

### DIFF
--- a/modules/machine-autoscaler-cr.adoc
+++ b/modules/machine-autoscaler-cr.adoc
@@ -3,6 +3,7 @@
 // * machine_management/applying-autoscaling.adoc
 // * post_installation_configuration/cluster-tasks.adoc
 
+:_content-type: CONCEPT
 [id="machine-autoscaler-cr_{context}"]
 = MachineAutoscaler resource definition
 
@@ -24,16 +25,16 @@ spec:
     kind: MachineSet <5>
     name: worker-us-east-1a <6>
 ----
-<1> Specify the machine autoscaler name. To make it easier to identify which machine set this machine autoscaler scales, specify or include the name of the machine set to scale. The machine set name takes the following form: `<clusterid>-<machineset>-<aws-region-az>`.
+<1> Specify the machine autoscaler name. To make it easier to identify which machine set this machine autoscaler scales, specify or include the name of the machine set to scale. The machine set name takes the following form: `<clusterid>-<machineset>-<region>`.
 <2> Specify the minimum number machines of the specified type that must remain in the specified zone after the cluster autoscaler initiates cluster scaling. If running in AWS, GCP, Azure, {rh-openstack}, or vSphere, this value can be set to `0`. For other providers, do not set this value to `0`.
 +
 You can save on costs by setting this value to `0` for use cases such as running expensive or limited-usage hardware that is used for specialized workloads, or by scaling a machine set with extra large machines. The cluster autoscaler scales the machine set down to zero if the machines are not in use.
 +
 [IMPORTANT]
 ====
-Do not set the `spec.minReplicas` value to `0` for the three compute plane machine sets that are created during the {product-title} installation process for an installer provisioned infrastructure.
+Do not set the `spec.minReplicas` value to `0` for the three compute machine sets that are created during the {product-title} installation process for an installer provisioned infrastructure.
 ====
-<3> Specify the maximum number machines of the specified type that the cluster autoscaler can deploy in the specified AWS zone after it initiates cluster scaling. Ensure that the `maxNodesTotal` value in the `ClusterAutoscaler` resource definition is large enough to allow the machine autoscaler to deploy this number of machines.
+<3> Specify the maximum number machines of the specified type that the cluster autoscaler can deploy in the specified zone after it initiates cluster scaling. Ensure that the `maxNodesTotal` value in the `ClusterAutoscaler` resource definition is large enough to allow the machine autoscaler to deploy this number of machines.
 <4> In this section, provide values that describe the existing machine set to scale.
 <5> The `kind` parameter value is always `MachineSet`.
 <6> The `name` value must match the name of an existing machine set, as shown in the `metadata.name` parameter value.


### PR DESCRIPTION
Version(s):
4.6+

Issue:
Relates to effort in [OSDOCS-2876](https://issues.redhat.com//browse/OSDOCS-2876)

Link to docs preview:
[MachineAutoscaler resource definition](http://file.rdu.redhat.com/jrouth/typo-compute-plane/machine_management/applying-autoscaling.html#machine-autoscaler-cr_applying-autoscaling)

Additional information:
Just a few things that I noticed in this topic while planning some reorganization. This applies in part to 4.6+ but will need manual CP lower than at least 4.8 due to some other differences.