### PR TITLE
[SRVCOM-1840] Add Serverless 1.24.0 release notes

### DIFF
--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -13,18 +13,20 @@ For the most recent list of major functionality deprecated and removed within {S
 // OCP + OSD table
 ifdef::openshift-enterprise,openshift-dedicated[]
 .Deprecated and removed features tracker
-[cols="3,1,1,1,1",options="header"]
+[cols="3,1,1,1,1,1",options="header"]
 |====
-|Feature |1.20|1.21|1.22|1.23
+|Feature |1.20|1.21|1.22|1.23|1.24
 
 |`KafkaBinding` API
 |Deprecated
 |Deprecated
 |Removed
 |Removed
+|Removed
 
 |`kn func emit` (`kn func invoke` in 1.21+)
 |Deprecated
+|Removed
 |Removed
 |Removed
 |Removed
@@ -35,14 +37,16 @@ endif::[]
 // ROSA table
 ifdef::openshift-rosa[]
 .Deprecated and removed features tracker
-[cols="3,1",options="header"]
+[cols="3,1,1",options="header"]
 |====
-|Feature |1.23
+|Feature |1.23|1.24
 
 |`KafkaBinding` API
 |Removed
+|Removed
 
 |`kn func emit` (`kn func invoke` in 1.21+)
+|Removed
 |Removed
 
 |====

--- a/modules/serverless-rn-1-24-0.adoc
+++ b/modules/serverless-rn-1-24-0.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-24-0_{context}"]
+= Release notes for Red Hat {ServerlessProductName} 1.24.0
+
+{ServerlessProductName} 1.24.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+[id="new-features-1.24.0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.3.
+* {ServerlessProductName} now uses Knative Eventing 1.3.
+* {ServerlessProductName} now uses Kourier 1.3.
+* {ServerlessProductName} now uses Knative `kn` CLI 1.3.
+* {ServerlessProductName} now uses Knative Kafka 1.3.
+* The `kn func` CLI plug-in now uses `func` 0.24.
+
+* Init containers support for Knative services is now generally available (GA).
+
+* {ServerlessProductName} logic is now available as a Developer Preview. It enables defining declarative workflow models for managing serverless applications.
+
+ifdef::openshift-enterprise[]
+* You can now use the cost management service with {ServerlessProductName}.
+endif::[]
+
+[id="fixed-issues-1.24.0_{context}"]
+== Fixed issues
+
+* Integrating {ServerlessProductName} with {SMProductName} causes the `net-istio-controller` pod to run out of memory on startup when too many secrets are present on the cluster.
++
+It is now possible to enable secret filtering, which causes `net-istio-controller` to consider only secrets with a `networking.internal.knative.dev/certificate-uid` label, thus reducing the amount of memory needed.
+
+* The {FunctionsProductName} Technology Preview now uses link:https://buildpacks.io/[Cloud Native Buildpacks] by default to build container images.
+
+[id="known-issues-1-24-0_{context}"]
+== Known issues
+
+* The Federal Information Processing Standards (FIPS) mode is disabled for Kafka broker, Kafka source, and Kafka sink.
+
+* In {ServerlessProductName} 1.23, support for KafkaBindings and the `kafka-binding` webhook were removed. However, an existing `kafkabindings.webhook.kafka.sources.knative.dev MutatingWebhookConfiguration` might remain, pointing to the `kafka-source-webhook` service, which no longer exists.
++
+For certain specifications of KafkaBindings on the cluster, `kafkabindings.webhook.kafka.sources.knative.dev MutatingWebhookConfiguration` might be configured to pass any create and update events to various resources, such as Deployments, Knative Services, or Jobs, through the webhook, which would then fail.
++
+To work around this issue, manually delete `kafkabindings.webhook.kafka.sources.knative.dev MutatingWebhookConfiguration` from the cluster after upgrading to {ServerlessProductName} 1.23:
++
+[source,terminal]
+----
+$ oc delete mutatingwebhookconfiguration kafkabindings.webhook.kafka.sources.knative.dev
+----

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -13,61 +13,43 @@ The following table provides information about which {ServerlessProductName} fea
 // OCP + OSD table
 ifdef::openshift-enterprise,openshift-dedicated[]
 .Generally Available and Technology Preview features tracker
-[cols="3,1,1,1,1",options="header"]
+[cols="3,1,1",options="header"]
 |====
-|Feature |1.20|1.21|1.22|1.23
+|Feature |1.23|1.24
 
 |`kn func`
 |TP
 |TP
-|TP
-|TP
 
 |`kn func invoke`
-|-
-|TP
 |TP
 |TP
 
 |Service Mesh mTLS
 |GA
 |GA
-|GA
-|GA
 
 |`emptyDir` volumes
-|GA
-|GA
 |GA
 |GA
 
 |HTTPS redirection
 |GA
 |GA
-|GA
-|GA
 
 |Kafka broker
 |TP
 |TP
-|TP
-|TP
 
 |Kafka sink
-|-
-|TP
 |TP
 |TP
 
 |Init containers support for Knative services
-|-
-|-
 |TP
-|TP
+|GA
 
 |PVC support for Knative services
-|-
-|-
 |TP
 |TP
 
@@ -77,35 +59,44 @@ endif::[]
 // ROSA table
 ifdef::openshift-rosa[]
 .Generally Available and Technology Preview features tracker
-[cols="3,1",options="header"]
+[cols="3,1,1",options="header"]
 |====
-|Feature |1.23
+|Feature |1.23|1.24
 
 |`kn func`
+|TP
 |TP
 
 |`kn func invoke`
 |TP
+|TP
 
 |Service Mesh mTLS
+|GA
 |GA
 
 |`emptyDir` volumes
 |GA
+|GA
 
 |HTTPS redirection
+|GA
 |GA
 
 |Kafka broker
 |TP
+|TP
 
 |Kafka sink
+|TP
 |TP
 
 |Init containers support for Knative services
 |TP
+|GA
 
 |PVC support for Knative services
+|TP
 |TP
 
 |====

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -23,6 +23,7 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-24-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-23-0.adoc[leveloffset=+1]
 
 // 1.23.0 additional resources, OCP docs
@@ -40,7 +41,6 @@ include::modules/serverless-rn-1-20-0.adoc[leveloffset=+1]
 endif::[]
 
 ifdef::openshift-enterprise[]
-// unsupported versions - remove for 4.10+ after this PR is merged
 include::modules/serverless-rn-1-19-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-18-0.adoc[leveloffset=+1]
 endif::[]


### PR DESCRIPTION
Version(s):
OCP 4.6+, OSD, ROSA

Issues:
https://issues.redhat.com/browse/SRVCOM-1840

Preview:
http://file.brq.redhat.com/~msvistun/serverless-release-notes-1.24.html