### PR TITLE
unhide all wmco content

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -603,8 +603,8 @@ Topics:
     File: troubleshooting-s2i
   - Name: Troubleshooting storage issues
     File: troubleshooting-storage-issues
-#  - Name: Troubleshooting Windows container workload issues
-#    File: troubleshooting-windows-container-workload-issues
+  - Name: Troubleshooting Windows container workload issues
+    File: troubleshooting-windows-container-workload-issues
   - Name: Investigating monitoring issues
     File: investigating-monitoring-issues
   - Name: Diagnosing OpenShift CLI (oc) issues
@@ -2091,37 +2091,38 @@ Topics:
   Topics:
   - Name: Adding worker nodes to single-node OpenShift clusters
     File: nodes-sno-worker-nodes
-#Name: Windows Container Support for OpenShift
-#Dir: windows_containers
-#Distros: openshift-origin,openshift-enterprise
-#Topics:
-#- Name: Red Hat OpenShift support for Windows Containers overview
-#  File: index
-#- Name: Red Hat OpenShift support for Windows Containers release notes
-#  File: windows-containers-release-notes-6-x
-#- Name: Understanding Windows container workloads
-#  File: understanding-windows-container-workloads
-#- Name: Enabling Windows container workloads
-#  File: enabling-windows-container-workloads
-#- Name: Creating Windows MachineSet objects
-#  Dir: creating_windows_machinesets
-#  Topics:
-#  - Name: Creating a Windows MachineSet object on AWS
-#    File: creating-windows-machineset-aws
-#  - Name: Creating a Windows MachineSet object on Azure
-#    File: creating-windows-machineset-azure
-#  - Name: Creating a Windows MachineSet object on vSphere
-#    File: creating-windows-machineset-vsphere
-#- Name: Scheduling Windows container workloads
-#  File: scheduling-windows-workloads
-#- Name: Windows node upgrades
-#  File: windows-node-upgrades
-#- Name: Using Bring-Your-Own-Host Windows instances as nodes
-#  File: byoh-windows-instance
-#- Name: Removing Windows nodes
-#  File: removing-windows-nodes
-#- Name: Disabling Windows container workloads
-#  File: disabling-windows-container-workloads
+---    
+Name: Windows Container Support for OpenShift
+Dir: windows_containers
+Distros: openshift-origin,openshift-enterprise
+Topics:
+- Name: Red Hat OpenShift support for Windows Containers overview
+  File: index
+- Name: Red Hat OpenShift support for Windows Containers release notes
+  File: windows-containers-release-notes-6-x
+- Name: Understanding Windows container workloads
+  File: understanding-windows-container-workloads
+- Name: Enabling Windows container workloads
+  File: enabling-windows-container-workloads
+- Name: Creating Windows MachineSet objects
+  Dir: creating_windows_machinesets
+  Topics:
+  - Name: Creating a Windows MachineSet object on AWS
+    File: creating-windows-machineset-aws
+  - Name: Creating a Windows MachineSet object on Azure
+    File: creating-windows-machineset-azure
+  - Name: Creating a Windows MachineSet object on vSphere
+    File: creating-windows-machineset-vsphere
+- Name: Scheduling Windows container workloads
+  File: scheduling-windows-workloads
+- Name: Windows node upgrades
+  File: windows-node-upgrades
+- Name: Using Bring-Your-Own-Host Windows instances as nodes
+  File: byoh-windows-instance
+- Name: Removing Windows nodes
+  File: removing-windows-nodes
+- Name: Disabling Windows container workloads
+  File: disabling-windows-container-workloads
 ---
 Name: Sandboxed Containers Support for OpenShift
 Dir: sandboxed_containers

--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -111,7 +111,7 @@ For a production cluster, you must configure the following integrations:
 == Preparing your cluster for workloads
 
 Depending on your workload needs, you might need to take extra steps before you begin deploying applications. For example, after you prepare infrastructure to support your application xref:../cicd/builds/build-strategies.adoc#build-strategies[build strategy], you might need to make provisions for xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#cnf-low-latency-tuning[low-latency] workloads or to xref:../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets[protect sensitive workloads]. You can also configure xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[monitoring] for application workloads.
-//If you plan to run ../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Windows workloads], you must enable xref:../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-networking[hybrid networking with OVN-Kubernetes] during the installation process; hybrid networking cannot be enabled after your cluster is installed.
+If you plan to run xref:../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Windows workloads], you must enable xref:../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-networking[hybrid networking with OVN-Kubernetes] during the installation process; hybrid networking cannot be enabled after your cluster is installed.
 
 [id="supported-installation-methods-for-different-platforms"]
 == Supported installation methods for different platforms

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -65,12 +65,11 @@ include::modules/nw-aws-nlb-new-cluster.adoc[leveloffset=+1]
 
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-////
+
 [NOTE]
 ====
 For more information on using Linux and Windows nodes in the same cluster, see xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
-////
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/installing-azure-network-customizations.adoc
@@ -47,12 +47,12 @@ include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-////
+
 [NOTE]
 ====
 For more information on using Linux and Windows nodes in the same cluster, see xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
-////
+
 
 // Enabling Accelerated Networking during install
 include::modules/machineset-azure-enabling-accelerated-networking-new-install.adoc[leveloffset=+1]

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
@@ -52,12 +52,12 @@ include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-////
+
 [NOTE]
 ====
 For more information on using Linux and Windows nodes in the same cluster, see xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
-////
+
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
@@ -16,7 +16,7 @@ Complete any further installation configurations, and then create your cluster. 
 [id="configuring-hybrid-networking-additional-resources"]
 == Additional resources
 
-//*../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads]
-//*../../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Enabling Windows container workloads]
+* xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads]
+* xref:../../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Enabling Windows container workloads]
 * xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[Installing a cluster on AWS with network customizations]
 * xref:../../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[Installing a cluster on Azure with network customizations]

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -33,7 +33,7 @@ The WMCO is not supported in clusters that use a xref:../networking/enable-clust
 
 [role="_additional-resources"]
 .Additional resources
-//* For the comprehensive prerequisites for the Windows Machine Config Operator, see xref:../windows_containers/understanding-windows-container-workloads.adoc#wmco-prerequisites_understanding-windows-container-workloads[Understanding Windows container workloads].
+* For the comprehensive prerequisites for the Windows Machine Config Operator, see xref:../windows_containers/understanding-windows-container-workloads.adoc#wmco-prerequisites_understanding-windows-container-workloads[Understanding Windows container workloads].
 
 [id="installing-the-wmco"]
 == Installing the Windows Machine Config Operator


### PR DESCRIPTION
The Windows Containers content and any refs should now be unhidden to sync with the 23rd Aug WMCO 6.0.0. release for OCP 4.11.

- Merge to main only (creating a separate PR for [4.11](https://github.com/openshift/openshift-docs/pull/49225))
- [Preview](http://file.del.redhat.com/asakthiv/unhide-wmco-content-6.0.0/windows_containers/index.html) 
- QE not required
- @mburke5678, please merge on 23rd Aug