### PR TITLE
OADP-666: Correct a log error in OADP Troubleshooting

### DIFF
--- a/modules/oadp-restic-issues.adoc
+++ b/modules/oadp-restic-issues.adoc
@@ -11,7 +11,7 @@ You might encounter these issues when you back up applications with Restic.
 [id="restic-permission-error-nfs-root-squash-enabled_{context}"]
 == Restic permission error for NFS data volumes with root_squash enabled
 
-The `Restic` pod log displays the error message, `controller=pod-volume-backup error="fork/exec/usr/bin/restic: permission denied"`.
+The `Restic` pod log displays the error message: `controller=pod-volume-backup error="fork/exec/usr/bin/restic: permission denied"`.
 
 .Cause
 
@@ -99,13 +99,40 @@ $ oc get all -n <namespace>
 [id="restic-backup-cannot-be-recreated-after-s3-bucket-emptied_{context}"]
 == Restic Backup CR cannot be recreated after bucket is emptied
 
-If you create a Restic `Backup` CR for a namespace, empty the S3 bucket, and then recreate the `Backup` CR for the same namespace, the recreated `Backup` CR fails.
+If you create a Restic `Backup` CR for a namespace, empty the object storage bucket, and then recreate the `Backup` CR for the same namespace, the recreated `Backup` CR fails.
 
-The `velero` pod log displays the error message, `msg="Error checking repository for stale locks"`.
+The `velero` pod log displays the following error message: `stderr=Fatal: unable to open config file: Stat: The specified key does not exist.\nIs there a repository at the following location?`.
 
 .Cause
 
-Velero does not create the Restic repository from the `ResticRepository` manifest if the Restic directories are deleted on object storage. See (link:https://github.com/vmware-tanzu/velero/issues/4421[Velero issue 4421]) for details.
+Velero does not recreate or update the Restic repository from the `ResticRepository` manifest if the Restic directories are deleted from object storage. See link:https://github.com/vmware-tanzu/velero/issues/4421[Velero issue 4421] for more information.
 
-// For https://issues.redhat.com/browse/OADP-177
-// I am linking to GitHub in this isolated instance because it is a link to an issue, not to the repo. The user needs to have this link in order to know whether it has been resolved.
+.Solution
+
+* Remove the related Restic repository from the namespace by running the following command:
++
+[source,terminal]
+----
+$ oc delete resticrepository openshift-adp <name_of_the_restic_repository>
+----
++
+
+In the following error log, `mysql-persistent` is the problematic Restic repository. The name of the repository appears in italics for clarity.
++
+[source,text,options="nowrap",subs="+quotes,verbatim"]
+----
+ time="2021-12-29T18:29:14Z" level=info msg="1 errors
+ encountered backup up item" backup=velero/backup65
+ logSource="pkg/backup/backup.go:431" name=mysql-7d99fc949-qbkds
+ time="2021-12-29T18:29:14Z" level=error msg="Error backing up item"
+ backup=velero/backup65 error="pod volume backup failed: error running
+ restic backup, stderr=Fatal: unable to open config file: Stat: The
+ specified key does not exist.\nIs there a repository at the following
+ location?\ns3:http://minio-minio.apps.mayap-oadp-
+ veleo-1234.qe.devcluster.openshift.com/mayapvelerooadp2/velero1/
+ restic/_mysql-persistent_\n: exit status 1" error.file="/remote-source/
+ src/github.com/vmware-tanzu/velero/pkg/restic/backupper.go:184"
+ error.function="github.com/vmware-tanzu/velero/
+ pkg/restic.(*backupper).BackupPodVolumes"
+ logSource="pkg/backup/backup.go:435" name=mysql-7d99fc949-qbkds
+----


### PR DESCRIPTION
OADP 1.1.0, OCP 4.9+

Resolves: https://issues.redhat.com/browse/OADP-666

Preview: http://file.emea.redhat.com/rhoch/restic_error_log/backup_and_restore/application_backup_and_restore/troubleshooting.html#restic-backup-cannot-be-recreated-after-s3-bucket-emptied_oadp-troubleshooting

Please do not merge before Sept. 1.
