### PR TITLE
[RHACS] ROX-11051: Doc changes to reflect UI updates

### DIFF
--- a/modules/configure-ocp-oauth-identity-provider.adoc
+++ b/modules/configure-ocp-oauth-identity-provider.adoc
@@ -1,29 +1,31 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-user-access/configure-ocp-oauth.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="configure-ocp-oauth-identity-provider_{context}"]
-= Configuring {ocp} OAuth server as an identity provider in {product-title}
+= Configuring {ocp} OAuth server as an identity provider
 
 [role="_abstract"]
-To integrate the built-in {ocp} OAuth server as an identity provider for {product-title} ({product-title-short}) use the instructions in this section.
+To integrate the built-in {ocp} OAuth server as an identity provider for {product-title-short}, use the instructions in this section.
 
 .Prerequisites
 * You must have the `AuthProvider` permission to configure identity providers in {product-title-short}.
-* You must have already configured users and groups in {ocp} OAuth server through an identity provider. For information on the identity provider requirements, see link:https://docs.openshift.com/container-platform/4.9/authentication/understanding-identity-provider.html[Understanding identity provider configuration].
+* You must have already configured users and groups in {ocp} OAuth server through an identity provider. For information about identity provider requirements, see "Understanding identity provider configuration" in the "Additional resources" section.
 
 .Procedure
-. On the RHACS portal, navigate to *Platform Configuration* -> *Access Control*.
-. Open the *Add an Auth Provider* menu and select *OpenShift Auth*.
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Access Control*.
+. Click *Create auth provider* and select *Auth0* from the drop-down list.
 . Enter a name for the authentication provider in the *Name* field.
-. Choose a *Minimum access role* for users accessing {product-title-short} by using the selected identity provider.
+. Enter the *Auth0 tenant*, or the container where your `Auth0` data is configured and stored. The *Auth0 tenant* is in the form of a domain name (for example, `your-tenant.auth0.com`).
+. Enter the *Client ID*, or the unique identifier that you are using for authentication of your application. 
+. Assign a *Minimum access role* for users that access {product-title-short} using the selected identity provider. A user must have the permissions granted to this role or a role with higher permissions to log in to {product-title-short}. 
 +
 [TIP]
 ====
-For security, Red Hat recommends setting the *Minimum access role* to *None* while you complete setup. Later, you can return to the *Access Control* page to set up more tailored access rules based on user metadata from your identity provider.
+For security, Red Hat recommends first setting the *Minimum access role* to *None* while you complete setup. Later, you can return to the *Access Control* page to set up more tailored access rules based on user metadata from your identity provider.
 ====
 
-. To add access rules for users and groups accessing {product-title-short}, use the *Rules* section. For example:
+. To add access rules for users and groups accessing {product-title-short}, click *Add new rule* in the *Rules* section. For example:
 .. To give the *Admin* role to a user called `administrator`, you can use the following key-value pairs to create access rules:
 +
 |===
@@ -33,7 +35,7 @@ For security, Red Hat recommends setting the *Minimum access role* to *None* whi
 |Role
 |Admin
 |===
-.. If you are using the link:https://docs.openshift.com/container-platform/4.9/authentication/understanding-identity-provider.html[HTPasswd Identity Provider] with the username `UserA` that is part of the group `GroupA`, you can use the following key-value pairs to create access rules:
+.. If you are using the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/authentication_and_authorization/index#configuring-htpasswd-identity-provider[HTPasswd Identity Provider] with the username `UserA` that is part of the group `GroupA`, you can use the following key-value pairs to create access rules:
 +
 |===
 | *Key* | *Value*

--- a/modules/configure-oidc-identity-provider.adoc
+++ b/modules/configure-oidc-identity-provider.adoc
@@ -1,57 +1,70 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-user-access/configure-google-workspace-identity.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="configure-oidc-identity-provider_{context}"]
-= Configuring an OIDC identity provider in {product-title}
+= Configuring an OIDC identity provider
 
-You can configure {product-title} to use your OpenID Connect (OIDC) identity provider.
+You can configure {product-title} ({product-title-short}) to use your OpenID Connect (OIDC) identity provider.
 
 .Prerequisites
 * You must have already configured an application in your identity provider, such as Google Workspace.
-* You must have permissions to configure identity providers in {product-title}.
+* You must have permissions to configure identity providers in {product-title-short}.
 
 .Procedure
