### PR TITLE
BZ-1940371: Fixed a broken step that caused auto numbering to restart.

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -61,8 +61,7 @@ $ sudo restorecon -Rv /home/kni/rhcos_image_cache/
 $ export RHCOS_QEMU_URI=$(/usr/local/bin/openshift-baremetal-install coreos print-stream-json | jq -r --arg ARCH "$(arch)" '.architectures[$ARCH].artifacts.qemu.formats["qcow2.gz"].disk.location')
 ----
 
-.
-Get the name of the image that the installation program will deploy on the bootstrap VM:
+. Get the name of the image that the installation program will deploy on the bootstrap VM:
 +
 [source,terminal]
 ----
@@ -75,6 +74,7 @@ $ export export RHCOS_QEMU_NAME=${RHCOS_QEMU_URI##*/}
 ----
 $ export RHCOS_QEMU_UNCOMPRESSED_SHA256=$(/usr/local/bin/openshift-baremetal-install coreos print-stream-json | jq -r --arg ARCH "$(arch)" '.architectures[$ARCH].artifacts.qemu.formats["qcow2.gz"].disk["uncompressed-sha256"]')
 ----
+
 . Get the URI for the image that the installation program will deploy on the cluster nodes:
 +
 [source,terminal]
@@ -94,9 +94,7 @@ $ export RHCOS_OPENSTACK_NAME=${RHCOS_OPENSTACK_URI##*/}
 [source,terminal]
 ----
 $ export RHCOS_OPENSTACK_UNCOMPRESSED_SHA256=$(/usr/local/bin/openshift-baremetal-install coreos print-stream-json | jq -r --arg ARCH "$(arch)" '.architectures[$ARCH].artifacts.openstack.formats["qcow2.gz"].disk["uncompressed-sha256"]')
-
 ----
-
 
 . Download the images and place them in the `/home/kni/rhcos_image_cache` directory:
 +


### PR DESCRIPTION
While researching BZ-1940371, I noticed a broken step in the module causing auto numbering to restart around step 5. This PR fixes it.

Signed-off-by: John Wilkins <jowilkin@redhat.com>

Version(s): 4.9

Issue: BZ-1940371

Link to docs preview:
Error example: https://docs.openshift.com/container-platform/4.9/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-creating-an-rhcos-images-cache_ipi-install-installation-workflow

Fixed example: http://jowilkin.com/BZ-1940371-4.9/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-creating-an-rhcos-images-cache_ipi-install-installation-workflow 