### PR TITLE
RHDEVDOCS-4060 - config map settings for data retention period for Thanos Ruler

### DIFF
--- a/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
+++ b/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+:_content-type: PROCEDURE
+[id="modifying-the-retention-time-for-thanos-ruler-metrics-data_{context}"]
+= Modifying the retention time for Thanos Ruler metrics data
+
+By default, for user-defined projects, Thanos Ruler automatically retains metrics data for 24 hours.
+You can modify the retention time to change how long this data is retained by specifying a time value in the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* A cluster administrator has enabled monitoring for user-defined projects.
+* You have access to the cluster as a user with the `cluster-admin` role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* You have created the `user-workload-monitoring-config` `ConfigMap` object.
+
+[WARNING]
+====
+Saving changes to a monitoring config map might restart monitoring processes and redeploy the pods and other resources in the related project.
+The running monitoring processes in that project might also restart.
+====
+
+.Procedure
+
+. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
+----
+
+. Add the retention time configuration under `data/config.yaml`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    thanosRuler:
+      retention: <time_specification> <1>
+----
++
+<1> Specify the retention time in the following format: a number directly followed by `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks), or `y` (years).
+You can also combine time values for specific times, such as `1h30m15s`.
+The default is `24h`.
++
+The following example sets the retention time to 10 days for Thanos Ruler data:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    thanosRuler:
+      retention: 10d
+----
+
+. Save the file to apply the changes. The pods affected by the new configuration automatically restart.

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -80,6 +80,7 @@ include::modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.ado
 include::modules/monitoring-configuring-persistent-storage.adoc[leveloffset=+1]
 include::modules/monitoring-configuring-a-local-persistent-volume-claim.adoc[leveloffset=+2]
 include::modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc[leveloffset=+2]
+include::modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Summary: This PR documents how to configure the retention time for Thanos Ruler for user-workload monitoring metrics data.

- Aligned team: DevTools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4060
- Direct link to doc preview: http://file.rdu.redhat.com/bburt/RHDEVDOCS-4060-config-map-settings-for-data-retention-period-for-thanos-ruler/monitoring/configuring-the-monitoring-stack.html#modifying-the-retention-time-for-thanos-ruler-metrics-data_configuring-the-monitoring-stack
- SME review: @slashpai 
- QE review: @lihongyan1 
- Peer review: @jc-berger 
