### PR TITLE
OSDOCS-3546: Egress firewall supports logging

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1029,8 +1029,6 @@ Topics:
   Topics:
   - Name: About network policy
     File: about-network-policy
-  - Name: Logging network policy
-    File: logging-network-policy
   - Name: Creating a network policy
     File: creating-network-policy
   - Name: Viewing a network policy
@@ -1155,6 +1153,8 @@ Topics:
     File: rollback-to-openshift-sdn
   - Name: Converting to IPv4/IPv6 dual stack networking
     File: converting-to-dual-stack
+  - Name: Logging for egress firewall and network policy rules
+    File: logging-network-policy
   - Name: Configuring IPsec encryption
     File: configuring-ipsec-ovn
   - Name: Configuring an egress firewall for a project

--- a/logging/cluster-logging-external.adoc
+++ b/logging/cluster-logging-external.adoc
@@ -198,6 +198,6 @@ include::modules/cluster-logging-collector-collecting-ovn-logs.adoc[leveloffset=
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../networking/network_policy/logging-network-policy.adoc#nw-networkpolicy-audit-concept_logging-network-policy[Network policy audit logging]
+* xref:../networking/ovn_kubernetes_network_provider/logging-network-policy.adoc#logging-network-policy[Logging for egress firewall and network policy rules]
 
 include::modules/cluster-logging-troubleshooting-log-forwarding.adoc[leveloffset=+1]

--- a/modules/nw-networkpolicy-audit-concept.adoc
+++ b/modules/nw-networkpolicy-audit-concept.adoc
@@ -1,12 +1,12 @@
 [id="nw-networkpolicy-audit-concept_{context}"]
-= Network policy audit logging
+= Audit logging
 
-The OVN-Kubernetes cluster network provider uses Open Virtual Network (OVN) ACLs to manage network policy. Audit logging exposes allow and deny ACL events.
+The OVN-Kubernetes cluster network provider uses Open Virtual Network (OVN) ACLs to manage egress firewalls and network policies. Audit logging exposes allow and deny ACL events.
 
-You can configure the destination for network policy audit logs, such as a syslog server or a UNIX domain socket.
+You can configure the destination for audit logs, such as a syslog server or a UNIX domain socket.
 Regardless of any additional configuration, an audit log is always saved to `/var/log/ovn/acl-audit-log.log` on each OVN-Kubernetes pod in the cluster.
 
-Network policy audit logging is enabled per namespace by annotating the namespace with the `k8s.ovn.org/acl-logging` key as in the following example:
+Audit logging is enabled per namespace by annotating the namespace with the `k8s.ovn.org/acl-logging` key as in the following example:
 
 .Example namespace annotation
 [source,yaml]
@@ -25,7 +25,7 @@ metadata:
 
 The logging format is compatible with syslog as defined by RFC5424. The syslog facility is configurable and defaults to `local0`. An example log entry might resemble the following:
 
-.Example ACL deny log entry
+.Example ACL deny log entry for a network policy
 [source,text]
 ----
 2021-06-13T19:33:11.590Z|00005|acl_log(ovn_pinctrl0)|INFO|name="verify-audit-logging_deny-all", verdict=drop, severity=alert: icmp,vlan_tci=0x0000,dl_src=0a:58:0a:80:02:39,dl_dst=0a:58:0a:80:02:37,nw_src=10.128.2.57,nw_dst=10.128.2.55,nw_tos=0,nw_ecn=0,nw_ttl=64,icmp_type=8,icmp_code=0
@@ -33,14 +33,14 @@ The logging format is compatible with syslog as defined by RFC5424. The syslog f
 
 The following table describes namespace annotation values:
 
-.Network policy audit logging namespace annotation
+.Audit logging namespace annotation
 [cols=".^4,.^6a",options="header"]
 |====
 |Annotation|Value
 
 |`k8s.ovn.org/acl-logging`
 |
-You must specify at least one of `allow`, `deny`, or both to enable network policy audit logging for a namespace.
+You must specify at least one of `allow`, `deny`, or both to enable audit logging for a namespace.
 
 `deny`:: Optional: Specify `alert`, `warning`, `notice`, `info`, or `debug`.
 `allow`:: Optional: Specify `alert`, `warning`, `notice`, `info`, or `debug`.

--- a/modules/nw-networkpolicy-audit-configure.adoc
+++ b/modules/nw-networkpolicy-audit-configure.adoc
@@ -1,8 +1,8 @@
 :_content-type: PROCEDURE
 [id="nw-networkpolicy-audit-configure_{context}"]
-= Configuring network policy auditing for a cluster
+= Configuring egress firewall and network policy auditing for a cluster
 
-As a cluster administrator, you can customize network policy audit logging for your cluster.
+As a cluster administrator, you can customize audit logging for your cluster.
 
 .Prerequisites
 
@@ -11,7 +11,7 @@ As a cluster administrator, you can customize network policy audit logging for y
 
 .Procedure
 
-* To customize the network policy audit logging configuration, enter the following command:
+* To customize the audit logging configuration, enter the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-networkpolicy-audit-disable.adoc
+++ b/modules/nw-networkpolicy-audit-disable.adoc
@@ -1,8 +1,8 @@
 :_content-type: PROCEDURE
 [id="nw-networkpolicy-audit-disable_{context}"]
-= Disabling network policy audit logging for a namespace
+= Disabling egress firewall and network policy audit logging for a namespace
 
-As a cluster administrator, you can disable network policy audit logging for a namespace.
+As a cluster administrator, you can disable audit logging for a namespace.
 
 .Prerequisites
 
@@ -11,7 +11,7 @@ As a cluster administrator, you can disable network policy audit logging for a n
 
 .Procedure
 
-* To disable network policy audit logging for a namespace, enter the following command:
+* To disable audit logging for a namespace, enter the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-networkpolicy-audit-enable.adoc
+++ b/modules/nw-networkpolicy-audit-enable.adoc
@@ -1,8 +1,8 @@
 :_content-type: PROCEDURE
 [id="nw-networkpolicy-audit-enable_{context}"]
-= Enabling network policy audit logging for a namespace
+= Enabling egress firewall and network policy audit logging for a namespace
 
-As a cluster administrator, you can enable network policy audit logging for a namespace.
+As a cluster administrator, you can enable audit logging for a namespace.
 
 .Prerequisites
 
@@ -11,7 +11,7 @@ As a cluster administrator, you can enable network policy audit logging for a na
 
 .Procedure
 
-* To enable network policy audit logging for a namespace, enter the following command:
+* To enable audit logging for a namespace, enter the following command:
 +
 [source,terminal]
 ----
@@ -52,7 +52,7 @@ namespace/verify-audit-logging annotated
 
 .Verification
 
-* Display the latest entries in the network policy audit log:
+* Display the latest entries in the audit log:
 +
 [source,terminal]
 ----

--- a/networking/network_policy/creating-network-policy.adoc
+++ b/networking/network_policy/creating-network-policy.adoc
@@ -24,4 +24,5 @@ ifndef::openshift-rosa,openshift-dedicated[]
 == Additional resources
 
 * xref:../../web_console/web-console.adoc#web-console[Accessing the web console]
+* xref:../../networking/ovn_kubernetes_network_provider/logging-network-policy.adoc#logging-network-policy[Logging for egress firewall and network policy rules]
 endif::[]

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -30,7 +30,7 @@ include::modules/nw-ovn-kuberentes-limitations.adoc[leveloffset=+1]
 
 * xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]
 * xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
