### PR TITLE
[BZ2106760] backport 4.10 Change delete-local-data to delete-emptydir-data

### DIFF
--- a/modules/cleaning-crio-storage.adoc
+++ b/modules/cleaning-crio-storage.adoc
@@ -45,7 +45,7 @@ $ oc adm cordon <nodename>
 [source, terminal]
 +
 ----
-$ oc adm drain <nodename> --ignore-daemonsets --delete-local-data
+$ oc adm drain <nodename> --ignore-daemonsets --delete-emptydir-data
 ----
 +
 [NOTE]

--- a/modules/nodes-nodes-working-evacuating.adoc
+++ b/modules/nodes-nodes-working-evacuating.adoc
@@ -89,12 +89,12 @@ value of `0` sets an infinite length of time:
 $ oc adm drain <node1> <node2> --timeout=5s
 ----
 
-** Delete pods even if there are pods using emptyDir using the `--delete-local-data` flag set to `true`. Local data is deleted when the node
+** Delete pods even if there are pods using `emptyDir` volumes by setting the `--delete-emptydir-data` flag to `true`. Local data is deleted when the node
 is drained:
 +
 [source,terminal]
 ----
-$ oc adm drain <node1> <node2> --delete-local-data=true
+$ oc adm drain <node1> <node2> --delete-emptydir-data=true
 ----
 
 ** List objects that will be migrated without actually performing the evacuation,

--- a/modules/rhel-removing-rhcos.adoc
+++ b/modules/rhel-removing-rhcos.adoc
@@ -35,7 +35,7 @@ $ oc adm cordon <node_name> <1>
 +
 [source,terminal]
 ----
-$ oc adm drain <node_name> --force --delete-local-data --ignore-daemonsets <1>
+$ oc adm drain <node_name> --force --delete-emptydir-data --ignore-daemonsets <1>
 ----
 <1> Specify the node name of the {op-system} compute machine that you isolated.
 

--- a/modules/virt-setting-node-maintenance-cli.adoc
+++ b/modules/virt-setting-node-maintenance-cli.adoc
@@ -21,10 +21,10 @@ $ oc adm cordon <node1>
 +
 [source,terminal]
 ----
-$ oc adm drain <node1> --delete-local-data --ignore-daemonsets=true --force
+$ oc adm drain <node1> --delete-emptydir-data --ignore-daemonsets=true --force
 ----
 
-* The `--delete-local-data` flag removes any virtual machine instances on the node that use `emptyDir` volumes. Data in these volumes is ephemeral and is safe to be deleted after termination.
+* The `--delete-emptydir-data` flag removes any virtual machine instances on the node that use `emptyDir` volumes. Data in these volumes is ephemeral and is safe to be deleted after termination.
 
 * The `--ignore-daemonsets=true` flag ensures that daemon sets are ignored and pod eviction can continue successfully.
 


### PR DESCRIPTION
Backport of this PR to 4.10 https://github.com/openshift/openshift-docs/pull/47957

Version(s): 4.10

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2106760

Link to docs preview:

~~http://file.str.redhat.com/~sniemann/delete_emptydir_410/support/troubleshooting/troubleshooting-crio-issues.html#cleaning-crio-storage~~
http://file.rdu.redhat.com/~mburke/49227/support/troubleshooting/troubleshooting-crio-issues.html#cleaning-crio-storage
http://file.str.redhat.com/~sniemann/delete_emptydir_410/post_installation_configuration/node-tasks.html#rhel-removing-rhcos_post-install-node-tasks
http://file.str.redhat.com/~sniemann/delete_emptydir_410/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-evacuating_nodes-nodes-working
~~http://file.str.redhat.com/~sniemann/delete_emptydir_410/virt/node_maintenance/virt-setting-node-maintenance.html~~
http://file.rdu.redhat.com/~mburke/49227/virt/node_maintenance/virt-setting-node-maintenance.html

Additional information: Flag --delete-local-data has been deprecated see:
https://access.redhat.com/solutions/6801291


<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
