### PR TITLE
Updating link for updating heterogeneous 

### DIFF
--- a/modules/mixed-arch-upgrade-mirrors.adoc
+++ b/modules/mixed-arch-upgrade-mirrors.adoc
@@ -19,4 +19,4 @@ You must perform an explicit upgrade command to upgrade your existing cluster to
 ----
 $ oc adm upgrade --allow-explicit-upgrade --to-image <image-pullspec> <1>
 ----
-<1> You can access the `image-pullspec` object from the link:https://mirror.openshift.com/pub/openshift-v4/multi/clients/ocp/4.11.0-multi-rc.6/[mixed-arch mirrors page] in the `release.txt` file.
+<1> You can access the `image-pullspec` object from the link:https://mirror.openshift.com/pub/openshift-v4/multi/clients/ocp/latest[mixed-arch mirrors page] in the `release.txt` file.


### PR DESCRIPTION
 For versions 4.11+ 
Description: Updating link to the latest for the mirrors page
Preview: [Configuring heterogeneous cluster -> Post-installation configuration](https://kelbrown20.github.io/openshift-docs/update-heterogeneous-link/post_installation_configuration/deploy-heterogeneous-configuration.html#mixed-arch-upgrade-mirrors_deploy-heterogeneous-configuration)