### PR TITLE
TELCODOCS-374: container scope fix

### DIFF
--- a/modules/cnf-deploying-the-numa-aware-scheduler.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler.adoc
@@ -53,8 +53,10 @@ spec:
     systemReserved:
       memory: "512Mi"
     topologyManagerPolicy: "single-numa-node" <1>
+    topologyManagerScope: "pod" <2>
 ----
 <1> `topologyManagerPolicy` must be set to `single-numa-node`.
+<2> `topologyManagerScope` must be set to pod.
 
 .. Create the `KubeletConfig` custom resource (CR) by running the following command:
 +


### PR DESCRIPTION
Adding back the `topologyManagerScope: "pod"` field to the `KubeletConfig`
 CR that configures the pod admittance policy for the machine profile, since this is required for 4.11.

Preview: http://file.emea.redhat.com/aireilly/telcodocs-374-container-scope-fix/scalability_and_performance/cnf-numa-aware-scheduling.html

Merge to main, CP to enterprise-4.11, enterprise-4.12.