### PR TITLE
[GH#45384] Cleans up documentation mistakes on uninstalling GitOps.

### DIFF
--- a/modules/go-deleting-argocd-instance.adoc
+++ b/modules/go-deleting-argocd-instance.adoc
@@ -14,7 +14,7 @@ Delete the Argo CD instances added to the namespace of the GitOps Operator.
 
 [source,terminal]
 ----
-$ oc delete gitopsservice cluster -n openshift-gitops
+$ oc delete gitopsservice cluster
 ----
 
 [NOTE]
@@ -22,11 +22,11 @@ $ oc delete gitopsservice cluster -n openshift-gitops
 You cannot delete an Argo CD cluster from the web console UI.
 ====
 
-After the command runs successfully all the Argo CD instances will be deleted from the `openshift-gitops` namespace.
+After the previous command runs successfully the default `gitopsservice` and its respective Argo CD instance will be deleted from the `openshift-gitops` namespace.
 
-Delete any other Argo CD instances from other namespaces using the same command:
+Delete any other custom ArgoCD instances from other namespaces by running the following command:
 
 [source,terminal]
 ----
-$ oc delete gitopsservice cluster -n <namespace>
+$ oc delete argocd <argocd-name> -n <namespace>
 ----


### PR DESCRIPTION
Version(s):
Any versions with GitOps information.  

Issue:
https://github.com/openshift/openshift-docs/issues/45384

GitOpsService is not a namespaced object:

```
# oc api-resources | grep -E "NAMESPACED|gitopsservice"
NAME                                  SHORTNAMES                     APIVERSION                                            NAMESPACED   KIND
gitopsservices                                                       pipelines.openshift.io/v1alpha1                       false        GitopsService
```

In addition, there can only be one GitOpsService in a cluster that functions to create the default ArgoCD instance.  However, users can add additional namespaced ArgoCD instances.  These would need to be cleaned up manually.

