### PR TITLE
Vale check update: only send requests if there are errors

### DIFF
--- a/scripts/check-with-vale.sh
+++ b/scripts/check-with-vale.sh
@@ -14,8 +14,8 @@ if [ -n "${FILES}" ] ;
         echo "==============================================================================================================================="
         echo ""
         #clean out conditional markup
-        sed -i -e 's/ifdef::.*\|ifndef::.*\|ifeval::.*\|endif::.*/ /' ${FILES}
-        vale ${FILES} --minAlertLevel=error --glob='*.adoc' --no-exit 
+        sed -i -e 's/ifdef::.*\|ifndef::.*\|ifeval::.*\|endif::.*/ /' "${FILES}"
+        vale "${FILES}" --minAlertLevel=error --glob='*.adoc' --no-exit
         echo ""
         if [ "$TRAVIS" = true ] ; then
             set -x
@@ -27,9 +27,14 @@ if [ -n "${FILES}" ] ;
                 PR_DATA='{"PR": [{"Number": "'"$1"'", "SHA": "'"$2"'"}]',
             fi
             echo "${PR_DATA}" > vale_errors.json
-            ERROR_DATA=$(vale ${FILES} --minAlertLevel=error --glob='*.adoc' --output=JSON --no-exit)
+            ERROR_DATA=$(vale "${FILES}" --minAlertLevel=error --glob='*.adoc' --output=JSON --no-exit)
             echo "${ERROR_DATA:1}" >> vale_errors.json
-            curl -H "Content-Type: text/json" --data "@vale_errors.json" https://eox4isrzuh8pnai.m.pipedream.net
+            LAST_LINE=$(tail -n1 vale_errors.json)
+            if echo "$LAST_LINE" | grep -q ',.$'; then
+                echo "No Vale errors."
+            else
+                curl -H "Content-Type: text/json" --data "@vale_errors.json" https://eox4isrzuh8pnai.m.pipedream.net
+            fi
         fi
     else
         echo "No asciidoc files added or modified."


### PR DESCRIPTION
Currently, the `Vale against PR asciidoc files` sends curl requests even if there are no errors. This update checks for such cases and stops requests.

- Fixes shell check issues for https://www.shellcheck.net/wiki/SC2086
- Added logic to only send requests if the JSON includes errors.


Applies to:
- `enterprise-4.10`
- `enterprise-4.11`
- `enterprise-4.12`
- `rhacs-docs`
- `rhacs-docs-3.71`
- `rhacs-docs-3.70`
- `rhacs-docs-3.69`