### PR TITLE
TELCODOCS-805: KataConfig Create/Delete  Draft

### DIFF
--- a/modules/sandboxed-containers-create-kata-config-resource-cli.adoc
+++ b/modules/sandboxed-containers-create-kata-config-resource-cli.adoc
@@ -24,6 +24,17 @@ Kata is installed on all worker nodes by default. If you want to install `kata` 
 * You have access to the cluster as a user with the `cluster-admin` role.
 * You have installed the {sandboxed-containers-operator}.
 
+[IMPORTANT]
+====
+Creating the `KataConfig` CR automatically reboots the worker nodes. The reboot can take from 10 to more than 60 minutes. Factors that impede reboot time are as follows:
+
+* A larger {product-title} deployment with a greater number of worker nodes.
+* Activation of the BIOS and Diagnostics utility.
+* Deployment on a hard drive rather than an SSD.
+* Deployment on physical nodes such as bare metal, rather than on virtual nodes.
+* A slow CPU and network.
+====
+
 .Procedure
 
 . Create a YAML file with the following manifest:
@@ -60,7 +71,7 @@ spec:
 $ oc create -f <file name>.yaml
 ----
 
-The new `KataConfig` CR is created and begins to install `kata` as a `RuntimeClass` on the worker nodes.
+The new `KataConfig` CR is created and begins to install `kata` as a `RuntimeClass` on the worker nodes. Wait for the `kata` installation to complete and the worker nodes to reboot before continuing to the next step.
 
 [IMPORTANT]
 ====

--- a/modules/sandboxed-containers-create-kataconfig-resource-web-console.adoc
+++ b/modules/sandboxed-containers-create-kataconfig-resource-web-console.adoc
@@ -8,6 +8,17 @@
 
 You must create one `KataConfig` custom resource (CR) to enable installing `kata` as a `RuntimeClass` on your cluster nodes.
 
+[IMPORTANT]
+====
+Creating the `KataConfig` CR automatically reboots the worker nodes. The reboot can take from 10 to more than 60 minutes. Factors that impede reboot time are as follows:
+
+* A larger {product-title} deployment with a greater number of worker nodes.
+* Activation of the BIOS and Diagnostics utility.
+* Deployment on a hard drive rather than an SSD.
+* Deployment on physical nodes such as bare metal, rather than on virtual nodes.
+* A slow CPU and network.
+====
+
 .Prerequisites
 
 * You have installed {product-title} {product-version} on your cluster.
@@ -60,7 +71,7 @@ spec:
 
 . Click *Create*.
 
-The new `KataConfig` CR is created and begins to install `kata` as a `RuntimeClass` on the worker nodes.
+The new `KataConfig` CR is created and begins to install `kata` as a `RuntimeClass` on the worker nodes. Wait for the `kata` installation to complete and the worker nodes to reboot before continuing to the next step.
 
 [IMPORTANT]
 ====

--- a/modules/sandboxed-containers-deleting-kataconfig-cli.adoc
+++ b/modules/sandboxed-containers-deleting-kataconfig-cli.adoc
@@ -6,13 +6,24 @@
 [id="sandboxed-containers-deleting-kataconfig-cli_{context}"]
 = Deleting the KataConfig custom resource using the CLI
 
-Remove and uninstall the `kata` runtime and all its related resources, such as CRI-O config and `RuntimeClass`, from your cluster. The deletion typically takes between ten to forty minutes, depending on the size of the deployment.
+Remove and uninstall the `kata` runtime and all its related resources, such as CRI-O config and `RuntimeClass`, from your cluster.
 
 .Prerequisites
 
 * You have {product-title} {product-version} installed on your cluster.
 * You have installed the OpenShift CLI (`oc`).
 * You have access to the cluster as a user with the `cluster-admin` role.
