### PR TITLE
[Enterprise 4.9] OSSMDOC-638: IOR should copy labels from Gateway to Route

### DIFF
--- a/modules/ossm-auto-route-annotations.adoc
+++ b/modules/ossm-auto-route-annotations.adoc
@@ -3,8 +3,13 @@
 //
 
 [id="ossm-auto-route-annotations_{context}"]
-= {SMProductName} route annotations
+= {SMProductName} route labels and annotations
 
-Sometimes specific annotations are needed in an OpenShift Route. For example, some advanced features in OpenShift Routes are managed via xref:../../networking/routes/route-configuration.adoc[special annotations]. For this and other use cases, {SMProductName} will copy all annotations present in the Istio Gateway resource (with the exception of those starting with `kubectl.kubernetes.io`) into the managed OpenShift Route resource.
+Sometimes specific labels or annotations are needed in an OpenShift Route.
+ifdef::openshift-enterprise[]
+For example, some advanced features in OpenShift Routes are managed using special annotations. See "Route-specific annotations" in the following "Additional resources" section.
+endif::[]
 
-If you need specific annotations in the OpenShift Routes created by {SMProductShortName}, create them in the Istio Gateway resource and they will be copied into the OpenShift Route resources managed by the {SMProductShortName}.
+For this and other use cases, {SMProductName} will copy all labels and annotations present in the Istio Gateway resource (with the exception of annotations starting with `kubectl.kubernetes.io`) into the managed OpenShift Route resource.
+
+If you need specific labels or annotations in the OpenShift Routes created by {SMProductShortName}, create them in the Istio Gateway resource and they will be copied into the OpenShift Route resources managed by the {SMProductShortName}.

--- a/service_mesh/v2x/ossm-traffic-manage.adoc
+++ b/service_mesh/v2x/ossm-traffic-manage.adoc
@@ -38,6 +38,11 @@ include::modules/ossm-auto-route.adoc[leveloffset=+2]
 
 include::modules/ossm-auto-route-annotations.adoc[leveloffset=+2]
 
+ifdef::openshift-enterprise[]
+.Additional resources
+* xref:../../networking/routes/route-configuration.adoc#nw-route-specific-annotations_route-configuration[Route-specific annotations].
+endif::[]
+
 include::modules/ossm-auto-route-enable.adoc[leveloffset=+2]
 
 include::modules/ossm-routing-sc.adoc[leveloffset=+2]


### PR DESCRIPTION
Cherry picked from ff51c403bfbb5e11362ce5def23e592565b3c208 xref:#49167

