### PR TITLE
[enterprise-4.11] OSDOCS-3754: Document RHODF registry storage

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1379,6 +1379,8 @@ Topics:
     File: configuring-registry-storage-baremetal
   - Name: Configuring the registry for vSphere
     File: configuring-registry-storage-vsphere
+  - Name: Configuring the registry for OpenShift Data Foundation
+    File: configuring-registry-storage-rhodf
   Distros: openshift-enterprise,openshift-origin
 - Name: Accessing the registry
   File: accessing-the-registry

--- a/modules/registry-configuring-registry-storage-rhodf-cephfs.adoc
+++ b/modules/registry-configuring-registry-storage-rhodf-cephfs.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
+//
+// * registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
+//
+// * registry/configuring_registry_storage/Configuring-the-registry-for-rhodf.adoc
+
+:_content-type: PROCEDURE
+[id="registry-configuring-registry-storage-rhodf-cephfs_{context}"]
+= Configuring the Image Registry Operator to use CephFS storage with Red Hat OpenShift Data Foundation
+
+{rh-storage-first} integrates multiple storage types that you can use with the internal image registry:
+
+* Ceph, a shared and distributed file system and on-premises object storage
+* NooBaa, providing a Multicloud Object Gateway
+
+This document outlines the procedure to configure the image registry to use CephFS storage.
+
+[NOTE]
+====
+CephFS uses persistent volume claim (PVC) storage. It is not recommended to use PVCs for image registry storage if there are other options are available, such as Ceph RGW or Noobaa.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the {product-title} web console.
+* You installed the `oc` CLI.
+* You installed the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10[{rh-storage} Operator] to provide object storage and CephFS file storage.
+
+
+.Procedure
+
+. Create a PVC to use the `cephfs` storage class. For example:
++
+[source,terminal]
+----
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+ name: registry-storage-pvc
+ namespace: openshift-image-registry
+spec:
+ accessModes:
+ - ReadWriteMany
+ resources:
+   requests:
+     storage: 100Gi
+ storageClassName: ocs-storagecluster-cephfs
+EOF
+----
+
+. Configure the image registry to use the CephFS file system storage by entering the following command:
++
+[source,terminal]
+----
+$ oc patch config.image/cluster -p '{"spec":{"managementState":"Managed","replicas":2,"storage":{"managementState":"Unmanaged","pvc":{"claim":"registry-storage-pvc"}}}}' --type=merge
+----
+

