### PR TITLE
WMCO 6 RN move vSphere note

### DIFF
--- a/windows_containers/windows-containers-release-notes-6-x.adoc
+++ b/windows_containers/windows-containers-release-notes-6-x.adoc
@@ -33,11 +33,6 @@ endif::openshift-origin[]
 
 This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 6.0.0 were released in link:https://access.redhat.com/errata/RHBA-2022:6129[RHBA-2022:6129].
 
-[NOTE]
-====
-Windows Server 2019 is not supported in vSphere.
-====
-
 === Bug fixes
 * Previously, a Windows instance could not be unconfigured when the node's external IP was present without a pointer record (PTR). As a result, the node's external IP address without reverse lookup records was used to associate the Windows instance. With this release, a Windows instance can be unconfigured when the node's external IP address is present without a PTR .
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2070892[**BZ#2070892**])
@@ -47,6 +42,7 @@ Windows Server 2019 is not supported in vSphere.
 
 === Deprecated features
 * Windows Server 20H2 is no longer supported for vSphere worker nodes.
+* Windows Server 2019 is not supported in vSphere.
 
 === New features and improvements
 [id="wmco-6.0.0-node-certificates"]


### PR DESCRIPTION
Wondering if the [Windows Server 2019 is not supported in vSphere.](https://docs.openshift.com/container-platform/4.11/windows_containers/windows-containers-release-notes-6-x.html#wmco-6-0-0) would be better in the [deprecated features section](https://docs.openshift.com/container-platform/4.11/windows_containers/windows-containers-release-notes-6-x.html#deprecated-features), which has a similar note.
[
Preview](http://file.rdu.redhat.com/~mburke/winc-move-note-in-rn/windows_containers/windows-containers-release-notes-6-x.html#deprecated-features)