### PR TITLE
GH49619: Add provider agnostic to network table

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -52,7 +52,7 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |VMware vSphere
 |Hybrid networking with OVN-Kubernetes with a custom VXLAN port
 
-|bare metal
+|Bare metal or provider agnostic
 |Hybrid networking with OVN-Kubernetes
 |===
 


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/49619

Table 1. Platform networking support.
This table should be updated so that the verbiage matches and it also says 'bare metal or provider agnostic'

Preview: Table 1. [Platform networking support](http://file.rdu.redhat.com/~mburke/winc-fix-networking-table/windows_containers/windows-containers-release-notes-6-x.html#supported-networking).
