### PR TITLE
[enterprise-4.11] 4.11 relnote: Rm PO references

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1166,6 +1166,14 @@ If you have Operator projects that were previously created or maintained with Op
 
 * xref:../operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.adoc#osdk-upgrading-projects_osdk-hybrid-helm-updating-projects[Updating Hybrid Helm-based Operator projects]
 
+[discrete]
+[id="ocp-4-11-cluster-operators-naming"]
+==== Cluster Operators no longer referred to as platform Operators
+
+{product-title} documentation previously referred to cluster Operators interchangeably with the alternative naming "platform Operators". Because this double naming could cause confusion about the type of Operators being discussed, the term "platform Operator" is no longer used when referring to cluster Operators, which are represented by `ClusterOperator` API objects. The documentation sets for {product-title} {product-version} and earlier have been updated to now solely use the term "cluster Operator".
+
+For example, see xref:../operators/operator-reference.adoc#cluster-operators-ref[Cluster Operators reference]. 
+
 [id="ocp-4-11-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3846

Release note for related PR: https://github.com/openshift/openshift-docs/pull/48734

Preview (internal): http://file.rdu.redhat.com/adellape/081722/411rn_po_rename/release_notes/ocp-4-11-release-notes.html#ocp-4-11-cluster-operators-naming