### PR TITLE
TELCODOCS-78: Creating a node health check module added

### DIFF
--- a/modules/eco-node-health-check-operator-creating-node-health-check.adoc
+++ b/modules/eco-node-health-check-operator-creating-node-health-check.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * ../nodes/nodes/eco-node-health-check-operator.adoc
+
+:_content-type: PROCEDURE
+[id="eco-node-health-check-operator-creating-node-health-check_{context}"]
+= Creating a node health check
+Using the web console, you can create a node health check to identify unhealthy nodes and specify the remediation type and strategy to fix them.
+
+.Procedure
+
+. From the *Administrator* perspective of the {product-title} web console, click *Compute* -> *NodeHealthChecks* -> *CreateNodeHealthCheck*.
+. Specify whether to configure the node health check using the *Form view*  or the *YAML view*.
+. Enter a *Name* for the node health check. The name must consist of lower case, alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+. Specify the *Remediator* type, and *Self node remediation* or *Other*. The Self node remediation option is part of the Self Node Remediation Operator that is installed with the Node Health Check Operator. Selecting *Other* requires an *API version*, *Kind*, *Name*, and *Namespace* to be entered, which then points to the remediation template resource of a remediator.
+. Make a *Nodes* selection by specifying the labels of the nodes you want to remediate. The selection matches labels that you want to check. If more than one label is specified, the nodes must contain each label. The default value is empty, which selects both worker and control-plane nodes.
++
+[NOTE]
+====
+When creating a node health check with the Self Node Remediation Operator, you must select either `node-role.kubernetes.io/worker` or `node-role.kubernetes.io/control-plane` as the value.
+====
++
+. Specify the minimum number of healthy nodes, using either a percentage or a number, required for a *NodeHealthCheck* to remediate nodes in the targeted pool. If the number of healthy nodes equals to or exceeds the limit set by *Min healthy*, remediation occurs. The default value is 51%.
+. Specify a list of *Unhealthy conditions* that if a node meets determines whether the node is considered unhealthy, and requires remediation. You can specify the *Type*, *Status* and *Duration*. You can also create your own custom type.
+. Click *Create* to create the node health check.
+
+.Verification
+
+* Navigate to the *Compute* -> *NodeHealthCheck* page and verify that the corresponding node health check is listed, and their status displayed. Once created, node health checks can be paused, modified, and deleted.

--- a/nodes/nodes/eco-node-health-check-operator.adoc
+++ b/nodes/nodes/eco-node-health-check-operator.adoc
@@ -19,6 +19,8 @@ include::modules/eco-node-health-check-operator-installation-web-console.adoc[le
 
 include::modules/eco-node-health-check-operator-installation-cli.adoc[leveloffset=+1]
 
+include::modules/eco-node-health-check-operator-creating-node-health-check.adoc[leveloffset=+1]
+
 [id="gather-data-nhc"]
 == Gathering data about the Node Health Check Operator
 To collect debugging information about the Node Health Check Operator, use the `must-gather` tool. For information about the `must-gather` image for the Node Health Check Operator, see xref:../../support/gathering-cluster-data.adoc#gathering-data-specific-features_gathering-cluster-data[Gathering data about specific features].


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-78 D/S doc & RN: [MGMT-6459](https://issues.redhat.com//browse/MGMT-6459) - Fencing: Improved UI for Health Check Remediation

Applies to OpenShift version : 4.12 +

Preview: [Creating a node health check](http://file.emea.redhat.com/pogrady/TELCODOCS-78/nodes/nodes/eco-node-health-check-operator.html#eco-node-health-check-operator-creating-node-health-check_node-health-check-operator)

/label telco

Dev review complete @slintes 
UI review complete @batzionb 
QE review complete @anna-savina
Peer review complete @jldohmann 

Thank you.