### PR TITLE
OSDOCS-3926: removes depricated extension point and replaces with correct console-extensions.json

### DIFF
--- a/modules/adding-tab-pods-page.adoc
+++ b/modules/adding-tab-pods-page.adoc
@@ -15,16 +15,18 @@ The following procedure adds a tab to the *Pod Details* page as an example exten
 
 ----
 {
-    "type": "console.page/resource/tab",
-    "properties": {
-        "name": "Example Tab",
-        "href": "example",
-        "model": {
-            "group": "core",
-            "version": "v1",
-            "kind": "Pod"
-        },
-        "component": { "$codeRef": "ExampleTab" }
+  "type": "console.tab/horizontalNav",
+  "properties": {
+    "page": {
+      "name": "Example Tab",
+      "href": "example"
+    },
+    "model": {
+      "group": "core",
+      "version": "v1",
+      "kind": "Pod"
+    },
+    "component": { "$codeRef": "ExampleTab" }
 }
 ----
 


### PR DESCRIPTION
[OSDOCS-3926](https://issues.redhat.com//browse/OSDOCS-3926): removes depricated extension point and replaces with correct console-extensions.json

Applies to enterprise-4.10+

Issue:
[OSDOCS-3926](https://issues.redhat.com/browse/OSDOCS-3926)

Link to docs preview:
http://file.rdu.redhat.com/opayne/OSDOCS-3926/web_console/dynamic-plug-ins.html#adding-tab-to-pods-page_dynamic-plugins




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
