### PR TITLE
Missing oc command in the sample code

### DIFF
--- a/modules/nw-networkpolicy-audit-disable.adoc
+++ b/modules/nw-networkpolicy-audit-disable.adoc
@@ -15,7 +15,7 @@ As a cluster administrator, you can disable network policy audit logging for a n
 +
 [source,terminal]
 ----
-$ annotate --overwrite namespace <namespace> k8s.ovn.org/acl-logging={}
+$ oc annotate --overwrite namespace <namespace> k8s.ovn.org/acl-logging={}
 ----
 +
 --


### PR DESCRIPTION
### Missing oc command

Version(s):
PR applies to all versions after a specific version (e.g. 4.8): 4.8+

Issue:
Missing oc command.

Link to docs preview:
https://docs.openshift.com/container-platform/4.8/networking/network_policy/logging-network-policy.html#nw-networkpolicy-audit-disable_logging-network-policy
https://docs.openshift.com/container-platform/4.9/networking/network_policy/logging-network-policy.html#nw-networkpolicy-audit-disable_logging-network-policy
https://docs.openshift.com/container-platform/4.10/networking/network_policy/logging-network-policy.html#nw-networkpolicy-audit-disable_logging-network-policy
https://docs.openshift.com/container-platform/4.11/networking/network_policy/logging-network-policy.html#nw-networkpolicy-audit-disable_logging-network-policy