### PR TITLE
OSDOCS-3803 - Adding custom ARN path content for ROSA

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -6,8 +6,51 @@
 [id="rosa-create-objects_{context}"]
 = Create objects
 
-
 This section describes the `create` commands for clusters and resources.
+
+[id="rosa-create-account-roles_{context}"]
+== create account-roles
+
+Create the needed account-wide role and policy resources for your cluster.
+
+.Syntax
+[source,terminal]
+----
+$ rosa create account-roles [flags]
+----
+
+.Flags
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--debug
+|Enable debug mode.
+
+|-i, --interactive
+|Enable interactive mode.
+
+|-m, --mode string
+|How to perform the operation. Valid options are:
+    auto: Resource changes will be automatic applied using the current AWS account
+    manual: Commands necessary to modify AWS resources will be output to be run manually
+
+|--path string
+|The ARN path for the account-wide roles and policies, including the Operator policies.
+
+|--permissions-boundary string
+|The ARN of the policy that is used to set the permissions boundary for the account roles.
+
+|--prefix string
+|User-defined prefix for all generated AWS resources. The default is `ManagedOpenShift`.
+
+|--profile string
+|Use a specific AWS profile from your credential file.
+
+|-y, --yes
+|Automatically answer yes to confirm operation.
+
+|===
 
 [id="rosa-create-admin_{context}"]
 == create admin
@@ -83,6 +126,9 @@ $ rosa create cluster --cluster=<cluster_name> | <cluster_id> [arguments]
 |--compute-nodes
 |The number (integer) of worker nodes to provision per zone. Single-zone clusters require at least 2 nodes. Multi-zone clusters require at least 3 nodes. Default: `2` for single-az; `3` for multi-az
 
+|--controlplane-iam-role string
+|The Amazon Resource Name (ARN) of the IAM role that will be attached to control plane instances.
+
 |--disable-scp-checks
 |Indicates whether cloud permission checks are disabled when attempting to install a cluster.
 
@@ -119,17 +165,25 @@ $ rosa create cluster --cluster=<cluster_name> | <cluster_id> [arguments]
 |--region
 |The AWS region (string) where your worker pool will be located. This argument overrides the `AWS_REGION` environment variable.
 
+|--role-arn string
+|The Amazon Resource Name (ARN) of the installer role that {cluster-manager} will assume to create the cluster.
+
 |--service-cidr
 |Block of IP addresses (ipNet) for services. Example: `172.30.0.0/16`
 
 |--subnet-ids
 |The subnet IDs (string) to use when installing the cluster. Subnet IDs must be in pairs with one private subnet ID and one public subnet ID per availability zone. Subnets are comma-delimited. Example: `--subnet-ids=subnet-1,subnet-2`. Leave the value empty for installer-provisioned subnet IDs.
 
-
 When using `--private-link`, the `--subnet-ids` argument is required and only one private subnet is allowed per zone.
+
+|--support-role-arn string
+|The Amazon Resource Name (ARN) of the role used by Red Hat Site Reliabilty Engineers (SREs) to enable access to the cluster account to provide support.
 
 |--version
 |The version (string) of OpenShift Container Platform that will be used to install the cluster. Example: `4.3.10`
+
+|--worker-iam-role string
+|The Amazon Resource Name (ARN) of the IAM role that will be attached to compute instances.
 |===
 
 .Optional arguments inherited from parent commands
@@ -499,7 +553,7 @@ $ rosa create machinepool --cluster=mycluster --replicas=2 --instance-type=r5.2x
 [id="rosa-create-ocm-role_{context}"]
 == create ocm-role
 
-Create the needed ocm-role resources for your cluster.
+Create the required ocm-role resources for your cluster.
 
 .Syntax
 [source,terminal]
@@ -522,25 +576,73 @@ $ rosa create ocm-role [flags]
 |Enable interactive mode.
 
 |-m, --mode string
-|How to perform the operation. Valid options are:
-    auto: Resource changes will be automatic applied using the current AWS account
-    manual: Commands necessary to modify AWS resources will be output to be run manually
+a|How to perform the operation. Valid options are:
+
+* `auto`: Resource changes will be automatic applied using the current AWS account
+* `manual`: Commands necessary to modify AWS resources will be output to be run manually
+
+|--path string
+|The ARN path for the OCM role and policies.
 
 |--permissions-boundary string
 |The ARN of the policy that is used to set the permissions boundary for the OCM role.
 
 |--prefix string
-|User-defined prefix for all generated AWS resources (default "ManagedOpenShift")
+|User-defined prefix for all generated AWS resources. The default is `ManagedOpenShift`.
 
 |--profile string
 |Use a specific AWS profile from your credential file.
-
-|--region string
-|Use a specific AWS region, overriding the AWS_REGION environment variable.
 
 |-y, --yes
 |Automatically answer yes to confirm operation.
 
 |===
 
-For more information about the ocm-roles and the roles created with the `rosa create ocm-roles`, see the Additional resources section.
+For more information about the OCM role created with the `rosa create ocm-role` command, see _Account-wide IAM role and policy reference_.
+
+[id="rosa-create-user-role_{context}"]
+== create user-role
+
+Create the required user-role resources for your cluster.
+
+.Syntax
+[source,terminal]
+----
+$ rosa create user-role [flags]
+----
+
+.Flags
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--debug
+|Enable debug mode.
+
+|-i, --interactive
+|Enable interactive mode.
+
+|-m, --mode string
+a|How to perform the operation. Valid options are:
+
+* `auto`: Resource changes will be automatic applied using the current AWS account
+* `manual`: Commands necessary to modify AWS resources will be output to be run manually
+
+|--path string
+|The ARN path for the user role and policies.
+
+|--permissions-boundary string
+|The ARN of the policy that is used to set the permissions boundary for the user role.
+
+|--prefix string
+|User-defined prefix for all generated AWS resources The default is `ManagedOpenShift`.
+
+|--profile string
+|Use a specific AWS profile from your credential file.
+
+|-y, --yes
+|Automatically answer yes to confirm operation.
+
+|===
+
+For more information about the user role created with the `rosa create user-role` command, see _Understanding AWS account association_.

