### PR TITLE
RHDEVDOCS-4266 Jenkins cleanup items

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1696,8 +1696,8 @@ Topics:
     File: images-other-jenkins-agent
   - Name: Migrating from Jenkins to OpenShift Pipelines
     File: migrating-from-jenkins-to-openshift-pipelines
-  - Name: OpenShift Jenkins
-    File: openshift-jenkins
+  - Name: Important changes to OpenShift Jenkins images
+    File: important-changes-to-openshift-jenkins-images
 ---
 Name: Images
 Dir: openshift_images

--- a/cicd/jenkins/images-other-jenkins.adoc
+++ b/cicd/jenkins/images-other-jenkins.adoc
@@ -18,7 +18,7 @@ For example:
 
 [source,terminal]
 ----
-$ podman pull registry.redhat.io/openshift4/ose-jenkins:<v4.3.0>
+$ podman pull registry.redhat.io/ocp-tools-4/jenkins-rhel8:<image_tag>
 ----
 
 To use these images, you can either access them directly from these registries or push them into your {product-title} container image registry. Additionally, you can create an image stream that points to the image, either in your container image registry or at the external location. Your {product-title} resources can then reference the image stream.
@@ -51,6 +51,10 @@ The Jenkins image can be run with mounted volumes to enable persistent storage f
 include::modules/images-other-jenkins-customize-s2i.adoc[leveloffset=+1]
 
 include::modules/images-other-jenkins-config-kubernetes.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../../cicd/jenkins/important-changes-to-openshift-jenkins-images.adoc#important-changes-to-openshift-jenkins-images[Important changes to OpenShift Jenkins images]
 
 include::modules/images-other-jenkins-permissions.adoc[leveloffset=+1]
 

--- a/cicd/jenkins/important-changes-to-openshift-jenkins-images.adoc
+++ b/cicd/jenkins/important-changes-to-openshift-jenkins-images.adoc
@@ -1,16 +1,16 @@
 :_content-type: ASSEMBLY
-[id="openshift-jenkins_{context}"]
-= {product-title} Jenkins
+[id="important-changes-to-openshift-jenkins-images"]
+= Important changes to OpenShift Jenkins images
 include::_attributes/common-attributes.adoc[]
-:context: openshift-jenkins
+:context: important-changes-to-openshift-jenkins-images
 
 toc::[]
 
-{product-title} 4.11 moves the "OpenShift Jenkins" and "OpenShift Agent Base" images to the `ocp-tools-4` repository at `registry.redhat.io`. It also removes the "OpenShift Jenkins Maven" and "NodeJS Agent" images from its payload:
+{product-title} 4.11 moves the OpenShift Jenkins and OpenShift Agent Base images to the `ocp-tools-4` repository at `registry.redhat.io`. It also removes the OpenShift Jenkins Maven and NodeJS Agent images from its payload:
 
-* {product-title} 4.11 moves the "OpenShift Jenkins" and "OpenShift Agent Base" images to the `ocp-tools-4` repository at `registry.redhat.io` so that Red Hat can produce and update the images outside the {product-title} lifecycle. Previously, these images were in the {product-title} install payload and the `openshift4` repository at `registry.redhat.io`.
+* {product-title} 4.11 moves the OpenShift Jenkins and OpenShift Agent Base images to the `ocp-tools-4` repository at `registry.redhat.io` so that Red Hat can produce and update the images outside the {product-title} lifecycle. Previously, these images were in the {product-title} install payload and the `openshift4` repository at `registry.redhat.io`.
 
-* {product-title} 4.10 deprecated the "OpenShift Jenkins Maven" and "NodeJS Agent" images. {product-title} 4.11 removes these images from its payload. Red Hat no longer produces these images, and they are not available from the `ocp-tools-4` repository at `registry.redhat.io`. Red Hat maintains the 4.10 and earlier versions of these images for any significant bug fixes or security CVEs, following the link:https://access.redhat.com/support/policy/updates/openshift[{product-title} lifecycle policy].
+* {product-title} 4.10 deprecated the OpenShift Jenkins Maven and NodeJS Agent images. {product-title} 4.11 removes these images from its payload. Red Hat no longer produces these images, and they are not available from the `ocp-tools-4` repository at `registry.redhat.io`. Red Hat maintains the 4.10 and earlier versions of these images for any significant bug fixes or security CVEs, following the link:https://access.redhat.com/support/policy/updates/openshift[{product-title} lifecycle policy].
 
 These changes support the {product-title} 4.10 recommendation to use xref:../../cicd/jenkins/images-other-jenkins.adoc#images-other-jenkins-config-kubernetes_images-other-jenkins[multiple container Pod Templates with the Jenkins Kubernetes Plug-in].
 
