### PR TITLE
OSDOCS:3623: Document how to use the new EFS operator in OSD/ROSA clusters

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -197,6 +197,8 @@ Topics:
   Topics:
     - Name: Persistent storage using AWS EFS
       File: osd-persistent-storage-aws
+    - Name: AWS Elastic File Service CSI Driver Operator
+      File: osd-persistent-storage-aws-efs-csi
 ---
 Name: Networking
 Dir: networking

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -293,10 +293,12 @@ Topics:
   Dir: persistent_storage
   Distros: openshift-rosa
   Topics:
-  - Name: Persistent storage using AWS Elastic Block Store (EBS)
+  - Name: Persistent storage using AWS Elastic Block Store
     File: rosa-persistent-storage-aws-ebs
-  - Name: Persistent storage using AWS EFS
+  - Name: Persistent storage using AWS Elastic File Service
     File: osd-persistent-storage-aws
+  - Name: AWS Elastic File Service CSI Driver Operator
+    File: rosa-persistent-storage-aws-efs-csi
 ---
 Name: Networking
 Dir: networking

--- a/modules/persistent-storage-csi-about.adoc
+++ b/modules/persistent-storage-csi-about.adoc
@@ -3,6 +3,9 @@
 // * storage/container_storage_interface/persistent-storage-csi-ebs.adoc
 // * storage/container_storage_interface/persistent-storage-csi-manila.adoc
 // * storage/container_storage_interface/persistent-storage-csi-ovirt.adoc
+// * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+// * storage/container_storage_interface/rosa-persistent-storage-aws-efs-csi.adoc
 
 :_content-type: CONCEPT
 [id="csi-about_{context}"]

--- a/modules/persistent-storage-csi-dynamic-provisioning-aws-efs.adoc
+++ b/modules/persistent-storage-csi-dynamic-provisioning-aws-efs.adoc
@@ -1,6 +1,8 @@
 // Module included in the following assemblies:
 //
 // * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+// * storage/container_storage_interface/rosa-persistent-storage-aws-efs-csi.adoc
 
 :_content-type: PROCEDURE
 [id="csi-dynamic-provisioning-aws-efs_{context}"]

--- a/modules/persistent-storage-csi-efs-create-volume.adoc
+++ b/modules/persistent-storage-csi-efs-create-volume.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * storage/persistent_storage/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+// * storage/container_storage_interface/rosa-persistent-storage-aws-efs-csi.adoc
 
 :_content-type: PROCEDURE
 [id="efs-create-volume_{context}"]

--- a/modules/persistent-storage-csi-efs-security.adoc
+++ b/modules/persistent-storage-csi-efs-security.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * storage/persistent_storage/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+// * storage/container_storage_interface/rosa-persistent-storage-aws-efs-csi.adoc
 
 [id="efs-security_{context}"]
 = AWS EFS security

--- a/modules/persistent-storage-csi-efs-static-pv.adoc
+++ b/modules/persistent-storage-csi-efs-static-pv.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * storage/persistent_storage/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+// * storage/container_storage_interface/rosa-persistent-storage-aws-efs-csi.adoc
 
 :_content-type: PROCEDURE
 [id="efs-create-static-pv_{context}"]
@@ -10,7 +13,7 @@ It is possible to use an AWS EFS volume as a single PV without any dynamic provi
 
 .Prerequisites
 
-* xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#efs-create-volume_persistent-storage-csi-aws-efs[Created AWS EFS volume(s).]
+* You have created AWS EFS volumes.
 
 .Procedure
 

--- a/modules/persistent-storage-csi-efs-sts.adoc
+++ b/modules/persistent-storage-csi-efs-sts.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * storage/persistent_storage/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+// * storage/container_storage_interface/rosa-persistent-storage-aws-efs-csi.adoc
 
 :_content-type: PROCEDURE
 [id="efs-sts_{context}"]

--- a/modules/persistent-storage-csi-efs-troubleshooting.adoc
+++ b/modules/persistent-storage-csi-efs-troubleshooting.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * storage/persistent_storage/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+// * storage/container_storage_interface/rosa-persistent-storage-aws-efs-csi.adoc
 
 [id="efs-troubleshooting_{context}"]
 = AWS EFS troubleshooting
