### PR TITLE
BZ2078813: Added CLI steps for StorageClass creation

### DIFF
--- a/modules/persistent-storage-csi-dynamic-provisioning-aws-efs.adoc
+++ b/modules/persistent-storage-csi-dynamic-provisioning-aws-efs.adoc
@@ -21,40 +21,13 @@ Using monitoring of EFS volume sizes in AWS is strongly recommended.
 .Prerequisites
 
 * xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#efs-create-volume_persistent-storage-csi-aws-efs[Created AWS EFS volume(s).]
+* xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#storage-create-storage-class_persistent-storage-csi-aws-efs[Creating the AWS EFS storage class]
 
 .Procedure
 
 To enable dynamic provisioning:
 
-. Create a `StorageClass` as follows:
-+
-[source,yaml]
-----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: efs-sc
-provisioner: efs.csi.aws.com
-parameters:
-  provisioningMode: efs-ap <1>
-  fileSystemId: fs-a5324911 <2>
-  directoryPerms: "700" <3>
-  gidRangeStart: "1000" <4>
-  gidRangeEnd: "2000" <4>
-  basePath: "/dynamic_provisioning" <5>
-----
-<1> `provisioningMode` must be `efs-ap` to enable dynamic provisioning.
-<2> `fileSystemId` must be the ID of the EFS volume created manually above.
-<3> `directoryPerms` is the default permission of the root directory of the volume. In this case, the volume is accessible only by the owner.
-<4> `gidRangeStart` and `gidRangeEnd` set the range of POSIX Group IDs (GIDs) that are used to set the GID of the AWS access point. If not specified, the default range is 50000-7000000. Each provisioned volume, and thus AWS access point, is assigned a unique GID from this range.
-<5> `basePath` is the directory on the EFS volume that is used to create dynamically provisioned volumes. In this case, a PV is provisioned as “/dynamic_provisioning/<random uuid>” on the EFS volume. Only the subdirectory is mounted to pods that use the PV.
-+
-[NOTE]
-====
-A cluster admin can create several `StorageClasses`, each using a different EFS volume.
-====
-+
-. Create a PVC (or StatefulSet or Template) as usual, referring to the `StorageClass` created above.
+* Create a PVC (or StatefulSet or Template) as usual, referring to the `StorageClass` created above.
 +
 [source,yaml]
 ----

--- a/modules/storage-create-storage-class.adoc
+++ b/modules/storage-create-storage-class.adoc
@@ -22,6 +22,8 @@ endif::[]
 
 .Procedure
 
+To create the AWS EFS storage class from the web console, follow these steps:
+
 . In the {product-title} console, click *Storage* -> *Storage Classes*.
 
 . On the *StorageClasses* overview page, click *Create Storage Class*.
@@ -49,3 +51,33 @@ endif::[]
 
 // Undefine {StorageClass} attribute, so that any mistakes are easily spotted
 :!StorageClass:
+
+To create the AWS EFS storage class from the CLI, follow these steps:
+
+* Create a `StorageClass` as follows:
++
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: efs-sc
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap <1>
+  fileSystemId: fs-a5324911 <2>
+  directoryPerms: "700" <3>
+  gidRangeStart: "1000" <4>
+  gidRangeEnd: "2000" <4>
+  basePath: "/dynamic_provisioning" <5>
+----
+<1> `provisioningMode` must be `efs-ap` to enable dynamic provisioning.
+<2> `fileSystemId` must be the ID of the EFS volume created manually above.
+<3> `directoryPerms` is the default permission of the root directory of the volume. In this case, the volume is accessible only by the owner.
+<4> `gidRangeStart` and `gidRangeEnd` set the range of POSIX Group IDs (GIDs) that are used to set the GID of the AWS access point. If not specified, the default range is 50000-7000000. Each provisioned volume, and thus AWS access point, is assigned a unique GID from this range.
+<5> `basePath` is the directory on the EFS volume that is used to create dynamically provisioned volumes. In this case, a PV is provisioned as “/dynamic_provisioning/<random uuid>” on the EFS volume. Only the subdirectory is mounted to pods that use the PV.
++
+[NOTE]
+====
+A cluster admin can create several `StorageClasses`, each using a different EFS volume.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.9+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2078813
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/dnagaraj/BZ2078813/storage/container_storage_interface/persistent-storage-csi-aws-efs.html#storage-create-storage-class_persistent-storage-csi-aws-efs

http://file.rdu.redhat.com/dnagaraj/BZ2078813/storage/container_storage_interface/persistent-storage-csi-aws-efs.html#csi-dynamic-provisioning-aws-efs_persistent-storage-csi-aws-efs

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. -->

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information: @duanwei33 PTAL and let me know your feedback.
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