-. On the RHACS portal, navigate to *Platform Configuration* -> *Access Control*.
-. Open the *Add an Auth Provider* menu and select *OpenID Connect*.
-. Fill out the details for:
-** *Integration Name*: A name to identify your authentication provider.
-For example, *Auth0* or *Google Workspace*". The integration name is shown on the login page to help users select the right sign-in option.
-** *Callback Mode*: Select *HTTP POST* (default).
-An alternative mode called _Fragment_, designed around the limitations of Single Page Applications (SPAs), is also available.
-Red Hat only supports the _Fragment_ mode for legacy integrations, and does not recommended using it for new integrations.
-** *Issuer*: The root URL of your identity provider, for example `\https://accounts.google.com` for Google Workspace.
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Access Control*.
+. Click *Create auth provider* and select *OpenID Connect* from the drop-down list.
+. Enter information in the following fields:
+** *Name*: A name to identify your authentication provider; for example, *Google Workspace*. The integration name is shown on the login page to help users select the correct sign-in option.
+** *Callback mode*: Select *Auto-select (recommended)*, which is the default value, unless the identity provider requires another mode.
++
+[NOTE]
+====
+`Fragment` mode is designed around the limitations of Single Page Applications (SPAs). Red Hat only supports the `Fragment` mode for early integrations and does not recommended using it for later integrations.
+====
+** *Issuer*: The root URL of your identity provider; for example, `\https://accounts.google.com` for Google Workspace.
 See your identity provider documentation for more information.
 +
 [NOTE]
 ====
-If you are using {product-title} version 3.0.49 and newer, for *Issuer* you can:
+If you are using {product-title-short} version 3.0.49 and later, for *Issuer* you can perform these actions:
 
 * Prefix your root URL with `https+insecure://` to skip TLS validation.
 This configuration is insecure and Red Hat does not recommended it.
 Only use it for testing purposes.
-* Specify query strings, for example, `?key1=value1&key2=value2` along with the root URL.
-{product-title} appends the value of *Issuer* as is to the authorization endpoint.
+* Specify query strings; for example, `?key1=value1&key2=value2` along with the root URL.
+{product-title-short} appends the value of *Issuer* as you entered it to the authorization endpoint.
 You can use it to customize your provider's login screen.
-For example, you can optimize the Google Workspace login screen to a specific hosted domain by using the  link:https://developers.google.com/identity/protocols/oauth2/openid-connect#hd-param[`hd` parameter], or pre-select an authentication method in PingFederate by using the link:https://docs.pingidentity.com/bundle/pingfederate-93/page/nfr1564003024683.html[`pfidpadapterid` parameter].
+For example, you can optimize the Google Workspace login screen to a specific hosted domain by using the link:https://developers.google.com/identity/protocols/oauth2/openid-connect#hd-param[`hd` parameter], or preselect an authentication method in `PingFederate` by using the link:https://docs.pingidentity.com/bundle/pingfederate-93/page/nfr1564003024683.html[`pfidpadapterid` parameter].
 ====
 ** *Client ID*: The OIDC Client ID for your configured project.
-. Choose a *Minimum access role* for users accessing {product-title} by using the selected identity provider.
+** *Client Secret*: Enter the client secret provided by your identity provider (IdP). If you are not using a client secret, which is not recommended, select *Do not use Client Secret*.
+
+. Assign a *Minimum access role* for users who access {product-title-short} using the selected identity provider.
 +
 [TIP]
 ====
-Set the *Minimum access role* to *Admin* while you complete setup.
-Later, you can return to the *Access Control* page to set up more tailored access rules based on user metadata from your identity provider.
+Set the *Minimum access role* to *Admin* while you complete setup. Later, you can return to the *Access Control* page to set up more tailored access rules based on user metadata from your identity provider. 
 ====
+
+. To add access rules for users and groups accessing {product-title-short}, click *Add new rule* in the *Rules* section. For example, to give the *Admin* role to a user called `administrator`, you can use the following key-value pairs to create access rules:
++
+|===
+| *Key* | *Value*
+|Name
+|administrator
+|Role
+|Admin
+|===
 . Click *Save*.
 
 .Verification
