### PR TITLE
OSDOCS-2175: Add release note for improved OVN-Kubernetes migration

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -260,6 +260,16 @@ For more information, see xref:../networking/dns-operator.adoc#nw-dns-cache-tuni
 
 {rh-openstack}, paired with {product-title}, now supports automatic attachment and detachment of Egress IP addresses. The traffic from one or more pods in any number of namespaces has a consistent source IP address for services outside of the cluster. This support applies to OpenShift SDN and OVN-Kubernetes as default network providers.
 
+[id="ocp-4-12-openshift-sdn-ovn-kubernetes-feature-migration-support"]
+==== OpenShift SDN to OVN-Kubernetes feature migration support
+
+If you plan to migrate from the OpenShift SDN network plug-in to the OVN-Kubernetes network plug-in, your configurations for the following capabilities are automatically converted to work with OVN-Kubernetes:
+
+* Egress IP addresses
+* Egress firewalls
+* Multicast
+
+For more information about how the migration to OVN-Kubernetes works, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#migrate-from-openshift-sdn[Migrating from the OpenShift SDN cluster network provider].
 
 [id="ocp-4-12-storage"]
 === Storage


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2175

This adds a release note for https://github.com/openshift/openshift-docs/pull/49375.

Preview: https://49376--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-openshift-sdn-ovn-kubernetes-feature-migration-support
