### PR TITLE
BZ#2094430: Adding minimum version of Azure Stack Hub enterprise-4.9

### DIFF
--- a/installing/installing_azure_stack_hub/preparing-to-install-on-azure-stack-hub.adoc
+++ b/installing/installing_azure_stack_hub/preparing-to-install-on-azure-stack-hub.adoc
@@ -11,6 +11,7 @@ toc::[]
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You have installed Azure Stack Hub version 2008 or later.
 
 [id="requirements-for-installing-ocp-on-ash"]
 == Requirements for installing {product-title} on Azure Stack Hub


### PR DESCRIPTION
Original PR #49378 

Version(s): 4.9 ONLY

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2094430

Link to docs preview: http://file.rdu.redhat.com/snarayan/BZ2094430_stackhub_4_9/installing/installing_azure_stack_hub/preparing-to-install-on-azure-stack-hub.html