### PR TITLE
TELCODOCS#652: adding new params for MetalLB deployment

### DIFF
--- a/modules/nw-metallb-operator-deployment-specifications-for-metallb.adoc
+++ b/modules/nw-metallb-operator-deployment-specifications-for-metallb.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * networking/metallb/metallb-operator-install.adoc
+
+[id="nw-metallb-operator-deployment-specifications-for-metallb_{context}"]
+= Deployment specifications for MetalLB
+
+When you start an instance of MetalLB using the `MetalLB` custom resource, you can configure deployment specifications in the `MetalLB` custom resource to manage how the `controller` or `speaker` pods deploy and run in your cluster. Use these deployment specifications to manage the following tasks:
+
+* Select nodes for MetalLB pod deployment.
+* Manage scheduling by using pod priority and pod affinity.
+* Assign CPU limits for MetalLB pods.
+* Assign a container RuntimeClass for MetalLB pods.
+* Assign metadata for MetalLB pods.

--- a/modules/nw-metallb-operator-setting-pod-CPU-limits.adoc
+++ b/modules/nw-metallb-operator-setting-pod-CPU-limits.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * networking/metallb/metallb-operator-install.adoc
+
+[id="nw-metallb-operator-setting-pod-CPU-limits_{context}"]
+= Configuring pod CPU limits in a MetalLB deployment
+
+You can optionally assign pod CPU limits to `controller` and `speaker` pods by configuring the `MetalLB` custom resource. Defining CPU limits for the `controller` or `speaker` pods helps you to manage compute resources on the node. This ensures all pods on the node have the necessary compute resources to manage workloads and cluster housekeeping. 
+
+.Prerequisites
+
+* You are logged in as a user with `cluster-admin` privileges.
+
+* You have installed the MetalLB Operator.
+
+.Procedure
+. Create a `MetalLB` custom resource file, such as `CPULimits.yaml`, to specify the `cpu` value for the `controller` and `speaker` pods: 
++
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: metallb-system
+spec:
+  logLevel: debug
+  controllerConfig:
+    resources:
+      limits:
+        cpu: "200m"
+  speakerConfig:
+    resources:
+      limits:
+        cpu: "300m"
+----
+
+. Apply the `MetalLB` custom resource configuration:
++
+[source,bash]
+----
+$ oc apply -f CPULimits.yaml
+----
+
+.Verification
+* To view compute resources for a pod, run the following command, replacing `<pod_name>` with your target pod:
++
+[source,bash]
+----
+$ oc describe pod <pod_name>
+----

--- a/modules/nw-metallb-operator-setting-pod-priority-affinity.adoc
+++ b/modules/nw-metallb-operator-setting-pod-priority-affinity.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * networking/metallb/metallb-operator-install.adoc
+
+[id="nw-metallb-operator-setting-pod-priority-affinity_{context}"]
+= Configuring pod priority and pod affinity in a MetalLB deployment
+
+You can optionally assign pod priority and pod affinity rules to `controller` and `speaker` pods by configuring the `MetalLB` custom resource. The pod priority indicates the relative importance of a pod on a node and schedules the pod based on this priority. Set a high priority on your `controller` or `speaker` pod to ensure scheduling priority over other pods on the node. 
+
+Pod affinity manages relationships among pods. Assign pod affinity to the `controller` or `speaker` pods to control on what node the scheduler places the pod in the context of pod relationships. For example, you can allow pods with logically related workloads on the same node, or ensure pods with conflicting workloads are on separate nodes. 
+
+.Prerequisites
+
+* You are logged in as a user with `cluster-admin` privileges.
+
+* You have installed the MetalLB Operator.
+
+.Procedure
+. Create a `PriorityClass` custom resource, such as `myPriorityClass.yaml`, to configure the priority level. This example uses a high-priority class:
++
+[source,yaml]
+----
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high-priority
+value: 1000000
+----
+
+. Apply the `PriorityClass` custom resource configuration:
++
+[source,bash]
+----
+$ oc apply -f myPriorityClass.yaml
+----
+
+. Create a `MetalLB` custom resource, such as `MetalLBPodConfig.yaml`, to specify the `priorityClassName` and `podAffinity` values: 
++
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: metallb-system
+spec:
+  logLevel: debug
+  controllerConfig:
+    priorityClassName: high-priority
+    runtimeClassName: myclass
+  speakerConfig:
+    priorityClassName: high-priority
+    runtimeClassName: myclass
+  affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+             app: metallb
+          topologyKey: kubernetes.io/hostname
+----
+
+. Apply the `MetalLB` custom resource configuration:
++
+[source,bash]
+----
+$ oc apply -f MetalLBPodConfig.yaml
+----
+
+.Verification
+* To view the priority class that you assigned to pods in a namespace, run the following command, replacing `<namespace>` with your target namespace:
++
+[source,bash]
+----
+$ oc get pods -n <namespace> -o custom-columns=NAME:.metadata.name,PRIORITY:.spec.priorityClassName
+----
+
+* To verify that the scheduler placed pods according to pod affinity rules, view the metadata for the pod's node by running the following command, replacing `<namespace>` with your target namespace:
++
+[source,bash]
+----
+$ oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name -n <namespace>
+----

