### PR TITLE
RNs-4.10.25 Added with Bug Fix & Security Update

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2691,7 +2691,7 @@ This update contains changes from Kubernetes 1.23.3 up to 1.23.5. More informati
 ==== Bug fixes
 * Previously, the query for subnets in Cisco ACI's neutron implementation, which is avaiable in {rh-openstack-first}-16, returned unexpected results for a given network. Consequently, the {rh-openstack} `cluster-api-provider` could potentially try to provision instances with duplicated ports on the same subnet, which caused failed provision. With this update, an additional filter is added in the {rh-openstack} `cluster-api-provider` to ensure there is only one port per subnet. As a result, it is now possible to deploy {product-title} on {rh-openstack}-16 with Cisco ACI. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2050064[*BZ#2050064*])
 
-* Previously, `oc adm must gather` fell back to the `oc adm inspect` command when the specified image could not run. Consequently, it was difficult to understand information from the logs when the fall back happened. With this update, the logs are improved to make it explicit when a fall back inspection is performed. As a result, the output of `oc adm must gather` is easier to understand. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049427[*BZ#2049427*])
+* Previously, fell back to the `oc adm inspect` command when the specified image could not run. Consequently, it was difficult to understand information from the logs when the fall back happened. With this update, the logs are improved to make it explicit when a fall back inspection is performed. As a result, the output of `oc adm must gather` is easier to understand. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049427[*BZ#2049427*])
 
 * Previously, the `oc debug node` command did not have timeout specified on idle. Consequently, the users were never logged out of the cluster. With this update, a `TMOUT` environment variable for debug pod has been added to counter inactivity timeout. As a result, the session will be automatically terminated after `TMOUT` inactivity. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2060888[*BZ#2060888*])
 
@@ -3166,6 +3166,29 @@ Space precluded documenting all of the container images for this release in the 
 link:https://access.redhat.com/solutions/6969074[{product-title} 4.10.24 container image list]
 
 [id="ocp-4-10-24-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-25"]
+=== RHSA-2022:5730 - {product-title} 4.10.25 bug fix and security update
+
+Issued: 2022-08-01
+
+{product-title} release 4.10.24, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:5730[RHSA-2022:5730] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:5729[RHSA-2022:5729] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6970052[{product-title} 4.10.25 container image list]
+
+[id="ocp-4-10-25-bug-fixes"]
+==== Bug fixes
+
+* Previously, the Ingress Controller did not set the `allowPrivilegeEscalation` in the router container, causing router pods to fail when the Security Context Constraint (SCC) does not match the default `HostNetwork` SCC. This fix adds `allowPrivilegeEscalation` to the router containers' SCC to ensure it matches the `HostNetwork` SCC. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2079034#[*BZ#2079034*])
+
+* Previously, routers stuck in the terminating state and the OC CP command not timing out caused delays in the `oc adm must gather` of up to one hour. This fix adds a timeout for each OC CP command, resulting in the `oc adm must gather` not being delayed by terminating pods. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2106842#[*BZ#2106842*])
+
+[id="ocp-4-10-25-upgrading"]
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
**RNs-4.10.25**
Added with Bug Fix & Security Update

**Version(s):**
PR applies only to enterprise-4.10

**Issue:**


**Link to docs preview:**


**Additional information:**
n/a



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
