### PR TITLE
Update references to servicebinding.io/v1alpha3 with servicebinding.io/v1beta1

### DIFF
--- a/applications/connecting_applications_to_services/understanding-service-binding-operator.adoc
+++ b/applications/connecting_applications_to_services/understanding-service-binding-operator.adoc
@@ -31,11 +31,9 @@ The {servicebinding-title} consists of a controller and an accompanying custom r
 
 As a result, the {servicebinding-title} enables workloads to use backing services or external services by automatically collecting and sharing binding data with the workloads. The process involves making the backing service bindable and binding the workload and the service together.
 
-
 [id="making-an-operator-managed-backing-service-bindable"]
 === Making an Operator-managed backing service bindable
 To make a service bindable, as an Operator provider you need to expose the binding data required by workloads to bind with the services provided by the Operator. You can provide the binding data either as annotations or as descriptors in the CRD of the Operator that manages the backing service.
-
 
 [id="binding-a-workload-together-with-a-backing-service"]
 === Binding a workload together with a backing service
@@ -44,13 +42,7 @@ By using the {servicebinding-title}, as an application developer, you need to de
 The CRD of the {servicebinding-title} supports the following APIs:
 
 * *Service Binding* with the `binding.operators.coreos.com` API group.
-* *Service Binding (Spec API Tech Preview)* with the `servicebinding.io` API group.
-+
-[IMPORTANT]
-====
-*Service Binding (Spec API Tech Preview)* with the `servicebinding.io` API group is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
-For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/.
-====
+* *Service Binding (Spec API)* with the `servicebinding.io` API group.
 
 With {servicebinding-title}, you can:
 
@@ -58,7 +50,6 @@ With {servicebinding-title}, you can:
 * Automate configuration of binding data.
 * Provide service operators a low-touch administrative experience to provision and manage access to services.
 * Enrich development lifecycle with a consistent and declarative service binding method that eliminates discrepancies in cluster environments.
-
 
 [id="sbo-key-features"]
 == Key features
@@ -77,7 +68,6 @@ With {servicebinding-title}, you can:
 ** Support for non-`PodSpec` compliant workload resources.
 * Security
 ** Support for role-based access control (RBAC).
-
 
 == Additional resources
 * xref:../../applications/connecting_applications_to_services/getting-started-with-service-binding.adoc#getting-started-with-service-binding[Getting started with service binding].

--- a/modules/sbo-advanced-binding-options.adoc
+++ b/modules/sbo-advanced-binding-options.adoc
@@ -155,7 +155,7 @@ spec:
 .Example `ServiceBinding` CR in the `servicebinding.io` API
 [source,yaml]
 ----
-apiVersion: servicebindings.io/v1alpha3
+apiVersion: servicebindings.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: multi-application-binding

--- a/modules/sbo-binding-workloads-that-are-not-compliant-with-PodSpec.adoc
+++ b/modules/sbo-binding-workloads-that-are-not-compliant-with-PodSpec.adoc
@@ -177,7 +177,7 @@ The following example shows how to define a mapping for the `CronJob.batch/v1` r
 .Example: Mapping for `CronJob.batch/v1` resources
 [source,yaml]
 ----
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ClusterWorkloadResourceMapping
 metadata:
  name: cronjobs.batch <1>

--- a/modules/sbo-methods-of-exposing-binding-data.adoc
+++ b/modules/sbo-methods-of-exposing-binding-data.adoc
@@ -82,16 +82,10 @@ spec:
     resource: deployments
 ----
 
-[IMPORTANT]
-====
-*Service Binding (Spec API Tech Preview)* with the `servicebinding.io` API group is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
-For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/.
-====
-
 .Example: `ServiceBinding` resource in Specification API
 [source,yaml]
 ----
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: account-service
@@ -132,7 +126,7 @@ spec:
 .Example: Specification that is compliant with the `servicebinding.io` API
 [source,yaml]
 ----
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: account-service


### PR DESCRIPTION
[RHDEVDOCS-4316](https://issues.redhat.com/browse/RHDEVDOCS-4316): Downstream Docs - Update references to servicebinding.io/v1alpha3 with servicebinding.io/v1beta1

- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: enterprise-`4.10`, enterprise-`4.11` and later
- **JIRA issues**: [RHDEVDOCS-4316](https://issues.redhat.com/browse/RHDEVDOCS-4316)
- **Preview pages**: [Download to see the preview in your browser - [1](https://drive.google.com/file/d/19bBn8VewcI7i3RoqmRdR-gQA0qjDgG1m/view?usp=sharing), [2](https://drive.google.com/file/d/1HZVROx30DKFCRPUoR6N_cyGJef8eK_Ji/view?usp=sharing), and [3](https://drive.google.com/file/d/1t3ZSCZXhyBdN80rgN46CbRAIXwmIY_A-/view?usp=sharing)]
- **SME Review**: Completed by @baijum, @dperaza4dustbit, @sadlerap
- **QE review**: Completed by @pmacik 
- **Peer-review**: Completed by @bburt-rh 