### PR TITLE
BZ-2046109: Removed 9th Gen HP servers from virtual media requirements

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -12,8 +12,7 @@ The installer for installer-provisioned {product-title} clusters validates the h
 [frame="topbot", options="header"]
 |====
 |Hardware| Model | Management | Firmware Versions
-.2+| HP | 10th Generation | iLO5 | N/A
-| 9th Generation | iLO4 | N/A
+| HP | 10th Generation | iLO5 | N/A
 
 .2+| Dell | 14th Generation | iDRAC 9 | v4.20.20.20 - 04.40.00.00
 
@@ -25,7 +24,7 @@ The installer for installer-provisioned {product-title} clusters validates the h
 ====
 See the hardware documentation for the nodes or contact the hardware vendor for information on updating the firmware.
 
-There are no known firmware limitations for HP servers.
+For HP servers, Redfish virtual media is not supported on 9th generation systems running iLO4, because Ironic does not support iLO4 with virtual media.
 
 For Dell servers, ensure the {product-title} cluster nodes have AutoAttach Enabled through the iDRAC console. The menu path is: *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach* . With iDRAC 9 firmware version `04.40.00.00`, the Virtual Console plug-in defaults to `eHTML5`, which causes problems with the *InsertVirtualMedia* workflow. Set the plug-in to `HTML5` to avoid this issue. The menu path is: *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
 ====


### PR DESCRIPTION
This PR:

1. Removes HP 9th Gen servers from the table
2. Updates the comment on HP servers in the note admonition.

Version(s): 4.11, 4.10, 4.9, 4.8, 4.7

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2046109

Link to docs preview: http://jowilkin.com:8080/BZ-2046109/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites

Signed-off-by: John Wilkins <jowilkin@redhat.com>