### PR TITLE
OSSMDOC-641: Update Federation for OSSM 2.2.

### DIFF
--- a/modules/ossm-federation-checklist.adoc
+++ b/modules/ossm-federation-checklist.adoc
@@ -12,15 +12,15 @@ Federating services meshes involves the following activities:
 
 ** [ ] Configure the load balancers supporting the services associated with the federation gateways to support raw TLS traffic.
 
-* [ ] Installing the {SMProductName} version 2.1 Operator in each of your clusters.
+* [ ] Installing the {SMProductName} version 2.1 or later Operator in each of your clusters.
 
-* [ ] Deploying a version 2.1 `ServiceMeshControlPlane` to each of your clusters.
+* [ ] Deploying a version 2.1 or later `ServiceMeshControlPlane` to each of your clusters.
 
 * [ ] Configuring the SMCP for federation for each mesh that you want to federate:
 
-** [ ] Create a federation egress gateway for each mesh you are going to federate with
-** [ ] Create a federation ingress gateway for each mesh you are going to federate with
-** [ ] Configure a unique trust domain
+** [ ] Create a federation egress gateway for each mesh you are going to federate with.
+** [ ] Create a federation ingress gateway for each mesh you are going to federate with.
+** [ ] Configure a unique trust domain.
 
 * [ ] Federate two or more meshes by creating a `ServiceMeshPeer` resource for each mesh pair.
 


### PR DESCRIPTION
This is a "fresh" PR PR to replace #48327.  The original  PR also fixed typos ExportServiceSet -> ExportedServiceSet  and ImportServiceSet -> ImportedServiceSet, but then I forgot that I'd moved them to a separate PR and fixed them again in #48128.  When I went to rebase, somehow pulled to changes that I did not make. So, second attempt....  😛


This PR updates the federation docs for OSSM 2.2.  (updates references to 2.1 to read "2.1 or later" now that we have more than one release that supports federation)

Version(s): 4.6 - 4.11

Issue: [OSSMDOC - 641](https://issues.redhat.com/browse/OSSMDOC-641)

Link to docs preview: http://file.bos.redhat.com/jstickle/OSSMDOC-641/service_mesh/v2x/ossm-federation.html#ossm-federation-prerequisites_federation

Additional information:
QE Review: skondkar (review on #48327)
Peer Review: 