### PR TITLE
cluster_matrix1 Fix typo and add support for RHV IPI UPI compatibility in cluster matrix tables

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -165,6 +165,7 @@ ifndef::openshift-origin[]
 |
 |
 
+
 |Network customization
 |xref:../installing/installing_alibaba/installing-alibaba-network-customizations.adoc#installing-alibaba-network-customizations[X]
 |xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[X]
@@ -472,6 +473,7 @@ ifndef::openshift-origin[]
 
 // Add RHV UPI link when docs are available: https://github.com/openshift/openshift-docs/pull/26484
 
+
 |Network customization
 |
 |
@@ -501,7 +503,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[X]
 |
 |
-|
+|xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[X]
 |xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[X]
 |
 |xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[X]
@@ -625,3 +627,4 @@ endif::openshift-origin[]
 
 |===
 ////
+// sync


### PR DESCRIPTION
ISSUE: 
Fix typo and add support for RHV IPI UPI compatibility for Restricted Networks in cluster matrix tables 
(OpenShift guide > Installation introductory chapter)
This is a new PR  - a followup PR to complete the broken PR https://github.com/openshift/openshift-docs/pull/49082
(merge conflicts, extraneous branch/file added to commit by mistake)

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
enterprise-4.10
enterprise-4.11
enterprise-4.12

<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
http://file.tlv.redhat.com/emarcus/cluster_matrix1/installing/installing-preparing.html#supported-installation-methods-for-different-platforms

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. -->

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:

**comments/discussion/approvals from previous PR:**


[emarcusRH](https://github.com/emarcusRH) commented [7 days ago](https://github.com/openshift/openshift-docs/pull/49082#issuecomment-1215023182)
@engelmi , @janosdebugs
I need someone to double check that the support for UPI on restricted networks exists in both 4.10 and 4.11.
In the installation instructions in the guide, it implies that both are supported - callout description https://github.com/openshift/openshift-docs/pull/4 in this sample YAML file indicates that IPI is supported - https://docs.openshift.com/container-platform/4.11/installing/installing_rhv/installing-rhv-restricted-network.html#installation-bare-metal-config-yaml_installing-rhv-restricted-network
@[engelmi](https://github.com/engelmi)
Member
engelmi commented [6 days ago](https://github.com/openshift/openshift-docs/pull/49082#issuecomment-1216723544)

Based on the documentation for [4.10](https://docs.openshift.com/container-platform/4.10/installing/installing_rhv/installing-rhv-restricted-network.html#installation-bare-metal-config-yaml_installing-rhv-restricted-network) and [4.11](https://docs.openshift.com/container-platform/4.11/installing/installing_rhv/installing-rhv-restricted-network.html#installation-bare-metal-config-yaml_installing-rhv-restricted-network), I'd say yes - not sure how to verify this correctly. Can you help? @janosdebugs
@[openshift-merge-robot](https://github.com/openshift-merge-robot) openshift-merge-robot added[ needs-rebase ](https://github.com/openshift/openshift-docs/labels/needs-rebase)and removed[ needs-rebase ](https://github.com/openshift/openshift-docs/labels/needs-rebase)labels [6 days ago](https://github.com/openshift/openshift-docs/pull/49082#event-7197857932)
@[janosdebugs](https://github.com/janosdebugs)
Member
janosdebugs commented [6 days ago](https://github.com/openshift/openshift-docs/pull/49082#issuecomment-1216748056)

Sadly, I don't know the answer. I have to assume that the previous version would be correct, but @peterclauterbach would probably know more.
@[peterclauterbach](https://github.com/peterclauterbach)
Member
peterclauterbach commented [6 days ago](https://github.com/openshift/openshift-docs/pull/49082#issuecomment-1216781409)

I'm not sure I understand the question. 
**Once we support a deployment option, we continue to support it, unless it is explicitly deprecated.
Since it was it was supported in OCP 4.9, it is correct that support continues in OCP 4.10 and OCP 4.11.**
@[janosdebugs](https://github.com/janosdebugs)
Member
janosdebugs commented [6 days ago](https://github.com/openshift/openshift-docs/pull/49082#issuecomment-1216787974)

I believe the question is between UPI and IPI: which one do we support for a restricted network installation?
@emarcusRH
Member Author
[emarcusRH](https://github.com/emarcusRH) commented [6 days ago](https://github.com/openshift/openshift-docs/pull/49082#issuecomment-1216801727)

I'm not sure I understand the question. 
**Once we support a deployment option, we continue to support it, unless it is explicitly deprecated. Since it was it was supported in OCP 4.9, it is correct that support continues in OCP 4.10 and OCP 4.11.**

@peterclauterbach the instructions for OCP on RHV/restricted networks provides the procdure for UPI installations - https://docs.openshift.com/container-platform/4.11/installing/installing_rhv/installing-rhv-restricted-network.html#installation-network-user-infra_installing-rhv-restricted-network
But the support matrix in the general Installation chapter is missing an "X" under UPI/Restricted Networks > RHV
https://docs.openshift.com/container-platform/4.11/installing/installing-preparing.html#supported-installation-methods-for-different-platforms

is this simply an oversight that it was not updated?

@[peterclauterbach](https://github.com/peterclauterbach)
Member
peterclauterbach commented [6 days ago](https://github.com/openshift/openshift-docs/pull/49082#issuecomment-1217188334)

**Yes, it's an oversight. We support UPI installations on restricted networks.** The bulk of UPI installations are direconnected.

<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
