### PR TITLE
Removing duplicate prereq

### DIFF
--- a/applications/odc-editing-applications.adoc
+++ b/applications/odc-editing-applications.adoc
@@ -10,7 +10,6 @@ You can edit the configuration and the source code of the application you create
 
 == Prerequisites
 
-* You have xref:../web_console/web-console.adoc#web-console[logged in to the web console] and have switched to the xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[About the *Developer* perspective].
 * You have the appropriate xref:../authentication/using-rbac.adoc#default-roles_using-rbac[roles and permissions] in a project to create and modify applications in {product-title}.
 * You have xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[created and deployed an application on {product-title} using the *Developer* perspective].
 * You have xref:../web_console/web-console.adoc#web-console[logged in to the web console] and have switched to xref:../web_console/web-console-overview.adoc#about-developer-perspective_web-console-overview[the *Developer* perspective].


### PR DESCRIPTION
Removing duplicate bullet that was introduced by #47809.

Version(s):
4.8+

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue:
None

Link to docs preview:
http://file.rdu.redhat.com/~ahoffer/2022/removing-dupe-bullet/applications/odc-editing-applications.html#prerequisites

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



