### PR TITLE
[enterprise-4.9] Fixing vSphere installation callout build warnings

### DIFF
--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -149,8 +149,8 @@ The use of FIPS Validated / Modules in Process cryptographic libraries is only s
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]
-<15> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
-<16> The public portion of the default SSH key for the `core` user in
+<14> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+<15> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 endif::openshift-origin[]
 ifdef::openshift-origin[]


### PR DESCRIPTION
Fixing vSphere installation callout build warnings. 

4.9

[Doc preview](https://bscott-rh.github.io/openshift-docs/vsphere-callout-errors-4.9/installing/installing_vmc/installing-vmc-network-customizations-user-infra.html#installation-vsphere-config-yaml_installing-vmc-network-customizations-user-infra)