### PR TITLE
CNV-17637: Corrected clouInitNoCloud userData syntax

### DIFF
--- a/modules/virt-accessing-vm-yaml-ssh.adoc
+++ b/modules/virt-accessing-vm-yaml-ssh.adoc
@@ -20,7 +20,6 @@ The following examples show the configurations for the VM's YAML file and the se
 .Example `VirtualMachine` definition
 [source,yaml]
 ----
-...
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -62,9 +61,11 @@ spec:
       - name: cloudinitdisk
         cloudInitNoCloud:
           userData: |
-            #!/bin/bash
-            echo "fedora" | passwd fedora --stdin
-...
+            #cloud-config
+            user: fedora
+            password: fedora
+            chpasswd: {expire: False}
+# ...
 ----
 <1> Name of the namespace created by the `oc create namespace` command.
 <2> Label used by the service to identify the virtual machine instances that are enabled for SSH traffic connections. The label can be any `key:value` pair that is added as a `label` to this YAML file and as a `selector` in the service YAML file.
@@ -90,7 +91,6 @@ $ virtctl start vm-ssh
 .Example `Service` definition
 [source,yaml]
 ----
-...
 apiVersion: v1
 kind: Service
 metadata:
@@ -104,7 +104,7 @@ spec:
   selector:
     special: vm-ssh <4>
   type: NodePort
-...
+# ...
 ----
 <1> Name of the SSH service.
 <2> Name of the namespace created by the `oc create namespace` command.

--- a/modules/virt-creating-a-service-from-a-virtual-machine.adoc
+++ b/modules/virt-creating-a-service-from-a-virtual-machine.adoc
@@ -82,8 +82,11 @@ spec:
         - name: cloudinitdisk
           cloudInitNoCloud:
             userData: |
-              #!/bin/bash
-              echo "fedora" | passwd fedora --stdin
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: {expire: False}
+# ...
 ----
 <1> Add the label `special: key` in the `spec.template.metadata.labels` section.
 +
@@ -206,8 +209,11 @@ spec:
         - name: cloudinitdisk
           cloudInitNoCloud:
             userData: |
-              #!/bin/bash
-              echo "fedora" | passwd fedora --stdin
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd: {expire: False}
+# ...
 ----
 +
 

--- a/modules/virt-template-vm-pxe-config.adoc
+++ b/modules/virt-template-vm-pxe-config.adoc
@@ -55,8 +55,10 @@ spec:
           image: kubevirt/fedora-cloud-container-disk-demo
       - cloudInitNoCloud:
           userData: |
-            #!/bin/bash
-            echo "fedora" | passwd fedora --stdin
+            #cloud-config
+            user: fedora
+            password: fedora
+            chpasswd: {expire: False}
         name: cloudinitdisk
     status: {}
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.9+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: [CNV-17637](https://issues.redhat.com//browse/CNV-17637)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Creating a service from a virtual machine](http://file.rdu.redhat.com/sjhala/cnv-17637/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html#virt-creating-a-service-from-a-virtual-machine_virt-using-the-default-pod-network-with-virt)

[Virtual machine template for PXE booting](http://file.rdu.redhat.com/sjhala/cnv-17637/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.html#virt-pxe-vm-template_pxe-booting)

[Accessing virtual machine consoles](http://file.rdu.redhat.com/sjhala/cnv-17637/virt/virtual_machines/virt-accessing-vm-consoles.html#virt-accessing-vm-yaml-ssh_virt-accessing-vm-consoles)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. -->

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

<!---Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
