### PR TITLE
OSDOCS#3977: Tech preview of cgroup v2 and crun Release Note

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -98,6 +98,16 @@ For more information, see xref:../installing/installing-troubleshooting.adoc#ins
 [id="ocp-4-12-nodes"]
 === Nodes
 
+[id="ocp-4-12-node-cgroups-v2"]
+==== Linux Control Group version 2 promoted to Techology Preview
+
+{product-title} support for link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux Control Group version 2] (cgroup v2) has been promoted to Technology Preview. cgroup v2 is the next version of the kernel link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/resource_management_guide/ch01[control groups]. cgroups v2 offers multiple improvements, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation. For more information, see xref:../nodes/clusters/nodes-cluster-cgroups-2.adoc#nodes-cluster-cgroups-2[Enabling Linux Control Group version 2 (cgroup v2)].
+
+[id="ocp-4-12-node-cgroups-crun"]
+==== crun container runtime (Technology Preview) 
+
+{product-title} now supports the crun container runtime in Technology Preview. You can switch between the crun container runtime and the default container runtime as needed by using a `ContainerRuntimeConfig` custom resource (CR). For more information, see xref:../nodes/containers/nodes-containers-using.adoc#nodes-containers-runtimes[About the container engine and container runtime].
+
 [id="ocp-4-11-logging"]
 === Logging
 
@@ -719,6 +729,16 @@ In the table below, features are marked with the following statuses:
 |Managing machines with the Cluster API
 |-
 |TP
+|TP
+
+|Linux Control Group version 2 (cgroup v2)
+|-
+|-
+|TP
+
+|crun container runtime
+|-
+|-
 |TP
 |====
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3977
https://issues.redhat.com/browse/OSDOCS-3978

Previews
[cgroup and crun release notes](http://file.rdu.redhat.com/~mburke/nodes-cgroups-vs-tech-preview-rn/release_notes/ocp-4-12-release-notes.html#ocp-4-12-node-cgroups-v2)
[Technology Preview features, final rows in table](http://file.rdu.redhat.com/~mburke/nodes-cgroups-vs-tech-preview-rn/release_notes/ocp-4-12-release-notes.html#ocp-4-12-technology-preview)

PR to update the rest of the docs: https://github.com/openshift/openshift-docs/pull/49472