### PR TITLE
BZ2096868: Add steps to restore to a previous cluster state

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -284,6 +284,57 @@ etcd-ip-10-0-143-125.ec2.internal                1/1     Running     1          
 If the status is `Pending`, or the output lists more than one running etcd pod, wait a few minutes and check again.
 
 .. Repeat this step for each lost control plane host that is not the recovery host.
++
+[NOTE]
+====
+Perform the following step only if you are using `OVNKubernetes` Container Network Interface (CNI) plug-in.
+====
++
+. Restart the Open Virtual Network (OVN) Kubernetes pods on all the hosts.
+
+.. Remove the northbound database (nbdb) and southbound database (sbdb). Access the recovery host and the remaining control plane nodes by using Secure Shell (SSH) and run the following command:
++
+[source,terminal]
+----
+$ sudo rm -f /var/lib/ovn/etc/*.db
+----
+
+.. Delete all OVN-Kubernetes control plane pods by running the following command:
++
+[source,terminal]
+----
+$ oc delete pods -l app=ovnkube-master -n openshift-ovn-kubernetes
+----
+
+.. Ensure that all the OVN-Kubernetes control plane pods are deployed again and are in a `Running` state by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -l app=ovnkube-master -n openshift-ovn-kubernetes
+----
++
+.Example output
+[source,terminal]
+----
+NAME                   READY   STATUS    RESTARTS   AGE
+ovnkube-master-nb24h   4/4     Running   0          48s
+ovnkube-master-rm8kw   4/4     Running   0          47s
+ovnkube-master-zbqnh   4/4     Running   0          56s
+----
+
+.. Delete all `ovnkube-node` pods by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes -o name | grep ovnkube-node | while read p ; do oc delete $p -n openshift-ovn-kubernetes ; done
+----
+
+.. Ensure that all the `ovnkube-node` pods are deployed again and are in a `Running` state by running the following command:
++
+[source,terminal]
+----
+$ oc get  pods -n openshift-ovn-kubernetes | grep ovnkube-node
+----
 
 . Delete and recreate other non-recovery, control plane machines, one by one. After these machines are recreated, a new revision is forced and etcd scales up automatically.
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> ---> Add steps to restore to a previous cluster state
 
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.9+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2096868
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/sdudhgao/disaster-recovery/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. -->

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
