### PR TITLE
RHACS typo fix

### DIFF
--- a/modules/expose-portal-http-existing-deployment.adoc
+++ b/modules/expose-portal-http-existing-deployment.adoc
@@ -3,7 +3,7 @@
 // * dir/filename.adoc
 :_module-type: PROCEDURE
 [id="expose-portal-http-existing-deployment_{context}"]
-= Exposing the RHACS portal over HTTP for an existing desployment
+= Exposing the RHACS portal over HTTP for an existing deployment
 
 [role="_abstract"]
 You can enable the HTTP server on an existing {product-title} deployment.


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to:
- `rhacs-docs-3.71`
- `rhacs-docs-3.70`
- `rhacs-docs-3.69`

[Issue](https://github.com/openshift/openshift-docs/issues/45505)

[Link to docs preview](https://openshift-docs-5yvljoq7h-kcarmichael08.vercel.app/openshift-acs/master/configuration/expose-portal-over-http.html)
