### PR TITLE
OSDOCS-3908: enhances egressfirewall to include nodeSelector

### DIFF
--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -46,11 +46,7 @@ endif::ovn[]
 
 [IMPORTANT]
 ====
-If your egress firewall includes a deny rule for `0.0.0.0/0`, access to your {product-title} API servers is blocked. You must include the IP address range that the API servers listen on in your egress firewall rules.
-
-ifdef::ovn[]
-If you use the OVN-Kubernetes network plugin, you must include the built-in join network `100.64.0.0/16` to allow access when using node ports together with an egress firewall. If you changed this join network during cluster installation, use the value that you specified instead of `100.64.0.0/16`.
-endif::ovn[]
+If your egress firewall includes a deny rule for `0.0.0.0/0`, access to your {product-title} API servers is blocked. You must either add allow rules for each IP address or use the `nodeSelector` type allow rule in your egress policy rules to connect to API servers.
 
 The following example illustrates the order of the egress firewall rules necessary to ensure API server access:
 

--- a/modules/nw-egressnetworkpolicy-object.adoc
+++ b/modules/nw-egressnetworkpolicy-object.adoc
@@ -49,7 +49,7 @@ endif::ovn[]
 [id="egressnetworkpolicy-rules_{context}"]
 == {kind} rules
 
-The following YAML describes an egress firewall rule object. The `egress` stanza expects an array of one or more objects.
+The following YAML describes an egress firewall rule object. The user can select either an IP address range in CIDR format, a domain name, or use the `nodeSelector` to allow or deny egress traffic. The `egress` stanza expects an array of one or more objects.
 
 // - OVN-Kubernetes does not support DNS
 // - OpenShift SDN does not support port and protocol specification
@@ -77,14 +77,16 @@ egress:
   to: <2>
     cidrSelector: <cidr> <3>
     dnsName: <dns_name> <4>
-  ports: <5>
+    nodeSelector: <label_name>: <label_value> <5>
+  ports: <6>
       ...
 ----
 <1> The type of rule. The value must be either `Allow` or `Deny`.
 <2> A stanza describing an egress traffic match rule that specifies the `cidrSelector` field or the `dnsName` field. You cannot use both fields in the same rule.
 <3> An IP address range in CIDR format.
 <4> A DNS domain name.
-<5> Optional: A stanza describing a collection of network ports and protocols for the rule.
+<5> Labels are key/value pairs that the user defines. Labels are attached to objects, such as pods. The `nodeSelector` allows for one or more node labels to be selected and attached to pods.
+<6> Optional: A stanza describing a collection of network ports and protocols for the rule.
 
 .Ports stanza
 [source,yaml]
@@ -143,6 +145,31 @@ spec:
       protocol: TCP
     - port: 443
 ----
+
+[id="configuringNodeSelector-example_{context}"]
+== Example nodeSelector for {kind}
+
+As a cluster administrator, you can allow or deny egress traffic to nodes in your cluster by specifying a label using `nodeSelector`. Labels can be applied to one or more nodes. The following is an example with the `region=east` label:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: default
+spec:
+    egress:
+    - to:
+        nodeSelector:
+          matchLabels:
+            region: east
+      type: Allow
+----
+
+[TIP]
+====
+Instead of adding manual rules per node IP address, use node selectors to create a label that allows pods behind an egress firewall to access host network pods.
+====
 endif::ovn[]
 
 ifdef::kind[]


### PR DESCRIPTION
[OSDOCS-3098](https://issues.redhat.com//browse/OSDOCS-3098): enhances egress firewall on OVN-Kubernetes cluster network provider to include `NodeSelector`
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue:
[Jira](https://issues.redhat.com/browse/OSDOCS-3908)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Preview](https://49806--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.html#configuring-egress-firewall-ovn)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. -->

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
#49867 
@huiran0826 PTAL
I have QE acks
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
