### PR TITLE
css fix for RHS hamburger menu

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -22,6 +22,14 @@ nav#main {
   }
 }
 
+@media (max-width: 767px) {
+  .navbar-default .navbar-collapse, .navbar-default .navbar-form {
+    border-color: #dedede;
+    background: white;
+    filter: drop-shadow(0.6em 0.01em 0.2em);
+  }
+}
+    
 .navbar.navbar-default.navbar-openshift .navbar-brand.origin {
   background: url("../_images/okd_logo.svg") no-repeat scroll 0% 95%;
   background-size: 140px;


### PR DESCRIPTION
Fixes RHS hamburger overlapping on body pages for https://github.com/openshift/openshift-docs/issues/49031

Merge to main, CP to enterprise-4.1

Preview (viewport < 767px): http://file.emea.redhat.com/aireilly/fix-css-rhs-hamburger/welcome/index.html

![image](https://user-images.githubusercontent.com/74046732/184179535-07922077-3580-40ef-ba61-1ac88d865b2c.png)