--- a/modules/rosa-sts-arn-path-customization-for-iam-roles-and-policies.adoc
+++ b/modules/rosa-sts-arn-path-customization-for-iam-roles-and-policies.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-creating-a-cluster-with-customizations.adoc
+
+:_content-type: CONCEPT
+[id="rosa-sts-arn-path-customization-for-iam-roles-and-policies_{context}"]
+= ARN path customization for IAM roles and policies
+
+When you create the AWS IAM roles and policies required for {product-title} (ROSA) clusters that use the AWS Security Token Service (STS), you can specify custom Amazon Resource Name (ARN) paths. This enables you to use role and policy ARN paths that meet the security requirements of your organization.
+
+You can specify custom ARN paths when you create your OCM role, user role, and account-wide roles and policies.
+
+If you define a custom ARN path when you create a set of account-wide roles and policies, the same path is applied to all of the roles and policies in the set. The following example shows the ARNs for a set of account-wide roles and policies. In the example, the ARNs use the custom path `/test/path/dev/` and the custom role prefix `test-env`:
+
+* `arn:aws:iam::<account_id>:role/test/path/dev/test-env-Worker-Role`
+* `arn:aws:iam::<account_id>:role/test/path/dev/test-env-Support-Role`
+* `arn:aws:iam::<account_id>:role/test/path/dev/test-env-Installer-Role`
+* `arn:aws:iam::<account_id>:role/test/path/dev/test-env-ControlPlane-Role`
+* `arn:aws:iam::<account_id>:policy/test/path/dev/test-env-Worker-Role-Policy`
+* `arn:aws:iam::<account_id>:policy/test/path/dev/test-env-Support-Role-Policy`
+* `arn:aws:iam::<account_id>:policy/test/path/dev/test-env-Installer-Role-Policy`
+* `arn:aws:iam::<account_id>:policy/test/path/dev/test-env-ControlPlane-Role-Policy`
+
+When you create the cluster-specific Operator roles, the ARN path for the relevant account-wide installer role is automatically detected and applied to the Operator roles.
+
+For more information about ARN paths, see link:https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[Amazon Resource Names (ARNs)] in the AWS documentation.

--- a/modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
@@ -39,9 +39,7 @@ endif::[]
 
 . On the *Create an OpenShift cluster* page, select *Create cluster* in the *{product-title} (ROSA)* row.
 
-. Review and complete the *Prerequisites* listed on the *Accounts and roles* page. Select the checkbox to acknowledge that you have read and completed all of the prerequisites.
-
-. Verify that your AWS account ID is listed in the *Associated AWS accounts* drop-down menu and that the installer, support, worker, and control plane account role Amazon Resource Names (ARNs) are listed on the *Accounts and roles* page.
+. Verify that your AWS account ID is listed in the *Associated AWS accounts* drop-down menu and that the installer, support, worker, and control plane account role Amazon Resource Names (ARNs) are listed on the *Accounts and roles* page. 
 +
 [NOTE]
 ====

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -42,9 +42,57 @@ To successfully install ROSA clusters, use latest version of the ROSA CLI.
 +
 [source,terminal]
 ----
-$ rosa create account-roles --mode manual <1>
+$ rosa create account-roles --interactive \ <1>
+                            --mode manual <2>
 ----
-<1> `manual` mode generates the `aws` CLI commands and JSON files needed to create the account-wide roles and policies. After review, you must run the commands manually to create the resources.
+<1> `interactive` mode enables you to specify configuration options at the interactive prompts. For more information, see _Interactive cluster creation mode reference_.
+<2> `manual` mode generates the `aws` CLI commands and JSON files needed to create the account-wide roles and policies. After review, you must run the commands manually to create the resources.
++
+--
+.Example output
+[source,terminal]
+----
+I: Logged in as '<red_hat_username>' on 'https://api.openshift.com'
+I: Validating AWS credentials...
+I: AWS credentials are valid!
+I: Validating AWS quota...
+I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
+I: Verifying whether OpenShift command-line tool is available...
+I: Current OpenShift Client Version: 4.11.6
+I: Creating account roles
+? Role prefix: ManagedOpenShift <1>
+? Permissions boundary ARN (optional): <2>
+? Path (optional): [? for help] <3>
+? Role creation mode: auto <4>
+I: Creating roles using 'arn:aws:iam::<aws_account_number>:user/<aws_username>'
+? Create the 'ManagedOpenShift-Installer-Role' role? Yes <5>
+I: Created role 'ManagedOpenShift-Installer-Role' with ARN 'arn:aws:iam::<aws_account_number>:role/ManagedOpenShift-Installer-Role'
+? Create the 'ManagedOpenShift-ControlPlane-Role' role? Yes <5>
+I: Created role 'ManagedOpenShift-ControlPlane-Role' with ARN 'arn:aws:iam::<aws_account_number>:role/ManagedOpenShift-ControlPlane-Role'
+? Create the 'ManagedOpenShift-Worker-Role' role? Yes <5>
+I: Created role 'ManagedOpenShift-Worker-Role' with ARN 'arn:aws:iam::<aws_account_number>:role/ManagedOpenShift-Worker-Role'
+? Create the 'ManagedOpenShift-Support-Role' role? Yes <5>
+I: Created role 'ManagedOpenShift-Support-Role' with ARN 'arn:aws:iam::<aws_account_number>:role/ManagedOpenShift-Support-Role'
+I: To create a cluster with these roles, run the following command:
+rosa create cluster --sts
+----
+<1> Specify the prefix to include in the {cluster-manager} IAM role name. The default is `ManagedOpenShift`.
++
+[IMPORTANT]
+====
+You must specify an account-wide role prefix that is unique across your AWS account, even if you use a custom ARN path for your account roles.
+====
++
+<2> Optional: Specifies a permissions boundary Amazon Resource Name (ARN) for the role. For more information, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html[Permissions boundaries for IAM entities] in the AWS documentation.
+<3> Specify a custom ARN path for your account-wide roles. The path must contain alphanumeric characters only and start and end with `/`, for example `/test/path/dev/`. For more information, see _ARN path customization for IAM roles and policies_.
+<4> Select the role creation mode. You can use `auto` mode to automatically create the account wide roles and policies. In `manual` mode, the `rosa` CLI generates the `aws` commands needed to create the roles and policies. In `manual` mode, the corresponding policy JSON files are also saved to the current directory. `manual` mode enables you to review the details before running the `aws` commands manually.
+<5> Creates the account-wide installer, control plane, worker and support roles and corresponding IAM policies. For more information, see _Account-wide IAM role and policy reference_.
++
+[NOTE]
+====
+In this step, the ROSA CLI also automatically creates the account-wide Operator IAM policies that are used by the cluster-specific Operator policies to permit the ROSA cluster Operators to carry out core OpenShift functionality. For more information, see _Account-wide IAM role and policy reference_.
+====
+--
 +
 .. After review, run the `aws` commands manually to create the roles and policies. Alternatively, you can run the preceding command using `--mode auto` to run the `aws` commands immediately.
 
