### PR TITLE
OSDOCS-2175: Add optional migration of OpenShift SDN features

### DIFF
--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -46,7 +46,13 @@ endif::ovn[]
 
 [IMPORTANT]
 ====
-If your egress firewall includes a deny rule for `0.0.0.0/0`, access to your {product-title} API servers is blocked. To ensure that pods can access the {product-title} API servers, you must include the built-in join network `100.64.0.0/16` of Open Virtual Network (OVN) to allow access when using node ports together with an EgressFirewall. You must also include the IP address range that the API servers listen on in your egress firewall rules, as in the following example:
+If your egress firewall includes a deny rule for `0.0.0.0/0`, access to your {product-title} API servers is blocked. You must include the IP address range that the API servers listen on in your egress firewall rules.
+
+ifdef::ovn[]
+If you use the OVN-Kubernetes network plug-in, you must include the built-in join network `100.64.0.0/16` to allow access when using node ports together with an egress firewall. If you changed this join network during cluster installation, use the value that you specified instead of `100.64.0.0/16`.
+endif::ovn[]
+
+The following example illustrates the order of the egress firewall rules necessary to ensure API server access:
 
 [source,yaml,subs="attributes+"]
 ----

--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -13,6 +13,7 @@ A migration to the OVN-Kubernetes cluster network provider is supported on the f
 * Bare metal hardware
 * Amazon Web Services (AWS)
 * Google Cloud Platform (GCP)
+* IBM Cloud
 * Microsoft Azure
 * {rh-openstack-first}
 * {rh-virtualization-first}
@@ -25,17 +26,22 @@ The subnets assigned to nodes and the IP addresses assigned to individual pods a
 
 While the OVN-Kubernetes network provider implements many of the capabilities present in the OpenShift SDN network provider, the configuration is not the same.
 
+* If your cluster uses any of the following OpenShift SDN capabilities, the migration to OVN-Kubernetes migrates the configuration for these features as well:
++
+--
+* Egress IPs
+* Egress firewall
+* Multicast
+--
+
 * If your cluster uses any of the following OpenShift SDN capabilities, you must manually configure the same capability in OVN-Kubernetes:
 +
 --
 * Namespace isolation
-* Egress IP addresses
-* Egress network policies
 * Egress router pods
-* Multicast
 --
 
-* If your cluster uses any part of the `100.64.0.0/16` IP address range, you cannot migrate to OVN-Kubernetes because it uses this IP address range internally.
+* If your cluster uses any part of the 100.64.0.0/16 IP address range, you must specify an alternative IP address range for OVN-Kubernetes during the migration to avoid a conflict because OVN-Kubernetes uses this IP address range internally.
 
 The following sections highlight the differences in configuration between the aforementioned capabilities in OVN-Kubernetes and OpenShift SDN.
 
@@ -53,6 +59,13 @@ If your cluster uses OpenShift SDN configured in either the multitenant or subne
 [discrete]
 [id="egress-ip-addresses_{context}"]
 === Egress IP addresses
+
+OpenShift SDN supports two different Egress IP modes:
+
+* In the _automatically assigned_ approach, an egress IP address range is assigned to a node.
+* In the _manually assigned_ approach, a list of one or more egress IP addresses is assigned to a node.
+
+The migration process supports migrating Egress IP configurations that use the automatically assigned mode.
 
 The differences in configuring an egress IP address between OVN-Kubernetes and OpenShift SDN is described in the following table:
 
@@ -90,7 +103,14 @@ The difference in configuring an egress network policy, also known as an egress 
 * Create an `EgressNetworkPolicy` object in a namespace
 |===
 
+[NOTE]
+====
+Because the name of an `EgressFirewall` object can only be set to `default`, after the migration all migrated `EgressNetworkPolicy` objects are named `default`, regardless of what the name was under OpenShift SDN.
+
+If you subsequently rollback to OpenShift SDN, all `EgressNetworkPolicy` objects are named `default` as the prior name is lost.
+
 For more information on using an egress firewall in OVN-Kubernetes, see "Configuring an egress firewall for a project".
+====
 
 [discrete]
 [id="egress-router-pods_{context}"]

