### PR TITLE
[OSDOCS-2970]: AWS Marketplace images in machineset YAML

### DIFF
--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -125,13 +125,13 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ifndef::infra[]
 <2> Specify the infrastructure ID, node label, and zone.
 <3> Specify the node label to add.
-<4> Specify a valid {op-system-first} AMI for your AWS zone for your {product-title} nodes.
+<4> Specify a valid {op-system-first} AMI for your AWS zone for your {product-title} nodes. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
 endif::infra[]
 ifdef::infra[]
 <2> Specify the infrastructure ID, `<infra>` node label, and zone.
 <3> Specify the `<infra>` node label.
 <4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
-<5> Specify a valid {op-system-first} AMI for your AWS zone for your {product-title} nodes.
+<5> Specify a valid {op-system-first} AMI for your AWS zone for your {product-title} nodes. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
~4.10+~
4.8+

:heavy_check_mark: Also 4.8-4.9, ~but needs to wait for the installer content backport, which is not a simple CP. Will add labels and CP for 4.8-4.9 later.~
Cc: @bscott-rh 

Issue:
[OSDOCS-2970](https://issues.redhat.com//browse/OSDOCS-2970)

Link to docs preview:
- [Sample YAML for a machine set custom resource on AWS
](http://file.rdu.redhat.com/jrouth/OSDOCS-2970-AWS-marketplace-machine-sets/machine_management/creating_machinesets/creating-machineset-aws.html#machineset-yaml-aws_creating-machineset-aws)
- [Sample YAML for a machine set custom resource on AWS](http://file.rdu.redhat.com/jrouth/OSDOCS-2970-AWS-marketplace-machine-sets/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-aws_creating-infrastructure-machinesets) (infra version)

Additional information:
Relates to #48413 (installer), #50617 (installer 4.9), #50559 (installer 4.8), and #48797 (Azure machine set content)