### PR TITLE
Document a note on file permissions in projected secrets

### DIFF
--- a/applications/connecting_applications_to_services/projecting-binding-data.adoc
+++ b/applications/connecting_applications_to_services/projecting-binding-data.adoc
@@ -19,6 +19,8 @@ After the backing service exposes the binding data, for a workload to access and
 include::modules/sbo-configuration-of-directory-path-to-project-binding-data.adoc[leveloffset=+1]
 include::modules/sbo-projecting-the-binding-data.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+[id="additional-resources_projecting-binding-data-sbo"]
 == Additional resources
 * xref:../../applications/connecting_applications_to_services/exposing-binding-data-from-a-service.adoc#exposing-binding-data-from-a-service[Exposing binding data from a service].
 * link:https://redhat-developer.github.io/service-binding-operator/userguide/using-projected-bindings/using-projected-bindings.html[Using the projected binding data in the source code of the application].

--- a/modules/sbo-configuration-of-directory-path-to-project-binding-data.adoc
+++ b/modules/sbo-configuration-of-directory-path-to-project-binding-data.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * /applications/connecting_applications_to_services/projecting-binding-data.adoc
+
+:_content-type: CONCEPT
 [id="sbo-configuration-of-directory-path-to-project-binding-data_{context}"]
 = Configuration of the directory path to project the binding data inside workload container
 
@@ -33,6 +38,13 @@ username = os.getenv("USERNAME")
 password = os.getenv("PASSWORD")
 ----
 
+[WARNING]
+====
+.For using the binding data directory name to look up the binding data
+{servicebinding-title} uses the `ServiceBinding` resource name (`.metadata.name`) as the binding data directory name. The spec also provides a way to override that name through the `.spec.name` field. As a result, there is a chance for binding data name collision if there are multiple `ServiceBinding` resources in the namespace. However, due to the nature of the volume mount in Kubernetes, the binding data directory will contain values from only one of the `Secret` resources.
+====
+
+[id="computation-of-the-final-path-for-projecting-the-binding-data-as-files_{context}"]
 == Computation of the final path for projecting the binding data as files
 
 The following table summarizes the configuration of how the final path for the binding data projection is computed when files are mounted at a specific directory:
@@ -50,6 +62,11 @@ The following table summarizes the configuration of how the final path for the b
 |===
 
 In the previous table, the `<ServiceBinding_ResourceName>` entry specifies the name of the `ServiceBinding` resource that you configure in the `.metadata.name` section of the custom resource (CR).
+
+[NOTE]
+====
+By default, the projected files get their permissions set to 0644.  {servicebinding-title} cannot set specific permissions due to a bug in Kubernetes that causes issues if the service expects specific permissions such as `0600`.  As a workaround, you can modify the code of the program or the application that is running inside a workload resource to copy the file to the `/tmp` directory and set the appropriate permissions.
+====
 
 To access and consume the binding data within the existing `SERVICE_BINDING_ROOT` environment variable, use the built-in language feature of your programming language of choice that can read environment variables.
 

--- a/modules/sbo-projecting-the-binding-data.adoc
+++ b/modules/sbo-projecting-the-binding-data.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * /applications/connecting_applications_to_services/projecting-binding-data.adoc
+
 :_content-type: PROCEDURE
 [id="sbo-projecting-the-binding-data_{context}"]
 = Projecting the binding data


### PR DESCRIPTION
[RHDEVDOCS-4255](https://issues.redhat.com/browse/RHDEVDOCS-4255): Document a note on file permissions in projected secrets

- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: enterprise-`4.10`, enterprise-`4.11` and later
- **JIRA issues**: [RHDEVDOCS-4255](https://issues.redhat.com/browse/RHDEVDOCS-4255)
- **Preview pages**: [Download to see the preview in your browser](https://drive.google.com/file/d/1s9PSFzZTEBH6nhqfEMf0JRVRgp9xGfWo/view?usp=sharing)
- **SME Review**: Completed by @baijum, @dperaza4dustbit
- **QE review**: Completed by @pmacik 
- **Peer-review**: Completed by @jc-berger 