@@ -168,6 +216,7 @@ I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for th
 ? AWS region: us-east-1
 ? PrivateLink cluster (optional): No
 ? Install into an existing VPC (optional): No
+? Select availability zones (optional): No
 ? Enable Customer Managed key (optional): No <5>
 ? Compute nodes instance type (optional):
 ? Enable autoscaling (optional): No
@@ -184,12 +233,16 @@ I: To create this cluster again in the future, you can run:
 I: To view a list of clusters and their status, run 'rosa list clusters'
 I: Cluster '<cluster_name>' has been created.
 I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
-I: To determine when your cluster is Ready, run 'rosa describe cluster -c <cluster_name>'.
-I: To watch your cluster installation logs, run 'rosa logs install -c <cluster_name> --watch'.
+...
 ----
 <1> When creating the cluster, the listed `OpenShift version` options include the major, minor, and patch versions, for example `4.8.9`.
-<2> If more than one matching set of account-wide roles are available in your account for a cluster version, an interactive list of options is provided.
+<2> If you have more than one set of account roles in your AWS account for your cluster version, an interactive list of options is provided.
 <3> Optional: By default, the cluster-specific Operator role names are prefixed with the cluster name and random 4-digit hash. You can optionally specify a custom prefix to replace `<cluster_name>-<hash>` in the role names. The prefix is applied when you create the cluster-specific Operator IAM roles. For information about the prefix, see _Defining an Operator IAM role prefix_.
++
+[NOTE]
+====
+If you specified custom ARN paths when you created the associated account-wide roles, the custom path is automatically detected. The custom path is applied to the cluster-specific Operator roles when you create them in a later step.
+====
 <4> Multiple availability zones are recommended for production workloads. The default is a single availability zone.
 <5> Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, worker node root volumes, and PVs. Specify the ARN for the KMS key that you added to the account-wide role ARN to in the preceding step.
 +
@@ -230,6 +283,8 @@ $ rosa create operator-roles --mode manual --cluster <cluster_name|cluster_id> <
 [NOTE]
 ====
 A custom prefix is applied to the Operator role names if you specified the prefix in the preceding step.
+
+If you specified custom ARN paths when you created the associated account-wide roles, the custom path is automatically detected and applied to the Operator roles.
 ====
 
 . Create the OpenID Connect (OIDC) provider that the cluster Operators use to authenticate:

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -38,8 +38,6 @@ To successfully install ROSA clusters, use the latest version of the ROSA CLI.
 
 . On the *Create an OpenShift cluster* page, select *Create cluster* in the *{product-title} (ROSA)* row.
 
-. Review and complete the *Prerequisites* listed on the *Accounts and roles* page. Select the checkbox to acknowledge that you have read and completed all of the prerequisites.
-
 . If an AWS account is automatically detected, the account ID is listed in the *Associated AWS accounts* drop-down menu. If no AWS accounts are automatically detected, click *Select an account* -> *Associate AWS account* and follow these steps:
 +
 .. On the *Authenticate* page, click the copy button next to the `rosa login` command. The command includes your {cluster-manager} API login token.
@@ -80,20 +78,22 @@ I: Creating ocm role
 ? Role prefix: ManagedOpenShift <1>
 ? Enable admin capabilities for the OCM role (optional): No <2>
 ? Permissions boundary ARN (optional):  <3>
-? Role creation mode: auto <4>
+? Role Path (optional): <4>
+? Role creation mode: auto <5>
 I: Creating role using 'arn:aws:iam::<aws_account_id>:user/<aws_username>'
 ? Create the 'ManagedOpenShift-OCM-Role-<red_hat_organization_external_id>' role? Yes
 I: Created role 'ManagedOpenShift-OCM-Role-<red_hat_organization_external_id>' with ARN 'arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-OCM-Role-<red_hat_organization_external_id>'
 I: Linking OCM role
 ? OCM Role ARN: arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-OCM-Role-<red_hat_organization_external_id>
