### PR TITLE
RHDEVDOCS-4303 - Added release notes for 1.4.11 and 1.5.5

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -25,6 +25,8 @@ include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 // Modules included, most to least recent
 include::modules/gitops-release-notes-1-6-0.adoc[leveloffset=+1]
 
+include::modules/gitops-release-notes-1-5-5.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-5-4.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-5-3.adoc[leveloffset=+1]
@@ -34,6 +36,8 @@ include::modules/gitops-release-notes-1-5-2.adoc[leveloffset=+1]
 include::modules/gitops-release-notes-1-5-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-5-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-4-11.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-4-6.adoc[leveloffset=+1]
 

--- a/modules/gitops-release-notes-1-4-11.adoc
+++ b/modules/gitops-release-notes-1-4-11.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-4-11_{context}"]
+= Release notes for {gitops-title} 1.4.11
+
+{gitops-title} 1.4.11 is now available on {product-title} 4.8, 4.9, and 4.10.
+
+[id="new-features-1-4-11_{context}"]
+== New features
+
+The current release adds the following improvements:
+
+* With this update, the bundled Argo CD has been updated to version 2.2.12.
+
+[id="fixed-issues-1-4-11_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, the `redis-ha-haproxy` pods of an ArgoCD instance failed when more restrictive SCCs were present in the cluster. This update fixes the issue by updating the security context in workloads. link:https://issues.redhat.com/browse/GITOPS-2034[GITOPS-2034]
+
+[id="known-issues-1-4-11_{context}"]
+== Known issues
+
+*  {gitops-title} Operator can use RHSSO (KeyCloak) with OIDC and Dex. However, with a recent security fix applied, the Operator cannot validate the RHSSO certificate in some scenarios. link:https://issues.redhat.com/browse/GITOPS-2214[GITOPS-2214]
++
+As a workaround, disable TLS validation for the OIDC (Keycloak/RHSSO) endpoint in the ArgoCD specification. 
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  extraConfig:
+    "admin.enabled": "true"
+...
+----

--- a/modules/gitops-release-notes-1-5-5.adoc
+++ b/modules/gitops-release-notes-1-5-5.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-5-5_{context}"]
+= Release notes for {gitops-title} 1.5.5
+
+{gitops-title} 1.5.5 is now available on {product-title} 4.8, 4.9, and 4.10.
+
+[id="new-features-1-5-5_{context}"]
+== New features
+
+The current release adds the following improvements:
+
+* With this update, the bundled Argo CD has been updated to version 2.3.7.
+
+[id="fixed-issues-1-5-5_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, the `redis-ha-haproxy` pods of an ArgoCD instance failed when more restrictive SCCs were present in the cluster. This update fixes the issue by updating the security context in workloads. link:https://issues.redhat.com/browse/GITOPS-2034[GITOPS-2034]
+
+[id="known-issues-1-5-5_{context}"]
+== Known issues
+
+*  {gitops-title} Operator can use RHSSO (KeyCloak) with OIDC and Dex. However, with a recent security fix applied, the Operator cannot validate the RHSSO certificate in some scenarios. link:https://issues.redhat.com/browse/GITOPS-2214[GITOPS-2214]
++
+As a workaround, disable TLS validation for the OIDC (Keycloak/RHSSO) endpoint in the ArgoCD specification. 
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  extraConfig:
+    "admin.enabled": "true"
+...
+----


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise- 4.10, 4.11

JIRA issue:
https://issues.redhat.com/browse/RHDEVDOCS-4303

Preview pages: https://drive.google.com/file/d/1Piq2Shz7renj6iI-DXYnLxSFQRqjIT9m/view?usp=sharing

SME+QE review: @jannfis @wtam2018 
Peer-review: @rolfedh 