### PR TITLE
WINC 1176: Add Windows node limitations

### DIFF
--- a/modules/windows-containers-release-notes-limitations.adoc
+++ b/modules/windows-containers-release-notes-limitations.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/windows-containers-release-notes-#-x
+
+[id="windows-containers-release-notes-limitations_{context}"]
+= Known limitations
+
+Note the following limitations when working with Windows nodes managed by the WMCO (Windows nodes):
+
+* The following {product-title} features are not supported on Windows nodes:
+** Red Hat OpenShift Developer CLI (odo)
+** Image builds
+** OpenShift Pipelines
+** OpenShift Service Mesh
+** OpenShift monitoring of user-defined projects
+
+* The following Red Hat features are not supported on Windows nodes:
+** link:https://access.redhat.com/documentation/en-us/cost_management_service/2022/html/getting_started_with_cost_management/assembly-introduction-cost-management?extIdCarryOver=true&sc_cid=701f2000001OH74AAG#about-cost-management_getting-started[Red Hat cost management]
+** link:https://developers.redhat.com/products/openshift-local/overview[Red Hat OpenShift Local]
+
+* Windows nodes do not support pulling container images from private registries. You can use images from public registries or pre-pull the images.
+
+* Windows nodes do not support workloads created by using deployment configs. You can use a deployment or other method to deploy workloads.
+
+* Windows nodes are not supported in clusters that use a cluster-wide proxy. This is because the WMCO is not able to route traffic through the proxy connection for the workloads.
+
+* Windows nodes are not supported in clusters that are in a disconnected environment.
+
+* {productwinc} supports only in-tree storage drivers for all cloud providers. 
+
+* Kubernetes has identified the following link:https://kubernetes.io/docs/concepts/windows/intro/#limitations[node feature limitations] :
+** Huge pages are not supported for Windows containers.
+** Privileged containers are not supported for Windows containers.
+** Pod termination grace periods require the containerd container runtime to be installed on the Windows node.
+
+* Kubernetes has identified link:https://kubernetes.io/docs/concepts/windows/intro/#api[several API compatability issues].
+

--- a/windows_containers/understanding-windows-container-workloads.adoc
+++ b/windows_containers/understanding-windows-container-workloads.adoc
@@ -25,4 +25,6 @@ include::modules/windows-workload-management.adoc[leveloffset=+1]
 
 include::modules/windows-node-services.adoc[leveloffset=+1]
 
+include::modules/windows-containers-release-notes-limitations.adoc[leveloffset=+1]
+
 //modules/windows-linux-containers-differences.adoc[leveloffset=+1]

--- a/windows_containers/windows-containers-release-notes-6-x.adoc
+++ b/windows_containers/windows-containers-release-notes-6-x.adoc
@@ -51,7 +51,5 @@ The WMCO supports a Windows golden image with or without Docker for vSphere and 
 
 include::modules/wmco-prerequisites.adoc[leveloffset=+1]
 
-[IMPORTANT]
-====
-Running Windows container workloads is not supported for clusters in a restricted network or disconnected environment.
-====
+include::modules/windows-containers-release-notes-limitations.adoc[leveloffset=+1]
+


### PR DESCRIPTION
Add lists of limitations for WMCO and Windows nodes.

Based on https://github.com/openshift/windows-machine-config-operator/pull/1176, https://github.com/openshift/windows-machine-config-operator/pull/1188; https://kubernetes.io/docs/concepts/windows/intro/#limitations
The private registries and disconnected cluster limitations were already in place 

Preview:
[Known limitations](http://file.rdu.redhat.com/~mburke/winc-add-limitations/windows_containers/windows-containers-release-notes-6-x.html#windows-containers-release-notes-limitations)