### PR TITLE
adding .vale to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dev_guide/builds/images/chained-build.png.cache
 bin
 commercial_package
 .vscode
+.vale

--- a/scripts/check-with-vale.sh
+++ b/scripts/check-with-vale.sh
@@ -17,18 +17,20 @@ if [ -n "${FILES}" ] ;
         sed -i -e 's/ifdef::.*\|ifndef::.*\|ifeval::.*\|endif::.*/ /' ${FILES}
         vale ${FILES} --minAlertLevel=error --glob='*.adoc' --no-exit 
         echo ""
-        set -x
-        #run again, and this time send to pipedream
-        PR_DATA=''
-        if [ "$1" == false ] ; then
-            PR_DATA='{"PR": [{"Number": "None", "SHA": "None"}],'
-        else
-            PR_DATA='{"PR": [{"Number": "'"$1"'", "SHA": "'"$2"'"}]',
+        if [ "$TRAVIS" = true ] ; then
+            set -x
+            #run vale again, and this time send to pipedream
+            PR_DATA=''
+            if [ "$1" == false ] ; then
+                PR_DATA='{"PR": [{"Number": "None", "SHA": "None"}],'
+            else
+                PR_DATA='{"PR": [{"Number": "'"$1"'", "SHA": "'"$2"'"}]',
+            fi
+            echo "${PR_DATA}" > vale_errors.json
+            ERROR_DATA=$(vale ${FILES} --minAlertLevel=error --glob='*.adoc' --output=JSON --no-exit)
+            echo "${ERROR_DATA:1}" >> vale_errors.json
+            curl -H "Content-Type: text/json" --data "@vale_errors.json" https://eox4isrzuh8pnai.m.pipedream.net
         fi
-        echo "${PR_DATA}" > vale_errors.json
-        ERROR_DATA=$(vale ${FILES} --minAlertLevel=error --glob='*.adoc' --output=JSON --no-exit)
-        echo "${ERROR_DATA:1}" >> vale_errors.json
-        curl -H "Content-Type: text/json" --data "@vale_errors.json" https://eox4isrzuh8pnai.m.pipedream.net
     else
         echo "No asciidoc files added or modified."
 fi


### PR DESCRIPTION
Adding `.vale` folder to gitignore and updating the vale-check script to run locally without pinging the pipedream sheet.

Adding .vale folder to .gitignore is also required to allow writers to pull down the VRH rules locally.