### PR TITLE
[enterprise-4.9] BZ#2099211-Correcting issues with the procedure for expanding a bare-metal cluster

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
@@ -24,6 +24,8 @@ include::modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc[leve
 
 * xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[Backing up etcd]
 
+* xref:../installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
+
 include::modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc[leveloffset=+1]
 
 include::modules/ipi-install-diagnosing-duplicate-mac-address.adoc[leveloffset=+1]

--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -46,11 +46,13 @@ baremetal   4.9.0     True        False         False      3d15h
 +
 [source,terminal]
 ----
-$ oc delete bmh -n openshift-machine-api vmaster-0
-$ oc delete machine -n openshift-machine-api kni1-master-0
+$ oc delete bmh -n openshift-machine-api <host_name>
+$ oc delete machine -n openshift-machine-api <machine_name>
 ----
++ 
+Replace `<host_name>` with the name of the host and `<machine_name>` with the name of the machine. The machine name appears under the `CONSUMER` field.
 +
-After you remove the `BareMetalHost` and `Machine` objects, then the `Machine` controller automatically deletes the `Node` object.
+After you remove the `BareMetalHost` and `Machine` objects, then the machine controller automatically deletes the `Node` object.
 
 . Create the new `BareMetalHost` object and the secret to store the BMC credentials:
 +
@@ -60,30 +62,35 @@ $ cat <<EOF | oc apply -f -
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kni1-master-0-bmc-secret
+  name: control-plane-<num>-bmc-secret <1> 
   namespace: openshift-machine-api
 data:
-  password: <username>
-  username: <password>
+  password: <base64_of_uid> <2>
+  username: <base64_of_pwd> <3>
 type: Opaque
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: kni1-master-0
+  name: control-plane-<num> <1>
   namespace: openshift-machine-api
 spec:
   automatedCleaningMode: disabled
   bmc:
-    address: redfish-virtualmedia+http://192.168.124.113:8000/redfish/v1/Systems/f87eaf82-b32d-4291-ace6-b28677964e78
-    credentialsName: kni1-master-0-bmc-secret
-  bootMACAddress: aa:aa:aa:aa:ab:03
+    address: <protocol>://<bmc_ip> <4>
+    credentialsName: control-plane-<num>-bmc-secret <1>
+  bootMACAddress: <NIC1_mac_address> <5>
   bootMode: UEFI
   externallyProvisioned: false
   hardwareProfile: unknown
   online: true
 EOF
 ----
+<1> Replace `<num>` for the control plane number of the bare metal node in the `name` fields and the `credentialsName` field.
+<2> Replace `<base64_of_uid>` with the `base64` string of the user name.
+<3> Replace `<base64_of_pwd>` with the `base64` string of the password.
+<4> Replace `<protocol>` with the BMC protocol, such as `redfish`, `redfish-virtualmedia`, `idrac-virtualmedia`, or others. Replace `<bmc_ip>` with the IP address of the bare metal node's baseboard management controller. For additional BMC configuration options, see "BMC addressing" in the _Additional resources_ section.
+<5> Replace `<NIC1_mac_address>` with the MAC address of the bare metal node's first NIC. 
 +
 After the inspection is complete, the `BareMetalHost` object is created and available to be provisioned.
 
@@ -97,12 +104,12 @@ $ oc get bmh -n openshift-machine-api
 .Example output
 [source,terminal]
 ----
-NAME           STATE                    CONSUMER                   ONLINE   ERROR   AGE
-kni1-master-0  available                ocp-hkw9p-master-0         true             1h10m
-kni1-master-1  externally provisioned   ocp-hkw9p-master-1         true             4h53m
-kni1-master-2  externally provisioned   ocp-hkw9p-master-2         true             4h53m
-kni1-worker-0  provisioned              ocp-hkw9p-worker-0-ktmmx   true             4h53m
-kni1-worker-1  provisioned              ocp-hkw9p-worker-0-l2zmb   true             4h53m
+NAME                          STATE                    CONSUMER                   ONLINE   ERROR   AGE
+control-plane-1.example.com   available                control-plane-1            true             1h10m
+control-plane-2.example.com   externally provisioned   control-plane-2            true             4h53m
+control-plane-3.example.com   externally provisioned   control-plane-3            true             4h53m
+compute-1.example.com         provisioned              compute-1-ktmmx            true             4h53m
+compute-1.example.com         provisioned              compute-2-l2zmb            true             4h53m
 ----
 +
 There are no `MachineSet` objects for control plane nodes, so you must create a `Machine` object instead. You can copy the `providerSpec` from another control plane `Machine` object.
@@ -116,12 +123,12 @@ apiVersion: machine.openshift.io/v1beta1
 kind: Machine
 metadata:
   annotations:
-    metal3.io/BareMetalHost: openshift-machine-api/kni1-master-0
+    metal3.io/BareMetalHost: openshift-machine-api/control-plane-<num> <1>
   labels:
-    machine.openshift.io/cluster-api-cluster: kni1
+    machine.openshift.io/cluster-api-cluster: control-plane-<num> <1>
     machine.openshift.io/cluster-api-machine-role: master
     machine.openshift.io/cluster-api-machine-type: master
-  name: kni1-master-0
+  name: control-plane-<num> <1>
   namespace: openshift-machine-api
 spec:
   metadata: {}
@@ -141,15 +148,7 @@ spec:
         name: master-user-data-managed
 EOF
 ----
-+
-. To define and create the `BareMetalHost`, `Secret`, and `Machine` objects in a single step, create a YAML file (`example.yaml`) with their definitions and run the following command:
-+
-[source,terminal]
-----
-$ oc create -f example.yaml
-----
-+
-The provisioning process uses the baremetal-operator to install RHCOS and prepare the host to be added to the cluster.
+<1> Replace `<num>` for the control plane number of the bare metal node in the `name`, `labels` and `annotations` fields.
 +
 . To view the `BareMetalHost` objects, run the following command:
 +
@@ -161,12 +160,12 @@ $ oc get bmh -A
 .Example output
 [source,terminal]
 ----
-NAME           STATE                    CONSUMER                   ONLINE   ERROR   AGE
-kni1-master-0  provisioned              ocp-hkw9p-master-0         true             2h53m
-kni1-master-1  externally provisioned   ocp-hkw9p-master-1         true             5h53m
-kni1-master-2  externally provisioned   ocp-hkw9p-master-2         true             5h53m
-kni1-worker-0  provisioned              ocp-hkw9p-worker-0-ktmmx   true             5h53m
-kni1-worker-1  provisioned              ocp-hkw9p-worker-0-l2zmb   true             5h53m
+NAME                          STATE                    CONSUMER                   ONLINE   ERROR   AGE
+control-plane-1.example.com   provisioned              control-plane-1            true             2h53m
+control-plane-2.example.com   externally provisioned   control-plane-2            true             5h53m
+control-plane-3.example.com   externally provisioned   control-plane-3            true             5h53m
+compute-1.example.com         provisioned              compute-1-ktmmx            true             5h53m
+compute-2.example.com         provisioned              compute-2-l2zmb            true             5h53m
 ----
 +
 . After the RHCOS installation, verify that the `BareMetalHost` is added to the cluster:
@@ -179,14 +178,15 @@ $ oc get nodes
 .Example output
 [source,terminal]
 ----
-NAME             STATUS      ROLES    AGE   VERSION
-kni1-master-0    available	 master   4m2s  v1.18.2
-kni1-master-1    available	 master   141m  v1.18.2
-kni1-master-2    available	 master   141m  v1.18.2
-kni1-worker-0    available	 worker   87m   v1.18.2
+NAME                           STATUS      ROLES     AGE   VERSION
+control-plane-1.example.com    available   master    4m2s  v1.18.2
+control-plane-2.example.com    available   master    141m  v1.18.2
+control-plane-3.example.com    available   master    141m  v1.18.2
+compute-1.example.com          available   worker    87m   v1.18.2
+compute-2.example.com          available   worker    87m   v1.18.2
 ----
 +
 [NOTE]
 ====
-After replacement of the new control plane node, the etcd pod running in the new node is in `crashloopback` status. See "Replacing an unhealthy etcd member" for more information.
+After replacement of the new control plane node, the etcd pod running in the new node is in `crashloopback` status. See "Replacing an unhealthy etcd member" in the _Additional resources_ section for more information.
 ====


### PR DESCRIPTION
CP to 4.9 of https://github.com/openshift/openshift-docs/pull/48788.

BZ#2099211: Making code samples generic and removing step from procedure.

Version(s):
CP to 4.9

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2099211

Link to docs preview:
http://file.emea.redhat.com/rohennes/BZ2099211-4.9/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#replacing-a-bare-metal-control-plane-node_ipi-install-expanding