### PR TITLE
BZ2117751: OSDK Remove references to `operator-sdk olm status' 4.7

### DIFF
--- a/modules/osdk-bundle-deploy-olm.adoc
+++ b/modules/osdk-bundle-deploy-olm.adoc
@@ -88,14 +88,6 @@ $ make bundle-build BUNDLE_IMG=<registry>/<user>/<bundle_image_name>:<tag>
 $ docker push <registry>/<user>/<bundle_image_name>:<tag>
 ----
 
-. Check the status of OLM on your cluster by using the following Operator SDK command:
-+
-[source,terminal]
-----
-$ operator-sdk olm status \
-    --olm-namespace=openshift-operator-lifecycle-manager
-----
-
 . Run the Operator on your cluster by using the OLM integration in Operator SDK:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s): 4.7

Issue: [BZ2117751](https://bugzilla.redhat.com/show_bug.cgi?id=2117751)

Link to docs preview (requires VPN):
- [Go-based Operators](http://file.rdu.redhat.com/mipeter/bz2117751-4.7-osdk-olm-status/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-bundle-deploy-olm_osdk-golang-tutorial)
- [Helm-based Operators](http://file.rdu.redhat.com/mipeter/bz2117751-4.7-osdk-olm-status/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-bundle-deploy-olm_osdk-helm-tutorial)
- [Ansible-based Operators](http://file.rdu.redhat.com/mipeter/bz2117751-4.7-osdk-olm-status/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-bundle-deploy-olm_osdk-ansible-tutorial)

Additional information:
The `operator-sdk olm status` command ensures that the Operator Lifecycle Manager (OLM) is installed on the Kubernetes cluster. Since OLM is part of the OpenShift payload, this step is unnecessary. Additionally, the olm status subcommand does not work properly on OpenShift.