### PR TITLE
OSDOCS-3615: Adds command in place of KCS solution for 4.10

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2648,9 +2648,12 @@ Issued: 2022-03-10
 
 {product-title} release 4.10.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:0056[RHSA-2022:0056] advisory. A secondary set of bug fixes can be found in the link:https://access.redhat.com/errata/RHEA-2022:0748[RHEA-2022:0748] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0055[RHSA-2022:0055] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6765671[{product-title} 4.10.3 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.3 --pullspecs
+----
 
 [id="ocp-4-10-3-bug-fixes"]
 ==== Bug fixes
@@ -2663,9 +2666,12 @@ Issued: 2022-03-15
 
 {product-title} release 4.10.4, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0811[RHBA-2022:0811] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0810[RHSA-2022:0810] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6815061[{product-title} 4.10.4 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.4 --pullspecs
+----
 
 [id="ocp-4-10-4-updating"]
 ==== Updating
@@ -2679,9 +2685,12 @@ Issued: 2022-03-21
 
 {product-title} release 4.10.5, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0928[RHBA-2022:0928] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0927[RHSA-2022:0927] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6828301[{product-title} 4.10.5 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.5 --pullspecs
+----
 
 [id="ocp-4-10-5-known-issues"]
 ==== Known issues
@@ -2705,9 +2714,12 @@ Issued: 2022-03-28
 
 {product-title} release 4.10.6, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1026[RHBA-2022:1026] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:1025[RHSA-2022:1025] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6849321[{product-title} 4.10.6 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.6 --pullspecs
+----
 
 [id="ocp-4-10-6-features"]
 ==== Features
@@ -2740,9 +2752,12 @@ Issued: 2022-04-07
 
 {product-title} release 4.10.8, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:1162[RHSA-2022:1162] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1161[RHBA-2022:1161] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6877401[{product-title} 4.10.8 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.8 --pullspecs
+----
 
 [id="ocp-4-10-8-removed-feature-azure-mint-mode"]
 ==== Removed features
@@ -2780,9 +2795,12 @@ Issued: 2022-04-12
 
 {product-title} release 4.10.9 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1241[RHBA-2022:1241] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1240[RHBA-2022:1240] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6902561[{product-title} 4.10.9 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.9 --pullspecs
+----
 
 [id="ocp-4-10-9-known-issues"]
 ==== Known issues
@@ -2801,9 +2819,12 @@ Issued: 2022-04-20
 
 {product-title} release 4.10.10 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:1357[RHSA-2022:1357] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1355[RHBA-2022:1355] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6932751[{product-title} 4.10.10 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.10 --pullspecs
+----
 
 [id="ocp-4-10-10-bug-fixes"]
 ==== Bug fixes
@@ -2822,9 +2843,12 @@ Issued: 2022-04-25
 
 {product-title} release 4.10.11 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1431[RHBA-2022:1431] advisory. There are no RPM packages for this release.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6954628[{product-title} 4.10.11 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.11 --pullspecs
+----
 
 [id="ocp-4-10-11-bug-fixes"]
 ==== Bug fixes
@@ -2842,9 +2866,12 @@ Issued: 2022-05-02
 
 {product-title} release 4.10.12, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1601[RHBA-2022:1601] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:1600[RHSA-2022:1600] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6955942[{product-title} 4.10.12 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.12 --pullspecs
+----
 
 [id="ocp-4-10-12-bug-fixes"]
 ==== Bug fixes
@@ -2862,9 +2889,12 @@ Issued: 2022-05-11
 
 {product-title} release 4.10.13 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:1690[RHBA-2022:1690] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:1689[RHBA-2022:1689] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6956858[{product-title} 4.10.13 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.13 --pullspecs
+----
 
 [id="ocp-4-10-13-known-issues"]
 ==== Known issues
@@ -2889,9 +2919,12 @@ Issued: 2022-05-18
 
 {product-title} release 4.10.14 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:2178[RHBA-2022:2178] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:2177[RHBA-2022:2177] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6958424[{product-title} 4.10.14 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.14 --pullspecs
+----
 
 [id="ocp-4-10-14-features"]
 ==== Features
@@ -2924,9 +2957,12 @@ Issued: 2022-05-23
 
 {product-title} release 4.10.15 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:2258[RHBA-2022:2258] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:2257[RHBA-2022:2257] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6960407[{product-title} 4.10.15 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.15 --pullspecs
+----
 
 [id="ocp-4-10-15-bug-fixes"]
 ==== Bug fixes
@@ -2945,9 +2981,12 @@ Issued: 2022-05-31
 
 {product-title} release 4.10.16 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:4754[RHBA-2022:4754] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:4753[RHBA-2022:4753] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6961369[{product-title} 4.10.16 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.16 --pullspecs
+----
 
 [id="ocp-4-10-16-updating"]
 ==== Updating
@@ -2961,9 +3000,12 @@ Issued: 2022-06-07
 
 {product-title} release 4.10.17 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:4882[RHBA-2022:4882] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:4881[RHBA-2022:4881] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6962052[{product-title} 4.10.17 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.17 --pullspecs
+----
 
 [id="ocp-4-10-17-updating"]
 ==== Updating
@@ -2977,9 +3019,12 @@ Issued: 2022-06-13
 
 {product-title} release 4.10.18, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:4944[RHBA-2022:4944] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:4943[RHSA-2022:4943] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6962977[{product-title} 4.10.18 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.18 --pullspecs
+----
 
 [id="ocp-4-10-18-bug-fixes"]
 ==== Bug fixes
@@ -3001,9 +3046,12 @@ Issued: 2022-06-28
 
 {product-title} release 4.10.20 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5172[RHBA-2022:5172] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5171[RHBA-2022:5171] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6964873[{product-title} 4.10.20 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.20 --pullspecs
+----
 
 [id="ocp-4-10-20-bug-fixes"]
 ==== Bug fixes
@@ -3022,9 +3070,12 @@ Issued: 2022-07-06
 
 {product-title} release 4.10.21 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5428[RHBA-2022:5428] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5427[RHBA-2022:5427] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6966086[{product-title} 4.10.21 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.21 --pullspecs
+----
 
 [id="ocp-4-10-21-new-features"]
 ==== New features
@@ -3043,9 +3094,12 @@ Issued: 2022-07-11
 
 {product-title} release 4.10.22 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5513[RHBA-2022:5513] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5512[RHBA-2022:5512] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6967084[{product-title} 4.10.22 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.22 --pullspecs
+----
 
 [id="ocp-4-10-22-upgrading"]
 ==== Updating
@@ -3059,9 +3113,12 @@ Issued: 2022-07-20
 
 {product-title} release 4.10.23 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:5568[RHBA-2022:5568] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5567[RHBA-2022:5567] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6968082[{product-title} 4.10.23 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.23 --pullspecs
+----
 
 [id="ocp-4-10-23-features"]
 ==== Features
@@ -3190,9 +3247,12 @@ Issued: 2022-07-25
 
 {product-title} release 4.10.24 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:5664[RHSA-2022:5664] advisory. There are no RPM packages for this release.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6969074[{product-title} 4.10.24 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.24 --pullspecs
+----
 
 [id="ocp-4-10-24-upgrading"]
 ==== Updating
@@ -3206,9 +3266,12 @@ Issued: 2022-08-01
 
 {product-title} release 4.10.25, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:5730[RHSA-2022:5730] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:5729[RHSA-2022:5729] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6970049[{product-title} 4.10.25 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.25 --pullspecs
+----
 
 [id="ocp-4-10-25-bug-fixes"]
 ==== Bug fixes
@@ -3229,9 +3292,12 @@ Issued: 2022-08-08
 
 {product-title} release 4.10.26, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:5875[RHSA-2022:5875] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:5874[RHBA-2022:5874] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6971191[{product-title} 4.10.26 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.26 --pullspecs
+----
 
 [id="ocp-4-10-26-bug-fixes"]
 ==== Bug fixes
@@ -3255,9 +3321,12 @@ Issued: 2022-08-23
 
 {product-title} release 4.10.28, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:6095[RHBA-2022:6095] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:6094[RHSA-2022:6094] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+You can view the container images in this release by running the following command:
 
-link:https://access.redhat.com/solutions/6972787[{product-title} 4.10.28 container image list]
+[source,terminal]
+----
+$ oc adm release info 4.10.28 --pullspecs
+----
 
 [id="ocp-4-10-28-upgrading"]
 ==== Updating


### PR DESCRIPTION
This PR removes the KCS solutions from the async errata releases and provides the oc command for 4.10.

Issue:
[OSDOCS-3615](https://issues.redhat.com/browse/OSDOCS-3615)
Change management acks are in https://github.com/openshift/openshift-docs/pull/46497

Link to docs preview:
http://file.rdu.redhat.com/opayne/kcs-oc-RN-pt3/release_notes/ocp-4-10-release-notes.html#ocp-4-10-3-ga

<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
