### PR TITLE
[OSDOCS-3212] - Removed "their" from bullet description.

### DIFF
--- a/modules/policy-customer-responsibility.adoc
+++ b/modules/policy-customer-responsibility.adoc
@@ -27,6 +27,7 @@ The customer is responsible for the applications, workloads, and data that they 
 * Create clusters with image pull secrets so that customer deployments can pull images from the Red Hat Container Catalog registry.
 * Provide access to OpenShift APIs that a customer can use to set up Operators to add community, third-party, and Red Hat services to the cluster.
 * Provide storage classes and plug-ins to support persistent volumes for use with customer applications.
+* Provide a container image registry so that customers can securely store their application container images on the cluster to deploy and manage their applications.
 |* Maintain responsibility for customer and third-party applications, data, and their complete lifecycle.
 * If a customer adds Red Hat, community, third-party, their own, or other services to the cluster by using Operators or external images, the customer is responsible for these services and for working with the appropriate provider (including Red Hat) to troubleshoot any issues.
 * Use the provided tools and features to configure and deploy; keep up-to-date; set up resource requests and limits; size the cluster to have enough resources to run apps; set up permissions; integrate with other services; manage any image streams or templates that the customer deploys; externally serve; save, back up, and restore data; and otherwise manage their highly available and resilient workloads.

--- a/modules/policy-customer-responsibility.adoc
+++ b/modules/policy-customer-responsibility.adoc
@@ -27,7 +27,7 @@ The customer is responsible for the applications, workloads, and data that they 
 * Create clusters with image pull secrets so that customer deployments can pull images from the Red Hat Container Catalog registry.
 * Provide access to OpenShift APIs that a customer can use to set up Operators to add community, third-party, and Red Hat services to the cluster.
 * Provide storage classes and plug-ins to support persistent volumes for use with customer applications.
-* Provide a container image registry so that customers can securely store their application container images on the cluster to deploy and manage their applications.
+* Provide a container image registry so customers can securely store application container images on the cluster to deploy and manage applications.
 |* Maintain responsibility for customer and third-party applications, data, and their complete lifecycle.
 * If a customer adds Red Hat, community, third-party, their own, or other services to the cluster by using Operators or external images, the customer is responsible for these services and for working with the appropriate provider (including Red Hat) to troubleshoot any issues.
 * Use the provided tools and features to configure and deploy; keep up-to-date; set up resource requests and limits; size the cluster to have enough resources to run apps; set up permissions; integrate with other services; manage any image streams or templates that the customer deploys; externally serve; save, back up, and restore data; and otherwise manage their highly available and resilient workloads.


### PR DESCRIPTION
Per Olivia's peer review suggestion, I removed "their" from the bullet description in the Customer applications row, Red Hat responsibilities column.

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-3212


<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
