### PR TITLE
Incorporated 4.10 bootstrap nodes when no DHCP server

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -42,7 +42,9 @@ include::modules/ipi-install-modifying-install-config-for-dual-stack-network.ado
 include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
+
+* See link:http://nmstate.io/examples.html#interfaces-ethernet[the NMState documentation] for additional examples of NMState syntax.
 
 * xref:../../release_notes/ocp-4-10-release-notes.adoc#ocp-4-10-known-issues[OpenShift Container Platform 4.10 release notes]
 
@@ -63,7 +65,17 @@ include::modules/ipi-install-deploying-routers-on-worker-nodes.adoc[leveloffset=
 
 include::modules/ipi-install-configuring-bios-for-worker-node.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* See the xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration] documentation for additional details.
+
 include::modules/ipi-install-configuring-raid-for-worker-node.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See the xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration] documentation for additional details.
 
 include::modules/ipi-install-creating-a-disconnected-registry.adoc[leveloffset=+1]
 
@@ -79,6 +91,8 @@ include::modules/ipi-install-mirroring-for-disconnected-registry.adoc[leveloffse
 
 include::modules/ipi-modify-install-config-for-a-disconnected-registry.adoc[leveloffset=+2]
 
+include::modules/ipi-install-assigning-a-static-ip-address-to-the-bootstrap-vm.adoc[leveloffset=+1]
+
 include::modules/ipi-install-validation-checklist-for-installation.adoc[leveloffset=+1]
 
 include::modules/ipi-install-deploying-the-cluster-via-the-openshift-installer.adoc[leveloffset=+1]
@@ -88,6 +102,7 @@ include::modules/ipi-install-following-the-installation.adoc[leveloffset=+1]
 include::modules/ipi-install-verifying-static-ip-address-configuration.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_creating_manifest_ignition"]
 == Additional resources
-
+* xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-generate-k8s-manifest-ignition_installing-bare-metal[Creating the Kubernetes manifest and Ignition config files]
 * xref:../../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[{product-title} upgrade channels and releases]

--- a/modules/ipi-install-assigning-a-static-ip-address-to-the-bootstrap-vm.adoc
+++ b/modules/ipi-install-assigning-a-static-ip-address-to-the-bootstrap-vm.adoc
@@ -1,0 +1,67 @@
+// This is included in the following assemblies:
+//
+// ipi-install-installation-workflow.adoc
+
+:_content-type: PROCEDURE
+[id="assigning-a-static-ip-address-to-the-bootstrap-vm_{context}"]
+= Assigning a static IP address to the bootstrap VM
+
+If you are deploying {product-title} without a DHCP server on the `baremetal` network, you must configure a static IP address for the bootstrap VM using Ignition.
+
+.Procedure
+
+. Create the ignition configuration files:
++
+[source,terminal]
+----
+$ ./openshift-baremetal-install --dir <cluster_configs> create ignition-configs
+----
++
+Replace `<cluster_configs>` with the path to your cluster configuration files.
+
+. Create the `bootstrap_config.sh` file:
++
+[source,bash]
+----
+#!/bin/bash
+
+BOOTSTRAP_CONFIG="[connection]
+type=ethernet
+interface-name=ens3
+[ethernet]
+[ipv4]
+method=manual
+addresses=<ip_address>/<cidr>
+gateway=<gateway_ip_address>
+dns=<dns_ip_address>"
+
+cat <<_EOF_ > bootstrap_network_config.ign
+{
+  "path": "/etc/NetworkManager/system-connections/ens3.nmconnection",
+  "mode": 384,
+  "contents": {
+    "source": "data:text/plain;charset=utf-8;base64,$(echo "${BOOTSTRAP_CONFIG}" | base64 -w 0)"
+  }
+}
+_EOF_
+
+mv <cluster_configs>/bootstrap.ign <cluster_configs>/bootstrap.ign.orig
+
+jq '.storage.files += $input' <cluster_configs>/bootstrap.ign.orig --slurpfile input bootstrap_network_config.ign > <cluster_configs>/bootstrap.ign
+----
++
+Replace `<ip_address>` and `<cidr>` with the IP address and CIDR of the address range. Replace `<gateway_ip_address>` with the IP address of the gateway on the `baremetal` network. Replace `<dns_ip_address>` with the IP address of the DNS server on the `baremetal` network. Replace `<cluster_configs>` with the path to your cluster configuration files.
+
+. Make the `bootstrap_config.sh` file executable:
++
+[source,terminal]
+----
+$ chmod 755 bootstrap_config.sh
+----
+
+. Run the `bootstrap_config.sh` script to create the `bootstrap_network_config.ign` file:
++
+[source,terminal]
+----
+$ ./bootstrap_config.sh
+----

--- a/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -6,64 +6,101 @@
 [id="configuring-host-network-interfaces-in-the-install-config-yaml-file_{context}"]
 = (Optional) Configuring host network interfaces
 
-During installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState. To use the `networkConfig` configuration setting, you must provide an NMState YAML configuration.
+Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState.
 
-[IMPORTANT]
+The most common use case for this functionality is to specify a static IP address on the `baremetal` network, but you can also configure other networks such as a storage network. This functionality supports other NMState features such as VLAN, VXLAN, bridges, bonds, routes, MTU, and DNS resolver settings.
+
+.Prequisites
+
+* Configure a `PTR` DNS record with a valid hostname for each node with a static IP address.
+* Install the NMState CLI (`nmstate`).
+
+.Procedure
+
+. Optional: Consider testing the NMState syntax with `nmstatectl gc` before including it in the `install-config.yaml` file, because the installer will not check the NMState YAML syntax.
++
+[NOTE]
 ====
-Before configuring host network interfaces, review the OpenShift Container Platform 4.10 release notes.
-
-link:https://bugzilla.redhat.com/show_bug.cgi?id=2048600[*BZ#2048600*] is a known issue where the bootstrap VM does not receive an IP address in the absence of a DHCP server. To assign an IP address to the bootstrap VM, see link:https://access.redhat.com/articles/6850661[Assigning a bootstrap VM an IP address on the baremetal network without a DHCP server].
-
-link:https://bugzilla.redhat.com/show_bug.cgi?id=2036677[*BZ#2036677*] is a known issue where the configured IP addresses get reset by the DHCP server, if present. To prevent DHCP from assigning an IP address to a node on reboot, see link:https://access.redhat.com/articles/6865841[Preventing DHCP from assigning an IP address on node reboot].
+Errors in the YAML syntax might result in a failure to apply the network configuration. Additionally, maintaining the validated YAML syntax is useful when applying changes using Kubernetes NMState after deployment or when expanding the cluster.
 ====
 
-See link:https://nmstate.io/examples.html#interfaces-ethernet[NMState] for additional examples of the NMState syntax.
 
-.Example
+.. Create an NMState YAML file:
++
 [source,yaml]
 ----
-  hosts:
-        - name: openshift-master-0
-          role: master
-          bmc:
-            address: redfish+http://<out-of-band-ip>/redfish/v1/Systems/
-            username: <user>
-            password: <password>
-            disableCertificateVerification: null
-          bootMACAddress: <NIC1_mac_address>
-          bootMode: UEFI
-          rootDeviceHints:
-            deviceName: "/dev/sda"
-          networkConfig: <1>
-            interfaces:
-            - name: <NIC1_name>
-              type: ethernet
-              state: up
-              ipv4:
-                address:
-                - ip: "<IP_address>"
-                  prefix-length: 24
-                enabled: true
-            dns-resolver:
-              config:
-                server:
-                - <DNS_IP_address>
-            routes:
-              config:
-              - destination: 0.0.0.0/0
-                next-hop-address: <IP_address>
-                next-hop-interface: <NIC1_name>
+interfaces:
+- name: <nic1_name> <1>
+  type: ethernet
+  state: up
+  ipv4:
+    address:
+    - ip: <ip_address> <1>
+      prefix-length: 24
+    enabled: true
+dns-resolver:
+  config:
+    server:
+    - <dns_ip_address> <1>
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: <next_hop_ip_address> <1>
+    next-hop-interface: <next_hop_nic1_name> <1>
 ----
-<1> Add NMState YAML syntax to configure host interfaces.
++
+<1> Replace `<nic1_name>`, `<ip_address>`, `<dns_ip_address>`, `<next_hop_ip_address>` and `<next_hop_nic1_name>` with appropriate values.
 
-[TIP]
-====
-Consider saving the `networkConfig` YAML syntax to a file and testing it using the NMState command line interface before including it in the `install-config.yaml` file, because the installer will not check the NMState YAML syntax. Execute `nmstatectl gc <yaml-config>` to test the syntax. Errors in the YAML syntax might result in a failure to apply the network configuration. Additionally, maintaining the validated YAML syntax is useful when applying changes using Kubernetes NMState after deployment or when expanding the cluster.
-====
+.. Test the configuration file by running the following command:
++
+[source,terminal]
+----
+$ nmstatectl gc <nmstate_yaml_file>
+----
++
+Replace `<nmstate_yaml_file>` with the configuration file name.
 
-The most common use case for this functionality is to specify a static IP address on the `baremetal` network, but you can also configure other networks such as a storage network. This functionality will also support other NMState features such as VLAN, VXLAN, bridges, bonds, routes, MTU, and DNS resolver settings.
-
+. Use the `networkConfig` configuration setting by adding the NMState configuration to hosts within the `install-config.yaml` file:
++
+[source,yaml]
+----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish+http://<out_of_band_ip>/redfish/v1/Systems/
+          username: <user>
+          password: <password>
+          disableCertificateVerification: null
+        bootMACAddress: <NIC1_mac_address>
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: "/dev/sda"
+        networkConfig: <1>
+          interfaces:
+          - name: <nic1_name> <2>
+            type: ethernet
+            state: up
+            ipv4:
+              address:
+              - ip: <ip_address> <2>
+                prefix-length: 24
+              enabled: true
+          dns-resolver:
+            config:
+              server:
+              - <dns_ip_address> <2>
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-address: <next_hop_ip_address> <2>
+              next-hop-interface: <next_hop_nic1_name> <2>
+----
+<1> Add the NMState YAML syntax to configure the host interfaces.
++
+<2> Replace `<nic1_name>`, `<ip_address>`, `<dns_ip_address>`, `<next_hop_ip_address>` and `<next_hop_nic1_name>` with appropriate values.
++
 [IMPORTANT]
 ====
-Once deployed, you cannot modify the `networkConfig` configuration setting of `install-config.yaml` file to make changes to the host network interface. Use the Kubernetes NMState Operator to make changes to the host network interface after deployment.
+After deploying the cluster, you cannot modify the `networkConfig` configuration setting of `install-config.yaml` file to make changes to the host network interface. Use the Kubernetes NMState Operator to make changes to the host network interface after deployment.
 ====


### PR DESCRIPTION
When deploying without a DHCP server, the bootstrap VM doesn't get an IP address unless the following workaround is not included. It was published as a KBase article. This PR incorporates it into the 4.10 module.

Version(s): 4.10

Issue: https://issues.redhat.com/browse/TELCODOCS-321

Link to docs preview: http://jowilkin.com:8080/TELCODOCS-321-interfaces-4.10/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow

Signed-off-by: John Wilkins <jowilkin@redhat.com>