### PR TITLE
[enterprise-4.12] Adds update procedure to OMR in 412

### DIFF
--- a/installing/disconnected_install/installing-mirroring-creating-registry.adoc
+++ b/installing/disconnected_install/installing-mirroring-creating-registry.adoc
@@ -29,7 +29,9 @@ These requirements are based on local testing results with only release images a
 
 include::modules/mirror-registry-introduction.adoc[leveloffset=+1]
 include::modules/mirror-registry-localhost.adoc[leveloffset=+1]
+include::modules/mirror-registry-localhost-update.adoc[leveloffset=+1]
 include::modules/mirror-registry-remote.adoc[leveloffset=+1]
+include::modules/mirror-registry-remote-host-update.adoc[leveloffset=+1]
 include::modules/mirror-registry-uninstall.adoc[leveloffset=+1]
 include::modules/mirror-registry-flags.adoc[leveloffset=+1]
 include::modules/mirror-registry-release-notes.adoc[leveloffset=+1]

--- a/modules/mirror-registry-localhost-update.adoc
+++ b/modules/mirror-registry-localhost-update.adoc
@@ -1,0 +1,32 @@
+// module included in the following assembly: 
+//
+// * installing-mirroring-creating-registry.adoc
+
+:_content-type: PROCEDURE
+[id="mirror-registry-localhost-update_{context}"]
+= Updating mirror registry for Red Hat OpenShift from a local host 
+
+This procedure explains how to update the _mirror registry for Red Hat OpenShift_ from a local host using the `upgrade` command. Updating to the latest version ensures bug fixes and security vulnerability fixes. 
+
+[IMPORTANT]
+====
+When updating, there is intermittent downtown of your mirror registry, as it is restarted during the update process. 
+====
+
+.Prerequisites
+
+* You have installed the _mirror registry for Red Hat OpenShift_ on a local host. 
+
+.Procedure 
+
+* To upgrade the the _mirror registry for Red Hat OpenShift_ from localhost, enter the following command:
++
+[source,terminal]
+----
+$ sudo ./mirror-registry upgrade -v 
+----
++
+[NOTE]
+====
+Users who upgrade the _mirror registry for Red Hat OpenShift_ with the `./mirror-registry upgrade -v` flag must include the same credentials used when creating their mirror registry. For example, if you installed the _mirror registry for Red Hat OpenShift_ with `--quayHostname <host_example_com>` and `--quayRoot <example_directory_name>`, you must include that string to properly upgrade the mirror registry.
+====

--- a/modules/mirror-registry-remote-host-update.adoc
+++ b/modules/mirror-registry-remote-host-update.adoc
@@ -1,0 +1,32 @@
+// module included in the following assembly: 
+//
+// * installing-mirroring-creating-registry.adoc
+
+:_content-type: PROCEDURE
+[id="mirror-registry-remote-host-update_{context}"]
+= Updating mirror registry for Red Hat OpenShift from a remote host 
+
+This procedure explains how to update the _mirror registry for Red Hat OpenShift_ from a remote host using the `upgrade` command. Updating to the latest version ensures bug fixes and security vulnerability fixes. 
+
+[IMPORTANT]
+====
+When updating, there is intermittent downtown of your mirror registry, as it is restarted during the update process. 
+====
+
+.Prerequisites
+
+* You have installed the _mirror registry for Red Hat OpenShift_ on a remote host. 
+
+.Procedure 
+
+* To upgrade the the _mirror registry for Red Hat OpenShift_ from a remote host, enter the following command:
++
+[source,terminal]
+----
+$ sudo ./mirror-registry upgrade -v --targetHostname <remote_host_url> --targetUsername <user_name> -k ~/.ssh/my_ssh_key
+----
++
+[NOTE]
+====
+Users who upgrade the _mirror registry for Red Hat OpenShift_ with the `./mirror-registry upgrade -v` flag must include the same credentials used when creating their mirror registry. For example, if you installed the _mirror registry for Red Hat OpenShift_ with `--quayHostname <host_example_com>` and `--quayRoot <example_directory_name>`, you must include that string to properly upgrade the mirror registry.
+====


### PR DESCRIPTION
Upgrade instructions for mirror registry for OpenShift are missing

For 4.12

Issue: https://issues.redhat.com/browse/OSDOCS-3962

Preview: https://stevsmit.github.io/openshift-docs/installing-mirroring-creating-registry.html

QE approved. 

Cherry-picked from 5260affa1c1779a1f713f6fa1d3ceca917e4ca3e.

xref: https://github.com/openshift/openshift-docs/pull/49318