### PR TITLE
RHDEVDOCS-4235 - Add alertmanager permission changes to 4.9 Release Notes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -805,6 +805,15 @@ Red Hat does not guarantee backward compatibility for metrics, recording rules, 
 
 * You can add and configure additional external Alertmanagers for both platform and user-defined project monitoring stacks.
 * You can disable the local Alertmanager instance.
+* With the new `monitoring-alertmanager-edit` user role, non-administrator users can create and silence alerts for default platform monitoring.
+To allow these users to create and silence alerts, you must assign them the new `monitoring-alertmanager-edit` role in addition to the `cluster-monitoring-view` role.
++
+[IMPORTANT]
+====
+With this release, the `cluster-monitoring-view` role is now restricted to allowing access to Alertmanager.
+Non-administrator users assigned to this role, who were allowed in earlier versions of {product-title} to create and silence alerts, cannot now do this.  
+To allow non-administrator users to create and silence alerts in Alertmanager in {product-title} {product-version}, you must assign them the new `monitoring-alertmanager-edit` role in addition to the `cluster-monitoring-view` role.
+====
 
 ==== Prometheus
 
@@ -1477,6 +1486,16 @@ The Cluster Samples Operator can bootstrap itself as `removed` in a variety of c
 
 * Previously, there was a race between the installer pod and the cert-syncer container, which were writing to the same path. This could leave some certificates empty and prevent the server from running. Kubernetes API server certificates are now written in an atomic way to prevent races between multiple processes.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971624[*BZ#1971624*])
+
+
+[discrete]
+[id="ocp-4-9-monitoring-bug-fixes"]
+==== Monitoring
+
+* Before this update, even though the aim of the `cluster-monitoring-view` user role was to only allow access to Alertmanager, non-administrator users assigned to this role could still create and silence alerts. 
+With this update, users assigned only to this role can no longer create or silence alerts.
+To allow non-administrator users to create and silence alerts, you must assign them the new `monitoring-alertmanager-edit` role in addition to the `cluster-monitoring-view` role. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1947005[*BZ#1947005*])
+
 
 [discrete]
 [id="ocp-4-9-networking-bug-fixes"]


### PR DESCRIPTION
Summary: This PR adds OCP 4.9 Release Notes content regarding changes to Alertmanager user roles. This content was inadvertently left out at the time of the OCP 4.9 release.

- Aligned team: DevTools
- For branches: 
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4235
- Direct link to doc preview (RH VPN access required):
- - http://file.rdu.redhat.com/bburt/RHDEVDOCS-4235-4-9-add-alertmanager-permission-changes-to-RNs/release_notes/ocp-4-9-release-notes.html#alertmanager
- - New Monitoring section in Bug Fixes section: http://file.rdu.redhat.com/bburt/RHDEVDOCS-4235-4-9-add-alertmanager-permission-changes-to-RNs/release_notes/ocp-4-9-release-notes.html#ocp-4-9-bug-fixes
- SME review: @simonpasquier (approved)
- QE review: @juzhao (approved)
- Peer review: @gabriel-rh (approved)

**Change Management**
ACK from Eng: @danielm0hr (approved)
ACK from PM: Roger Floren (approved in Slack)
ACK from Product Experience: @Senthamilarasu-STA (approved)
ACK from QE: @juzhao  
ACK from DPM: Provided in https://issues.redhat.com/browse/RHDEVDOCS-4235
ACK from CS: Provided in https://issues.redhat.com/browse/RHDEVDOCS-4235