### PR TITLE
WMCO-1156: Document WMCO proxy limitation

### DIFF
--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -26,6 +26,11 @@ Dual NIC is not supported on WMCO-managed Windows instances.
 
 * You are running an {product-title} cluster version 4.6.8 or later.
 
+[NOTE]
+====
+The WMCO is not supported in clusters that use a xref:../networking/enable-cluster-wide-proxy.html[cluster-wide proxy] because the WMCO is not able to route traffic through the proxy connection for the workloads.
+====
+
 [role="_additional-resources"]
 .Additional resources
 //* For the comprehensive prerequisites for the Windows Machine Config Operator, see xref:../windows_containers/understanding-windows-container-workloads.adoc#wmco-prerequisites_understanding-windows-container-workloads[Understanding Windows container workloads].

--- a/windows_containers/scheduling-windows-workloads.adoc
+++ b/windows_containers/scheduling-windows-workloads.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 You can schedule Windows workloads to Windows compute nodes.
 
+[NOTE]
+====
+The WMCO is not supported in clusters that use a xref:../networking/enable-cluster-wide-proxy.html[cluster-wide proxy] because the WMCO is not able to route traffic through the proxy connection for the workloads.
+====
+
 [discrete]
 == Prerequisites
 


### PR DESCRIPTION
https://github.com/openshift/windows-machine-config-operator/pull/1156/files

Previews: 
Added NOTE to
[Scheduling Windows container workloads](http://file.rdu.redhat.com/mburke/winc-cluster-proxy/windows_containers/scheduling-windows-workloads.html)
[Enabling Windows container workloads](http://file.rdu.redhat.com/mburke/winc-cluster-proxy/windows_containers/enabling-windows-container-workloads.html) 

Only these two WINC files are present as the topics are currently hidden in main awaiting the 6.0.0 release.
