### PR TITLE
[BZ#2117370] Add step for ansible-core migration in 4.10 BYOH updates procedure

### DIFF
--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -53,6 +53,7 @@ By default, the base OS RHEL with "Minimal" installation option enables firewall
 [source,terminal]
 ----
 # subscription-manager repos --disable=rhocp-4.10-for-rhel-8-x86_64-rpms \
+                             --disable=ansible-2.9-for-rhel-8-x86_64-rpms \
                              --enable=rhocp-4.11-for-rhel-8-x86_64-rpms
 ----
 +
@@ -60,6 +61,13 @@ By default, the base OS RHEL with "Minimal" installation option enables firewall
 ====
 As of {product-title} 4.11, the Ansible playbooks are provided only for {op-system-base} 8.  If a {op-system-base} 7 system was used as a host for the {product-title} 4.10 Ansible playbooks, you must either upgrade the Ansible host to {op-system-base} 8, or create a new Ansible host on a {op-system-base} 8 system and copy over the inventories from the old Ansible host.
 ====
+
+.. On the machine that you run the Ansible playbooks, update the Ansible package:
++
+[source,terminal]
+----
+# yum swap ansible ansible-core
+----
 
 .. On the machine that you run the Ansible playbooks, update the required packages, including `openshift-ansible`:
 +


### PR DESCRIPTION
Version(s):
4.11

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2117370

Link to docs preview:
http://shell.lab.bos.redhat.com/~yselkowi/openshift-docs/byoh-ansible-core/updating/updating-cluster-rhel-compute.html#rhel-compute-updating-minor_updating-cluster-rhel-compute

Additional information:
openshift-ansible has switched from ansible 2.9 to ansible-core, requiring an additional step in 4.10-to-4.11 upgrades.
