### PR TITLE
A little RN clean-up and adding a few KI from the GH tracker

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1385,7 +1385,8 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 . When the vMedia attachment request fails with an error indicating that the `TransferProtocolType` attribute is missing, retry the request and explicitly specify this attribute.
 . Check for the presence of the RedFish settings resource in the system. If it is present, use it for the boot sequence override.
 
-As a result, virtual media based provisioning will succeed on Nokia OE 20 machines. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2059567[*BZ#2059567*])
++
+As a result to these workarounds, virtual media based provisioning will succeed on Nokia OE 20 machines. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2059567[*BZ#2059567*])
 
 * Previously, the Ironic API inspector image failed to clean disks that were part of passive multipath setups when using {product-title} bare-metal IPI deployments. This update fixes the failures when active or passive storage arrays are in use. As a result, it is now possible to use {product-title} bare metal IPI when customers want to use multipath setups that are active or passive. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2089309[*BZ#2089309*])
 
@@ -1585,6 +1586,8 @@ sourceStrategy:
 
 * Because vSphere UPI clusters do not set the `PlatformStatus.VSphere` parameter at installation, the parameter was set to `nil`. This caused the MCO logs to be filled with unnecessary and repetitive messages that this parameter cannot have the value `nil`. This fix removes the warning, which was added to resolve a separate issue. As a result, the logs no longer list this message for vSphere UPI installations. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2080267[*BZ#2080267*])
 
+* Previously, when you attempted to create a cluster with both FIPS and `realTimeKernel` the Machine Config Operator (MCO) degraded due to a merge logic issue within the code. With this update, the MCO no longer degrades when creating a cluster with both FIPS and `realTimeKernel`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2096496[*BZ#2096496*])
+
 [discrete]
 [id="ocp-4-11-compliance-operator-bug-fixes"]
 ==== Compliance Operator
@@ -1643,7 +1646,7 @@ With this update, the CMO now properly propagates the external labels that you c
 
 * Previously, when using the OVN-Kubernetes cluster network provider with multiple default gateways, the wrong gateway was selected, causing the OVN-Kubernetes pods to stop unexpectedly. Now the correct default gateway is selected such that these pods no longer fails. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2040933[*BZ#2040933*])
 
-* For clusters using the OVN-Kubernetes cluster network provider, previously if the NetworkManager service restarted on a node, that node lost network connectivity. Now network connectivity survives a restart of the NetworkManager service. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2048352[BZ#2048352])
+* For clusters using the OVN-Kubernetes cluster network provider, previously if the NetworkManager service restarted on a node, that node lost network connectivity. Now network connectivity survives a restart of the NetworkManager service. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2048352[*BZ#2048352*])
 
 * Previously a `goroutine` handling cache updates could stall writing to an unbuffered channel while holding a `mutex`. With this update, these race conditions were solved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2052398[*BZ#2052398*])
 
@@ -1705,7 +1708,7 @@ With this update, the CMO now properly propagates the external labels that you c
 
 * Previously, it was hard to understand from the logs when fallback inspect occurred. The logs are now improved to make this more explicit. As a result, the output of `must-gather run` is much more clear. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2035717[*BZ#2035717*])
 
-* Previously, if you ran `must-gather` with invalid arguments, it did not consistently report the error and instead might attempt to collect data even when that is not possible. Now if `must-gather` is called with invalid options, it provides useful error output. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1999891[BZ#1999891])
+* Previously, if you ran `must-gather` with invalid arguments, it did not consistently report the error and instead might attempt to collect data even when that is not possible. Now if `must-gather` is called with invalid options, it provides useful error output. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1999891[*BZ#1999891*])
 
 * Previously, if the `oc adm catalog mirror` command resulted in errors, it still continued and returned a `0` exit code. A `--continue-on-error` flag is now available that allows users to determine whether the command should continue if there are errors, or exit with a non-zero exit code. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2088483[*BZ#2088483*])
 
@@ -1847,7 +1850,7 @@ With this update, the CMO now properly propagates the external labels that you c
 
 * This fix ensures that read-only-many volumes are provisioned appropriately by GCP CSI Driver as read-only. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1968253#[*BZ#1968253*])
 
-* {product-title} allows installation of vSphere CSI drivers shipped by either the upstream community or VMware. Although Red Hat does not support this driver, cluster administrators can still install and use it because it has more features than the vSphere CSI driver shipped by Red Hat. {product-title} can be upgraded to {product-version} with the upstream and VMware vSphere CSI driver, however, you will be warned about the presence of a third party CSI driver. In a future release {product-title}, you will be required to upgrade to the version of vSphere CSI shipped by Red Hat before upgrading to the next version of {product-title}. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2089419[BZ#2089419] and link:https://bugzilla.redhat.com/show_bug.cgi?id=2052071[*BZ#2052071*]).
+* {product-title} allows installation of vSphere CSI drivers shipped by either the upstream community or VMware. Although Red Hat does not support this driver, cluster administrators can still install and use it because it has more features than the vSphere CSI driver shipped by Red Hat. {product-title} can be upgraded to {product-version} with the upstream and VMware vSphere CSI driver, however, you will be warned about the presence of a third party CSI driver. For more information, see (link:https://bugzilla.redhat.com/show_bug.cgi?id=2089419[*BZ#2089419*]) and (link:https://bugzilla.redhat.com/show_bug.cgi?id=2052071[*BZ#2052071*]).
 
 * With this update, the default credentials request for Amazon Web Services (AWS) is modified to allow mounting of encrypted volumes using customer managed keys from Key Managment Service (KMS). Administrators who created credentials requests in manual mode with the Cloud Creditial Operator (CCO) will need to apply those changes manually if they intend to mount encrypted volumes using customer managed keys on AWS. Other administrators should not be impacted by this change. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049872[*BZ#2049872*])
 
@@ -2325,12 +2328,9 @@ This script removes unauthenticated subjects from the following cluster role bin
 No workaround exists for this issue.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2100860[*BZ#2100860*])
 
-* On a newly installed {product-title} {product-version} cluster, platform monitoring alerts do not have the `openshift_io_alert_source="platform"` label.
-This issue does not affect clusters upgraded from a previous minor version.
-No workaround exists for this issue.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=2103127[*BZ#2103127*])
+* On a newly installed {product-title} {product-version} cluster, platform monitoring alerts do not have the `openshift_io_alert_source="platform"` label. This issue does not affect clusters upgraded from a previous minor version. There is currently no workaround exists for this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2103127[*BZ#2103127*])
 
-* In the {rh-openstack-first}, a potential issue can affect Kuryr when the ports pools are populated with a variety of bulk port creation requests made at the same time. During these bulk requests, if the IP allocation for one of the IP addresses fails, the Neutron retries the operation for all ports. This issue was resolved in a previous errata; however, Red Hat suggests setting a small value for the ports pools batch to avoid large bulk port creation requests. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2024690[*BZ2024690*])
+* In the {rh-openstack-first}, a potential issue can affect Kuryr when the ports pools are populated with a variety of bulk port creation requests made at the same time. During these bulk requests, if the IP allocation for one of the IP addresses fails, the Neutron retries the operation for all ports. This issue was resolved in a previous errata; however, you can set a small value for the ports pools batch to avoid large bulk port creation requests. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2024690[*BZ#2024690*])
 
 * The oc-mirror CLI plug-in cannot mirror {product-title} catalogs earlier than version 4.9. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097210[*BZ#2097210*])
 
@@ -2344,7 +2344,7 @@ For more information, see xref:../networking/metallb/metallb-upgrading-operator.
 
 * The OpenShift CLI (`oc`) for {product-title} 4.11 does not work properly on macOS due to a change in error handling of untrusted certificates in Go 1.18 libraries. Due to this change, `oc login` and other `oc` commands can fail with a `certificate is not trusted` error without proceeding further when running on macOS. Until the error handling is properly fixed in Go 1.18 (tracked by link:https://github.com/golang/go/issues/52010[Go issue #52010]), the workaround is to use the {product-title} 4.10 `oc` CLI instead. Note that when using the {product-title} 4.10 `oc` CLI with an {product-title} 4.11 cluster, it is no longer possible to get a token by using the `oc serviceaccounts get-token <service_account>` command. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097830[*BZ#2097830*]) (link:https://bugzilla.redhat.com/show_bug.cgi?id=2109799[*BZ#2109799*])
 
-* There is currently a known issue in the *Add Helm Chart Repositories* form to extend the Developer Catalog of a project. The *Quick Start* guides shows that you can add the `ProjectHelmChartRepository` CR in the desired namespace whereas it does not mention that to perform this you need permission from the kubeadmin. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054197[BZ#2054197])
+* There is currently a known issue in the *Add Helm Chart Repositories* form to extend the Developer Catalog of a project. The *Quick Start* guides shows that you can add the `ProjectHelmChartRepository` CR in the desired namespace whereas it does not mention that to perform this you need permission from the kubeadmin. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054197[*BZ#2054197*])
 
 * There is currently a known issue. If you create an instance of `ProjectHelmChartRepository` custom resource (CR) that uses TLS verification, you cannot list the repositories and perform Helm-related operations. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/HELM-343[*HELM-343*])
 
@@ -2362,7 +2362,7 @@ Identify the disk that holds the live image, in this example `nvme0n1p3`, and ru
 # kexec -l vmlinuz-*.ppc64le -i initramfs-*.img -c "ignition.firstboot rd.neednet=1 ip=dhcp $(grep options /var/petitboot/mnt/dev/nvme0n1p3/loader/entries/ostree-1-rhcos.conf | sed 's,^options ,,')" && kexec -e
 ----
 +
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=2107674[BZ#2107674])
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2107674[*BZ#2107674*])
 
 * In a disconnected environment, SRO does not try to fetch DTK from the main registry. It fetches from the mirror registry instead. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102724[*BZ#2102724*])
 
@@ -2372,7 +2372,7 @@ Identify the disk that holds the live image, in this example `nvme0n1p3`, and ru
 
 * In low-band systems, the system clock does not synchronize with the PTP ordinary clock after the grandmaster clock is disconnected for a few hours and recovered. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGSM-45173[*OCPBUGSM-45173*])
 
-* Previously, if you were using the OVN-Kubernetes cluster network provider, if a service with `type=LoadBalancer` was configured with `internalTrafficPolicy=cluster` set, then all traffic was routed to the default gateway, even if the host routing table included better routes to use. Now the best route is used rather than always using the default gateway. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2060159[BZ#2060159])
+* Previously, if you were using the OVN-Kubernetes cluster network provider, if a service with `type=LoadBalancer` was configured with `internalTrafficPolicy=cluster` set, then all traffic was routed to the default gateway, even if the host routing table included better routes to use. Now the best route is used rather than always using the default gateway. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2060159[*BZ#2060159*])
 
 * When an OVN cluster has more than 75 worker nodes, simultaneously creating 2000 or more services and route objects can cause pods created at the same time to hang in the `ContainerCreating` status. If this problem occurs, entering the `oc describe pod <podname>` command will show events with the following warning: `FailedCreatePodSandBox...failed to configure pod interface: timed out waiting for OVS port binding (ovn-installed)'. There is currently no workaround for this issue.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=2084062[*BZ#2084062*])
 
@@ -2422,23 +2422,41 @@ openshift.io/scc: hostmount-anyuid
 +
 (link:https://issues.redhat.com/browse/KATA-1373[*KATA-1373*])
 
-* There is currently a known issue that degrades the Machine Config Operator (MCO) when you attempt to create a cluster with both FIPS and `realTimeKernel`. As a workaround, modify the merge logic to create a `01-fips` MCO, which will prevent the MCO from degrading.
+* The pipeline metrics API does not support the required `pipelinerun/taskrun` histogram values from {rh-openstack} 1.6 and beyond. Consequently, the *Metrics* tab in the *Pipeline* -> *Details* page is removed instead of displaying incorrect values. There is currently no workaround for this issue. (link: https://bugzilla.redhat.com/show_bug.cgi?id=2074767[*BZ#2074767*])
+
+* Some Alibabacloud services are not placing all resources of a cluster into a specified resource group. Consequently, some resources created by the {product-title} installation program are placed in the default resource group. There is currently no workaround for this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2096692[*BZ#2096692*])
+
+* After rebooting each cluster node, cluster Operators `network` and `kube-apiserver` turns to `degraded` after rebooting each node of the cluster and the cluster turns unhealthy. There is currently no workaround for this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102011[*BZ#2102011*])
+
+* When `resourceGroupID` is specified in `install-config.yaml`, an error is displayed when deleting bootstrap resources and {product-title} installation fails. As a workaround for this issue, do not specify `resourceGroupID` in `install-config.yaml`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2100746[*BZ#2100746*])
+
+* There is a known issue with scale-up on RHEL compute nodes. The new nodes could turn into `Ready`, but Ingress pods cannot turn into `Running` on these nodes, and scale-up does not succeed. As a workaround, scale-up with {op-system} nodes does work. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2056387[*BZ#2056387*])
+
+* After creating a `machineset` in a Google Cloud Platform (GCP), the `capg-controller-manager` machine is stuck in `Provisioning`. There is currently no workaround for this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2107999[*BZ#2107999*])
+
+* There is a known issue on Nutanix where persistent volumes (PVs) created by a cluster are not cleaned up by the  `destroy cluster` command. As a workaround for this issue, you need to clean up the PVs manually. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2108700[*BZ#2108700*])
+
+* There is currently a known issue when creating and editing `egressqos` with incorect syntax or values success. The incorrect values in `egressqos` should not be able to be created successfully. As a workaround, use
 +
 [source,terminal]
-----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  labels:
-    machineconfiguration.openshift.io/role: "master"
-  name: 01-fips-master
-spec:
-  fips: true
-----
-+
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=2096496[*BZ#2096496*])
 
-* The pipeline metrics API does not support the required `pipelinerun/taskrun` histogram values from {rh-openstack} 1.6 and beyond. Consequently, the *Metrics* tab in the *Pipeline* -> *Details* page is removed instead of displaying incorrect values. There is currently no workaround for this issue. (link: https://bugzilla.redhat.com/show_bug.cgi?id=2074767[*BZ#2074767*])
+----
+diff --git a/go-controller/pkg/crd/egressqos/v1/types.go b/go-controller/pkg/crd/egressqos/v1/types.go
+index a90ab14ff..f7f6f1a71 100644
+--- a/go-controller/pkg/crd/egressqos/v1/types.go
++++ b/go-controller/pkg/crd/egressqos/v1/types.go
+@@ -59,6 +59,7 @@ type EgressQoSRule struct {
+        // This field is optional, and in case it is not set the rule is applied
+        // to all egress traffic regardless of the destination.
+        // +optional
++       // +kubebuilder:validation:Format="cidr"
+        DstCIDR *string `json:"dstCIDR,omitempty"`
+
+        // PodSelector applies the QoS rule only to the pods in the namespace whose label
+----
+
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2097579[*BZ#2097579*])
 
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
A little clean-up and resolving some entries from the [GH issue tracker ](https://github.com/openshift/openshift-docs/issues/43249)

Link to docs preview:
(known issues section) http://file.rdu.redhat.com/opayne/RN-cleanup-2/release_notes/ocp-4-11-release-notes.html#ocp-4-11-known-issues

Additional information:
[2096496](https://bugzilla.redhat.com/show_bug.cgi?id=2096496) was removed from known issues section and added to the bug fix section based on [this comment to the GH issue tracker ](https://github.com/openshift/openshift-docs/issues/43249#issuecomment-1207950133)



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
