### PR TITLE
RHDEVDOCS-4236: Support default resource type in User Preferences

### DIFF
--- a/modules/odc-importing-codebase-from-git-to-create-application.adoc
+++ b/modules/odc-importing-codebase-from-git-to-create-application.adoc
@@ -48,7 +48,7 @@ The resource name must be unique in a namespace. Modify the resource name if you
 +
 [NOTE]
 ====
-The *Serverless Deployment* option is displayed in the *Import from git* form only if the {ServerlessOperatorName} is installed in your cluster. For further details, refer to the {ServerlessProductName} documentation.
+You can set the default resource preference for Import by browsing the User Preferences page and clicking *Applications* -> *Resource type* field. The *Serverless Deployment* option is displayed in the *Import from Git* form only if the {ServerlessOperatorName} is installed in your cluster. For further details, refer to the {ServerlessProductName} documentation.
 ====
 
 . In the *Pipelines* section, select *Add Pipeline*, and then click *Show Pipeline Visualization* to see the pipeline for the application. A default pipeline is selected, but you can choose the pipeline you want from the list of available pipelines for the application.

--- a/modules/odc-setting-user-preferences.adoc
+++ b/modules/odc-setting-user-preferences.adoc
@@ -1,3 +1,6 @@
+// Module included in the following assemblies:
+//
+// *web_console/adding-user-preferences.adoc
 :_content-type: PROCEDURE
 [id="odc-setting-user-preferences_{context}"]
 = Setting user preferences
@@ -13,4 +16,7 @@ You can set the default user preferences for your cluster.
 .. In the *Project* field, select a project you want to work in. The console will default to the project every time you log in.
 .. In the *Topology* field, you can set the topology view to default to the graph or list view. If not selected, the console defaults to the last view you used.
 .. In the *Create/Edit resource method* field, you can set a preference for creating or editing a resource. If both the form and YAML options are available, the console defaults to your selection.
-. In the Language section, select *Default browser language* to use the default browser language settings. Otherwise, select the language that you want to use for the console.
+. In the *Language* section, select *Default browser language* to use the default browser language settings. Otherwise, select the language that you want to use for the console.
+. In the *Applications* section:
+.. You can view the default *Resource type*. For example, if the {ServerlessOperatorName} is installed, the default resource type is *Serverless Deployment*. Otherwise, the default resource type is *Deployment*.
+.. You can select another resource type to be the default resource type from the *Resource Type* field. 

--- a/web_console/adding-user-preferences.adoc
+++ b/web_console/adding-user-preferences.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can change the default preferences for your profile to meet your requirements. You can set your default project, topology view (graph/list), editing medium (form or YAML), and language preferences.
+[role="_abstract"]
+You can change the default preferences for your profile to meet your requirements. You can set your default project, topology view (graph or list), editing medium (form or YAML), language preferences, and resource type.
 
 The changes made to the user preferences are automatically saved.
 


### PR DESCRIPTION
[RHDEVDOCS-4236](https://issues.redhat.com//browse/RHDEVDOCS-4236): Doc: Support default resource type in User Preferences
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.12
JIRA issues: [RHDEVDOCS-4236](https://issues.redhat.com//browse/RHDEVDOCS-4236)
Preview pages: [Download to see the preview in your browser_1](https://drive.google.com/file/d/1Juke46zwpn6jvf-HAilCaiQTMArESPpy/view?usp=sharing)
[Download to see the preview in your browser_2](https://drive.google.com/file/d/1ODp5RhHu0w2H6iYpXBTw3EHvJoGJbVMS/view?usp=sharing)
SME Review: @divyanshiGupta / @vikram-raj  
QE review: @sanketpathak 
Peer-review:
Screenshots:
![image](https://user-images.githubusercontent.com/89447174/187139327-8099193a-864d-4023-8664-abe3fe824e90.png)

![image](https://user-images.githubusercontent.com/89447174/187139498-ea434c7e-656b-43e7-bb32-a1ee28f14d66.png)

![image](https://user-images.githubusercontent.com/89447174/187139910-05871d4f-c151-4316-8040-74f3c4308036.png)
