### PR TITLE
OSSMDOC-299: Document security settings for external Jaeger.

### DIFF
--- a/modules/distr-tracing-config-security-ossm-cli.adoc
+++ b/modules/distr-tracing-config-security-ossm-cli.adoc
@@ -1,0 +1,93 @@
+////
+This module included in the following assemblies:
+service_mesh/v2x/ossm-reference-jaeger.adoc
+////
+:_content-type: PROCEDURE
+[id="distr-tracing-config-security-ossm-cli_{context}"]
+= Configuring distributed tracing security for service mesh from the command line
+
+You can modify the Jaeger resource to configure {JaegerShortName} security for use with {SMproductShortName} from the command line using the `oc` utility.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role. If you use {product-dedicated}, you must have an account with the `dedicated-admin` role.
+* The {SMProductName} Operator must be installed.
+* The `ServiceMeshControlPlane` deployed to the cluster.
+* You have access to the OpenShift CLI (oc) that matches your OpenShift Container Platform version.
+
+.Procedure
+
+. Log in to the {product-title} CLI as a user with the `cluster-admin` role. If you use {product-dedicated}, you must have an account with the `dedicated-admin` role.
++
+[source,terminal]
+----
+$ oc login https://<HOSTNAME>:6443
+----
++
+. Change to the project where you installed the control plane, for example `istio-system`, by entering the following command:
++
+[source,terminal]
+----
+$ oc project istio-system
+----
++
+. Run the following command to edit the Jaeger custom resource file, where `jaeger.yaml` is the name of your Jaeger custom resource.
++
+[source,terminal]
+----
+$ oc edit -n tracing-system -f jaeger.yaml
+----
++
+. Edit the `Jaeger` custom resource file to add the `htpasswd` configuration as shown in the following example.
+
+* `spec.ingress.openshift.htpasswdFile`
+* `spec.volumes`
+* `spec.volumeMounts`
++
+.Example Jaeger resource showing `htpasswd` configuration
+[source,yaml]
+----
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+spec:
+  ingress:
+    enabled: true
+    openshift:
+      htpasswdFile: /etc/proxy/htpasswd/auth
+      sar: '{"namespace": "istio-system", "resource": "pods", "verb": "get"}'
+    options: {}
+    resources: {}
+    security: oauth-proxy
+  volumes:
+    - name: secret-htpasswd
+      secret:
+        secretName: htpasswd
+    - configMap:
+        defaultMode: 420
+        items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+        name: trusted-ca-bundle
+        optional: true
+      name: trusted-ca-bundle
+  volumeMounts:
+    - mountPath: /etc/proxy/htpasswd
+      name: secret-htpasswd
+    - mountPath: /etc/pki/ca-trust/extracted/pem/
+      name: trusted-ca-bundle
+      readOnly: true
+----
++
+. Run the following command to apply your changes, where <jaeger.yaml> is the name of your Jaeger custom resource.
++
+[source,terminal]
+----
+$ oc apply -n tracing-system -f <jaeger.yaml>
+----
++
+. Run the following command to watch the progress of the pod deployment:
++
+[source,terminal]
+----
+$ oc get pods -n tracing-system -w
+----

