### PR TITLE
BZ#1976798: Includes InventoryService.Tagging.ObjectAttachable privilege required to install OCP on vSphere 7

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -93,6 +93,7 @@ An additional role is required if the installation program is to create a vSpher
 |Always
 |
 [%hardbreaks]
+`InventoryService.Tagging.ObjectAttachable`
 `Resource.AssignVMToPool`
 `VApp.Import`
 `VirtualMachine.Config.AddExistingDisk`

--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -127,6 +127,7 @@ An additional role is required if the installation program is to create a vSpher
 |If the installation program creates the virtual machine folder
 |
 [%hardbreaks]
+`InventoryService.Tagging.ObjectAttachable`
 `Resource.AssignVMToPool`
 `VApp.Import`
 `VirtualMachine.Config.AddExistingDisk`


### PR DESCRIPTION

Version(s): 4.7+

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=1976798

Link to docs preview: Not Available

