### PR TITLE
BZ2117751: OSDK Remove references to `operator-sdk olm status` 4.8+

### DIFF
--- a/modules/osdk-deploy-olm.adoc
+++ b/modules/osdk-deploy-olm.adoc
@@ -35,14 +35,6 @@ endif::[]
 
 .Procedure
 
-. Check the status of OLM on your cluster by using the following Operator SDK command:
-+
-[source,terminal]
-----
-$ operator-sdk olm status \
-    --olm-namespace=openshift-operator-lifecycle-manager
-----
-
 . Enter the following command to run the Operator on the cluster: 
 +
 [source,terminal]


### PR DESCRIPTION
Version(s): 4.8+

Issue: [BZ2117751](https://bugzilla.redhat.com/show_bug.cgi?id=2117751)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview (requires VPN):
- [Go-based Operators](http://file.rdu.redhat.com/mipeter/bz2117751-main-osdk-olm-status/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-bundle-deploy-olm_osdk-golang-tutorial)
- [Ansible-based Operators](http://file.rdu.redhat.com/mipeter/bz2117751-main-osdk-olm-status/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-bundle-deploy-olm_osdk-ansible-tutorial)
- [Helm-based Operators](http://file.rdu.redhat.com/mipeter/bz2117751-main-osdk-olm-status/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-bundle-deploy-olm_osdk-helm-tutorial)
- [Java-based Operators (4.11+)
](http://file.rdu.redhat.com/mipeter/bz2117751-main-osdk-olm-status/operators/operator_sdk/java/osdk-java-tutorial.html#osdk-bundle-deploy-olm_osdk-java-tutorial)

Additional information:
The `operator-sdk olm status` call ensures that the Operator Lifecycle Manager (OLM) is installed on the Kubernetes cluster. Since OpenShift is released with OLM as part of the payload, this step is unnecessary. Additionally, the `olm status` subcommand does not work properly on OpenShift.