### PR TITLE
OSSMDOC-649: Fix Jaeger version error in 2.1.4 RN.

### DIFF
--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -121,7 +121,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 |1.17.1
 
 |Jaeger
-|1.29.1
+|1.30.2
 
 |Kiali
 |1.36.12-1


### PR DESCRIPTION
Fixing a small error that was somehow introduced to the Release Notes.
Version(s): 4.6 - 4.11

Issue: [OSSMDOC-649](https://issues.redhat.com/browse/OSSMDOC-649)

Link to docs preview: http://file.bos.redhat.com/jstickle/OSSMDOC-649/service_mesh/v2x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-2-1-4

Additional information:
Peer Review