### PR TITLE
[SRVOCF-427]: Add kn func run command docs

### DIFF
--- a/modules/serverless-kn-func-run.adoc
+++ b/modules/serverless-kn-func-run.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * serverless/cli_tools/kn-func-ref.adoc
+// * serverless/functions/serverless-functions-getting-started.adoc
+
+:_content-type: REFERENCE
+[id="serverless-kn-func-run_{context}"]
+= Running a function locally
+
+You can use the `kn func run` command to run a function locally in the current directory or in the directory specified by the `--path` flag. If the function that you are running has never previously been built, or if the project files have been modified since the last time it was built, the `kn func run` command builds the function before running it by default.
+
+.Example command to run a function in the current directory
+[source,terminal]
+----
+$ kn func run
+----
+
+.Example command to run a function in a directory specified as a path
+[source,terminal]
+----
+$ kn func run --path=<directory_path>
+----
+
+You can also force a rebuild of an existing image before running the function, even if there have been no changes to the project files, by using the `--build` flag:
+
+.Example run command using the build flag
+[source,terminal]
+----
+$ kn func run --build
+----
+
+If you set the `build` flag as false, this disables building of the image, and runs the function using the previously built image:
+
+.Example run command using the build flag
+[source,terminal]
+----
+$ kn func run --build=false
+----
+
+You can use the help command to learn more about `kn func run` command options:
+
+.Build help command
+[source,terminal]
+----
+$ kn func help run
+----

--- a/serverless/cli_tools/kn-func-ref.adoc
+++ b/serverless/cli_tools/kn-func-ref.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
+include::modules/serverless-kn-func-run.adoc[leveloffset=+1]
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]
 include::modules/functions-list-kn.adoc[leveloffset=+1]

--- a/serverless/functions/serverless-functions-getting-started.adoc
+++ b/serverless/functions/serverless-functions-getting-started.adoc
@@ -17,6 +17,7 @@ include::snippets/technology-preview.adoc[leveloffset=+2]
 Before you can complete the following procedures, you must ensure that you have completed all of the prerequisite tasks in xref:../../serverless/functions/serverless-functions-setup.adoc#serverless-functions-setup[Setting up {FunctionsProductName}].
 
 include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
+include::modules/serverless-kn-func-run.adoc[leveloffset=+1]
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-functions-on-cluster-builds.adoc[leveloffset=+1]
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
OCP 4.6+

Issue:
https://issues.redhat.com/browse/SRVOCF-427

Link to docs preview:
- http://file.rdu.redhat.com/abrennan/220822/SRVOCF-427/serverless/cli_tools/kn-func-ref.html#serverless-kn-func-run_kn-func-ref
- http://file.rdu.redhat.com/abrennan/220822/SRVOCF-427/serverless/functions/serverless-functions-getting-started.html#serverless-kn-func-run_serverless-functions-getting-started