### PR TITLE
[WIP] RHDEVDOCS-3785 Document configuring the Operator using TektonConfig CRD

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1801,6 +1801,8 @@ Topics:
     File: using-pipelines-as-code
   - Name: Working with OpenShift Pipelines using the Developer perspective
     File: working-with-pipelines-using-the-developer-perspective
+  - Name: Customizing configurations in the TektonConfig custom resource
+    File: customizing-configurations-in-the-tektonconfig-cr
   - Name: Reducing resource consumption of OpenShift Pipelines
     File: reducing-pipelines-resource-consumption
   - Name: Setting compute resource quota for OpenShift Pipelines

--- a/cicd/pipelines/customizing-configurations-in-the-tektonconfig-cr.adoc
+++ b/cicd/pipelines/customizing-configurations-in-the-tektonconfig-cr.adoc
@@ -1,0 +1,74 @@
+:_content-type: ASSEMBLY
+[id="customizing-configurations-in-the-tektonconfig-cr"]
+= Customizing configurations in the TektonConfig custom resource
+include::_attributes/common-attributes.adoc[]
+:context: customizing-configurations-in-the-tektonconfig-cr
+
+toc::[]
+
+You can customize the following {pipelines-title} behaviors by using the `TektonConfig` custom resource (CR):
+
+* Configuring the Tekton control plane
+* Disabling cluster tasks and pipeline templates
+* Changing the default service account
+* Disabling the automatic creation of RBAC resources
+* Pruning task runs and pipeline runs
+
+[NOTE] 
+====
+Most of the above are available in the release notes and need to get copied to a single doc that covers all configuration aspects.
+====
+
+Here is the default TektonConfig CR:
+
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  addon:
+    params:
+      - name: clusterTasks
+        value: 'true'
+      - name: pipelineTemplates
+        value: 'true'
+  pipeline:
+    running-in-environment-with-injected-sidecars: true
+    metrics.taskrun.duration-type: histogram
+    disable-home-env-overwrite: true
+    metrics.pipelinerun.duration-type: histogram
+    params:
+      - name: enableMetrics
+        value: 'true'
+    default-service-account: pipeline
+    disable-working-directory-overwrite: true
+    scope-when-expressions-to-task: false
+    require-git-ssh-secret-known-hosts: false
+    enable-tekton-oci-bundles: false
+    metrics.taskrun.level: task
+    metrics.pipelinerun.level: pipeline
+    enable-api-fields: stable
+    enable-custom-tasks: false
+    disable-creds-init: false
+    disable-affinity-assistant: true
+  config: {}
+  params:
+    - name: createRbacResource
+      value: 'true'
+  pruner:
+    keep: 100
+    resources:
+      - pipelinerun
+    schedule: 0 8 * * *
+  profile: all
+  targetNamespace: openshift-pipelines
+  dashboard:
+    readonly: false
+  trigger:
+    default-service-account: pipeline
+    enable-api-fields: stable
+----
+
+include::modules/op-creating-project-and-checking-pipeline-service-account.adoc[leveloffset=+1]


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`, `enterprise-4.12`, `enterprise-4.13`
- **JIRA issues**: [RHDEVDOCS-3785 Configuring Pipelines Operator using the TektonConfig CRD](https://issues.redhat.com/browse/RHDEVDOCS-3785)
- **Preview pages**: [Customizing configurations in the TektonConfig custom resource](http://file.pnq.redhat.com/sosarkar/3785-operator-config-using-tektonconfig-crd/cicd/pipelines/customizing-configurations-in-the-tektonconfig-cr.html)
- **SME review**: @sm43, @pradeepitm12 
- **QE review**: @VeereshAradhya