### PR TITLE
TELCODOCS-422 adding procedure to use node selector spec to announce IP address from subset of nodes

### DIFF
--- a/modules/nw-metallb-advertise-ip-pools-from-node-subset.adoc
+++ b/modules/nw-metallb-advertise-ip-pools-from-node-subset.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * networking/metallb/about-advertising-ipaddresspool.adoc
+
+:_content-type: PROCEDURE
+
+[id="nw-metallb-advertise-ip-pools-to-node-subset_{context}"]
+= Advertising an IP address pool from a subset of nodes 
+
+To advertise an IP address from an IP addresses pool, from a specific set of nodes only, use the `.spec.nodeSelector` specification in the BGPAdvertisement custom resource. This specification associates a pool of IP addresses with a set of nodes in the cluster. This is useful when you have nodes on different subnets in a cluster and you want to advertise an IP addresses from an address pool from a specific subnet, for example a public-facing subnet only. 
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+ 
+.Procedure
+
+. Create an IP address pool by using a custom resource:
++
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: pool1
+spec:
+  addresses:
+    - 4.4.4.100-4.4.4.200
+    - 2001:100:4::200-2001:100:4::400
+----
+
+. Control which nodes in the cluster the IP address from `pool1` advertises from by defining the `.spec.nodeSelector` value in the BGPAdvertisement custom resource:
++
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: BGPAdvertisement
+metadata:
+  name: example
+spec:
+  ipAddressPools:
+  - pool1
+  nodeSelector:
+  - matchLabels:
+      kubernetes.io/hostname: NodeA
+  - matchLabels:
+      kubernetes.io/hostname: NodeB
+----
+
+In this example, the IP address from `pool1` advertises from `NodeA` and `NodeB` only.

--- a/modules/nw-metallb-bgpadvertisement-cr.adoc
+++ b/modules/nw-metallb-bgpadvertisement-cr.adoc
@@ -67,10 +67,6 @@ This BGP attribute applies to BGP sessions within the Autonomous System.
 |`spec.nodeSelectors`
 |`string`
 |Optional: `NodeSelectors` allows to limit the nodes to announce as next hops for the load balancer IP. When empty, all the nodes are announced as next hops.
-[NOTE]
-====
-The functionality this supports is Technology Preview only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. 
-====
 
 |`spec.peers`
 |`string`

--- a/modules/nw-metallb-l2padvertisement-cr.adoc
+++ b/modules/nw-metallb-l2padvertisement-cr.adoc
@@ -40,7 +40,7 @@ Specify the same namespace that the MetalLB Operator uses.
 [NOTE]
 ====
 Limiting the nodes to announce as next hops is Technology Preview only. For more information about Technology Preview support, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope]. 
-]
+
 ====
 
 |===

--- a/networking/metallb/about-advertising-ipaddresspool.adoc
+++ b/networking/metallb/about-advertising-ipaddresspool.adoc
@@ -26,8 +26,10 @@ include::modules/nw-metallb-advertise-address-pool-with-bgp.adoc[leveloffset=+2]
 include::modules/nw-metallb-configure-bgp-advertisement-advanced.adoc[leveloffset=+1]
 
 // Advertise MetalLB with a BGP advertisement
-
 include::modules/nw-metallb-advertise-address-pool-with-bgp-advanced.adoc[leveloffset=+2]
+
+// Advertise IP address pools from a subset of nodes 
+include::modules/nw-metallb-advertise-ip-pools-from-node-subset.adoc[leveloffset=+1]
 
 // L2 advertisement custom resource
 include::modules/nw-metallb-l2padvertisement-cr.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-422](https://issues.redhat.com//browse/TELCODOCS-422): You can now use the nodeSelector specification to announce IP address from a subset of nodes on the cluster. 

Version(s):
4.12+

Issue: https://issues.redhat.com/browse/TELCODOCS-422

Link to docs preview: http://file.emea.redhat.com/rohennes/TELCODOCS-422-ip-pool-node-subset/networking/metallb/about-advertising-ipaddresspool.html#nw-metallb-advertise-ip-pools-to-node-subset_about-advertising-ip-address-pool


