### PR TITLE
BZ 2004210: Separate the configuing networking steps into their own module.

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -10,6 +10,8 @@ include::modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc[levelo
 
 include::modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc[leveloffset=+1]
 
+include::modules/ipi-install-configuring-networking.adoc[leveloffset=+1]
+
 include::modules/ipi-install-retrieving-the-openshift-installer.adoc[leveloffset=+1]
 
 include::modules/ipi-install-extracting-the-openshift-installer.adoc[leveloffset=+1]

--- a/modules/ipi-install-configuring-networking.adoc
+++ b/modules/ipi-install-configuring-networking.adoc
@@ -1,0 +1,108 @@
+// This is included in the following assemblies:
+//
+// ipi-install-installation-workflow.adoc
+
+:_content-type: PROCEDURE
+[id="configuring-networking_{context}"]
+= Configuring networking
+
+Before installation, you must configure the networking on the provisioner node. Installer-provisioned clusters deploy with a `baremetal` bridge and network, and an optional `provisioning` bridge and network.
+
+image::210_OpenShift_Baremetal_IPI_Deployment_updates_0122_1.png[Configure networking]
+
+[NOTE]
+====
+You can also configure networking from the web console.
+====
+
+.Procedure
+
+. Export the `baremetal` network NIC name:
++
+[source,terminal]
+----
+$ export PUB_CONN=<baremetal_nic_name>
+----
+
+. Configure the `baremetal` network:
++
+[source,terminal]
+----
+$ sudo nohup bash -c "
+    nmcli con down \"$PUB_CONN\"
+    nmcli con delete \"$PUB_CONN\"
+    # RHEL 8.1 appends the word \"System\" in front of the connection, delete in case it exists
+    nmcli con down \"System $PUB_CONN\"
+    nmcli con delete \"System $PUB_CONN\"
+    nmcli connection add ifname baremetal type bridge con-name baremetal
+    nmcli con add type bridge-slave ifname \"$PUB_CONN\" master baremetal
+    pkill dhclient;dhclient baremetal
+"
+----
++
+[NOTE]
+====
+The ssh connection might disconnect after executing these steps.
+====
+
+. Optional: If you are deploying with a `provisioning` network, export the `provisioning` network NIC name:
++
+[source,terminal]
+----
+$ export PROV_CONN=<prov_nic_name>
+----
+
+. Optional: If you are deploying with a `provisioning` network, configure the `provisioning` network:
++
+[source,terminal]
+----
+$ sudo nohup bash -c "
+    nmcli con down \"$PROV_CONN\"
+    nmcli con delete \"$PROV_CONN\"
+    nmcli connection add ifname provisioning type bridge con-name provisioning
+    nmcli con add type bridge-slave ifname \"$PROV_CONN\" master provisioning
+    nmcli connection modify provisioning ipv6.addresses fd00:1101::1/64 ipv6.method manual
+    nmcli con down provisioning
+    nmcli con up provisioning
+"
+----
++
+[NOTE]
+====
+The ssh connection might disconnect after executing these steps.
+
+The IPv6 address can be any address as long as it is not routable via the `baremetal` network.
+
+Ensure that UEFI is enabled and UEFI PXE settings are set to the IPv6 protocol when using IPv6 addressing.
+====
+
+. Optional: If you are deploying with a `provisioning` network, configure the IPv4 address on the `provisioning` network connection:
++
+[source,terminal]
+----
+$ nmcli connection modify provisioning ipv4.addresses 172.22.0.254/24 ipv4.method manual
+----
+
+. `ssh` back into the `provisioner` node (if required):
++
+[source,terminal]
+----
+# ssh kni@provisioner.<cluster-name>.<domain>
+----
+
+. Verify the connection bridges have been properly created:
++
+[source,terminal]
+----
+$ sudo nmcli con show
+----
++
+[source,terminal]
+----
+NAME               UUID                                  TYPE      DEVICE
+baremetal          4d5133a5-8351-4bb9-bfd4-3af264801530  bridge    baremetal
+provisioning       43942805-017f-4d7d-a2c2-7cb3324482ed  bridge    provisioning
+virbr0             d9bca40f-eee1-410b-8879-a2d4bb0465e7  bridge    virbr0
+bridge-slave-eno1  76a8ed50-c7e5-4999-b4f6-6d9014dd0812  ethernet  eno1
+bridge-slave-eno2  f31c3353-54b7-48de-893a-02d2b34c4736  ethernet  eno2
+----

--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -34,7 +34,6 @@ Perform the following steps to prepare the environment.
 # chmod 0440 /etc/sudoers.d/kni
 ----
 
-
 . Create an `ssh` key for the new user:
 +
 [source,terminal]
@@ -117,98 +116,6 @@ $ sudo virsh pool-start default
 [source,terminal]
 ----
 $ sudo virsh pool-autostart default
-----
-
-. Configure networking.
-+
-[NOTE]
-====
-You can also configure networking from the web console.
-====
-+
-Export the `baremetal` network NIC name:
-+
-[source,terminal]
-----
-$ export PUB_CONN=<baremetal_nic_name>
-----
-+
-Configure the `baremetal` network:
-+
-[source,terminal]
-----
-$ sudo nohup bash -c "
-    nmcli con down \"$PUB_CONN\"
-    nmcli con delete \"$PUB_CONN\"
-    # RHEL 8.1 appends the word \"System\" in front of the connection, delete in case it exists
-    nmcli con down \"System $PUB_CONN\"
-    nmcli con delete \"System $PUB_CONN\"
-    nmcli connection add ifname baremetal type bridge con-name baremetal
-    nmcli con add type bridge-slave ifname \"$PUB_CONN\" master baremetal
-    pkill dhclient;dhclient baremetal
-"
-----
-+
-If you are deploying with a `provisioning` network, export the `provisioning` network NIC name:
-+
-[source,terminal]
-----
-$ export PROV_CONN=<prov_nic_name>
-----
-+
-If you are deploying with a `provisioning` network, configure the `provisioning` network:
-+
-[source,terminal]
-----
-$ sudo nohup bash -c "
-    nmcli con down \"$PROV_CONN\"
-    nmcli con delete \"$PROV_CONN\"
-    nmcli connection add ifname provisioning type bridge con-name provisioning
-    nmcli con add type bridge-slave ifname \"$PROV_CONN\" master provisioning
-    nmcli connection modify provisioning ipv6.addresses fd00:1101::1/64 ipv6.method manual
-    nmcli con down provisioning
-    nmcli con up provisioning
-"
-----
-+
-[NOTE]
-====
-The `ssh` connection might disconnect after executing these steps.
-
-The IPv6 address can be any address as long as it is not routable via the `baremetal` network.
-
-Ensure that UEFI is enabled and UEFI PXE settings are set to the IPv6 protocol when using IPv6 addressing.
-====
-
-. Configure the IPv4 address on the `provisioning` network connection:
-+
-[source,terminal]
-----
-$ nmcli connection modify provisioning ipv4.addresses 172.22.0.254/24 ipv4.method manual
-----
-
-. `ssh` back into the `provisioner` node (if required):
-+
-[source,terminal]
-----
-# ssh kni@provisioner.<cluster-name>.<domain>
-----
-
-. Verify the connection bridges have been properly created:
-+
-[source,terminal]
-----
-$ sudo nmcli con show
-----
-+
-[source,terminal]
-----
-NAME               UUID                                  TYPE      DEVICE
-baremetal          4d5133a5-8351-4bb9-bfd4-3af264801530  bridge    baremetal
-provisioning       43942805-017f-4d7d-a2c2-7cb3324482ed  bridge    provisioning
-virbr0             d9bca40f-eee1-410b-8879-a2d4bb0465e7  bridge    virbr0
-bridge-slave-eno1  76a8ed50-c7e5-4999-b4f6-6d9014dd0812  ethernet  eno1
-bridge-slave-eno2  f31c3353-54b7-48de-893a-02d2b34c4736  ethernet  eno2
 ----
 
 . Create a `pull-secret.txt` file:


### PR DESCRIPTION
This long-standing BZ was found to not be a bug; however, we did agree that the module of "Preparing the provisioner node" was too long, and that the step of "Configuring networking" should be a standalone module. This PR makes that change. The PR: 

1. Removes the "Configure networking" steps from the "Preparing the provisioner node" module.
2. Creates a new "Configuring networking" module. 
3. Incorporates an introduction and the pre-install networking graphic.
4. Adds "Optional" to the optional provisioning network steps. 

There are no changes to the procedures. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>

Version(s): 4.11

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2004210

Link to docs preview: http://157.131.167.205/BZ-2004210-separate-networking/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-networking_ipi-install-installation-workflow