### PR TITLE
Fixing version of docs for 4.11

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -24,7 +24,7 @@ openshift-origin:
     enterprise-4.10:
       name: '4.10'
       dir: '4.10'
-    enterprise-4.10:
+    enterprise-4.11:
       name: '4.11'
       dir: '4.11'
     enterprise-3.6:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Followup to #48939 to fix the version of docs appearing for OKD 4.11.

Version(s):
For OKD, so main only

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->
