### PR TITLE
TELCODOCS-860: MGMT-10404 Use boot-artifacts API to fetch rootfs in minimal-iso (assisted-image-service)

### DIFF
--- a/modules/ztp-ai-install-ocp-clusters-on-bare-metal.adoc
+++ b/modules/ztp-ai-install-ocp-clusters-on-bare-metal.adoc
@@ -59,12 +59,11 @@ spec:
     - ReadWriteOnce
     resources:
       requests:
-        storage: <image_storage_volume_size> <3>      
+        storage: <image_storage_volume_size> <3>
   osImages: <4>
     - openshiftVersion: "<ocp_version>" <5>
       version: "<ocp_release_version>" <6>
       url: "<iso_url>" <7>
-      rootFSUrl: "<root_fs_url>" <8>
       cpuArchitecture: "x86_64"
 ----
 <1> Volume size for the `databaseStorage` field, for example `10Gi`.
@@ -74,7 +73,6 @@ spec:
 <5> {product-title} version to install, in either "x.y" (major.minor) or "x.y.z" (major.minor.patch) formats.
 <6> Specific install version, for example, `47.83.202103251640-0`.
 <7> ISO url, for example, `https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso`.
-<8> Root FS image URL, for example `https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img`.
 
 .. Create the `AgentServiceConfig` CR by running the following command:
 +


### PR DESCRIPTION
Fixes: [TELCODOCS-860](https://issues.redhat.com/browse/TELCODOCS-860)

For: Version 4.11+

Doc Preview: https://49123--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#enabling-assisted-installer-service-on-bare-metal_ztp-deploying-disconnected

Signed-off-by: Katie Tothill ktothill@redhat.com