### PR TITLE
OCPBUGS#677 Remove xref from Creating the installation configuration …

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -203,11 +203,7 @@ ifndef::nutanix[]
 * Obtain service principal permissions at the subscription level.
 endif::nutanix[]
 ifdef::nutanix[]
-* Verify that you have met the Nutanix networking requirements.
-
-[role="_additional-resources"]
-.Additional resources
-* xref:preparing-to-install-on-nutanix.adoc#preparing-to-install-on-nutanix[Nutanix networking requirements].
+* Verify that you have met the Nutanix networking requirements. For more information, see "Preparing to install on Nutanix".
 endif::nutanix[]
 
 .Procedure


### PR DESCRIPTION
Version(s):
CP to 4.11 and 4.12

Issue:
This issue addresses [OCPBUGS#677](https://issues.redhat.com/browse/OCPBUGS-677) and https://github.com/openshift/openshift-docs/issues/49717

Link to docs preview:
[Creating the installation configuration file](http://file.rdu.redhat.com/mpytlak/NutanixXref/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#installation-initializing_installing-nutanix-installer-provisioned)



