### PR TITLE
TELCODOCS-780-410-updated promoting bond CNI to GA for 410

### DIFF
--- a/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
+++ b/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
@@ -5,17 +5,18 @@
 [id="nw-sriov-cfg-bond-interface-with-virtual-functions_{context}"]
 = Configuring a bond interface from two SR-IOV interfaces
 
-Bonding enables multiple network interfaces to be aggregated into a single logical "bonded" interface. Bond-CNI brings bond capability into containers.
+Bonding enables multiple network interfaces to be aggregated into a single logical "bonded" interface. Bond Container Network Interface (Bond-CNI) brings bond capability into containers.
 
-Bond-CNI can be created using SR-IOV virtual functions and placing them in the container network namespace.
+Bond-CNI can be created using Single Root I/O Virtualization (SR-IOV) virtual functions and placing them in the container network namespace.
 
-{product-title} only supports Bond-CNI using SR-IOV virtual functions. Physical interfaces are not supported.
+{product-title} only supports Bond-CNI using SR-IOV virtual functions. The SR-IOV Network Operator provides the SR-IOV CNI plug-in needed to manage the virtual functions. Other CNIs or types of interfaces are not supported.
 
 .Prerequisites
 
-* The SR-IOV operator must be installed and configured to obtain virtual functions in a container.
+* The SR-IOV Network Operator must be installed and configured to obtain virtual functions in a container.
 * To configure SR-IOV interfaces, an SR-IOV network and policy must be created for each interface.
-* The SR-IOV operator creates a network attachment definition for each SR-IOV interface, based on the SR-IOV network and policy defined.
+* The SR-IOV Network Operator creates a network attachment definition for each SR-IOV interface, based on the SR-IOV network and policy defined.
+* The `linkState` is set to the default value `auto` for the SR-IOV virtual function.
 
 [id="nw-sriov-cfg-creating-bond-network-attachment-definition_{context}"]
 == Creating a bond network attachment definition
@@ -35,12 +36,12 @@ apiVersion: "k8s.cni.cncf.io/v1"
       "cniVersion": "0.3.1",
       "name": "bond-net1",
       "ifname: "bond0" <2>
-      "mode": "active-backup",
-      "failOverMac": 1, <3>
-      "linksInContainer": true, <4>
+      "mode": "active-backup", <3>
+      "failOverMac": 1, <4>
+      "linksInContainer": true, <5>
       "miimon": "100",
       "mtu": 1500,
-      "links": [ <5>
+      "links": [ <6>
             {"name": "net1"},
             {"name": "net2"}
         ],
@@ -56,9 +57,21 @@ apiVersion: "k8s.cni.cncf.io/v1"
 ----
 <1> The type is `bond`.
 <2> The `ifname` attribute specifies the name of the bond interface.
-<3> The `failover` attribute is mandatory for active-backup mode.
-<4> The `linksInContainer=true` flag tells the Bond CNI that the interfaces required are to be found inside the container. By default, Bond CNI looks for these interfaces on the host, which does not work for an integration with SRIOV/Multus.
-<5> The `links` section defines which interfaces will be used to create the bond. By default, Multus names the attached interfaces as: "net", plus a consecutive number, starting with one.
+<3> The `mode` attribute specifies the bonding mode. 
++
+[NOTE]
+====
+The bonding modes supported are:
+
+* `balance-rr` - 0 
+* `active-backup` - 1
+* `balance-xor` - 2
+
+For `balance-rr` or `balance-xor` modes, you must set the `trust` mode to `on` for the SR-IOV virtual function.
+====
+<4> The `failover` attribute is mandatory for active-backup mode.
+<5> The `linksInContainer=true` flag informs the Bond CNI that the interfaces required are to be found inside the container. By default Bond CNI looks for these interfaces on the host which does not work for integration with SRIOV and Multus.
+<6> The `links` section defines which interfaces will be used to create the bond. By default, Multus names the attached interfaces as: "net", plus a consecutive number, starting with one.
 
 [id="nw-sriov-cfg-creating-pod-using-interface_{context}"]
 == Creating a pod using a bond interface
@@ -77,7 +90,7 @@ apiVersion: v1
     spec:
       containers:
       - name: podexample
-        image: quay.io/openshift/origin-network-interface-bond-cni:4.10.0
+        image: quay.io/openshift/origin-network-interface-bond-cni:4.11.0
         command: ["/bin/bash", "-c", "sleep INF"]
 ----
 <1> Note the network annotation: it contains two SR-IOV network attachments, and one bond network attachment. The bond attachment uses the two SR-IOV interfaces as bonded port interfaces.

--- a/networking/hardware_networks/using-pod-level-bonding.adoc
+++ b/networking/hardware_networks/using-pod-level-bonding.adoc
@@ -6,18 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-
 :FeatureName: Bond Container Network Interface (CNI)
-include::snippets/technology-preview.adoc[leveloffset=+1]
 
 Bonding at the pod level is vital to enable workloads inside pods that require high availability and more throughput. With pod-level bonding, you can create a bond interface from multiple single root I/O virtualization (SR-IOV) virtual function interfaces in a kernel mode interface. The SR-IOV virtual functions are passed into the pod and attached to a kernel driver.
 
 One scenario where pod level bonding is required is creating a bond interface from multiple SR-IOV virtual functions on different physical functions. Creating a bond interface from two different physical functions on the host can be used to achieve high availability and throughput at pod level.
-
-[NOTE]
-====
-The current functionality of Bond CNI is available only in active-backup mode. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2037214[*BZ#2037214*].
-====
 
 For guidance on tasks such as creating a SR-IOV network, network policies, network attachment definitions and pods, see  xref:../../networking/hardware_networks/configuring-sriov-device.adoc#configuring-sriov-device[Configuring an SR-IOV network device].
 


### PR DESCRIPTION
[TELCODOCS-780](https://issues.redhat.com//browse/TELCODOCS-780): Promote bond CNI to GA

Version(s):
PR applies to 4.10 only

Issue:
https://issues.redhat.com/browse/TELCODOCS-780

NOTE: This takes the changes in https://github.com/openshift/openshift-docs/pull/47172 and https://github.com/openshift/openshift-docs/pull/49791 and with 4.10.30 now GA the main docs need to reflect this. 

Link to docs preview: http://file.emea.redhat.com/kquinn/TELCODOCS-780-410-updated/networking/hardware_networks/using-pod-level-bonding.html


Item 1. Remove the TP notice
Item 2. Remove the note about [BZ#2037214](https://bugzilla.redhat.com/show_bug.cgi?id=2037214)
Item 3. Add the additional bonding options. Need confirmation on which modes are supported. List of all bonding modes are [here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/configuring-network-bonding_configuring-and-managing-networking#upstream-switch-configuration-depending-on-the-bonding-modes_configuring-network-bonding)
Item 4. For bonding options note, mentioned that trust mode must be set to on.