### PR TITLE
OADP-227: Which K8s API version is used; how to use Enable API Group Versions 

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2388,6 +2388,8 @@ Topics:
     File: troubleshooting
   - Name: OADP API
     File: oadp-api
+  - Name: Advanced OADP features and functionalities
+    File: oadp-advanced-topics
 - Name: Control plane backup and restore
   Dir: control_plane_backup_and_restore
   Topics:

--- a/backup_and_restore/application_backup_and_restore/oadp-advanced-topics.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-advanced-topics.adoc
@@ -1,0 +1,19 @@
+:_content-type: ASSEMBLY
+[id="oadp-advanced-topics"]
+= Advanced OADP features and functionalities
+include::_attributes/common-attributes.adoc[]
+:context: oadp-advanced-topics
+:oadp-advanced-topics:
+
+toc::[]
+
+This document provides information on advanced features and functionalities of OpenShift API for Data Protection (OADP).
+
+[id="oadp-different-kubernetes-api-versions"]
+== Working with different Kubernetes API versions on the same cluster
+
+include::modules/oadp-checking-api-group-versions.adoc[leveloffset=+2]
+include::modules/oadp-about-enable-api-group-versions.adoc[leveloffset=+2]
+include::modules/oadp-using-enable-api-group-versions.adoc[leveloffset=+2]
+
+:!oadp-advanced-topics:

--- a/modules/oadp-about-enable-api-group-versions.adoc
+++ b/modules/oadp-about-enable-api-group-versions.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/advanced-topics.adoc
+
+
+:_content-type: CONCEPT
+[id="oadp-about-enable-api-group-versions_{context}"]
+= About Enable API Group Versions
+
+By default, Velero only backs up resources that use the preferred version of the Kubernetes API. However, Velero also includes a feature, link:https://velero.io/docs/v1.9/enable-api-group-versions-feature/[Enable API Group Versions], that overcomes this limitation. When enabled on the source cluster, this feature causes Velero to back up _all_ Kubernetes API group versions that are supported on the cluster, not only the preferred one. After the versions are stored in the backup .tar file, they are available to be restored on the destination cluster.
+
+For example, a source cluster with an API named `Example` might be available in the `example.com/v1` and `example.com/v1beta2` API groups, with `example.com/v1` being the preferred API.
+
+Without the Enable API Group Versions feature enabled, Velero backs up only the preferred API group version for `Example`, which is `example.com/v1`. With the feature enabled, Velero also backs up `example.com/v1beta2`.
+
+When the Enable API Group Versions feature is enabled on the destination cluster, Velero selects the version to restore on the basis of the order of priority of API group versions.
+
+[NOTE]
+====
+Enable API Group Versions is still in beta.
+====
+
+Velero uses the following algorithm to assign priorities to API versions, with `1` as the top priority:
+
+. Preferred version of the _destination_ cluster
+. Preferred version of the source_ cluster
+. Common non-preferred supported version with the highest Kubernetes version priority
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://velero.io/docs/v1.9/enable-api-group-versions-feature/[Enable API Group Versions Feature]

--- a/modules/oadp-checking-api-group-versions.adoc
+++ b/modules/oadp-checking-api-group-versions.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/advanced-topics.adoc
+
+
+:_content-type: PROCEDURE
+[id="oadp-checking-api-group-versions_{context}"]
+= Listing the Kubernetes API group versions on a cluster
+
+A source cluster might offer multiple versions of an API, where one of these versions is the preferred API version. For example, a source cluster with an API named `Example` might be available in the `example.com/v1` and `example.com/v1beta2` API groups.
+
+If you use Velero to back up and restore such a source cluster, Velero backs up only the version of that resource that uses the preferred version of its Kubernetes API.
+
+To return to the above example, if `example.com/v1` is the preferred API, then Velero only backs up the version of a resource that uses `example.com/v1`. Moreover, the target cluster needs to have `example.com/v1` registered in its set of available API resources in order for Velero to restore the resource on the target cluster.
+
+Therefore, you need to generate a list of the Kubernetes API group versions on your target cluster to be sure the prefered API version is registered in its set of available API resources.
+
+.Procedure
+
+* Enter the following command:
+
+[source,terminal]
+----
+$ oc api-resources
+----

--- a/modules/oadp-using-enable-api-group-versions.adoc
+++ b/modules/oadp-using-enable-api-group-versions.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/advanced-topics.adoc
+
+
+:_content-type: PROCEDURE
+[id="oadp-using-enable-api-group-versions_{context}"]
+= Using Enable API Group Versions
+
+You can use Velero's Enable API Group Versions feature to back up _all_ Kubernetes API group versions that are supported on a cluster, not only the preferred one.
+
+[NOTE]
+====
+Enable API Group Versions is still in beta.
+====
+
+.Procedure
+
+* Configure the `EnableAPIGroupVersions` feature flag:
+
+[source,yaml]
+----
+apiVersion: oadp.openshift.io/vialpha1
+kind: DataProtectionApplication
+...
+spec:
+  configuration:
+    velero:
+      featureFlags:
+      - EnableAPIGroupVersions
+----
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://velero.io/docs/v1.9/enable-api-group-versions-feature/[Enable API Group Versions Feature]


### PR DESCRIPTION
OADP 1.1.0; OCP 4.9+

Resolves: https://issues.redhat.com/browse/OADP-227

Preview: http://file.emea.redhat.com/rhoch/api_group_versions/backup_and_restore/application_backup_and_restore/oadp-advanced-topics.html

Please do not merge before Sept. 1.
