### PR TITLE
Added snippet to 'Tested AWS machine types'

### DIFF
--- a/modules/installation-supported-aws-machine-types.adoc
+++ b/modules/installation-supported-aws-machine-types.adoc
@@ -25,9 +25,11 @@ endif::[]
 
 
 [id="installation-supported-aws-machine-types_{context}"]
-= Supported AWS machine types
+= Tested AWS machine types
 
-The following Amazon Web Services (AWS) instance types are supported with {product-title}.
+include::snippets/supported-instance-types.adoc[]
+
+The following Amazon Web Services (AWS) instance types have been tested with {product-title}.
 
 .Machine types based on x86_64 architecture
 [%collapsible]

--- a/snippets/supported-instance-types.adoc
+++ b/snippets/supported-instance-types.adoc
@@ -1,0 +1,5 @@
+// Used by:
+// modules/installation-supported-aws-machine-types.adoc
+
+:_content-type: SNIPPET
+{product-title} supports instance types that meet the minimum resource requirements for cluster installation. For more information, see the section titled "Minimum resource requirements for cluster installation". 


### PR DESCRIPTION
Changed "supported" instance types to "tested" instance types and added a snippet about resource requirements.
[Doc preview](https://bscott-rh.github.io/openshift-docs/updating-aws-instance-types/installing/installing_aws/installing-aws-network-customizations.html#installation-supported-aws-machine-types_installing-aws-network-customizations)