### PR TITLE
OSDOCS4041: Support Windows Containers on GCP -- WMCO 7.0.0

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2184,6 +2184,8 @@ Topics:
     File: creating-windows-machineset-azure
   - Name: Creating a Windows MachineSet object on vSphere
     File: creating-windows-machineset-vsphere
+  - Name: Creating a Windows MachineSet object on GCP
+    File: creating-windows-machineset-gcp
 - Name: Scheduling Windows container workloads
   File: scheduling-windows-workloads
 - Name: Windows node upgrades

--- a/modules/machine-api-overview.adoc
+++ b/modules/machine-api-overview.adoc
@@ -9,6 +9,7 @@
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
+// * windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
 
 :_content-type: CONCEPT
 [id="machine-api-overview_{context}"]

--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -11,6 +11,7 @@
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
+// * windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
 
 ifeval::["{context}" == "creating-windows-machineset-aws"]
 :win:

--- a/modules/windows-machineset-gcp.adoc
+++ b/modules/windows-machineset-gcp.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
+
+[id="windows-machineset-gcp_{context}"]
+= Sample YAML for a Windows MachineSet object on GCP
+
+This sample YAML file defines a Windows `MachineSet` object running on Google Cloud Platform (GCP) that the Windows Machine Config Operator (WMCO) can use.
+
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+  name: <infrastructure_id>-windows-worker-<zone_suffix> <2>
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-windows-worker-<zone_suffix> <2>
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-windows-worker-<zone_suffix> <2>
+        machine.openshift.io/os-id: Windows <3>
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/worker: "" <4>
+      providerSpec:
+        value:
+          apiVersion: machine.openshift.io/v1beta1
+          canIPForward: false
+          credentialsSecret:
+            name: gcp-cloud-credentials
+          deletionProtection: false
+          disks:
+          - autoDelete: true
+            boot: true
+            image: <windows_server_image> <5>
+            sizeGb: 128
+            type: pd-ssd
+          kind: GCPMachineProviderSpec
+          machineType: n1-standard-4
+          networkInterfaces:
+          - network: <infrastructure_id>-network <1>
+            subnetwork: <infrastructure_id>-worker-subnet
+          projectID: <project_id> <6>
+          region: <region> <7>
+          serviceAccounts:
+          - email: <infrastructure_id>-w@<project_id>.iam.gserviceaccount.com
+            scopes:
+            - https://www.googleapis.com/auth/cloud-platform
+          tags:
+          - <infrastructure_id>-worker
+          userDataSecret:
+            name: windows-user-data <8>
+          zone: <zone> <9>
+----
+<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. You can obtain the infrastructure ID by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
+<2> Specify the infrastructure ID, worker label, and zone suffix (such as `a`).
+<3> Configure the machine set as a Windows machine.
+<4> Configure the Windows node as a compute machine.
+<5> Specify the full path to an image of a supported version of Windows Server. 
+<6> Specify the GCP project that this cluster was created in.
+<7> Specify the GCP region, such as `us-central1`. 
+<8> Created by the WMCO when it configures the first Windows machine. After that, the `windows-user-data` is available for all subsequent machine sets to consume.
+<9> Specify the zone within the chosen region, such as `us-central1-a`.

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -27,6 +27,9 @@ a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic
 |VMware vSphere
 |Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
 
+|Google Cloud Platform (GCP)
+|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+
 |Bare metal or provider agnostic
 a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
 * Windows Server 2019, version 1809
@@ -51,6 +54,9 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 
 |VMware vSphere
 |Hybrid networking with OVN-Kubernetes with a custom VXLAN port
+
+|Google Cloud Platform (GCP)
+|Hybrid networking with OVN-Kubernetes
 
 |Bare metal or provider agnostic
 |Hybrid networking with OVN-Kubernetes

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
@@ -1,0 +1,25 @@
+:_content-type: ASSEMBLY
+[id="creating-windows-machineset-gcp"]
+= Creating a Windows `MachineSet` object on GCP
+include::_attributes/common-attributes.adoc[]
+:context: creating-windows-machineset-gcp
+
+toc::[]
+
+You can create a Windows `MachineSet` object to serve a specific purpose in your {product-title} cluster on Google Cloud Platform (GCP). For example, you might create infrastructure Windows machine sets and related machines so that you can move supporting Windows workloads to the new Windows machines.
+
+[discrete]
+== Prerequisites
+
+* You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
+* You are using a supported Windows Server as the operating system image. 
+
+include::modules/machine-api-overview.adoc[leveloffset=+1]
+include::modules/windows-machineset-gcp.adoc[leveloffset=+1]
+include::modules/machineset-creating.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="creating-windows-machineset-gcp-additional"]
+== Additional resources
+
+* For more information on managing machine sets, see xref:../../machine_management/index.adoc#overview-of-machine-management[Overview of machine management].


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-4041

Previews:
[Creating a Windows MachineSet object on GCP](http://file.rdu.redhat.com/mburke/winc-add-gcp/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html) Intro and the [Sample YAML for a Windows MachineSet object on GCP](http://file.rdu.redhat.com/mburke/winc-add-gcp/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html#windows-machineset-gcp_creating-windows-machineset-gcp)
 module. The other modules are existing and repreated in all _Creating a Windows MachineSet_ assemblies.

[WMCO 7.0.0 supported platforms and Windows Server versions](http://file.rdu.redhat.com/mburke/winc-add-gcp/windows_containers/windows-containers-release-notes-6-x.html#wmco-prerequisites-supported-6.0.0_windows-containers-release-notes) -- Added GCP to table
