### PR TITLE
RHDEVDOCS-4432- fix for Pantheon build failure

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2242,6 +2242,8 @@ Topics:
   File: enabling-alert-routing-for-user-defined-projects
 - Name: Managing metrics
   File: managing-metrics
+- Name: Querying metrics
+  File: querying-metrics
 - Name: Managing metrics targets
   File: managing-metrics-targets
 - Name: Managing alerts

--- a/modules/monitoring-about-querying-metrics.adoc
+++ b/modules/monitoring-about-querying-metrics.adoc
@@ -1,11 +1,11 @@
 // Module included in the following assemblies:
 //
-// * monitoring/managing-metrics.adoc
+// * monitoring/querying-metrics.adoc
 // * virt/logging_events_monitoring/virt-prometheus-queries.adoc
 
 :_content-type: CONCEPT
-[id="querying-metrics_{context}"]
-= Querying metrics
+[id="about-querying-metrics_{context}"]
+= About querying metrics
 
 The {product-title} monitoring dashboard enables you to run Prometheus Query Language (PromQL) queries to examine metrics visualized on a plot. This functionality provides information about the state of a cluster and any user-defined workloads that you are monitoring.
 

--- a/monitoring/managing-metrics.adoc
+++ b/monitoring/managing-metrics.adoc
@@ -30,32 +30,7 @@ include::modules/monitoring-specifying-how-a-service-is-monitored.adoc[leveloffs
 * xref:../rest_api/monitoring_apis/podmonitor-monitoring-coreos-com-v1.adoc[PodMonitor API]
 * xref:../rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.adoc[ServiceMonitor API]
 
-// Querying metrics
-include::modules/monitoring-querying-metrics.adoc[leveloffset=+1]
-//include::modules/monitoring-contents-of-the-metrics-ui.adoc[leveloffset=+2]
-include::modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* For more information about creating PromQL queries, see the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus query documentation].
-
-include::modules/monitoring-querying-metrics-for-user-defined-projects-as-a-developer.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* For more information about creating PromQL queries, see the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus query documentation]. 
-
-include::modules/monitoring-exploring-the-visualized-metrics.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../monitoring/managing-metrics.adoc#querying-metrics_managing-metrics[Querying metrics] for details on using the PromQL interface
-* See xref:../monitoring/managing-metrics.adoc#querying-metrics-for-all-projects-as-an-administrator_managing-metrics[Querying metrics for all projects as an administrator] for details on accessing metrics for all projects as an administrator.
-* See xref:../monitoring/managing-metrics.adoc#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics[Querying metrics for user-defined projects as a developer] for details on accessing non-cluster metrics as a developer or a privileged user.
-
+[id="next-steps_querying-metrics"]
 == Next steps
 
-* xref:../monitoring/managing-metrics-targets.adoc#managing-metrics-targets[Managing metrics targets]
+* xref:../monitoring/querying-metrics.adoc#querying-metrics[Querying metrics]

--- a/monitoring/querying-metrics.adoc
+++ b/monitoring/querying-metrics.adoc
@@ -1,0 +1,40 @@
+:_content-type: ASSEMBLY
+[id="querying-metrics"]
+= Querying metrics
+include::_attributes/common-attributes.adoc[]
+:context: querying-metrics
+
+toc::[]
+
+You can query metrics to view data about how cluster components and your own workloads are performing.
+
+// Querying metrics
+include::modules/monitoring-about-querying-metrics.adoc[leveloffset=+1]
+//include::modules/monitoring-contents-of-the-metrics-ui.adoc[leveloffset=+2]
+include::modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about creating PromQL queries, see the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus query documentation].
+
+include::modules/monitoring-querying-metrics-for-user-defined-projects-as-a-developer.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about creating PromQL queries, see the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus query documentation]. 
+
+include::modules/monitoring-exploring-the-visualized-metrics.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See xref:../monitoring/querying-metrics.adoc#about-querying-metrics_querying-metrics[Querying metrics] for details on using the PromQL interface
+* See xref:../monitoring/querying-metrics.adoc#querying-metrics-for-all-projects-as-an-administrator_querying-metrics[Querying metrics for all projects as an administrator] for details on accessing metrics for all projects as an administrator.
+* See xref:../monitoring/querying-metrics.adoc#querying-metrics-for-user-defined-projects-as-a-developer_querying-metrics[Querying metrics for user-defined projects as a developer] for details on accessing non-cluster metrics as a developer or a privileged user.
+
+[id="next-steps_managing-metrics-targets"]
+== Next steps
+
+* xref:../monitoring/managing-metrics-targets.adoc#managing-metrics-targets[Managing metrics targets]

--- a/networking/metallb/metallb-troubleshoot-support.adoc
+++ b/networking/metallb/metallb-troubleshoot-support.adoc
@@ -26,7 +26,7 @@ include::modules/nw-metallb-metrics.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../monitoring/managing-metrics.adoc#querying-metrics_managing-metrics[Querying metrics] for information about using the monitoring dashboard.
+* See xref:../../monitoring/querying-metrics.adoc#querying-metrics[Querying metrics] for information about using the monitoring dashboard.
 
 // Collecting data
 include::modules/nw-metallb-collecting-data.adoc[leveloffset=+1]

--- a/sandboxed_containers/monitoring-sandboxed-containers.adoc
+++ b/sandboxed_containers/monitoring-sandboxed-containers.adoc
@@ -17,7 +17,7 @@ include::modules/sandboxed-containers-query-metrics.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about creating PromQL queries to view metrics, see xref:../monitoring/managing-metrics.adoc#querying-metrics_managing-metrics[Querying Metrics].
+* For more information about creating PromQL queries to view metrics, see xref:../monitoring/querying-metrics.adoc#querying-metrics[Querying metrics].
 
 include::modules/sandboxed-containers-dashboard.adoc[leveloffset=+1]
 

--- a/virt/logging_events_monitoring/virt-prometheus-queries.adoc
+++ b/virt/logging_events_monitoring/virt-prometheus-queries.adoc
@@ -22,7 +22,7 @@ Use the {product-title} monitoring dashboard to query virtualization metrics.
 
 * For guest memory swapping queries to return data, memory swapping must be enabled on the virtual guests.
 
-include::modules/monitoring-querying-metrics.adoc[leveloffset=+1]
+include::modules/monitoring-about-querying-metrics.adoc[leveloffset=+1]
 
 include::modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Summary: 
This PR splits one assembly file in the Monitoring section of the OCP docs into two assembly files in an attempt to address a build failure occurring with the Monitoring book on Pantheon.

Notes:
- **For peer reviewer**: This PR requires only a check that the links work and that the reorg of the assembly has not introduced rendering or other issues. This PR does **NOT** require language review. It does not change any existing content even though it appears there is new content because the PR moves some content from one existing assembly into a new assembly.
- **For merge**: no QE approval is required because no technical content has been changed in this PR.

PR reviewing details:
- Aligned team: DevTools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4432
- Direct link to doc previews (RH VPN access required):
- - http://file.rdu.redhat.com/bburt/RHDEVDOCS-4432-fix-for-pantheon-build-failure/monitoring/managing-metrics.html
- - http://file.rdu.redhat.com/bburt/RHDEVDOCS-4432-fix-for-pantheon-build-failure/monitoring/querying-metrics.html
- SME review: N/A
- QE review: N/A
- Peer review: @rolfedh 
