### PR TITLE
[BZ2106817] Add ShiftStack DPDK IPI ifeval to cluster deploy module

### DIFF
--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -24,6 +24,7 @@
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc
+// * installing/installing_openstack/installing-openstack-installer-ovs-dpdk.adoc
 // * installing/installing_openstack/installing-openstack-installer.adoc
 // * installing/installing_rhv/installing-rhv-customizations.adoc
 // * installing/installing_rhv/installing-rhv-default.adoc
@@ -129,6 +130,10 @@ ifeval::["{context}" == "installing-openstack-installer-kuryr"]
 :custom-config:
 endif::[]
 ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:osp:
+:custom-config:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-ovs-dpdk"]
 :osp:
 :custom-config:
 endif::[]
@@ -554,6 +559,10 @@ ifeval::["{context}" == "installing-openstack-installer-kuryr"]
 :!custom-config:
 endif::[]
 ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:!osp:
+:!custom-config:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-ovs-dpdk"]
 :!osp:
 :!custom-config:
 endif::[]


### PR DESCRIPTION
Version(s): 4.10

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2106817

Link to docs preview: http://file.rdu.redhat.com/~mbridges/ifeval-fix-pt2/installing/installing_openstack/installing-openstack-installer-ovs-dpdk.html#installation-launching-installer_installing-openstack-installer-ovs-dpdk

Additional information: This PR only addresses the OVS-DPDK ShiftStack IPI assembly. More are coming to fix additional ifeval problems for other platforms that I've found in the module.
