### PR TITLE
BZ1979956: clarify terminology issues around  "provision host" and "provision node"

### DIFF
--- a/modules/ipi-install-troubleshooting-bootstrap-vm.adoc
+++ b/modules/ipi-install-troubleshooting-bootstrap-vm.adoc
@@ -94,7 +94,7 @@ $ ssh core@172.22.0.2
 
 If you are not successful logging in to the bootstrap VM, you have likely encountered one of the following scenarios:
 
-* You cannot reach the `172.22.0.0/24` network. Verify network connectivity on the provisioner host specifically around the `provisioning` network bridge. This will not be the issue if you are not using the `provisioning` network.
+* You cannot reach the `172.22.0.0/24` network. Verify the network connectivity between the provisioner and the `provisioning` network bridge. This will not be an issue unless you are using a `provisioning` network.
 
 * You cannot reach the bootstrap VM through the public network. When attempting
 to SSH via `baremetal` network, verify connectivity on the

--- a/modules/nw-sriov-concept-dpdk-line-rate.adoc
+++ b/modules/nw-sriov-concept-dpdk-line-rate.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/using-dpdk-and-rdma.adoc
+
+:_content-type: PROCEDURE
+[id="nw-sriov-example-dpdk-line-rate_{context}"]
+= Overview of achieving a specific DPDK line rate
+
+To achieve a specific Data Plane Development Kit (DPDK) line rate, deploy a Node Tuning Operator, configure Single Root I/O Virtualization (SR-IOV), and tune DPDK settings for:
+
+- isolated CPUs
+- hugepages
+- topology scheduler
+
+[NOTE]
+====
+In previous versions of {product-title}, the Performance Addon Operator was used to implement automatic tuning to achieve low latency performance for OpenShift applications. In {product-title}{product-version} 4.11, this functionality is part of the Node Tuning Operator.
+====
+
+.DPDK test environment
+The following diagram shows the components of a traffic-testing environment:
+
+image::261_OpenShift_DPDK_0722.png[DPDK test environment]
+
+- **Traffic generator**: An application that can generate high-volume packet traffic.
+- **SR-IOV-supporting NIC**: A network interface card compatible with SR-IOV. The card runs a number of virtual functions on a physical interface.
+- **Physical Function (PF)**: A PCI Express (PCIe) function of a network adapter that supports the SR-IOV interface.
+- **Virtual Function (VF)**:  A lightweight PCIe function on a network adapter that supports SR-IOV. The VF is associated with the PCIe Physical Function (PF) on the network adapter. The VF represents a virtualized instance of the network adapter.
+- **Switch**: A network switch. Nodes can also be connected back-to-back.
+- **`testpmd`**: An example application included with DPDK. The `testpmd` application can be used to test the DPDK in a packet-forwarding mode. The `testpmd` application is also an example of how to build a fully-fledged application using the DPDK Software Development Kit (SDK).
+- **worker 0** and **worker 1**: {product-title} nodes.

