### PR TITLE
4.11 fix attempt for portal build error

### DIFF
--- a/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
+++ b/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
@@ -66,3 +66,13 @@ data:
 ----
 
 . Save the file to apply the changes. The pods affected by the new configuration automatically restart.
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Summary: This PR is an attempt to fix a Pantheon build error related to the Monitoring book files. The only change in this PR is to add 10 blank lines to the end of an .adoc module file in the Monitoring book.

- Aligned team: DevTools
- For branches: 4.11
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-tbd
- Direct link to doc preview: n/a
- SME review: n/a
- QE review: n/a
- Peer review: @kalexand-rh 