### PR TITLE
WINC remove docker step

### DIFF
--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -66,8 +66,6 @@ PS C:\> Get-Service -Name VMTools | Select Status, StartType
 The public key used in the instructions must correspond to the private key you create later in the WMCO namespace that holds your secret. See the "Configuring a secret for the Windows Machine Config Operator" section for more details.
 ==== 
 
-. Install the `docker` container runtime on your Windows VM following the link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server[Microsoft documentation].
-
 . You must create a new firewall rule in the Windows VM that allows incoming connections for container logs. Run the following PowerShell command to create the firewall rule on TCP port 10250:
 +
 [source,posh]


### PR DESCRIPTION
After reverting https://github.com/openshift/openshift-docs/pull/47588,  I [recreated that PR](https://github.com/openshift/openshift-docs/pull/49248), but missed this change:

* Removed the [Install the `docker` container runtime](http://file.rdu.redhat.com/~mburke/winc-add-golder-image-step/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html#creating-the-vsphere-windows-vm-golden-image_creating-windows-machineset-vsphere) (before) step, from procedure. [It was previously step 6](https://docs.openshift.com/container-platform/4.10/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html#creating-the-vsphere-windows-vm-golden-image_creating-windows-machineset-vsphere) (after).


Preview: [Step 8](http://file.rdu.redhat.com/~mburke/winc-add-golder-image-step/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html#creating-the-vsphere-windows-vm-golden-image_creating-windows-machineset-vsphere)