--- a/modules/nw-sriov-dpdk-example-mellanox.adoc.adoc
+++ b/modules/nw-sriov-dpdk-example-mellanox.adoc.adoc
@@ -1,0 +1,146 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/using-dpdk-and-rdma.adoc
+
+:_content-type: PROCEDURE
+[id="example-vf-use-in-dpdk-mode-mellanox_{context}"]
+= Using a virtual function in DPDK mode with a Mellanox NIC
+You can create a network node policy and create a DPDK pod using a virtual function in DPDK mode with a Mellanox NIC.
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You have installed the SR-IOV Network Operator.
+* You have logged in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create the following `SriovNetworkNodePolicy` object, then save the YAML in the `mlx-dpdk-node-policy.yaml` file.
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: mlx-dpdk-node-policy
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: mlxnics
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  priority: <priority>
+  numVfs: <num>
+  nicSelector:
+    vendor: "15b3"
+    deviceID: "1015" <1>
+    pfNames: ["<pf_name>", ...]
+    rootDevices: ["<pci_bus_id>", "..."]
+  deviceType: netdevice <2>
+  isRdma: true <3>
+----
+<1> Specify the device hex code of the SR-IOV network device. The only allowed values for Mellanox cards are `1015`, `1017`.
+<2> Specify the driver type for the virtual functions to `netdevice`. Mellanox SR-IOV VF can work in DPDK mode without using the `vfio-pci` device type. VF device appears as a kernel network interface inside a container.
+<3> Enable RDMA mode. This is required for Mellanox cards to work in DPDK mode.
++
+[NOTE]
+=====
+See the `Configuring SR-IOV network devices` section for detailed explanation on each option in the `SriovNetworkNodePolicy` object.
+
+When applying the configuration specified in a `SriovNetworkNodePolicy` object, the SR-IOV Operator may drain the nodes, and in some cases, reboot nodes.
+It may take several minutes for a configuration change to apply.
+Ensure that there are enough available nodes in your cluster to handle the evicted workload beforehand.
+
+After the configuration update is applied, all the pods in the `openshift-sriov-network-operator` namespace will change to a `Running` status.
+=====
+
+. Create the `SriovNetworkNodePolicy` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f mlx-dpdk-node-policy.yaml
+----
+
+. Create the following `SriovNetwork` object, and then save the YAML in the `mlx-dpdk-network.yaml` file.
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: mlx-dpdk-network
+  namespace: openshift-sriov-network-operator
+spec:
+  networkNamespace: <target_namespace>
+  ipam: |- <1>
+# ...
+  vlan: <vlan>
+  resourceName: mlxnics
+----
+<1> Specify a configuration object for the ipam CNI plug-in as a YAML block scalar. The plug-in manages IP address assignment for the attachment definition.
++
+[NOTE]
+=====
+See the "Configuring SR-IOV additional network" section for a detailed explanation on each option in the `SriovNetwork` object.
+=====
++
+An optional library, `app-netutil`, provides several API methods for gathering network information about a container's parent pod.
+
+. Create the `SriovNetworkNodePolicy` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f mlx-dpdk-network.yaml
+----
+
+. Create the following `Pod` spec, and then save the YAML in the `mlx-dpdk-pod.yaml` file.
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dpdk-app
+  namespace: <target_namespace> <1>
+  annotations:
+    k8s.v1.cni.cncf.io/networks: mlx-dpdk-network
+spec:
+  containers:
+  - name: testpmd
+    image: <DPDK_image> <2>
+    securityContext:
+      runAsUser: 0
+      capabilities:
+        add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"] <3>
+    volumeMounts:
+    - mountPath: /dev/hugepages <4>
+      name: hugepage
+    resources:
+      limits:
+        openshift.io/mlxnics: "1" <5>
+        memory: "1Gi"
+        cpu: "4" <6>
+        hugepages-1Gi: "4Gi" <7>
+      requests:
+        openshift.io/mlxnics: "1"
+        memory: "1Gi"
+        cpu: "4"
+        hugepages-1Gi: "4Gi"
+    command: ["sleep", "infinity"]
+  volumes:
+  - name: hugepage
+    emptyDir:
+      medium: HugePages
+----
+<1> Specify the same `target_namespace` where `SriovNetwork` object `mlx-dpdk-network` is created. To create the pod in a different namespace, change `target_namespace` in both `Pod` spec and `SriovNetwork` object.
+<2> Specify the DPDK image which includes your application and the DPDK library used by the application.
+<3> Specify additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
+<4> Mount the hugepage volume to the DPDK pod under `/dev/hugepages`. The hugepage volume is backed by the emptyDir volume type with the medium being `Hugepages`.
+<5> Optional: Specify the number of DPDK devices allocated to the DPDK pod. This resource request and limit, if not explicitly specified, will be automatically added by SR-IOV network resource injector. The SR-IOV network resource injector is an admission controller component managed by SR-IOV Operator. It is enabled by default and can be disabled by setting the `enableInjector` option to `false` in the default `SriovOperatorConfig` CR.
+<6> Specify the number of CPUs. The DPDK pod usually requires that exclusive CPUs be allocated from kubelet. To do this, set CPU Manager policy to `static` and create a pod with `Guaranteed` QoS.
+<7> Specify hugepage size `hugepages-1Gi` or `hugepages-2Mi` and the quantity of hugepages that will be allocated to DPDK pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepages requires adding kernel arguments to Nodes.
+
+. Create the DPDK pod by running the following command:
++
+[source,terminal]
+----
+$ oc create -f mlx-dpdk-pod.yaml
+----