--- a/modules/distr-tracing-config-security-ossm-web.adoc
+++ b/modules/distr-tracing-config-security-ossm-web.adoc
@@ -1,0 +1,74 @@
+////
+This module included in the following assemblies:
+service_mesh/v2x/ossm-reference-jaeger.adoc
+////
+:_content-type: PROCEDURE
+[id="distr-tracing-config-security-ossm-web_{context}"]
+= Configuring distributed tracing security for service mesh from the OpenShift console
+
+You can modify the Jaeger resource to configure {JaegerShortName} security for use with {SMproductShortName} in the OpenShift console.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role. If you use {product-dedicated}, you must have an account with the `dedicated-admin` role.
+* The {SMProductName} Operator must be installed.
+* The `ServiceMeshControlPlane` deployed to the cluster.
+* You have access to the OpenShift Container Platform web console.
+
+.Procedure
+
+. Log in to the {product-title} web console as a user with the `cluster-admin` role. 
+
+. Navigate to Operators → Installed Operators.
+
+. Click the *Project* menu and select the project where your `ServiceMeshControlPlane` resource is deployed from the list, for example `istio-system`.
+
+. Click the *{JaegerName} Operator*.
+
+. On the *Operator Details* page, click the *Jaeger* tab.
+
+. Click the name of your Jaeger instance.
+
+. On the Jaeger details page, click the `YAML` tab to modify your configuration.
+
+. Edit the `Jaeger` custom resource file to add the `htpasswd` configuration as shown in the following example.
+
+* `spec.ingress.openshift.htpasswdFile`
+* `spec.volumes`
+* `spec.volumeMounts`
++
+.Example Jaeger resource showing `htpasswd` configuration
+[source,yaml]
+----
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+spec:
+  ingress:
+    enabled: true
+    openshift:
+      htpasswdFile: /etc/proxy/htpasswd/auth
+      sar: '{"namespace": "istio-system", "resource": "pods", "verb": "get"}'
+    options: {}
+    resources: {}
+    security: oauth-proxy
+  volumes:
+    - name: secret-htpasswd
+      secret:
+        secretName: htpasswd
+    - configMap:
+        defaultMode: 420
+        items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+        name: trusted-ca-bundle
+        optional: true
+      name: trusted-ca-bundle
+  volumeMounts:
+    - mountPath: /etc/proxy/htpasswd
+      name: secret-htpasswd
+    - mountPath: /etc/pki/ca-trust/extracted/pem/
+      name: trusted-ca-bundle
+      readOnly: true
+----
++
+. Click *Save*.

--- a/modules/distr-tracing-config-security-ossm.adoc
+++ b/modules/distr-tracing-config-security-ossm.adoc
@@ -1,0 +1,11 @@
+////
+This module included in the following assemblies:
+service_mesh/v2x/ossm-reference-jaeger.adoc
+////
+:_content-type: CONCEPT
+[id="distr-tracing-config-security-ossm_{context}"]
+= Configuring distributed tracing security for service mesh
+
+The {JaegerShortName} uses OAuth for default authentication. However {SMProductName} uses a secret called `htpasswd` to facilitate communication between dependent services such as Grafana, Kiali, and the {JaegerShortName}. When you configure your {JaegerShortName} in the `ServiceMeshControlPlane` the {SMProductShortName} automatically configures security settings to use `htpasswd`.
+
+If you are specifying your {JaegerShortName} configuration in a Jaeger custom resource, you must manually configure the `htpasswd` settings and ensure the `htpasswd` secret is mounted into your Jaeger instance so that Kiali can communicate with it.

--- a/service_mesh/v2x/ossm-reference-jaeger.adoc
+++ b/service_mesh/v2x/ossm-reference-jaeger.adoc
@@ -18,6 +18,12 @@ include::modules/ossm-configuring-external-jaeger.adoc[leveloffset=+1]
 
 include::modules/distr-tracing-deployment-best-practices.adoc[leveloffset=+2]
 
+include::modules/distr-tracing-config-security-ossm.adoc[leveloffset=+2]
+
+include::modules/distr-tracing-config-security-ossm-web.adoc[leveloffset=+3]
+
+include::modules/distr-tracing-config-security-ossm-cli.adoc[leveloffset=+3]
+
 include::modules/distr-tracing-config-default.adoc[leveloffset=+2]
 
 include::modules/distr-tracing-config-jaeger-collector.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): 4.6 - 4.12

Issue: [OSSMDOC-299](https://issues.redhat.com/browse/OSSMDOC-299) (followup issue, see comments)


Link to docs preview:  http://file.bos.redhat.com/jstickle/OSSMDOC-299/service_mesh/v2x/ossm-reference-jaeger.html#distr-tracing-config-security-ossm_jaeger-config-reference

Additional information:
QE review: FilipB
Peer review: michaelryanpeter