@@ -43,7 +46,7 @@ $ oc describe pod
 +
 This error is frequently caused by AWS dropping packets between an {product-title} node and AWS EFS.
 +
-Check that the following are correct (see xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#efs-create-volume_persistent-storage-csi-aws-efs[Creating and configuring access to EFS volumes in AWS]):
+Check that the following are correct:
 +
 --
 * AWS firewall and Security Groups

--- a/modules/persistent-storage-csi-olm-operator-install.adoc
+++ b/modules/persistent-storage-csi-olm-operator-install.adoc
@@ -1,6 +1,8 @@
 // Module included in the following assemblies:
 //
 // * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+// * storage/container_storage_interface/rosa-persistent-storage-aws-efs-csi.adoc
 
 :_content-type: PROCEDURE
 [id="persistent-storage-csi-olm-operator-install_{context}"]

--- a/modules/persistent-storage-csi-olm-operator-uninstall.adoc
+++ b/modules/persistent-storage-csi-olm-operator-uninstall.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+// * storage/container_storage_interface/rosa-persistent-storage-aws-efs-csi.adoc
 
 :_content-type: PROCEDURE
 [id="persistent-storage-csi-olm-operator-uninstall_{context}"]

--- a/modules/storage-create-storage-class.adoc
+++ b/modules/storage-create-storage-class.adoc
@@ -7,6 +7,9 @@
 //
 // * storage/persistent_storage/persistent-storage-aws.adoc
 // * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc
+// * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+// * storage/container_storage_interface/rosa-persistent-storage-aws-efs-csi.adoc
 
 :_content-type: PROCEDURE
 [id="storage-create-storage-class_{context}"]

--- a/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
@@ -15,7 +15,8 @@ Familiarity with xref:../../storage/understanding-persistent-storage.adoc#unders
 After installing the AWS EFS CSI Driver Operator, {product-title} installs the AWS EFS CSI Operator and the AWS EFS CSI driver by default in the `openshift-cluster-csi-drivers` namespace. This allows the AWS EFS CSI Driver Operator to create CSI-provisioned PVs that mount to AWS EFS assets.
 
 * The _AWS EFS CSI Driver Operator_, after being installed, does not create a storage class by default to use to create persistent volume claims (PVCs). However, you can manually create the AWS EFS `StorageClass`.
-The AWS EFS CSI Driver Operator supports dynamic volume provisioning by allowing storage volumes to be created on-demand, eliminating the need for cluster administrators to pre-provision storage.
+The AWS EFS CSI Driver Operator supports dynamic volume provisioning by allowing storage volumes to be created on-demand.
+This eliminates the need for cluster administrators to pre-provision storage.
 
 * The _AWS EFS CSI driver_ enables you to create and mount AWS EFS PVs.
 

--- a/storage/persistent_storage/osd-persistent-storage-aws-efs-csi.adoc
+++ b/storage/persistent_storage/osd-persistent-storage-aws-efs-csi.adoc
@@ -1,0 +1,81 @@
+:_content-type: ASSEMBLY
+[id="osd-persistent-storage-aws-efs-csi"]
+= Setting up AWS Elastic File Service CSI Driver Operator
+include::_attributes//attributes-openshift-dedicated.adoc[]
+:context: osd-persistent-storage-aws-efs-csi
+toc::[]
+
+//Content similar to persistent-storage-csi-aws-efs.adoc and rosa-persistent-storage-aws-efs-csi.adoc. Modules are reused.
+
+[IMPORTANT]
+====
+This procedure is specific to the Amazon Web Services Elastic File System (AWS EFS) CSI Driver Operator, which is only applicable for {product-title} 4.10 and later versions.
+====
+
+== Overview
+
+{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for AWS Elastic File Service (EFS).
+
+Familiarity with link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/storage/index#persistent-storage-overview_understanding-persistent-storage[persistent storage] and link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/storage/index#persistent-storage-csi[configuring CSI volumes] is recommended when working with a CSI Operator and driver.
+
+After installing the AWS EFS CSI Driver Operator, {product-title} installs the AWS EFS CSI Operator and the AWS EFS CSI driver by default in the `openshift-cluster-csi-drivers` namespace. This allows the AWS EFS CSI Driver Operator to create CSI-provisioned PVs that mount to AWS EFS assets.
+
+* The _AWS EFS CSI Driver Operator_, after being installed, does not create a storage class by default to use to create persistent volume claims (PVCs). However, you can manually create the AWS EFS `StorageClass`.
+The AWS EFS CSI Driver Operator supports dynamic volume provisioning by allowing storage volumes to be created on-demand.
+This eliminates the need for cluster administrators to pre-provision storage.
+
+* The _AWS EFS CSI driver_ enables you to create and mount AWS EFS PVs.
+
+[NOTE]
+====
+AWS EFS only supports regional volumes, not zonal volumes.
+====
+
+include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
+
+:FeatureName: AWS EFS
+
+include::modules/persistent-storage-csi-olm-operator-install.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../storage/persistent_storage/osd-persistent-storage-aws-efs-csi.adoc#efs-sts_osd-persistent-storage-aws-efs-csi[Configuring AWS EFS CSI Driver with STS]
+
+include::modules/persistent-storage-csi-efs-sts.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../storage/persistent_storage/osd-persistent-storage-aws-efs-csi.adoc#persistent-storage-csi-olm-operator-install_osd-persistent-storage-aws-efs-csi[Installing the AWS EFS CSI Driver Operator]
+
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/authentication_and_authorization/index#cco-ccoctl-configuring_cco-mode-sts[Configuring the Cloud Credential Operator utility]
+
+:StorageClass: AWS EFS
+:Provisioner: efs.csi.aws.com
+
+include::modules/storage-create-storage-class.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-efs-create-volume.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-dynamic-provisioning-aws-efs.adoc[leveloffset=+1]
+
+If you have problems setting up dynamic provisioning, see xref:../../storage/persistent_storage/osd-persistent-storage-aws-efs-csi.adoc#efs-troubleshooting_osd-persistent-storage-aws-efs-csi[AWS EFS troubleshooting].
+
+include::modules/persistent-storage-csi-efs-static-pv.adoc[leveloffset=+1]
+
+If you have problems setting up static PVs, see xref:../../storage/persistent_storage/osd-persistent-storage-aws-efs-csi.adoc#efs-troubleshooting_osd-persistent-storage-aws-efs-csi[AWS EFS troubleshooting].
+
+include::modules/persistent-storage-csi-efs-security.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-efs-troubleshooting.adoc[leveloffset=+1]
+
+:FeatureName: AWS EFS
+
+include::modules/persistent-storage-csi-olm-operator-uninstall.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/storage/index#persistent-storage-csi[Configuring CSI volumes]
+

--- a/storage/persistent_storage/osd-persistent-storage-aws.adoc
+++ b/storage/persistent_storage/osd-persistent-storage-aws.adoc
@@ -6,6 +6,13 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+ifdef::openshift-rosa[]
+[WARNING]
+====
+This procedure is specific to the Amazon Web Services Elastic File System (AWS EFS) community Operator, which is only applicable up to {product-title} 4.9. 
+====
+endif::openshift-rosa[]
+
 The Amazon Web Services Elastic File System (AWS EFS) is a Network File System (NFS) that can be provisioned on {product-title} clusters. AWS also provides and supports a CSI EFS Driver to be used with Kubernetes that allows Kubernetes workloads to leverage this shared file storage.
 
 This document describes the basic steps needed to set up your AWS account to prepare EFS to be used by {product-title}. For more information about AWS EFS, see the link:https://docs.aws.amazon.com/efs/index.html[AWS EFS documentation].

--- a/storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc
+++ b/storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc
@@ -1,0 +1,84 @@
+:_content-type: ASSEMBLY
+[id="rosa-persistent-storage-aws-efs-csi"]
+= Setting up AWS Elastic File Service CSI Driver Operator
+include::_attributes//attributes-openshift-dedicated.adoc[]
+:context: rosa-persistent-storage-aws-efs-csi
+toc::[]
+
+//Content similar to persistent-storage-csi-aws-efs.adoc and osd-persistent-storage-aws-efs-csi.adoc. Modules are reused.
+
+[IMPORTANT]
+====
+This procedure is specific to the Amazon Web Services Elastic File System (AWS EFS) CSI Driver Operator, which is only applicable for {product-title} 4.10 and later versions.
+====
+
+== Overview
+
+{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for AWS Elastic File Service (EFS).
+
+Familiarity with link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/storage/index#persistent-storage-overview_understanding-persistent-storage[persistent storage] and link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/storage/index#persistent-storage-csi[configuring CSI volumes] is recommended when working with a CSI Operator and driver.
+
+After installing the AWS EFS CSI Driver Operator, {product-title} installs the AWS EFS CSI Operator and the AWS EFS CSI driver by default in the `openshift-cluster-csi-drivers` namespace. This allows the AWS EFS CSI Driver Operator to create CSI-provisioned PVs that mount to AWS EFS assets.
+
+* The _AWS EFS CSI Driver Operator_, after being installed, does not create a storage class by default to use to create persistent volume claims (PVCs). However, you can manually create the AWS EFS `StorageClass`.
+The AWS EFS CSI Driver Operator supports dynamic volume provisioning by allowing storage volumes to be created on-demand.
+This eliminates the need for cluster administrators to pre-provision storage.
+
+* The _AWS EFS CSI driver_ enables you to create and mount AWS EFS PVs.
+
+[NOTE]
+====
+AWS EFS only supports regional volumes, not zonal volumes.
+====
+
+include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
+
+:FeatureName: AWS EFS
+
+include::modules/persistent-storage-csi-olm-operator-install.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc#efs-sts_rosa-persistent-storage-aws-efs-csi[Configuring AWS EFS CSI Driver with STS]
+
+include::modules/persistent-storage-csi-efs-sts.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+
+* xref:../../storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc#persistent-storage-csi-olm-operator-install_rosa-persistent-storage-aws-efs-csi[Installing the AWS EFS CSI Driver Operator]
+
+
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/authentication_and_authorization/index#cco-ccoctl-configuring_cco-mode-sts[Configuring the Cloud Credential Operator utility]
+
+:StorageClass: AWS EFS
+:Provisioner: efs.csi.aws.com
+
+include::modules/storage-create-storage-class.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-efs-create-volume.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-dynamic-provisioning-aws-efs.adoc[leveloffset=+1]
+
+If you have problems setting up dynamic provisioning, see xref:../../storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc#efs-troubleshooting_rosa-persistent-storage-aws-efs-csi[AWS EFS troubleshooting].
+
+
+include::modules/persistent-storage-csi-efs-static-pv.adoc[leveloffset=+1]
+
+If you have problems setting up static PVs, see xref:../../storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc#efs-troubleshooting_rosa-persistent-storage-aws-efs-csi[AWS EFS troubleshooting].
+
+include::modules/persistent-storage-csi-efs-security.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-efs-troubleshooting.adoc[leveloffset=+1]
+
+:FeatureName: AWS EFS
+
+include::modules/persistent-storage-csi-olm-operator-uninstall.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/storage/index#persistent-storage-csi[Configuring CSI volumes]
+


### PR DESCRIPTION
Version(s):
4.11, 412

Issue:
https://issues.redhat.com/browse/OSDOCS-3623

Link to docs preview:
**ROSA**: https://49569--docspreview.netlify.app/openshift-rosa/latest/storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.html
**Dedicated (OSD)**: https://49569--docspreview.netlify.app/openshift-dedicated/latest/storage/persistent_storage/osd-persistent-storage-aws-efs-csi.html

Additional information:
This PR adds Setting up AWS Elastic File Service CSI Driver Operator assemblies (pages) to the ROSA and Dedicated topic maps. The modules (contextual and procedural content) are shared across OCP, Dedicated, and ROSA.