### PR TITLE
[RHACS] Add clarification to Release Notes for RHACS 3.71

### DIFF
--- a/release_notes/371-release-notes.adoc
+++ b/release_notes/371-release-notes.adoc
@@ -264,7 +264,7 @@ In the table, features are marked with the following statuses:
 * Previously, groups were retrieved by the field props (`props.authProviderId`, `props.key`, `props.value`). This field will be replaced by the new `props.id` field. Use the `props.id` field to retrieve groups in the Application Programming Interface (API). Note the following:
 ** Retrieval using the `props` fields will be removed in version a future release.
 ** Until removal, retrieval using the `props` field will work if the result is unambiguous (no more than one group is found with the `props` field).
-* `/v1/cves/suppress` and `/v1/cves/unsuppress` have been deprecated and will be removed in a future release. 
+* `/v1/cves/suppress` and `/v1/cves/unsuppress` have been deprecated and will be removed in a future release. After these are removed:
 ** Use `/v1/imagecves/suppress` and `/v1/imagecves/unsuppress` to snooze and unsnooze image vulnerabilities.
 ** Use `/v1/nodecves/suppress` and `/v1/nodecves/unsuppress` to snooze and unsnooze node and host vulnerabilities.
 ** Use `/v1/clustercves/suppress` and `/v1/clustercves/unsuppress` to snooze and unsnooze platform (Kubernetes, Istio, and {ocp}) vulnerabilities.


### PR DESCRIPTION
Version(s):

- merge to `rhacs-docs`
- cherry pick to `rhacs-docs-3.71`
- cherry pick to `rhacs-docs-3.72.0`

Labels:

`RHACS`

Issue: none (Eng request)

[Link to docs preview](https://openshift-docs-qvbxo0n78-kcarmichael08.vercel.app/openshift-acs/master/release_notes/371-release-notes.html#deprecated-features-371)