@@ -19,7 +19,7 @@ include::modules/relocation-of-openshift-jenkins-images.adoc[leveloffset=+1]
 include::modules/customizing-the-jenkins-image-stream-tag.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_openshift-jenkins_{context}"]
+[id="additional-resources_important-changes-to-openshift-jenkins-images_{context}"]
 == Additional resources
 
 * xref:../../openshift_images/managing_images/tagging-images.adoc#images-add-tags-to-imagestreams_tagging-images[Adding tags to image streams]
@@ -28,4 +28,6 @@ include::modules/customizing-the-jenkins-image-stream-tag.adoc[leveloffset=+1]
 * link:https://catalog.redhat.com/software/containers/search?q=Jenkins%202&p=1[Certified `jenkins` images]
 * link:https://catalog.redhat.com/software/containers/search?q=Jenkins%20Agent%20Base&p=1[Certified `jenkins-agent-base` images]
 * link:https://catalog.redhat.com/software/containers/search?q=jenkins-agent-maven&p=1[Certified `jenkins-agent-maven` images]
+// Writer, remove this line in 4.12
 * link:https://catalog.redhat.com/software/containers/search?q=jenkins-agent-nodejs&p=1[Certified `jenkins-agent-nodejs` images]
+// Writer, remove this line in 4.12

--- a/modules/customizing-the-jenkins-image-stream-tag.adoc
+++ b/modules/customizing-the-jenkins-image-stream-tag.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cicd/jenkins/openshift-jenkins.adoc
+// * cicd/jenkins/important-changes-to-openshift-jenkins-images.adoc
 :_content-type: PROCEDURE
 
 [id="customizing-the-jenkins-image-stream-tag_{context}"]

--- a/modules/images-other-jenkins-agent-images.adoc
+++ b/modules/images-other-jenkins-agent-images.adoc
@@ -12,27 +12,12 @@ Jenkins images are available through the Red Hat Registry:
 
 [source,terminal]
 ----
-$ docker pull registry.redhat.io/openshift4/ose-jenkins:<v4.5.0>
+$ docker pull registry.redhat.io/ocp-tools-4/jenkins-rhel8:<image_tag>
 ----
 
 [source,terminal]
 ----
-$ docker pull registry.redhat.io/openshift4/jenkins-agent-nodejs-10-rhel7:<v4.5.0>
-----
-
-[source,terminal]
-----
-$ docker pull registry.redhat.io/openshift4/jenkins-agent-nodejs-12-rhel7:<v4.5.0>
-----
-
-[source,terminal]
-----
-$ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-maven:<v4.5.0>
-----
-
-[source,terminal]
-----
-$ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-base:<v4.5.0>
+$ docker pull registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:<image_tag>
 ----
 
 To use these images, you can either access them directly from link:https://quay.io[Quay.io] or link:https://registry.redhat.io[registry.redhat.io] or push them into your {product-title} container image registry.

--- a/modules/images-other-jenkins-auth.adoc
+++ b/modules/images-other-jenkins-auth.adoc
@@ -18,5 +18,5 @@ The first time Jenkins starts, the configuration is created along with the admin
 ----
 $ oc new-app -e \
     JENKINS_PASSWORD=<password> \
-    openshift4/ose-jenkins
+    ocp-tools-4/jenkins-rhel8
 ----

--- a/modules/images-other-jenkins-config-kubernetes.adoc
+++ b/modules/images-other-jenkins-config-kubernetes.adoc
@@ -6,9 +6,18 @@
 [id="images-other-jenkins-config-kubernetes_{context}"]
 = Configuring the Jenkins Kubernetes plug-in
 
