### PR TITLE
GH#50067: Fix oc adm cordon output

### DIFF
--- a/modules/nodes-nodes-working-evacuating.adoc
+++ b/modules/nodes-nodes-working-evacuating.adoc
@@ -33,7 +33,7 @@ $ oc adm cordon <node1>
 node/<node1> cordoned
 ----
 
-.. Check that the node status is `NotReady,SchedulingDisabled`:
+.. Check that the node status is `Ready,SchedulingDisabled`:
 +
 [source,terminal]
 ----
@@ -43,8 +43,8 @@ $ oc get node <node1>
 .Example output
 [source,terminal]
 ----
-NAME        STATUS                        ROLES     AGE       VERSION
-<node1>     NotReady,SchedulingDisabled   worker    1d        v1.24.0
+NAME        STATUS                     ROLES     AGE       VERSION
+<node1>     Ready,SchedulingDisabled   worker    1d        v1.24.0
 ----
 
 . Evacuate the pods using one of the following methods:


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/50067

There is a mistake in this [section in nodes](https://docs.openshift.com/container-platform/4.11/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-evacuating_nodes-nodes-working)
Example output
```
NAME        STATUS                        ROLES     AGE       VERSION
<node1>     NotReady,SchedulingDisabled   worker    1d        v1.24.0
```
It should be Ready,SchedulingDisabled after node is cordoned

4.6+

Preview: [Output of Step 1b](http://file.rdu.redhat.com/~mburke/node-fix-cordon/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-evacuating_nodes-nodes-working).