### PR TITLE
RHDEVDOCS-4258 Distinguish between stopping support for v1alpha1 and …

### DIFF
--- a/modules/op-release-notes-1-8.adoc
+++ b/modules/op-release-notes-1-8.adoc
@@ -26,14 +26,20 @@ include::snippets/technology-preview.adoc[]
 
 * Support for the `tekton.dev/v1alpha1` API version, which was deprecated in {pipelines-title} GA 1.6, is planned to be removed in the upcoming {pipelines-title} GA 1.9 release.
 +
-This change affects the pipeline component, which includes the `TaskRun`, `PipelineRun`, `Task`, `Pipeline`, and similar `tekton.dev/v1alpha1` resources. The `operator.tekton.dev/v1alpha1` API version is not deprecated and still used by the Operator.
+This change affects the pipeline component, which includes the `TaskRun`, `PipelineRun`, `Task`, `Pipeline`, and similar `tekton.dev/v1alpha1` resources. As an alternative, update existing resources to use `apiVersion: tekton.dev/v1beta1` as described in link:https://tekton.dev/docs/pipelines/migrating-v1alpha1-to-v1beta1/[Migrating From Tekton v1alpha1 to Tekton v1beta1].
 +
-Bug fixes and support for the `tekton.dev/v1alpha1` API version are provided only through the end of the current GA 1.8 lifecycle. Use the `tekton.dev/v1beta1` API version instead.
+Bug fixes and support for the `tekton.dev/v1alpha1` API version are provided only through the end of the current GA 1.8 lifecycle.
++
+[IMPORTANT]
+====
+For the *Tekton Operator*, the `operator.tekton.dev/v1alpha1` API version is *not* deprecated. You do not need to make changes to this value.
+====
 //  (link:https://github.com/tektoncd/triggers/pull/1103[#1103])
 
-* In {pipelines-title} 1.8, support for the `PipelineResource` custom resource (CR) has been removed. The `PipelineResource` CR was a Tech Preview feature and part of the `tekton.dev/v1alpha1` API.
 
-* In {pipelines-title} 1.8, support for the `Condition` custom resource (CR) has been removed. The `PipelineResource` CR was part of the `tekton.dev/v1alpha1` API.
+* In {pipelines-title} 1.8, the `PipelineResource` custom resource (CR) is available but no longer supported. The `PipelineResource` CR was a Tech Preview feature and part of the `tekton.dev/v1alpha1` API, which had been deprecated and planned to be removed in the upcoming {pipelines-title} GA 1.9 release.
+
+* In {pipelines-title} 1.8, the `Condition` custom resource (CR) is removed. The `Condition` CR was part of the `tekton.dev/v1alpha1` API, which has been deprecated and is planned to be removed in the upcoming {pipelines-title} GA 1.9 release.
 
 [id="known-issues-1-8_{context}"]
 == Known issues


### PR DESCRIPTION
- This is a continuation of https://github.com/openshift/openshift-docs/pull/48576, which I accidentally closed and cannot reopen.
- Aligned team: Dev Tools
- For branches: 4.11
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4258
- Direct link to doc preview: [Deprecated and removed features (in the Release Notes)](https://rolfedh.github.io/previews/RHDEVDOCS-4258/cicd/pipelines/op-release-notes.html#deprecated-features-1-8_op-release-notes)
- SME review: @siamaksade @vdemeester 
- QE review: @ppitonak
- Peer review: @ 	tbd
- <All reviews complete. Please merge now>