### PR TITLE
TELCODOCS-321: D/S Docs & RN: METAL-1 (MPINSTALL-72) Metal Day 1 Networking

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -48,7 +48,8 @@ include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-
 
 * See link:https://nmstate.io/examples.html#interfaces-ethernet[NMState] for additional examples of NMState syntax.
 
-* xref:../../release_notes/ocp-4-10-release-notes.adoc#ocp-4-10-known-issues[OpenShift Container Platform 4.10 release notes]
+//Add this to the enterprise-4.10 branch. It can't resolve in the main branch.
+//* xref:../../release_notes/ocp-4-10-release-notes.adoc#ocp-4-10-known-issues[OpenShift Container Platform 4.10 release notes]
 
 include::modules/ipi-install-configure-multiple-cluster-nodes.adoc[leveloffset=+2]
 

--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -46,7 +46,9 @@ include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-
 [id="additional-resources_relnotes"]
 .Additional resources
 
-* xref:../../release_notes/ocp-4-11-release-notes.adoc#ocp-4-11-known-issues[OpenShift Container Platform 4.11 release notes]
+* See link:https://nmstate.io/examples.html#interfaces-ethernet[NMState] for additional examples of NMState syntax.
+
+* xref:../../release_notes/ocp-4-10-release-notes.adoc#ocp-4-10-known-issues[OpenShift Container Platform 4.10 release notes]
 
 include::modules/ipi-install-configure-multiple-cluster-nodes.adoc[leveloffset=+2]
 

