### PR TITLE
BZ2099314 updating procedure for accessing registry from the cluster

### DIFF
--- a/modules/registry-accessing-directly.adoc
+++ b/modules/registry-accessing-directly.adoc
@@ -13,7 +13,7 @@ You can access the registry from inside the cluster.
 Access the registry from the cluster by using internal routes:
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
-. Access the node by getting the node's address:
+. Access the node by getting the node's name:
 +
 [source,terminal]
 ----
@@ -22,7 +22,7 @@ $ oc get nodes
 +
 [source,terminal]
 ----
-$ oc debug nodes/<node_address>
+$ oc debug nodes/<node_name>
 ----
 
 . To enable access to tools such as `oc` and `podman` on the node, run the following command:


### PR DESCRIPTION
Version(s):
  * PR applies to all versions including and after: 4.6+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2099314

Link to docs preview:
http://file.rdu.redhat.com/shdiaz/BZ2099314/registry/accessing-the-registry.html#registry-accessing-directly_accessing-the-registry

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
