### PR TITLE
Issue #48197 removed PAO from origin topic map

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2231,7 +2231,7 @@ Topics:
   Distros: openshift-origin,openshift-enterprise
 - Name: Performance Addon Operator for low latency nodes
   File: cnf-performance-addon-operator-for-low-latency-nodes
-  Distros: openshift-origin,openshift-enterprise
+  Distros: openshift-enterprise
 - Name: Topology Aware Lifecycle Manager for cluster updates
   File: cnf-talm-for-cluster-upgrades
   Distros: openshift-origin,openshift-enterprise


### PR DESCRIPTION
Version(s):
4.6-4.10

Issue:
Fixes #48197 

Additional information:
The Performance Addon Operator is not available in OKD. This section of documentation has been removed from main and 4.11 branches, however it needs to be removed from the remaining branches we support. 

Link to docs preview:
The link below requires a description, because this PR removes the "[Performance Addon Operator for low latency nodes](https://docs.okd.io/4.10/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#installing-the-performance-addon-operator_cnf-master)" from OKD docs. 

The [build preview](http://file.rdu.redhat.com/antaylor/issue-48197/scalability_and_performance/recommended-install-practices.html) does not have that section. 