### PR TITLE
TELCODOCS-657: Update headings under the IPI book 

### DIFF
--- a/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
+++ b/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id='configure-network-components-to-run-on-the-control-plane_{context}']
-= (Optional) Configuring network components to run on the control plane
+= Optional: Configuring network components to run on the control plane
 
 You can configure networking components to run exclusively on the control plane nodes. By default, {product-title} allows any node in the machine config pool to host the `ingressVIP` virtual IP address. However, some environments deploy worker nodes in separate subnets from the control plane nodes. When deploying remote workers in separate subnets, you must place the `ingressVIP` virtual IP address exclusively with the control plane nodes.
 

--- a/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="configuring-host-network-interfaces-in-the-install-config-yaml-file_{context}"]
-= (Optional) Configuring host network interfaces
+= Optional: Configuring host network interfaces
 
 During installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState. To use the `networkConfig` configuration setting, you must provide an NMState YAML configuration.
 

--- a/modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="configuring-managed-secure-boot-in-the-install-config-file_{context}"]
-= (Optional) Configuring managed Secure Boot
+= Optional: Configuring managed Secure Boot
 
 You can enable managed Secure Boot when deploying an installer-provisioned cluster using Redfish BMC addressing, such as `redfish`, `redfish-virtualmedia`, or `idrac-virtualmedia`. To enable managed Secure Boot, add the `bootMode` configuration setting to each node:
 

--- a/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
+++ b/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
@@ -5,7 +5,7 @@
 
 :_content-type: PROCEDURE
 [id="configuring-ntp-for-disconnected-clusters_{context}"]
-= (Optional) Configuring NTP for disconnected clusters
+= Optional: Configuring NTP for disconnected clusters
 
 //This procedure can be executed as a day 1 or day 2 operation with minor differences.
 //The conditional text picks up the context and displays the appropriate alternate steps.

--- a/modules/ipi-install-configuring-the-bios.adoc
+++ b/modules/ipi-install-configuring-the-bios.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="configuring-the-bios_{context}"]
-= (Optional) Configuring the BIOS
+= Optional: Configuring the BIOS
 
 The following procedure configures the BIOS during the installation process.
 

--- a/modules/ipi-install-configuring-the-raid.adoc
+++ b/modules/ipi-install-configuring-the-raid.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="configuring-the-raid_{context}"]
-= (Optional) Configuring the RAID
+= Optional: Configuring the RAID
 
 The following procedure configures a redundant array of independent disks (RAID) during the installation process.
 

--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="ipi-install-creating-an-rhcos-images-cache_{context}"]
-= (Optional) Creating an {op-system} images cache
+= Optional: Creating an {op-system} images cache
 
 To employ image caching, you must download the {op-system-first} image used by the bootstrap VM to provision the cluster nodes. Image caching is optional, but it is especially useful when running the installation program on a network with limited bandwidth.
 

--- a/modules/ipi-install-deploying-routers-on-worker-nodes.adoc
+++ b/modules/ipi-install-deploying-routers-on-worker-nodes.adoc
@@ -5,7 +5,7 @@
 
 :_content-type: PROCEDURE
 [id="deploying-routers-on-worker-nodes_{context}"]
-= (Optional) Deploying routers on worker nodes
+= Optional: Deploying routers on worker nodes
 
 During installation, the installer deploys router pods on worker nodes. By default, the installer installs two router pods. If a deployed cluster requires additional routers to handle external traffic loads destined for services within the {product-title} cluster, you can create a `yaml` file to set an appropriate number of router replicas.
 

--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id='modifying-install-config-for-dual-stack-network_{context}']
-= (Optional) Deploying with dual-stack networking
+= Optional: Deploying with dual-stack networking
 
 To deploy an {product-title} cluster with dual-stack networking, edit the `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings in the `install-config.yaml` file. Each setting must have two CIDR entries each. Ensure the first CIDR entry is the IPv4 setting and the second CIDR entry is the IPv6 setting.
 

--- a/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id='modifying-install-config-for-no-provisioning-network_{context}']
-= (Optional) Deploying with no provisioning network
+= Optional: Deploying with no provisioning network
 
 To deploy an {product-title} cluster without a `provisioning` network, make the following changes to the `install-config.yaml` file.
 

--- a/modules/ipi-install-setting-proxy-settings-within-install-config.adoc
+++ b/modules/ipi-install-setting-proxy-settings-within-install-config.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id='ipi-install-setting-proxy-settings-within-install-config_{context}']
-= (Optional) Setting proxy settings
+= Optional: Setting proxy settings
 
 To deploy an {product-title} cluster using a proxy, make the following changes to the `install-config.yaml` file.
 


### PR DESCRIPTION
Replaces https://github.com/openshift/openshift-docs/pull/46219. Replaces (Optional) to Optional: in ipi bare metal titles.

Fixes: [TELCODOCS-657](https://issues.redhat.com//browse/TELCODOCS-657)

See https://issues.redhat.com/browse/TELCODOCS-657 for additional details.

Preview URL: http://jowilkin.com:8080/TELCODOCS-657-2/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html

For release(s): 4.12, 4.11
Signed-off-by: John Wilkins <jowilkin@redhat.com>