-? Link the 'arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-OCM-Role-<red_hat_organization_external_id>' role with organization '<red_hat_organization_id>'? Yes <5>
+? Link the 'arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-OCM-Role-<red_hat_organization_external_id>' role with organization '<red_hat_organization_id>'? Yes <6>
 I: Successfully linked role-arn 'arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-OCM-Role-<red_hat_organization_external_id>' with organization account '<red_hat_organization_id>'
 ----
-<1> Specifies the prefix to include in the {cluster-manager} IAM role name. The default is `ManagedOpenShift`.
-<2> Enables the admin {cluster-manager} IAM role, which is equivalent to specifying the `--admin` argument. The admin role is required if you want to use *Auto* mode to automatically provision the cluster-specific Operator roles and the OIDC provider by using {cluster-manager}.
-<3> Optional: Specifies a permissions boundary Amazon Resource Name (ARN) for the role. For more information, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html[Permissions boundaries for IAM entities] in the AWS documentation.
-<4> Selects the role creation mode. You can use `auto` mode to automatically create the {cluster-manager} IAM role and link it to your Red Hat organization account. In `manual` mode, the `rosa` CLI generates the `aws` commands needed to create and link the role. In `manual` mode, the corresponding policy JSON files are also saved to the current directory. `manual` mode enables you to review the details before running the `aws` commands manually.
-<5> Links the {cluster-manager} IAM role to your Red Hat organization account.
+<1> Specify the prefix to include in the OCM IAM role name. The default is `ManagedOpenShift`. You can create only one OCM role per AWS account for your Red Hat organization.
+<2> Enable the admin {cluster-manager} IAM role, which is equivalent to specifying the `--admin` argument. The admin role is required if you want to use *Auto* mode to automatically provision the cluster-specific Operator roles and the OIDC provider by using {cluster-manager}.
+<3> Optional: Specify a permissions boundary Amazon Resource Name (ARN) for the role. For more information, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html[Permissions boundaries for IAM entities] in the AWS documentation.
+<4> Specify a custom ARN path for your OCM role. The path must contain alphanumeric characters only and start and end with `/`, for example `/test/path/dev/`. For more information, see _ARN path customization for IAM roles and policies_.
+<5> Select the role creation mode. You can use `auto` mode to automatically create the {cluster-manager} IAM role and link it to your Red Hat organization account. In `manual` mode, the `rosa` CLI generates the `aws` commands needed to create and link the role. In `manual` mode, the corresponding policy JSON files are also saved to the current directory. `manual` mode enables you to review the details before running the `aws` commands manually.
+<6> Link the {cluster-manager} IAM role to your Red Hat organization account.
 .. If you opted not to link the {cluster-manager} IAM role to your Red Hat organization account in the preceding command, copy the `rosa link` command from the {cluster-manager} *OCM role* page and run it:
 +
 [source,terminal]
@@ -117,19 +117,21 @@ $ rosa create user-role
 I: Creating User role
 ? Role prefix: ManagedOpenShift <1>
 ? Permissions boundary ARN (optional): <2>
-? Role creation mode: auto <3>
+? Role Path (optional): [? for help] <3>
+? Role creation mode: auto <4>
 I: Creating ocm user role using 'arn:aws:iam::<aws_account_id>:user/<aws_username>'
-? Create the 'ManagedOpenShift-User-<ocm_username>-Role' role? Yes
-I: Created role 'ManagedOpenShift-User-<ocm_username>-Role' with ARN 'arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-User-<ocm_username>-Role'
+? Create the 'ManagedOpenShift-User-<red_hat_username>-Role' role? Yes
+I: Created role 'ManagedOpenShift-User-<red_hat_username>-Role' with ARN 'arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-User-<red_hat_username>-Role'
 I: Linking User role
-? User Role ARN: arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-User-<ocm_username>-Role
-? Link the 'arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-User-<ocm_username>-Role' role with account '<ocm_user_account_id>'? Yes <4>
-I: Successfully linked role ARN 'arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-User-<ocm_username>-Role' with account '<ocm_user_account_id>'
+? User Role ARN: arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-User-<red_hat_username>-Role
+? Link the 'arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-User-<red_hat_username>-Role' role with account '<red_hat_user_account_id>'? Yes <5>
+I: Successfully linked role ARN 'arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-User-<red_hat_username>-Role' with account '<red_hat_user_account_id>'
 ----
-<1> Specifies the prefix to include in the user role name. The default is `ManagedOpenShift`.
-<2> Optional: Specifies a permissions boundary Amazon Resource Name (ARN) for the role. For more information, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html[Permissions boundaries for IAM entities] in the AWS documentation.
-<3> Selects the role creation mode. You can use `auto` mode to automatically create the user role and link it to your {cluster-manager} user account. In `manual` mode, the `rosa` CLI generates the `aws` commands needed to create and link the role. In `manual` mode, the corresponding policy JSON files are also saved to the current directory. `manual` mode enables you to review the details before running the `aws` commands manually.
-<4> Links the user role to your {cluster-manager} user account.
+<1> Specify the prefix to include in the user role name. The default is `ManagedOpenShift`.
+<2> Optional: Specify a permissions boundary Amazon Resource Name (ARN) for the role. For more information, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html[Permissions boundaries for IAM entities] in the AWS documentation.
+<3> Specify a custom ARN path for your user role. The path must contain alphanumeric characters only and start and end with `/`, for example `/test/path/dev/`. For more information, see _ARN path customization for IAM roles and policies_.
+<4> Select the role creation mode. You can use `auto` mode to automatically create the user role and link it to your {cluster-manager} user account. In `manual` mode, the `rosa` CLI generates the `aws` commands needed to create and link the role. In `manual` mode, the corresponding policy JSON files are also saved to the current directory. `manual` mode enables you to review the details before running the `aws` commands manually.
+<5> Link the user role to your {cluster-manager} user account.
 .. If you opted not to link the user role to your {cluster-manager} user account in the preceding command, copy the `rosa link` command from the {cluster-manager} *User role* page and run it:
 +
 [source,terminal]