+
+[IMPORTANT]
+====
+Deleting the `KataConfig` CR automatically reboots the worker nodes. The reboot can take from 10 to more than 60 minutes. Factors that impede reboot time are as follows:
+
+* A larger {product-title} deployment with a greater number of worker nodes.
+* Activation of the BIOS and Diagnostics utility.
+* Deployment on a hard drive rather than an SSD.
+* Deployment on physical nodes such as bare metal, rather than on virtual nodes.
+* A slow CPU and network.
+====
 
 .Procedure
 
@@ -23,14 +34,12 @@ Remove and uninstall the `kata` runtime and all its related resources, such as C
 $ oc delete kataconfig <KataConfig_CR_Name>
 ----
 
-. Delete the `KataConfig` custom resource definition by running the following command:
-+
-[source,terminal]
-----
-$ oc delete crd kataconfigs.kataconfiguration.openshift.io
-----
-
 The {sandboxed-containers-operator} removes all resources that were initially created to enable the runtime on your cluster.
+
+[IMPORTANT]
+====
+During deletion, the CLI stops responding until all worker nodes reboot. Wait for the process to complete before performing the verification or continuing to the next procedure.
+====
 
 .Verification
 
@@ -46,18 +55,4 @@ $ oc get kataconfig <KataConfig_CR_Name>
 [source,terminal]
 ----
 No KataConfig instances exist
-----
-
-* To verify that the `KataConfig` custom resource definition is deleted, run the following command:
-+
-[source,terminal]
-----
-$ oc get crd kataconfigs.kataconfiguration.openshift.io
-----
-+
-.Example output
-+
-[source,terminal]
-----
-Unknown CR KataConfig
 ----

--- a/modules/sandboxed-containers-deleting-kataconfig-crd-cli.adoc
+++ b/modules/sandboxed-containers-deleting-kataconfig-crd-cli.adoc
@@ -1,0 +1,41 @@
+//Module included in the following assemblies:
+//
+// *uninstalling-sandboxed-containers.adoc
+
+:_content-type: PROCEDURE
+[id="sandboxed-containers-deleting-kataconfig-CRD-cli_{context}"]
+= Deleting the `KataConfig` custom resource definition using the CLI
+
+The `KataConfig` custom resource definition (CRD) lets you define the `KataConfig` CR. Delete the `KataConfig` CRD from your cluster.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have removed the `KataConfig` CR from your cluster.
+* You have removed the {sandboxed-containers-operator} from your cluster.
+
+.Procedure
+
+. Delete the `KataConfig` CRD by running the following command:
++
+[source,terminal]
+----
+$ oc delete crd kataconfigs.kataconfiguration.openshift.io
+----
+
+.Verification
+
+* To verify that the `KataConfig` CRD is deleted, run the following command:
++
+[source,terminal]
+----
+$ oc get crd kataconfigs.kataconfiguration.openshift.io
+----
++
+.Example output
++
+[source,terminal]
+----
+Unknown CR KataConfig
+----

--- a/modules/sandboxed-containers-deleting-kataconfig-crd-web.adoc
+++ b/modules/sandboxed-containers-deleting-kataconfig-crd-web.adoc
@@ -1,0 +1,24 @@
+//Module included in the following assemblies:
+//
+// *uninstalling-sandboxed-containers.adoc
+
+:_content-type: PROCEDURE
+[id="sandboxed-containers-deleting-kataconfig-crd-web_{context}"]
+= Deleting the `KataConfig` custom resource definition using the web console
+
+The `KataConfig` custom resource definition (CRD) lets you define the `KataConfig` CR. To complete the uninstall process, delete the `KataConfig` CRD from your cluster.
+
+.Prerequisites
+
+* You have {product-title} {product-version} installed on your cluster.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have removed the `KataConfig` CR from your cluster.
+* You have removed the {sandboxed-containers-operator} from your cluster.
+
+.Procedure
+
+. From the *Administrator* perspective, navigate to *Administration* → *CustomResourceDefinitions*.
+. Search for `KataConfig` using the *Search by name* field.
+. Click the *Options* menu  {kebab} for the `KataConfig` CRD, and then select *Delete CustomResourceDefinition*.
+. Click *Delete* in the confirmation window.
+. Wait for the `KataConfig` CRD to disappear from the list. This can take several minutes.

