### PR TITLE
ROX-12091: Add quay.io robot accounts for integrations

### DIFF
--- a/integration/integrate-with-image-registries.adoc
+++ b/integration/integrate-with-image-registries.adoc
@@ -7,23 +7,22 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{product-title} integrates with a variety of image registries so that you can understand your images and apply security policies for image usage.
+{product-title} ({product-title-short}) integrates with a variety of image registries so that you can understand your images and apply security policies for image usage.
 
 When you integrate with image registries, you can view important image details, such as image creation date and Dockerfile details (including image layers).
 
-After you integrate {product-title} with your registry, you can scan images, view image components, or apply security policies before you deploy images or to existing images that are already deployed in your clusters.
+After you integrate {product-title-short} with your registry, you can scan images, view image components, and apply security policies to images before or after deployment.
 
 [NOTE]
 ====
-When you integrate with an image registry, {product-title} does not scan all images in your registry.
-{product-title} only scans the images when you:
+When you integrate with an image registry, {product-title-short} does not scan all images in your registry. {product-title-short} only scans the images when you:
 
 * Use the images in deployments
 * Use the `roxctl` CLI to check images
 * Use a continuous integration (CI) system to enforce security policies
 ====
 
-You can integrate {product-title} with major image registries, including:
+You can integrate {product-title-short} with major image registries, including:
 
 * link:https://aws.amazon.com/ecr/[Amazon Elastic Container Registry (ECR)]
 * link:https://hub.docker.com[Docker Hub]
@@ -52,8 +51,7 @@ include::modules/manual-configuration-image-registry-ecr.adoc[leveloffset=+2]
 ==== Using assumerole with Amazon ECR
 
 You can use link:https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html[AssumeRole] to grant access to AWS resources without manually configuring each user's permissions.
-Instead, you can define a role with the desired permissions, and the user is granted access to assume that role.
-AssumeRole enables you to grant, revoke, or otherwise generally manage more fine-grained permissions.
+Instead, you can define a role with the desired permissions so that the user is granted access to assume that role. `AssumeRole` enables you to grant, revoke, or otherwise generally manage more fine-grained permissions.
 
 include::modules/configuring-assumerole-with-iam.adoc[leveloffset=+4]
 
@@ -70,6 +68,11 @@ include::modules/manual-configuration-image-registry-acr.adoc[leveloffset=+2]
 include::modules/manual-configuration-image-registry-jfrog.adoc[leveloffset=+2]
 
 include::modules/manual-configuration-image-registry-qcr.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_integrating-quay-scanner"]
+== Additional resources
+* xref:../integration/integrate-with-image-vulnerability-scanners.adoc#integrate-with-qcr-scanner_integrate-with-image-vulnerability-scanners[Integrating with Quay Container Registry to scan images]
 
 include::modules/manual-configuration-image-registry-ibm.adoc[leveloffset=+2]
 

--- a/modules/integrate-with-qcr-scanner.adoc
+++ b/modules/integrate-with-qcr-scanner.adoc
@@ -3,23 +3,29 @@
 // * integration/integrate-with-image-vulnerability-scanners.adoc
 :_module-type: PROCEDURE
 [id="integrate-with-qcr-scanner_{context}"]
-= Integrating with Quay Container Registry
+= Integrating with Quay Container Registry to scan images
 
 You can integrate {product-title} with Quay Container Registry for scanning images.
 
 .Prerequisites
-* You must have an OAuth token for authentication with the Quay Container Registry.
+* You must have an OAuth token for authentication with the Quay Container Registry to scan images.
 
 .Procedure
-. On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
-. Under the *Image Integrations* section, select *Quay Container Registry*.
-+
-The *Configure image integration* modal box opens.
-. Click *New Integration*.
-. Fill in the required details for:
-.. *Integration Name*: The name of the integration.
-.. *Types*: Select *Scanner*.
-.. *Endpoint*: The address of the registry.
-.. *OAuth Token*: The OAuth token for Quay Container Registry.
-. Select *Test* (`checkmark` icon) to test that the integration with the selected registry is working.
-. Select *Create* (`save` icon) to create the configuration.
+
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Integrations*.
+. Under the *Image Integrations* section, select *Red Hat Quay.io*.
+. Click *New integration*.
+. Enter the *Integration name.*
+. Under *Type*, select *Scanner*. (If you are also integrating with the registry, select *Scanner + Registry*.) Enter information in the following fields:
+** *Endpoint*: Enter the address of the registry.
+** *OAuth token*: Enter the OAuth token that {product-title-short} uses to authenticate by using the API.
+** Optional: *Robot username*: If you are configuring *Scanner + Registry* and are accessing the registry by using a Quay robot account, enter the user name in the format `_<namespace>+<accountname>_`.
+** Optional: *Robot password*: If you are configuring *Scanner + Registry* and are accessing the registry by using a Quay robot account, enter the password for the robot account user name.
+. Optional: If you are not using a TLS certificate when connecting to the registry, select *Disable TLS certificate validation (insecure)*.
+. Optional: To create the integration without testing, select *Create integration without testing*.
+. Select *Save*.
+
+[NOTE]
+====
+If you are editing a Quay integration but do not want to update your credentials, verify that *Update stored credentials* is not selected. 
+====

