### PR TITLE
Adds notes for 3.11.784 release

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -6057,3 +6057,91 @@ openshift3/ose-template-service-broker:v3.11.715-1.ge449bb4
 ==== Upgrading
 
 To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.
+
+[[ocp-3-11-784]]
+=== RHBA-2022:6251 - {product-title} 3.11.784 bug fix and security update
+
+Issued: 2022-09-07
+
+{product-title} release 3.11.784 is now available. The list of packages and bug fixes included in the update are documented in the link:https://access.redhat.com/errata/RHBA-2022:6251[RHBA-2022:6251] advisory. The container images included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:6252[RHSA-2022:6252] advisory.
+
+[[ocp-3-11-784-images]]
+==== Images
+
+This release updates the Red Hat Container Registry (`registry.redhat.io`) with the following images:
+
+----
+openshift3/ose-ansible:v3.11.784-1.g0bfa87c
+openshift3/ose-cluster-autoscaler:v3.11.784-1.g99b2acf
+openshift3/ose-descheduler:v3.11.784-1.gd435537
+openshift3/ose-metrics-server:v3.11.784-1.gf8bf728
+openshift3/ose-node-problem-detector:v3.11.784-1.gc8f26da
+openshift3/automation-broker-apb:v3.11.784-1
+openshift3/ose-cluster-monitoring-operator:v3.11.784-1.ga9fd527
+openshift3/ose-configmap-reloader:v3.11.784-1.gbb85bd3
+openshift3/csi-attacher:v3.11.784-1
+openshift3/csi-driver-registrar:v3.11.784-1
+openshift3/csi-livenessprobe:v3.11.784-1
+openshift3/csi-provisioner:v3.11.784-1
+openshift3/ose-efs-provisioner:v3.11.784-1.g04aa20d
+openshift3/oauth-proxy:v3.11.784-1.gedebe84
+openshift3/prometheus-alertmanager:v3.11.784-1.g13de638
+openshift3/prometheus-node-exporter:v3.11.784-1.g609cd20
+openshift3/prometheus:v3.11.784-1.g99aae51
+openshift3/grafana:v3.11.784-1.g423963f
+openshift3/image-inspector:v3.11.784-1
+openshift3/ose-kube-rbac-proxy:v3.11.784-1.g31106c3
+openshift3/ose-kube-state-metrics:v3.11.784-1.gb7c6d38
+openshift3/kuryr-cni:v3.11.784-1.g0c4bf66
+openshift3/ose-logging-curator5:v3.11.784-1.ge84e80c
+openshift3/ose-logging-elasticsearch5:v3.11.784-1.ge84e80c
+openshift3/ose-logging-eventrouter:v3.11.784-1
+openshift3/logging-fluentd:v3.11.784-1.ge84e80c
+openshift3/ose-logging-kibana5:v3.11.784-1.ge84e80c
+openshift3/metrics-heapster:v3.11.784-1
+openshift3/metrics-schema-installer:v3.11.784-1
+openshift3/apb-base:v3.11.784-1.g5b9d189
+openshift3/apb-tools:v3.11.784-1
+openshift3/ose-ansible-service-broker:v3.11.784-1
+openshift3/ose-docker-builder:v3.11.784-1.gc4590b1
+openshift3/ose-cli:v3.11.784-1.gc4590b1
+openshift3/ose-cluster-capacity:v3.11.784-1.g22be164
+openshift3/ose-console:v3.11.784-1.g755b880
+openshift3/ose:v3.11.784-1.gc4590b1
+openshift3/ose-deployer:v3.11.784-1.gc4590b1
+openshift3/ose-egress-dns-proxy:v3.11.784-1.gc4590b1
+openshift3/ose-egress-router:v3.11.784-1.gc4590b1
+openshift3/ose-haproxy-router:v3.11.784-1.gc4590b1
+openshift3/ose-hyperkube:v3.11.784-1.gc4590b1
+openshift3/ose-hypershift:v3.11.784-1.gc4590b1
+openshift3/ose-keepalived-ipfailover:v3.11.784-1.gc4590b1
+openshift3/mariadb-apb:v3.11.784-1
+openshift3/mediawiki-apb:v3.11.784-1
+openshift3/mediawiki:v3.11.784-1
+openshift3/mysql-apb:v3.11.784-1
+openshift3/node:v3.11.784-1.gc4590b1
+openshift3/ose-pod:v3.11.784-1.gc4590b1
+openshift3/postgresql-apb:v3.11.784-1
+openshift3/ose-recycler:v3.11.784-1.gc4590b1
+openshift3/ose-docker-registry:v3.11.784-1.g0fa231c
+openshift3/ose-service-catalog:v3.11.784-1.g2e6be86
+openshift3/ose-tests:v3.11.784-1.gc4590b1
+openshift3/local-storage-provisioner:v3.11.784-1
+openshift3/manila-provisioner:v3.11.784-1
+openshift3/ose-operator-lifecycle-manager:v3.11.784-1.g1054881
+openshift3/ose-web-console:v3.11.784-1.gf26eca6
+openshift3/ose-egress-http-proxy:v3.11.784-1.gc4590b1
+openshift3/kuryr-controller:v3.11.784-1.g0c4bf66
+openshift3/ose-ovn-kubernetes:v3.11.784-1.g21370b4
+openshift3/ose-prometheus-config-reloader:v3.11.784-1.gd4bae2d
+openshift3/ose-prometheus-operator:v3.11.784-1.gd4bae2d
+openshift3/registry-console:v3.11.784-1
+openshift3/snapshot-controller:v3.11.784-1
+openshift3/snapshot-provisioner:v3.11.784-1
+openshift3/ose-template-service-broker:v3.11.784-1.gc4590b1
+----
+
+[[ocp-3-11-784-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.


### PR DESCRIPTION
Adds notes for 3.11.784 release

Link to docs preview:
http://file.rdu.redhat.com/opayne/RN-3.11.784/release_notes/ocp_3_11_release_notes.html#ocp-3-11-784




<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
