### PR TITLE
[OSDOCS-4064]: Updates for the etcd automatic backup release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -49,7 +49,7 @@ This release adds improvements related to the following components and concepts.
 
 [id="ocp-4-12-gcp-azure-serial-console-logs"]
 ==== Troubleshooting bootstrap failures during installation on GCP and Azure
-The installer now gathers serial console logs from the bootstrap and control plane hosts on GCP and Azure. This log data is added to the standard bootstrap log bundle. 
+The installer now gathers serial console logs from the bootstrap and control plane hosts on GCP and Azure. This log data is added to the standard bootstrap log bundle.
 
 For more information, see xref:../installing/installing-troubleshooting.adoc#installation-bootstrap-gather_installing-troubleshooting[Troubleshooting installation issues].
 
@@ -106,6 +106,14 @@ For more information, see xref:../installing/installing-troubleshooting.adoc#ins
 
 [id="ocp-4-12-scalability-and-performance"]
 === Scalability and performance
+
+[id="ocp-4-12-backup-and-restore"]
+=== Backup and restore
+
+[id="ocp-4-12-automatic-backup-etcd-clusters"]
+==== Automatic backup for etcd data
+
+{product-title} 4.12 adds support for automatic backup of etcd data. This allows for cluster recovery in case of temporary server failure, quorum unavailability, or any situation where the cluster cannot continue to function. The most recent backup restores the data for continued operation.
 
 [id="ocp-4-12-insights-operator"]
 === Insights Operator


### PR DESCRIPTION
JIRA: [OSDOCS-4064](https://issues.redhat.com/browse/OSDOCS-4064)
Version: 4.12
Issue: [ETCD-81](https://issues.redhat.com/browse/ETCD-81)
Link to docs preview: http://file.rdu.redhat.com/tlove/etcd81-relnotes-auto-backup/release_notes/ocp-4-12-release-notes.html#ocp-4-12-automatic-backup-etcd-clusters


