### PR TITLE
OSDOCS-4031 Remove Windows Server 20H2 Support in 4.8 and 4.9

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -91,7 +91,7 @@ The following table lists the supported link:https://docs.microsoft.com/en-us/wi
 |Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
 
 |VMware vSphere
-|Windows Server Semi-Annual Channel (SAC): Windows Server 20H2
+|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2022 (OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later)
 
 |bare metal
 |Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
@@ -131,5 +131,5 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
 
 |Custom VXLAN port
-|Windows Server Semi-Annual Channel (SAC): Windows Server 20H2
+|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2022 (OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later)
 |===


### PR DESCRIPTION
Replacing Windows 20H2 support with 2022 for vSphere for 4.8 and 4.9. 

Separate [PR for 4.10](https://github.com/openshift/openshift-docs/pull/49548) as the table is different; PR for [4.11+](https://github.com/openshift/openshift-docs/pull/49570)

Preview
[Supported Windows Server versions](http://file.rdu.redhat.com/~mburke/winc-update-vsphere-versioning/windows_containers/windows-containers-release-notes-3-x.html#supported-windows-server-versions)
[Supported networking, table 2](http://file.rdu.redhat.com/~mburke/winc-update-vsphere-versioning/windows_containers/windows-containers-release-notes-3-x.html#supported-networking)