### PR TITLE
Adds a note to the quayHostname flag about IP addresses

### DIFF
--- a/modules/mirror-registry-flags.adoc
+++ b/modules/mirror-registry-flags.adoc
@@ -25,5 +25,5 @@ The following flags are available for the _mirror registry for Red Hat OpenShift
 |`--version` | Shows the version for the _mirror registry for Red Hat OpenShift_.
 |===
 [.small]
-1. `--quayHostname` must be modified if the public DNS name of your system is different from the local hostname.
+1. `--quayHostname` must be modified if the public DNS name of your system is different from the local hostname. Additionally, the `--quayHostname` flag does not support installation with an IP address. Installation with a hostname is required. 
 2. `--sslCheckSkip` is used in cases when the mirror registry is set behind a proxy and the exposed hostname is different from the internal Quay hostname. It can also be used when users do not want the certificates to be validated against the provided Quay hostname during installation.


### PR DESCRIPTION
Adds a note to the quayHostname flag about IP addresses

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/PROJQUAY-4375

Link to docs preview:
https://stevsmit.github.io/openshift-docs/installing-mirroring-creating-registry.html#mirror-registry-flags_installing-mirroring-creating-registry


