### PR TITLE
TELCODOCS-860 RN: MGMT-10404 Use boot-artifacts API to fetch rootfs in minimal-iso (assisted-image-service)

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -540,6 +540,7 @@ For more information, see xref:../nodes/scheduling/nodes-descheduler.adoc#nodes-
 
 [id="ocp-4-11-scalability-and-performance"]
 === Scalability and performance
+Beginning with {product-title} 4.11, users no longer need to set the Root FS image URL (`rootFSUrl`) in the `agent_service_config.yaml` file. The `rootFSUrl` is now handled automatically.
 
 [id=ocp-4-11-enhance-scaleup-operations-etcd-clusters]
 ==== Enhancement to scale-up operations for etcd clusters


### PR DESCRIPTION
Fixes: [TELCODOCS-860 RN](https://issues.redhat.com/browse/TELCODOCS-860)

For: Version 4.11 

Doc Preview: https://49125--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-scalability-and-performance

Signed-off-by: Katie Tothill ktothill@redhat.com