### PR TITLE
[Bug 2115923] vSphere: Add updating hw version in a template

### DIFF
--- a/modules/update-vsphere-virtual-hardware-on-template.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-template.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// updating/updating-hardware-on-nodes-running-in-vsphere.adoc
+
+:_content-type: PROCEDURE
+[id="update-vsphere-virtual-hardware-on-template_{context}"]
+= Updating the virtual hardware for template on vSphere
+
+.Prerequisites
+
+* You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
+* Your vSphere ESXi hosts are version 6.7U3 or later.
+
+.Procedure
+
+. If the RHCOS template is configured as a vSphere template follow link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-D632CAC5-BA5E-4A1E-959B-382D9ACB1DD0_copy.html[Convert a Template to a Virtual Machine]
+in the VMware documentation prior to the next step.
+
+[NOTE]
+====
+Once converted from a template, do not power on the virtual machine.
+====
+
+. Update the VM in the vSphere client. Follow link:https://kb.vmware.com/s/article/1010675[Upgrading a virtual machine to the latest hardware version] in the VMware documentation for more information.
+. Convert the VM in the vSphere client from a VM to template. Follow link:https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.hostclient.doc/GUID-846238E4-A1E3-4A28-B230-33BDD1D57454.html[Convert a Virtual Machine to a Template in the vSphere Client] in the VMware documentation for more information.
+

--- a/updating/updating-hardware-on-nodes-running-on-vsphere.adoc
+++ b/updating/updating-hardware-on-nodes-running-on-vsphere.adoc
@@ -22,6 +22,7 @@ To update the hardware of your virtual machines (VMs) on VMware vSphere, update 
 
 include::modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc[leveloffset=+2]
 include::modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc[leveloffset=+2]
+include::modules/update-vsphere-virtual-hardware-on-template.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s):

  * PR applies to all versions after a specific version (e.g. 4.8): 4.9+

Issue:
- https://bugzilla.redhat.com/show_bug.cgi?id=2115923

Preview:
http://file.rdu.redhat.com/jbrigman/update-hw-vers/updating/updating-hardware-on-nodes-running-on-vsphere.html