--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -17,7 +17,6 @@ include::modules/ipi-install-extracting-the-openshift-installer.adoc[leveloffset
 include::modules/ipi-install-creating-an-rhcos-images-cache.adoc[leveloffset=+1]
 
 [id="ipi-install-configuration-files"]
-[id="additional-resources_config"]
 == Configuring the install-config.yaml file
 
 include::modules/ipi-install-configuring-the-install-config-file.adoc[leveloffset=+2]
@@ -47,9 +46,6 @@ include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-
 .Additional resources
 
 * See link:https://nmstate.io/examples.html#interfaces-ethernet[NMState] for additional examples of NMState syntax.
-
-//Add this to the enterprise-4.10 branch. It can't resolve in the main branch.
-//* xref:../../release_notes/ocp-4-10-release-notes.adoc#ocp-4-10-known-issues[OpenShift Container Platform 4.10 release notes]
 
 include::modules/ipi-install-configure-multiple-cluster-nodes.adoc[leveloffset=+2]
 

--- a/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -6,55 +6,144 @@
 [id="configuring-host-network-interfaces-in-the-install-config-yaml-file_{context}"]
 = (Optional) Configuring host network interfaces
 
-During installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState. To use the `networkConfig` configuration setting, you must provide an NMState YAML configuration.
-
-See link:https://nmstate.io/examples.html#interfaces-ethernet[NMState] for additional examples of the NMState syntax.
-
-.Example
-[source,yaml]
-----
-  hosts:
-        - name: openshift-master-0
-          role: master
-          bmc:
-            address: redfish+http://<out-of-band-ip>/redfish/v1/Systems/
-            username: <user>
-            password: <password>
-            disableCertificateVerification: null
-          bootMACAddress: <NIC1_mac_address>
-          bootMode: UEFI
-          rootDeviceHints:
-            deviceName: "/dev/sda"
-          networkConfig: <1>
-            interfaces:
-            - name: <NIC1_name>
-              type: ethernet
-              state: up
-              ipv4:
-                address:
-                - ip: "<IP_address>"
-                  prefix-length: 24
-                enabled: true
-            dns-resolver:
-              config:
-                server:
-                - <DNS_IP_address>
-            routes:
-              config:
-              - destination: 0.0.0.0/0
-                next-hop-address: <IP_address>
-                next-hop-interface: <NIC1_name>
-----
-<1> Add NMState YAML syntax to configure host interfaces.
-
-[TIP]
-====
-Consider saving the `networkConfig` YAML syntax to a file and testing it using the NMState command line interface before including it in the `install-config.yaml` file, because the installer will not check the NMState YAML syntax. Execute `nmstatectl gc <yaml-config>` to test the syntax. Errors in the YAML syntax might result in a failure to apply the network configuration. Additionally, maintaining the validated YAML syntax is useful when applying changes using Kubernetes NMState after deployment or when expanding the cluster.
-====
+Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState.
 
 The most common use case for this functionality is to specify a static IP address on the `baremetal` network, but you can also configure other networks such as a storage network. This functionality will also support other NMState features such as VLAN, VXLAN, bridges, bonds, routes, MTU, and DNS resolver settings.
 
+.Prequisites
+
+* Configure a `PTR` DNS record with a valid hostname for each node with a static IP address.
+* Install `nmstate`.
+
+.Procedure
+
+. Optional. Consider testing the NMState syntax with `nmstatectl gc` before including it in the `install-config.yaml` file, because the installer will not check the NMState YAML syntax. Errors in the YAML syntax might result in a failure to apply the network configuration. Additionally, maintaining the validated YAML syntax is useful when applying changes using Kubernetes NMState after deployment or when expanding the cluster.
+
+.. Create an NMState YAML file:
++
+[source,yaml]
+----
+interfaces:
+- name: <NIC1_name>
+  type: ethernet
+  state: up
+  ipv4:See link:https://nmstate.io/examples.html#interfaces-ethernet[NMState] for additional examples of the NMState syntax.
+
+    address:
+    - ip: <IP_address>
+      prefix-length: 24
+    enabled: true
+dns-resolver:
+  config:
+    server:
+    - <DNS_IP_address>
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: <next_hop_IP_address>
+    next-hop-interface: <next_hop_NIC1_name>
+----
++
+Replace `<NIC1_name>`, `<IP_address>`, `<DNS_IP_address>`, `<next_hop_IP_address>` and `<next_hop_NIC1_name>` with appropriate values.
+
+.. Test the configuration file by running the following command:
++
+[source,terminal]
+----
+$ nmstatectl gc <networkConfig-configuration-file>
+----
+
+. To use the `networkConfig` configuration setting, add the `NMState` configuration within `install-config.yaml`, as shown in the following example:
++
+[source,terminal]
+----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish+http://<out_of_band_ip>/redfish/v1/Systems/
+          username: <user>
+          password: <password>
+          disableCertificateVerification: null
+        bootMACAddress: <NIC1_mac_address>
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: "/dev/sda"
+        networkConfig: <1>
+          interfaces:
+          - name: <NIC1_name>
+            type: ethernet
+            state: up
+            ipv4:
+              address:
+              - ip: <IP_address>
+                prefix-length: 24
+              enabled: true
+          dns-resolver:
+            config:
+              server:
+              - <DNS_IP_address>
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-address: <next_hop_IP_address>
+              next-hop-interface: <next_hop_NIC1_name>
+----
+<1> Add NMState YAML syntax to configure host interfaces.
++
 [IMPORTANT]
 ====
 Once deployed, you cannot modify the `networkConfig` configuration setting of `install-config.yaml` file to make changes to the host network interface. Use the Kubernetes NMState Operator to make changes to the host network interface after deployment.
 ====
+
+. Optional: In the case of deploying {product-title} without a DHCP server on the `baremetal` network, use the following procedure to configure a static IP address for the bootstrap VM using Ignition:
+
+.. Create the `bootstrap_config.sh` file:
++
+[source,terminal]
+----
+$ cat bootstrap_config.sh
+#!/bin/bash
+BOOTSTRAP_CONFIG="[connection]
+type=ethernet
+interface-name=<interface_name>
+[ethernet]
+[ipv4]
+method=manual
+addresses=<ip_address>/<CIDR>
+gateway=
+dns=<dns_IP_address>"
+cat > bootstrap_network_config.ign << EOF
+{
+  "path": "/etc/NetworkManager/system-connections/ens3.nmconnection",
+  "mode": 384,
+  "contents": {
+    "source": "data:text/plain;charset=utf-8;base64,$(echo "${BOOTSTRAP_CONFIG}" | base64 -w 0)"
+  }
+}
+EOF
+----
++
+Replace `<interface_name>` with the name of the NIC. Replace `<ip_address>` and `<CIDR>` with the IP address and CIDR of the address range. Replace `<gateway_IP_address>` with the IP address of
+the gateway on the `baremetal` network. Replace `<dns_IP_address>` with the IP address of the DNS server on the `baremetal` network.
+
+.. Run the `bootstrap_config.sh` script to create the `json` configuration file:
++
+[source,terminal]
+----
+$ ./bootstrap_config.sh
+----
+
+.. Optional: Create a backup of the original `bootstrap.ign` file:
++
+[source,terminal]
+----
+$ mv clusterconfigs/bootstrap.ign clusterconfigs/bootstrap.ign.orig
+----
+
+.. Inject the Ignition file into the configuration:
++
+[source,terminal]
+----
+$ jq '.storage.files += $input' clusterconfigs/bootstrap.ign.orig --slurpfile input bootstrap_network_config.ign (output of bootstrap_config.sh) > clusterconfigs/bootstrap.ign
+----


### PR DESCRIPTION
Restructured the interfaces module to incorporate the workaround for deploying without a DHCP server on the baremetal network.

Fixes: [TELCODOCS-321](https://issues.redhat.com//browse/TELCODOCS-321)

See https://issues.redhat.com/browse/TELCODOCS-321 for additional details.

Preview URL: http://157.131.167.205/TELCODOCS-321-interfaces/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow

For release(s): 4.10
Signed-off-by: John Wilkins <jowilkin@redhat.com>
