### PR TITLE
[OSDOCS-2969]: Azure Marketplace images in machineset YAML

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -40,6 +40,10 @@ include::modules/machineset-yaml-azure.adoc[leveloffset=+3]
 
 Machine sets running on Azure support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-non-guaranteed-instance_creating-machineset-azure[Spot VMs]. You can save on costs by using Spot VMs at a lower price compared to standard VMs on Azure. You can xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-azure[configure Spot VMs] by adding `spotVMOptions` to the `MachineSet` YAML file.
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#installation-azure-marketplace-subscribe_creating-machineset-azure[Selecting an Azure Marketplace image]
+
 include::modules/machineset-yaml-azure-stack-hub.adoc[leveloffset=+3]
 
 [NOTE]

--- a/machine_management/creating_machinesets/creating-machineset-azure.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure.adoc
@@ -20,6 +20,9 @@ include::modules/machineset-yaml-azure.adoc[leveloffset=+1]
 //Creating a machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 
+//Selecting an Azure Marketplace image
+include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+1]
+
 //Machine sets that deploy machines as Spot VMs
 include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
 

--- a/modules/installation-azure-marketplace-subscribe.adoc
+++ b/modules/installation-azure-marketplace-subscribe.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/installing_aws/installing-azure-customizations.adoc
 // * installing/installing_aws/installing-azure-user-infra.adoc
+// * machine_management/creating-machineset-azure.adoc
 
 ifeval::["{context}" == "installing-azure-customizations"]
 :ipi:
@@ -9,13 +10,22 @@ endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]
 :upi:
 endif::[]
+ifeval::["{context}" == "creating-machineset-azure"]
+:mapi:
+endif::[]
 
 //mpytlak: The procedure differs depending on whether this module is used in an IPI or UPI assembly.
+//jrouth: Also some variations for when it appears in the machine management content (`mapi`).
 
 :_content-type: PROCEDURE
 [id="installation-azure-marketplace-subscribe_{context}"]
 = Selecting an Azure Marketplace image
+ifndef::mapi[]
 If you are deploying an {product-title} cluster using the Azure Marketplace offering, you must first obtain the Azure Marketplace image. The installation program uses this image to deploy worker nodes. When obtaining your image, consider the following:
+endif::mapi[]
+ifdef::mapi[]
+You can create a machine set running on Azure that deploys machines that use the Azure Marketplace offering. To use this offering, you must first obtain the Azure Marketplace image. When obtaining your image, consider the following:
+endif::mapi[]
 
 * While the images are the same, the Azure Marketplace publisher is different depending on your region. If you are located in North America, specify `redhat` as the publisher. If you are located in EMEA, specify `redhat-limited` as the publisher.
 * The offer includes a `rh-ocp-worker` SKU and a `rh-ocp-worker-gen1` SKU. The `rh-ocp-worker` SKU represents a Hyper-V generation version 2 VM image. The default instance types used in {product-title} are version 2 compatible. If you are going to use an instance type that is only version 1 compatible, use the image associated with the `rh-ocp-worker-gen1` SKU. The `rh-ocp-worker-gen1` SKU represents a Hyper-V version 1 VM image.
@@ -111,6 +121,9 @@ endif::ipi[]
 ifdef::upi[]
 . Record the image details of your offer. If you use the Azure Resource Manager (ARM) template to deploy your worker nodes, you can update `storageProfile.imageReference` by deleting the `id` parameter and adding the `offer`, `publisher`, `sku`, and `version` parameters using the values from your offer.
 endif::upi[]
+ifdef::mapi[]
+. Record the image details of your offer, specifically the values for `publisher`, `offer`, `sku`, and `version`.
+endif::mapi[]
 
 ifdef::ipi[]
 .Sample `install-config.yaml` file with the Azure Marketplace worker nodes
@@ -133,10 +146,30 @@ compute:
   replicas: 3
 ----
 endif::ipi[]
