### PR TITLE
Fixing malformed link in WMCO docs

### DIFF
--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -28,7 +28,7 @@ Dual NIC is not supported on WMCO-managed Windows instances.
 
 [NOTE]
 ====
-The WMCO is not supported in clusters that use a xref:../networking/enable-cluster-wide-proxy.html[cluster-wide proxy] because the WMCO is not able to route traffic through the proxy connection for the workloads.
+The WMCO is not supported in clusters that use a xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide proxy] because the WMCO is not able to route traffic through the proxy connection for the workloads.
 ====
 
 [role="_additional-resources"]

--- a/windows_containers/scheduling-windows-workloads.adoc
+++ b/windows_containers/scheduling-windows-workloads.adoc
@@ -10,7 +10,7 @@ You can schedule Windows workloads to Windows compute nodes.
 
 [NOTE]
 ====
-The WMCO is not supported in clusters that use a xref:../networking/enable-cluster-wide-proxy.html[cluster-wide proxy] because the WMCO is not able to route traffic through the proxy connection for the workloads.
+The WMCO is not supported in clusters that use a xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide proxy] because the WMCO is not able to route traffic through the proxy connection for the workloads. 
 ====
 
 [discrete]


### PR DESCRIPTION
Fixing malformed link added via https://github.com/openshift/openshift-docs/pull/48660/

Hat tip @bergerhoffer 

[Enabling Windows container workloads](http://file.rdu.redhat.com/~mburke/winc-cluster-proxy-fix-take-3/windows_containers/enabling-windows-container-workloads.html)
[Scheduling Windows container workloads](http://file.rdu.redhat.com/~mburke/winc-cluster-proxy-fix-take-3/windows_containers/scheduling-windows-workloads.html)