### PR TITLE
contributing: streamline and improve docs for CI jobs

### DIFF
--- a/contributing_to_docs/tools_and_setup.adoc
+++ b/contributing_to_docs/tools_and_setup.adoc
@@ -36,7 +36,7 @@ upper right-hand corner.
 . In the terminal on your workstation, change into the directory where you want
 to clone the forked repository.
 
-.  Clone the forked repository onto your workstation with the following
+. Clone the forked repository onto your workstation with the following
 command, replacing _<user_name>_ with your actual GitHub username.
 +
 ----
@@ -85,7 +85,7 @@ live content editing on a Fedora Linux system.
 +
 [NOTE]
 ====
-On certain systems, `yum` installs an older version of RubyGems that can cause issues. As an alternative, you can install RubyGems by using RVM. The following example is referenced from the link:https://rvm.io/rvm/install[RVM site]:
+On certain systems (such as RHEL 8), `yum` installs an older version of RubyGems that can cause issues. As an alternative, you can install RubyGems by using RVM. The following example is referenced from the link:https://rvm.io/rvm/install[RVM site]:
 
 [source,terminal]
 ----
@@ -93,16 +93,15 @@ $ curl -sSL https://get.rvm.io | bash -s stable --ruby
 ----
 ====
 
-2. Install _Ruby_ development packages with `yum install ruby-devel`
-3. Install _gcc_ with `yum install gcc-c++`
-4. Install _redhat-rpm-config_ with `yum install redhat-rpm-config`
-5. Install _make_ with `yum install make`
-6. Install _asciidoctor-diagram_ with `gem install asciidoctor-diagram`
-7. Install the _ascii_binder_ gem with `gem install ascii_binder`
+2. Install _Ruby_ development packages along with the necessary dependencies with `yum install gcc-c++ make redhat-rpm-config ruby-devel`
+3. Install the necessary _Asciidoctor_ and _AsciiBinder_ gems with `gem install asciidoctor asciidoctor-diagram ascii_binder`
 
-NOTE: If you already have AsciiBinder installed, you might be due for an update.
+NOTE: If you already have AsciiBinder and/or Asciidoctor installed, you might be due for an update.
 These directions assume that you are using AsciiBinder 0.2.0 or newer. To check
-and update if necessary, simply run `gem update ascii_binder`. Note that you might require root permissions.
+and update if necessary, simply run `gem update asciidoctor asciidoctor-diagram ascii_binder`. Note that this command
+may require root permissions.
+
+NOTE: It may be necessary to add the location of the `asciibinder` and `asciidoctor` binaries to your `PATH` environment variable after the installation is complete.  Use the following command to do so: `export PATH=$PATH:$HOME/bin`
 
 === Building the collection
 With the initial setup complete, you are ready to build the collection.
@@ -117,6 +116,46 @@ $ asciibinder build
 `openshift-docs/_preview/<distro>/<branch>` directory, with the same path and
 filename as the original `.adoc` file you edited, only it will be with the
 `.html` extension.
+
+=== Running CI jobs locally
+To avoid wasting CI resources, it is possible to run the same commands that the CI jobs run before creating a PR.
+This will help catch errors before the PR is submitted.
+
+1. Install PyYAML and the Aura package (must be in the `openshift-docs` directory)
++
+`$ pip3 install PyYAML aura.tar.gz`
++
+[NOTE]
+====
+If you encounter an error similar to the following:
+
+`PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.6'`
+
+You should re-run the command with the `--user` flag:
+
+`$ pip3 install --user PyYAML aura.tar.gz`
+====
+
+2. Run the following commands to build the various distributions of the documentation:
++
+----
+$ python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.11 --no-upstream-fetch && python3 makeBuild.py
+$ python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch && python3 makeBuild.py
+$ python3 build.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch && python3 makeBuild.py
+----
+
+[NOTE]
+====
+
+If you encounter errors about PyYAML when running these commands, i.e.
+
+`AttributeError: module 'yaml' has no attribute 'FullLoader'`
+
+...you likely already have the `PyYAML` package already installed and it should be updated via `pip3 install --upgrade PyYAML`
+====
+
+If the above `python3` commands complete successfully, there is no additional action needed and you may submit your PR.
+If the commands return errors, correct the highlighted errors before submitting a PR.
 
 == Clean up
 The `.gitignore` file is set up to prevent anything under the `_preview` and


### PR DESCRIPTION
While assisting folks with questions about how the OpenShift docs are
built and tested, I observed that there are no docs about running the
same commands that the Travis CI job runs.

This enhances the docs for contributing to the repo by streamlining
some of the commands being run, providing workarounds in the face of
possible errors, and providing instructions for configuring your
enivornment to run the same commands run during the CI jobs.
