### PR TITLE
RNs-4.9.45 Added with bug fix and security update

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -3005,3 +3005,24 @@ link:https://access.redhat.com/solutions/6968056[{product-title} 4.9.43 containe
 ==== Updating
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-9-45"]
+=== RHSA-2022:5879 - {product-title} 4.9.45 bug fix update and security update
+
+Issued: 2022-08-09
+
+{product-title} release 4.9.45, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:5879[RHSA-2022:5879] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5878[RHBA-2022:5878] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6970809[{product-title} 4.9.45 container image list]
+
+[id="ocp-4-9-45-bug-fixes"]
+==== Bug fixes
+
+* Previously, the metrics endpoints for the {rh-openstack-first} Manila and Cinder CSI Driver Operators used unsecured Transport Layer Security (TLS) configurations. These configurations allowed access to vulnerable cryptography, where they can decrypt or modify traffic to and from these endpoints. With this update, the TLS configurations are more secure and eliminate access to vulnerable cryptography. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2110255#[*BZ#2110255*])
+
+[id="ocp-4-9-45-updating"]
+==== Updating
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
**RNs-4.9.45**
Added with bug fix and security update

**Version(s):**
* PR applies only to enterprise-4.9

**Issue:**
https://issues.redhat.com/browse/ART-4369

**Link to docs preview:**
https://wiharris.github.io/openshift-docs/RNs-4.9.45/release_notes/ocp-4-9-release-notes.html#ocp-4-9-45

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

**Additional information:**
`shipped live`



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
