### PR TITLE
TELCODOCS-321: D/S Docs & RN: METAL-1 (MPINSTALL-72) Metal Day 1 Networking

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
@@ -16,11 +16,10 @@ Expanding the cluster using RedFish Virtual Media involves meeting minimum firmw
 include::modules/ipi-install-preparing-the-bare-metal-node.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_ipi-install-expanding"]
 .Additional resources
 
-* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow[(Optional) Configuring host network interfaces in the install-config.yaml file]
-* xref:../../scalability_and_performance/managing-bare-metal-hosts.adoc#automatically-scaling-machines-to-available-bare-metal-hosts_managing-bare-metal-hosts[Automatically scaling machines to the number of available bare metal hosts]
+* See xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow[Optional: Configuring host network interfaces in the install-config.yaml file] for details on configuring the NMState syntax.
+* See xref:../../scalability_and_performance/managing-bare-metal-hosts.adoc#automatically-scaling-machines-to-available-bare-metal-hosts_managing-bare-metal-hosts[Automatically scaling machines to the number of available bare metal hosts] for details on automatically scaling machines.
 
 include::modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc[leveloffset=+1]
 
@@ -31,7 +30,7 @@ include::modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc[leve
 
 * xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[Backing up etcd]
 
-* xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration] 
+* xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
 
 include::modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc[leveloffset=+1]
 

--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -11,14 +11,14 @@ Expanding the cluster requires a DHCP server. Each node must have a DHCP reserva
 [IMPORTANT]
 .Reserving IP addresses so they become static IP addresses
 ====
-Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To configure static IP addresses with NMState, see "(Optional) Configuring host network interfaces in the `install-config.yaml` file" in the "Setting up the environment for an OpenShift installation" section for additional details.
+Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To configure static IP addresses with NMState, see "Optional: Configuring host network interfaces in the `install-config.yaml` file" in the "Setting up the environment for an OpenShift installation" section for additional details.
 ====
 
 Preparing the bare metal node requires executing the following procedure from the provisioner node.
 
 .Procedure
 
-. Get the `oc` binary, if needed. It should already exist on the provisioner node.
+. Optional: Get the `oc` binary:
 +
 [source,terminal]
 ----
@@ -29,6 +29,11 @@ $ curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/ope
 ----
 $ sudo cp oc /usr/local/bin
 ----
++
+[NOTE]
+====
+The `oc` binary should already exist on the provisioner node.
+====
 
 . Power off the bare metal node by using the baseboard management controller (BMC), and ensure it is off.
 
@@ -44,7 +49,7 @@ $ echo -ne "root" | base64
 $ echo -ne "password" | base64
 ----
 
-. Create a configuration file for the bare metal node.
+. Create a configuration file for the bare metal node using the following example `bmh.yaml` file, replacing values in the YAML to match your environment:
 +
 [source,terminal]
 ----
@@ -53,41 +58,42 @@ $ vim bmh.yaml
 +
 [source,yaml]
 ----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: openshift-worker-<num>-network-config-secret <1> <2>  
-type: Opaque
-stringData:
- nmstate: |
-   routes:
-     config:
-     - destination: 0.0.0.0/0
-       next-hop-address: 192.168.123.1
-       next-hop-interface: enp0s4
-   dns-resolver:
-     config:
-       server:
-       - 192.168.123.1
-   interfaces:
-   - name: enp0s4
-     state: up
-     ipv4:
-       address:
-       - ip: 192.168.123.16
-         prefix-length: 24
-       enabled: true
-       dhcp: false
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: openshift-worker-<num>-bmc-secret <2> 
+ name: openshift-worker-<num>-network-config-secret <1> <2>
+type: Opaque
+stringData:
+ nmstate: |
+  routes: <3>
+   config:
+   - destination: 0.0.0.0/0
+     next-hop-address: <next_hop_address>
+     next-hop-interface: <next_hop_interface>
+  dns-resolver:
+   config:
+    server:
+    - <dns_server_ip_address>
+  interfaces:
+  - name: <nic_interface>
+    state: up
+    ipv4:
+     address:
+     - ip: <ip_address>
+       prefix-length: <cidr>
+     enabled: true
+     dhcp: false
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshift-worker-<num>-bmc-secret <2>
   namespace: openshift-machine-api
 type: Opaque
 data:
-  username: <base64-of-uid> <3>
-  password: <base64-of-pwd> <4>
+  username: <base64_of_uid> <4>
+  password: <base64_of_pwd> <5>
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -95,33 +101,49 @@ metadata:
   name: openshift-worker-<num> <2>
   namespace: openshift-machine-api
 spec:
