### PR TITLE
CNV20102: new upgrade doc note for NMO

### DIFF
--- a/virt/upgrading-virt.adoc
+++ b/virt/upgrading-virt.adoc
@@ -8,6 +8,16 @@ toc::[]
 
 Learn how Operator Lifecycle Manager (OLM) delivers z-stream and minor version updates for {VirtProductName}.
 
+[NOTE]
+====
+* The Node Maintenance Operator (NMO) is no longer shipped with {VirtProductName}. You can xref:../nodes/nodes/eco-node-maintenance-operator.adoc#node-maintenance-operator[install the NMO] from the *OperatorHub* in the {product-title} web console, or by using the OpenShift CLI (`oc`).
++
+You must perform one of the following tasks before updating to {VirtProductName} 4.11 from {VirtProductName} 4.10.2 and later releases:
+
+** Move all nodes out of maintenance mode.
+** Install the standalone NMO and replace the `nodemaintenances.nodemaintenance.kubevirt.io` custom resource (CR) with a `nodemaintenances.nodemaintenance.medik8s.io` CR.
+====
+
 include::modules/virt-about-upgrading-virt.adoc[leveloffset=+1]
 
 [id="configuring-workload-updates_upgrading-virt"]


### PR DESCRIPTION
Version(s): 4.11+

Issue: [CNV-20102](https://issues.redhat.com//browse/CNV-20102)

Link to docs preview: [preview unavailable at this time.](http://file.rdu.redhat.com/sjess/CNV20102/virt/upgrading-virt.html#virt-about-upgrading-virt_upgrading-virt)