### PR TITLE
BZ1996012 - Adding clarificaton for machine types

### DIFF
--- a/modules/installation-aws-arm-tested-machine-types.adoc
+++ b/modules/installation-aws-arm-tested-machine-types.adoc
@@ -14,6 +14,11 @@
 
 The following Amazon Web Services (AWS) ARM instance types have been tested with {product-title}.
 
+[NOTE]
+====
+Use the machine types included in the following charts for your AWS ARM instances. If you use an instance type that is not listed in the chart, ensure that the instance size you use matches the minimum resource requirements that are listed in "Minimum resource requirements for cluster installation". 
+====
+
 .Machine types based on arm64 architecture
 [%collapsible]
 ====

--- a/modules/installation-aws-tested-machine-types.adoc
+++ b/modules/installation-aws-tested-machine-types.adoc
@@ -14,6 +14,11 @@
 
 The following Amazon Web Services (AWS) instance types have been tested with {product-title}.
 
+[NOTE]
+====
+Use the machine types included in the following charts for your AWS instances. If you use an instance type that is not listed in the chart, ensure that the instance size you use matches the minimum resource requirements that are listed in "Minimum resource requirements for cluster installation". 
+====
+
 .Machine types based on x86_64 architecture
 [%collapsible]
 ====


### PR DESCRIPTION
For version 4.10+
[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1996012)
Description: Some users were using instance types not included in the list, adding clarification to suggest using the types in the charts

Preview:
[Installing on AWS with customizations -> Tested instance types for AWS](https://kelbrown20.github.io/bug-fix-previews/BZ1996012-instance-type-clarification/installing/installing_aws/installing-aws-customizations.html#installation-supported-aws-machine-types_installing-aws-customizations)

For peer reviewer: 
The repeated NOTE might not be necessary, but it looked a bit odd having one module with it and one without, but I wanted a second opinion as well. Thank you!