-. On the RHACS portal, navigate to *Platform Configuration* -> *Access Control*.
-. Select the *Auth Provider Rules* tab.
-. Under the *Auth Providers* section, select the authentication provider that you want to verify the configuration for.
-. Select *Test Login* from the *Auth Provider* section header.
-The *Test Login* page opens in a new browser tab.
-. Sign in with your credentials.
-** On success, {product-title} shows the `User ID` and `User Attributes` the identity provider sent for the credentials you have used to log in.
-** On failure, {product-title} shows a message describing why the identity provider's response could not be processed.
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Access Control*.
+. Select the *Auth providers* tab.
+. Select the authentication provider for which you want to verify the configuration.
+. Select *Test login* from the *Auth Provider* section header.
+The *Test login* page opens in a new browser tab.
+. Log in with your credentials.
+** If you logged in successfully, {product-title-short} shows the `User ID` and `User Attributes` that the identity provider sent for the credentials that you used to log in to the system.
+** If your login attempt failed, {product-title-short} shows a message describing why the identity provider's response could not be processed.
 . Close the *Test Login* browser tab.

--- a/modules/configure-pki-authentication-portal.adoc
+++ b/modules/configure-pki-authentication-portal.adoc
@@ -1,16 +1,31 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-user-access/enable-pki-authentication.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="configure-pki-authentication-portal_{context}"]
 = Configuring PKI authentication by using the RHACS portal
 
-You can configure PKI authentication by using the RHACS portal.
+You can configure Public Key Infrastructure (PKI) authentication by using the {product-title-short} portal.
 
 .Procedure
-. On the RHACS portal, navigate to *Platform Configuration* -> *Access Control*.
-. Click *Add an Auth Provider*, and then select *User Certificates*.
-. In the *Name* box, specify a name for this authentication provider.
-. Paste your root CA certificate in PEM format into the text box.
-. Optional: Change the *Minimum access role* and add role mappings by attributes.
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Access Control*.
+. Click *Create Auth Provider* and select *User Certificates* from the drop-down list.
+. In the *Name* field, specify a name for this authentication provider.
+. In the *CA certificate(s) (PEM)* field, paste your root CA certificate in PEM format.
+. Assign a *Minimum access role* for users who access {product-title-short} using PKI authentication. A user must have the permissions granted to this role or a role with higher permissions to log in to {product-title-short}. 
++
+[TIP]
+====
+For security, Red Hat recommends first setting the *Minimum access role* to *None* while you complete setup. Later, you can return to the *Access Control* page to set up more tailored access rules based on user metadata from your identity provider.
+====
+
+. To add access rules for users and groups accessing {product-title-short}, click *Add new rule* in the *Rules* section. For example, to give the *Admin* role to a user called `administrator`, you can use the following key-value pairs to create access rules:
++
+|===
+| *Key* | *Value*
+|Name
+|administrator
+|Role
+|Admin
+|===
 . Click *Save*.

--- a/modules/configure-saml-identity-provider.adoc
+++ b/modules/configure-saml-identity-provider.adoc
@@ -1,53 +1,56 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-user-access/configure-okta-identity-cloud.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="configure-saml-identity-provider_{context}"]
-= Configuring a SAML 2.0 identity provider in {product-title}
+= Configuring a SAML 2.0 identity provider
 
-Use the instructions in this section to integrate a SAML 2.0 identity provider with {product-title}.
+Use the instructions in this section to integrate a Security Assertion Markup Language (SAML) 2.0 identity provider with {product-title} ({product-title-short}).
 
 .Prerequisites
-* You must have permissions to configure identity providers in {product-title}.
-* You must have an Okta app configured for {product-title}.
+* You must have permissions to configure identity providers in {product-title-short}.
+* For Okta identity providers, you must have an Okta app configured for {product-title-short}.
 
 .Procedure