-The {product-title} Jenkins image includes the pre-installed link:https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin[Kubernetes plug-in] that allows Jenkins agents to be dynamically provisioned on multiple container hosts using Kubernetes and {product-title}.
+The OpenShift Jenkins image includes the pre-installed link:https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin[Kubernetes plug-in] so that Jenkins agents can be dynamically provisioned on multiple container hosts using Kubernetes and {product-title}.
 
 To use the Kubernetes plug-in, {product-title} provides images that are suitable for use as Jenkins agents, including the Base, Maven, and Node.js images.
+
+[IMPORTANT]
+====
+{product-title} 4.11 moves the OpenShift Jenkins and OpenShift Agent Base images to the `ocp-tools-4` repository at `registry.redhat.io` so that Red Hat can produce and update the images outside the {product-title} lifecycle. Previously, these images were in the {product-title} install payload and the `openshift4` repository at `registry.redhat.io`.
+
+{product-title} 4.11 removes the OpenShift Jenkins Maven and NodeJS Agent images from its payload. Red Hat no longer produces these images, and they are not available from the `ocp-tools-4` repository at `registry.redhat.io`. Red Hat maintains the 4.10 and earlier versions of these images for any significant bug fixes or security CVEs, following the link:https://access.redhat.com/support/policy/updates/openshift[{product-title} lifecycle policy].
+
+For more information, see the "Important changes to OpenShift Jenkins images" link in the following "Additional resources" section.
+====
 
 Both the Maven and Node.js agent images are automatically configured as Kubernetes pod template images within the {product-title} Jenkins image configuration for the Kubernetes plug-in. That configuration includes labels for each of the images that can be applied to any of your Jenkins jobs under their Restrict where this project can be run setting. If the label is applied, jobs run under an {product-title} pod running the respective agent image.
 
@@ -66,6 +75,7 @@ data:
         <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
           <name>jnlp</name>
           <image>openshift/jenkins-agent-maven-35-centos7:v3.10</image>
+          // Writer, remove or update this in 4.12
           <privileged>false</privileged>
           <alwaysPullImage>true</alwaysPullImage>
           <workingDir>/tmp</workingDir>
@@ -110,7 +120,7 @@ data:
           <containers>
             <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
               <name>jnlp</name>
-              <image>image-registry.openshift-image-registry.svc:5000/openshift/jenkins-agent-base:latest</image>
+              <image>image-registry.openshift-image-registry.svc:5000/openshift/jenkins-agent-base-rhel8:latest</image>
               <privileged>false</privileged>
               <alwaysPullImage>true</alwaysPullImage>
               <workingDir>/home/jenkins/agent</workingDir>

--- a/modules/images-other-jenkins-env-var.adoc
+++ b/modules/images-other-jenkins-env-var.adoc
@@ -82,19 +82,10 @@ By default, the JVM sets the initial heap size.
 |When running this image with an {product-title} PVC for the Jenkins configuration directory, this environment variable allows the fatal error log file to persist when a fatal error occurs. The fatal error file is saved at `/var/lib/jenkins/logs`.
 |Default: `false`
 
-|`NODEJS_SLAVE_IMAGE`
-|Setting this value overrides the image that is used for the default Node.js agent pod configuration. A related image stream tag named `jenkins-agent-nodejs` is in the project. This variable must be set before Jenkins starts the first time for it to have an effect.
-|Default Node.js agent image in Jenkins server: `image-registry.openshift-image-registry.svc:5000/openshift/jenkins-agent-nodejs:latest`
-
-|`MAVEN_SLAVE_IMAGE`
-|Setting this value overrides the image used for the default maven agent pod configuration. A related image stream tag named `jenkins-agent-maven` is in the project. This variable must be set before Jenkins starts the first time for it to have an effect.
-|Default Maven agent image in Jenkins server:
-`image-registry.openshift-image-registry.svc:5000/openshift/jenkins-agent-maven:latest`
-
 |`AGENT_BASE_IMAGE`
-|Setting this value overrides the image used for the `jnlp` container in the sample Kubernetes plug-in pod templates provided with this image. Otherwise, the image from the `jenkins-agent-base:latest` image stream tag in the `openshift` namespace is used.
+|Setting this value overrides the image used for the `jnlp` container in the sample Kubernetes plug-in pod templates provided with this image. Otherwise, the image from the `jenkins-agent-base-rhel8:latest` image stream tag in the `openshift` namespace is used.
 |Default:
