### PR TITLE
Adds the understanding AWS Load Balancer Operator page

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1047,6 +1047,8 @@ Topics:
   Dir: aws_load_balancer_operator
   Distros: openshift-enterprise,openshift-origin
   Topics:
+  - Name: Understanding the AWS Load Balancer Operator
+    File: understanding-aws-load-balancer-operator  
   - Name: Installing the AWS Load Balancer Operator
     File: install-aws-load-balancer-operator
   - Name: Creating an instance of the AWS Load Balancer Controller

--- a/modules/nw-aws-load-balancer-logs.adoc
+++ b/modules/nw-aws-load-balancer-logs.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+// * networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.adoc
+
+:_content-type: PROCEDURE
+[id="nw-aws-load-balancer-operator-logs_{context}"]
+= AWS Load Balancer Operator logs
+
+Use the `oc logs` command to view the AWS Load Balancer Operator logs.
+
+.Procedure
+
+* View the logs of the AWS Load Balancer Operator:
++
+[source,terminal]
+----
+$ oc logs -n aws-load-balancer-operator deployment/aws-load-balancer-operator-controller-manager -c manager
+----

--- a/modules/nw-aws-load-balancer-operator.adoc
+++ b/modules/nw-aws-load-balancer-operator.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+// * networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.adoc
+
+:_content-type: PROCEDURE
+[id="nw-aws-load-balancer-operator_{context}"]
+= AWS Load Balancer Operator
+
+The AWS Load Balancer Operator can tag the public subnets if the `kubernetes.io/role/elb` tag is missing. Also, the AWS Load Balancer Operator detects the following from the underlying AWS cloud:
+
+* The ID of the virtual private cloud (VPC) on which the cluster hosting the Operator is deployed in.
+
+* Public and private subnets of the discovered VPC.
+
+.Prerequisites
+
+* You must have the AWS credentials secret. The credentials are used to provide subnet tagging and VPC discovery.
+
+.Procedure
+
+. You can deploy the AWS Load Balancer Operator on demand from the OperatorHub, by creating a `Subscription` object:
++
+[source,terminal]
+----
+$ oc -n aws-load-balancer-operator get sub aws-load-balancer-operator --template='{{.status.installplan.name}}{{"\n"}}'
+----
++
+.Example output
+[source,terminal]
+----
+install-zlfbt
+----
+
+. Check the status of an install plan. The status of an install plan must be `Complete`:
++
+[source,terminal]
+----
+$ oc -n aws-load-balancer-operator get ip <install_plan_name> --template='{{.status.phase}}{{"\n"}}'
+----
++
+.Example output
+[source,terminal]
+----
+Complete
+----
+
+. Use the `oc get` command to view the `Deployment` status:
++
+[source,terminal]
+----
+$ oc get -n aws-load-balancer-operator deployment/aws-load-balancer-operator-controller-manager
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                           READY     UP-TO-DATE   AVAILABLE   AGE
+aws-load-balancer-operator-controller-manager  1/1       1            1           23h
+----

--- a/networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.adoc
+++ b/networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.adoc
@@ -1,0 +1,13 @@
+:_content-type: ASSEMBLY
+[id="aws-load-balancer-operator"]
+= AWS Load Balancer Operator in {product-title}
+include::_attributes/common-attributes.adoc[]
+:context: aws-load-balancer-operator
+
+toc::[]
+
+The AWS Load Balancer (ALB) Operator deploys and manages an instance of the `aws-load-balancer-controller`. You can install the ALB Operator from the OperatorHub by using {product-title} web console or CLI.
+
+include::modules/nw-aws-load-balancer-operator.adoc[leveloffset=+1]
+
+include::modules/nw-aws-load-balancer-logs.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: None
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/sdudhgao/understanding-ALB-Operator/networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. -->

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->

@alebedev87- LGTM'd