### PR TITLE
OSDOCS-2524: Windows Containers: containerd Mark II

### DIFF
--- a/_unused_topics/windows-machine-config-operator.adoc
+++ b/_unused_topics/windows-machine-config-operator.adoc
@@ -13,4 +13,4 @@ The Windows Machine Config Operator (WMCO) orchestrates the process of deploying
 [discrete]
 == Project
 
-link:https://github.com/openshift/windows-machine-config-operator[windows-machine-config-operator]
+link:https://github.com/openshift/windows-machine-config-operator[windows-machine-config-operator] 

--- a/modules/byoh-configuring.adoc
+++ b/modules/byoh-configuring.adoc
@@ -11,7 +11,6 @@ Creating a BYOH Windows instance requires creating a config map in the WMCO name
 .Prerequisites
 Any Windows instances that are to be attached to the cluster as a node must fulfill the following requirements:
 
-* The Docker container runtime must be installed on the instance.
 * The instance must be on the same network as the Linux worker nodes in the cluster.
 * Port 22 must be open and running an SSH server.
 * The default shell for the SSH server must be the link:https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration#configuring-the-default-shell-for-openssh-in-windows[Windows Command shell], or `cmd.exe`.
@@ -22,6 +21,11 @@ Any Windows instances that are to be attached to the cluster as a node must fulf
 ** Contains only lowercase alphanumeric characters or '-'.
 ** Starts with an alphanumeric character.
 ** Ends with an alphanumeric character.
+
+[NOTE]
+====
+Windows instances deployed by the WMCO are configured with the containerd container runtime. Because the WMCO installs and manages the runtime, it is recommended that you not manually install containerd on nodes. 
+====
 
 .Procedure
 . Create a ConfigMap named `windows-instances` in the WMCO namespace that describes the Windows instances to be added.

--- a/modules/creating-runtimeclass.adoc
+++ b/modules/creating-runtimeclass.adoc
@@ -18,7 +18,7 @@ apiVersion: node.k8s.io/v1beta1
 kind: RuntimeClass
 metadata:
   name: <runtime_class_name> <1>
-handler: 'docker'
+handler: 'runhcs-wcow-process' 
 scheduling:
   nodeSelector: <2>
     kubernetes.io/os: 'windows'

--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -62,7 +62,7 @@ PS C:\> Get-Service -Name VMTools | Select Status, StartType
 [IMPORTANT]
 ====
 The public key used in the instructions must correspond to the private key you create later in the WMCO namespace that holds your secret. See the "Configuring a secret for the Windows Machine Config Operator" section for more details.
-====
+==== 
 
 . Install the `docker` container runtime on your Windows VM following the link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server[Microsoft documentation].
 

--- a/modules/windows-workload-management.adoc
+++ b/modules/windows-workload-management.adoc
@@ -10,12 +10,7 @@ To run Windows workloads in your cluster, you must first install the Windows Mac
 .WMCO design
 image::wmco-design.png[WMCO workflow]
 
-Before deploying Windows workloads, you must create a Windows compute node and have it join the cluster. The Windows node hosts the Windows workloads in a cluster, and can run alongside other Linux-based compute nodes. You can create a Windows compute node by creating a Windows machine set to host Windows Server compute machines. You must apply a Windows-specific label to the machine set that specifies a Windows OS image that has the Docker-formatted container runtime add-on enabled.
-
-[IMPORTANT]
-====
-Currently, the Docker-formatted container runtime is used in Windows nodes. Kubernetes is deprecating Docker as a container runtime; you can reference the Kubernetes documentation for more information in link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Docker deprecation]. Containerd will be the new supported container runtime for Windows nodes in a future release of Kubernetes.
-====
+Before deploying Windows workloads, you must create a Windows compute node and have it join the cluster. The Windows node hosts the Windows workloads in a cluster, and can run alongside other Linux-based compute nodes. You can create a Windows compute node by creating a Windows machine set to host Windows Server compute machines. You must apply a Windows-specific label to the machine set that specifies a Windows OS image. 
 
 The WMCO watches for machines with the Windows label. After a Windows machine set is detected and its respective machines are provisioned, the WMCO configures the underlying Windows virtual machine (VM) so that it can join the cluster as a compute node.
 

--- a/modules/wmco-upgrades.adoc
+++ b/modules/wmco-upgrades.adoc
@@ -7,6 +7,23 @@
 
 When a new version of the Windows Machine Config Operator (WMCO) is released that is compatible with the current cluster version, the Operator is upgraded based on the upgrade channel and subscription approval strategy it was installed with when using the Operator Lifecycle Manager (OLM). The WMCO upgrade results in the Kubernetes components in the Windows machine being upgraded.
 