--- a/modules/registry-configuring-registry-storage-rhodf-cephrgw.adoc
+++ b/modules/registry-configuring-registry-storage-rhodf-cephrgw.adoc
@@ -1,0 +1,104 @@
+// Module included in the following assemblies:
+//
+// * registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
+//
+// * registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
+//
+// * registry/configuring_registry_storage/Configuring-the-registry-for-rhodf.adoc
+
+:_content-type: PROCEDURE
+[id="registry-configuring-registry-storage-rhodf-cephrgw_{context}"]
+= Configuring the Image Registry Operator to use Ceph RGW storage with Red Hat OpenShift Data Foundation
+
+{rh-storage-first} integrates multiple storage types that you can use with the internal image registry:
+
+* Ceph, a shared and distributed file system and on-premises object storage
+* NooBaa, providing a Multicloud Object Gateway
+
+This document outlines the procedure to configure the image registry to use Ceph RGW storage.
+
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the {product-title} web console.
+* You installed the `oc` CLI.
+* You installed the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10[{rh-storage} Operator] to provide object storage and Ceph RGW object storage.
+
+.Procedure
+
+. Create the object bucket claim using the `ocs-storagecluster-ceph-rgw` storage class. For example:
++
+[source,terminal]
+----
+cat <<EOF | oc apply -f -
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: rgwtest
+  namespace: openshift-storage
+spec:
+  storageClassName: ocs-storagecluster-ceph-rgw
+  generateBucketName: rgwtest
+EOF
+----
+
+. Get the bucket name by entering the following command:
++
+[source,terminal]
+----
+$ bucket_name=$(oc get obc -n openshift-storage rgwtest -o jsonpath='{.spec.bucketName}')
+----
+
+. Get the AWS credentials by entering the following commands:
++
+[source,terminal]
+----
+$ AWS_ACCESS_KEY_ID=$(oc get secret -n openshift-storage rgwtest -o yaml | grep -w "AWS_ACCESS_KEY_ID:" | head -n1 | awk '{print $2}' | base64 --decode)
+----
++
+[source,terminal]
+----
+$ AWS_SECRET_ACCESS_KEY=$(oc get secret -n openshift-storage rgwtest -o yaml | grep -w "AWS_SECRET_ACCESS_KEY:" | head -n1 | awk '{print $2}' | base64 --decode)
+----
+
+. Create the secret `image-registry-private-configuration-user` with the AWS credentials for the new bucket under `openshift-image-registry project` by entering the following command:
++
+[source,terminal]
+----
+$ oc create secret generic image-registry-private-configuration-user --from-literal=REGISTRY_STORAGE_S3_ACCESSKEY=${AWS_ACCESS_KEY_ID} --from-literal=REGISTRY_STORAGE_S3_SECRETKEY=${AWS_SECRET_ACCESS_KEY} --namespace openshift-image-registry
+----
+
+. Create a encryption route for Ceph RGW by entering the following command:
++
+[source,terminal]
+----
+$ oc create route reencrypt <route_name> --service=rook-ceph-rgw-ocs-storagecluster-cephobjectstore --port=https -n openshift-storage
+----
++
+.. Get the route host by entering the following command:
++
+[source,terminal]
+----
+$ route_host=$(oc get route <route_name> -n openshift-storage -o=jsonpath='{.spec.host}')
+----
+. Create a config map that uses an ingress certificate by entering the following commands:
++
+[source,terminal]
+----
+$ oc extract secret/router-certs-default  -n openshift-ingress  --confirm
+----
++
+[source,terminal]
+----
+$ oc create configmap image-registry-s3-bundle --from-file=ca-bundle.crt=./tls.crt  -n openshift-config
+----
+
+. Configure the image registry to use the Ceph RGW object storage by entering the following command:
++
+[source,terminal]
+----
+$ oc patch config.image/cluster -p '{"spec":{"managementState":"Managed","replicas":2,"storage":{"managementState":"Unmanaged","s3":{"bucket":'\"${bucket_name}\"',"region":"us-east-1","regionEndpoint":'\"https://${route_host}\"',"virtualHostedStyle":false,"encrypt":true,"trustedCA":{"name":"image-registry-s3-bundle"}}}}}' --type=merge
+----
+
+

