### PR TITLE
RHDEVDOCS-4125 - Monitoring - 4.10 backport of data retention time settings for Thanos Ruler

### DIFF
--- a/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
+++ b/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+:_content-type: PROCEDURE
+[id="modifying-the-retention-time-for-thanos-ruler-metrics-data_{context}"]
+= Modifying the retention time for Thanos Ruler metrics data
+
+By default, for user-defined projects, Thanos Ruler automatically retains metrics data for 24 hours.
+You can modify the retention time to change how long this data is retained by specifying a time value in the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* A cluster administrator has enabled monitoring for user-defined projects.
+* You have access to the cluster as a user with the `cluster-admin` role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* You have created the `user-workload-monitoring-config` `ConfigMap` object.
+
+[WARNING]
+====
+Saving changes to a monitoring config map might restart monitoring processes and redeploy the pods and other resources in the related project.
+The running monitoring processes in that project might also restart.
+====
+
+.Procedure
+
+. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
+----
+
+. Add the retention time configuration under `data/config.yaml`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    thanosRuler:
+      retention: <time_specification> <1>
+----
++
+<1> Specify the retention time in the following format: a number directly followed by `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks), or `y` (years).
+You can also combine time values for specific times, such as `1h30m15s`.
+The default is `24h`.
++
+The following example sets the retention time to 10 days for Thanos Ruler data:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    thanosRuler:
+      retention: 10d
+----
+
+. Save the file to apply the changes. The pods affected by the new configuration automatically restart.

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -98,6 +98,8 @@ If you use a local volume for persistent storage, do not use a raw block volume,
 include::modules/monitoring-configuring-a-local-persistent-volume-claim.adoc[leveloffset=+2]
 include::modules/monitoring-modifying-retention-time-for-prometheus-metrics-data.adoc[leveloffset=+2]
 
+include::modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 

--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3009,9 +3009,13 @@ $ oc adm release info 4.10.17 --pullspecs
 
 [id="ocp-4-10-17-bug-fixes"]
 ==== Bug fixes
-* Previously, the federation endpoint for Prometheus that stored user-defined metrics was not exposed. Thus, you could not access it to scrape these metrics from a network location outside the cluster.
+* Previously, the federation endpoint for Prometheus that stored user-defined metrics was not exposed. Therefore, you could not access it to scrape these metrics from a network location outside the cluster.
 With this update, you can now use the federation endpoint to scrape user-defined metrics from a network location outside the cluster.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2090602[*BZ#2090602*])
+
+* Previously, for user-defined projects, you could not change the default data retention time period value of 24 hours for the Thanos Ruler monitoring component. 
+With this update, you can now change how long Thanos Ruler metrics data is retained for user-defined projects. 
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2090422[*BZ#2090422*])
 
 [id="ocp-4-10-17-updating"]
 ==== Updating


### PR DESCRIPTION
Summary: This PR adds release notes text as well as cherry-picked content from the completed 4.11 documentation to the 4.10 doc set for a feature that has already been backported to OCP 4.10 in the 4.10.17 z-stream release. The feature enables users to modify how long Thanos Ruler metrics data is retained in user workload monitoring.

**Reviews are only needed for the new release notes text.** No SME or peer review is needed for the feature docs since the content is identical to the 4.11 content that was already approved and merged in the following PR: https://github.com/openshift/openshift-docs/pull/49264.

- Aligned team: DevTools
- For branches: 4.10 only
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4125
- Direct link to doc previews (RH VPN access required):
- - Release Notes: http://file.rdu.redhat.com/bburt/RHDEVDOCS-4125-4-10-backport-of-config-map-retention-time-settings-for-thanos-ruler/release_notes/ocp-4-10-release-notes.html#ocp-4-10-17-bug-fixes
- - Content: http://file.rdu.redhat.com/bburt/RHDEVDOCS-4125-4-10-backport-of-config-map-retention-time-settings-for-thanos-ruler/monitoring/configuring-the-monitoring-stack.html#modifying-the-retention-time-for-thanos-ruler-metrics-data_configuring-the-monitoring-stack
- SME review: n/a
- QE review: @lihongyan1 
- Peer review: @rolfedh 

**Change Management**
ACK from Eng: Provided in https://issues.redhat.com/browse/MON-1913
ACK from PM: Provided in https://issues.redhat.com/browse/MON-1913
Need an ACK from Product Experience: @Senthamilarasu-STA 
ACK from QE: Provided in https://issues.redhat.com/browse/MON-1913
ACK from DPM: Provided in https://issues.redhat.com/browse/RHDEVDOCS-4125
ACK from CS: Provided in https://issues.redhat.com/browse/RHDEVDOCS-4125