+ifdef::mapi[]
+. Add the following parameters to the `providerSpec` section of your machine set YAML file using the image details for your offer:
++
+.Sample `providerSpec` image values for Azure Marketplace compute machines
+[source,yaml]
+----
+providerSpec:
+  value:
+    image:
+      offer: rh-ocp-worker
+      publisher: redhat
+      resourceID: ""
+      sku: rh-ocp-worker
+      type: MarketplaceWithPlan
+      version: 4.8.2021122100
+----
+endif::mapi[]
 
 ifeval::["{context}" == "installing-azure-customizations"]
 :!ipi:
 endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]
 :!upi:
+endif::[]
+ifeval::["{context}" == "creating-machineset-azure"]
+:!mapi:
 endif::[]

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -81,15 +81,15 @@ endif::infra[]
           credentialsSecret:
             name: azure-cloud-credentials
             namespace: openshift-machine-api
-          image:
+          image: <5>
             offer: ""
             publisher: ""
-            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/images/<infrastructure_id> <5>
+            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/images/<infrastructure_id> <6>
             sku: ""
             version: ""
           internalLoadBalancer: ""
           kind: AzureMachineProviderSpec
-          location: <region> <6>
+          location: <region> <7>
           managedIdentity: <infrastructure_id>-identity <1>
           metadata:
             creationTimestamp: null
@@ -110,9 +110,9 @@ endif::infra[]
             name: worker-user-data <2>
           vmSize: Standard_D4s_v3
           vnet: <infrastructure_id>-vnet <1>
-          zone: "1" <7>
+          zone: "1" <8>
 ifdef::infra[]
-      taints: <8>
+      taints: <9>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -149,11 +149,12 @@ ifdef::infra[]
 <3> Specify the infrastructure ID, `<infra>` node label, and region.
 endif::infra[]
 <4> Optional: Specify the machine set name to enable the use of availability sets. This setting only applies to new compute machines.
-<5> Specify an image that is compatible with your instance type. The Hyper-V generation V2 images created by the installation program have a `-gen2` suffix, while V1 images have the same name without the suffix.
-<6> Specify the region to place machines on.
-<7> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
+<5> Specify the image details for your machine set. If you want to use an Azure Marketplace image, see "Selecting an Azure Marketplace image".
+<6> Specify an image that is compatible with your instance type. The Hyper-V generation V2 images created by the installation program have a `-gen2` suffix, while V1 images have the same name without the suffix.
+<7> Specify the region to place machines on.
+<8> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
 ifdef::infra[]
-<8> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<9> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 endif::infra[]
 
 


### PR DESCRIPTION
Version(s):
4.8+

Also 4.8-4.10, but needs to wait for the installer content backport, which is not a simple CP. ~Will add labels and CP for 4.8-4.10 later.~
Cc: @bscott-rh

Installer backports:
4.8: https://github.com/openshift/openshift-docs/pull/50828
4.9: https://github.com/openshift/openshift-docs/pull/50895
4.10: https://github.com/openshift/openshift-docs/pull/51370

Issue:
[OSDOCS-2969](https://issues.redhat.com//browse/OSDOCS-2969)

Link to docs preview:
- [Sample YAML for a machine set custom resource on Azure
](http://file.rdu.redhat.com/jrouth/OSDOCS-2969-Azure-marketplace-machine-sets/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-yaml-azure_creating-machineset-azure)
- [Selecting an Azure Marketplace image](http://file.rdu.redhat.com/jrouth/OSDOCS-2969-Azure-marketplace-machine-sets/machine_management/creating_machinesets/creating-machineset-azure.html#installation-azure-marketplace-subscribe_creating-machineset-azure)
- [Sample YAML for a machine set custom resource on Azure](http://file.rdu.redhat.com/jrouth/OSDOCS-2969-Azure-marketplace-machine-sets/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-azure_creating-infrastructure-machinesets) (infra version)

Additional information:
Relates to #48577 (installer, should merge first) and #48753 (AWS machine set content)