### PR TITLE
BZ#2078913:[WMCO] Adding BYOH instance in AWS IPI fails with: Tag KubernetesCluster nor kubernetes.io/cluster/

### DIFF
--- a/modules/byoh-configuring.adoc
+++ b/modules/byoh-configuring.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="configuring-byoh-windows-instance"]
-= Configuring BYOH Windows instance
+= Configuring a BYOH Windows instance
 
 Creating a BYOH Windows instance requires creating a config map in the Windows Machine Config Operator (WMCO) namespace.
 
@@ -16,6 +16,7 @@ Any Windows instances that are to be attached to the cluster as a node must fulf
 * The default shell for the SSH server must be the link:https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration#configuring-the-default-shell-for-openssh-in-windows[Windows Command shell], or `cmd.exe`.
 * Port 10250 must be open for log collection.
 * An administrator user is present with the private key used in the secret set as an authorized SSH key.
+* If you are creating a BYOH Windows instance for an installer-provisioned infrastructure (IPI) AWS cluster, you must add a tag to the AWS instance that matches the `spec.template.spec.value.tag` value in the machine set for your worker nodes. For example, `kubernetes.io/cluster/<cluster_id>: owned` or `kubernetes.io/cluster/<cluster_id>: shared`.
 * If you are creating a BYOH Windows instance on vSphere, communication with the internal API server must be enabled.
 * The hostname of the instance must follow the link:https://datatracker.ietf.org/doc/html/rfc1123[RFC 1123] DNS label requirements, which include the following standards:
 ** Contains only lowercase alphanumeric characters or '-'.


### PR DESCRIPTION
The user will have to add the tag to the AWS instance they are creating using whatever method (AWS console or AWS API) they using.
https://bugzilla.redhat.com/show_bug.cgi?id=2078913

Preview: [Configuring a BYOH Windows instance, prereq bullet 6](http://file.rdu.redhat.com/mburke/winc-add-byoh-aws-note/windows_containers/byoh-windows-instance.html#configuring-byoh-windows-instance_%3Cbyoh-windows-instance%3E).