### PR TITLE
OCPBUGS#760 Added N1 machine type prerequisite and note

### DIFF
--- a/installing/installing_gcp/installing-gcp-default.adoc
+++ b/installing/installing_gcp/installing-gcp-default.adoc
@@ -16,6 +16,12 @@ Google Cloud Platform (GCP) that uses the default configuration options.
 * You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a GCP project] to host the cluster.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 * If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
+* You have determined that the GCP region to which you are installing supports the `N1` machine type. For more information, see the link:https://cloud.google.com/compute/docs/regions-zones#available[Google documentation]. By default, the installation program deploys control plane and compute nodes with the `N1` machine type.
+
+[NOTE]
+====
+If the region to which you are installing does not support the `N1` machine type, you cannot complete the installation using these steps. You must specify a supported machine type in the `install-config.yaml` file before you install the cluster. For more information, see xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[Installing a cluster on GCP with customizations].
+====
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
 4.11

Issue:
This issue addresses [OCPBUGS-760](https://issues.redhat.com/browse/OCPBUGS-760)

Link to docs preview:
[Prerequisites](http://file.rdu.redhat.com/mpytlak/ocpbugs-760/installing/installing_gcp/installing-gcp-default.html#prerequisites)

Additional information:
This is the first of two [1] PR to address this issue, as it applies to 4.11 and 4.10 only.

[1] 4.10 https://github.com/openshift/openshift-docs/pull/49804