### PR TITLE
Adds notes for 4.11.1 release

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2495,8 +2495,6 @@ Issued: 2022-08-10
 
 {product-title} release 4.11.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:5069[RHSA-2022:5069] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:5068[RHSA-2022:5068] advisory.
 
-Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
-
 You can view the container images in this release by running the following command:
 
 [source,terminal]
@@ -2504,3 +2502,34 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.11.0 --pullspecs
 ----
 //replace 4.y.z for the correct values for the release. You do not need to update oc to run this command.
+
+[id="ocp-4-11-1"]
+=== RHSA-2022:6103 - {product-title} 4.11.1 bug fix and security update
+
+Issued: 2022-08-23
+
+{product-title} release 4.11.1, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:6103[RHSA-2022:6103] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:6102[RHSA-2022:6102] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.1 --pullspecs
+----
+
+[id="ocp-4-11-1-bug-fixes"]
+==== Bug fixes
+
+* Previously, the functionality of Bond-CNI was limited to only active-backup mode. With this update, the bonding modes supported are:
+
+** `balance-rr - 0`
+** `active-backup - 1`
+** `balance-xor - 2`
+
++                      
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2102047[*BZ#2102047*])
+
+[id="ocp-4-11-1-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.11.1 release that ships out today. Links will not work yet.


Link to docs preview (VPN required)
http://file.rdu.redhat.com/opayne/RN-4.11.1/release_notes/ocp-4-11-release-notes.html#ocp-4-11-1




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