--- a/modules/nw-metallb-operator-setting-runtimeclass.adoc
+++ b/modules/nw-metallb-operator-setting-runtimeclass.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * networking/metallb/metallb-operator-install.adoc
+
+[id="nw-metallb-operator-setting-runtimeclass_{context}"]
+= Configuring a container runtime class in a MetalLB deployment
+
+You can optionally assign a container runtime class to `controller` and `speaker` pods by configuring the `MetalLB` custom resource. For example, for Windows workloads, you can assign a Windows runtime class to the pod, which uses this runtime class for all containers in the pod.  
+
+.Prerequisites
+
+* You are logged in as a user with `cluster-admin` privileges.
+
+* You have installed the MetalLB Operator.
+
+.Procedure
+. Create a `RuntimeClass` custom resource, such as `myRuntimeClass.yaml`, to define your runtime class:
++
+[source,yaml,options="nowrap",role="white-space-pre"]
+----
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: myclass 
+handler: myconfiguration
+----
+
+. Apply the `RuntimeClass` custom resource configuration:
++
+[source,bash]
+----
+$ oc apply -f myRuntimeClass.yaml
+----
+
+. Create a `MetalLB` custom resource, such as `MetalLBRuntime.yaml`, to specify the `runtimeClassName` value: 
++
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: metallb-system
+spec:
+  logLevel: debug
+  controllerConfig:
+    runtimeClassName: myclass
+    annotations: <1>
+      controller: demo
+  speakerConfig: 
+    runtimeClassName: myclass
+    annotations: <1>
+      speaker: demo
+----
+<1> This example uses `annotations` to add metadata such as build release information or GitHub pull request information. You can populate annotations with characters not permitted in labels. However, you cannot use annotations to identify or select objects. 
+
+. Apply the `MetalLB` custom resource configuration:
++
+[source,bash,options="nowrap",role="white-space-pre"]
+----
+$ oc apply -f MetalLBRuntime.yaml
+----
+
+.Verification
+* To view the container runtime for a pod, run the following command:
++
+[source,bash,options="nowrap",role="white-space-pre"]
+----
+$ oc get pod -o custom-columns=NAME:metadata.name,STATUS:.status.phase,RUNTIME_CLASS:.spec.runtimeClassName
+----

--- a/modules/nw-metallb-software-components.adoc
+++ b/modules/nw-metallb-software-components.adoc
@@ -7,7 +7,12 @@
 
 When you install the MetalLB Operator, the `metallb-operator-controller-manager` deployment starts a pod. The pod is the implementation of the Operator. The pod monitors for changes to all the relevant resources.
 
-When the Operator starts an instance of MetalLB, it starts a `controller` deployment and a `speaker` daemon set.
+When the Operator starts an instance of MetalLB, it starts a `controller` deployment and a `speaker` daemon set. 
+
+[NOTE]
+====
+You can configure deployment specifications in the MetalLB custom resource to manage how `controller` and `speaker` pods deploy and run in your cluster. For more information about these deployment specifications, see the _Additional Resources_ section.
+====
 
 `controller`::
 The Operator starts the deployment and a single pod. When you add a service of type `LoadBalancer`, Kubernetes uses the `controller` to allocate an IP address from an address pool.

