### PR TITLE
OSDOCS-3815: Updated text to cover PVs

### DIFF
--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -151,7 +151,14 @@ endif::osd-on-aws[]
 ifdef::osd-on-gcp[]
 encryption keys through the Google Cloud Key Management Service.
 endif::osd-on-gcp[]
-These keys are used for encrypting all control plane, infrastructure, and worker node root volumes.
+The key is used for encrypting all control plane, infrastructure, worker node root volumes, and persistent volumes in your cluster.
++
+[IMPORTANT]
+====
+Only persistent volumes (PVs) created from the default storage class are encrypted with this specific key.
+
+PVs created by using any other storage class are still encrypted, but the PVs are not encrypted with this key unless the storage class is specifically configured to use this key.
+====
 
 .. Click *Next*.
 

--- a/modules/rosa-policy-security-regulation-compliance.adoc
+++ b/modules/rosa-policy-security-regulation-compliance.adoc
@@ -15,7 +15,7 @@ Red Hat defines and follows a data classification standard to determine the sens
 
 [id="rosa-policy-data-management_{context}"]
 == Data management
-{product-title} (ROSA) uses AWS Key Management Service (KMS) to help securely manage keys for encrypted data. These keys are used for control plane data volumes that are encrypted by default.
+{product-title} (ROSA) uses AWS Key Management Service (KMS) to help securely manage keys for encrypted data. These keys are used for control plane data volumes that are encrypted by default. Persistent volumes (PVs) for customer applications also use AWS KMS for key management.
 
 When a customer deletes their ROSA cluster, all cluster data is permanently deleted, including control plane data volumes and customer application data volumes, such as persistent volumes (PV).
 

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -48,7 +48,15 @@ $ rosa create account-roles --mode manual <1>
 +
 .. After review, run the `aws` commands manually to create the roles and policies. Alternatively, you can run the preceding command using `--mode auto` to run the `aws` commands immediately.
 
-. Optional: If you are using your own AWS KMS key to encrypt the control plane, infrastructure, and worker node root volumes, add the ARN for the account-wide installer role to your KMS key policy.
+. Optional: If you are using your own AWS KMS key to encrypt the control plane, infrastructure, worker node root volumes, and persistent volumes (PVs), add the ARN for the account-wide installer role to your KMS key policy.
++
+[IMPORTANT]
+====
+Only persistent volumes (PVs) created from the default storage class are encrypted with this specific key.
+
+PVs created by using any other storage class are still encrypted, but the PVs are not encrypted with this key unless the storage class is specifically configured to use this key.
+====
+
 .. Save the key policy for your KMS key to a file on your local machine. The following example saves the output to `kms-key-policy.json` in the current working directory:
 +
 [source,terminal]
@@ -183,7 +191,15 @@ I: To watch your cluster installation logs, run 'rosa logs install -c <cluster_n
 <2> If more than one matching set of account-wide roles are available in your account for a cluster version, an interactive list of options is provided.
 <3> Optional: By default, the cluster-specific Operator role names are prefixed with the cluster name and random 4-digit hash. You can optionally specify a custom prefix to replace `<cluster_name>-<hash>` in the role names. The prefix is applied when you create the cluster-specific Operator IAM roles. For information about the prefix, see _Defining an Operator IAM role prefix_.
 <4> Multiple availability zones are recommended for production workloads. The default is a single availability zone.
-<5> Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, and worker node root volumes. Specify the ARN for the KMS key that you added to the account-wide role ARN to in the preceding step.
+<5> Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, worker node root volumes, and PVs. Specify the ARN for the KMS key that you added to the account-wide role ARN to in the preceding step.
++
+[IMPORTANT]
+====
+Only persistent volumes (PVs) created from the default storage class are encrypted with this specific key.
+
+PVs created by using any other storage class are still encrypted, but the PVs are not encrypted with this key unless the storage class is specifically configured to use this key.
+====
+
 <6> Enable this option only if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted, but not the keys.
 +
 [IMPORTANT]

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -200,6 +200,14 @@ rosa create cluster --sts
 By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Consider enabling etcd encryption only if you specifically require it for your use case.
 ====
 .. Optional: Select *Encrypt persistent volumes with customer keys* if you want to provide your own AWS Key Management Service (KMS) key Amazon Resource Name (ARN). The key is used for encryption of persistent volumes in your cluster.
++
+[IMPORTANT]
+====
+Only persistent volumes (PVs) created from the default storage class are encrypted by default.
+
+PVs created by using any other storage class are only encrypted if the the storage class is configured to be encrypted.
+====
+
 .. Click *Next*.
 
 . On the *Default machine pool* page, select a *Compute node instance type*.

--- a/modules/rosa-sts-interactive-mode-reference.adoc
+++ b/modules/rosa-sts-interactive-mode-reference.adoc
@@ -42,7 +42,7 @@ You can create a {product-title} cluster with the AWS Security Token Service (ST
 |Install a cluster into an existing AWS VPC. To use this option, your VPC must have 2 subnets for each availability zone that you are installing the cluster into. The default is `No`.
 
 |`Enable customer managed key`
-|Enable this option to use a specific AWS Key Management Service (KMS) key as the encryption key for persistent data. This key is used as the encryption key for control plane, infrastructure, and worker node root volumes. When disabled, the account KMS key for the specified region is used by default to ensure persistent data is always encrypted. The default is `No`.
+|Enable this option to use a specific AWS Key Management Service (KMS) key as the encryption key for persistent data. This key functions as the encryption key for control plane, infrastructure, and worker node root volumes. The key is also configured on the default storage class to ensure that persistent volumes created with the default storage class will be encrypted with the specific KMS key. When disabled, the account KMS key for the specified region is used by default to ensure persistent data is always encrypted. The default is `No`.
 
 |`Compute nodes instance type`
 |Select a compute node instance type. The default is `m5.xlarge`.


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-3815

Link to docs preview:
**ROSA**
- [Understanding the interactive cluster creation mode option](http://file.rdu.redhat.com/eponvell/OSDOCS-3815_EncryptPVs/rosa/rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference.html#rosa-sts-understanding-interactive-mode-options_rosa-sts-interactive-mode-references)
- [Data Management](http://file.rdu.redhat.com/eponvell/OSDOCS-3815_EncryptPVs/rosa/rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.html#rosa-policy-data-management_rosa-policy-process-security) under Policies
- [Creating a Cluster with customizations](http://file.rdu.redhat.com/eponvell/OSDOCS-3815_EncryptPVs/rosa/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-ocm_rosa-sts-creating-a-cluster-with-customizations) - Step 7, g.

**OSD**
- [Creating a cluster on AWS](http://file.rdu.redhat.com/eponvell/OSDOCS-3815_EncryptPVs/dedicated/osd_install_access_delete_cluster/creating-an-aws-cluster.html#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws) - see Step 8, g.


Additional information:
Updated the text to show support for persistent volumes.