### PR TITLE
OSSMDOC-588: Distributed tracing 2.5 Release Notes.

### DIFF
--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -13,6 +13,32 @@ Result – If changed, describe the current user experience.
 
 This release adds improvements related to the following components and concepts.
 
+== New features and enhancements {DTProductName} 2.5
+
+This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
+
+This release introduces support for ingesting OpenTelemetry protocol (OTLP) to the {JaegerName} Operator. The Operator now automatically enables the OTLP ports:
+
+* Port 4317 is used for OTLP gRPC protocol.
+* Port 4318 is used for OTLP HTTP protocol.
+
+This release also adds support for collecting Kubernetes resource attributes to the {OTELName} Operator.
+
+=== Component versions supported in {DTProductName} version 2.5
+
+[options="header"]
+|===
+|Operator |Component |Version
+|{JaegerName}
+|Jaeger
+|1.36
+
+|{OTELName}
+|OpenTelemetry
+|0.56
+|===
+
+
 == New features and enhancements {DTProductName} 2.4
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
@@ -24,7 +50,7 @@ This release also adds support for auto-provisioning certificates using the Red 
 
 [NOTE]
 ====
-When upgrading to {DTProductName} 2.4, the Operator recreates the Elasticsearch instance, which might take five to ten minutes.  Distributed tracing will be down and unavailable for that period.
+When upgrading to {DTProductName} 2.4, the Operator recreates the Elasticsearch instance, which might take five to ten minutes. Distributed tracing will be down and unavailable for that period.
 ====
 
 === Component versions supported in {DTProductName} version 2.4
@@ -63,7 +89,7 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
-With this release, the {JaegerName} Operator is now installed to the `openshift-distributed-tracing` namespace by default.  Previously the default installation had been in the `openshift-operator` namespace.
+With this release, the {JaegerName} Operator is now installed to the `openshift-distributed-tracing` namespace by default. Previously the default installation had been in the `openshift-operators` namespace.
 
 === Component versions supported in {DTProductName} version 2.3.0
 


### PR DESCRIPTION
Version(s): 4.6 - 4.12

Issue: [OSSMDOC-588](https://issues.redhat.com/browse/OSSMDOC-588)

Link to docs preview: http://file.bos.redhat.com/jstickle/OSSMDOC-588/distr_tracing/distributed-tracing-release-notes.html#distr-tracing-rn-new-features_distributed-tracing-release-notes

Additional information:
Eng review: pavolloffay
QE review:  iblancasa
Peer review: tmalove