### PR TITLE
TELCODOCS:606 - document erratum for osc 1.3

### DIFF
--- a/sandboxed_containers/sandboxed-containers-4.11-release-notes.adoc
+++ b/sandboxed_containers/sandboxed-containers-4.11-release-notes.adoc
@@ -41,3 +41,12 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 ====
 
 This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {sandboxed-containers-first} {sandboxed-containers-version}.
+
+[id="sandboxed-containers-1-3-0"]
+=== RHSA-2022:6072 - {sandboxed-containers-first} {sandboxed-containers-version}.0 image release, bug fix, and enhancement advisory.
+
+Issued: 2022-08-17
+
+{sandboxed-containers-first} release {sandboxed-containers-version}.0 is now available. This advisory contains an update for {sandboxed-containers-first} with enhancements and bug fixes.
+
+The list of bug fixes included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2022:6072[RHSA-2022:6072] advisory.


### PR DESCRIPTION
Version(s): Only 4.11

Issue:
[TELCODOCS-606](https://issues.redhat.com/browse/TELCODOCS-606)

[Link to docs preview](http://file.emea.redhat.com/miweiss/TELCODOCS-606/sandboxed_containers/sandboxed-containers-4.11-release-notes.html#sandboxed-containers-1-3-asynchronous-errata-updates)

Reviewed and approved by QE.