### PR TITLE
BZ2088485: Removed future statement for sample install config yaml files

### DIFF
--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -42,7 +42,7 @@ endif::[]
 
 :_content-type: REFERENCE
 [id="installation-aws-config-yaml_{context}"]
-= Sample customized `install-config.yaml` file for AWS
+= Sample customized install-config.yaml file for AWS
 
 You can customize the installation configuration file (`install-config.yaml`) to specify more details about
 your {product-title} cluster's platform or modify the values of the required
@@ -292,13 +292,10 @@ endif::gov,secret,china[]
 <2> Optional: Add this parameter to force the Cloud Credential Operator (CCO) to use the specified mode, instead of having the CCO dynamically try to determine the capabilities of the credentials. For details about CCO modes, see the _Cloud Credential Operator_ entry in the _Red Hat Operators reference_ content.
 <3> If you do not provide these parameters and values, the installation program
 provides the default value.
-<4> The `controlPlane` section is a single mapping, but the compute section is a
+<4> The `controlPlane` section is a single mapping, but the `compute` section is a
 sequence of mappings. To meet the requirements of the different data structures,
 the first line of the `compute` section must begin with a hyphen, `-`, and the
-first line of the `controlPlane` section must not. Although both sections
-currently define a single machine pool, it is possible that future versions
-of {product-title} will support defining multiple compute pools during
-installation. Only one control plane pool is used.
+first line of the `controlPlane` section must not. Only one control plane pool is used.
 <5> Whether to enable or disable simultaneous multithreading, or
 `hyperthreading`. By default, simultaneous multithreading is enabled
 to increase the performance of your machines' cores. You can disable it by

--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -23,7 +23,7 @@ ifeval::["{context}" == "installing-azure-government-region"]
 endif::[]
 
 [id="installation-azure-config-yaml_{context}"]
-= Sample customized `install-config.yaml` file for Azure
+= Sample customized install-config.yaml file for Azure
 
 You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
 
@@ -190,7 +190,7 @@ ifdef::gov[]
 <1> Required.
 endif::gov[]
 <2> If you do not provide these parameters and values, the installation program provides the default value.
-<3> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
+<3> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
 <4> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
 +
 [IMPORTANT]

--- a/modules/installation-azure-stack-hub-config-yaml.adoc
+++ b/modules/installation-azure-stack-hub-config-yaml.adoc
@@ -89,7 +89,7 @@ capabilities:
   additionalEnabledCapabilities:
   - openshift-samples
 ----
-<1> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
+<1> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
 <2> You can specify the size of the disk to use in GB. Minimum recommendation for control plane nodes is 1024 GB.
 <3> Specify the name of the cluster.
 <4> Specify the Azure Resource Manager endpoint that your Azure Stack Hub operator provides.

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -47,19 +47,19 @@ endif::[]
 // Assumption is that attribute once outside ifdef works for several level one headings.
 [id="installation-bare-metal-config-yaml_{context}"]
 ifndef::ibm-z,ibm-z-kvm,ibm-power,agnostic,rhv[]
-= Sample `install-config.yaml` file for bare metal
+= Sample install-config.yaml file for bare metal
 endif::ibm-z,ibm-z-kvm,ibm-power,agnostic,rhv[]
 ifdef::ibm-z,ibm-z-kvm[]
-= Sample `install-config.yaml` file for IBM Z
+= Sample install-config.yaml file for IBM Z
 endif::ibm-z,ibm-z-kvm[]
 ifdef::ibm-power[]
-= Sample `install-config.yaml` file for IBM Power
+= Sample install-config.yaml file for IBM Power
 endif::ibm-power[]
 ifdef::agnostic[]
-= Sample `install-config.yaml` file for other platforms
+= Sample install-config.yaml file for other platforms
 endif::agnostic[]
 ifdef::rhv[]
-= Sample `install-config.yaml` file for RHV
+= Sample install-config.yaml file for RHV
 endif::rhv[]
 
 You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