-`image-registry.openshift-image-registry.svc:5000/openshift/jenkins-agent-base:latest`
+`image-registry.openshift-image-registry.svc:5000/openshift/jenkins-agent-base-rhel8:latest`
 
 |`JAVA_BUILDER_IMAGE`
 |Setting this value overrides the image used for the `java-builder` container in the `java-builder` sample Kubernetes plug-in pod templates provided with this image. Otherwise, the image from the `java:latest` image stream tag in the `openshift` namespace is used.

--- a/modules/images-other-jenkins-kubernetes-plugin.adoc
+++ b/modules/images-other-jenkins-kubernetes-plugin.adoc
@@ -100,6 +100,8 @@ spec:
 <8> An environment variable `CONTAINER_HEAP_PERCENT`, with value `0.25`, is specified.
 <9> The node stanza references the name of the defined pod template.
 
+// Writer, remove or update jenkins-agent-maven reference in 4.12
+
 By default, the pod is deleted when the build completes. This behavior can be modified with the plug-in or within a pipeline Jenkinsfile.
 
 Upstream Jenkins has more recently introduced a YAML declarative format for defining a `podTemplate` pipeline DSL in-line with your pipelines. An example of this format, using the sample `java-builder` pod template that is defined in the {product-title} Jenkins image:
@@ -122,7 +124,7 @@ metadata:
 spec:
   containers:
   - name: jnlp
-    image: image-registry.openshift-image-registry.svc:5000/openshift/jenkins-agent-base:latest
+    image: image-registry.openshift-image-registry.svc:5000/openshift/jenkins-agent-base-rhel8:latest
     args: ['\$(JENKINS_SECRET)', '\$(JENKINS_NAME)']
   - name: java
     image: image-registry.openshift-image-registry.svc:5000/openshift/java:latest

--- a/modules/installation-restricted-network-samples.adoc
+++ b/modules/installation-restricted-network-samples.adoc
@@ -22,29 +22,6 @@ Mirroring
 will not apply to these image streams.
 endif::[]
 
-[IMPORTANT]
-====
-The `jenkins`, `jenkins-agent-maven`, and `jenkins-agent-nodejs` image streams
-come from the install payload and are managed by the Samples
-ifdef::restrictednetwork[]
-Operator, so no further mirroring procedures are needed for those image streams.
-endif::[]
-ifdef::samplesoperatoraltreg[]
-Operator.
-endif::[]
-
-Setting the `samplesRegistry` field in the Sample Operator configuration file to link:https://registry.redhat.io[registry.redhat.io] is redundant because it is already directed to link:https://registry.redhat.io[registry.redhat.io] for everything but Jenkins images and image streams.
-
-////
-The Cluster Samples Operator prevents the use of the following registries for the Jenkins image streams:
-
-* link:https://docker.io[docker.io]
-* link:https://registry.redhat.io[registry.redhat.io]
-* link:https://registry.access.redhat.com[registry.access.redhat.com]
-* link:https://quay.io[quay.io].
-////
-====
-
 [NOTE]
 ====
 The `cli`, `installer`, `must-gather`, and `tests` image streams, while

--- a/modules/relocation-of-openshift-jenkins-images.adoc
+++ b/modules/relocation-of-openshift-jenkins-images.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * cicd/jenkins/openshift-jenkins.adoc
+// * cicd/jenkins/important-changes-to-openshift-jenkins-images.adoc
 :_content-type: CONCEPT
 
 [id="relocation-of-openshift-jenkins-images_{context}"]
@@ -23,11 +23,11 @@ Previously, each Jenkins image supported only one version of {product-title} and
 
 .What additions are there with the OpenShift Jenkins and Jenkins Agent Base ImageStream and ImageStreamTag objects?
 
-By moving from an "in-payload" image stream to an image stream that references non-payload images, {product-title} can define additional image stream tags. Red Hat has created a series of new image stream tags to go along with the existing `"value": "jenkins:2"` and `"value": "image-registry.openshift-image-registry.svc:5000/openshift/jenkins-agent-base:latest"` image stream tags present in {product-title} 4.10 and earlier. These new image stream tags address some requests to improve how the Jenkins-related image streams are maintained.
+By moving from an in-payload image stream to an image stream that references non-payload images, {product-title} can define additional image stream tags. Red Hat has created a series of new image stream tags to go along with the existing `"value": "jenkins:2"` and `"value": "image-registry.openshift-image-registry.svc:5000/openshift/jenkins-agent-base-rhel8:latest"` image stream tags present in {product-title} 4.10 and earlier. These new image stream tags address some requests to improve how the Jenkins-related image streams are maintained.
 
 About the new image stream tags:
 
