### PR TITLE
[RHACS] Enable vale checking for rhacs-docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ dev_guide/builds/images/chained-build.png.cache
 .gem
 bin
 commercial_package
+.vscode
+.vale

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,34 @@ language: python
 
 cache: pip
 
-sudo: required
+git:
+  depth: 1
 
-before_install:
- - gem install asciidoctor
- - gem install asciidoctor-diagram
+jobs:
+  include:
+    - stage: build
+      name: "Build openshift-acs distro"
+      before_install:
+        - gem install asciidoctor
+        - gem install asciidoctor-diagram
+      install:
+        - pip3 install pyyaml
+        - pip3 install aura.tar.gz
+      script:
+        - python3 build.py --distro openshift-acs --product "Red Hat Advanced Cluster Security for Kubernetes" --version 3.71 --no-upstream-fetch && python3 makeBuild.py
+    - stage: check-with-vale
+      if: type IN (pull_request)
+      name: "Run Vale against PR asciidoc files"
+      before_script:
+        - gem install asciidoctor
+      script:
+        - wget https://github.com/errata-ai/vale/releases/download/v2.20.1/vale_2.20.1_Linux_64-bit.tar.gz
+        - mkdir bin && tar -xvzf vale_2.20.1_Linux_64-bit.tar.gz -C bin
+        - export PATH=./bin:"$PATH"
+        - vale sync # pull down VRH rules package
+        - chmod +x ./scripts/check-with-vale.sh
+        - ./scripts/check-with-vale.sh $TRAVIS_PULL_REQUEST $TRAVIS_PULL_REQUEST_SHA
 
-install:
- - pip3 install pyyaml
- - pip3 install aura.tar.gz
-
-script:
- - python3 build.py --distro openshift-acs --product "Red Hat Advanced Cluster Security for Kubernetes" --version 3.69 --no-upstream-fetch && python3 makeBuild.py
-
-# Commenting out to disable auto-merging of PRs
-# after_success:
-# - bash ./automerge.sh
+stages:
+  - build
+  - check-with-vale

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,13 @@
+StylesPath = .vale/styles
+
+MinAlertLevel = error
+
+Packages = RedHat
+
+#ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
+[[!.]*.adoc]
+BasedOnStyles = RedHat
+
+#optional: pass doc attributes to asciidoctor before linting
+#[asciidoctor]
+#openshift-enterprise = YES

--- a/scripts/check-with-vale.sh
+++ b/scripts/check-with-vale.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+# list of *.adoc files excluding files in /rest_api, generated files, and deleted files
+FILES=$(git diff --name-only HEAD~1 HEAD --diff-filter=d "*.adoc" ':(exclude)rest_api/*' ':(exclude)modules/example-content.adoc' ':(exclude)modules/oc-adm-by-example-content.adoc')
+
+if [ -n "${FILES}" ] ;
+    then
+        echo "Validating language usage in added or modified asciidoc files with $(vale -v)"
+        echo ""
+        echo "==============================================================================================================================="
+        echo "Read about the error terms that cause the build to fail at https://redhat-documentation.github.io/vale-at-red-hat/docs/reference-guide/termserrors/"
+        echo "==============================================================================================================================="
+        echo ""
+        #clean out conditional markup
+        sed -i -e 's/ifdef::.*\|ifndef::.*\|ifeval::.*\|endif::.*/ /' ${FILES}
+        vale ${FILES} --minAlertLevel=error --glob='*.adoc' --no-exit
+        echo ""
+        if [ "$TRAVIS" = true ] ; then
+            set -x
+            #run vale again, and this time send to pipedream
+            PR_DATA=''
+            if [ "$1" == false ] ; then
+                PR_DATA='{"PR": [{"Number": "None", "SHA": "None"}],'
+            else
+                PR_DATA='{"PR": [{"Number": "'"$1"'", "SHA": "'"$2"'"}]',
+            fi
+            echo "${PR_DATA}" > vale_errors.json
+            ERROR_DATA=$(vale ${FILES} --minAlertLevel=error --glob='*.adoc' --output=JSON --no-exit)
+            echo "${ERROR_DATA:1}" >> vale_errors.json
+            curl -H "Content-Type: text/json" --data "@vale_errors.json" https://eox4isrzuh8pnai.m.pipedream.net
+        fi
+    else
+        echo "No asciidoc files added or modified."
+fi


### PR DESCRIPTION
Based on https://github.com/openshift/openshift-docs/pull/45699

Applies to:
- `rhacs-docs-3.71`
- `rhacs-docs-3.70`
- `rhacs-docs-3.69`

Adds vale checking for rhacs-docs.