### PR TITLE
Removed backticks from module titles.

### DIFF
--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="configuring-the-install-config-file_{context}"]
-= Configuring the `install-config.yaml` file
+= Configuring the install-config.yaml file
 
 The `install-config.yaml` file requires some additional details.
 Most of the information teaches the installation program and the resulting cluster enough about the available hardware that it is able to fully manage it.

--- a/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id='modifying-install-config-for-no-provisioning-network_{context}']
-= (Optional) Deploying with no `provisioning` network
+= (Optional) Deploying with no provisioning network
 
 To deploy an {product-title} cluster without a `provisioning` network, make the following changes to the `install-config.yaml` file.
 


### PR DESCRIPTION
There were two titles with backticks. Those were removed. That's all. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>

Version(s): 4.11

Issue: I've been using https://bugzilla.redhat.com/show_bug.cgi?id=2004210 to track a number of editorial only changes.

Link to docs preview: http://157.131.167.205/BZ-2004210/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-the-install-config-file_ipi-install-installation-workflow

http://157.131.167.205/BZ-2004210/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#modifying-install-config-for-no-provisioning-network_ipi-install-installation-workflow