-  online: true
-  bootMACAddress: <NIC1-mac-address> <5>
+  online: True
+  bootMACAddress: <nic1_mac_address> <6>
   bmc:
-    address: <protocol>://<bmc-ip> <6>
+    address: <protocol>://<bmc_url> <7>
     credentialsName: openshift-worker-<num>-bmc-secret <2>
-    disableCertificateVerification: true <7>
-    username: <bmc-username> <8>
-    password: <bmc-password> <9>
-  preprovisioningNetworkDataName: openshift-worker-<num>-network-config-secret <10> <2>
+    disableCertificateVerification: True <8>
+    username: <bmc_username> <9>
+    password: <bmc_password> <10>
+  rootDeviceHints:
+    deviceName: <root_device_hint> <11>
+  preprovisioningNetworkDataName: openshift-worker-<num>-network-config-secret <12>
 ----
++
 <1> Optional: To configure network for a newly created node, specify the name of the secret that contains the network configuration. Follow the `nmstate` syntax to define the network configuration for your node.
++
 <2> Replace `<num>` for the worker number of the bare metal node in the `name` fields, the `credentialsName` field, and the `preprovisioningNetworkDataName` field.
-<3> Replace `<base64-of-uid>` with the `base64` string of the user name.
-<4> Replace `<base64-of-pwd>` with the `base64` string of the password.
-<5> Replace `<NIC1-mac-address>` with the MAC address of the bare metal node's first NIC. See the "BMC addressing" section for additional BMC configuration options.
-<6> Replace `<protocol>` with the BMC protocol, such as IPMI, RedFish, or others. Replace `<bmc-ip>` with the IP address of the bare metal node's baseboard management controller.
-<7> To skip certificate validation, set `disableCertificateVerification` to `true`.
-<8> Replace `<bmc-username>` with the `bmc` string of the user name.
-<9> Replace `<bmc-password>` with the `bmc` string of the password.
-<10> Optional: Provide the network configuration secret name in the `preprovisioningNetworkDataName` of the `BareMetalHost` CR if you have configured network for the newly created node.
++
+<3> See "Optional: Configuring host network interfaces in the install-config.yaml file" for details on configuring NMState syntax.
++
+<4> Replace `<base64_of_uid>` with the base64 string of the user name.
++
+<5> Replace `<base64_of_pwd>` with the base64 string of the password.
++
+<6> Replace `<nic1_mac_address>` with the MAC address of the bare metal node's first NIC. See the "BMC addressing" section for additional BMC configuration options.
++
+<7> Replace `<protocol>` with the BMC protocol, such as IPMI, RedFish, or others. Replace `<bmc_url>` with the URL of the bare metal node's baseboard management controller.
++
+<8> To skip certificate validation, set `disableCertificateVerification` to true.
++
+<9> Replace `<bmc_username>` with the string of the BMC user name.
++
+<10> Replace `<bmc_password>` with the string of the BMC password.
++
+<11> Optional: Replace `<root_device_hint>` with a device path if you specify a root device hint.
++
+<12> Optional: Provide the network configuration secret name in the `preprovisioningNetworkDataName` of the BareMetalHost CR if you have configured the network for the newly created node.
 +
 [NOTE]
 ====
 If the MAC address of an existing bare metal node matches the MAC address of a bare metal host that you are attempting to provision, then the Ironic installation will fail. If the host enrollment, inspection, cleaning, or other Ironic steps fail, the Bare Metal Operator retries the installation continuously. See "Diagnosing a host duplicate MAC address" for more information.
 ====
 
-. Create the bare metal node.
+. Create the bare metal node:
 +
 [source,terminal]
 ----
@@ -138,7 +160,7 @@ baremetalhost.metal3.io/openshift-worker-<num> created
 +
 Where `<num>` will be the worker number.
 
-. Power up and inspect the bare metal node.
+. Power up and inspect the bare metal node:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Contains a syntax fix for the BMH config file and additional minor edits.

Fixes: [TELCODOCS-321](https://issues.redhat.com//browse/TELCODOCS-321)

See https://issues.redhat.com/browse/TELCODOCS-321 for additional details.

Preview URL: http://jowilkin.com:8080/TELCODOCS-321-prep-node/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-the-bare-metal-node_ipi-install-expanding

For release(s): 4.12, 4.11 and 4.10
Signed-off-by: John Wilkins <jowilkin@redhat.com>
