### PR TITLE
Added propagateusertags key value 

### DIFF
--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -150,15 +150,19 @@ platform:
   aws:
 ifndef::gov,china,secret[]
     region: us-west-2 <1>
+    propagateUserTags: true <3>
 endif::gov,china,secret[]
 ifdef::china[]
     region: cn-north-1 <1>
+    propagateUserTags: true <3>
 endif::china[]
 ifdef::gov[]
     region: us-gov-west-1 <1>
+    propagateUserTags: true <3>
 endif::gov[]
 ifdef::secret[]
     region: us-iso-east-1 <1>
+    propagateUserTags: true <3>
 endif::secret[]
     userTags:
       adminContact: jdoe

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -757,6 +757,10 @@ host must trust the certificate.
 |A map of keys and values that the installation program adds as tags to all resources that it creates.
 |Any valid YAML map, such as key value pairs in the `<key>: <value>` format. For more information about AWS tags, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html[Tagging Your Amazon EC2 Resources] in the AWS documentation.
 
+|`platform.aws.propagateUserTags`
+| A flag that directs in-cluster Operators to include the specified user tags in the tags of the AWS resources that the Operators create.
+| Boolean values, for example `true` or `false`.
+
 |`platform.aws.subnets`
 |If you provide the VPC instead of allowing the installation program to create the VPC for you, specify the subnet for the cluster to use. The subnet must be part of the same `machineNetwork[].cidr` ranges that you specify. For a standard cluster, specify a public and a private subnet for each availability zone. For a private cluster, specify a private subnet for each availability zone.
 |Valid subnet IDs.


### PR DESCRIPTION
This Pr adds the new key and value  to:

- Sample customized install-config.yaml file for AWS
- Optional AWS configuration parameters  
- Applies to 4.12 
- [Jira](https://issues.redhat.com/browse/CFE-524)
- [Preview 1](http://file.del.redhat.com/asakthiv/CFE509-524new/installing/installing_aws/installing-aws-customizations.html#installation-aws-config-yaml_installing-aws-customizations)
- [Preview 2](http://file.del.redhat.com/asakthiv/CFE509-524new/installing/installing_aws/installing-aws-customizations.html#installation-configuration-parameters_installing-aws-customizations)
- @TrilokGeer 


