### PR TITLE
BZ2108643: Update file system overhead documentation

### DIFF
--- a/modules/virt-overriding-default-fs-overhead-value.adoc
+++ b/modules/virt-overriding-default-fs-overhead-value.adoc
@@ -6,7 +6,7 @@
 [id="virt-overriding-default-fs-overhead-value_{context}"]
 = Overriding the default file system overhead value
 
-Change the amount of persistent volume claim (PVC) space that the Containerized Data Importer (CDI) reserves for file system overhead by editing the `spec.config.filesystemOverhead` attribute of the `CDI` object.
+Change the amount of persistent volume claim (PVC) space that OpenShift Virtualization reserves for file system overhead by editing the `spec.filesystemOverhead` attribute of the `HCO` object.
 
 .Prerequisites
 
@@ -14,35 +14,34 @@ Change the amount of persistent volume claim (PVC) space that the Containerized 
 
 .Procedure
 
-. Open the `CDI` object for editing by running the following command:
+. Open the `HCO` object for editing by running the following command:
 +
 [source,terminal]
 ----
-$ oc edit cdi
+$ oc edit hco
 ----
 
-. Edit the `spec.config.filesystemOverhead` fields, populating them with your chosen values:
+. Edit the `spec.filesystemOverhead` fields. You can choose from either or both a global value that will apply to all storage classes, or a storage class specific value.
 +
 [source,yaml]
 ----
 ...
 spec:
-  config:
-    filesystemOverhead:
-      global: "<new_global_value>" <1>
-      storageClass:
-        <storage_class_name>: "<new_value_for_this_storage_class>" <2>
+  filesystemOverhead:
+    global: "<new_global_value>" <1>
+    storageClass:
+      <storage_class_name>: "<new_value_for_this_storage_class>" <2>
 ----
-<1> The file system overhead percentage that CDI uses across the cluster. For example, `global: "0.07"` reserves 7% of the PVC for file system overhead.
-<2> The file system overhead percentage for the specified storage class. For example, `mystorageclass: "0.04"` changes the default overhead value for PVCs in the `mystorageclass` storage class to 4%.
+<1> The file system overhead percentage that OpenShift Virtualization uses across the cluster. For example, `global: "0.07"` reserves 7% of the PVC for file system overhead.
+<2> The file system overhead percentage for the specified storage class. For example, `mystorageclass: "0.04"` changes the default overhead value for PVCs in the `mystorageclass` storage class to 4%. If both a global value and a storage class value appear, the storage class specific value will be used.
 
-. Save and exit the editor to update the `CDI` object.
+. Save and exit the editor to update the `HCO` object.
 
 .Verification
 
-* View the `CDI` status and verify your changes by running the following command:
+* View the `CDIConfig` status and verify your changes by running the following command:
 +
 [source,terminal]
 ----
-$ oc get cdi -o yaml
+$ oc get cdiconfig -o jsonpath='{.items..status.filesystemOverhead}'
 ----


### PR DESCRIPTION
- Refer to openshift virtualization instead of CDI
- Mention that the specific storage class overrides the global
- Mention that we want to look at CDIConfig for verification,
it doesn't appear in the CDI object.

There was some confusion about where to put the tunable when it
was introduced, and whether it's tunable downstream at all.
It wasn't tunable downstream since its introduction as HCO will
override changes to CDI object.
As of 4.11, it is tunable downstream, but you need to use the HCO
object to do so.

Version(s):
PR applies to all versions after 4.11, but we wanted to document these changes only from 4.12.

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2108643