### PR TITLE
[RHACS] Version fix for 3.70

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -44,11 +44,10 @@ endif::[]
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 3.70.0
+:rhacs-version: 3.70.1
 :ocp-supported-version: 4.5
+:product-title: Red Hat Advanced Cluster Security for Kubernetes
+:product-version: 3.70
+:product-title-short: RHACS
 // Following are used in modules/configure-policy-notifications.adoc
 :toolname: PagerDuty
-// Following variables are required for publishing using PV2
-:product-title: Red Hat Advanced Cluster Security for Kubernetes
-:product-version: 3.70.1
-:product-title-short: RHACS


### PR DESCRIPTION
Fixes version number to 3.70.1

Applies to `rhacs-docs-3.70`

Preview: https://openshift-docs-git-version-fix-370-gnelson.vercel.app/openshift-acs/master/installing/install-quick-roxctl.html#installing-cli-on-linux_install-quick-roxctl