### PR TITLE
[enterprise-4.7] BZ2104374: Removed period (.) as supported character from metadata.name

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -194,7 +194,12 @@ Required installation configuration parameters are described in the following ta
 
 |`metadata.name`
 |The name of the cluster. DNS records for the cluster are all subdomains of `{{.metadata.name}}.{{.baseDomain}}`.
+ifndef::bare,vmc,vsphere[]
 |String of lowercase letters, hyphens (`-`), and periods (`.`), such as `dev`.
+endif::bare,vmc,vsphere[]
+ifdef::bare,vmc,vsphere[]
+|String of lowercase letters and hyphens (`-`), such as `dev`.
+endif::bare,vmc,vsphere[]
 ifdef::osp[]
 The string must be 14 characters or fewer long.
 endif::osp[]


### PR DESCRIPTION
This is a manual cherry pick for https://github.com/openshift/openshift-docs/pull/49100.

Cherry Picked from ba76a40031b332112cb015d267eb41139e5dd73c