### PR TITLE
BZ#2094726: It should be clarified that multipath is not supported in environments upgraded from 4.6 or earlier.

### DIFF
--- a/modules/rhcos-enabling-multipath.adoc
+++ b/modules/rhcos-enabling-multipath.adoc
@@ -23,7 +23,14 @@ On IBM Z and LinuxONE, you can enable multipathing only if you configured your c
 The following procedure enables multipath at installation time and appends kernel arguments to the `coreos-installer install` command so that the installed system itself will use multipath beginning from the first boot.
 
 .Prerequisites
+
 * You have a running {product-title} cluster that uses version 4.8 or later.
++
+[NOTE]
+====
+{product-title} does not support enabling multipathing as a day-2 activity on nodes that have been upgraded from 4.6 or earlier. 
+====
+
 * You are logged in to the cluster as a user with administrative privileges.
 
 .Procedure


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-1084

Preview: [Enabling multipathing with kernel arguments on RHCOS](http://file.rdu.redhat.com/mburke/BZ-2094726-4.7/post_installation_configuration/machine-configuration-tasks.html#rhcos-enabling-multipath_post-install-machine-configuration-tasks)
