### PR TITLE
Fixing an Asciidoctor error for Velero plug-in content

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
@@ -11,7 +11,7 @@ OpenShift API for Data Protection (OADP) features provide options for backing up
 The default plug-ins enable Velero to integrate with certain cloud providers and to back up and restore {product-title} resources.
 
 include::modules/oadp-features.adoc[leveloffset=+1]
-include::modules/oadp-plugins.adoc[leveloffset=+1
+include::modules/oadp-plugins.adoc[leveloffset=+1]
 include::modules/oadp-configuring-velero-plugins.adoc[leveloffset=+1]
 
 [id="oadp-support-for-ibm-power-systems-and-ibm-z"]

--- a/modules/oadp-plugins.adoc
+++ b/modules/oadp-plugins.adoc
@@ -3,7 +3,6 @@
 // * backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
 
 :_content-type: CONCEPT
-include::_attributes/common-attributes.adoc[]
 [id="oadp-plugins_{context}"]
 = OADP plug-ins
 


### PR DESCRIPTION
This applies to `main`, `enterprise-4.12`, `enterprise-4.11`, `enterprise-4.10`, `enterprise-4.9`, `enterprise-4.8`, `enterprise-4.7` and `enterprise-4.6`.

The PR resolves the following Asciidoctor error that was introduced in https://github.com/openshift/openshift-docs/pull/47365. 

```
asciidoctor: ERROR: modules/oadp-configuring-velero-plugins.adoc: line 7: level 0 sections can only be used when doctype is book
```

The PR also resolves the TOC alignment issues seen in https://docs.openshift.com/container-platform/4.11/backup_and_restore/application_backup_and_restore/oadp-features-plugins.html#oadp-configuring-velero-plugins_oadp-features-plugins, to use the 4.11 example and includes the "OADP plug-ins" section in the assembly.

The preview is [here](http://file.fab.redhat.com/pneedle/pr49977/oadp-features-plugins.html).