### PR TITLE
[TELCODOCS-598] 4.10 release note: Filtering custom resources during ZTP spoke cluster installation using SiteConfig filters

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1162,6 +1162,10 @@ The default {product-title} scheduler does not see individual non-uniform memory
 
 For more information, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-about-numa-aware-scheduling_numa-aware[About NUMA-aware scheduling].
 
+[id="ocp-4-10-filtering-ztp-installation-crs"]
+==== Filtering custom resources during ZTP spoke cluster installation using SiteConfig filters
+You can now use filters to customize `SiteConfig` CRs to include or exclude other CRs for use in the installation phase of the zero touch provisioning (ZTP) GitOps pipeline. For more information, see xref:../scalability_and_performance/ztp-deploying-disconnected.adoc#ztp-filtering-ai-crs-using-siteconfig_ztp-deploying-disconnected[Filtering custom resources using SiteConfig filters].
+
 [id="ocp-4-10-backup-and-restore"]
 === Backup and restore
 


### PR DESCRIPTION
4.10 Release note for https://issues.redhat.com/browse/TELCODOCS-598

Merge to enterprise-4.10

Preview: http://file.emea.redhat.com/aireilly/filter-siteconfig-crs-rn/release_notes/ocp-4-10-release-notes.html#ocp-4-10-filtering-ztp-installation-crs