-. On the RHACS portal, navigate to *Platform Configuration* -> *Access Control*.
-. Open the *Add an Auth Provider* menu and select *SAML 2.0*.
-. Fill out the details for:
-** *Integration Name:* A name to identify this authentication provider, for example, *Okta* or *Google*. The integration name is shown on the login page to help users select the right sign-in option.
-** *ServiceProvider Issuer:* The value you are using as the `Audience URI` or `SP Entity ID` in Okta, or a similar value in other providers.
-** *IdP Metadata URL:* Use the URL of *Identity Provider metadata* available from your identity provider console.
-If you do not want to use the *IdP Metadata URL*, you can instead copy the required static fields from the *View Setup Instructions* link in the Okta console, or a similar location for other providers.
-. Choose a *Minimum access role* for users accessing {product-title} by using the selected identity provider.
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Access Control*.
+. Click *Create auth provider* and select *SAML 2.0* from the drop-down list.
+. In the *Name* field, enter a name to identify this authentication provider; for example, *Okta* or *Google*. The integration name is shown on the login page to help users select the correct sign-in option.
+. In the *ServiceProvider issuer* field, enter the value that you are using as the `Audience URI` or `SP Entity ID` in Okta, or a similar value in other providers.
+. Select the type of *Configuration*: 
+** *Option 1: Dynamic Configuration*: If you select this option, enter the *IdP Metadata URL*, or the URL of *Identity Provider metadata* available from your identity provider console. The configuration values are acquired from the URL.
+** *Option 2: Static Configuration*: Copy the required static fields from the *View Setup Instructions* link in the Okta console, or a similar location for other providers:
+*** *IdP Issuer*
+*** *IdP SSO URL*
+*** *Name/ID Format*
+*** *IdP Certificate(s) (PEM)*
+
+. Assign a *Minimum access role* for users who access {product-title-short} using SAML.
 +
 [TIP]
 ====
-Set the *Minimum access role* to *Admin* while you complete setup.
-Later, you can return to the *Access Control* page to set up more tailored access rules based on user metadata from your identity provider.
+Set the *Minimum access role* to *Admin* while you complete setup. Later, you can return to the *Access Control* page to set up more tailored access rules based on user metadata from your identity provider.
 ====
 . Click *Save*.
 
 [IMPORTANT]
 ====
-If your SAML identity provider's authentication response:
+If your SAML identity provider's authentication response meets the following criteria:
 
-* Includes a `NotValidAfter` assertion, the user session remains valid until the time specified in the `NotValidAfter` field has elapsed.
-After its expiry, users must re-authenticate.
-* Does not include a `NotValidAfter` assertion, the user session remains valid for 30 days, after which, the users must re-authenticate.
+* Includes a `NotValidAfter` assertion: The user session remains valid until the time specified in the `NotValidAfter` field has elapsed. After the user session expires, users must reauthenticate.
+* Does not include a `NotValidAfter` assertion: The user session remains valid for 30 days, and then users must reauthenticate.
 ====
 
 .Verification
 
-. On the RHACS portal, navigate to *Platform Configuration* -> *Access Control*.
-. Select the *Auth Provider Rules* tab.
-. Under the *Auth Providers* section, select the authentication provider that you want to verify the configuration for.
-. Select *Test Login* from the *Auth Provider* section header.
-The *Test Login* page opens in a new browser tab.
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Access Control*.
+. Select the *Auth Providers* tab.
+. Click the authentication provider for which you want to verify the configuration.
+. Select *Test login* from the *Auth Provider* section header.
+The *Test login* page opens in a new browser tab.
 . Sign in with your credentials.
-** On success, {product-title} shows the `User ID` and `User Attributes` the identity provider sent for the credentials you have used to log in.
-** On failure, {product-title} shows a message describing why the identity provider's response could not be processed.
-. Close the *Test Login* browser tab.
+** If you logged in successfully, {product-title-short} shows the `User ID` and `User Attributes` that the identity provider sent for the credentials that you used to log in to the system.
+** If your login attempt failed, {product-title-short} shows a message describing why the identity provider's response could not be processed.
+. Close the *Test login* browser tab.
 +
 [NOTE]
 ====

--- a/modules/create-a-custom-access-scope.adoc
+++ b/modules/create-a-custom-access-scope.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-role-based-access-control.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="create-a-custom-access-scope_{context}"]
 = Creating a custom access scope
 
@@ -12,14 +12,14 @@ You can create new access scopes from the *Access Control* view.
 * You must have the *Admin* role, or a role with the permission set with read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete permission sets.
 
 .Procedure
-. On the RHACS portal, navigate to *Platform Configuration* -> *Access control*.
-. Select the *Access scope* tab.
-. Click *Add access scope*.
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Access control*.
+. Select *Access scopes*.
+. Click *Create access scope*.
 . Enter a *Name* and *Description* for the new access scope.
 . Under the *Allowed resources* section:
