### PR TITLE
WMCO add 2022 to default vxlan port

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -63,7 +63,8 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Supported Windows Server version
 
 |Default VXLAN port
-|Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)
+a|* Windows Server 2022 Long-Term Servicing Channel (LTSC)
+* Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)
 
 |Custom VXLAN port
 |Windows Server 2022 Long-Term Servicing Channel (LTSC)


### PR DESCRIPTION
Adding Windows Server 2022 Long-Term Servicing Channel (LTSC) support to the Hybrid networking with OVN-Kubernetes table for default vxlan, per [WINC PR 1207](https://github.com/openshift/windows-machine-config-operator/pull/1207/files)

Preview: [Table 2. Hybrid OVN-Kubernetes Windows Server support, first row](http://file.rdu.redhat.com/~mburke/winc-update-networking-prereq/windows_containers/understanding-windows-container-workloads.html#supported-networking)