### PR TITLE
BZ2116646, BZ2116742, BZ2116748, & BZ2116794: OSDK version bumps

### DIFF
--- a/modules/osdk-installing-cli-linux-macos.adoc
+++ b/modules/osdk-installing-cli-linux-macos.adoc
@@ -3,8 +3,8 @@
 // * cli_reference/osdk/cli-osdk-install.adoc
 // * operators/operator_sdk/osdk-installing-cli.adoc
 
-:ocp_ver: 4.10
-:osdk_ver: v1.16.0
+:ocp_ver: 4.11
+:osdk_ver: v1.22.0
 
 :_content-type: PROCEDURE
 [id="osdk-installing-cli-linux-macos_{context}"]
@@ -14,7 +14,7 @@ You can install the OpenShift SDK CLI tool on Linux.
 
 .Prerequisites
 
-* link:https://golang.org/dl/[Go] v1.16+
+* link:https://golang.org/dl/[Go] v1.18+
 ifdef::openshift-origin[]
 * link:https://docs.docker.com/install/[`docker`] v17.03+, link:https://github.com/containers/libpod/blob/master/install.md[`podman`] v1.2.0+, or link:https://github.com/containers/buildah/blob/master/install.md[`buildah`] v1.7+
 endif::[]
@@ -24,7 +24,7 @@ endif::[]
 
 .Procedure
 
-. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/{ocp_ver}/[OpenShift mirror site].
+. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/[OpenShift mirror site].
 
 . From the latest {ocp_ver} directory, download the latest version of the tarball for Linux.
 

--- a/operators/operator_sdk/osdk-about.adoc
+++ b/operators/operator_sdk/osdk-about.adoc
@@ -28,7 +28,7 @@ Operator authors with cluster administrator access to a Kubernetes-based cluster
 
 [NOTE]
 ====
-{product-title} 4.9 supports Operator SDK v1.10.0 or later.
+{product-title} {product-version} supports Operator SDK v1.22.0 or later.
 ====
 
 [id="osdk-about-what-are-operators"]

--- a/operators/operator_sdk/osdk-installing-cli.adoc
+++ b/operators/operator_sdk/osdk-installing-cli.adoc
@@ -4,7 +4,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: osdk-installing-cli
 
-:osdk_ver: v1.16.0
+:osdk_ver: v1.22.0
 
 toc::[]
 


### PR DESCRIPTION
Version(s): 4.11+



I missed some version bumps for OSDK and a dependency in the 4.11 documentation. This PR addresses those mistakes.

Issue:

- [BZ2116646](https://bugzilla.redhat.com/show_bug.cgi?id=2116646): [Line 31](https://github.com/openshift/openshift-docs/pull/48978/files#diff-e9f38ee6bf0ee81c3ea6dbde8f564fed2e321ae11574e65a30ada1ba42c2307eR31) and [Line 7](https://github.com/openshift/openshift-docs/pull/48978/files#diff-9411c438386474c7e81cbb7e60a063b10c0b4083923aa46580a9378fd326834cR7)
- [BZ2116742](https://bugzilla.redhat.com/show_bug.cgi?id=2116742): [Line 17](https://github.com/openshift/openshift-docs/pull/48978/files#diff-4935ab3e5656397ebbd295e53757cf82feb7be47db4fede33e233d4f72cc1534R17)
- [BZ2116748](https://bugzilla.redhat.com/show_bug.cgi?id=2116748): [Line 27](https://github.com/openshift/openshift-docs/pull/48978/files#diff-4935ab3e5656397ebbd295e53757cf82feb7be47db4fede33e233d4f72cc1534R27)
- [BZ2116794](https://bugzilla.redhat.com/show_bug.cgi?id=2116794): [Lines 6-7](https://github.com/openshift/openshift-docs/pull/48978/files#diff-4935ab3e5656397ebbd295e53757cf82feb7be47db4fede33e233d4f72cc1534R6-R7) update the OCP and OSDK version

Link to docs preview (requires VPN):
Note: the text "Branch Build" in the preview will resolve to the appropriate OCP version after it is merged.

- [About Operator SDK](http://file.rdu.redhat.com/mipeter/osdk-version-bump-BZs/operators/operator_sdk/osdk-about.html)
- [Installing Operator SDK CLI (Note admonition)](http://file.rdu.redhat.com/mipeter/osdk-version-bump-BZs/operators/operator_sdk/osdk-installing-cli.html)
- [Installing Operator SDK CLI (Procedure)](http://file.rdu.redhat.com/mipeter/osdk-version-bump-BZs/operators/operator_sdk/osdk-installing-cli.html#osdk-installing-cli-linux-macos_osdk-installing-cli)

Additional information:
Though this does not apply to OpenShift 4.12, we still need to cherrypick the changes forward to `enterprise-4.12`. The content will be updated to the appropriate version numbers closer to the 4.12 release date.