### PR TITLE
WIP - TELCODOCS#652-adding release note for new metallb deployment specs

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -74,6 +74,12 @@ For more information, see xref:../installing/installing-troubleshooting.adoc#ins
 [id="ocp-4-12-networking"]
 === Networking
 
+[id="ocp-4-12-ne-metallb-deployment-specs"]
+==== Additional deployment specifications for MetalLB
+This update provides additional deployment specifications for MetalLB. When you use a custom resource to deploy MetalLB, you can use these additional deployment specifications to manage how MetalLB `speaker` and `controller` pods deploy and run in your cluster. For example, you can use MetalLB deployment specifications to manage where MetalLB pods are deployed, define CPU limits for MetalLB pods, and assign runtime classes to MetalLB pods. 
+
+For more information about deployment specifications for MetalLB, see xref:../networking/metallb/metallb-operator-install.adoc#nw-metallb-operator-deployment-specifications-for-metallb_metallb-operator-install[Deployment specifications for MetalLB].
+
 [id="ocp-4-12-storage"]
 === Storage
 


### PR DESCRIPTION
TELCODOCS#652: Adding RN for additional deployment specs that you can use in the MetalLB custom resource. 

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/TELCODOCS-652

Link to docs preview:
http://file.emea.redhat.com/rohennes/TELCODOCS-652-RN-metallb-params/release_notes/ocp-4-12-release-notes.html#ocp-4-12-ne-metallb-deployment-specs
