### PR TITLE
Added common attributes for OpenShift Locals and Dev Spaces product names

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -143,3 +143,6 @@ endif::[]
 :cgu-operator-full: Topology Aware Lifecycle Manager
 :cgu-operator: TALM
 :redfish-operator: Bare Metal Event Relay
+//Formerly known as CodeReady Containers and CodeReady Workspaces
+:openshift-local-productname: Red Hat OpenShift Local
+:openshift-dev-spaces-productname: Red Hat OpenShift Dev Spaces


### PR DESCRIPTION
Added product names for OpenShift Locals (formerly CodeReady Containers) and OpenShift Dev Spaces (formerly CodeReady Workspaces) related to https://issues.redhat.com/browse/OCPBUGS-175.

This should apply to all branches 4.6+. 