### PR TITLE
[SRVOCF-418, SRVOCF-422] Update `kn func build` docs regarding Buildpacks and S2I

### DIFF
--- a/modules/serverless-build-func-kn.adoc
+++ b/modules/serverless-build-func-kn.adoc
@@ -8,6 +8,21 @@
 
 Before you can run a function, you must build the function project by using the `kn func build` command. This command creates an OCI container image that can be run locally on your computer or on an {product-title} cluster. The build command uses the function project name and the image registry name to construct a fully qualified image name for your function.
 
+By default, `kn func build` creates a container image using the Red Hat Source-to-Image (S2I) technology. To use the link:https://buildpacks.io/[CNCF Cloud Native Buildpacks] technology instead, supply the `-b` flag:
+
+.Example build command
+[source,terminal]
+----
+$ kn func build -b pack
+----
+
+.Example output
+[source,terminal]
+----
+Building function image
+Function image has been built, image: registry.redhat.io/example/example-function:latest
+----
+
 The OpenShift Container Registry is used by default as the image registry for storing function images. You can override this by using the `-r` flag:
 
 .Example build command

--- a/modules/serverless-functions-func-yaml-fields.adoc
+++ b/modules/serverless-functions-func-yaml-fields.adoc
@@ -8,16 +8,6 @@
 
 Many of the fields in `func.yaml` are generated automatically when you create, build, and deploy your function. However, there are also fields that you modify manually to change things, such as the function name or the image name.
 
-[id="serverless-functions-func-yaml-builder_{context}"]
-== builder
-
-The `builder` field specifies the Buildpack builder image to use when building the function. In most cases, this value should not be changed. When you do change it, use a value that is listed in the `builders` field.
-
-[id="serverless-functions-func-yaml-builders_{context}"]
-== builders
-
-Some function runtimes can be built in multiple ways. For example, a Quarkus function can be built for the JVM or as a native binary. The `builders` field contains all of the builders available for a given runtime.
-
 [id="serverless-functions-func-yaml-buildenvs_{context}"]
 == buildEnvs
 

--- a/serverless/discover/serverless-functions-about.adoc
+++ b/serverless/discover/serverless-functions-about.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-With {FunctionsProductName}, developers can create and deploy stateless, event-driven functions as a Knative service on {product-title}. The Knative (`kn`) CLI is provided as a plug-in for the Knative CLI. {FunctionsProductName} uses the link:https://buildpacks.io/[CNCF Buildpack API] to create container images. After a container image is created, you can use the `kn func` CLI to deploy the container image as a Knative service on the cluster.
+{FunctionsProductName} enables developers to create and deploy stateless, event-driven functions as a Knative service on {product-title}. The `kn func` CLI is provided as a plug-in for the Knative `kn` CLI. You can use the `kn func` CLI to create, build, and deploy the container image as a Knative service on the cluster.
 
 :FeatureName: {FunctionsProductName}
 include::snippets/technology-preview.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
OCP 4.6+, OSD, ROSA

Issues:
https://issues.redhat.com/browse/SRVOCF-418
https://issues.redhat.com/browse/SRVOCF-422

Previews:
"Building functions"
http://file.brq.redhat.com/~msvistun/serverless/srvls-kn-func-buildpack-s2i/Getting%20started%20with%20functions.html#serverless-build-func-kn_serverless-functions-getting-started

"About OpenShift Serverless Functions"
http://file.brq.redhat.com/~msvistun/serverless/srvls-kn-func-buildpack-s2i/About%20OpenShift%20Serverless%20Functions.html

"Function project configuration in func.yaml"
http://file.brq.redhat.com/~msvistun/serverless/srvls-kn-func-buildpack-s2i/Function%20project%20configuration%20in%20func.yaml.html#serverless-functions-func-yaml_serverless-functions-yaml
