### PR TITLE
[enterprise-4.8] BZ-2009339: Compatibility matrix update

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -102,7 +102,7 @@ You can perform different types of installations on different platforms.
 
 [NOTE]
 ====
-Not all installation options are supported for all platforms, as shown in the following tables.
+Not all installation options are supported for all platforms, as shown in the following tables. A checkmark indicates that the option is supported and links to the relevant section.
 ====
 
 .Installer-provisioned infrastructure options
@@ -115,57 +115,57 @@ ifdef::openshift-origin[]
 endif::openshift-origin[]
 
 |Default
-|xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[X]
-|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[X]
-|xref:../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[X]
+|xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[&#10003;]
+|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[&#10003;]
 |
-|xref:../installing/installing_rhv/installing-rhv-default.adoc#installing-rhv-default[X]
-|xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[X]
-|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc#installing-vsphere-installer-provisioned[X]
-|xref:../installing/installing_vmc/installing-vmc.adoc#installing-vmc[X]
+|xref:../installing/installing_rhv/installing-rhv-default.adoc#installing-rhv-default[&#10003;]
+|xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[&#10003;]
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc#installing-vsphere-installer-provisioned[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc.adoc#installing-vmc[&#10003;]
 |
 |
 
 |Custom
-|xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[X]
-|xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[X]
-|xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[X]
-|xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#installing-openstack-installer-custom[X]
-|xref:../installing/installing_rhv/installing-rhv-customizations.adoc#installing-rhv-customizations[X]
+|xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[&#10003;]
+|xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#installing-openstack-installer-custom[&#10003;]
+|xref:../installing/installing_rhv/installing-rhv-customizations.adoc#installing-rhv-customizations[&#10003;]
 |
-|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installing-vsphere-installer-provisioned-customizations[X]
-|xref:../installing/installing_vmc/installing-vmc-customizations.adoc#installing-vmc-customizations[X]
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installing-vsphere-installer-provisioned-customizations[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc-customizations.adoc#installing-vmc-customizations[&#10003;]
 |
 |
 
 |Network customization
-|xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[X]
-|xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[X]
-|xref:../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[X]
-|xref:../installing/installing_openstack/installing-openstack-installer-kuryr.adoc#installing-openstack-installer-kuryr[X]
+|xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[&#10003;]
+|xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-installer-kuryr.adoc#installing-openstack-installer-kuryr[&#10003;]
 |
 |
-|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#installing-vsphere-installer-provisioned-network-customizations[X]
-|xref:../installing/installing_vmc/installing-vmc-network-customizations.adoc#installing-vmc-network-customizations[X]
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#installing-vsphere-installer-provisioned-network-customizations[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc-network-customizations.adoc#installing-vmc-network-customizations[&#10003;]
 |
 |
 
 |Restricted network
-|xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[X]
+|xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[&#10003;]
 |
-|xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[X]
-|xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[X]
-|xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[X]
-|
-|xref:../installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[X]
-|xref:../installing/installing_vmc/installing-restricted-networks-vmc.adoc#installing-restricted-networks-vmc[X]
+|xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[&#10003;]
+|xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[&#10003;]
+|xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-install-installation-workflow[&#10003;]
+|xref:../installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[&#10003;]
+|xref:../installing/installing_vmc/installing-restricted-networks-vmc.adoc#installing-restricted-networks-vmc[&#10003;]
 |
 |
 
 |Private clusters
-|xref:../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[X]
-|xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[X]
-|xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[X]
+|xref:../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[&#10003;]
+|xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[&#10003;]
 |
 |
 |
@@ -175,9 +175,9 @@ endif::openshift-origin[]
 |
 
 |Existing virtual private networks
-|xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[X]
-|xref:../installing/installing_azure/installing-azure-vnet.adoc#installing-azure-vnet[X]
-|xref:../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[X]
+|xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[&#10003;]
+|xref:../installing/installing_azure/installing-azure-vnet.adoc#installing-azure-vnet[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[&#10003;]
 |
 |
 |
@@ -187,8 +187,8 @@ endif::openshift-origin[]
 |
 
 |Government regions
-|xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[X]
-|xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[X]
+|xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[&#10003;]
+|xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[&#10003;]
 |
 |
 |
@@ -211,20 +211,20 @@ endif::openshift-origin[]
 
 
 |Custom
-|xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[X]
-|xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[X]
-|xref:../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[X]
-|xref:../installing/installing_openstack/installing-openstack-user.adoc#installing-openstack-user[X]
-|xref:../installing/installing_openstack/installing-openstack-user-sr-iov.adoc#installing-openstack-user-sr-iov[X]
-|xref:../installing/installing_rhv/installing-rhv-user-infra.adoc#installing-rhv-user-infra[X]
-|xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[X]
-|xref:../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[X]
-|xref:../installing/installing_vmc/installing-vmc-user-infra.adoc#installing-vmc-user-infra[X]
-|xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[X]
-|xref:../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[X]
-|xref:../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power[X]
+|xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[&#10003;]
+|xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-user.adoc#installing-openstack-user[&#10003;]
+|xref:../installing/installing_openstack/installing-openstack-user-sr-iov.adoc#installing-openstack-user-sr-iov[&#10003;]
+|xref:../installing/installing_rhv/installing-rhv-user-infra.adoc#installing-rhv-user-infra[&#10003;]
+|xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[&#10003;]
+|xref:../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc-user-infra.adoc#installing-vmc-user-infra[&#10003;]
+|xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[&#10003;]
+|xref:../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[&#10003;]
+|xref:../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power[&#10003;]
 |
-xref:../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installing-platform-agnostic[X]
+xref:../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installing-platform-agnostic[&#10003;]
 
 // Add RHV UPI link when docs are available: https://github.com/openshift/openshift-docs/pull/26484
 
@@ -232,36 +232,36 @@ xref:../installing/installing_platform_agnostic/installing-platform-agnostic.ado
 |
 |
 |
-|xref:../installing/installing_openstack/installing-openstack-user-kuryr.adoc#installing-openstack-user-kuryr[X]
+|xref:../installing/installing_openstack/installing-openstack-user-kuryr.adoc#installing-openstack-user-kuryr[&#10003;]
 |
 |
-|xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[X]
-|xref:../installing/installing_vsphere/installing-vsphere-network-customizations.adoc#installing-vsphere-network-customizations[X]
-|xref:../installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc#installing-vmc-network-customizations-user-infra[X]
+|xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[&#10003;]
+|xref:../installing/installing_vsphere/installing-vsphere-network-customizations.adoc#installing-vsphere-network-customizations[&#10003;]
+|xref:../installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc#installing-vmc-network-customizations-user-infra[&#10003;]
 |
 |
 |
 |
 
 |Restricted network
-|xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[X]
+|xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[&#10003;]
 |
-|xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[X]
+|xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[&#10003;]
 |
 |
 |
-|xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[X]
-|xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[X]
-|xref:../installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc#installing-restricted-networks-vmc-user-infra[X]
-|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[X]
-|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[X]
-|xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[X]
+|xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[&#10003;]
+|xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[&#10003;]
+|xref:../installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc#installing-restricted-networks-vmc-user-infra[&#10003;]
+|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[&#10003;]
+|xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[&#10003;]
+|xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[&#10003;]
 |
 
 |Shared VPC hosted outside of cluster project
 |
 |
-|xref:../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[X]
+|xref:../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[&#10003;]
 |
 |
 |


### PR DESCRIPTION
Version(s):
Enterprise-4.8

Issue:
(https://bugzilla.redhat.com/show_bug.cgi?id=2009339)

Link to docs preview:
(http://file.emea.redhat.com/tshwartz/BZ-2009339-48/installing/installing-preparing.html)

Additional information:

    Added Restricted Network support for Bare Metal in the Installer-Provisioned Infrastructure Options table.
    Added a second sentence to the note above the table.
    Replaced X with ✓across the two tables.


NoteL Line 151 was added - not sure why it's not appearing in green.

<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->

Refs https://github.com/openshift/openshift-docs/pull/49195