### PR TITLE
Remove git depth from git clone cmd in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: python
 cache: pip
 # env:
 #   - PR_AUTHOR=${TRAVIS_PULL_REQUEST_SLUG::-15}
-
+git:
+  depth: 1
 jobs:
   include:
     - stage: build
+      name: "build openshift-enterprise"
       before_install:
         - gem install asciidoctor
         - gem install asciidoctor-diagram
@@ -15,6 +17,7 @@ jobs:
       script:
         - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.11 --no-upstream-fetch && python3 makeBuild.py
     - # stage name not required, will continue to use `build`
+      name: "build openshift-dedicated"
       if: branch IN (main, enterprise-4.10, enterprise-4.11)
       before_install:
         - gem install asciidoctor
@@ -25,6 +28,7 @@ jobs:
       script:
         - python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch && python3 makeBuild.py
     - # stage name not required, will continue to use `build`
+      name: "build openshift-rosa"
       if: branch IN (main, enterprise-4.10, enterprise-4.11)
       before_install:
         - gem install asciidoctor


### PR DESCRIPTION
We currently use the default git clone `depth=50` in the travis build. This is sub-optimal. Per https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth you can adjust with the following in `openshift-docs/.travis.yml`. This should speed up the git clone stage of the build from ~ 20s to about 3s.

```yaml
git:
  depth: 1
```

Also added build stage names for ease of use - now easier to see which stage is which :)
![image](https://user-images.githubusercontent.com/74046732/184718259-957e8419-34d6-4292-9a4d-64918ba1d7e6.png)

