### PR TITLE
OSDOCS-3807.2: Fixed a needlessly complicated attributes section.

### DIFF
--- a/cicd/builds/setting-up-trusted-ca.adoc
+++ b/cicd/builds/setting-up-trusted-ca.adoc
@@ -1,12 +1,8 @@
 :_content-type: ASSEMBLY
 [id="setting-up-trusted-ca"]
 = Setting up additional trusted certificate authorities for builds
-ifndef::openshift-dedicated,openshift-rosa[]
 include::_attributes/common-attributes.adoc[]
-endif::[]
-ifdef::openshift-dedicated,openshift-rosa[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
-endif::[]
 :context: setting-up-trusted-ca
 
 toc::[]


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
N/A

Link to docs preview:

* [OSD](https://file.rdu.redhat.com/eponvell/OSDOCS-3807-2_Cleaning-Attributes/dedicated/cicd/builds/setting-up-trusted-ca.html)
* [ROSA](http://file.rdu.redhat.com/eponvell/OSDOCS-3807-2_Cleaning-Attributes/rosa/cicd/builds/setting-up-trusted-ca.html)

Additional information:
Simplified the attributes section.