### PR TITLE
GH#48337 - Fixing data foundation version typo

### DIFF
--- a/storage/persistent_storage/persistent-storage-ocs.adoc
+++ b/storage/persistent_storage/persistent-storage-ocs.adoc
@@ -81,7 +81,7 @@ toc::[]
 |Scaling operations in {rh-storage-first}
 |link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/scaling_storage[Scaling storage]
 
-|Monitoring a {rh-storage-first} 4.9 cluster
+|Monitoring a {rh-storage-first} 4.10 cluster
 |link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/monitoring_openshift_data_foundation[Monitoring OpenShift Data Foundation 4.10]
 
 |Troubleshooting errors and issues


### PR DESCRIPTION
For version 4.10
Fixes issue #48337

Description: One small part of the chart need to be changed from 4.9 -> 4.10. This fix was also addressed in #48154

Preview: [Storage -> Configuring Persistent storage ->  Red Hat OpenShift Data Foundation](https://kelbrown20.github.io/bug-fix-previews/GH48337-fix-data-foundation-version/storage/persistent_storage/persistent-storage-ocs.html) 