### PR TITLE
GH#47482 - Removing master node language

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -105,7 +105,7 @@ For the `baremetal` network, a network administrator must reserve a number of IP
 - One virtual IP address for the wildcard ingress endpoint.
 +
 . One IP address for the provisioner node.
-. One IP address for each control plane (master) node.
+. One IP address for each control plane node.
 . One IP address for each worker node, if applicable.
 
 [IMPORTANT]
@@ -133,9 +133,9 @@ The following table provides an exemplary embodiment of fully qualified domain n
 | API | `api.<cluster_name>.<base_domain>` | `<ip>`
 | Ingress LB (apps) |  `*.apps.<cluster_name>.<base_domain>`  | `<ip>`
 | Provisioner node | `provisioner.<cluster_name>.<base_domain>` | `<ip>`
-| Master-0 | `openshift-master-0.<cluster_name>.<base_domain>` | `<ip>`
-| Master-1 | `openshift-master-1.<cluster_name>-.<base_domain>` | `<ip>`
-| Master-2 | `openshift-master-2.<cluster_name>.<base_domain>` | `<ip>`
+| Control-plane-0 | `openshift-control-plane-0.<cluster_name>.<base_domain>` | `<ip>`
+| Control-plane-1 | `openshift-control-plane-1.<cluster_name>-.<base_domain>` | `<ip>`
+| Control-plane-2 | `openshift-control-plane-2.<cluster_name>.<base_domain>` | `<ip>`
 | Worker-0 | `openshift-worker-0.<cluster_name>.<base_domain>` | `<ip>`
 | Worker-1 | `openshift-worker-1.<cluster_name>.<base_domain>` | `<ip>`
 | Worker-n | `openshift-worker-n.<cluster_name>.<base_domain>` | `<ip>`

--- a/modules/ipi-install-validation-checklist-for-nodes.adoc
+++ b/modules/ipi-install-validation-checklist-for-nodes.adoc
@@ -9,7 +9,7 @@
 .When using the `provisioning` network
 
 * [ ] NIC1 VLAN is configured for the `provisioning` network.
-* [ ] NIC1 for the `provisioning` network is PXE-enabled on the provisioner, control plane (master), and worker nodes.
+* [ ] NIC1 for the `provisioning` network is PXE-enabled on the provisioner, control plane, and worker nodes.
 * [ ] NIC2 VLAN is configured for the `baremetal` network.
 * [ ] PXE has been disabled on all other NICs.
 * [ ] DNS is configured with API and Ingress endpoints.


### PR DESCRIPTION
For versions 4.10+
Issue: #47482

Description: Removing some instances of `master` in this document to use inclusive language 

Preview: 

- [Deploying installer-provisioned clusters on bare metal -> Prerequisites -> Reserving IP addresses for nodes with the DHCP](https://kelbrown20.github.io/bug-fix-previews/GH474882-fixing-master-wording/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-reserving-ip-addresses_ipi-install-prerequisites)
- [Deploying installer-provisioned clusters on bare metal -> Prerequisites -> Dynamic Host Configuration Protocol (DHCP) requirements](https://kelbrown20.github.io/bug-fix-previews/GH474882-fixing-master-wording/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-dhcp-reqs_ipi-install-prerequisites)
- [Deploying installer-provisioned clusters on bare metal -> Prerequisites -> Validation checklist for nodes](https://kelbrown20.github.io/bug-fix-previews/GH474882-fixing-master-wording/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#validation-checklist-for-nodes_ipi-install-prerequisites)

**Question for QE:** The text says that the host names can use any hosting naming convention the user prefers and looks to not be hard coded, which is why I changed the language in the table. Please let me know if that is not the case and the Usage/Host name has to use `master`. Thank you! 
