### PR TITLE
OSDOCS-3615: Adds command in place of KCS solution for 4.9

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2274,9 +2274,12 @@ Issued: 2021-10-18
 
 {product-title} release 4.9.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:3759[RHSA-2021:3759] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3758[RHSA-2021:3758] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6415591[{product-title} 4.9.0 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.0 --pullspecs
+----
 
 [id="ocp-4-9-4"]
 === RHBA-2021:3935 - {product-title} 4.9.4 bug fix and security update
@@ -2285,9 +2288,12 @@ Issued: 2021-10-26
 
 {product-title} release 4.9.4 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3935[RHBA-2021:3935] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3934[RHSA-2021:3934] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6446131[{product-title} 4.9.4 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.4 --pullspecs
+----
 
 [id="ocp-4-9-4-enhancements"]
 ==== Enhancements
@@ -2311,9 +2317,12 @@ Issued: 2021-11-01
 
 {product-title} release 4.9.5 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4005[RHBA-2021:4005] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4004[RHBA-2021:4004] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6465271[{product-title} 4.9.5 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.5 --pullspecs
+----
 
 [id="ocp-4-9-5-known-issues"]
 ==== Known issues
@@ -2338,9 +2347,12 @@ Issued: 2021-11-10
 
 {product-title} release 4.9.6, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4119[RHBA-2021:4119] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:4118[RHSA-2021:4118] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6486731[{product-title} 4.9.6 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.6 --pullspecs
+----
 
 [id="ocp-4-9-6-known-issues"]
 ==== Known issues
@@ -2370,9 +2382,12 @@ Issued: 2021-11-15
 
 {product-title} release 4.9.7 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4579[RHBA-2021:4579] advisory. There are no RPM packages for this release.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6505271[{product-title} 4.9.7 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.7 --pullspecs
+----
 
 [id="ocp-4-9-7-features"]
 ==== Features
@@ -2394,9 +2409,12 @@ Issued: 2021-11-22
 
 {product-title} release 4.9.8 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4712[RHBA-2021:4712] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4711[RHBA-2021:4711] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6532501[{product-title} 4.9.8 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.8 --pullspecs
+----
 
 [id="ocp-4-9-8-bug-fixes"]
 ==== Bug fixes
@@ -2415,9 +2433,12 @@ Issued: 2021-11-29
 
 {product-title} release 4.9.9, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4834[RHBA-2021:4834] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:4833[RHSA-2021:4833] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6542521[{product-title} 4.9.9 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.9 --pullspecs
+----
 
 [id="ocp-4-9-9-features"]
 ==== Features
@@ -2444,9 +2465,12 @@ Issued: 2021-12-06
 
 {product-title} release 4.9.10 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4889[RHBA-2021:4889] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4888[RHBA-2021:4888] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6562471[{product-title} 4.9.10 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.10 --pullspecs
+----
 
 [id="ocp-4-9-10-updating"]
 ==== Updating
@@ -2460,9 +2484,12 @@ Issued: 2021-12-13
 
 {product-title} release 4.9.11 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:5003[RHBA-2021:5003] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:5002[RHSA-2021:5002] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6578291[{product-title} 4.9.11 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.11 --pullspecs
+----
 
 [id="ocp-4-9-11-updating"]
 ==== Updating
@@ -2476,9 +2503,12 @@ Issued: 2022-01-04
 
 {product-title} release 4.9.12 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:5214[RHBA-2021:5214] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:5213[RHBA-2021:5213] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6606181[{product-title} 4.9.12 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.12 --pullspecs
+----
 
 [id="ocp-4-9-12-updating"]
 ==== Updating
@@ -2492,10 +2522,12 @@ Issued: 2022-01-17
 
 {product-title} release 4.9.15 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0110[RHBA-2022:0110] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0109[RHBA-2022:0109] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6644371[{product-title} 4.9.15 container image list]
-
+[source,terminal]
+----
+$ oc adm release info 4.9.15 --pullspecs
+----
 
 [id="ocp-4-9-15-updating"]
 ==== Updating
@@ -2509,9 +2541,12 @@ Issued: 2022-01-24
 
 {product-title} release 4.9.17 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0195[RHBA-2022:0195] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0194[RHBA-2022:0194] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6662631[{product-title} 4.9.17 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.17 --pullspecs
+----
 
 [id="ocp-4-9-17-bug-fixes"]
 ==== Bug fixes
@@ -2533,9 +2568,12 @@ Issued: 2022-01-31
 
 {product-title} release 4.9.18 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0279[RHBA-2022:0279] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0276[RHBA-2022:0276] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6682531[{product-title} 4.9.18 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.18 --pullspecs
+----
 
 [id="ocp-4-9-18-bug-fixes"]
 ==== Bug fixes
@@ -2556,9 +2594,12 @@ Issued: 2022-02-09
 
 {product-title} release 4.9.19, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0340[RHBA-2022:0340] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0339[RHSA-2022:0339] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6713251[{product-title} 4.9.19 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.19 --pullspecs
+----
 
 
 [id="ocp-4-9-19-preparing-upgrade-next-release"]
@@ -2577,9 +2618,12 @@ Issued: 2022-02-14
 
 {product-title} release 4.9.21, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0488[RHBA-2022:0488] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0487[RHBA-2022:0487] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6727301[{product-title} 4.9.21 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.21 --pullspecs
+----
 
 [id="ocp-4-9-21-bug-fixes"]
 ==== Bug fixes
@@ -2604,9 +2648,12 @@ Issued: 2022-02-22
 
 {product-title} release 4.9.22, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:0561[RHSA-2022:0561] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0557[RHSA-2022:0557] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6750371[{product-title} 4.9.22 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.22 --pullspecs
+----
 
 [id="ocp-4-9-22-bug-fixes"]
 ==== Bug fixes
@@ -2625,9 +2672,12 @@ Issued: 2022-02-28
 
 {product-title} release 4.9.23, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:0655[RHSA-2022:0655] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0654[RHBA-2022:0654] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6762051[{product-title} 4.9.23 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.23 --pullspecs
+----
 
 [id="ocp-4-9-23-known-issues"]
 ==== Known issues
@@ -2653,9 +2703,12 @@ Issued: 2022-03-16
 
 {product-title} release 4.9.24 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0798[RHBA-2022:0798] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0794[RHBA-2022:0794] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6818041[{product-title} 4.9.24 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.24 --pullspecs
+----
 
 [id="ocp-4-9-24-features"]
 ==== Features
@@ -2686,9 +2739,12 @@ Issued: 2022-03-21
 
 {product-title} release 4.9.25 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0861[RHBA-2022:0861] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0860[RHSA-2022:0860] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6828761[{product-title} 4.9.25 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.25 --pullspecs
+----
 
 [id="ocp-4-9-25-updating"]
 ==== Updating
@@ -2702,9 +2758,12 @@ Issued: 2022-03-29
 
 {product-title} release 4.9.26, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1022[RHBA-2022:1022] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:1021[RHSA-2022:1021] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6843421[{product-title} 4.9.26 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.26 --pullspecs
+----
 
 [id="ocp-4-9-26-known-issue"]
 ==== Known issues
@@ -2732,10 +2791,12 @@ Issued: 2022-04-07
 
 {product-title} release 4.9.27, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:1158[RHSA-2022:1158] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1157[RHBA-2022:1157] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6885691[{product-title} 4.9.27 container image list]
-
+[source,terminal]
+----
+$ oc adm release info 4.9.27 --pullspecs
+----
 [id="ocp-4-9-27-bug-fixes"]
 ==== Bug fixes
 
@@ -2753,9 +2814,12 @@ Issued: 2022-04-13
 
 {product-title} OpenShift Container Platform release 4.9.28 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1245[RHBA-2022:1245] advisory. There are no RPM packages for this release.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6906441[{product-title} 4.9.28 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.28 --pullspecs
+----
 
 [id="ocp-4-9-28-known-issues"]
 ==== Known issues
@@ -2776,9 +2840,12 @@ Issued: 2022-04-20
 
 {product-title} release 4.9.29, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:1363[RHSA-2022:1363] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1362[RHBA-2022:1362] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6934361[{product-title} 4.9.29 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.29 --pullspecs
+----
 
 [id="ocp-4-9-29-bug-fixes"]
 ==== Bug fixes
@@ -2800,9 +2867,12 @@ Issued: 2022-05-03
 
 {product-title} release 4.9.31, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1605[RHBA-2022:1605] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1604[RHBA-2022:1604] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6955866[{product-title} 4.9.31 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.31 --pullspecs
+----
 
 [id="ocp-kubernetes-1-22-8-updates"]
 ==== Updates from Kubernetes 1.22.8
@@ -2829,9 +2899,12 @@ Issued: 2022-05-12
 
 {product-title} release 4.9.32 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1694[RHBA-2022:1694] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1693[RHBA-2022:1693] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6957131[{product-title} 4.9.32 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.32 --pullspecs
+----
 
 [id="ocp-4-9-32-updating"]
 ==== Updating
@@ -2845,9 +2918,12 @@ Issued: 2022-05-18
 
 {product-title} release 4.9.33, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:2206[RHBA-2022:2206] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:2205[RHSA-2022:2205] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6958609[{product-title} 4.9.33 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.33 --pullspecs
+----
 
 [id="ocp-4-9-33-bug-fixes"]
 ==== Bug fixes
@@ -2868,9 +2944,12 @@ Issued: 2022-05-24
 
 {product-title} release 4.9.35, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:2283[RHSA-2022:2283] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:2282[RHBA-2022:2282] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6959309[{product-title} 4.9.35 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.35 --pullspecs
+----
 
 [id="ocp-4-9-35-updating"]
 ==== Updating
@@ -2884,9 +2963,12 @@ Issued: 2022-05-31
 
 {product-title} release 4.9.36 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:4741[RHBA-2022:4741] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:4740[RHBA-2022:4740] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6961378[{product-title} 4.9.36 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.36 --pullspecs
+----
 
 [id="ocp-4-9-36-updating"]
 ==== Updating
@@ -2900,9 +2982,12 @@ Issued: 2022-06-07
 
 {product-title} release 4.9.37 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:4906[RHBA-2022:4906] advisory. There are no RPM packages for this release.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6961861[{product-title} 4.9.37 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.37 --pullspecs
+----
 
 [id="ocp-4-9-37-updating"]
 ==== Updating
@@ -2916,9 +3001,12 @@ Issued: 2022-06-14
 
 {product-title} release 4.9.38, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:4973[RHBA-2022:4973] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:4972[RHSA-2022:4972] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6962832[{product-title} 4.9.38 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.38 --pullspecs
+----
 
 [id="ocp-4-9-38-bug-fixes"]
 ==== Bug fixes
@@ -2937,9 +3025,12 @@ Issued: 2022-06-29
 
 {product-title} release 4.9.40 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5180[RHBA-2022:5180] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5179[RHBA-2022:5179] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6964719[{product-title} 4.9.40 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.40 --pullspecs
+----
 
 [id="ocp-4-9-40-updating"]
 ==== Updating
@@ -2953,9 +3044,12 @@ Issued: 2022-07-05
 
 {product-title} release 4.9.41, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5434[RHBA-2022:5434] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5433[RHBA-2022:5433] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6965553[{product-title} 4.9.41 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.41 --pullspecs
+----
 
 [id="ocp-4-9-41-bug-fixes"]
 ==== Bug fixes
@@ -2976,9 +3070,12 @@ Issued: 2022-07-12
 
 {product-title} release 4.9.42 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5509[RHBA-2022:5509] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5508[RHBA-2022:5508] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6967088[{product-title} 4.9.42 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.42 --pullspecs
+----
 
 [id="ocp-4-9-42-updating"]
 ==== Updating
@@ -2992,9 +3089,12 @@ Issued: 2022-07-20
 
 {product-title} release 4.9.43, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5561[RHBA-2022:5561] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5560[RHBA-2022:5560] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6968056[{product-title} 4.9.43 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.43 --pullspecs
+----
 
 [id="ocp-4-9-43-bug-fixes"]
 ==== Bug fixes
@@ -3015,9 +3115,12 @@ Issued: 2022-08-09
 
 {product-title} release 4.9.45, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:5879[RHSA-2022:5879] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5878[RHBA-2022:5878] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6970809[{product-title} 4.9.45 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.45 --pullspecs
+----
 
 [id="ocp-4-9-45-bug-fixes"]
 ==== Bug fixes
@@ -3036,9 +3139,12 @@ Issued: 2022-08-17
 
 {product-title} release 4.9.46, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:6033[RHBA-2022:6033] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:6032[RHBA-2022:6032] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6971686[{product-title} 4.9.46 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.9.46 --pullspecs
+----
 
 [id="ocp-4-9-46-updating"]
 ==== Updating


### PR DESCRIPTION
This PR removes the KCS solutions from the async errata releases and provides the oc command for 4.9.

Issue:
[OSDOCS-3615](https://issues.redhat.com/browse/OSDOCS-3615)
Change management acks are in https://github.com/openshift/openshift-docs/pull/46497

Link to docs preview:
http://file.rdu.redhat.com/opayne/kcs-oc-RN-pt2/release_notes/ocp-4-9-release-notes.html#ocp-4-9-0-ga



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
