### PR TITLE
Use stable tag for oc-compliance install procedure

### DIFF
--- a/modules/oc-compliance-installing.adoc
+++ b/modules/oc-compliance-installing.adoc
@@ -12,7 +12,7 @@
 +
 [source,terminal]
 ----
-$ podman run --rm -v ~/.local/bin:/mnt/out:Z registry.redhat.io/compliance/oc-compliance-rhel8 /bin/cp /usr/bin/oc-compliance /mnt/out/
+$ podman run --rm -v ~/.local/bin:/mnt/out:Z registry.redhat.io/compliance/oc-compliance-rhel8:stable /bin/cp /usr/bin/oc-compliance /mnt/out/
 ----
 +
 .Example output


### PR DESCRIPTION
Without the tag the user would pull down 'latest', which is an outdated image.

Versions: 4.6+
@openshift/infrastructure-security-compliance @Wiharris 