### PR TITLE
OSDOCS-3777: Updated links for role creation

### DIFF
--- a/modules/rosa-sts-ocm-role-creation.adoc
+++ b/modules/rosa-sts-ocm-role-creation.adoc
@@ -31,7 +31,7 @@ $ rosa create ocm-role
 $ rosa create ocm-role --admin
 ----
 +
-This command allows you create the role by specifying specific attributes. The following example output shows the "auto mode" selected, which lets the `rosa` CLI to create your Operator roles and policies. See "Understanding the auto and manual deployment modes" in the Additional resources for more information.
+This command allows you create the role by specifying specific attributes. The following example output shows the "auto mode" selected, which lets the `rosa` CLI to create your Operator roles and policies. See "Methods of account-wide role creation" in the Additional resources for more information.
 
 .Example output
 [source,terminal]

--- a/modules/rosa-sts-understanding-ocm-role.adoc
+++ b/modules/rosa-sts-understanding-ocm-role.adoc
@@ -10,7 +10,7 @@ Creating ROSA clusters in {cluster-manager-url} require an `ocm-role` IAM role. 
 
 [NOTE]
 ====
-This elevated IAM role allows {cluster-manager} to automatically create the cluster-specific Operator roles and OIDC provider during cluster creation. For more information about this automatic role and policy creation, see the "Understanding the auto and manual deployment modes" link in Additional resources.
+This elevated IAM role allows {cluster-manager} to automatically create the cluster-specific Operator roles and OIDC provider during cluster creation. For more information about this automatic role and policy creation, see the "Methods of account-wide role creation" link in Additional resources.
 ====
 
 [id="rosa-sts-understanding-user-role_{context}"]

--- a/rosa_architecture/rosa-sts-about-iam-resources.adoc
+++ b/rosa_architecture/rosa-sts-about-iam-resources.adoc
@@ -46,6 +46,11 @@ The `ocm-role` IAM resource refers to the combination of the IAM role and the ne
 You must create this user role as well as an administrative `ocm-role` resource, if you want to use the auto mode in {cluster-manager} to create your Operator role policies and OIDC provider.
 
 include::modules/rosa-sts-understanding-ocm-role.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation]
+
 [discrete]
 include::modules/rosa-sts-ocm-role-creation.adoc[leveloffset=+2]
 
@@ -57,6 +62,7 @@ AWS IAM roles link to your AWS account to create and manage the clusters. For mo
 * link:https://docs.aws.amazon.com/IAM/latest/APIReference/API_Types.html[AWS Identity and Access Management Data Types]
 * link:https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Types.html[Amazon Elastic Computer Cloud Data Types]
 * link:https://docs.aws.amazon.com/STS/latest/APIReference/API_Types.html[AWS Token Security Service Data Types]
+* xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation]
 //
 // Keep this commented out until PR # 45306 is merged
 //


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-3777

Link to docs preview:
1. [Reference updated](http://file.rdu.redhat.com/eponvell/OSDOCS-3777_OCM-Role-Note/rosa/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-understanding-ocm-role_rosa-sts-about-iam-resources) in "Understanding the OpenShift Cluster Manager role" note.
2. Also updated the reference in the "Creating an OpenShift Cluster Manager IAM Role" as well as added the link to the additional resources. That section is discrete, but [this link will navigate to below these changes](https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources).

Additional information:

Created crossreferences for the methods of creating roles in ROSA.