### PR TITLE
[OCPBUGS#163] Install config initialization conditional stack mystery

### DIFF
--- a/modules/cli-installing-cli-web-console-macos.adoc
+++ b/modules/cli-installing-cli-web-console-macos.adoc
@@ -1,7 +1,3 @@
-ifeval::["{context}" == "updating-restricted-network-cluster"]
-:restricted:
-endif::[]
-
 :_content-type: PROCEDURE
 [id="cli-installing-cli-web-console-macos_{context}"]
 = Installing the OpenShift CLI on macOS using the web console

--- a/modules/installation-aws-user-infra-installation.adoc
+++ b/modules/installation-aws-user-infra-installation.adoc
@@ -6,6 +6,9 @@
 ifeval::["{context}" == "installing-restricted-networks-aws"]
 :restricted:
 endif::[]
+ifdef::openshift-origin[]
+:restricted:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="installation-aws-user-infra-installation_{context}"]

--- a/modules/installation-complete-user-infra.adoc
+++ b/modules/installation-complete-user-infra.adoc
@@ -19,6 +19,9 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :restricted:
 endif::[]
+ifdef::openshift-origin[]
+:restricted:
+endif::[]
 ifeval::["{context}" == "installing-ibm-z"]
 :ibm-z:
 endif::[]
@@ -193,7 +196,7 @@ ifeval::["{context}" == "installing-ibm-power"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :!ibm-power:
-:restricted:
+:!restricted:
 endif::[]
 ifeval::["{context}" == "installing-ibm-z-kvm"]
 :!ibm-z-kvm:

--- a/modules/installation-load-balancing-user-infra.adoc
+++ b/modules/installation-load-balancing-user-infra.adoc
@@ -44,9 +44,6 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :restricted:
 endif::[]
-ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
-:restricted:
-endif::[]
 
 :_content-type: CONCEPT
 [id="installation-load-balancing-user-infra_{context}"]
@@ -271,5 +268,8 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
 :!restricted:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:!restricted:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :!restricted:
 endif::[]

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -50,9 +50,6 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :restricted:
 endif::[]
-ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
-:restricted:
-endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]
 :azure:
 endif::[]
@@ -305,6 +302,9 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
 :!restricted:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:!restricted:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :!restricted:
 endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -540,4 +540,5 @@ ifeval::["{context}" == "installing-ibm-power"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :!ibm-power:
+:!restricted:
 endif::[]

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -10,6 +10,9 @@
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
 :restricted:
 endif::[]
+ifdef::openshift-origin[]
+:restricted:
+endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
 :restricted:
 endif::[]


### PR DESCRIPTION
Version(s):
4.6+, in various capacities


Issue:
[OCPBUGS-163](https://issues.redhat.com/browse/OCPBUGS-163)

Link to docs previews: 
- [openshift-enterprise](http://file.rdu.redhat.com/~mbridges/conditional-mystery/welcome/)
- [openshift-origin](http://file.rdu.redhat.com/~mbridges/conditional-mystery-origin/welcome/)

_Note:_ You must use a portal build to catch these particular errors in context. 

The problem does look like it's resolved on the page mentioned in the bug if I build from this branch.
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. -->

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->
---
 I kludge-scripted a look across all modules for offending items, here. The problem doesn't seem to be from any of the OSP modules--rather, there is an unmatched `restricted` attribute in a page that appears before the ShiftStack docs. This issue only occurs on the portal, as portal builds rely on a single `master.adoc` file. 
 
 Resolving these `:restricted:` mismatches might help: 

- [x]  installation-network-user-infra.adoc
- [x] installation-aws-user-infra-installation.adoc
- [x] installation-load-balancing-user-infra.adoc
- [x] cli-installing-cli-web-console-macos.adoc
- [x] installation-vsphere-config-yaml.adoc
- [x] installation-user-infra-machines-static-network.adoc
- [x] installation-complete-user-infra.adoc

Aside from this, I'd like to verify that the openshift-origin _closing only_ items were not added as gum + tape for this bug. As the original writer is no longer documenting this content, I'll need to verify with a currently responsible party that this change wouldn't ruin anything.