--- a/modules/registry-configuring-registry-storage-rhodf-nooba.adoc
+++ b/modules/registry-configuring-registry-storage-rhodf-nooba.adoc
@@ -1,0 +1,95 @@
+// Module included in the following assemblies:
+//
+// * registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
+//
+// * registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
+//
+// * registry/configuring_registry_storage/Configuring-the-registry-for-rhodf.adoc
+
+:_content-type: PROCEDURE
+[id="registry-configuring-registry-storage-rhodf-nooba_{context}"]
+= Configuring the Image Registry Operator to use Noobaa storage with Red Hat OpenShift Data Foundation
+
+{rh-storage-first} integrates multiple storage types that you can use with the internal image registry:
+
+* Ceph, a shared and distributed file system and on-premises object storage
+* NooBaa, providing a Multicloud Object Gateway
+
+This document outlines the procedure to configure the image registry to use Noobaa storage.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the {product-title} web console.
+* You installed the `oc` CLI.
+* You installed the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10[{rh-storage} Operator] to provide object storage and Noobaa object storage.
+
+.Procedure
+
+. Create the object bucket claim using the `openshift-storage.noobaa.io` storage class. For example:
++
+[source,terminal]
+----
+cat <<EOF | oc apply -f -
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: noobaatest
+  namespace: openshift-storage
+spec:
+  storageClassName: openshift-storage.noobaa.io
+  generateBucketName: noobaatest
+EOF
+----
+
+. Get the bucket name by entering the following command:
++
+[source,terminal]
+----
+$ bucket_name=$(oc get obc -n openshift-storage noobaatest -o jsonpath='{.spec.bucketName}')
+----
+
+. Get the AWS credentials by entering the following commands:
++
+[source,terminal]
+----
+$ AWS_ACCESS_KEY_ID=$(oc get secret -n openshift-storage noobaatest -o yaml | grep -w "AWS_ACCESS_KEY_ID:" | head -n1 | awk '{print $2}' | base64 --decode)
+----
++
+[source,terminal]
+----
+$ AWS_SECRET_ACCESS_KEY=$(oc get secret -n openshift-storage noobaatest -o yaml | grep -w "AWS_SECRET_ACCESS_KEY:" | head -n1 | awk '{print $2}' | base64 --decode)
+----
+
+. Create the secret `image-registry-private-configuration-user` with the AWS credentials for the new bucket under `openshift-image-registry project` by entering the following command:
++
+[source,terminal]
+----
+$ oc create secret generic image-registry-private-configuration-user --from-literal=REGISTRY_STORAGE_S3_ACCESSKEY=${AWS_ACCESS_KEY_ID} --from-literal=REGISTRY_STORAGE_S3_SECRETKEY=${AWS_SECRET_ACCESS_KEY} --namespace openshift-image-registry
+----
+
+. Get the route host by entering the following command:
++
+[source,terminal]
+----
+$ route_host=$(oc get route s3 -n openshift-storage -o=jsonpath='{.spec.host}')
+----
+. Create a config map that uses an ingress certificate by entering the following commands:
++
+[source,terminal]
+----
+$ oc extract secret/router-certs-default  -n openshift-ingress  --confirm
+----
++
+[source,terminal]
+----
+$ oc create configmap image-registry-s3-bundle --from-file=ca-bundle.crt=./tls.crt  -n openshift-config
+----
+
+. Configure the image registry to use the Nooba object storage by entering the following command:
++
+[source,terminal]
+----
+$ oc patch config.image/cluster -p '{"spec":{"managementState":"Managed","replicas":2,"storage":{"managementState":"Unmanaged","s3":{"bucket":'\"${bucket_name}\"',"region":"us-east-1","regionEndpoint":'\"https://${route_host}\"',"virtualHostedStyle":false,"encrypt":true,"trustedCA":{"name":"image-registry-s3-bundle"}}}}}' --type=merge
+----
+

--- a/registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
@@ -12,15 +12,21 @@ include::modules/registry-change-management-state.adoc[leveloffset=+1]
 
 include::modules/installation-registry-storage-config.adoc[leveloffset=+1]
 
-include::modules/registry-configuring-storage-baremetal.adoc[leveloffset=+1]
+include::modules/registry-configuring-storage-baremetal.adoc[leveloffset=+2]
 
-include::modules/installation-registry-storage-non-production.adoc[leveloffset=+1]
+include::modules/installation-registry-storage-non-production.adoc[leveloffset=+2]
 
-include::modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc[leveloffset=+1]
+include::modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc[leveloffset=+2]
 
+include::modules/registry-configuring-registry-storage-rhodf-cephrgw.adoc[leveloffset=+2]
+
+include::modules/registry-configuring-registry-storage-rhodf-nooba.adoc[leveloffset=+2]
+
+include::modules/registry-configuring-registry-storage-rhodf-cephfs.adoc[leveloffset=+1]
 
 [id="configuring-registry-storage-baremetal-addtl-resources"]
 [role="_additional-resources"]
 == Additional resources
 