-** Use the *Cluster filter* and *Namespace filter* boxes to filter the list of clusters and namespaces visible in the list.
-** Expand the *<Cluster_name>* to see the list of namespaces in that cluster.
-** Turn on the toggle under the *Manual selection* column for a cluster to allow access to all namespaces in that cluster.
+** Use the *Cluster filter* and *Namespace filter* fields to filter the list of clusters and namespaces visible in the list.
+** Expand the *Cluster name* to see the list of namespaces in that cluster.
+** To allow access to all namespaces in a cluster, toggle the switch in the *Manual selection* column.
 +
 [NOTE]
 ====
@@ -30,7 +30,7 @@ Access to a specific cluster provides users with access to the following resourc
 * Node metadata and security information
 * Access to all namespaces in that cluster and their associated security information
 ====
-** Turn on the toggle under the *Manual selection* column for a namespace to allow access to that namespace.
+** To allow access to a namespace, toggle the switch in the *Manual selection* column for a namespace.
 +
 [NOTE]
 ====
@@ -44,5 +44,5 @@ Access to a specific namespace gives access to the following information within 
 * Process information and process baseline configuration
 * Prioritized risk information for each deployment
 ====
-. If you want to allow access to clusters and namespaces based on labels, click *Add label selector* under the *Label selection rules* section. Then click *Add rules* to specify *Key* and *Value* pairs for the label selector. You can specify labels for clusters and namespaces.
+. If you want to allow access to clusters and namespaces based on labels, click *Add label selector* under the *Label selection rules* section. Then click *Add rule* to specify *Key* and *Value* pairs for the label selector. You can specify labels for clusters and namespaces.
 . Click *Save*.

--- a/modules/create-a-custom-permission-set.adoc
+++ b/modules/create-a-custom-permission-set.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-role-based-access-control.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="create-a-custom-permission-set_{context}"]
 = Creating a custom permission set
 
@@ -12,11 +12,11 @@ You can create new permission sets from the *Access Control* view.
 * You must have the *Admin* role, or a role with the permission set with read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete permission sets.
 
 .Procedure
-. On the RHACS portal, navigate to *Platform Configuration* -> *Access control*.
-. Select the *Permission sets* tab.
-. Click *Add permission set*.
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Access Control*.
+. Select *Permission sets*.
+. Click *Create permission set*.
 . Enter a *Name* and *Description* for the new permission set.
-. For each resource, under the *Access level* column, select one of the permissions from `No access`, `Read access`, `Read and Write access`.
+. For each resource, under the *Access level* column, select one of the permissions from `No access`, `Read access`, or `Read and Write access`.
 +
 [WARNING]
 ====
@@ -29,7 +29,7 @@ You can create new permission sets from the *Access Control* view.
 ** `NetworkGraph`
 ** `Policy`
 ** `Secret`
-* These permissions are pre-selected when you create a new permission set.
-* If you do not grant these permissions, users will experience issues with viewing pages in the RHACS portal.
+* These permissions are preselected when you create a new permission set.
+* If you do not grant these permissions, users will experience issues with viewing pages in the {product-title-short} portal.
 ====
 . Click *Save*.

--- a/modules/create-a-custom-role-3630.adoc
+++ b/modules/create-a-custom-role-3630.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-role-based-access-control.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="create-a-custom-role-3630_{context}"]
 = Creating a custom role
 
@@ -13,9 +13,9 @@ You can create new roles from the *Access Control* view.
 * You must create a permissions set and an access scope for the custom role before creating the role.
 
 .Procedure
-. On the RHACS portal, navigate to *Platform Configuration* -> *Access control*.
-. Select the *Roles* tab.
-. Click *Add role*.
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Access Control*.
+. Select *Roles*.
+. Click *Create role*.
 . Enter a *Name* and *Description* for the new role.
 . Select a *Permission set* for the role.
 . Select an *Access scope* for the role.

--- a/modules/create-a-custom-role.adoc
+++ b/modules/create-a-custom-role.adoc
@@ -29,7 +29,7 @@ You can create new roles from the *Access Control* view.
 ** `NetworkGraph`
 ** `Policy`
 ** `Secret`
-* These permissions are pre-selected when you create a new role.
+* These permissions are preselected when you create a new role.
 * If you do not grant these permissions, users will experience issues viewing pages in the RHACS portal.
 ====
 . Click *Save*.

--- a/modules/manage-access-for-specific-users-or-groups.adoc
+++ b/modules/manage-access-for-specific-users-or-groups.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-role-based-access-control.adoc
+// applies to old versions, do not maintain
 :_module-type: PROCEDURE
 [id="manage-access-for-specific-users-or-groups_{context}"]
 = Managing access for specific users or groups
