### PR TITLE
OSDOCS-3881 - Updating the OCM support tab content

### DIFF
--- a/modules/ocm-support-tab.adoc
+++ b/modules/ocm-support-tab.adoc
@@ -5,4 +5,9 @@
 [id="ocm-support-tab_{context}"]
 = Support tab
 
-The **Support** tab allows you to add individuals that should receive notifications about this cluster.  Also from this tab, users can open a support case ticket should technical support be required.
+In the *Support* tab, you can add notification contacts for individuals that should receive cluster notifications. The username or email address that you provide must relate to a user account in the Red Hat organization where the cluster is deployed.
+ifdef::openshift-dedicated,openshift-rosa[]
+For the steps to add a notification contact, see _Adding cluster notification contacts_.
+endif::openshift-dedicated,openshift-rosa[]
+
+Also from this tab, you can open a support case to request technical support for your cluster.

--- a/ocm/ocm-overview.adoc
+++ b/ocm/ocm-overview.adoc
@@ -59,3 +59,9 @@ include::modules/ocm-settings-tab.adoc[leveloffset=+2]
 == Additional resources
 
 * For the complete documentation for {cluster-manager}, see link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2022/html-single/managing_clusters/index[{cluster-manager} documentation].
+ifdef::openshift-dedicated[]
+* For steps to add cluster notification contacts, see xref:../osd_cluster_admin/osd_logging/osd-accessing-the-service-logs.adoc#adding-cluster-notification-contacts_osd-accessing-the-service-logs[Adding cluster notification contacts].
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+* For steps to add cluster notification contacts, see xref:../rosa_cluster_admin/rosa_logging/rosa-accessing-the-service-logs.adoc#adding-cluster-notification-contacts_rosa-accessing-the-service-logs[Adding cluster notification contacts].
+endif::openshift-rosa[]


### PR DESCRIPTION
This applies to `main`, `enterprise-4.11` and `enterprise-4.10`.

This PR relates to https://issues.redhat.com/browse/OSDOCS-3881.

The previews are as follows:

#### OCP

- http://file.fab.redhat.com/pneedle/pr48679/ocp/ocm-overview-ocp.html#ocm-support-tab_ocm-overview-ocp

#### OpenShift Dedicated

- http://file.fab.redhat.com/pneedle/pr48679/osd/ocm/ocm-overview.html#ocm-support-tab_ocm-overview

#### ROSA

- http://file.fab.redhat.com/pneedle/pr48679/rosa/ocm/ocm-overview.html#ocm-support-tab_ocm-overview