### PR TITLE
[BZ2106817] Add ShiftStack SRIOV IPI ifeval to deploy mod (4.10)

### DIFF
--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -25,6 +25,7 @@
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc
 // * installing/installing_openstack/installing-openstack-installer-ovs-dpdk.adoc
+// * installing/installing_openstack/installing-openstack-installer-sr-iov.adoc
 // * installing/installing_openstack/installing-openstack-installer.adoc
 // * installing/installing_rhv/installing-rhv-customizations.adoc
 // * installing/installing_rhv/installing-rhv-default.adoc
@@ -134,6 +135,10 @@ ifeval::["{context}" == "installing-openstack-installer-restricted"]
 :custom-config:
 endif::[]
 ifeval::["{context}" == "installing-openstack-installer-ovs-dpdk"]
+:osp:
+:custom-config:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-sr-iov"]
 :osp:
 :custom-config:
 endif::[]
@@ -563,6 +568,10 @@ ifeval::["{context}" == "installing-openstack-installer-restricted"]
 :!custom-config:
 endif::[]
 ifeval::["{context}" == "installing-openstack-installer-ovs-dpdk"]
+:!osp:
+:!custom-config:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-sr-iov"]
 :!osp:
 :!custom-config:
 endif::[]


### PR DESCRIPTION
Version(s): 4.10

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2106817

Link to docs preview: http://file.rdu.redhat.com/~mbridges/ifeval-fix-pt5/installing/installing_openstack/installing-openstack-installer-sr-iov.html#installation-launching-installer_installing-openstack-installer-sr-iov

Additional information: This PR only addresses the SR-IOV ShiftStack IPI assembly. More are coming to fix additional ifeval problems for other platforms that I've found in the module.