### PR TITLE
OSDOCS#4059 Added note about us-west2 and N2 machine types

### DIFF
--- a/installing/installing_gcp/installing-gcp-default.adoc
+++ b/installing/installing_gcp/installing-gcp-default.adoc
@@ -9,6 +9,11 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on
 Google Cloud Platform (GCP) that uses the default configuration options.
 
+[NOTE]
+====
+By default, the installation program deploys control plane and compute nodes with the N2 machine type. However, the GCP `us-west2-c` zone does not support this machine type. If you are installing to the `us-west2` region, you cannot complete the installation using these steps. You must specify a supported machine type in the `install-config.yaml` file before you install the cluster. For more information, see xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[Installing a cluster on GCP with customizations].
+====
+
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.


### PR DESCRIPTION
Version(s):
CP to 4.12

Issue:
This issue addresses [OSDOCS-4059](https://issues.redhat.com/browse/OSDOCS-4059)

Link to docs preview:
[Installing a cluster quickly on GCP](http://file.rdu.redhat.com/mpytlak/osdocs-4059/installing/installing_gcp/installing-gcp-default.html)