### PR TITLE
[BZ#2117370] Update openshift-ansible repositories

### DIFF
--- a/modules/rhel-preparing-playbook-machine.adoc
+++ b/modules/rhel-preparing-playbook-machine.adoc
@@ -63,7 +63,6 @@ If you use SSH key-based authentication, you must manage the key with an SSH age
 # subscription-manager repos \
     --enable="rhel-8-for-x86_64-baseos-rpms" \
     --enable="rhel-8-for-x86_64-appstream-rpms" \
-    --enable="ansible-2.9-for-rhel-8-x86_64-rpms" \
     --enable="rhocp-4.11-for-rhel-8-x86_64-rpms"
 ----
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2117370

Link to docs preview:
http://shell.lab.bos.redhat.com/~yselkowi/openshift-docs/byoh-ansible-core/machine_management/adding-rhel-compute.html#rhel-preparing-playbook-machine_adding-rhel-compute

Additional information:
openshift-ansible has been ported to ansible-core in RHEL AppStream; the separate Ansible Engine repository (and its older ansible package) is no longer used.