### PR TITLE
Update branch versions for OSD and ROSA Travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       script:
         - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.11 --no-upstream-fetch && python3 makeBuild.py
     - # stage name not required, will continue to use `build`
-      if: branch IN (main, enterprise-4.10, enterprise-4.11)
+      if: branch IN (main, enterprise-4.11, enterprise-4.12)
       before_install:
         - gem install asciidoctor
         - gem install asciidoctor-diagram
@@ -25,7 +25,7 @@ jobs:
       script:
         - python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch && python3 makeBuild.py
     - # stage name not required, will continue to use `build`
-      if: branch IN (main, enterprise-4.10, enterprise-4.11)
+      if: branch IN (main, enterprise-4.11, enterprise-4.12)
       before_install:
         - gem install asciidoctor
         - gem install asciidoctor-diagram


### PR DESCRIPTION
This applies to `main` only.

Docs PRs for the OSD and ROSA distributions are currently based on `main` and cherry picked only to `enterprise-4.12` and `enterprise-4.11`. This PR updates the branch versions for the OSD and ROSA Travis checks.