### PR TITLE
[RHACS] Update to 3.71 Release Notes 

### DIFF
--- a/release_notes/371-release-notes.adoc
+++ b/release_notes/371-release-notes.adoc
@@ -6,7 +6,8 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-*Release date:* 25 July 2022
+*Release date:* 25 July 2022 +
+*Updated:* 30 August 2022
 
 {product-title} ({product-title-short}) is an enterprise-ready, Kubernetes-native container security solution that protects your vital applications across build, deploy, and runtime. It deploys in your infrastructure and integrates with your DevOps tooling and workflows to deliver better security and compliance and to enable DevOps and InfoSec teams to operationalize security.
 
@@ -158,6 +159,8 @@ You should switch to kernel module collection if you are using:
 
 The image registries hosted at the `stackrox.io` and `collector.stackrox.io` addresses were shut down. Images for {product-title-short} are available from `registry.redhat.io`.
 
+
+
 [id="deprecation-notices-371"]
 == Deprecated and removed features
 
@@ -233,11 +236,20 @@ In the table, features are marked with the following statuses:
 | GA
 | DEP
 
-| `/v1/cves/suppress` and `/v1/cves/unsuppress` 
+| `/v1/cves/suppress` and `/v1/cves/unsuppress`
 | GA
 | GA
 | DEP
 
+|`ids` field in the `/v1/cves/suppress` and `/v1/cves/unsuppress` API payload 
+| GA
+| GA
+| DEP
+
+|`cves.ids` field of the `storage.VulnerabilityRequest` object in the response of `VulnerabilityRequestService` endpoints
+| GA
+| GA
+| DEP
 
 |====
 
@@ -256,7 +268,9 @@ In the table, features are marked with the following statuses:
 ** Use `/v1/imagecves/suppress` and `/v1/imagecves/unsuppress` to snooze and unsnooze image vulnerabilities.
 ** Use `/v1/nodecves/suppress` and `/v1/nodecves/unsuppress` to snooze and unsnooze node and host vulnerabilities.
 ** Use `/v1/clustercves/suppress` and `/v1/clustercves/unsuppress` to snooze and unsnooze platform (Kubernetes, Istio, and {ocp}) vulnerabilities.
-
+* *Updated 30 August 2022:* 
+** The `ids` field in the `/v1/cves/suppress` and `/v1/cves/unsuppress` API payload will be renamed to `cves` in the {product-title-short} 3.73 release.
+** The `cves.ids` field of the `storage.VulnerabilityRequest` object in the response of `VulnerabilityRequestService` endpoints will be renamed to `cves.cves` in the {product-title-short} 3.73 release.
 
 [id="removed-features-371"]
 === Removed features


### PR DESCRIPTION
Version(s):

- `rhacs-docs`
- `rhacs-docs-3.71`

Labels:

`RHACS`

Issue: none - see PR https://github.com/stackrox/stackrox/pull/2849 and [slack thread](https://srox.slack.com/archives/CGDK78KRV/p1661811353421829)

[Link to docs preview](https://openshift-docs-4mfwn7h4p-kcarmichael08.vercel.app/openshift-acs/master/release_notes/371-release-notes.html)