### PR TITLE
[OSDOCS-1875] added addtional policy constraints to GCP procedure page

### DIFF
--- a/modules/ccs-gcp-customer-procedure.adoc
+++ b/modules/ccs-gcp-customer-procedure.adoc
@@ -5,11 +5,16 @@
 // TODO: Same as other module - Better procedure heading that tells you what this is doing
 
 
-The Customer Cloud Subscription (CCS) model allows Red Hat to deploy and manage {product-title} into a customer’s Google Cloud Platform (GCP) project. Red Hat requires several prerequisites in order to provide these services.
+The Customer Cloud Subscription (CCS) model allows Red Hat to deploy and manage {product-title} into a customer's Google Cloud Platform (GCP) project. Red Hat requires several prerequisites to provide these services.
 
 [WARNING]
 ====
-To use {product-title} in your GCP project, the GCP organizational policy constraint, `constraints/iam.allowedPolicyMemberDomains`, cannot be in place.
+To use {product-title} in your GCP project, the following GCP organizational policy constraints cannot be in place:
+
+* `constraints/iam.allowedPolicyMemberDomains`
+* `constraints/storage.uniformBucketLevelAccess`
+* `constraints/compute.restrictLoadBalancerCreationForTypes`
+* `constraints/compute.vmExternalIpAccess` (This policy constraint is unsupported only during installation. You can re-enable the policy constraint after installation.)
 ====
 
 .Procedure


### PR DESCRIPTION
[OSDOCS-1875] added addtional policy constraints to GCP procedure page

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-1875

Link to docs preview:
http://file.rdu.redhat.com/aldiaz/OSDOCS-1875/osd_planning/gcp-ccs.html#ccs-gcp-customer-procedure_gcp-ccs

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->


<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
