### PR TITLE
BZ2104374: Removed period (.) as supported character from metadata.name

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -245,12 +245,12 @@ Required installation configuration parameters are described in the following ta
 
 |`metadata.name`
 |The name of the cluster. DNS records for the cluster are all subdomains of `{{.metadata.name}}.{{.baseDomain}}`.
-ifndef::nutanix[]
+ifndef::bare,nutanix,vmc,vsphere[]
 |String of lowercase letters, hyphens (`-`), and periods (`.`), such as `dev`.
-endif::nutanix[]
-ifdef::nutanix[]
+endif::bare,nutanix,vmc,vsphere[]
+ifdef::bare,nutanix,vmc,vsphere[]
 |String of lowercase letters and hyphens (`-`), such as `dev`.
-endif::nutanix[]
+endif::bare,nutanix,vmc,vsphere[]
 ifdef::osp[]
 The string must be 14 characters or fewer long.
 endif::osp[]


### PR DESCRIPTION
Version(s):
CP to 4.6+

Issue:
This PR addresses [BZ2104374](https://bugzilla.redhat.com/show_bug.cgi?id=2104374)

Link to docs preview:

- Installing a cluster on vSphere > [Required configuration parameters](http://file.rdu.redhat.com/mpytlak/bz2104374/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-configuration-parameters-required_installing-vsphere-installer-provisioned-customizations)
- Installing a cluster on VMC with customization > [Required configuration parameters](http://file.rdu.redhat.com/mpytlak/bz2104374/installing/installing_vmc/installing-vmc-customizations.html#installation-configuration-parameters-required_installing-vmc-customizations)
- Installing a user-provisioned cluster on bare metal > [Required configuration parameters](http://file.rdu.redhat.com/mpytlak/bz2104374/installing/installing_bare_metal/installing-bare-metal.html#installation-configuration-parameters-required_installing-bare-metal)

