### PR TITLE
json syntax fix in webconsole plugin docs

### DIFF
--- a/modules/adding-tab-pods-page.adoc
+++ b/modules/adding-tab-pods-page.adoc
@@ -27,6 +27,7 @@ The following procedure adds a tab to the *Pod Details* page as an example exten
       "kind": "Pod"
     },
     "component": { "$codeRef": "ExampleTab" }
+  }
 }
 ----
 


### PR DESCRIPTION
Fixes the json syntax of console-extensions.json code example in "Adding a tab to the pods page" part of the docs about creating webconsole plugin

Version(s):
  * PR applies to all versions after a specific version: 4.10+
