### PR TITLE
OSDOCS-3615:Adds command in place of KCS solution for 4.8

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2540,9 +2540,12 @@ Issued: 2021-07-27
 
 {product-title} release 4.8.2, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2021:2438[RHSA-2021:2438] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:2437[RHSA-2021:2437] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6164202[{product-title} 4.8.2 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.2 --pullspecs
+----
 
 [id="ocp-4-8-3"]
 === RHBA-2021:2896 - {product-title} 4.8.3 bug fix update
@@ -2551,9 +2554,12 @@ Issued: 2021-08-02
 
 {product-title} release 4.8.3 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:2896[RHBA-2021:2896] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2899[RHBA-2021:2899] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6221811[{product-title} 4.8.3 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.3 --pullspecs
+----
 
 [id="ocp-4-8-3-updating"]
 ==== Updating
@@ -2567,9 +2573,12 @@ Issued: 2021-08-09
 
 {product-title} release 4.8.4 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2021:2983[RHSA-2021:2983] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:2984[RHSA-2021:2984] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6246811[{product-title} 4.8.4 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.4 --pullspecs
+----
 
 [id="ocp-4-8-4-bug-fixes"]
 ==== Bug fixes
@@ -2590,7 +2599,6 @@ link:https://access.redhat.com/solutions/6246811[{product-title} 4.8.4 container
 
 * Previously, when using the automatic pinning for a VM, the name of the property was `disabled`, `existing`, or `adjust`. With this release, the name better describes each policy, and `existing` was removed because it is blocked on oVirt. The new property names are `none` and `resize_and_pin`, which align with the oVirt user interface. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1987182[*BZ#1987182*])
 
-
 [id="ocp-4-8-4-updating"]
 ==== Updating
 
@@ -2604,9 +2612,12 @@ Issued: 2021-08-16
 
 {product-title} release 4.8.5 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3121[RHBA-2021:3121] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3122[RHBA-2021:3122] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6261051[{product-title} 4.8.5 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.5 --pullspecs
+----
 
 [id="ocp-4-8-5-features"]
 ==== Features
@@ -2670,9 +2681,12 @@ $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.8.9-ppc64le
 +
 The image digest is `sha256:ded5e8d61915f74d938668cf58cdc9f37eb4172bc24e80c16c7fe1a6f84eff43`
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6287821[{product-title} 4.8.9 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.9 --pullspecs
+----
 
 [id="ocp-4-8-9-bug-fixes"]
 ==== Bug fixes
@@ -2695,9 +2709,12 @@ Issued: 2021-09-06
 
 {product-title} release 4.8.10 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3299[RHBA-2021:3299] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3300[RHBA-2021:3300] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6308491[{product-title} 4.8.10 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.10 --pullspecs
+----
 
 [id="ocp-4-8-10-updating"]
 ==== Updating
@@ -2711,9 +2728,12 @@ Issued: 2021-09-14
 
 {product-title} release 4.8.11 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3429[RHBA-2021:3429] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6324771[{product-title} 4.8.11 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.11 --pullspecs
+----
 
 [id="ocp-4-8-11-bug-fixes"]
 ==== Bug fixes
@@ -2732,9 +2752,12 @@ Issued: 2021-09-21
 
 {product-title} release 4.8.12 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3511[RHBA-2021:3511] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3512[RHBA-2021:3512] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6338301[{product-title} 4.8.12 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.12 --pullspecs
+----
 
 [id="ocp-4-8-12-features"]
 ==== Features
@@ -2763,9 +2786,12 @@ Issued: 2021-09-27
 
 {product-title} release 4.8.13, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3632[RHBA-2021:3632] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3631[RHSA-2021:3631] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6363171[{product-title} 4.8.13 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.13 --pullspecs
+----
 
 [id="ocp-4-8-13-features"]
 ==== Features
@@ -2793,9 +2819,12 @@ Issued: 2021-10-11
 
 {product-title} release 4.8.14 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3682[RHBA-2021:3682] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3865[RHBA-2021:3865] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6395061[{product-title} 4.8.14 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.14 --pullspecs
+----
 
 [id="ocp-4-8-14-preparing-upgrade-next-release"]
 ==== Preparing to upgrade to the next {product-title} release
@@ -2827,9 +2856,12 @@ Issued: 2021-10-19
 
 {product-title} release 4.8.15, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3821[RHBA-2021:3821] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3820[RHSA-2021:3820] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6417501[{product-title} 4.8.15 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.15 --pullspecs
+----
 
 [id="ocp-4-8-15-known-issues"]
 ==== Known issues
@@ -2857,9 +2889,12 @@ Issued: 2021-10-27
 
 {product-title} release 4.8.17, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3927[RHBA-2021:3927] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3926[RHSA-2021:3926] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6455311[{product-title} 4.8.17 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.17 --pullspecs
+----
 
 [id="ocp-4-8-17-updating"]
 ==== Updating
@@ -2873,9 +2908,12 @@ Issued: 2021-11-02
 
 {product-title} release 4.8.18 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4020[RHBA-2021:4020] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4019[RHBA-2021:4019] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6469021[{product-title} 4.8.18 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.18 --pullspecs
+----
 
 [id="ocp-4-8-18-bug-fixes"]
 ==== Bug fixes
@@ -2894,9 +2932,12 @@ Issued: 2021-11-11
 
 {product-title} release 4.8.19 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4109[RHBA-2021:4109] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4108[RHBA-2021:4108] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6487101[{product-title} 4.8.19 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.19 --pullspecs
+----
 
 [id="ocp-4-8-19-updating"]
 ==== Updating
@@ -2910,9 +2951,12 @@ Issued: 2021-11-16
 
 {product-title} release 4.8.20 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4574[RHBA-2021:4574] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4571[RHBA-2021:4571] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6507841[{product-title} 4.8.20 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.20 --pullspecs
+----
 
 [id="ocp-4-8-20-known-issues"]
 ==== Known Issues
@@ -2932,10 +2976,12 @@ Issued: 2021-11-23
 
 {product-title} release 4.8.21 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4716[RHBA-2021:4716] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4715[RHBA-2021:4715] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6532121[{product-title} 4.8.21 container image list]
-
+[source,terminal]
+----
+$ oc adm release info 4.8.21 --pullspecs
+----
 
 [id="ocp-4-8-21-features"]
 ==== Features
@@ -2958,9 +3004,12 @@ Issued: 2021-11-30
 
 {product-title} release 4.8.22, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4830[RHBA-2021:4830] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:4829[RHSA-2021:4829] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6545551[{product-title} 4.8.22 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.22 --pullspecs
+----
 
 
 [id="ocp-4-8-22-features"]
@@ -2984,9 +3033,12 @@ Issued: 2021-12-07
 
 {product-title} release 4.8.23, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4881[RHBA-2021:4881] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4880[RHBA-2021:4880] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6559931[{product-title} 4.8.23 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.23 --pullspecs
+----
 
 [id="ocp-4-8-23-updating"]
 ==== Updating
@@ -3002,9 +3054,12 @@ Issued: 2021-12-14
 
 This release includes critical security updates for link:https://access.redhat.com/security/cve/CVE-2021-44228[CVE-2021-44228], link:https://access.redhat.com/security/cve/CVE-2021-45046[CVE-2021-45046], link:https://access.redhat.com/security/cve/CVE-2021-4104[CVE-2021-4104], and link:https://access.redhat.com/security/cve/CVE-2021-4125[CVE-2021-4125], all of which concern the Apache Log4j utility. Fixes for these flaws are provided by the link:https://access.redhat.com/errata/RHSA-2021:5108[RHSA-2021:5108], link:https://access.redhat.com/errata/RHSA-2021:5148[RHSA-2021:5148], and link:https://access.redhat.com/errata/RHSA-2021:5183[RHSA-2021:5183] advisories.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6585021[{product-title} 4.8.24 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.24 --pullspecs
+----
 
 [id="ocp-4-8-24-updating"]
 ==== Updating
@@ -3018,9 +3073,12 @@ Issued: 2022-01-05
 
 {product-title} release 4.8.25, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:5209[RHBA-2021:5209] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:5208[RHSA-2021:5208] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6620441[{product-title} 4.8.25 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.25 --pullspecs
+----
 
 [id="ocp-4-8-25-bug-fixes"]
 ==== Bug fixes
@@ -3043,9 +3101,12 @@ Issued: 2022-01-11
 
 {product-title} release 4.8.26 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0021[RHBA-2022:0021] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0020[RHBA-2022:0020] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6631251[{product-title} 4.8.26 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.26 --pullspecs
+----
 
 [id="ocp-4-8-26-updating"]
 ==== Updating
@@ -3059,9 +3120,12 @@ Issued: 2022-01-18
 
 {product-title} release 4.8.27 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0113[RHBA-2022:0113] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0111[RHBA-2022:0111] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6643691[{product-title} 4.8.27 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.27 --pullspecs
+----
 
 [id="ocp-4-8-27-updating"]
 ==== Updating
@@ -3075,9 +3139,12 @@ Issued: 2022-01-25
 
 {product-title} release 4.8.28 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0172[RHBA-2022:0172] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0171[RHBA-2022:0171] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6656881[{product-title} 4.8.28 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.28 --pullspecs
+----
 
 [id="ocp-4-8-28-updating"]
 ==== Updating
@@ -3091,9 +3158,12 @@ Issued: 2022-02-01
 
 {product-title} release 4.8.29 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0278[RHBA-2022:0278] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0277[RHBA-2022:0277] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6681391[{product-title} 4.8.29 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.29 --pullspecs
+----
 
 [id="ocp-4-8-29-bug-fixes"]
 ==== Bug fixes
@@ -3116,9 +3186,12 @@ Issued: 2022-02-15
 
 {product-title} release 4.8.31, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0484[RHBA-2022:0484] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0483[RHSA-2022:0483] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6730091[{product-title} 4.8.31 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.31 --pullspecs
+----
 
 [id="ocp-4-8-31-features"]
 ==== Features
@@ -3167,9 +3240,12 @@ Issued: 2022-02-23
 
 {product-title} release 4.8.32 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0559[RHBA-2022:0559] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0558[RHBA-2022:0558] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6749841[{product-title} 4.8.32 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.32 --pullspecs
+----
 
 [id="ocp-4-8-32-updating"]
 ==== Updating
@@ -3183,9 +3259,12 @@ Issued: 2022-03-01
 
 {product-title} release 4.8.33 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0651[RHBA-2022:0651] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0650[RHBA-2022:0650] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6764661[{product-title} 4.8.33 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.33 --pullspecs
+----
 
 [id="ocp-4-8-33-updating"]
 ==== Updating
@@ -3199,9 +3278,12 @@ Issued: 2022-03-16
 
 {product-title} release 4.8.34 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0795[RHBA-2022:0795] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0793[RHBA-2022:0793] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6818161[{product-title} 4.8.34 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.34 --pullspecs
+----
 
 [id="ocp-4-8-34-features"]
 ==== Features
@@ -3240,9 +3322,12 @@ Issued: 2022-03-22
 
 {product-title} release 4.8.35, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0872[RHBA-2022:0872] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0871[RHSA-2022:0871] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6834631[{product-title} 4.8.35 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.35 --pullspecs
+----
 
 [id="ocp-4-8-35-updating"]
 ==== Updating
@@ -3256,9 +3341,12 @@ Issued: 2022-04-11
 
 {product-title} release 4.8.36, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:1154[RHSA-2022:1154] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:1153[RHSA-2022:1153] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6904371[{product-title} 4.8.36 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.36 --pullspecs
+----
 
 [id="ocp-4-8-36-bug-fixes"]
 ==== Bug fixes
@@ -3280,9 +3368,12 @@ Issued: 2022-04-21
 
 {product-title} release 4.8.37 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1369[RHBA-2022:1369] advisory. There are no RPM packages for this release.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6936291[{product-title} 4.8.37 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.37 --pullspecs
+----
 
 [id="ocp-4-8-37-bug-fixes"]
 ==== Bug fixes
@@ -3300,9 +3391,12 @@ Issued: 2022-04-27
 
 {product-title} release 4.8.39 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1427[RHBA-2022:1427] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1423[RHBA-2022:1423] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6954669[{product-title} 4.8.39 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.39 --pullspecs
+----
 
 [id="ocp-4-8-39-known-issues"]
 ==== Known Issue
@@ -3321,9 +3415,13 @@ Issued: 2022-05-25
 
 {product-title} release 4.8.41, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:2272[RHSA-2022:2272] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:2270[RHBA-2022:2270] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6958678[{product-title} 4.8.41 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.41 --pullspecs
+----
+
 
 [id="ocp-4-8-41-features"]
 ==== Features
@@ -3345,9 +3443,12 @@ Issued: 2022-06-01
 
 {product-title} release 4.8.42 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:4737[RHBA-2022:4737] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:4736[RHBA-2022:4736] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6961020[{product-title} 4.8.42 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.42 --pullspecs
+----
 
 [id="ocp-4-8-42-updating"]
 ==== Updating
@@ -3361,9 +3462,12 @@ Issued: 2022-06-16
 
 {product-title} release 4.8.43, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:4952[RHBA-2022:4952] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:4951[RHSA-2022:4951] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6963444[{product-title} 4.8.43 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.43 --pullspecs
+----
 
 [id="ocp-4-8-43-updating"]
 ==== Updating
@@ -3377,9 +3481,12 @@ Issued: 2022-06-22
 
 {product-title} release 4.8.44 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5032[RHBA-2022:5032] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5031[RHBA-2022:5031] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6963680[{product-title} 4.8.44 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.44 --pullspecs
+----
 
 [id="ocp-4-8-44-bug-fixes"]
 ==== Bug fixes
@@ -3397,9 +3504,12 @@ Issued: 2022-06-30
 
 {product-title} release 4.8.45 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5167[RHBA-2022:5167] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5166[RHBA-2022:5166] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6965038[{product-title} 4.8.45 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.45 --pullspecs
+----
 
 [id="ocp-4-8-45-bug-fixes"]
 ==== Bug fixes
@@ -3417,9 +3527,12 @@ Issued: 2022-07-06
 
 {product-title} release 4.8.46 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5424[RHBA-2022:5424] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5423[RHBA-2022:5423] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6966480[{product-title} 4.8.46 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.46 --pullspecs
+----
 
 ==== Updating
 
@@ -3432,9 +3545,12 @@ Issued: 2022-08-09
 
 {product-title} release 4.8.46 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5889[RHBA-2022:5889] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5888[RHBA-2022:5888] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6971193[{product-title} 4.8.47 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.8.47 --pullspecs
+----
 
 ==== Updating
 


### PR DESCRIPTION
This PR removes the KCS solutions from the async errata releases and provides the `oc` command. 

Issue:
[OSDOCS-3615](https://issues.redhat.com/browse/OSDOCS-3615)
Change management acks are in #46497 

Link to docs preview:
http://file.rdu.redhat.com/opayne/kcs-oc-RN-pt1/release_notes/ocp-4-8-release-notes.html#ocp-4-8-1-ga




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