@@ -19,7 +20,7 @@ For example:
 ** `email`
 ** `uid`
 ** `groups`
-* However, for Security Assertion Markup Language (SAML) based authentication providers, there are no restrictions and you can define custom attributes as metadata keys.
+* However, for Security Assertion Markup Language (SAML)-based authentication providers, there are no restrictions and you can define custom attributes as metadata keys.
 ====
 
 .Prerequisites

--- a/modules/view-system-permission-set.adoc
+++ b/modules/view-system-permission-set.adoc
@@ -1,14 +1,14 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-role-based-access-control.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="view-system-permission-set_{context}"]
 = Viewing the permissions for a system permission set
 
-You can view the permissions for a system permission set in the RHACS portal.
+You can view the permissions for a system permission set in the {product-title-short} portal.
 
 .Procedure
-. On the RHACS portal, navigate to *Platform Configuration* -> *Access control*.
+. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Access control*.
 . Select *Permission sets*.
 . Click on one of the permission sets to view its details. The details page shows a list of resources and their permissions for the selected permission set.
 

--- a/operating/manage-user-access/configure-ocp-oauth.adoc
+++ b/operating/manage-user-access/configure-ocp-oauth.adoc
@@ -26,5 +26,6 @@ $ oc -n stackrox set env deploy/central ROX_ENABLE_OPENSHIFT_AUTH=true
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.openshift.com/container-platform/4.9/authentication/identity_providers/configuring-ldap-identity-provider.html[Configuring an LDAP identity provider ]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/authentication_and_authorization/understanding-identity-provider[Understanding identity provider configuration]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/authentication_and_authorization/configuring-identity-providers#configuring-ldap-identity-provider[Configuring an LDAP identity provider]
 * xref:../../configuration/add-trusted-ca.adoc[Adding trusted certificate authorities ]


### PR DESCRIPTION
Version(s):

- merge to `rhacs-docs-3.72.0`
- cherry pick to `rhacs-docs`

Label:

`RHACS/next`
`RHACS`

[Issue](https://issues.redhat.com/browse/ROX-11051)

Links to docs preview:

- [Configuring OpenShift Container Platform OAuth server as an identity provider](https://openshift-docs-hnuo0aywi-kcarmichael08.vercel.app/openshift-acs/master/operating/manage-user-access/configure-ocp-oauth.html#configure-ocp-oauth-identity-provider_configure-ocp-oauth)

- [Configure OIDC identity provider](https://openshift-docs-hnuo0aywi-kcarmichael08.vercel.app/openshift-acs/master/operating/manage-user-access/configure-google-workspace-identity.html#configure-oidc-identity-provider_configure-google-workspace-identity)

- [Configuring PKI authentication](https://openshift-docs-hnuo0aywi-kcarmichael08.vercel.app/openshift-acs/master/operating/manage-user-access/enable-pki-authentication.html#configure-pki-authentication-portal_enable-pki-authentication)

- [Configuring a SAML 2.0 identity provider](https://openshift-docs-hnuo0aywi-kcarmichael08.vercel.app/openshift-acs/master/operating/manage-user-access/configure-okta-identity-cloud.html#configure-saml-identity-provider_configure-okta-identity-cloud)

- [Creating a custom access scope](https://openshift-docs-hnuo0aywi-kcarmichael08.vercel.app/openshift-acs/master/operating/manage-user-access/manage-role-based-access-control-3630.html#create-a-custom-access-scope_manage-role-based-access-control)

- [Creating a custom permission set](https://openshift-docs-hnuo0aywi-kcarmichael08.vercel.app/openshift-acs/master/operating/manage-user-access/manage-role-based-access-control-3630.html#create-a-custom-permission-set_manage-role-based-access-control)

- [Create custom role](https://openshift-docs-hnuo0aywi-kcarmichael08.vercel.app/openshift-acs/master/operating/manage-user-access/manage-role-based-access-control-3630.html#create-a-custom-role-3630_manage-role-based-access-control)

- Manage access for specific users or groups - added comment in the internal comment field in the doc to not update it anymore since it's a legacy doc.

- [Viewing permissions for a specific permission set](https://openshift-docs-hnuo0aywi-kcarmichael08.vercel.app/openshift-acs/master/operating/manage-user-access/manage-role-based-access-control-3630.html#view-system-permission-set_manage-role-based-access-control)
