### PR TITLE
OADP-649 and 650: Supported backup targets 

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
@@ -13,3 +13,15 @@ The default plug-ins enable Velero to integrate with certain cloud providers and
 
 include::modules/oadp-features.adoc[leveloffset=+1]
 include::modules/oadp-plugins.adoc[leveloffset=+1]
+
+[id=oadp-support-for-ibm-power-systems-and-ibm-z]
+== OADP support for IBM Power Systems and IBM Z
+
+OpenShift API for Data Protection (OADP) is platform neutral. The information that follows relates only to IBM Power Systems and to IBM Z.
+
+OADP 1.1.0 was tested successfully against {product-title} 4.11 for both IBM Power Systems and IBM Z. The sections that follow give testing and support information for OADP 1.1.0 in terms of backup locations for these systems.
+
+include::modules/oadp-ibm-power-test-support.adoc[leveloffset=+2]
+include::modules/oadp-ibm-z-test-support.adoc[leveloffset=+2]
+
+:oadp-features-plugins!:

--- a/modules/oadp-ibm-power-test-support.adoc
+++ b/modules/oadp-ibm-power-test-support.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+
+:_content-type: CONCEPT
+[id="oadp-ibm-power-test-matrix_{context}"]
+= OADP support for target backup locations using IBM Power Systems
+
+IBM Power Systems ("cloud systems") running with {product-title} 4.11 and OpenShift API for Data Protection (OADP) 1.1.0 was tested successfully against an AWS S3 backup location target. Although the test involved only an AWS S3 target, Red Hat supports running IBM Power Systems with {product-title} 4.11 and OADP 1.1.0 against all non-AWS S3 backup location targets as well.

--- a/modules/oadp-ibm-z-test-support.adoc
+++ b/modules/oadp-ibm-z-test-support.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+
+:_content-type: CONCEPT
+[id="oadp-ibm-z-test-support_{context}"]
+= OADP testing and support for target backup locations using IBM Z
+
+IBM Z ("bare metal") running with {product-title} 4.11 and OpenShift API for Data Protection (OADP) 1.1.0 was tested successfully against an AWS S3 backup location target. Although the test involved only an AWS S3 target, Red Hat supports running IBM Z with {product-title} 4.11 and OADP 1.1.0 against all non-AWS S3 backup location targets as well.


### PR DESCRIPTION
OADP 1.1.0 OCP 4.11

Resolves: https://issues.redhat.com/browse/OADP-649 and https://issues.redhat.com/browse/OADP-650 by adding tables to indicate which backup target locations are supported for IBM Cloud and IBM Z systems respecticely.

Preview: http://file.emea.redhat.com/rhoch/ibm_power/backup_and_restore/application_backup_and_restore/oadp-features-plugins.html#oadp-support-for-ibm-power-systems-and-ibm-z

Please do not merge before Sept. 1. 