-`ocp-upgrade-redeploy`:: To update your Jenkins image when you upgrade {product-title}, use this image stream tag in your Jenkins deployment configuration. This image stream tag corresponds to the existing `2` image stream tag of the `jenkins` image stream and the `latest` image stream tag of the `jenkins-agent-base` image stream. It employs an image tag specific to only one SHA or image digest. When the `ocp-tools-4` image changes, such as for Jenkins security advisories, Red Hat Engineering updates the Cluster Samples Operator payload.
+`ocp-upgrade-redeploy`:: To update your Jenkins image when you upgrade {product-title}, use this image stream tag in your Jenkins deployment configuration. This image stream tag corresponds to the existing `2` image stream tag of the `jenkins` image stream and the `latest` image stream tag of the `jenkins-agent-base-rhel8` image stream. It employs an image tag specific to only one SHA or image digest. When the `ocp-tools-4` image changes, such as for Jenkins security advisories, Red Hat Engineering updates the Cluster Samples Operator payload.
 
 `user-maintained-upgrade-redeploy`:: To manually redeploy Jenkins after you upgrade {product-title}, use this image stream tag in your Jenkins deployment configuration. This image stream tag uses the least specific image version indicator available. When you redeploy Jenkins, run the following command: `$ oc import-image jenkins:user-maintained-upgrade-redeploy -n openshift`. When you issue this command, the {product-title} `ImageStream` controller accesses the `registry.redhat.io` image registry and stores any updated images in the {product-title} internal image registry's slot for that Jenkins `ImageStreamTag` object. Otherwise, if you do not run this command, your Jenkins deployment configuration does not trigger a redeployment.
 
@@ -36,7 +36,7 @@ About the new image stream tags:
 
 .What happens with the `jenkins-agent-maven` and `jenkins-agent-nodejs` image streams in the `openshift` namespace?
 
-The "OpenShift Jenkins Maven" and "NodeJS Agent" images for {product-title} were deprecated in 4.10, and are removed from the {product-title} install payload in 4.11. They do not have alternatives defined in the `ocp-tools-4` repository. However, you can work around this by using the sidecar pattern described in the "Jenkins agent" topic mentioned in the following "Additional resources" section.
+The OpenShift Jenkins Maven and NodeJS Agent images for {product-title} were deprecated in 4.10, and are removed from the {product-title} install payload in 4.11. They do not have alternatives defined in the `ocp-tools-4` repository. However, you can work around this by using the sidecar pattern described in the "Jenkins agent" topic mentioned in the following "Additional resources" section.
 
 However, the Cluster Samples Operator does not delete the `jenkins-agent-maven` and `jenkins-agent-nodejs` image streams created by prior releases, which point to the tags of the respective {product-title} payload images on `registry.redhat.io`. Therefore, you can pull updates to these images by running the following commands:
 


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4266
- Direct link to doc preview: 
  - [Configuring Jenkins images](https://rolfedh.github.io/previews/RHDEVDOCS-4266/cicd/jenkins/images-other-jenkins.html)
  - [Jenkins agent](https://rolfedh.github.io/previews/RHDEVDOCS-4266/cicd/jenkins/images-other-jenkins-agent.html)
  - [Important changes to OpenShift Jenkins images](https://rolfedh.github.io/previews/RHDEVDOCS-4266/cicd/jenkins/important-changes-to-openshift-jenkins-images.html)
  - [Using Cluster Samples Operator image streams with alternate or mirrored registries](https://rolfedh.github.io/previews/RHDEVDOCS-4266/openshift_images/samples-operator-alt-registry.html#installation-restricted-network-samples_samples-operator-alt-registry)

- SME review: @coreydaley (approved)
- QE review: @jitendar-singh  (waiting)
- Peer review: @bburt-rh (approved)
- All reviews complete. Please merge now.