### PR TITLE
TELCODOCS-780-CM making small update based on feedback from change man

### DIFF
--- a/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
+++ b/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
@@ -5,17 +5,17 @@
 [id="nw-sriov-cfg-bond-interface-with-virtual-functions_{context}"]
 = Configuring a bond interface from two SR-IOV interfaces
 
-Bonding enables multiple network interfaces to be aggregated into a single logical "bonded" interface. Bond-CNI brings bond capability into containers.
+Bonding enables multiple network interfaces to be aggregated into a single logical "bonded" interface. Bond Container Network Interface (Bond-CNI) brings bond capability into containers.
 
-Bond-CNI can be created using SR-IOV virtual functions and placing them in the container network namespace.
+Bond-CNI can be created using Single Root I/O Virtualization (SR-IOV) virtual functions and placing them in the container network namespace.
 
-{product-title} only supports Bond-CNI using SR-IOV virtual functions. Physical interfaces are not supported.
+{product-title} only supports Bond-CNI using SR-IOV virtual functions. The SR-IOV Network Operator provides the SR-IOV CNI plug-in needed to manage the virtual functions. Other CNIs or types of interfaces are not supported.
 
 .Prerequisites
 
-* The SR-IOV operator must be installed and configured to obtain virtual functions in a container.
+* The SR-IOV Network Operator must be installed and configured to obtain virtual functions in a container.
 * To configure SR-IOV interfaces, an SR-IOV network and policy must be created for each interface.
-* The SR-IOV operator creates a network attachment definition for each SR-IOV interface, based on the SR-IOV network and policy defined.
+* The SR-IOV Network Operator creates a network attachment definition for each SR-IOV interface, based on the SR-IOV network and policy defined.
 * The `linkState` is set to the default value `auto` for the SR-IOV virtual function.
 
 [id="nw-sriov-cfg-creating-bond-network-attachment-definition_{context}"]


### PR DESCRIPTION
[TELCODOCS-780](https://issues.redhat.com//browse/TELCODOCS-780): Promote bond CNI to GA

Version(s):
PR applies to main, 4.12, and 4.11

Issue:
https://issues.redhat.com/browse/TELCODOCS-780

Notes: I added a clarification note to one line based on feedback from change management review.
The original PR is https://github.com/openshift/openshift-docs/pull/47172 which went through the whole process. Afterwards I issued CM request as I missed in initial PR. 

Preview: http://file.emea.redhat.com/kquinn/TELCODOCS-780-CM/networking/hardware_networks/using-pod-level-bonding.html