### PR TITLE
OCPBUGS#752 Change documentation from supported instance types to tested instance types

### DIFF
--- a/installing/installing_aws/installing-aws-china.adoc
+++ b/installing/installing_aws/installing-aws-china.adoc
@@ -44,7 +44,10 @@ include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
-include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
+
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]

--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -41,7 +41,9 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
-include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
+
+include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 

--- a/installing/installing_aws/installing-aws-government-region.adoc
+++ b/installing/installing_aws/installing-aws-government-region.adoc
@@ -43,7 +43,8 @@ include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
-include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -45,7 +45,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
-include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 

--- a/installing/installing_aws/installing-aws-private.adoc
+++ b/installing/installing_aws/installing-aws-private.adoc
@@ -40,7 +40,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
-include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 

--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -46,6 +46,8 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]

--- a/installing/installing_aws/installing-aws-vpc.adoc
+++ b/installing/installing_aws/installing-aws-vpc.adoc
@@ -36,7 +36,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
-include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -65,6 +65,8 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -32,6 +32,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-government-region.adoc
+++ b/installing/installing_azure/installing-azure-government-region.adoc
@@ -42,6 +42,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/installing-azure-network-customizations.adoc
@@ -37,6 +37,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-private.adoc
+++ b/installing/installing_azure/installing-azure-private.adoc
@@ -37,6 +37,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-user-infra.adoc
+++ b/installing/installing_azure/installing-azure-user-infra.adoc
@@ -70,6 +70,7 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/installing-azure-vnet.adoc
+++ b/installing/installing_azure/installing-azure-vnet.adoc
@@ -31,6 +31,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -31,6 +31,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_gcp/installing-gcp-network-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-network-customizations.adoc
@@ -38,6 +38,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_gcp/installing-gcp-private.adoc
+++ b/installing/installing_gcp/installing-gcp-private.adoc
@@ -35,6 +35,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -60,6 +60,7 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-user-infra-config-host-project-vpc.adoc[leveloffset=+1]
 include::modules/installation-gcp-dns.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -55,6 +55,7 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
 include::modules/installation-disk-partitioning-upi-templates.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -31,6 +31,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -42,6 +42,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -62,6 +62,7 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
 include::modules/installation-disk-partitioning-upi-templates.adoc[leveloffset=+2]

--- a/modules/installation-aws-arm-tested-machine-types.adoc
+++ b/modules/installation-aws-arm-tested-machine-types.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// installing/installing_aws/installing-aws-china.adoc
+// installing/installing_aws/installing-aws-customizations.adoc
+// installing/installing_aws/installing-aws-government-region.adoc
+// installing/installing_aws/installing-aws-network-customizations.adoc
+// installing/installing_aws/installing-aws-private.adoc
+// installing/installing_aws/installing-aws-user-infra.adoc
+// installing/installing_aws/installing-aws-vpc.adoc
+// installing/installing_aws/installing-restricted-networks-aws.adoc
+
+[id="installation-aws-arm-tested-machine-types_{context}"]
+= Tested instance types for AWS ARM
+
+The following Amazon Web Services (AWS) ARM instance types have been tested with {product-title}.
+
+.Machine types based on arm64 architecture
+[%collapsible]
+====
+include::https://raw.githubusercontent.com/openshift/installer/master/docs/user/aws/tested_instance_types_aarch64.md[]
+====

--- a/modules/installation-aws-tested-machine-types.adoc
+++ b/modules/installation-aws-tested-machine-types.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// installing/installing_aws/installing-aws-china.adoc
+// installing/installing_aws/installing-aws-customizations.adoc
+// installing/installing_aws/installing-aws-government-region.adoc
+// installing/installing_aws/installing-aws-network-customizations.adoc
+// installing/installing_aws/installing-aws-private.adoc
+// installing/installing_aws/installing-aws-user-infra.adoc
+// installing/installing_aws/installing-aws-vpc.adoc
+// installing/installing_aws/installing-restricted-networks-aws.adoc
+
+[id="installation-aws-tested-machine-types_{context}"]
+= Tested instance types for AWS
+
+The following Amazon Web Services (AWS) instance types have been tested with {product-title}.
+
+.Machine types based on x86_64 architecture
+[%collapsible]
+====
+include::https://raw.githubusercontent.com/openshift/installer/master/docs/user/aws/tested_instance_types_x86_64.md[]
+====

--- a/modules/installation-azure-tested-machine-types.adoc
+++ b/modules/installation-azure-tested-machine-types.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// installing/installing_azure/installing-azure-customizations.adoc
+// installing/installing_azure/installing-azure-government-region.adoc
+// installing/installing_azure/installing-azure-network-customizations.adoc
+// installing/installing_azure/installing-azure-private.adoc
+// installing/installing_azure/installing-azure-user-infra.adoc
+// installing/installing_azure/installing-azure-vnet.adoc
+
+[id="installation-azure-tested-machine-types_{context}"]
+= Tested instance types for Azure
+
+The following Microsoft Azure instance types have been tested with {product-title}.
+
+.Machine types
+[%collapsible]
+====
+include::https://raw.githubusercontent.com/openshift/installer/master/docs/user/azure/tested_instance_types.md[]
+====

--- a/modules/installation-gcp-tested-machine-types.adoc
+++ b/modules/installation-gcp-tested-machine-types.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// installing/installing_gcp/installing-gcp-customizations.adoc
+// installing/installing_gcp/installing-gcp-network-customizations.adoc
+// installing/installing_gcp/installing-gcp-private.adoc
+// installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+// installing/installing_gcp/installing-gcp-user-infra.adoc
+// installing/installing_gcp/installing-gcp-vpc.adoc
+// installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+// installing/installing_gcp/installing-restricted-networks-gcp.adoc
+
+[id="installation-gcp-tested-machine-types_{context}"]
+= Tested instance types for GCP
+
+The following Google Cloud Platform instance types have been tested with {product-title}.
+
+.Machine series
+[%collapsible]
+====
+include::https://raw.githubusercontent.com/openshift/installer/master/docs/user/gcp/tested_instance_types.md[]
+====

--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -188,6 +188,8 @@ You are required to use Azure virtual machines with `premiumIO` set to `true`. T
 ====
 endif::azure[]
 
+If an instance type for your platform meets the minimum requirements for cluster machines, it is supported to use in {product-title}.
+
 ifeval::["{context}" == "installing-azure-customizations"]
 :!azure:
 endif::[]


### PR DESCRIPTION
Resuming work from https://github.com/openshift/openshift-docs/pull/41796. Adding "tested instance types" tables to AWS, Azure and GCP install docs. 

CP to 4.10, 4.11, 4.12

Jira: https://issues.redhat.com/browse/OCPBUGS-752

Doc preview: 
[AWS](https://bscott-rh.github.io/openshift-docs/tested-instance-types/installing/installing_aws/installing-aws-customizations.html#installation-aws-tested-machine-types_installing-aws-customizations)
[AWS ARM](https://bscott-rh.github.io/openshift-docs/tested-instance-types/installing/installing_aws/installing-aws-customizations.html#installation-aws-arm-tested-machine-types_installing-aws-customizations)
[Azure](https://bscott-rh.github.io/openshift-docs/tested-instance-types/installing/installing_azure/installing-azure-customizations.html#installation-azure-tested-machine-types_installing-azure-customizations)
[GCP](https://bscott-rh.github.io/openshift-docs/tested-instance-types/installing/installing_gcp/installing-gcp-customizations.html#installation-gcp-tested-machine-types_installing-gcp-customizations)