-* xref:../../networking/network_policy/logging-network-policy.adoc#logging-network-policy[Logging network policy events]
+* xref:../../networking/ovn_kubernetes_network_provider/logging-network-policy.adoc#logging-network-policy[Logging network policy events]
 * xref:../../networking/ovn_kubernetes_network_provider/enabling-multicast.adoc#nw-ovn-kubernetes-enabling-multicast[Enabling multicast for a project]
 * xref:../../networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
 * xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1\]]

--- a/networking/ovn_kubernetes_network_provider/logging-network-policy.adoc
+++ b/networking/ovn_kubernetes_network_provider/logging-network-policy.adoc
@@ -1,23 +1,24 @@
 :_content-type: ASSEMBLY
 [id="logging-network-policy"]
-= Logging network policy events
+= Logging for egress firewall and network policy rules
 include::_attributes/common-attributes.adoc[]
 :context: logging-network-policy
 
 toc::[]
 
-As a cluster administrator, you can configure network policy audit logging for your cluster and enable logging for one or more namespaces.
+As a cluster administrator, you can configure audit logging for your cluster and enable logging for one or more namespaces. {product-title} produces audit logs for both egress firewalls and network policies.
 
 [NOTE]
 ====
-Audit logging of network policies is available for only the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes cluster network provider].
+Audit logging is available for only the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes cluster network provider].
 ====
 
 include::modules/nw-networkpolicy-audit-concept.adoc[leveloffset=+1]
 
-== Network policy audit configuration
+[id="network-policy-audit-configuration-{context}"]
+== Audit configuration
 
-The configuration for audit logging is specified as part of the OVN-Kubernetes cluster network provider configuration. The following YAML illustrates default values for network policy audit logging feature.
+The configuration for audit logging is specified as part of the OVN-Kubernetes cluster network provider configuration. The following YAML illustrates the default values for the audit logging:
 
 .Audit logging configuration
 [source,yaml]
@@ -36,7 +37,7 @@ spec:
         syslogFacility: local0
 ----
 
-The following table describes the configuration fields for network policy audit logging.
+The following table describes the configuration fields for audit logging.
 
 include::modules/nw-operator-cr.adoc[tag=policy-audit]
 
@@ -49,3 +50,4 @@ include::modules/nw-networkpolicy-audit-disable.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
+* xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]


### PR DESCRIPTION
Because the logging mechanism for EgressFirewall is an extension
of that for network policy, this PR reshuffles and expands the
content to reflect this. The new location of the content is with
the rest of the OVN-Kubernetes documentation.

- https://issues.redhat.com/browse/OSDOCS-3546

Preview: [Logging for egress firewall and network policy rules](https://49778--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/logging-network-policy.html)


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