+//the following paragraph and lists taken from https://github.com/openshift/enhancements/pull/962/files#diff-be9b7fd31ea4585b2c617aa51f14f35cb1212da129acf3455806aba6cddf782dR137 
+Because WMCO 6.0.0 uses containerd as the default container runtime instead of Docker, note the following changes that are made during the upgrade:
+
+* For nodes created using a machine set:
+** All `machine` objects are deleted, which results in the draining and deletion of any Windows nodes.
+** New Windows nodes are created.
+** The upgraded WMCO configures the new Windows nodes with containerd as the default runtime.
+** After the new Windows nodes join the {product-title} cluster, you can deploy pods on those nodes.
+
+* For Bring-Your-Own-Host (BYOH) nodes:
+** The kubelet, kube-proxy, CNI, and the hybrid-overlay components, which were installed by the WMCO, are all uninstalled.
+** Any Windows OS-specific configurations that were created as part of configuring the instance, such as HNS networks, are deleted or reverted.
+** The WMCO installs containerd as the default runtime, and reinstalls the kubelet, kube-proxy, CNI, and hybrid-overlay components.
+** The kubelet service starts.
+** After the new Windows nodes join the {product-title} cluster, you can deploy pods on those nodes.
+** If any Docker service is present, it continues to run. Alternatively, you can manually uninstall Docker.
+
 [NOTE]
 ====
 If you are upgrading to a new version of the WMCO and want to use cluster monitoring, you must have the `openshift.io/cluster-monitoring=true` label present in the WMCO namespace. If you add the label to a pre-existing WMCO namespace, and there are already Windows nodes configured, restart the WMCO pod to allow monitoring graphs to display.

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
@@ -12,12 +12,7 @@ You can create a Windows `MachineSet` object to serve a specific purpose in your
 == Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
-* You are using a supported Windows Server as the operating system image with the Docker-formatted container runtime add-on enabled.
-
-[IMPORTANT]
-====
-Currently, the Docker-formatted container runtime is used in Windows nodes. Kubernetes is deprecating Docker as a container runtime; you can reference the Kubernetes documentation for more information in link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Docker deprecation]. Containerd will be the new supported container runtime for Windows nodes in a future release of Kubernetes.
-====
+* You are using a supported Windows Server as the operating system image. 
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 include::modules/windows-machineset-aws.adoc[leveloffset=+1]

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
@@ -12,12 +12,7 @@ You can create a Windows `MachineSet` object to serve a specific purpose in your
 == Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
-* You are using a supported Windows Server as the operating system image with the Docker-formatted container runtime add-on enabled.
-
-[IMPORTANT]
-====
-Currently, the Docker-formatted container runtime is used in Windows nodes. Kubernetes is deprecating Docker as a container runtime; you can reference the Kubernetes documentation for more information in link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Docker deprecation]. Containerd will be the new supported container runtime for Windows nodes in a future release of Kubernetes.
-====
+* You are using a supported Windows Server as the operating system image. 
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 include::modules/windows-machineset-azure.adoc[leveloffset=+1]

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
@@ -12,12 +12,7 @@ You can create a Windows `MachineSet` object to serve a specific purpose in your
 == Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
-* You are using a supported Windows Server as the operating system image with the Docker-formatted container runtime add-on enabled.
-
-[IMPORTANT]
-====
-Currently, the Docker-formatted container runtime is used in Windows nodes. Kubernetes is deprecating Docker as a container runtime; you can reference the Kubernetes documentation for more information on link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Docker deprecation]. Containerd will be the new supported container runtime for Windows nodes in a future release of Kubernetes.
-====
+* You are using a supported Windows Server as the operating system image. 
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -28,7 +28,7 @@ Dual NIC is not supported on WMCO-managed Windows instances.
 
 [NOTE]
 ====
-The WMCO is not supported in clusters that use a xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide proxy] because the WMCO is not able to route traffic through the proxy connection for the workloads.
+Windows instances deployed by the WMCO are configured with the containerd container runtime. Because WMCO installs and manages the runtime, it is recommanded that you do not manually install containerd on nodes. 
 ====
 
 [role="_additional-resources"]
@@ -39,6 +39,11 @@ The WMCO is not supported in clusters that use a xref:../networking/enable-clust
 == Installing the Windows Machine Config Operator
 
 You can install the Windows Machine Config Operator using either the web console or OpenShift CLI (`oc`).
+
+[NOTE]
+====
+The WMCO is not supported in clusters that use a xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide proxy] because the WMCO is not able to route traffic through the proxy connection for the workloads. 
+====
 
 include::modules/installing-wmco-using-web-console.adoc[leveloffset=+2]
 

--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. For more information, see the xref:../windows_containers/windows-containers-release-notes-6-x.adoc#windows-containers-release-notes-6-x[release notes].
+{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/windows-containers-release-notes-6-x.adoc#windows-containers-release-notes-6-x[release notes]. 
 
 You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Window instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[configuration map].
 

--- a/windows_containers/scheduling-windows-workloads.adoc
+++ b/windows_containers/scheduling-windows-workloads.adoc
@@ -17,13 +17,8 @@ The WMCO is not supported in clusters that use a xref:../networking/enable-clust
 == Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
-* You are using a Windows container as the OS image with the Docker-formatted container runtime add-on enabled.
+* You are using a Windows container as the OS image. 
 * You have created a Windows machine set.
-
-[IMPORTANT]
-====
-Currently, the Docker-formatted container runtime is used in Windows nodes. Kubernetes is deprecating Docker as a container runtime; you can reference the Kubernetes documentation for more information in link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Docker deprecation]. Containerd will be the new supported container runtime for Windows nodes in a future release of Kubernetes.
-====
 
 include::modules/windows-pod-placement.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Merged https://github.com/openshift/openshift-docs/pull/47588/ prematurely. Need to wait for WINC 6.0.0 release on or about August 23. I reverted 47588. This PR replaces the changes made in 47588.