### PR TITLE
Updating heterogeneous release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -221,9 +221,9 @@ For more information, see xref:../post_installation_configuration/cluster-capabi
 [id="ocp-4-11-heterogeneous-tech-preview"]
 ==== {product-title} on heterogeneous architectures (Technology Preview)
 {product-title} 4.11 introduces heterogeneous architecture cluster support using Azure installer-provisioned infrastructure in Technology Preview. This feature offers, as a day-two operation, the ability to add `arm64` worker nodes to an existing `x86_64` Azure cluster that is installer provisioned with a heterogeneous installer binary. You can add `arm64` workers to your heterogeneous cluster by creating a custom Azure machine set that uses a manually generated `arm64` boot image. Control planes on `arm64` architectures are not currently supported. For more information, see xref:../post_installation_configuration/deploy-heterogeneous-configuration.adoc[Configuring a heterogeneous cluster].
-[IMPORTANT]
+[NOTE]
 ====
-The heterogeneous installer binary will not be updated in every {product-title} z-stream release.
+You can manually upgrade your cluster to the latest heterogeneous release image by using the release `image-pullsec`. For more information, see xref:../post_installation_configuration/deploy-heterogeneous-configuration.adoc#mixed-arch-upgrade-mirrors_deploy-heterogeneous-configuration[Upgrading your heterogeneous cluster].
 ====
 
 [id="ocp-4-11-web-console"]


### PR DESCRIPTION
For version 4.11
Description: Heterogeneous payload now updates with the z-stream. But changing the statement to show the fact that upgrading has to be done manually. 

Preview: [OpenShift Container Platform 4.11 release notes -> Post-Installation configuration ](https://kelbrown20.github.io/openshift-docs/update-heterogeneous-release-notes/release_notes/ocp-4-11-release-notes.html#ocp-4-11-post-installation)