--- a/modules/nw-sriov-example-dpdk-line-rate.adoc
+++ b/modules/nw-sriov-example-dpdk-line-rate.adoc
@@ -1,0 +1,278 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/using-dpdk-and-rdma.adoc
+
+:_content-type: PROCEDURE
+[id="nw-example-dpdk-line-rate_{context}"]
+= Using SR-IOV and the Node Tuning Operator to achieve a DPDK line rate
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You have installed the SR-IOV Network Operator.
+* You have logged in as a user with `cluster-admin` privileges.
+* You have deployed a standalone Node Tuning Operator.
+
+The Node Tuning Operator is used to configure isolated CPUs, hugepages, and a topology scheduler.
+You can then use the Node Tuning Operator with SR-IOV to achieve a specific DPDK line rate networking.
+
+[NOTE]
+====
+In previous versions of {product-title}, the Performance Addon Operator was used to implement automatic tuning to achieve low latency performance for OpenShift applications. In {product-title}{product-version} 4.11, this functionality is part of the Node Tuning Operator.
+====
+
+.Procedure
+
+== Using the Node Tuning Operator to optimize line rate
+
+.Procedure
+. Create a `PerformanceProfile` object based on the following example:
++
+[source,yaml]
+----
+    apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    metadata:
+     name: performance
+    spec:
+     globallyDisableIrqLoadBalancing: true
+     cpu:
+       isolated: 21-51,73-103 <1>
+       reserved: 0-20,52-72 <2>
+     hugepages:
+       defaultHugepagesSize: 1G <3>
+       pages:
+       - count: 32
+         size: 1G
+     net:
+        userLevelNetworking: true
+     numa:
+       topologyPolicy: "single-numa-node"
+     nodeSelector:
+       node-role.kubernetes.io/worker-cnf: ""
+----
+<1> If hyperthreading is enabled on the system, allocate the symbolic link to the same CPU group (isolated/reserved). If the system contains multiple NUMAs, allocate CPUs from both NUMAs to both groups. You can also use the Performance Profile Creator for this task: see "Creating a performance profile" for more information.
+<2> You can also specify a list of devices that will have the queues set to the reserved CPU count. See "Reducing NIC queues using the Node Tuning Operator" for more information.
+<3> Allocate the number and size of hugepages needed. You can specify the NUMA for the hugepages. By default, the system allocates an even number to every NUMA on the system. If needed, you can request the use of a realtime kernel for the nodes. See "Provisioning a worker with real-time capabilities" for more information.
+. Save the `yaml` file as `mlx-dpdk-perfprofile-policy.yaml`.
+. Apply the performance profile.
+
+== Configuring an SR-IOV Network Operator
+The SR-IOV network operator is used to allocate and configure Virtual Functions from SR-IOV-supporting Physical Function NICs on the nodes.
+
+For more information on deploying the operator, see "Installing the SR-IOV Network Operator".
+For more information on configuring an SR-IOV network device, see "Configuring an SR-IOV network device".
+
+There are some differences between running DPDK workloads on Intel VFs or Mellanox VFs. We will look at both cases.
+
+The following is an example of an `sriovNetworkNodePolicy` object used to run DPDK applications on Intel NICs:
+[source,yaml]
+----
+    apiVersion: sriovnetwork.openshift.io/v1
+    kind: SriovNetworkNodePolicy
+    metadata:
+     name: dpdk-nic-1
+     namespace: openshift-sriov-network-operator
+    spec:
+     deviceType: vfio-pci <1>
+     needVhostNet: true <2>
+     nicSelector:
+       pfNames: ["ens3f0"]
+     nodeSelector:
+       node-role.kubernetes.io/worker-cnf: ""
+     numVfs: 10
+     priority: 99
+     resourceName: dpdk_nic_1
+    ---
+    apiVersion: sriovnetwork.openshift.io/v1
+    kind: SriovNetworkNodePolicy
+    metadata:
+     name: dpdk-nic-1
+     namespace: openshift-sriov-network-operator
+    spec:
+     deviceType: vfio-pci
+     needVhostNet: true
+     nicSelector:
+         pfNames: ["ens3f1"]
+     nodeSelector:
+     node-role.kubernetes.io/worker-cnf: ""
+     numVfs: 10
+     priority: 99
+     resourceName: dpdk_nic_2
+
+----
+<1> For Intel NICs, `deviceType` must be `vfio-pci`.
+<2> If kernel communication with DPDK workloads is required, add `needVhostNet: true`. This will mount the `/dev/net/tun` and `/dev/vhost-net` devices into the container so the application can create a tap device and connect the tap device to the DPDK workload.
+
+The following is an example of `sriovNetworkNodePolicy` for Mellanox NICs:
+[source,yaml]
+----
+    apiVersion: sriovnetwork.openshift.io/v1
+    kind: SriovNetworkNodePolicy
+    metadata:
+     name: dpdk-nic-1
+     namespace: openshift-sriov-network-operator
+    spec:
+     deviceType: netdevice <1>
+     isRdma: true <2>
+     nicSelector:
+       rootDevices:
+         - "0000:5e:00.1"
+     nodeSelector:
+       node-role.kubernetes.io/worker-cnf: ""
+     numVfs: 5
+     priority: 99
+     resourceName: dpdk_nic_1
+    ---
+    apiVersion: sriovnetwork.openshift.io/v1
+    kind: SriovNetworkNodePolicy
+    metadata:
+     name: dpdk-nic-2
+     namespace: openshift-sriov-network-operator
+    spec:
+     deviceType: netdevice
+     isRdma: true
+     nicSelector:
+       rootDevices:
+         - "0000:5e:00.0"
+     nodeSelector:
+       node-role.kubernetes.io/worker-cnf: ""
+     numVfs: 5
+     priority: 99
+     resourceName: dpdk_nic_2
+----
+<1> For Mellanox devices the `deviceType` must be `netdevice`.
+<2> For Mellanox devices `isRDMA` must be `true`.
+Mellanox cards are connected to DPDK applications using Flow Bifurcation. This mechanism splits traffic between Linux user space and kernel space, and can enhance line rate processing capability.
+
+== Using the SR-IOV network operator to create the `sriovNetwork` object
+The following is an example definition of an `sriovNetwork` object. In this case Intel and Mellanox configurations are identical.
+[source,yaml]
+----
+    apiVersion: sriovnetwork.openshift.io/v1
+    kind: SriovNetwork
+    metadata:
+     name: dpdk-network-1
+     namespace: openshift-sriov-network-operator
+    spec:
+     ipam: '{"type": "host-local","ranges": [[{"subnet": "10.0.1.0/24"}]],"dataDir":
+       "/run/my-orchestrator/container-ipam-state-1"}' <1>
+     networkNamespace: dpdk-test <2>
+     spoofChk: "off"
+     trust: "on"
+     resourceName: dpdk_nic_1 <3>
+    ---
+    apiVersion: sriovnetwork.openshift.io/v1
+    kind: SriovNetwork
+    metadata:
+     name: dpdk-network-2
+     namespace: openshift-sriov-network-operator
+    spec:
+     ipam: '{"type": "host-local","ranges": [[{"subnet": "10.0.2.0/24"}]],"dataDir":
+       "/run/my-orchestrator/container-ipam-state-1"}'
+     networkNamespace: dpdk-test
+     spoofChk: "off"
+     trust: "on"
+     resourceName: dpdk_nic_2
+----
+<1> You can use a different IPAM, such as Whereabouts. See "Dynamic IP address assignment configuration with Whereabouts" for more information.
+<2> You must request the `networkNamespace` where the network attachment definition will be created. The `sriovNetwork` CR must be created under the `openshift-sriov-network-operator` namespace.
+<3> The `resourceName` value must match that of the `resourceName` created under the `sriovNetworkNodePolicy`.
+
+== Running a DPDK base workload
+The following is an example of a DPDK container:
+[source,yaml]
+----
+    ---
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: dpdk-test
+    ---
+    apiVersion: v1
+    kind: Pod
+    metadata:
+     annotations:
+       k8s.v1.cni.cncf.io/networks: '[ <1>
+         {
+          "name": "dpdk-network-1",
+          "namespace": "dpdk-test"
+         },
+         {
+          "name": "dpdk-network-2",
+          "namespace": "dpdk-test"
+         }
+       ]'
+       irq-load-balancing.crio.io: "disable" <2>
+       cpu-load-balancing.crio.io: "disable"
+       cpu-quota.crio.io: "disable"
+     labels:
+       app: dpdk
+     name: testpmd
+     namespace: dpdk-test
+    spec:
+     runtimeClassName: performance-performance <3>
+     containers:
+       - command:
+           - /bin/bash
+           - -c
+           - sleep INF
+         image: registry.redhat.io/openshift4/dpdk-base-rhel8
+         imagePullPolicy: Always
+         name: dpdk
+         resources:
+           limits:
+             cpu: "16"
+             hugepages-1Gi: 8Gi
+             memory: 2Gi
+           requests:
+             cpu: "16"
+             hugepages-1Gi: 8Gi
+             memory: 2Gi
+         securityContext:
+           capabilities:
+             add:
+               - IPC_LOCK
+               - SYS_RESOURCE
+               - NET_RAW
+               - NET_ADMIN
+           runAsUser: 0
+         volumeMounts:
+           - mountPath: /mnt/huge
+             name: hugepages
+     terminationGracePeriodSeconds: 5
+     volumes:
+       - emptyDir:
+           medium: HugePages
+         name: hugepages
+----
+<1> Request the SR-IOV networks you need: resources for the devices will be injected automatically.
+<2> Disable the CPU and IRQ load balancing base. See "Disabling interrupt processing for individual pods" for more information.
+<3> Set the `runtimeClass` to `performance-performance`.
+[NOTE]
+====
+Do not use `HostNetwork` or `privileged`.
+====
+[NOTE]
+====
+Request an equal number of resources for requests and limits to start the pod with guaranteed QOS.
+====
+[NOTE]
+====
+Do not start the pod with `SLEEP` and then exec into the pod to start the testpmd or the DPDK workload. This can add additional interrupts as the `exec` process is not pinned to any CPU.
+====
+
+== Running `testpmd`
+
+The following is an example script for running `testpmd`:
+
+[source,yaml]
+----
+    set -ex
+    export CPU=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
+    echo ${CPU}
+
+    dpdk-testpmd -l ${CPU} -a ${PCIDEVICE_OPENSHIFT_IO_DPDK_NIC_1} -a ${PCIDEVICE_OPENSHIFT_IO_DPDK_NIC_2} -n 4 -- -i --nb-cores=15 --rxd=4096 --txd=4096 --rxq=7 --txq=7 --forward-mode=mac --eth-peer=0,50:00:00:00:00:01 --eth-peer=1,50:00:00:00:00:02
+----
+This example uses two different `sriovNetwork` CRs. The environment variable contains the VF PCI address that was allocated for the pod. If you use the same network in the pod definition, you must split the `pciAddress`.
+It is important to configure the correct MAC addresses of the traffic generator. In this example, custom MACs are used.

