### PR TITLE
BZ1946268: Updating project name for PAO install via the web console

### DIFF
--- a/modules/cnf-installing-the-performance-addon-operator.adoc
+++ b/modules/cnf-installing-the-performance-addon-operator.adoc
@@ -136,15 +136,15 @@ You must create the `Namespace` CR and `OperatorGroup` CR as mentioned in the pr
 
 .. Switch to the *Operators* -> *Installed Operators* page.
 
-.. Ensure that *Performance Addon Operator* is listed in the *openshift-performance-addon-operator* project with a *Status* of *InstallSucceeded*.
+.. Ensure that *Performance Addon Operator* is listed in the *openshift-operators* project with a *Status* of *Succeeded*.
 +
 [NOTE]
 ====
-During installation an Operator might display a *Failed* status. If the installation later succeeds with an *InstallSucceeded* message, you can ignore the *Failed* message.
+During installation an Operator might display a *Failed* status. If the installation later succeeds with a *Succeeded* message, you can ignore the *Failed* message.
 ====
 +
-If the Operator does not appear as installed, to troubleshoot further:
+If the Operator does not appear as installed, you can troubleshoot further:
 +
 * Go to the *Operators* -> *Installed Operators* page and inspect the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors
 under *Status*.
-* Go to the *Workloads* -> *Pods* page and check the logs for pods in the `performance-addon-operator` project.
+* Go to the *Workloads* -> *Pods* page and check the logs for pods in the `openshift-operators` project.


### PR DESCRIPTION
**BZ#1946268:** The project for the Performance Addon Operator (PAO) is different depending on whether you install via the web console or cli. There is no functional change. I am updating the project for the web console to match the correct project name. 
PAO is replaced by the Node Tuning Operator from version 4.11 onwards so this update applies to versions 4.10 and earlier only. 

Version(s):
4.6, 4.7, 4.8, 4.9, 4.10

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=1946268

Link to docs preview:
http://file.emea.redhat.com/rohennes/BZ1946268-PAO-install-cli-vs-web/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#install-operator-web-console_cnf-master
