### PR TITLE
Add version handling and banner for RHACS

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -58,7 +58,7 @@
 <body onload="selectVersion('<%= version %>');">
   <%= render("_templates/_topnav.html.erb", :distro_key => distro_key) %>
   <%
-    unsupported_versions = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5"];
+    unsupported_versions = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5", "3.65", "3.66", "3.67", "3.68"];
   %>
   <div class="container">
     <button id="hc-open-btn" class="open-btn-sm" onclick="openNav()" aria-label="Open"><span class="fa fa-bars" /></button>
@@ -78,6 +78,16 @@
           <strong>You are viewing documentation for a release that is no longer maintained.</strong> The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html" class="link-primary" style="color: #545454 !important;">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.
         </div>
       </span>
+
+      <% end %>
+
+      <% if ((unsupported_versions.include? version) && (distro_key == "openshift-acs")) %>
+
+        <span>
+          <div class="alert alert-danger" role="alert" id="support-alert">
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/acs/welcome/index.html" style="color: #545454 !important" class="link-primary">latest RHACS docs</a>.
+          </div>
+        </span>
 
       <% end %>
 
@@ -121,7 +131,22 @@
               <option value="3.0">3.0</option>
           </select>
         <% else %>
-        <%= breadcrumb_root %>
+          <% if (distro_key == "openshift-acs") %>
+            <a href="https://docs.openshift.com/acs/<%= version %>/welcome/index.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="3.71">3.71</option>
+              <option value="3.70">3.70</option>
+              <option value="3.69">3.69</option>
+              <option value="3.68">3.68</option>
+              <option value="3.67">3.67</option>
+              <option value="3.66">3.66</option>
+              <option value="3.65">3.65</option>
+            </select>
+          <% else %>
+            <%= breadcrumb_root %>
+          <% end %>
         <% end %>
       </li>
       <li class="hidden-xs active">
@@ -131,7 +156,7 @@
       <li class="hidden-xs active">
         <%= breadcrumb_topic %>
       </li>
-      <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro") %>
+      <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro" && distro_key != "openshift-acs") %>
       <span text-align="right" style="float: right !important">
         <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-enterprise") ? "enterprise-#{version}" : "dedicated-4" %>/<%= repo_path %>"><span class="material-icons-outlined" title="Page history">history</span></a>
         <%
@@ -151,6 +176,25 @@
         <% end %>
         <% end %>
       </span>
+      <% else %>
+        <% if (distro_key == "openshift-acs") %>
+          <span text-align="right" style="float: right !important">
+            <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-acs") ? "rhacs-docs-#{version}" : "rhacs-docs" %>/<%= repo_path %>">
+              <span class="material-icons-outlined" title="Page history">history
+              </span>
+            </a>
+            <% unless (unsupported_versions.include? version) %>
+              <a href="https://github.com/openshift/openshift-docs/issues/new?title=<%= "[rhacs-docs-#{version}] Issue in file #{repo_path}" %>">
+                <span class="material-icons-outlined" title="Open an issue">bug_report
+                </span>
+              </a>
+              <a href="javascript: void(0);" onclick="getPDF();">
+                <span class="material-icons-outlined" title="Download PDF (may take a while for large pages)">picture_as_pdf
+                </span>
+              </a>
+            <% end %>
+          </span>
+        <% end %>
       <% end %>
     </ol>
     <div class="row row-offcanvas row-offcanvas-left">


### PR DESCRIPTION
Changes:
. Added version selector for RHACS docs.
. Added unsupported RHACS versions to the unsupported versions list.
. Added banner for unsupported RHACS versions.
. Fixed links for History and Issues for RHACS docs.


Version(s):
- Applies to main only.

Link to docs preview:
https://openshift-docs-git-template-update-for-rhacs-gnelson.vercel.app/openshift-enterprise/master/welcome/index.html

Additional information:
Based on changes in #49788
- After merging that PR, I realized that the template page for the OpenShift docs site is always from the `main` branch and not from the individual version branches.
