### PR TITLE
TELCODOCS-504 - Remove chronyd note in enterprise-4.10

### DIFF
--- a/modules/ztp-checking-du-cluster-config.adoc
+++ b/modules/ztp-checking-du-cluster-config.adoc
@@ -188,16 +188,11 @@ sh-4.4# systemctl status chronyd
 [source,terminal]
 ----
 ● chronyd.service - NTP client/server
-  Loaded: loaded (/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: enabled)
-  Drop-In: /etc/systemd/system/chronyd.service.d
-  └─20-conditional-start.conf
-  Active: inactive (dead) since Mon 2022-07-18 10:55:01 UTC; 3h 33min ago
+    Loaded: loaded (/usr/lib/systemd/system/chronyd.service; disabled; vendor preset: enabled)
+    Active: inactive (dead)
+      Docs: man:chronyd(8)
+            man:chrony.conf(5)
 ----
-+
-[NOTE]
-====
-In {product-title} {product-version}, `chronyd` is dynamically started or stopped depending on whether or not the node is synced to the primary clock. If the PTP interface loses the `LOCKED` state, `chronyd` is restarted. When the interface returns to the `LOCKED` state, `chronyd` is automatically disabled.
-====
 
 . Check that the PTP interface is successfully synchronized to the primary clock using a remote shell connection to the `linuxptp-daemon` container and the PTP Management Client (`pmc`) tool:
 
@@ -491,6 +486,7 @@ spec:
       group.ice-ptp=0:f:10:*:ice-ptp.*
       [service]
       service.stalld=start,enable
+      service.chronyd=stop,disable
     name: performance-patch
   recommend:
   - machineConfigLabels:


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-504

cherry-pick https://github.com/openshift/openshift-docs/pull/48977 to enterprise-4.10

Preview: http://file.emea.redhat.com/aireilly/backport-chronyd-change/scalability_and_performance/ztp-vdu-validating-cluster-tuning.html#ztp-checking-du-cluster-config_vdu-config-ref

(search for `chronyd.service - NTP client/server`)