### PR TITLE
BZ1991850: Adding ptp4lConf parameter to PtpConfig.yaml

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp.adoc
+++ b/modules/nw-ptp-configuring-linuxptp.adoc
@@ -32,12 +32,13 @@ spec:
     interface: "ens787f1" <5>
     ptp4lOpts: "-s -2" <6>
     phc2sysOpts: "-a -r" <7>
-  recommend: <8>
-  - profile: "profile1" <9>
-    priority: 10 <10>
-    match: <11>
-    - nodeLabel: "node-role.kubernetes.io/worker" <12>
-      nodeName: "dev-worker-0" <13>
+    ptp4lConf: "" <8>
+  recommend: <9>
+  - profile: "profile1" <10>
+    priority: 10 <11>
+    match: <12>
+    - nodeLabel: "node-role.kubernetes.io/worker" <13>
+      nodeName: "dev-worker-0" <14>
 ----
 <1> Specify a name for the `PtpConfig` CR.
 <2> Specify the namespace where the PTP Operator is installed.
@@ -46,12 +47,13 @@ spec:
 <5> Specify the network interface name to use by the `ptp4l` service, for example `ens787f1`.
 <6> Specify system config options for the `ptp4l` service, for example `-s -2`. This should not include the interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because these will be automatically appended.
 <7> Specify system config options for the `phc2sys` service, for example `-a -r`.
-<8> Specify an array of one or more `recommend` objects which define rules on how the `profile` should be applied to nodes.
-<9> Specify the `profile` object name defined in the `profile` section.
-<10> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority will be applied to that node.
-<11> Specify `match` rules with `nodeLabel` or `nodeName`.
-<12> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command.
-<13> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command.
+<8> Specify a string that contains the configuration to replace the default `/etc/ptp4l.conf` file. To use the default configuration, leave the field empty.
+<9> Specify an array of one or more `recommend` objects, which define rules on how the `profile` should be applied to nodes.
+<10> Specify the `profile` object name defined in the `profile` section.
+<11> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority will be applied to that node.
+<12> Specify `match` rules with `nodeLabel` or `nodeName`.
+<13> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command.
+<14> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command.
 
 . Create the CR by running the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.8
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=1991850
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.emea.redhat.com/amolnar/BZ1991850/networking/configuring-ptp.html#configuring-linuxptp_configuring-ptp
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. -->

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information: This parameter is present in main and 4.9+.
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