--- a/modules/manual-configuration-image-registry-qcr.adoc
+++ b/modules/manual-configuration-image-registry-qcr.adoc
@@ -5,21 +5,31 @@
 [id="manual-configuration-image-registry-qcr_{context}"]
 = Manually configuring Quay Container Registry
 
-You can integrate {product-title} with Quay Container Registry.
+You can integrate {product-title} ({product-title-short}) with Quay Container Registry. You can integrate with Quay by using the following methods:
+
+- Integrating with the Quay public repository (registry): This method does not require authentication.
+- Integrating with a Quay private registry by using a robot account: This method requires that you create a robot account to use with Quay (recommended). See the link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/use_red_hat_quay/use-quay-manage-repo#allow-robot-access-user-repo[Quay documentation] for more information.
+- Integrating with Quay to use the Quay scanner rather than the {product-title-short} scanner:  This method uses the API and requires an OAuth token for authentication. See "Integrating with Quay Container Registry to scan images" in the "Additional Resources" section.
 
 .Prerequisites
-* You must have an OAuth token for authentication with the Quay Container Registry.
+* For authentication with a Quay private registry, you need the credentials associated with a robot account or an OAuth token (deprecated).
 
 .Procedure
-. On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Integrations*.
 . Under the *Image Integrations* section, select *Red Hat Quay.io*.
 . Click *New integration*.
-. Enter the details for the following fields:
-.. *Integration name*: The name of the integration.
-.. *Type*: Select *Registry*.
-.. *Endpoint*: The address of the registry.
-.. *OAuth Token*
-. If you are not using a TLS certificate when connecting to the registry, select *Disable TLS certificate validation (insecure)*.
-. Select *Create integration without testing* to create the integration without testing the connection to the registry.
-. Select *Test* to test that the integration with the selected registry is working.
+. Enter the *Integration name.*
+. Enter the *Endpoint*, or the address of the registry.
+.. If you are integrating with the Quay public repository, under *Type*, select *Registry*, and then go to the next step. 
+.. If you are integrating with a Quay private registry, under *Type*, select *Registry* and enter information in the following fields:
+** *Robot username*: If you are accessing the registry by using a Quay robot account, enter the user name in the format `_<namespace>+<accountname>_`.
+** *Robot password*: If you are accessing the registry by using a Quay robot account, enter the password for the robot account user name.
+** *OAuth token*: If you are accessing the registry by using an OAuth token (deprecated), enter it in this field. 
+. Optional: If you are not using a TLS certificate when connecting to the registry, select *Disable TLS certificate validation (insecure)*.
+. Optional: To create the integration without testing, select *Create integration without testing*.
 . Select *Save*.
+
+[NOTE]
+====
+If you are editing a Quay integration but do not want to update your credentials, verify that *Update stored credentials* is not selected. 
+====


### PR DESCRIPTION
Version(s):

- `rhacs-docs-3.72`
- `rhacs-docs`

Labels:

- `RHACS/next`
- `RHACS`

[Issue](https://issues.redhat.com/browse/ROX-12091)

Links to docs previews:

- [Integrating with image registries](https://openshift-docs-8xwtznwon-kcarmichael08.vercel.app/openshift-acs/master/integration/integrate-with-image-registries.html)

- [Manually configuring Quay Container Registry](https://openshift-docs-8xwtznwon-kcarmichael08.vercel.app/openshift-acs/master/integration/integrate-with-image-registries.html#manual-configuration-image-registry-qcr_integrate-with-image-registries)

- [Integrating with Quay Container Registry to scan images](https://openshift-docs-8xwtznwon-kcarmichael08.vercel.app/openshift-acs/master/integration/integrate-with-image-vulnerability-scanners.html#integrate-with-qcr-scanner_integrate-with-image-vulnerability-scanners)
