### PR TITLE
OADP-742: Add documentation regarding OADP-MTC support versions

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 As a cluster administrator, you install the OpenShift API for Data Protection (OADP) by installing the OADP Operator. The OADP Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
 
+include::snippets/oadp-mtc-operator.adoc[]
+
 To back up Kubernetes resources and internal images, you must have object storage as a backup location, such as one of the following storage types:
 
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#installing-oadp-aws[Amazon Web Services]

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
@@ -11,6 +11,8 @@ toc::[]
 
 You install the OpenShift API for Data Protection (OADP) with Amazon Web Services (AWS) by installing the OADP Operator. The Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
 
+include::snippets/oadp-mtc-operator.adoc[]
+
 You configure AWS for Velero, create a default `Secret`, and then install the Data Protection Application.
 
 To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details.

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
@@ -11,6 +11,8 @@ toc::[]
 
 You install the OpenShift API for Data Protection (OADP) with Microsoft Azure by installing the OADP Operator. The Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
 
+include::snippets/oadp-mtc-operator.adoc[]
+
 You configure Azure for Velero, create a default `Secret`, and then install the Data Protection Application.
 
 To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details.

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
@@ -11,6 +11,8 @@ toc::[]
 
 You install the OpenShift API for Data Protection (OADP) with Google Cloud Platform (GCP) by installing the OADP Operator. The Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
 
+include::snippets/oadp-mtc-operator.adoc[]
+
 You configure GCP for Velero, create a default `Secret`, and then install the Data Protection Application.
 
 To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details.

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
@@ -11,6 +11,8 @@ toc::[]
 
 You install the OpenShift API for Data Protection (OADP) with Multicloud Object Gateway (MCG) by installing the OADP Operator. The Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
 
+include::snippets/oadp-mtc-operator.adoc[]
+
 You configure xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway] as a backup location.
 MCG is a component of {rh-storage}. You configure MCG as a backup location in the `DataProtectionApplication` custom resource (CR).
 

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -11,6 +11,8 @@ toc::[]
 
 You install the OpenShift API for Data Protection (OADP) with {rh-storage} by installing the OADP Operator and configuring a backup location and a snapshot location. Then, you install the Data Protection Application.
 
+include::snippets/oadp-mtc-operator.adoc[]
+
 You can configure xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway] or any S3-compatible object storage as a backup location.
 
 :FeatureName: The `CloudStorage` API, which automates the creation of a bucket for object storage,

--- a/snippets/oadp-mtc-operator.adoc
+++ b/snippets/oadp-mtc-operator.adoc
@@ -1,0 +1,15 @@
+
+//This snippet appears in the following assemblies:
+//
+// * .../backup_and_restore/backing_up_and_restoring/installing/about-installing-oadp.adoc
+// * .../backup_and_restore/backing_up_and_restoring/installing/installing-oadp-aws.adoc
+// * .../backup_and_restore/backing_up_and_restoring/installing/installing-oadp-azure.adoc
+// * .../backup_and_restore/backing_up_and_restoring/installing/installing-oadp-gcp.adoc
+// * .../backup_and_restore/backing_up_and_restoring/installing/installing-oadp-mcg.adoc
+// * .../backup_and_restore/backing_up_and_restoring/installing/installing-oadp-ocs.adoc
+
+:_content-type: SNIPPET
+[NOTE]
+====
+Starting from OADP 1.0.4, all OADP 1.0._z_ versions can only be used as a dependency of the MTC Operator and are not available as a standalone Operator.
+====


### PR DESCRIPTION
OADP  1.0._x_ and 1.1.0; OCP 4.9+

Resolves https://issues.redhat.com/browse/OADP-742 by adding a note about OADP compatibility with MTC to the introduction to all installation instructions. The location was chosen to maximize the chances that users will see this note before beginning any other installation activity or pre-activity. 

Previews [identical]:
http://file.emea.redhat.com/rhoch/mtc_lim/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html

http://file.emea.redhat.com/rhoch/mtc_lim/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html

http://file.emea.redhat.com/rhoch/mtc_lim/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.html

http://file.emea.redhat.com/rhoch/mtc_lim/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.html

http://file.emea.redhat.com/rhoch/mtc_lim/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.html

http://file.emea.redhat.com/rhoch/mtc_lim/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html