### PR TITLE
BZ-2010564-10 updating piece for 4.10 and under

### DIFF
--- a/modules/configuring-default-seccomp-profile.adoc
+++ b/modules/configuring-default-seccomp-profile.adoc
@@ -1,15 +1,80 @@
+// Module included in the following assemblies:
+//
+// * security/seccomp-profiles.adoc
+
+:_content-type: PROCEDURE
 [id="configuring-default-seccomp-profile_{context}"]
-= Configuring the default seccomp profile
-OpenShift ships with a default seccomp profile that is referenced as `runtime/default`. You can enable the default seccomp profile for a pod or container workload by setting `RuntimeDefault` as following:
+= Enabling the default seccomp profile for all pods
 
-.Example
+{product-title} ships with a default seccomp profile that is referenced as `runtime/default`. You can enable the default seccomp profile for a pod or container workload by creating a custom Security Context Constraint (SCC).
 
+[NOTE]
+====
+There is a requirement to create a custom SCC. Do not edit the default SCCs. Editing the default SCCs can lead to issues when some of the platform pods deploy or {product-title} is upgraded. For more information, see the section entitled "Default security context constraints". 
+====
+
+Follow these steps to enable the default seccomp profile for all pods:
+
+. Export the available `restricted` SCC to a yaml file: 
++
+[source, terminal]
+----
+$ oc get scc restricted -o yaml > restricted-seccomp.yaml
+----
+
+. Edit the created `restricted` SCC yaml file: 
++
+[source, terminal]
+----
+$ vi restricted-seccomp.yaml
+----
+
+. Update as shown in this example: 
++
 [source, yaml]
 ----
-spec:
-  securityContext:
-    seccompProfile:
-      type: RuntimeDefault
+kind: SecurityContextConstraints
+metadata:
+  name: restricted  <1> 
+<..snip..>
+seccompProfiles:    <2> 
+- runtime/default   <3> 
+----
+<1> Change to `restricted-seccomp`
+<2> Add `seccompProfiles:`
+<3> Add `- runtime/default`
+
+. Create the custom SCC: 
++
+[source, terminal]
+----
+$ oc create -f restricted-seccomp.yaml
+----
++
+.Expected output
++
+[source, terminal]
+----
+securitycontextconstraints.security.openshift.io/restricted-seccomp created
 ----
 
-Alternatively, you can use the pod annotations `seccomp.security.alpha.kubernetes.io/pod: runtime/default` and `container.seccomp.security.alpha.kubernetes.io/<container_name>: runtime/default`. However, this method is deprecated in {product-title} {product-version}.
+. Add the custom SCC to the ServiceAccount: 
++
+[source, terminal]
+----
+$ oc adm policy add-scc-to-user restricted-seccomp -z default
+----
++
+[NOTE]
+====
+The default service account is the ServiceAccount that is applied unless the user configures a different one. {product-title} configures the seccomp profile of the pod based on the information in the SCC. 
+====
++
+.Expected output
+
+[source, terminal]
+----
+clusterrole.rbac.authorization.k8s.io/system:openshift:scc:restricted-seccomp added: "default"
+----
+
+In {product-title} {product-version} the ability to add the pod annotations `seccomp.security.alpha.kubernetes.io/pod: runtime/default` and `container.seccomp.security.alpha.kubernetes.io/<container_name>: runtime/default` is deprecated. 


### PR DESCRIPTION
BZ-2010564: Lack of description about creating and configuring custom SCC that allows configuring seccomp profile

Version(s):

PR applies to multiple specific versions: 4.10 and cherry-picked to 4.9, 4.8, 4.7 and 4.6 

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2010564

Link to docs preview:http://file.emea.redhat.com/kquinn/BZ-2010564-410/security/seccomp-profiles.html
