### PR TITLE
[WIP] Update serverless docs structure

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1048,7 +1048,7 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
   Topics:
   - Name: Understanding the AWS Load Balancer Operator
-    File: understanding-aws-load-balancer-operator  
+    File: understanding-aws-load-balancer-operator
   - Name: Installing the AWS Load Balancer Operator
     File: install-aws-load-balancer-operator
   - Name: Creating an instance of the AWS Load Balancer Controller
@@ -3488,14 +3488,14 @@ Name: Serverless
 Dir: serverless
 Distros: openshift-enterprise
 Topics:
+- Name: About OpenShift Serverless
+  File: about-serverless
 - Name: Release notes
   File: serverless-release-notes
-- Name: Discover
+- Name: Resources
   Dir: discover
   Topics:
-  - Name: About OpenShift Serverless
-    File: about-serverless
-  - Name: About OpenShift Serverless Functions
+  - Name: Functions
     File: serverless-functions-about
   - Name: Event sources
     File: knative-event-sources

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -160,13 +160,13 @@ Topics:
 - Name: Upgrading OpenShift Dedicated
   File: osd-upgrades
   Distros: openshift-dedicated
----  
+---
 Name: CI/CD
 Dir: cicd
 Topics:
 - Name: Builds
   Dir: builds
-  Distros: openshift-dedicated 
+  Distros: openshift-dedicated
   Topics:
   - Name: Setting up additional trusted certificate authorities for builds
     File: setting-up-trusted-ca
@@ -237,14 +237,14 @@ Name: Serverless
 Dir: serverless
 Distros: openshift-dedicated
 Topics:
+- Name: About OpenShift Serverless
+  File: about-serverless
 - Name: Release notes
   File: serverless-release-notes
-- Name: Discover
+- Name: Resources
   Dir: discover
   Topics:
-  - Name: About OpenShift Serverless
-    File: about-serverless
-  - Name: About OpenShift Serverless Functions
+  - Name: Functions
     File: serverless-functions-about
   - Name: Event sources
     File: knative-event-sources

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -261,13 +261,13 @@ Topics:
   File: rosa-upgrading-sts
 - Name: Upgrading ROSA
   File: rosa-upgrading
----  
+---
 Name: CI/CD
 Dir: cicd
 Topics:
 - Name: Builds
   Dir: builds
-  Distros: openshift-rosa 
+  Distros: openshift-rosa
   Topics:
   - Name: Setting up additional trusted certificate authorities for builds
     File: setting-up-trusted-ca
@@ -440,14 +440,14 @@ Name: Serverless
 Dir: serverless
 Distros: openshift-rosa
 Topics:
+- Name: About OpenShift Serverless
+  File: about-serverless
 - Name: Release notes
   File: serverless-release-notes
-- Name: Discover
+- Name: Resources
   Dir: discover
   Topics:
-  - Name: About OpenShift Serverless
-    File: about-serverless
-  - Name: About OpenShift Serverless Functions
+  - Name: Functions
     File: serverless-functions-about
   - Name: Event sources
     File: knative-event-sources

--- a/serverless/discover/serverless-functions-about.adoc
+++ b/serverless/discover/serverless-functions-about.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="serverless-functions-about"]
-= About {FunctionsProductName}
+= Functions
 :context: serverless-functions-about
 include::_attributes/common-attributes.adoc[]
 


### PR DESCRIPTION
There is no related Jira issue for this PR. The idea is just to update the structure of our downstream docs in some places to align them better with the evolving structure of upstream docs, to make content more portable between the two sites.
No QE approval is required since these are docs only changes.

**Proposed changes:**
- Rename functions conceptual page to simply "Functions"
- Rename Discover section to Resources

**Version(s):**
OCP 4.6+
Manual CPs required for older versions (4.6 - 4.8) that are OCP only

**Link to docs preview:**
TBA