### PR TITLE
OCPBUGS#452 VMware vSphere registry RWO storage requires Recreate mode

### DIFF
--- a/modules/registry-configuring-storage-vsphere.adoc
+++ b/modules/registry-configuring-storage-vsphere.adoc
@@ -28,7 +28,7 @@ As a cluster administrator, following installation you must configure your regis
 +
 [IMPORTANT]
 ====
-{product-title} supports `ReadWriteOnce` access for image registry storage when you have only one replica. To deploy an image registry that supports high availability with two or more replicas, `ReadWriteMany` access is required.
+{product-title} supports `ReadWriteOnce` access for image registry storage when you have only one replica. `ReadWriteOnce` access also requires that the registry uses the `Recreate` rollout strategy. To deploy an image registry that supports high availability with two or more replicas, `ReadWriteMany` access is required.
 ====
 +
 * Must have "100Gi" capacity.


### PR DESCRIPTION
[OCPBUGS#452](https://issues.redhat.com/browse/OCPBUGS-452) RWO access for registry storage requires `Recreate` rollout strategy

4.8+ 

[Doc preview](https://bscott-rh.github.io/openshift-docs/OCPBUGS-452/registry/configuring_registry_storage/configuring-registry-storage-vsphere.html#registry-configuring-storage-vsphere_configuring-registry-storage-vsphere)