### PR TITLE
OPNET-8: Added a release note for VMware vSphere - Migrate to using unicast keepalived

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -646,6 +646,11 @@ For clusters that run on {rh-openstack}, the network functions virtualization de
 
 These changes are reflected in simplified post-installation and network configuration documentation.
 
+[id="ocp-4-11-vsphere-unicast-default"]
+==== Installations on Red Hat OpenStack Platform, VMware vSphere, or oVirt now configure keepalived with unicast as the default
+
+For {product-title} installer-provisioned installations on {rh-openstack-first}, VMware vSphere, or oVirt, keepalived is now configured with unicast as the default instead of multicast. You no longer need to allow multicast traffic. The unicast migration occurs a few minutes after the cluster finishes upgrading because all of the nodes must migrate at the same time. Having both multicast and unicast clusters at the same time should not result in any issues because keepalived treats unicast and multicast as completely separate.
+
 [id="ocp-4-11-storage"]
 === Storage
 
@@ -1172,7 +1177,7 @@ If you have Operator projects that were previously created or maintained with Op
 
 {product-title} documentation previously referred to cluster Operators interchangeably with the alternative naming "platform Operators". Because this double naming could cause confusion about the type of Operators being discussed, the term "platform Operator" is no longer used when referring to cluster Operators, which are represented by `ClusterOperator` API objects. The documentation sets for {product-title} {product-version} and earlier have been updated to now solely use the term "cluster Operator".
 
-For example, see xref:../operators/operator-reference.adoc#cluster-operators-ref[Cluster Operators reference]. 
+For example, see xref:../operators/operator-reference.adoc#cluster-operators-ref[Cluster Operators reference].
 
 [id="ocp-4-11-deprecated-removed-features"]
 == Deprecated and removed features


### PR DESCRIPTION
Version(s):
4.11 RN only

Addresses:
https://issues.redhat.com/browse/OPNET-8

Link to docs preview:
http://file.rdu.redhat.com/~ahardin/August-2022/4-11-unicast-keepalived/release_notes/ocp-4-11-release-notes.html#ocp-4-11-vsphere-unicast-default

Change management required