### PR TITLE
Adds Telco bug for 4.10.30 release

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3357,6 +3357,18 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.10.30 --pullspecs
 ----
 
+[id="ocp-4-10-30-bug-fixes"]
+==== Bug fixes
+
+* Previously, the functionality of Bond-CNI was limited to only active-backup mode. With this update, the bonding modes supported are:
+
+** `balance-rr` -0
+** `active-backup` -1
+** `balance-xor` -2
+
++                      
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2102047[*BZ#2102047*])
+
 [id="ocp-4-10-30-upgrading"]
 ==== Updating
 


### PR DESCRIPTION
This PR adds a Telco bug for the 4.10.30 release. It was my interpretation that this was going in for 4.10.31 due to the bump of 4.10.29 to 4.10.30. Upon discussing with @EinatGlottmann it was this 4.10.30 the note needed to be in. cc @kquinn1204 


Link to docs preview:
http://file.rdu.redhat.com/opayne/add-bond-cni-4.10.30/release_notes/ocp-4-10-release-notes.html#ocp-4-10-30




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
