### PR TITLE
GH#45872: Fixing vsphere address range

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -26,15 +26,21 @@
 ifeval::["{context}" == "installing-vsphere"]
 :vsphere:
 endif::[]
-
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
 :vsphere:
 endif::[]
-
 ifeval::["{context}" == "installing-vsphere-network-customizations"]
 :vsphere:
 endif::[]
-
+ifeval::["{context}" == "installing-vmc-user-infra"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations-user-infra"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
+:vmc:
+endif::[]
 ifeval::["{context}" == "installing-ibm-z"]
 :ibm-z:
 endif::[]
@@ -263,7 +269,7 @@ the Cluster Version Operator on port `9099`.
 
 |===
 
-ifdef::vsphere[]
+ifdef::vsphere,vmc[]
 [discrete]
 == Ethernet adaptor hardware address requirements
 
@@ -274,11 +280,11 @@ Identifier (OUI) allocation ranges:
 * `00:05:69:00:00:00` to `00:05:69:FF:FF:FF`
 * `00:0c:29:00:00:00` to `00:0c:29:FF:FF:FF`
 * `00:1c:14:00:00:00` to `00:1c:14:FF:FF:FF`
-* `00:50:56:00:00:00` to `00:50:56:FF:FF:FF`
+* `00:50:56:00:00:00` to `00:50:56:3F:FF:FF`
 
 If a MAC address outside the VMware OUI is used, the cluster installation will
 not succeed.
-endif::vsphere[]
+endif::vsphere,vmc[]
 
 ifdef::vsphere[]
 :!vsphere:
@@ -295,6 +301,15 @@ If a DHCP server provides NTP server information, the chrony time service on the
 endif::ibm-z[]
 endif::azure,gcp[]
 
+ifeval::["{context}" == "installing-vmc-user-infra"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations-user-infra"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
+:!vmc:
+endif::[]
 ifeval::["{context}" == "installing-ibm-z"]
 :!ibm-z:
 endif::[]


### PR DESCRIPTION
For versions 4.10+ 
Ref: #45872

Description: MAC address ranges should be 

- 00:50:56:00:00:00 to 00:50:56:3F:FF:FF

Preview:
- [Installing a cluster on vSphere with user-provisioned infrastructure -> Networking requirements for user-provisioned infrastructure ](https://kelbrown20.github.io/bug-fix-previews/GH45872-fixing-vsphere-address-range/installing/installing_vsphere/installing-vsphere-network-customizations.html#installation-network-user-infra_installing-vsphere-network-customizations)
- [Installing a cluster on VMC with user-provisioned infrastructure -> Networking requirements for user-provisioned infrastructure](https://kelbrown20.github.io/bug-fix-previews/GH45872-fixing-vsphere-address-range/installing/installing_vmc/installing-vmc-user-infra.html#installation-network-user-infra_installing-vmc-user-infra)
- [Installing a cluster on VMC with user-provisioned infrastructure and network customizations -> Networking requirements for user-provisioned infrastructure](https://kelbrown20.github.io/bug-fix-previews/GH45872-fixing-vsphere-address-range/installing/installing_vmc/installing-vmc-network-customizations-user-infra.html#installation-network-user-infra_installing-vmc-network-customizations-user-infra)
- [Installing a cluster on VMC in a restricted network with user-provisioned infrastructure with user provisioned infrastructure -> Networking requirements for user-provisioned infrastructure](https://kelbrown20.github.io/bug-fix-previews/GH45872-fixing-vsphere-address-range/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.html#installation-network-user-infra_installing-restricted-networks-vmc-user-infra)