### PR TITLE
[OSDOCS-4014] Created an ingress Operator responsibility matrix

### DIFF
--- a/modules/sd-ingress-responsibilities.adoc
+++ b/modules/sd-ingress-responsibilities.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+// * understanding-networking.adoc
+
+[id="sd-ingress-responsibility-matrix_{context}"]
+= {product-title} Ingress Operator configurations
+
+The following table details the components of the Ingress Operator and if Red Hat Site Reliability Engineers (SRE) maintains this component on {product-title} clusters.
+
+.Ingress Operator Responsibility Chart
+
+[cols="3,2a,2a",options="header"]
+|===
+
+|Ingress component
+|Managed by
+|Default configuration?
+
+|Scaling Ingress Controller | SRE | Yes
+
+|Ingress Operator thread count | SRE | Yes
+
+|Ingress Controller access logging | SRE | Yes
+
+|Ingress Controller sharding | SRE | Yes
+
+|Ingress Controller route admission policy | SRE | Yes
+
+|Ingress Controller wildcard routes | SRE | Yes
+
+|Ingress Controller X-Forwarded headers | SRE | Yes
+
+|Ingress Controller route compression | SRE | Yes
+
+|===

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -87,7 +87,13 @@ include::modules/nw-customize-ingress-error-pages.adoc[leveloffset=+2]
 //include::modules/nw-ingress-select-route.adoc[leveloffset=+2]
 
 include::modules/nw-ingress-setting-max-connections.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-dedicated[]
 
+ifdef::openshift-rosa,openshift-dedicated[]
+include::modules/sd-ingress-responsibilities.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
+
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 == Additional resources
 


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-4014](https://issues.redhat.com/browse/OSDOCS-4014)

Link to docs preview:

- **[OSD](http://file.rdu.redhat.com/eponvell/OSDOCS-4014_Responsibility-Matrix/dedicated/networking/ingress-operator.html)**
- **[ROSA](http://file.rdu.redhat.com/eponvell/OSDOCS-4014_Responsibility-Matrix/rosa/networking/ingress-operator.html)**

Additional information:
This PR continues the efforts of [OSDOCS-3870](https://issues.redhat.com/browse/OSDOCS-3870). For this PR, I added the responsibility matrix for what components are covered by SRE.