### PR TITLE
fix errata for 4.10.24

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3155,11 +3155,11 @@ sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-24"]
-=== RHBA-2022:5663 - {product-title} 4.10.24 bug fix and security update
+=== RHSA-2022:5664 - {product-title} 4.10.24 bug fix and security update
 
 Issued: 2022-07-25
 
-{product-title} release 4.10.24 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5663[RHBA-2022:5663] advisory. There are no RPM packages for this release.
+{product-title} release 4.10.24 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:5664[RHSA-2022:5664] advisory. There are no RPM packages for this release.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 


### PR DESCRIPTION
The release notes point to errata https://access.redhat.com/errata/RHBA-2022:5663 which does not exist, the correct errata is RHSA-2022:5664

https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/release_notes/ocp-4-10-release-notes#ocp-4-10-24

