### PR TITLE
BZ-2010564 Creating initial submit - configuring seccomp profile

### DIFF
--- a/modules/configuring-default-seccomp-profile.adoc
+++ b/modules/configuring-default-seccomp-profile.adoc
@@ -1,15 +1,111 @@
-[id="configuring-default-seccomp-profile_{context}"]
-= Configuring the default seccomp profile
-OpenShift ships with a default seccomp profile that is referenced as `runtime/default`. You can enable the default seccomp profile for a pod or container workload by setting `RuntimeDefault` as following:
+// Module included in the following assemblies:
+//
+// * security/seccomp-profiles.adoc
 
-.Example
+:_content-type: PROCEDURE
 
-[source, yaml]
+[id="verifying-default-seccomp-profile_{context}"]
+= Verifying the default seccomp profile applied to a pod
+
+{product-title} ships with a default seccomp profile that is referenced as `runtime/default`. In {product-version}, newly created pods have the Security Context Constraint (SCC) set to `restricted-v2` and the default seccomp profile applies to the pod. 
+
+.Procedure
+
+. You can verify the Security Context Constraint (SCC) and the default seccomp profile set on a pod by running the following commands: 
+
+.. Verify what pods are running in the namespace: 
++
+[source, terminal]
 ----
-spec:
-  securityContext:
-    seccompProfile:
-      type: RuntimeDefault
+$ oc get pods -n <namespace> 
+---- 
++
+For example, to verify what pods are running in the `workshop` namespace run the following: 
++
+[source, terminal]
+----
+$ oc get pods -n workshop 
+---- 
++
+.Example output 
++
+[source, terminal]
+----
+NAME                READY   STATUS      RESTARTS   AGE
+parksmap-1-4xkwf    1/1     Running     0          2m17s
+parksmap-1-deploy   0/1     Completed   0          2m22s
+---- 
++
+.. Inspect the pods: 
++
+[source, terminal]
+----
+$ oc get pod parksmap-1-4xkwf -n workshop -o yaml
+----
++
+.Example output 
++
+[source, terminal]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/network-status: |-
+      [{
+          "name": "openshift-sdn",
+          "interface": "eth0",
+          "ips": [
+              "10.131.0.18"
+          ],
+          "default": true,
+          "dns": {}
+      }]
+    k8s.v1.cni.cncf.io/networks-status: |-
+      [{
+          "name": "openshift-sdn",
+          "interface": "eth0",
+          "ips": [
+              "10.131.0.18"
+          ],
+          "default": true,
+          "dns": {}
+      }]
+    openshift.io/deployment-config.latest-version: "1"
+    openshift.io/deployment-config.name: parksmap
+    openshift.io/deployment.name: parksmap-1
+    openshift.io/generated-by: OpenShiftWebConsole
+    openshift.io/scc: restricted-v2 <1>
+    seccomp.security.alpha.kubernetes.io/pod: runtime/default <2>
+---- 
+<1> The `restricted-v2` SCC is added by default if your workload does not have access to a different SCC. 
+<2> Newly created pods in {product-version} will have the seccomp profile configured to `runtime/default` as mandated by the SCC. 
+
+[id="upgraded_cluster_{context}"]
+== Upgraded cluster
+
+In clusters upgraded to {product-version} all authenticated users have access to the `restricted` and `restricted-v2` SCC. 
+
+A workload admitted by the SCC `restricted` for example, on a {product-title} v4.10 cluster when upgraded may get admitted by `restricted-v2`. This is because `restricted-v2` is the more restrictive SCC between `restricted` and `restricted-v2`.
+[NOTE]
+====
+The workload must be able to run with `retricted-v2`.
+====
+
+Conversely with a workload that requires `privilegeEscalation: true` this workload will continue to have the `restricted` SCC available for any authenticated user. This is because `restricted-v2` does not allow `privilegeEscalation`.
+
+[id="newly_installed_{context}"]
+== Newly installed cluster
+
+For newly installed {product-title} v4.11 cluster, the `restricted-v2` replaces the `restricted` SCC as an SCC that is available to be used by any authenticated user. A workload with `privilegeEscalation: true`, is not admitted into the cluster since `restricted-v2` is the only SCC available for authenticated users by default. 
+
+The feature `privilegeEscalation` is allowed by `restricted` but not by `restricted-v2`. More features are denied by `restricted-v2` than were allowed by `restricted` SCC.  
+
+A workload with `privilegeEscalation: true` may be admitted into a newly installed {product-title} v4.11 cluster. To give access to the `restricted` SCC to the ServiceAccount running the workload (or any other SCC that can admit this workload) using a RoleBinding run the following command: 
+
+[source, terminal]
+----
+$ oc -n <workload-namespace> adm policy add-scc-to-user <scc-name> -z <serviceaccount_name>
 ----
 
-Alternatively, you can use the pod annotations `seccomp.security.alpha.kubernetes.io/pod: runtime/default` and `container.seccomp.security.alpha.kubernetes.io/<container_name>: runtime/default`. However, this method is deprecated in {product-title} {product-version}.
+In {product-title} {product-version} the ability to add the pod annotations `seccomp.security.alpha.kubernetes.io/pod: runtime/default` and `container.seccomp.security.alpha.kubernetes.io/<container_name>: runtime/default` is deprecated. 

--- a/security/seccomp-profiles.adoc
+++ b/security/seccomp-profiles.adoc
@@ -7,13 +7,11 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 An {product-title} container or a pod runs a single application that performs one or more well-defined tasks. The application usually requires only a small subset of the underlying operating system kernel APIs.
-Seccomp, secure computing mode, is a  Linux kernel feature that can be used to limit the process running in a container to only call a subset of the available system calls. These system calls can be configured by creating a profile that is applied to a container or pod.
-Seccomp profiles are stored as JSON files on the disk.
+Secure computing mode, seccomp, is a  Linux kernel feature that can be used to limit the process running in a container to only using a subset of the available system calls. 
 
-[IMPORTANT]
-====
-OpenShift workloads run unconfined by default, without any seccomp profile applied.
-====
+The `restricted-v2` SCC applies to all newly created pods in {product-version}. The default seccomp profile `runtime/default` is applied to these pods.  
+
+Seccomp profiles are stored as JSON files on the disk.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
BZ-2010564: Lack of description about creating and configuring custom SCC that allows configuring seccomp profile

Version(s):
  * PR applies to multiple specific versions:  4.11 and greater 

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2010564

Link to docs preview:
http://file.emea.redhat.com/kquinn/BZ-2010564/security/seccomp-profiles.html