### PR TITLE
updating PR template for OCPBUGS naming convention

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->
+<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->
 
 <!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->
 


### PR DESCRIPTION
To avoid the CI bot commenting on the docs bugs in the OCPBUGS process, we need to reformat the titles of the PRs that address these issues.