### PR TITLE
[BZ2106817] Add ShiftStack SRIOV IPI ifeval to deploy mod (4.9)

### DIFF
--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -20,6 +20,7 @@
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc
+// * installing/installing_openstack/installing-openstack-installer-sr-iov.adoc
 // * installing/installing_openstack/installing-openstack-installer.adoc
 // * installing/installing_rhv/installing-rhv-customizations.adoc
 // * installing/installing_rhv/installing-rhv-default.adoc
@@ -107,6 +108,10 @@ ifeval::["{context}" == "installing-openstack-installer-kuryr"]
 :custom-config:
 endif::[]
 ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:osp:
+:custom-config:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-sr-iov"]
 :osp:
 :custom-config:
 endif::[]
@@ -508,6 +513,10 @@ ifeval::["{context}" == "installing-openstack-installer-kuryr"]
 :!custom-config:
 endif::[]
 ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:!osp:
+:!custom-config:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-sr-iov"]
 :!osp:
 :!custom-config:
 endif::[]


### PR DESCRIPTION
Version(s): 4.9

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2106817

Link to docs preview: http://file.rdu.redhat.com/~mbridges/ifeval-fix-pt4/installing/installing_openstack/installing-openstack-installer-sr-iov.html#installation-launching-installer_installing-openstack-installer-sr-iov

Additional information: This PR only addresses the SR-IOV ShiftStack IPI assembly. More are coming to fix additional ifeval problems for other platforms that I've found in the module.