### PR TITLE
OADP-709: Correct information in "Enabling self-signed CA certificates"

### DIFF
--- a/modules/oadp-self-signed-certificate.adoc
+++ b/modules/oadp-self-signed-certificate.adoc
@@ -38,4 +38,4 @@ spec:
 ...
 ----
 <1> Specify the Base46-encoded CA certificate string.
-<2> Must be `false` to disable SSL/TLS security.
+<2> The `insecureSkipTLSVerify` configuration can be set to either `"true"` or `"false"`. If set to `"true"`, SSL/TLS security is disabled. If set to `"false"`, SSL/TLS security is enabled.


### PR DESCRIPTION
OADP 1.1.0, OCP 4.9+

Resolves: https://issues.redhat.com/browse/OADP-709 by changing callout 2 for the `yaml` file.

Preview:  http://file.emea.redhat.com/rhoch/ca_cert/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-self-signed-certificate_installing-oadp-aws callout  2 of the `yaml` file