### PR TITLE
[RHACS] Fixed the missing - in --file option

### DIFF
--- a/modules/using-cli.adoc
+++ b/modules/using-cli.adoc
@@ -134,7 +134,7 @@ For examle, the following command checks a deployment and then displays the resu
 [source,terminal]
 ----
 $ roxctl -e "$ROX_CENTRAL_ADDRESS" \
-  deployment check -file =<yaml_filename> \
+  deployment check --file =<yaml_filename> \
   -o csv
 ----
 


### PR DESCRIPTION
Minor change

Applies to 

- `rhacs-docs-3.68`
- `rhacs-docs-3.69`
- `rhacs-docs-3.70`
- `rhacs-docs-3.71`

Preview: https://openshift-docs-git-minor-fileoption-fix-gnelson.vercel.app/openshift-acs/master/cli/getting-started-cli.html#check-policy-compliance_cli-getting-started

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
