### PR TITLE
Adding worker nodes using the Assisted Installer REST API - invalid spaces

### DIFF
--- a/modules/ai-adding-worker-nodes-to-cluster.adoc
+++ b/modules/ai-adding-worker-nodes-to-cluster.adoc
@@ -69,8 +69,8 @@ $ CLUSTER_ID=$(curl "$API_URL/api/assisted-install/v2/clusters/import" -H "Autho
 [source,terminal]
 ----
 export INFRA_ENV_REQUEST=$(jq --null-input \
-    --slurpfile pull_secret <path_to_pull_secret_file> \ //<1>
-    --arg ssh_pub_key "$(cat <path_to_ssh_pub_key>)" \ //<2>
+    --slurpfile pull_secret <path_to_pull_secret_file> \//<1>
+    --arg ssh_pub_key "$(cat <path_to_ssh_pub_key>)" \//<2>
     --arg cluster_id "$CLUSTER_ID" '{
   "name": "<infraenv_name>", <3>
   "pull_secret": $pull_secret[0] | tojson,


### PR DESCRIPTION
The space following the `\` must be removed, otherwise the command
doesn't work when copied.

Version(s):
  * PR applies to all versions after 4.11+

Issue:
n/a

Link to docs preview:
n/a

Additional information:
n/a

/cc @aireilly