@@ -146,45 +148,54 @@ $ rosa link user-role <arn> <1>
 $ rosa create account-roles
 ----
 +
+--
 .Example output
 [source,terminal]
 ----
-I: Logged in as '<ocm_username>' on 'https://api.openshift.com'
+I: Logged in as '<red_hat_username>' on 'https://api.openshift.com'
 I: Validating AWS credentials...
 I: AWS credentials are valid!
 I: Validating AWS quota...
 I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
 I: Verifying whether OpenShift command-line tool is available...
-I: Current OpenShift Client Version: 4.9.12
+I: Current OpenShift Client Version: 4.11.6
 I: Creating account roles
 ? Role prefix: ManagedOpenShift <1>
 ? Permissions boundary ARN (optional): <2>
-? Role creation mode: auto <3>
+? Path (optional): [? for help] <3>
+? Role creation mode: auto <4>
 I: Creating roles using 'arn:aws:iam::<aws_account_number>:user/<aws_username>'
-? Create the 'ManagedOpenShift-Installer-Role' role? Yes <4>
+? Create the 'ManagedOpenShift-Installer-Role' role? Yes <5>
 I: Created role 'ManagedOpenShift-Installer-Role' with ARN 'arn:aws:iam::<aws_account_number>:role/ManagedOpenShift-Installer-Role'
-? Create the 'ManagedOpenShift-ControlPlane-Role' role? Yes <4>
+? Create the 'ManagedOpenShift-ControlPlane-Role' role? Yes <5>
 I: Created role 'ManagedOpenShift-ControlPlane-Role' with ARN 'arn:aws:iam::<aws_account_number>:role/ManagedOpenShift-ControlPlane-Role'
-? Create the 'ManagedOpenShift-Worker-Role' role? Yes <4>
+? Create the 'ManagedOpenShift-Worker-Role' role? Yes <5>
 I: Created role 'ManagedOpenShift-Worker-Role' with ARN 'arn:aws:iam::<aws_account_number>:role/ManagedOpenShift-Worker-Role'
-? Create the 'ManagedOpenShift-Support-Role' role? Yes <4>
+? Create the 'ManagedOpenShift-Support-Role' role? Yes <5>
 I: Created role 'ManagedOpenShift-Support-Role' with ARN 'arn:aws:iam::<aws_account_number>:role/ManagedOpenShift-Support-Role'
-? Create the operator policies? Yes <5>
-I: Created policy with ARN 'arn:aws:iam::<aws_account_number>:policy/ManagedOpenShift-openshift-cloud-credential-operator-cloud-crede'
-I: Created policy with ARN 'arn:aws:iam::<aws_account_number>:policy/ManagedOpenShift-openshift-image-registry-installer-cloud-creden'
-I: Created policy with ARN 'arn:aws:iam::<aws_account_number>:policy/ManagedOpenShift-openshift-ingress-operator-cloud-credentials'
-I: Created policy with ARN 'arn:aws:iam::<aws_account_number>:policy/ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credent'
-I: Created policy with ARN 'arn:aws:iam::<aws_account_number>:policy/ManagedOpenShift-openshift-cloud-network-config-controller-cloud'
-I: Created policy with ARN 'arn:aws:iam::<aws_account_number>:policy/ManagedOpenShift-openshift-machine-api-aws-cloud-credentials'
 I: To create a cluster with these roles, run the following command:
 rosa create cluster --sts
 ----
-<1> Specifies the prefix to include in the {cluster-manager} IAM role name. The default is `ManagedOpenShift`.
-<2> Optional: Specifies a permissions boundary Amazon Resource Name (ARN) for the role. For more information, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html[Permissions boundaries for IAM entities] in the AWS documentation.
-<3> Selects the role creation mode. You can use `auto` mode to automatically create the account wide roles and policies. In `manual` mode, the `rosa` CLI generates the `aws` commands needed to create the roles and policies. In `manual` mode, the corresponding policy JSON files are also saved to the current directory. `manual` mode enables you to review the details before running the `aws` commands manually.
-<4> Creates the account-wide installer, control plane, worker and support roles and corresponding IAM policies. For more information, see _Account-wide IAM role and policy reference_.
-<5> Creates the cluster-specific Operator IAM roles that permit the ROSA cluster Operators to carry out core OpenShift functionality. For more information, see _Account-wide IAM role and policy reference_.
+<1> Specify the prefix to include in the {cluster-manager} IAM role name. The default is `ManagedOpenShift`.
++
+[IMPORTANT]
+====
+You must specify an account-wide role prefix that is unique across your AWS account, even if you use a custom ARN path for your account roles.
+====
++
+<2> Optional: Specify a permissions boundary Amazon Resource Name (ARN) for the role. For more information, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html[Permissions boundaries for IAM entities] in the AWS documentation.
+<3> Specify a custom ARN path for your account-wide roles. The path must contain alphanumeric characters only and start and end with `/`, for example `/test/path/dev/`. For more information, see _ARN path customization for IAM roles and policies_.
+<4> Select the role creation mode. You can use `auto` mode to automatically create the account wide roles and policies. In `manual` mode, the `rosa` CLI generates the `aws` commands needed to create the roles and policies. In `manual` mode, the corresponding policy JSON files are also saved to the current directory. `manual` mode enables you to review the details before running the `aws` commands manually.
+<5> Creates the account-wide installer, control plane, worker and support roles and corresponding IAM policies. For more information, see _Account-wide IAM role and policy reference_.
++
+[NOTE]
+====
+In this step, the ROSA CLI also automatically creates the account-wide Operator IAM policies that are used by the cluster-specific Operator policies to permit the ROSA cluster Operators to carry out core OpenShift functionality. For more information, see _Account-wide IAM role and policy reference_.
+====
+--
 .. On the *Accounts and roles* page, click *Refresh ARNs* and verify that the installer, support, worker, and control plane account role ARNs are listed.
