### PR TITLE
OSDOCS-4031 Remove Windows Server 20H2 Support in 4.10

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -24,11 +24,10 @@ The following table lists the link:https://docs.microsoft.com/en-us/windows/rele
 |Windows Server 2019 (version 1809)
 
 |VMware vSphere
-a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.
-* Windows Server 20H2 
+|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2022 (OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later).
 
 |Bare metal or provider agnostic
-a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.
+a|* Windows Server 2022 Long-Term Servicing Channel (LTSC). OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later.
 * Windows Server 2019 (version 1809)
 |===
 
@@ -49,7 +48,7 @@ The following table lists the link:https://docs.microsoft.com/en-us/windows/rele
 |Windows Server 2019 (version 1809)
 
 |VMware vSphere
-|Windows Server 20H2 
+|Windows Server 2022 Long-Term Servicing Channel (LTSC). OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later.
 
 |Bare metal or provider agnostic
 |Windows Server 2019 (version 1809)  
@@ -88,8 +87,7 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Windows Server 2019 (version 1809)
 
 |Custom VXLAN port
-a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637] patch.
-* Windows Server 20H2 
+|Windows Server 2022 Long-Term Servicing Channel (LTSC). OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
 |===
 
 .WMCO 5.0.0 Hybrid OVN-Kubernetes Windows Server support
@@ -102,5 +100,7 @@ a|* Windows Server 2022 with the Windows link:https://support.microsoft.com/en-u
 |Windows Server 2019 (version 1809)
 
 |Custom VXLAN port
-|Windows Server 20H2 
+|Windows Server 2022 Long-Term Servicing Channel (LTSC). OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+
+ 
 |===


### PR DESCRIPTION
Replacing Windows 20H2 support with 2022 for vSphere for 4.10

Separate [PR for 4.8 and 4.9](https://github.com/openshift/openshift-docs/pull/49546) as the table is different; PR for [4.11+](https://github.com/openshift/openshift-docs/pull/49570)

Previews[
WMCO 5.1.0 supported platforms and Windows Server versions](http://file.rdu.redhat.com/~mburke/winc-update-vsphere-versioning-410/windows_containers/windows-containers-release-notes-5-x.html#wmco-prerequisites-supported-5.1.0_windows-containers-release-notes)[
WMCO 5.0.0 supported platforms and Windows Server versions](http://file.rdu.redhat.com/~mburke/winc-update-vsphere-versioning-410/windows_containers/windows-containers-release-notes-5-x.html#wmco-prerequisites-supported-5.0.0_windows-containers-release-notes)
[Supported networking, table 2 and 3](http://file.rdu.redhat.com/~mburke/winc-update-vsphere-versioning-410/windows_containers/windows-containers-release-notes-5-x.html#supported-networking)