### PR TITLE
BZ-2116322 Creating initial submit correction to GitOps ZTP pipeline

### DIFF
--- a/modules/ztp-installing-the-new-gitops-ztp-applications.adoc
+++ b/modules/ztp-installing-the-new-gitops-ztp-applications.adoc
@@ -10,7 +10,16 @@ Using the extracted `argocd/deployment` directory, and after ensuring that the a
 
 .Procedure
 
-* Apply the contents of the `argocd/deployment` directory using the following command:
+. To patch the ArgoCD instance in the hub cluster by using the patch file previously extracted into the `out/argocd/deployment/` directory, enter the following command:
++
+[source,terminal]
+----
+$ oc patch argocd openshift-gitops \
+-n openshift-gitops --type=merge \
+--patch-file out/argocd/deployment/argocd-openshift-gitops-patch.json
+---- 
+
+. To apply the contents of the `argocd/deployment` directory, enter the following command:
 +
 [source,terminal]
 ----

--- a/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
+++ b/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
@@ -36,7 +36,16 @@ You can configure your hub cluster with a set of ArgoCD applications that genera
 
 * The path should specify the path to the `SiteConfig` or `PolicyGenTemplate` CRs, respectively.
 
-. Apply the pipeline configuration to your hub cluster using the following command:
+. To patch the ArgoCD instance in the hub cluster by using the patch file previously extracted into the `out/argocd/deployment/` directory, enter the following command:
++
+[source,terminal]
+----
+$ oc patch argocd openshift-gitops \ 
+-n openshift-gitops --type=merge \ 
+--patch-file out/argocd/deployment/argocd-openshift-gitops-patch.json
+----
+
+. Apply the pipeline configuration to your hub cluster by using the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
BZ#2116322: The instructions for Installing and Upgrading the GitOps ZTP pipeline is missing a step

Version(s):

  * PR applies to all versions after a specific version: 4.12, 4.11, 4.10 and main

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2116322

Link to docs preview:
First section to update: 
http://file.emea.redhat.com/kquinn/BZ-2116322/scalability_and_performance/ztp-deploying-disconnected.html#ztp-preparing-the-hub-cluster-for-ztp_ztp-deploying-disconnected
Second section to update: 
http://file.emea.redhat.com/kquinn/BZ-2116322/scalability_and_performance/ztp-deploying-disconnected.html#ztp-installing-the-new-gitops-ztp-applications_ztp-deploying-disconnected