--- a/networking/metallb/about-metallb.adoc
+++ b/networking/metallb/about-metallb.adoc
@@ -52,3 +52,5 @@ MetalLB is incompatible with the IP failover feature. Before you install the Met
 * xref:../../networking/configuring_ingress_cluster_traffic/overview-traffic.adoc#overview-traffic-comparision_overview-traffic[Comparison: Fault tolerant access to external IP addresses]
 
 * xref:../../networking/configuring-ipfailover.adoc#nw-ipfailover-remove_configuring-ipfailover[Removing IP failover]
+
+* xref:../../networking/metallb/metallb-operator-install.adoc#nw-metallb-operator-deployment-specifications-for-metallb_metallb-operator-install[Deployment specifications for MetalLB]

--- a/networking/metallb/metallb-operator-install.adoc
+++ b/networking/metallb/metallb-operator-install.adoc
@@ -20,15 +20,29 @@ include::modules/nw-metallb-installing-operator-cli.adoc[leveloffset=+1]
 // Starting MetalLB on your cluster
 include::modules/nw-metallb-operator-initial-config.adoc[leveloffset=+1]
 
-// Limit speaker pods to specific nodes
+// Deployment specifications for metallb CR
+include::modules/nw-metallb-operator-deployment-specifications-for-metallb.adoc[leveloffset=+1]
+
+// Deployment specs to limit speaker pods to specific nodes
 include::modules/nw-metallb-operator-limit-speaker-to-nodes.adoc[leveloffset=+2]
+
+// Deployment specs to set pod priority and pod ffinity
+include::modules/nw-metallb-operator-setting-pod-priority-affinity.adoc[leveloffset=+2]
+
+// Deployment specs to set pod CPU limits
+include::modules/nw-metallb-operator-setting-pod-CPU-limits.adoc[leveloffset=+2]
+
+// Deployment specs to set RuntimeClass
+include::modules/nw-metallb-operator-setting-runtimeclass.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources_metallb-operator-install"]
 == Additional resources
 
-* xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors].
-* xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about[Understanding taints and tolerations].
+* xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]
+* xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about[Understanding taints and tolerations]
+* xref:../../nodes/pods/nodes-pods-priority.adoc#nodes-pods-priority-about_nodes-pods-priority[Understanding pod priority]
+* xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity-about_nodes-scheduler-pod-affinity[Understanding pod affinity]
 
 [id="next-steps_{context}"]
 == Next steps


### PR DESCRIPTION
TELCODOCS#652: Adding new parameters for MetalLB deployments

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/TELCODOCS-652

Link to docs preview:

Added a note to the software components module referencing Additional resources: http://file.emea.redhat.com/rohennes/TELCODOCS-652-metalLB-params/networking/metallb/about-metallb.html#nw-metallb-software-components_about-metallb-and-metallb-operator

Added link in the Additional resources: http://file.emea.redhat.com/rohennes/TELCODOCS-652-metalLB-params/networking/metallb/about-metallb.html#additional-resources_about-metallb-and-metallb-operator 

Created a parent concept module for deployment specs:
http://file.emea.redhat.com/rohennes/TELCODOCS-652-metalLB-params/networking/metallb/metallb-operator-install.html#nw-metallb-operator-deployment-specifications-for-metallb_metallb-operator-install

Three worked examples for configuring the new deployment specs:
- http://file.emea.redhat.com/rohennes/TELCODOCS-652-metalLB-params/networking/metallb/metallb-operator-install.html#nw-metallb-operator-setting-pod-priority-affinity_metallb-operator-install
- http://file.emea.redhat.com/rohennes/TELCODOCS-652-metalLB-params/networking/metallb/metallb-operator-install.html#nw-metallb-operator-setting-pod-CPU-limits_metallb-operator-install
- http://file.emea.redhat.com/rohennes/TELCODOCS-652-metalLB-params/networking/metallb/metallb-operator-install.html#nw-metallb-operator-setting-runtimeclass_metallb-operator-install
