### PR TITLE
[RHACS] ROX-12198: Add info about repos shut down to RNs

### DIFF
--- a/release_notes/371-release-notes.adoc
+++ b/release_notes/371-release-notes.adoc
@@ -153,6 +153,11 @@ You should switch to kernel module collection if you are using:
 * SELinux on {op-system-base} 7, which may also prevent the loading of eBPF probes.
 ====
 
+[id="stackrox-io-registry-shutdown"]
+=== Shutdown of Stackrox image registry sites
+
+The image registries hosted at the `stackrox.io` and `collector.stackrox.io` addresses were shut down. Images for {product-title-short} are available from `registry.redhat.io`.
+
 [id="deprecation-notices-371"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Versions:
- `rhacs-docs`
- `rhacs-docs-3.71`

Labels: 
`RHACS`

[Issue](https://issues.redhat.com/browse/ROX-12198)

[Preview](https://openshift-docs-18jaa1f1x-kcarmichael08.vercel.app/openshift-acs/master/release_notes/371-release-notes.html#stackrox-io-registry-shutdown)
