### PR TITLE
OSDOCS: Removes cluster-admin reference.

### DIFF
--- a/modules/support-submitting-a-case.adoc
+++ b/modules/support-submitting-a-case.adoc
@@ -11,10 +11,9 @@
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
 * You have installed the OpenShift CLI (`oc`).
 * You have a Red Hat Customer Portal account.
-* You have a Red Hat standard or premium Subscription.
+* You have access to {cluster-manager-url}.
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
Enterprise-4.6+

Link to docs preview:
[Updated prerequisites](http://file.rdu.redhat.com/eponvell/OSD-Support-Cleanup/dedicated/osd_architecture/osd-support.html#support-submitting-a-case_osd-getting-support)

Additional information:
Fixes #40302 This PR removes the reference to `cluster-admin` and adds the requirement of having OCM access. Users should not require elevated roles to submit a support ticket.