### PR TITLE
[enterprise-4.10] BZ-2009339: Compatibility matrix update

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -120,7 +120,7 @@ You can perform different types of installations on different platforms.
 
 [NOTE]
 ====
-Not all installation options are supported for all platforms, as shown in the following tables.
+Not all installation options are supported for all platforms, as shown in the following tables. A checkmark indicates that the option is supported and links to the relevant section.
 ====
 
 .Installer-provisioned infrastructure options
@@ -130,81 +130,81 @@ ifndef::openshift-origin[]
 ||Alibaba |AWS (x86_64) |AWS (arm64) |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Power
 
 |Default
-|xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[X]
-|xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[X]
-|xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[X]
-|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[X]
-|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc#installing-azure-stack-hub-default[X]
-|xref:../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[X]
+|xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[&#10003;]
+|xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[&#10003;]
+|xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[&#10003;]
+|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[&#10003;]
+|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc#installing-azure-stack-hub-default[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[&#10003;]
 |
 |
-|xref:../installing/installing_rhv/installing-rhv-default.adoc#installing-rhv-default[X]
-|xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[X]
-|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc#installing-vsphere-installer-provisioned[X]
-|xref:../installing/installing_vmc/installing-vmc.adoc#installing-vmc[X]
-|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[X]
+|xref:../installing/installing_rhv/installing-rhv-default.adoc#installing-rhv-default[&#10003;]
+|xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[&#10003;]
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc#installing-vsphere-installer-provisioned[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc.adoc#installing-vmc[&#10003;]
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[&#10003;]
 |
 |
 
 |Custom
-|xref:../installing/installing_alibaba/installing-alibaba-customizations.adoc#installing-alibaba-customizations[X]
-|xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[X]
-|xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[X]
-|xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[X]
-|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc#installing-azure-stack-hub-default[X]
-|xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[X]
-|xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#installing-openstack-installer-custom[X]
-|xref:../installing/installing_openstack/installing-openstack-installer-sr-iov.adoc#installing-openstack-installer-sr-iov[X]
-|xref:../installing/installing_rhv/installing-rhv-customizations.adoc#installing-rhv-customizations[X]
+|xref:../installing/installing_alibaba/installing-alibaba-customizations.adoc#installing-alibaba-customizations[&#10003;]
+|xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[&#10003;]
+|xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[&#10003;]
+|xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[&#10003;]
+|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc#installing-azure-stack-hub-default[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#installing-openstack-installer-custom[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-installer-sr-iov.adoc#installing-openstack-installer-sr-iov[&#10003;]
+|xref:../installing/installing_rhv/installing-rhv-customizations.adoc#installing-rhv-customizations[&#10003;]
 |
-|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installing-vsphere-installer-provisioned-customizations[X]
-|xref:../installing/installing_vmc/installing-vmc-customizations.adoc#installing-vmc-customizations[X]
-|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[X]
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installing-vsphere-installer-provisioned-customizations[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc-customizations.adoc#installing-vmc-customizations[&#10003;]
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[&#10003;]
 |
 |
 
 
 |Network customization
-|xref:../installing/installing_alibaba/installing-alibaba-network-customizations.adoc#installing-alibaba-network-customizations[X]
-|xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[X]
-|xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[X]
-|xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[X]
-|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc#installing-azure-stack-hub-network-customizations[X]
-|xref:../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[X]
-|xref:../installing/installing_openstack/installing-openstack-installer-kuryr.adoc#installing-openstack-installer-kuryr[X]
+|xref:../installing/installing_alibaba/installing-alibaba-network-customizations.adoc#installing-alibaba-network-customizations[&#10003;]
+|xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[&#10003;]
+|xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[&#10003;]
+|xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[&#10003;]
+|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc#installing-azure-stack-hub-network-customizations[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-installer-kuryr.adoc#installing-openstack-installer-kuryr[&#10003;]
 |
 |
 |
-|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#installing-vsphere-installer-provisioned-network-customizations[X]
-|xref:../installing/installing_vmc/installing-vmc-network-customizations.adoc#installing-vmc-network-customizations[X]
-|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc#installing-ibm-cloud-network-customizations[X]
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#installing-vsphere-installer-provisioned-network-customizations[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc-network-customizations.adoc#installing-vmc-network-customizations[&#10003;]
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc#installing-ibm-cloud-network-customizations[&#10003;]
 |
 |
 
 |Restricted network
 |
-|xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[X]
+|xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[&#10003;]
 |
 |
 |
-|xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[X]
-|xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[X]
+|xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[&#10003;]
 |
-|xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[X]
-|
-|xref:../installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[X]
-|xref:../installing/installing_vmc/installing-restricted-networks-vmc.adoc#installing-restricted-networks-vmc[X]
+|xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[&#10003;]
+|xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-install-installation-workflow[&#10003;]
+|xref:../installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[&#10003;]
+|xref:../installing/installing_vmc/installing-restricted-networks-vmc.adoc#installing-restricted-networks-vmc[&#10003;]
 |
 |
 |
 
 |Private clusters
 |
-|xref:../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[X]
-|xref:../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[X]
-|xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[X]
+|xref:../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[&#10003;]
+|xref:../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[&#10003;]
+|xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[&#10003;]
 |
-|xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[X]
+|xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[&#10003;]
 |
 |
 |
@@ -217,11 +217,11 @@ ifndef::openshift-origin[]
 
 |Existing virtual private networks
 |
-|xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[X]
-|xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[X]
-|xref:../installing/installing_azure/installing-azure-vnet.adoc#installing-azure-vnet[X]
+|xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[&#10003;]
+|xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[&#10003;]
+|xref:../installing/installing_azure/installing-azure-vnet.adoc#installing-azure-vnet[&#10003;]
 |
-|xref:../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[X]
+|xref:../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[&#10003;]
 |
 |
 |
@@ -234,9 +234,9 @@ ifndef::openshift-origin[]
 
 |Government regions
 |
-|xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[X]
+|xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[&#10003;]
 |
-|xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[X]
+|xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[&#10003;]
 |
 |
 |
@@ -251,7 +251,7 @@ ifndef::openshift-origin[]
 
 |Secret regions
 |
-|xref:../installing/installing_aws/installing-aws-secret-region.adoc#installing-aws-secret-region[X]
+|xref:../installing/installing_aws/installing-aws-secret-region.adoc#installing-aws-secret-region[&#10003;]
 |
 |
 |
@@ -268,7 +268,7 @@ ifndef::openshift-origin[]
 
 |China regions
 |
-|xref:../installing/installing_aws/installing-aws-china.adoc#installing-aws-china-region[X]
+|xref:../installing/installing_aws/installing-aws-china.adoc#installing-aws-china-region[&#10003;]
 |
 |
 |
@@ -291,75 +291,75 @@ ifdef::openshift-origin[]
 ||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |oVirt |Bare metal |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Power
 
 |Default
-|xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[X]
-|xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[X]
-|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[X]
-|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[X]
-|xref:../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[X]
+|xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[&#10003;]
+|xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[&#10003;]
+|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[&#10003;]
+|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[&#10003;]
 |
 |
-|xref:../installing/installing_rhv/installing-rhv-default.adoc#installing-rhv-default[X]
-|xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[X]
-|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc#installing-vsphere-installer-provisioned[X]
-|xref:../installing/installing_vmc/installing-vmc.adoc#installing-vmc[X]
-|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[X]
+|xref:../installing/installing_rhv/installing-rhv-default.adoc#installing-rhv-default[&#10003;]
+|xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[&#10003;]
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc#installing-vsphere-installer-provisioned[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc.adoc#installing-vmc[&#10003;]
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[&#10003;]
 |
 |
 
 |Custom
-|xref:../installing/installing_alibaba/installing-alibaba-customizations.adoc#installing-alibaba-customizations[X]
-|xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[X]
-|xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[X]
-|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[X]
-|xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[X]
-|xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#installing-openstack-installer-custom[X]
-|xref:../installing/installing_openstack/installing-openstack-installer-sr-iov.adoc#installing-openstack-installer-sr-iov[X]
-|xref:../installing/installing_rhv/installing-rhv-customizations.adoc#installing-rhv-customizations[X]
+|xref:../installing/installing_alibaba/installing-alibaba-customizations.adoc#installing-alibaba-customizations[&#10003;]
+|xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[&#10003;]
+|xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[&#10003;]
+|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#installing-openstack-installer-custom[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-installer-sr-iov.adoc#installing-openstack-installer-sr-iov[&#10003;]
+|xref:../installing/installing_rhv/installing-rhv-customizations.adoc#installing-rhv-customizations[&#10003;]
 |
-|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installing-vsphere-installer-provisioned-customizations[X]
-|xref:../installing/installing_vmc/installing-vmc-customizations.adoc#installing-vmc-customizations[X]
-|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[X]
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installing-vsphere-installer-provisioned-customizations[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc-customizations.adoc#installing-vmc-customizations[&#10003;]
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[&#10003;]
 |
 |
 
 |Network customization
-|xref:../installing/installing_alibaba/installing-alibaba-network-customizations.adoc#installing-alibaba-network-customizations[X]
-|xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[X]
-|xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[X]
-|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc#installing-azure-stack-hub-network-customizations[X]
-|xref:../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[X]
-|xref:../installing/installing_openstack/installing-openstack-installer-kuryr.adoc#installing-openstack-installer-kuryr[X]
+|xref:../installing/installing_alibaba/installing-alibaba-network-customizations.adoc#installing-alibaba-network-customizations[&#10003;]
+|xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[&#10003;]
+|xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[&#10003;]
+|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc#installing-azure-stack-hub-network-customizations[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-installer-kuryr.adoc#installing-openstack-installer-kuryr[&#10003;]
 |
 |
 |
-|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#installing-vsphere-installer-provisioned-network-customizations[X]
-|xref:../installing/installing_vmc/installing-vmc-network-customizations.adoc#installing-vmc-network-customizations[X]
-|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc#installing-ibm-cloud-network-customizations[X]
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#installing-vsphere-installer-provisioned-network-customizations[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc-network-customizations.adoc#installing-vmc-network-customizations[&#10003;]
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc#installing-ibm-cloud-network-customizations[&#10003;]
 |
 |
 
 |Restricted network
 |
-|xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[X]
+|xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[&#10003;]
 |
 |
-|xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[X]
-|xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[X]
+|xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[&#10003;]
 |
-|xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[X]
+|xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[&#10003;]
 |
-|xref:../installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[X]
-|xref:../installing/installing_vmc/installing-restricted-networks-vmc.adoc#installing-restricted-networks-vmc[X]
+|xref:../installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[&#10003;]
+|xref:../installing/installing_vmc/installing-restricted-networks-vmc.adoc#installing-restricted-networks-vmc[&#10003;]
 |
 |
 |
 
 |Private clusters
 |
-|xref:../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[X]
-|xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[X]
+|xref:../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[&#10003;]
+|xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[&#10003;]
 |
-|xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[X]
+|xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[&#10003;]
 |
 |
 |
@@ -372,10 +372,10 @@ ifdef::openshift-origin[]
 
 |Existing virtual private networks
 |
-|xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[X]
-|xref:../installing/installing_azure/installing-azure-vnet.adoc#installing-azure-vnet[X]
+|xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[&#10003;]
+|xref:../installing/installing_azure/installing-azure-vnet.adoc#installing-azure-vnet[&#10003;]
 |
-|xref:../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[X]
+|xref:../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[&#10003;]
 |
 |
 |
@@ -388,8 +388,8 @@ ifdef::openshift-origin[]
 
 |Government regions
 |
-|xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[X]
-|xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[X]
+|xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[&#10003;]
+|xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[&#10003;]
 |
 |
 |
@@ -404,7 +404,7 @@ ifdef::openshift-origin[]
 
 |Secret regions
 |
-|xref:../installing/installing_aws/installing-aws-secret-region.adoc#installing-aws-secret-region[X]
+|xref:../installing/installing_aws/installing-aws-secret-region.adoc#installing-aws-secret-region[&#10003;]
 |
 |
 |
@@ -420,7 +420,7 @@ ifdef::openshift-origin[]
 
 |China regions
 |
-|xref:../installing/installing_aws/installing-aws-china.adoc#installing-aws-china-region[X]
+|xref:../installing/installing_aws/installing-aws-china.adoc#installing-aws-china-region[&#10003;]
 |
 |
 |
@@ -444,22 +444,22 @@ ifndef::openshift-origin[]
 
 |Custom
 |
-|xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[X]
-|xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[X]
-|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installing-azure-stack-hub-user-infra[X]
-|xref:../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[X]
-|xref:../installing/installing_openstack/installing-openstack-user.adoc#installing-openstack-user[X]
-|xref:../installing/installing_openstack/installing-openstack-user-sr-iov.adoc#installing-openstack-user-sr-iov[X]
-|xref:../installing/installing_rhv/installing-rhv-user-infra.adoc#installing-rhv-user-infra[X]
-|xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[X]
-|xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[X]
-|xref:../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[X]
-|xref:../installing/installing_vmc/installing-vmc-user-infra.adoc#installing-vmc-user-infra[X]
+|xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[&#10003;]
+|xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[&#10003;]
+|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installing-azure-stack-hub-user-infra[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-user.adoc#installing-openstack-user[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-user-sr-iov.adoc#installing-openstack-user-sr-iov[&#10003;]
+|xref:../installing/installing_rhv/installing-rhv-user-infra.adoc#installing-rhv-user-infra[&#10003;]
+|xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[&#10003;]
+|xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[&#10003;]
+|xref:../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc-user-infra.adoc#installing-vmc-user-infra[&#10003;]
 |
-|xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[X]
-|xref:../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[X]
-|xref:../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power[X]
-|xref:../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installing-platform-agnostic[X]
+|xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[&#10003;]
+|xref:../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[&#10003;]
+|xref:../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power[&#10003;]
+|xref:../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installing-platform-agnostic[&#10003;]
 
 // Add RHV UPI link when docs are available: https://github.com/openshift/openshift-docs/pull/26484
 
@@ -470,13 +470,13 @@ ifndef::openshift-origin[]
 |
 |
 |
-|xref:../installing/installing_openstack/installing-openstack-user-kuryr.adoc#installing-openstack-user-kuryr[X]
+|xref:../installing/installing_openstack/installing-openstack-user-kuryr.adoc#installing-openstack-user-kuryr[&#10003;]
 |
 |
-|xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[X]
-|xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[X]
-|xref:../installing/installing_vsphere/installing-vsphere-network-customizations.adoc#installing-vsphere-network-customizations[X]
-|xref:../installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc#installing-vmc-network-customizations-user-infra[X]
+|xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[&#10003;]
+|xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[&#10003;]
+|xref:../installing/installing_vsphere/installing-vsphere-network-customizations.adoc#installing-vsphere-network-customizations[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc#installing-vmc-network-customizations-user-infra[&#10003;]
 |
 |
 |
@@ -485,21 +485,21 @@ ifndef::openshift-origin[]
 
 |Restricted network
 |
-|xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[X]
+|xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[&#10003;]
 |
 |
-|xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[X]
+|xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[&#10003;]
 |
 |
-|xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[X]
-|xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[X]
 |
-|xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[X]
-|xref:../installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc#installing-restricted-networks-vmc-user-infra[X]
+|xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[&#10003;]
 |
-|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[X]
-|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[X]
-|xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[X]
+|xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[&#10003;]
+|xref:../installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc#installing-restricted-networks-vmc-user-infra[&#10003;]
+|
+|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[&#10003;]
+|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[&#10003;]
+|xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[&#10003;]
 |
 
 |Shared VPC hosted outside of cluster project
@@ -507,7 +507,7 @@ ifndef::openshift-origin[]
 |
 |
 |
-|xref:../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[X]
+|xref:../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[&#10003;]
 |
 |
 |
@@ -530,21 +530,21 @@ ifdef::openshift-origin[]
 
 |Custom
 |
-|xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[X]
-|xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[X]
-|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installing-azure-stack-hub-user-infra[X]
-|xref:../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[X]
-|xref:../installing/installing_openstack/installing-openstack-user.adoc#installing-openstack-user[X]
-|xref:../installing/installing_openstack/installing-openstack-user-sr-iov.adoc#installing-openstack-user-sr-iov[X]
-|xref:../installing/installing_rhv/installing-rhv-user-infra.adoc#installing-rhv-user-infra[X]
-|xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[X]
-|xref:../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[X]
-|xref:../installing/installing_vmc/installing-vmc-user-infra.adoc#installing-vmc-user-infra[X]
+|xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[&#10003;]
+|xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[&#10003;]
+|xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installing-azure-stack-hub-user-infra[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-user.adoc#installing-openstack-user[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-user-sr-iov.adoc#installing-openstack-user-sr-iov[&#10003;]
+|xref:../installing/installing_rhv/installing-rhv-user-infra.adoc#installing-rhv-user-infra[&#10003;]
+|xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[&#10003;]
+|xref:../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc-user-infra.adoc#installing-vmc-user-infra[&#10003;]
 |
-|xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[X]
-|xref:../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[X]
-|xref:../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power[X]
-|xref:../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installing-platform-agnostic[X]
+|xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[&#10003;]
+|xref:../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[&#10003;]
+|xref:../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power[&#10003;]
+|xref:../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installing-platform-agnostic[&#10003;]
 
 // Add RHV UPI link when docs are available: https://github.com/openshift/openshift-docs/pull/26484
 
@@ -554,12 +554,12 @@ ifdef::openshift-origin[]
 |
 |
 |
-|xref:../installing/installing_openstack/installing-openstack-user-kuryr.adoc#installing-openstack-user-kuryr[X]
+|xref:../installing/installing_openstack/installing-openstack-user-kuryr.adoc#installing-openstack-user-kuryr[&#10003;]
 |
 |
-|xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[X]
-|xref:../installing/installing_vsphere/installing-vsphere-network-customizations.adoc#installing-vsphere-network-customizations[X]
-|xref:../installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc#installing-vmc-network-customizations-user-infra[X]
+|xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[&#10003;]
+|xref:../installing/installing_vsphere/installing-vsphere-network-customizations.adoc#installing-vsphere-network-customizations[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc#installing-vmc-network-customizations-user-infra[&#10003;]
 |
 |
 |
@@ -568,20 +568,20 @@ ifdef::openshift-origin[]
 
 |Restricted network
 |
-|xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[X]
+|xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[&#10003;]
 |
 |
-|xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[X]
+|xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[&#10003;]
 |
 |
 |
-|xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[X]
-|xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[X]
-|xref:../installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc#installing-restricted-networks-vmc-user-infra[X]
+|xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[&#10003;]
+|xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[&#10003;]
+|xref:../installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc#installing-restricted-networks-vmc-user-infra[&#10003;]
 |
-|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[X]
-|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[X]
-|xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[X]
+|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[&#10003;]
+|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[&#10003;]
+|xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[&#10003;]
 |
 
 |Shared VPC hosted outside of cluster project
@@ -589,7 +589,7 @@ ifdef::openshift-origin[]
 |
 |
 |
-|xref:../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[X]
+|xref:../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[&#10003;]
 |
 |
 |
@@ -609,7 +609,7 @@ endif::openshift-origin[]
 |===
 |Single Node
 
-|xref:../installing/installing_sno/install-sno-installing-sno.adoc#installing-sno[X]
+|xref:../installing/installing_sno/install-sno-installing-sno.adoc#installing-sno[&#10003;]
 
 
 |===


### PR DESCRIPTION
BZ-2009339 - Compatability Matrix Update (for enterprise 4.8 to 4.10)

Version(s):
4.10

Issue:
(https://bugzilla.redhat.com/show_bug.cgi?id=2009339)

Link to docs preview:
(http://file.emea.redhat.com/tshwartz/BZ-2009339-previous/installing/installing-preparing.html)


Additional information:

- Added Restricted Network support for Bare Metal in the Installer-Provisioned Infrastructure Options table.
- Added a second sentence to the note above the table.
- Replaced X with ✓across the two tables.

