### PR TITLE
[RHACS] Fix version number for 3.71.0

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -47,7 +47,7 @@ endif::[]
 :rhacs-version: 3.71.0
 :ocp-supported-version: 4.5
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
-:product-version: 3.71.0
+:product-version: 3.71
 :product-title-short: RHACS
 // Following are used in modules/configure-policy-notifications.adoc
 :toolname: PagerDuty


### PR DESCRIPTION
Fix product version for rhacs-3.71

Applies to `rhacs-docs-3.71`

Preview: https://openshift-docs-git-fix-version-3.71-gnelson.vercel.app/