++
+If you have more than one set of account roles in your AWS account for your cluster version, a drop-down list of *Installer role* ARNs is provided. Select the ARN for the installer role that you want to use with your cluster. The cluster uses the account-wide roles and policies that relate to the selected installer role.
 
 . Click *Next*.
 +
@@ -304,11 +315,11 @@ CIDR configurations cannot be changed later. Confirm your selections with your n
 //With *Manual* mode, you can use either AWS CloudFormation, `rosa` CLI commands, or `aws` CLI commands to generate the required Operator roles and OIDC provider for your cluster. *Manual* mode enables you to review the details before using your preferred option to create the IAM resources manually and complete your cluster installation.
 With *Manual* mode, you can use either `rosa` CLI commands or `aws` CLI commands to generate the required Operator roles and OIDC provider for your cluster. *Manual* mode enables you to review the details before using your preferred option to create the IAM resources manually and complete your cluster installation.
 +
-Alternatively, you can use *Auto* mode to automatically create the Operator roles and OIDC provider.
+Alternatively, you can use *Auto* mode to automatically create the Operator roles and OIDC provider. To enable *Auto* mode, the {cluster-manager} IAM role must have administrator capabilities.
 +
 [NOTE]
 ====
-To enable *Auto* mode, the {cluster-manager} IAM role must have administrator capabilities.
+If you specified custom ARN paths when you created the associated account-wide roles, the custom path is automatically detected and applied to the Operator roles. The custom ARN path is applied when the Operator roles are created by using either *Manual* or *Auto* mode.
 ====
 
 . Optional: Specify a *Custom operator roles prefix* for your cluster-specific Operator IAM roles.
@@ -359,6 +370,11 @@ In the event of critical security concerns that significantly impact the securit
 You must run the `aws` commands in the directory that contains the policy files.
 ====
 ** If you opted to use the *ROSA CLI* method, click the copy button next to the `rosa create` commands and run them in the CLI.
++
+[NOTE]
+====
+If you specified custom ARN paths when you created the associated account-wide roles, the custom path is automatically detected and applied to the Operator roles when you create them by using these manual methods.
+====
 .. In the *Action required to continue installation* dialog, click *x* to return to the *Overview* page for your cluster.
 .. Verify that the cluster *Status* in the *Details* section of the *Overview* page for your cluster has changed from *Waiting* to *Installing*. There might be a short delay of approximately two minutes before the status changes.
 --

--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -2,13 +2,15 @@
 //
 // * rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-interactive-mode-reference.adoc
 
-:_content-type: CONCEPT
-[id="rosa-sts-understanding-interactive-mode-options_{context}"]
-= Understanding the interactive cluster creation mode options
+:_content-type: REFERENCE
+[id="rosa-sts-interactive-cluster-creation-mode-options_{context}"]
+= Interactive cluster creation mode options
 
-You can create a {product-title} cluster with the AWS Security Token Service (STS) by using the interactive mode. You can enable the mode by specifying the `--interactive` option when you run `rosa create cluster`. The following table describes the interactive mode options.
+You can create a {product-title} cluster with the AWS Security Token Service (STS) by using the interactive mode. You can enable the mode by specifying the `--interactive` option when you run `rosa create cluster`.
 
-.`--interactive` mode options
+The following table describes the interactive cluster creation mode options:
+
+.`--interactive` cluster creation mode options
 [cols=".^2,.^3a",options="header"]
 |===
 
