### PR TITLE
OSDOCS-4071: Updates to dynamic plug-in deployment procedure

### DIFF
--- a/modules/deployment-plug-in-cluster.adoc
+++ b/modules/deployment-plug-in-cluster.adoc
@@ -6,36 +6,79 @@
 [id="deploy-on-cluster_{context}"]
 = Deploy your plug-in on a cluster
 
-After pushing an image with your changes to a registry, you can deploy the plug-in to a cluster.
+After pushing an image with your changes to a registry, you can deploy the plug-in to a cluster. A Helm chart is available to deploy a plug-in to a {product-title} environment. 
+
+.Prerequisites
+
+* You must have cloned the link:https://github.com/openshift/console-plugin-template[`console-plugin-template`].
+* You must have the Helm CLI installed. 
 
 .Procedure
 
-. To deploy your plug-in to a cluster, instantiate your plug-in by running the following command:
+. To deploy your plug-in to a cluster, install a Helm chart with the name of the plug-in as the Helm release name into a new namespace or an existing namespace as specified by the `-n` command-line option. Provide the location of the image within the `plugin.image` parameter by using the following command:
+
 +
 [source,terminal]
 ----
-$ oc process -f template.yaml \
-  -p PLUGIN_NAME=my-plugin \ <1>
-  -p NAMESPACE=my-plugin-namespace \ <2>
-  -p IMAGE=quay.io/my-repository/my-plugin:latest \ <3>
-  | oc create -f -
+$ helm upgrade -i  my-plugin charts/openshift-console-plugin -n my-plugin-namespace --create-namespace --set plugin.image=my-plugin-image-location
 ----
-<1> Update with the name of your plug-in.
-<2> Update with the namespace.
-<3> Update with the name of the image you created.
-+
-This command runs a light-weight NGINX HTTP server to serve the assets for your plug-in.
 
-[IMPORTANT]
-====
-`PLUGIN_NAME` must match the plug-in name you used in the `consolePlugin` declaration of `package.json`.
-====
-
-[start=2]
-. Patch the *Console Operator* configuration to enable the plug-in by running the following command:
+. Optional: You can specify additional parameters by using the values set of supported parameters. 
 +
-[source,terminal]
+[source,yaml]
 
 ----
-$ oc patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["my-plugin"] } }' --type=merge
+plugin:
+  name: ""
+  description: ""
+  image: ""
+  imagePullPolicy: IfNotPresent
+  replicas: 2
+  port: 9443
+  securityContext:
+    enabled: true
+  podSecurityContext:
+    enabled: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  resources:
+    requests:
+      cpu: 10m
+      memory: 50Mi
+  basePath: /
+  certificateSecretName: ""
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+  patcherServiceAccount:
+    create: true
+    annotations: {}
+    name: ""
+  jobs:
+    patchConsoles:
+      enabled: true
+      image: "registry.redhat.io/openshift4/ose-tools-rhel8@sha256:e44074f21e0cca6464e50cb6ff934747e0bd11162ea01d522433a1a1ae116103"
+      podSecurityContext:
+        enabled: true
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containerSecurityContext:
+        enabled: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi
 ----

--- a/modules/dynamic-plug-ins-get-started.adoc
+++ b/modules/dynamic-plug-ins-get-started.adoc
@@ -14,6 +14,14 @@ To get started using the dynamic plug-in, you must set up your environment to wr
 
 .Procedure
 
+. Visit the link:https://github.com/openshift/console-plugin-template[`console-plugin-template`] repository containing a template for creating plug-ins.
+
+. Select *Use this Template* to create a GitHub repository.
+
+. Re-name the template with the name of your plug-in.
+
+. From your copied repository, clone it to your local machine so you can edit the code.
+
 . Edit the plug-in metadata in the `consolePlugin` declaration of `package.json`.
 +
 [source,json]

--- a/modules/running-your-dynamic-plug-in.adoc
+++ b/modules/running-your-dynamic-plug-in.adoc
@@ -51,7 +51,7 @@ $ yarn http-server -a <server name>
 +
 [source,terminal]
 ----
-$ ./bin/bridge -plugins console-demo-plugin=http://localhost:9001/
+$ yarn run start-console
 ----
 
 .Verification


### PR DESCRIPTION
[OSDOCS-4071](https://issues.redhat.com//browse/OSDOCS-4071): This Pr provides updates to the procedure for deploying a plug-in on a cluster. 

Issue:
[OSDOCS-4071](https://issues.redhat.com/browse/OSDOCS-4071)

Link to docs preview:
Helm Chart: https://49996--docspreview.netlify.app/openshift-enterprise/latest/web_console/dynamic-plug-ins.html#deploy-on-cluster_dynamic-plugins

Template repo link steps: https://49996--docspreview.netlify.app/openshift-enterprise/latest/web_console/dynamic-plug-ins.html#getting-started-with-dynamic-plugins_dynamic-plugins

Command update: https://49996--docspreview.netlify.app/openshift-enterprise/latest/web_console/dynamic-plug-ins.html#running-your-dynamic-plugin_dynamic-plugins

Additional information:
There will be a separate PR for 4.10 because the template repo link is different.



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