--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -38,7 +38,7 @@ $ oc get Network.config.openshift.io cluster -o yaml > cluster-openshift-sdn.yam
 [source,terminal]
 ----
 $ oc patch Network.operator.openshift.io cluster --type='merge' \
-  --patch '{ "spec": { "migration": {"networkType": "OVNKubernetes" } } }'
+  --patch '{ "spec": { "migration": { "networkType": "OVNKubernetes" } } }'
 ----
 +
 [NOTE]
@@ -46,11 +46,46 @@ $ oc patch Network.operator.openshift.io cluster --type='merge' \
 This step does not deploy OVN-Kubernetes immediately. Instead, specifying the `migration` field triggers the Machine Config Operator (MCO) to apply new machine configs to all the nodes in the cluster in preparation for the OVN-Kubernetes deployment.
 ====
 
+. Optional: You can disable automatic migration of several OpenShift SDN capabilities to the OVN-Kubernetes equivalents:
++
+--
+* Egress IPs
+* Egress firewall
+* Multicast
+--
++
+To disable automatic migration of the configuration for any of the previously noted OpenShift SDN features, specify the following keys:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{
+    "spec": {
+      "migration": {
+        "networkType": "OVNKubernetes",
+        "features": {
+          "egressIP": <bool>,
+          "egressFirewall": <bool>,
+          "multicast": <bool>
+        }
+      }
+    }
+  }'
+----
++
+where:
++
+--
+`bool`: Specifies whether to enable migration of the feature. The default is `true`.
+--
+
 . Optional: You can customize the following settings for OVN-Kubernetes to meet your network infrastructure requirements:
 +
 --
 * Maximum transmission unit (MTU)
 * Geneve (Generic Network Virtualization Encapsulation) overlay network port
+* OVN-Kubernetes IPv4 internal subnet
+* OVN-Kubernetes IPv6 internal subnet
 --
 +
 To customize either of the previously noted settings, enter and customize the following command. If you do not need to change the default value, omit the key from the patch.
@@ -63,15 +98,23 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
       "defaultNetwork":{
         "ovnKubernetesConfig":{
           "mtu":<mtu>,
-          "genevePort":<port>
+          "genevePort":<port>,
+          "v4InternalSubnet":"<ipv4_subnet>",
+          "v6InternalSubnet":"<ipv6_subnet>"
     }}}}'
 ----
++
+where:
 +
 --
 `mtu`::
 The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
 `port`::
 The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by OpenShift SDN. The default value for the VXLAN port is `4789`.
+`ipv4_subnet`::
+An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
+`ipv6_subnet`::
+An IPv6 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `fd98::/48`.
 --
 +
 .Example patch command to update `mtu` field

--- a/modules/nw-ovn-kubernetes-rollback.adoc
+++ b/modules/nw-ovn-kubernetes-rollback.adoc
@@ -51,6 +51,39 @@ $ oc patch Network.config.openshift.io cluster --type='merge' \
   --patch '{ "spec": { "networkType": "OpenShiftSDN" } }'
 ----
 
+. Optional: You can disable automatic migration of several OVN-Kubernetes capabilities to the OpenShift SDN equivalents:
++
+--
+* Egress IPs
+* Egress firewall
+* Multicast
+--
++
+To disable automatic migration of the configuration for any of the previously noted OpenShift SDN features, specify the following keys:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{
+    "spec": {
+      "migration": {
+        "networkType": "OpenShiftSDN",
+        "features": {
+          "egressIP": <bool>,
+          "egressFirewall": <bool>,
+          "multicast": <bool>
+        }
+      }
+    }
+  }'
+----
++
+where:
++
+--
+`bool`: Specifies whether to enable migration of the feature. The default is `true`.
+--
+
 . Optional: You can customize the following settings for OpenShift SDN to meet your network infrastructure requirements:
 +
 --


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2175

This PR adds documentation for additional migration options when moving from OpenShift SDN to OVN-Kubernetes.

Previews:
- [Considerations for migrating to the OVN-Kubernetes network provider
](https://49375--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#considerations-migrating-ovn-kubernetes-network-provider_migrate-from-openshift-sdn)
- [Migrating to the OVN-Kubernetes default CNI network provider](https://49375--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn)