@@ -23,31 +25,37 @@ You can create a {product-title} cluster with the AWS Security Token Service (ST
 |`OpenShift version`
 |Select the version of OpenShift to install, for example `4.3.12`. The default is the latest version.
 
+|`Installer role ARN`
+|If you have more than one set of account roles in your AWS account for your cluster version, a list of installer role ARNs are provided. Select the ARN for the installer role that you want to use with your cluster. The cluster uses the account-wide roles and policies that relate to the selected installer role.
+
 |`External ID (optional)`
 |Specify an unique identifier that is passed by {cluster-manager} and the OpenShift installer when an account role is assumed. This option is only required for custom account roles that expect an external ID.
 
 |`Operator roles prefix`
 |Enter a prefix to assign to the cluster-specific Operator IAM roles. The default is the name of the cluster and a 4-digit random string, for example `my-rosa-cluster-a0b1`.
 
-|`Multiple availability zones`
+|`Multiple availability zones (optional)`
 |Deploy the cluster to multiple availability zones in the AWS region. The default is `No`, which results in a cluster being deployed to a single availability zone. If you deploy a cluster into multiple availability zones, the AWS region must have at least 3 availability zones. Multiple availability zones are recommended for production workloads.
 
 |`AWS region`
 |Specify the AWS region to deploy the cluster in. This overrides the `AWS_REGION` environment variable.
 
-|`PrivateLink cluster`
+|`PrivateLink cluster (optional)`
 |Create a cluster using AWS PrivateLink. This option provides private connectivity between Virtual Private Clouds (VPCs), AWS services, and your on-premise networks, without exposing your traffic to the public internet. To provide support, Red Hat Site Reliability Engineering (SRE) can connect to the cluster by using AWS PrivateLink Virtual Private Cloud (VPC) endpoints. This option cannot be changed after a cluster is created. The default is `No`.
 
-|`Install into an existing VPC`
+|`Install into an existing VPC (optional)`
 |Install a cluster into an existing AWS VPC. To use this option, your VPC must have 2 subnets for each availability zone that you are installing the cluster into. The default is `No`.
 
-|`Enable customer managed key`
+|`Select availability zones (optional)`
+|Specify the availability zones to use when installing into an existing AWS VPC. Use a comma-separated list to provide the availability zones. If you specify `No`, the installer selects the availability zones automatically.
+
+|`Enable customer managed key (optional)`
 |Enable this option to use a specific AWS Key Management Service (KMS) key as the encryption key for persistent data. This key functions as the encryption key for control plane, infrastructure, and worker node root volumes. The key is also configured on the default storage class to ensure that persistent volumes created with the default storage class will be encrypted with the specific KMS key. When disabled, the account KMS key for the specified region is used by default to ensure persistent data is always encrypted. The default is `No`.
 
 |`Compute nodes instance type`
 |Select a compute node instance type. The default is `m5.xlarge`.
 
-|`Enable autoscaling`
+|`Enable autoscaling (optional)`
 |Enable compute node autoscaling. The autoscaler adjusts the size of the cluster to meet your deployment demands. The default is `No`.
 
 |`Compute nodes`
@@ -73,7 +81,7 @@ You can create a {product-title} cluster with the AWS Security Token Service (ST
 By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Red Hat recommends that you enable etcd encryption only if you specifically require it for your use case.
 ====
 
-|`Disable workload monitoring`
+|`Disable workload monitoring (optional)`
 |Disable monitoring for user-defined projects. Monitoring for user-defined projects is enabled by default.
 
 |===

--- a/modules/rosa-sts-interactive-ocm-and-user-role-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-ocm-and-user-role-creation-mode-options.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-interactive-mode-reference.adoc
+
+:_content-type: REFERENCE
+[id="rosa-sts-interactive-ocm-and-user-role-creation-mode-options_{context}"]
+= Interactive OCM and user role creation mode options
+
+Before you can use {cluster-manager-first} to create {product-title} (ROSA) clusters that use the AWS Security Token Service (STS), you must associate your AWS account with your Red Hat organization by creating and linking the OCM and user roles. You can enable interactive mode by specifying the `--interactive` option when you run `rosa create ocm-role` or `rosa create user-role`.
+
+The following tables describe the interactive OCM role creation mode options:
+
+.`--interactive` OCM role creation mode options
+[cols=".^2,.^3a",options="header"]
+|===
+
+|Field|Description
+
+|`Role prefix`
+|Specify the prefix to include in the OCM IAM role name. The default is `ManagedOpenShift`. You can create only one OCM role per AWS account for your Red Hat organization.
+
+|`Enable admin capabilities for the OCM role (optional)`
+|Enable the admin OCM IAM role, which is equivalent to specifying the `--admin` argument. The admin role is required if you want to use `auto` mode to automatically provision the cluster-specific Operator roles and the OIDC provider by using {cluster-manager}.
+
+|`Permissions boundary ARN (optional)`
+|Specify a permissions boundary Amazon Resource Name (ARN) for the OCM role. For more information, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html[Permissions boundaries for IAM entities] in the AWS documentation.
+
+|`Role Path (optional)`
+|Specify a custom ARN path for your OCM role. The path must contain alphanumeric characters only and start and end with `/`, for example `/test/path/dev/`. For more information, see _ARN path customization for IAM roles and policies_.
+
+|`Role creation mode`
+|Select the role creation mode. You can use `auto` mode to automatically create the OCM role and link it to your Red Hat organization account. In `manual` mode, the `rosa` CLI generates the `aws` commands needed to create and link the role. In `manual` mode, the corresponding policy JSON files are also saved to the current directory. `manual` mode enables you to review the details before running the `aws` commands manually.
+
+|`Create the '<ocm_role_name>' role?`
+|Confirm if you want to create the OCM role.
+
+|`Link the '<ocm_role_arn>' role with organization '<red_hat_organization_id>'?`
+|Confirm if you want to link the OCM role with your Red Hat organization.
+
+|===
+
+The following tables describe the interactive user role creation mode options:
+
+.`--interactive` user role creation mode options
+[cols=".^2,.^3a",options="header"]
+|===
+
+|Field|Description
+
+|`Role prefix`
+|Specify the prefix to include in the user role name. The default is `ManagedOpenShift`.
+
+|`Permissions boundary ARN (optional)`
+|Specify a permissions boundary Amazon Resource Name (ARN) for the user role. For more information, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html[Permissions boundaries for IAM entities] in the AWS documentation.
+
+|`Role Path (optional)`
+|Specify a custom ARN path for your user role. The path must contain alphanumeric characters only and start and end with `/`, for example `/test/path/dev/`. For more information, see _ARN path customization for IAM roles and policies_.
+
+|`Role creation mode`
+|Selects the role creation mode. You can use `auto` mode to automatically create the user role and link it to your {cluster-manager} user account. In `manual` mode, the `rosa` CLI generates the `aws` commands needed to create and link the role. In `manual` mode, the corresponding policy JSON files are also saved to the current directory. `manual` mode enables you to review the details before running the `aws` commands manually.
+
+|`Create the '<user_role_name>' role?`
+|Confirm if you want to create the user role.
+
+|`Link the '<user_role_arn>' role with account '<red_hat_user_account_id>'?`
+|Confirm if you want to link the user role with your Red Hat user account.
+
+|===

--- a/rosa_cli/rosa-manage-objects-cli.adoc
+++ b/rosa_cli/rosa-manage-objects-cli.adoc
@@ -15,6 +15,7 @@ include::modules/rosa-create-objects.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 * See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference] for a list of IAM roles needed for cluster creation.
+* See xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-understanding-aws-account-association_rosa-sts-creating-a-cluster-with-customizations[Understanding AWS account association] for more information about the OCM role and user role.
 
 include::modules/rosa-edit-objects.adoc[leveloffset=+1]
 include::modules/rosa-delete-objects.adoc[leveloffset=+1]

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -19,6 +19,14 @@ include::modules/rosa-sts-understanding-aws-account-association.adoc[leveloffset
 
 * For detailed steps to create and link the {cluster-manager} and user IAM roles, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-cluster-customizations-ocm_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster with customizations by using OpenShift Cluster Manager].
 
+include::modules/rosa-sts-arn-path-customization-for-iam-roles-and-policies.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For the steps to specify custom ARN paths for IAM resources when you create {product-title} clusters, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-cluster-using-customizations_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster using customizations].
+//* TBC - ROSA CLI reference.
+
 include::modules/rosa-sts-support-considerations.adoc[leveloffset=+1]
 include::modules/rosa-sts-creating-a-cluster-using-customizations.adoc[leveloffset=+1]
 include::modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc[leveloffset=+2]
