### PR TITLE
Tuning CNI IFNAME clarification (omits using eth0)

### DIFF
--- a/modules/nodes-safe-sysctls-list.adoc
+++ b/modules/nodes-safe-sysctls-list.adoc
@@ -114,5 +114,5 @@ a| Define behavior for gratuitous ARP frames with an IPv6 address that is not al
 
 [NOTE]
 ====
-The interface name is represented by the `IFNAME` token, and is replaced with the actual name of the interface at runtime.
+When setting these values using the `tuning` CNI plugin, use the value `IFNAME` literally. The interface name is represented by the `IFNAME` token, and is replaced with the actual name of the interface at runtime.
 ====

--- a/nodes/containers/nodes-containers-sysctls.adoc
+++ b/nodes/containers/nodes-containers-sysctls.adoc
@@ -11,7 +11,7 @@ Sysctl settings are exposed through Kubernetes, allowing users to modify certain
 Network sysctls are a special category of sysctl. Network sysctls include:
 
 * System-wide sysctls, for example `net.ipv4.ip_local_port_range`, that are valid for all networking. You can set these independently for each pod on a node.
-* Interface-specific sysctls, for example `net.ipv4.conf.eth0.accept_local`, that only apply to a specific interface. You cannot set these independently for each pod on a node. You set these by using a configuration in the `tuning-cni` after the network interfaces are created.
+* Interface-specific sysctls, for example `net.ipv4.conf.IFNAME.accept_local`, that only apply to a specific additional network interface for a given pod. You can set these independently for each additional network configuration. You set these by using a configuration in the `tuning-cni` after the network interfaces are created.
 
 Moreover, only those sysctls considered _safe_ are whitelisted by default; you
 can manually enable other _unsafe_ sysctls on the node to be available to the


### PR DESCRIPTION
Omits the usage of eth0 in the example (which will not work with tuning CNI)

Clarifies that the `IFNAME` token should be used literally.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
* PR applies to all versions after a specific version (e.g. 4.8): 4.11+
<!-- Version examples:
  
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: discovered during assessment of https://issues.redhat.com/browse/RFE-2879
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
* The current docs @ https://docs.openshift.com/container-platform/4.11/nodes/containers/nodes-containers-sysctls.html seem to have some muddying of the waters between our "kinds of sysctls" -- that is, for a pod, for a node, or for a specific network interface. I will try to start a discussion.


<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
