### PR TITLE
OSDOCS-3807: Ported the Trusted Certificate Authorities to OSD/ROSA

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -160,6 +160,17 @@ Topics:
 - Name: Upgrading OpenShift Dedicated
   File: osd-upgrades
   Distros: openshift-dedicated
+---  
+Name: CI/CD
+Dir: cicd
+Topics:
+- Name: Builds
+  Dir: builds
+  Distros: openshift-dedicated 
+  Topics:
+  - Name: Setting up additional trusted certificate authorities for builds
+    File: setting-up-trusted-ca
+    Distros: openshift-dedicated
 ---
 Name: Add-on services
 Dir: adding_service_cluster

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -261,6 +261,17 @@ Topics:
   File: rosa-upgrading-sts
 - Name: Upgrading ROSA
   File: rosa-upgrading
+---  
+Name: CI/CD
+Dir: cicd
+Topics:
+- Name: Builds
+  Dir: builds
+  Distros: openshift-rosa 
+  Topics:
+  - Name: Setting up additional trusted certificate authorities for builds
+    File: setting-up-trusted-ca
+    Distros: openshift-rosa
 ---
   Name: Add-on services
   Dir: adding_service_cluster

--- a/cicd/builds/setting-up-trusted-ca.adoc
+++ b/cicd/builds/setting-up-trusted-ca.adoc
@@ -1,12 +1,17 @@
 :_content-type: ASSEMBLY
 [id="setting-up-trusted-ca"]
 = Setting up additional trusted certificate authorities for builds
+ifndef::openshift-dedicated,openshift-rosa[]
 include::_attributes/common-attributes.adoc[]
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+endif::[]
 :context: setting-up-trusted-ca
 
 toc::[]
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+ifdef::openshift-enterprise,openshift-rosa,openshift-dedicated,openshift-webscale,openshift-origin[]
 Use the following sections to set up additional certificate authorities (CA) to be trusted by builds when pulling images from an image registry.
 
 The procedure requires a cluster administrator to create a `ConfigMap` and add additional CAs as keys in the `ConfigMap`.
@@ -24,5 +29,7 @@ include::modules/configmap-adding-ca.adoc[leveloffset=+1]
 
 * link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#create-a-configmap[Create a `ConfigMap`]
 * link:https://kubectl.docs.kubernetes.io/guides/config_management/secrets_configmaps/[Secrets and `ConfigMaps`]
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../networking/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI]
+endif::[]
 endif::[]

--- a/modules/configmap-adding-ca.adoc
+++ b/modules/configmap-adding-ca.adoc
@@ -6,12 +6,17 @@
 [id="configmap-adding-ca_{context}"]
 = Adding certificate authorities to the cluster
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+ifdef::openshift-enterprise,openshift-rosa,openshift-dedicated,openshift-webscale,openshift-origin[]
 You can add certificate authorities (CA) to the cluster for use when pushing and pulling images with the following procedure.
 
 .Prerequisites
 
+ifdef::openshift-rosa[]
 * You must have cluster administrator privileges.
+endif::[]
+ifdef::openshift-dedicated[]
+* You must have at least dedicated administrator privileges.
+endif::[]
 * You must have access to the public certificates of the registry, usually a `hostname/ca.crt` file located in the `/etc/docker/certs.d/` directory.
 
 .Procedure


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-3807](https://issues.redhat.com/browse/OSDOCS-3807)

Link to docs preview:

- [ROSA](http://file.rdu.redhat.com/eponvell/OSDOCS-3807_Trusted-Ca-Port/rosa/cicd/builds/setting-up-trusted-ca.html)
- [OSD](http://file.rdu.redhat.com/eponvell/OSDOCS-3807_Trusted-Ca-Port/dedicated/cicd/builds/setting-up-trusted-ca.html)

Additional information:
Ported the Trusted Certificate Authority Information to OSD and ROSA.