### PR TITLE
BZ-2084280 Separating GCP required API table into required and optional tables

### DIFF
--- a/modules/installation-gcp-enabling-api-services.adoc
+++ b/modules/installation-gcp-enabling-api-services.adoc
@@ -28,7 +28,7 @@ to complete {product-title} installation.
 .Procedure
 
 * Enable the following required API services in the project that hosts your
-cluster. See
+cluster. You may also enable optional API services which are not required for installation. See
 link:https://cloud.google.com/service-usage/docs/enable-disable#enabling[Enabling services]
 in the GCP documentation.
 +
@@ -37,16 +37,8 @@ in the GCP documentation.
 |===
 |API service |Console service name
 
-ifdef::template[]
-|Cloud Deployment Manager V2 API
-|`deploymentmanager.googleapis.com`
-endif::template[]
-
 |Compute Engine API
 |`compute.googleapis.com`
-
-|Google Cloud APIs
-|`cloudapis.googleapis.com`
 
 |Cloud Resource Manager API
 |`cloudresourcemanager.googleapis.com`
@@ -59,6 +51,21 @@ endif::template[]
 
 |Identity and Access Management (IAM) API
 |`iam.googleapis.com`
+
+|===
++
+.Optional API services
+[cols="2a,3a",options="header"]
+|===
+|API service |Console service name
+
+ifdef::template[]
+|Cloud Deployment Manager V2 API
+|`deploymentmanager.googleapis.com`
+endif::template[]
+
+|Google Cloud APIs
+|`cloudapis.googleapis.com`
 
 |Service Management API
 |`servicemanagement.googleapis.com`


### PR DESCRIPTION
[BZ#2084280](https://bugzilla.redhat.com/show_bug.cgi?id=2084280)

Applies to 4.11 and 4.12 

[Doc preview](https://bscott-rh.github.io/openshift-docs/BZ2084280/installing/installing_gcp/installing-gcp-account.html#installation-gcp-enabling-api-services_installing-gcp-account)