@@ -35,7 +43,7 @@ include::modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc[levelo
 
 * For more information about the AWS Identity Access Management (IAM) resources required to deploy {product-title} with STS, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for clusters that use STS].
 * For details about optionally setting an Operator role name prefix, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-operator-role-prefixes_rosa-sts-about-iam-resources[About custom Operator IAM role prefixes].
-* For an overview of the options that are presented when you create a cluster using interactive mode, see xref:../rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference.adoc#rosa-sts-understanding-interactive-mode-options_rosa-sts-interactive-mode-reference[Interactive cluster creation mode reference].
+* For an overview of the options that are presented when you create the AWS IAM resources and clusters by using interactive mode, see xref:../rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference.adoc#rosa-sts-interactive-mode-reference[Interactive cluster creation mode reference].
 * For information about the prerequisites to installing ROSA with STS, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
 * For more information about using OpenID Connect (OIDC) identity providers in AWS IAM, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html[Creating OpenID Connect (OIDC) identity providers] in the AWS documentation.
 * For more information about etcd encryption, see the xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-etcd-encryption_rosa-service-definition[etcd encryption service definition].

--- a/rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference.adoc
@@ -6,14 +6,16 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-This section provides an overview of the options that are presented when you use the interactive mode to create a cluster by using the {product-title} (ROSA) CLI (`rosa`).
+This section provides an overview of the options that are presented when you use the interactive mode to create the OCM role, the user role, and {product-title} (ROSA) clusters by using the ROSA CLI (`rosa`).
 
-include::modules/rosa-sts-interactive-mode-reference.adoc[leveloffset=+1]
+include::modules/rosa-sts-interactive-ocm-and-user-role-creation-mode-options.adoc[leveloffset=+1]
+include::modules/rosa-sts-interactive-cluster-creation-mode-options.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_rosa-sts-interactive-mode-reference"]
 == Additional resources
- * For a list of the supported maximums, see xref:../rosa_planning/rosa-limits-scalability.adoc#tested-cluster-maximums_rosa-limits-scalability[ROSA tested cluster maximums].
+* For more information about using custom ARN paths for the OCM role, user role, and account-wide roles, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-arn-path-customization-for-iam-roles-and-policies_rosa-sts-creating-a-cluster-with-customizations[ARN path customization for IAM roles and policies].
+* For a list of the supported maximums, see xref:../rosa_planning/rosa-limits-scalability.adoc#tested-cluster-maximums_rosa-limits-scalability[ROSA tested cluster maximums].
 * For detailed steps to quickly create a ROSA cluster with STS, including the AWS IAM resources, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[Creating a ROSA cluster with STS using the default options].
 * For detailed steps to create a ROSA cluster with STS using customizations, including the AWS IAM resources, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-a-cluster-with-customizations[Creating a ROSA cluster with STS using customizations].
 * For more information about etcd encryption, see the xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-etcd-encryption_rosa-service-definition[etcd encryption service definition].


### PR DESCRIPTION
This applies to `main`, `enterprise-4.12` and `enterprise-4.11`.

This relates to https://issues.redhat.com/browse/OSDOCS-3803. The PR adds content about specifying custom ARN paths for the OCM role, user role and account-wide roles and policies for ROSA with STS clusters. The PR also refreshes some other aspects of the cluster installation procedures, the interactive mode reference and the ROSA CLI section for `rosa create`.

The previews are as follows:

- https://49586--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-arn-path-customization-for-iam-roles-and-policies_rosa-sts-creating-a-cluster-with-customizations
- https://49586--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-ocm_rosa-sts-creating-a-cluster-with-customizations
- https://49586--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations
- https://49586--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference.html
- https://49586--docspreview.netlify.app/openshift-rosa/latest/rosa_cli/rosa-manage-objects-cli.html#rosa-create-account-roles_rosa-managing-objects-cli
- https://49586--docspreview.netlify.app/openshift-rosa/latest/rosa_cli/rosa-manage-objects-cli.html#rosa-create-ocm-role_rosa-managing-objects-cli
- https://49586--docspreview.netlify.app/openshift-rosa/latest/rosa_cli/rosa-manage-objects-cli.html#rosa-create-user-role_rosa-managing-objects-cli