-* For more details about configuring registry storage for bare metal, see xref:../../scalability_and_performance/optimizing-storage.adoc#recommended-configurable-storage-technology_persistent-storage[Recommended configurable storage technology].
+* xref:../../scalability_and_performance/optimizing-storage.adoc#recommended-configurable-storage-technology_persistent-storage[Recommended configurable storage technology]
+* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html-single/managing_and_allocating_storage_resources/index#configuring-image-registry-to-use-openshift-data-foundation_rhodf[Configuring Image Registry to use OpenShift Data Foundation]

--- a/registry/configuring_registry_storage/configuring-registry-storage-rhodf.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-rhodf.adoc
@@ -1,0 +1,22 @@
+:_content-type: ASSEMBLY
+[id="configuring-registry-storage-rhodf"]
+= Configuring the registry for Red Hat OpenShift Data Foundation
+include::_attributes/common-attributes.adoc[]
+:context: configuring-registry-storage-rhodf
+
+toc::[]
+
+To configure the internal image registry on bare metal and vSphere to use {rh-storage-first} storage, you must install {rh-storage} and then configure image registry using Ceph or Noobaa.
+
+include::modules/registry-configuring-registry-storage-rhodf-cephrgw.adoc[leveloffset=+1]
+
+include::modules/registry-configuring-registry-storage-rhodf-nooba.adoc[leveloffset=+1]
+
+include::modules/registry-configuring-registry-storage-rhodf-cephfs.adoc[leveloffset=+1]
+
+[id="configuring-registry-storage-ocs"]
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html-single/managing_and_allocating_storage_resources/index#configuring-image-registry-to-use-openshift-data-foundation_rhodf[Configuring Image Registry to use OpenShift Data Foundation] 
+* link:https://access.redhat.com/solutions/6719951[Performance tuning guide for Multicloud Object Gateway (NooBaa)]

--- a/registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
@@ -10,18 +10,28 @@ include::modules/registry-removed.adoc[leveloffset=+1]
 
 include::modules/registry-change-management-state.adoc[leveloffset=+1]
 
-include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
+include::modules/installation-registry-storage-config.adoc[leveloffset=+1]
 
-include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+1]
+include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+2]
 
-include::modules/installation-registry-storage-non-production.adoc[leveloffset=+1]
+include::modules/installation-registry-storage-non-production.adoc[leveloffset=+2]
 
-include::modules/installation-registry-storage-block-recreate-rollout.adoc[leveloffset=+1]
+include::modules/installation-registry-storage-block-recreate-rollout.adoc[leveloffset=+2]
 
 For instructions about configuring registry storage so that it references the correct PVC, see xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#registry-configuring-storage-vsphere_configuring-registry-storage-vsphere[Configuring the registry for vSphere].
+
+include::modules/registry-configuring-registry-storage-rhodf-cephrgw.adoc[leveloffset=+2]
+
+include::modules/registry-configuring-registry-storage-rhodf-nooba.adoc[leveloffset=+2]
+
+include::modules/registry-configuring-registry-storage-rhodf-cephfs.adoc[leveloffset=+1]
 
 [id="configuring-registry-storage-vsphere-addtl-resources"]
 [role="_additional-resources"]
 == Additional resources
 
-* For more details about configuring registry storage for vSphere, see xref:../../scalability_and_performance/optimizing-storage.adoc#recommended-configurable-storage-technology_persistent-storage[Recommended configurable storage technology].
+* xref:../../scalability_and_performance/optimizing-storage.adoc#recommended-configurable-storage-technology_persistent-storage[Recommended configurable storage technology]
+* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html-single/managing_and_allocating_storage_resources/index#configuring-image-registry-to-use-openshift-data-foundation_rhodf[Configuring Image Registry to use OpenShift Data Foundation]
+
+
+


### PR DESCRIPTION
This is a manual cherrypick PR for https://github.com/openshift/openshift-docs/pull/47977. Resolved conflict in `configuring-registry-storage-baremetal`.