### PR TITLE
OSDOCS-4031 Remove Windows Server 20H2 Support in 4.11+

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -21,14 +21,14 @@ The following table lists the link:https://docs.microsoft.com/en-us/windows/rele
 |Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)
 
 |Microsoft Azure
-a|* Windows Server 2022 Long-Term Servicing Channel (LTSC)
+a|* Windows Server 2022 Long-Term Servicing Channel (LTSC). OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later.
 * Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)
 
 |VMware vSphere
-|Windows Server 2022 Long-Term Servicing Channel (LTSC)
+|Windows Server 2022 Long-Term Servicing Channel (LTSC). OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later.
 
 |Bare metal or provider agnostic
-|Windows Server 2022 Long-Term Servicing Channel (LTSC)
+|Windows Server 2022 Long-Term Servicing Channel (LTSC). OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later.
 
 |===
 
@@ -66,6 +66,6 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)
 
 |Custom VXLAN port
-|Windows Server 2022 Long-Term Servicing Channel (LTSC)
+|Windows Server 2022 Long-Term Servicing Channel (LTSC). OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later.
 
 |===


### PR DESCRIPTION
Replacing Windows 20H2 support with 2022 for vSphere, Azure, baremetal for 4.11+. 

Separate [PR for 4.8, 4.9](https://github.com/openshift/openshift-docs/pull/49546) and  [PR for 4.10](https://github.com/openshift/openshift-docs/pull/49548) as the table is different.
Preview
[Supported Windows Server versions](http://file.rdu.redhat.com/~mburke/winc-update-vsphere-versioning-411/windows_containers/windows-containers-release-notes-6-x.html#wmco-prerequisites-supported-6.0.0_windows-containers-release-notes)
[Supported networking, table 2](http://file.rdu.redhat.com/~mburke/winc-update-vsphere-versioning-411/windows_containers/windows-containers-release-notes-6-x.html#supported-networking)