### PR TITLE
Adding conditionals for OSD and ROSA attibute file includes

### DIFF
--- a/networking/network_policy/about-network-policy.adoc
+++ b/networking/network_policy/about-network-policy.adoc
@@ -2,8 +2,9 @@
 [id="about-network-policy"]
 = About network policy
 include::_attributes/common-attributes.adoc[]
+ifdef::openshift-dedicated,openshift-rosa[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
-
+endif::openshift-dedicated,openshift-rosa[]
 :context: about-network-policy
 
 toc::[]

--- a/networking/network_policy/creating-network-policy.adoc
+++ b/networking/network_policy/creating-network-policy.adoc
@@ -2,7 +2,9 @@
 [id="creating-network-policy"]
 = Creating a network policy
 include::_attributes/common-attributes.adoc[]
+ifdef::openshift-dedicated,openshift-rosa[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
+endif::openshift-dedicated,openshift-rosa[]
 :context: creating-network-policy
 
 toc::[]

--- a/networking/network_policy/deleting-network-policy.adoc
+++ b/networking/network_policy/deleting-network-policy.adoc
@@ -2,7 +2,9 @@
 [id="deleting-network-policy"]
 = Deleting a network policy
 include::_attributes/common-attributes.adoc[]
+ifdef::openshift-dedicated,openshift-rosa[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
+endif::openshift-dedicated,openshift-rosa[]
 :context: deleting-network-policy
 
 toc::[]

--- a/networking/network_policy/multitenant-network-policy.adoc
+++ b/networking/network_policy/multitenant-network-policy.adoc
@@ -2,7 +2,9 @@
 [id="multitenant-network-policy"]
 = Configuring multitenant isolation with network policy
 include::_attributes/common-attributes.adoc[]
+ifdef::openshift-dedicated,openshift-rosa[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
+endif::openshift-dedicated,openshift-rosa[]
 :context: multitenant-network-policy
 
 toc::[]

--- a/networking/network_policy/viewing-network-policy.adoc
+++ b/networking/network_policy/viewing-network-policy.adoc
@@ -2,7 +2,9 @@
 [id="viewing-network-policy"]
 = Viewing a network policy
 include::_attributes/common-attributes.adoc[]
+ifdef::openshift-dedicated,openshift-rosa[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
+endif::openshift-dedicated,openshift-rosa[]
 :context: viewing-network-policy
 
 toc::[]


### PR DESCRIPTION
This applies to `main`, `enterprise-4.12` and `enterprise-4.11`.

The PR adds conditional statements for the OSD and ROSA attribute file includes in the "Network policy" book.

The previews are as follows:

### OCP

- http://file.fab.redhat.com/pneedle/pr50016/ocp/about-network-policy.html
- http://file.fab.redhat.com/pneedle/pr50016/ocp/creating-network-policy.html
- http://file.fab.redhat.com/pneedle/pr50016/ocp/viewing-network-policy.html
- http://file.fab.redhat.com/pneedle/pr50016/ocp/deleting-network-policy.html
- http://file.fab.redhat.com/pneedle/pr50016/ocp/multitenant-network-policy.html

### OSD

- http://file.fab.redhat.com/pneedle/pr50016/osd/about-network-policy.html
- http://file.fab.redhat.com/pneedle/pr50016/osd/creating-network-policy.html
- http://file.fab.redhat.com/pneedle/pr50016/osd/viewing-network-policy.html
- http://file.fab.redhat.com/pneedle/pr50016/osd/deleting-network-policy.html
- http://file.fab.redhat.com/pneedle/pr50016/osd/multitenant-network-policy.html

### ROSA

- http://file.fab.redhat.com/pneedle/pr50016/rosa/about-network-policy.html
- http://file.fab.redhat.com/pneedle/pr50016/rosa/creating-network-policy.html
- http://file.fab.redhat.com/pneedle/pr50016/rosa/viewing-network-policy.html
- http://file.fab.redhat.com/pneedle/pr50016/rosa/deleting-network-policy.html
- http://file.fab.redhat.com/pneedle/pr50016/rosa/multitenant-network-policy.html