--- a/notes_on_bz1979956
+++ b/notes_on_bz1979956
@@ -1,0 +1,11 @@
+Report on terminology changes for BZ1979956
+
+ipi-install-troubleshooting-bootstrap-vm.adoc
+
+Solitary occurence of the term "provisioner host".
+
+"* You cannot reach the `172.22.0.0/24` network. Verify network connectivity on the provisioner host specifically around the `provisioning` network bridge. This will not be the issue if you are not using the `provisioning` network."
+
+-->
+
+"* You cannot reach the `172.22.0.0/24` network. Verify the network connectivity between the provisioner and the `provisioning` network bridge. This will not be an issue unless you are using a `provisioning` network."

--- a/notes_on_bz1979956)
+++ b/notes_on_bz1979956)
@@ -1,0 +1,11 @@
+Report on terminology changes for BZ1979956
+
+ipi-install-troubleshooting-bootstrap-vm.adoc
+
+Solitary occurence of the term "provisioner host".
+
+"* You cannot reach the `172.22.0.0/24` network. Verify network connectivity on the provisioner host specifically around the `provisioning` network bridge. This will not be the issue if you are not using the `provisioning` network."
+
+-->
+
+"* You cannot reach the `172.22.0.0/24` network. Verify the network connectivity between the provisioner and the `provisioning` network bridge. This will not be an issue unless you are using a `provisioning` network."

--- a/rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.adoc
+++ b/rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-This document describes how to create a ROSA cluster using AWS PrivateLink. Alternatively, you can create a ROSA cluster without AWS PrivateLink.
+This document describes how to create a ROSA cluster using AWS PrivateLink.
 
 include::modules/osd-aws-privatelink-about.adoc[leveloffset=+1]
 include::modules/osd-aws-privatelink-required-resources.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): PR applies to multiple specific versions: 4.6 and upwards to current version. Creating for enterprise-4.12 and cherry-picking for previous versions.

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=1979956

Previews
http://file.emea.redhat.com/tmulquee/BZ1979956/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.html#ipi-install-troubleshooting-bootstrap-vm_ipi-install-troubleshooting
Solo instance of "provisioner host" in the text changed to "provisioner". 