### PR TITLE
[enterprise-4.6] BZ2100901: Adds a note about usage of a CIDR range

### DIFF
--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -192,6 +192,12 @@ the cluster uses this values as the number of etcd endpoints in the cluster, the
 value must match the number of control plane machines that you deploy.
 <6> The cluster name that you specified in your DNS records.
 <7> A block of IP addresses from which pod IP addresses are allocated. This block must not overlap with existing physical networks. These IP addresses are used for the pod network. If you need to access the pods from an external network, you must configure load balancers and routers to manage the traffic.
++
+[NOTE]
+====
+Class E CIDR range is reserved for a future use. To use the Class E CIDR range, you must ensure your networking environment accepts the IP addresses within the Class E CIDR range.
+====
++
 <8> The subnet prefix length to assign to each individual node. For example, if
 `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of
 the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IPs addresses. If


### PR DESCRIPTION
CP PR for https://github.com/openshift/openshift-docs/pull/48437