### PR TITLE
[SRVOCF-426]: Add push flag docs for kn func build command

### DIFF
--- a/modules/serverless-build-func-kn.adoc
+++ b/modules/serverless-build-func-kn.adoc
@@ -6,14 +6,38 @@
 [id="serverless-build-func-kn_{context}"]
 = Building functions
 
-Before you can run a function, you must build the function project by using the `kn func build` command. This command creates an OCI container image that can be run locally on your computer or on an {product-title} cluster. The build command uses the function project name and the image registry name to construct a fully qualified image name for your function.
+Before you can run a function, you must build the function project. If you are using the `kn func run` command, the function is built automatically. However, you can use the `kn func build` command to build a function without running it, which can be useful for advanced users or debugging scenarios.
 
-By default, `kn func build` creates a container image using the Red Hat Source-to-Image (S2I) technology. To use the link:https://buildpacks.io/[CNCF Cloud Native Buildpacks] technology instead, supply the `-b` flag:
+The `kn func build` command creates an OCI container image that can be run locally on your computer or on an {product-title} cluster. This command uses the function project name and the image registry name to construct a fully qualified image name for your function.
 
-.Example build command
+[id="serverless-build-func-kn-image-containers_{context}"]
+== Image container types
+
+By default, `kn func build` creates a container image by using Red Hat Source-to-Image (S2I) technology.
+
+.Example build command using Red Hat Source-to-Image (S2I)
 [source,terminal]
 ----
-$ kn func build -b pack
+$ kn func build
+----
+
+You can use link:https://buildpacks.io/[CNCF Cloud Native Buildpacks] technology instead, by adding the `--builder` flag to the command and specifying the `pack` strategy:
+
+.Example build command using CNCF Cloud Native Buildpacks
+[source,terminal]
+----
+$ kn func build --builder pack
+----
+
+[id="serverless-build-func-kn-image-registries_{context}"]
+== Image registry types
+
+The OpenShift Container Registry is used by default as the image registry for storing function images.
+
+.Example build command using OpenShift Container Registry
+[source,terminal]
+----
+$ kn func build
 ----
 
 .Example output
@@ -23,14 +47,13 @@ Building function image
 Function image has been built, image: registry.redhat.io/example/example-function:latest
 ----
 
-The OpenShift Container Registry is used by default as the image registry for storing function images. You can override this by using the `-r` flag:
+You can override using OpenShift Container Registry as the default image registry by using the `--registry` flag:
 
-.Example build command
+.Example build command overriding OpenShift Container Registry to use quay.io
 [source,terminal]
 ----
-$ kn func build -r quay.io/username
+$ kn func build --registry quay.io/username
 ----
-// removed mentioning the `FUNC_REGISTRY` environment variable because we didn't provide an example and it seems unnecessary - can add it in later if it's important
 
 .Example output
 [source,terminal]
@@ -39,7 +62,21 @@ Building function image
 Function image has been built, image: quay.io/username/example-function:latest
 ----
 
-To learn more about `kn func build` command options, you can use the help command:
+[id="serverless-build-func-kn-push_{context}"]
+== Push flag
+
+You can add the `--push` flag to a `kn func build` command to automatically push the function image after it is successfully built:
+
+.Example build command using OpenShift Container Registry
+[source,terminal]
+----
+$ kn func build --push
+----
+
+[id="serverless-build-func-kn-help_{context}"]
+== Help command
+
+You can use the help command to learn more about `kn func build` command options:
 
 .Build help command
 [source,terminal]


### PR DESCRIPTION
Version(s):
OCP 4.6+

Issue:
https://issues.redhat.com/browse/SRVOCF-426

Link to docs preview:
- http://file.rdu.redhat.com/abrennan/240822/SRVOCF-426/serverless/functions/serverless-functions-getting-started.html#serverless-build-func-kn_serverless-functions-getting-started
- http://file.rdu.redhat.com/abrennan/240822/SRVOCF-426/serverless/cli_tools/kn-func-ref.html#serverless-build-func-kn_kn-func-ref