--- a/modules/sandboxed-containers-deleting-kataconfig-web-console.adoc
+++ b/modules/sandboxed-containers-deleting-kataconfig-web-console.adoc
@@ -6,7 +6,18 @@
 [id="sandboxed-containers-deleting-kataconfig-web-console_{context}"]
 = Deleting the KataConfig custom resource using the web console
 
-Deleting the `KataConfig` custom resource (CR) removes and uninstalls the `kata` runtime and its related resources from your cluster. The deletion typically takes between ten to forty minutes, depending on the size of the deployment.
+Deleting the `KataConfig` custom resource (CR) removes and uninstalls the `kata` runtime and its related resources from your cluster.
+
+[IMPORTANT]
+====
+Deleting the `KataConfig` CR automatically reboots the worker nodes. The reboot can take from 10 to more than 60 minutes. Factors that impede reboot time are as follows:
+
+* A larger {product-title} deployment with a greater number of worker nodes.
+* Activation of the BIOS and Diagnostics utility.
+* Deployment on a hard drive rather than an SSD.
+* Deployment on physical nodes such as bare metal, rather than on virtual nodes.
+* A slow CPU and network.
+====
 
 .Prerequisites
 
@@ -21,3 +32,5 @@ Deleting the `KataConfig` custom resource (CR) removes and uninstalls the `kata`
 . Click the Operator to open it, and then select the *KataConfig* tab.
 . Click the *Options* menu  {kebab} for the `KataConfig` resource, and then select *Delete `KataConfig`*.
 . Click *Delete* in the confirmation window.
+
+Wait for the `kata` runtime and resources to uninstall and for the worker nodes to reboot before continuing to the next step.

--- a/sandboxed_containers/uninstalling-sandboxed-containers.adoc
+++ b/sandboxed_containers/uninstalling-sandboxed-containers.adoc
@@ -20,6 +20,7 @@ You can retrieve a list of running pods that use `kata` as the `runtimeClass` fr
 include::modules/sandboxed-containers-deleting-kataconfig-web-console.adoc[leveloffset=+2]
 include::modules/sandboxed-containers-deleting-operator-web-console.adoc[leveloffset=+2]
 include::modules/sandboxed-containers-deleting-namespace-web-console.adoc[leveloffset=+2]
+include::modules/sandboxed-containers-deleting-kataconfig-crd-web.adoc[leveloffset=+2]
 
 == Uninstalling {sandboxed-containers-first} using the CLI
 
@@ -29,3 +30,4 @@ Follow the steps below in the order that they are presented.
 include::modules/sandboxed-containers-deleting-pods-cli.adoc[leveloffset=+2]
 include::modules/sandboxed-containers-deleting-kataconfig-cli.adoc[leveloffset=+2]
 include::modules/sandboxed-containers-deleting-operator-cli.adoc[leveloffset=+2]
+include::modules/sandboxed-containers-deleting-kataconfig-crd-cli.adoc[leveloffset=+2]


### PR DESCRIPTION
[TELCODOCS-805](https://issues.redhat.com//browse/TELCODOCS-805): KataConfig Creation/deletion reboots worker nodes and takes a long time

Version(s):
Main, 4.12, 4.11, 4.10

Issue:
(https://issues.redhat.com/browse/TELCODOCS-805?filter=-1)

Link to docs preview:
Deploying: 
(http://file.emea.redhat.com/tshwartz/TELCODOCS-805/sandboxed_containers/deploying-sandboxed-container-workloads.html)
Uninstalling: 
(http://file.emea.redhat.com/tshwartz/TELCODOCS-805/sandboxed_containers/uninstalling-sandboxed-containers.html)

Summary of Changes:
Added a note to the following sections about the KataConfig create/delete process being slow, and to wait for it to complete before progressing:

- Create KataConfig using Web Console
- Create KataConfig using CLI
- Delete KataConfig using Web Console
- Delete KataConfig using CLI