@@ -211,7 +211,7 @@ capabilities:
   - openshift-samples
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
-<2> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
+<2> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
 <3> Specifies whether to enable or disable simultaneous multithreading (SMT), or hyperthreading. By default, SMT is enabled to increase the performance of the cores in your machines. You can disable it by setting the parameter value to `Disabled`. If you disable SMT, you must disable it in all cluster machines; this includes both control plane and compute machines.
 ifndef::ibm-z,ibm-z-kvm[]
 +

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -24,7 +24,7 @@ ifeval::["{context}" == "installing-restricted-networks-gcp-installer-provisione
 endif::[]
 
 [id="installation-gcp-config-yaml_{context}"]
-= Sample customized `install-config.yaml` file for GCP
+= Sample customized install-config.yaml file for GCP
 
 You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
 
@@ -181,7 +181,7 @@ capabilities:
 ----
 <1> Required. The installation program prompts you for this value.
 <2> If you do not provide these parameters and values, the installation program provides the default value.
-<3> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
+<3> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
 <4> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
 +
 [IMPORTANT]

--- a/modules/installation-ibm-cloud-config-yaml.adoc
+++ b/modules/installation-ibm-cloud-config-yaml.adoc
@@ -78,7 +78,7 @@ capabilities:
 ----
 <1> Required. The installation program prompts you for this value.
 <2> If you do not provide these parameters and values, the installation program provides the default value.
-<3> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
+<3> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
 <4> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
 +
 [IMPORTANT]

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -23,7 +23,7 @@ endif::[]
 [id="installation-installer-provisioned-vsphere-config-yaml_{context}"]
 = Sample install-config.yaml file for an installer-provisioned VMware vSphere cluster
 
-You can customize the `install-config.yaml` file to specify more details about
+You can customize the install-config.yaml file to specify more details about
 your {product-title} cluster's platform or modify the values of the required
 parameters.
 
@@ -118,13 +118,7 @@ capabilities:
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this
 base and include the cluster name.
-<2> The `controlPlane` section is a single mapping, but the compute section is a
-sequence of mappings. To meet the requirements of the different data structures,
-the first line of the `compute` section must begin with a hyphen, `-`, and the
-first line of the `controlPlane` section must not. Although both sections
-currently define a single machine pool, it is possible that future versions
-of {product-title} will support defining multiple compute pools during
-installation. Only one control plane pool is used.
+<2> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
 <3> Whether to enable or disable simultaneous multithreading, or
 `hyperthreading`. By default, simultaneous multithreading is enabled
 to increase the performance of your machines' cores. You can disable it by


### PR DESCRIPTION
Version(s):
CP to 4.6+

Issue:
This PR addresses [bz2088485](https://bugzilla.redhat.com/show_bug.cgi?id=2088485)

Link to docs preview:

- [Sample customized install-config.yaml file for AWS](http://file.rdu.redhat.com/mpytlak/bz2088485/installing/installing_aws/installing-aws-customizations.html#installation-aws-config-yaml_installing-aws-customizations)
- [Sample customized install-config.yaml file for Azure](http://file.rdu.redhat.com/mpytlak/bz2088485/installing/installing_azure/installing-azure-customizations.html#installation-azure-config-yaml_installing-azure-customizations)
- [Sample customized install-config.yaml file for Azure Stack Hub](http://file.rdu.redhat.com/mpytlak/bz2088485/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.html#installation-azure-stack-hub-config-yaml_installing-azure-stack-hub-network-customizations)
- [Sample customized install-config.yaml file for GCP](http://file.rdu.redhat.com/mpytlak/bz2088485/installing/installing_gcp/installing-gcp-customizations.html#installation-gcp-config-yaml_installing-gcp-customizations)
- [Sample customized install-config.yaml file for IBM Cloud VPC](http://file.rdu.redhat.com/mpytlak/bz2088485/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.html#installation-ibm-cloud-config-yaml_installing-ibm-cloud-customizations)
- [Sample install-config.yaml file for bare metal](http://file.rdu.redhat.com/mpytlak/bz2088485/installing/installing_bare_metal/installing-bare-metal.html#installation-bare-metal-config-yaml_installing-bare-metal)
- [Sample install-config.yaml file for an installer-provisioned VMware vSphere cluster](http://file.rdu.redhat.com/mpytlak/bz2088485/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-installer-provisioned-vsphere-config-yaml_installing-vsphere-installer-provisioned-customizations)

Additional information:
Worth noting that while this issue was reported against vSphere, per the IBM style guide (Claims and recommendations), "Avoid claims that are related to the content or timing of a future product or release." As such, I have removed the statement across all applicable sample install config files. Additionally - the content that was removed does not fall under the guidance for exceptions that is detailed in the RH supplementary style guide [1}

[1] https://redhat-documentation.github.io/supplementary-style-guide/#statements-about-the-future