### PR TITLE
OSDOCS-3625: IPv6 and dual-stack support

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -614,7 +614,7 @@ With hosted control planes for {product-title}, you can host clusters at scale t
 Open Virtual Network (OVN) was redesigned to host its control plane and data store alongside the cluster's control plane. With hosted control planes, OVN supports split control planes.
 
 [id="ocp-4-11-dual-stack-user-provisioned-bare-metal-ovn-kubernetes-network-provider"]
-==== Dual-stack support on user-provisioned bare metal infrastructure with the OVN-Kubernetes cluster network provider
+==== IPv6 single and dual-stack support on user-provisioned bare metal infrastructure with the OVN-Kubernetes cluster network provider
 
 For clusters on user-provisioned xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-configuration-parameters-network_installing-bare-metal-network-customizations[bare metal infrastructure], the OVN-Kubernetes cluster network provider supports both IPv4 and IPv6 address families.
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-3625

Also state IPv6 single-stack support.

Preview
```
http://shell.lab.bos.redhat.com/~jboxman/rn-OSDOCS-3625/release_notes/ocp-4-11-release-notes.html#ocp-4-11-dual-stack-user-provisioned-bare-metal-ovn-kubernetes-network-provider
```
(gets eaten by GitHub)