### PR TITLE
OCPBUGS#714 RWO access for baremetal registry storage requires Recreate rollout strategy

### DIFF
--- a/modules/registry-configuring-storage-baremetal.adoc
+++ b/modules/registry-configuring-storage-baremetal.adoc
@@ -48,7 +48,7 @@ ifdef::ibm-z[* You have provisioned persistent storage for your cluster.]
 +
 [IMPORTANT]
 ====
-{product-title} supports `ReadWriteOnce` access for image registry storage when you have only one replica. To deploy an image registry that supports high availability with two or more replicas, `ReadWriteMany` access is required.
+{product-title} supports `ReadWriteOnce` access for image registry storage when you have only one replica. `ReadWriteOnce` access also requires that the registry uses the `Recreate` rollout strategy. To deploy an image registry that supports high availability with two or more replicas, `ReadWriteMany` access is required.
 ====
 +
 * Must have 100Gi capacity.


### PR DESCRIPTION
[OCPBUGS#714](https://issues.redhat.com/browse/OCPBUGS-714) RWO access for baremetal registry storage requires Recreate rollout strategy

4.8+

Related to https://issues.redhat.com/browse/OCPBUGS-452

[Doc preview](https://bscott-rh.github.io/openshift-docs/OCPBUGS-714/registry/configuring_registry_storage/configuring-registry-storage-baremetal.html#registry-configuring-storage-baremetal_configuring-registry-storage-baremetal)