### PR TITLE
Remove OpenShift SDN EgressIPs limitation ifeval

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -20,7 +20,7 @@ To ensure that you can reliably allow access to the server from only that specif
 
 An egress IP address assigned to a namespace is different from an egress router, which is used to send traffic to specific destinations.
 
-In some cluster configurations, application pods and ingress router pods run on the same node. If you configure an egress IP for an application project in this scenario, the IP is not used when you send a request to a route from the application project.
+In some cluster configurations, application pods and ingress router pods run on the same node. If you configure an egress IP address for an application project in this scenario, the IP address is not used when you send a request to a route from the application project.
 
 ifdef::openshift-sdn[]
 An egress IP address is implemented as an additional IP address on the primary network interface of a node and must be in the same subnet as the primary IP address of the node. The additional IP address must not be assigned to any other node in the cluster.
@@ -273,9 +273,6 @@ When using the automatic assignment approach for egress IP addresses the followi
 
 - You set the `egressCIDRs` parameter of each node's `HostSubnet` resource to indicate the range of egress IP addresses that can be hosted by a node.
 {product-title} sets the `egressIPs` parameter of the `HostSubnet` resource based on the IP address range you specify.
-ifeval::[{product-version} < 4.8]
-- Only a single egress IP address per namespace is supported when using the automatic assignment mode.
-endif::[]
 
 If the node hosting the namespace's egress IP address is unreachable, {product-title} will reassign the egress IP address to another node with a compatible egress IP address range.
 The automatic assignment approach works best for clusters installed in environments with flexibility in associating additional IP addresses with nodes.


### PR DESCRIPTION
This ifeval is not working for some reason, so remove it
entirely from the docs.

Preview: http://shell.lab.bos.redhat.com/~jboxman/egress-ips-openshift-sdn-ips-assignment/networking/openshift_sdn/assigning-egress-ips.html#considerations-automatic-egress-ips