### PR TITLE
OSDOCS-3939: [GCP] Enable user specified networking tags

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -232,7 +232,7 @@ Required installation configuration parameters are described in the following ta
 |Parameter|Description|Values
 
 |`apiVersion`
-|The API version for the `install-config.yaml` content. The current version is `v1`. The installer may also support older API versions.
+|The API version for the `install-config.yaml` content. The current version is `v1`. The installation program may also support older API versions.
 |String
 
 |`baseDomain`
@@ -599,7 +599,7 @@ accounts for the dramatically decreased machine performance.
 |The Cloud Credential Operator (CCO) mode. If no mode is specified, the CCO dynamically tries to determine the capabilities of the provided credentials, with a preference for mint mode on the platforms where multiple modes are supported.
 [NOTE]
 ====
-Not all CCO modes are supported for all cloud providers. For more information on CCO modes, see the _Cloud Credential Operator_ entry in the _Cluster Operators reference_ content.
+Not all CCO modes are supported for all cloud providers. For more information about CCO modes, see the _Cloud Credential Operator_ entry in the _Cluster Operators reference_ content.
 ====
 |`Mint`, `Passthrough`, `Manual`, or an empty string (`""`).
 ifndef::openshift-origin[]
@@ -841,13 +841,13 @@ Optional {rh-openstack} configuration parameters are described in the following 
 |A list of one or more UUIDs as strings. For example, `7ee219f3-d2e9-48a1-96c2-e7429f1b0da7`.
 
 |`compute.platform.openstack.zones`
-|{rh-openstack} Compute (Nova) availability zones (AZs) to install machines on. If this parameter is not set, the installer relies on the default settings for Nova that the {rh-openstack} administrator configured.
+|{rh-openstack} Compute (Nova) availability zones (AZs) to install machines on. If this parameter is not set, the installation program relies on the default settings for Nova that the {rh-openstack} administrator configured.
 
 On clusters that use Kuryr, {rh-openstack} Octavia does not support availability zones. Load balancers and, if you are using the Amphora provider driver, {product-title} services that rely on Amphora VMs, are not created according to the value of this property.
 |A list of strings. For example, `["zone-1", "zone-2"]`.
 
 |`compute.platform.openstack.rootVolume.zones`
-|For compute machines, the availability zone to install root volumes on. If you do not set a value for this parameter, the installer selects the default availability zone.
+|For compute machines, the availability zone to install root volumes on. If you do not set a value for this parameter, the installation program selects the default availability zone.
 |A list of strings, for example `["zone-1", "zone-2"]`.
 
 |`compute.platform.openstack.serverGroupPolicy`
@@ -867,13 +867,13 @@ If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is
 |A list of one or more UUIDs as strings. For example, `7ee219f3-d2e9-48a1-96c2-e7429f1b0da7`.
 
 |`controlPlane.platform.openstack.zones`
-|{rh-openstack} Compute (Nova) availability zones (AZs) to install machines on. If this parameter is not set, the installer relies on the default settings for Nova that the {rh-openstack} administrator configured.
+|{rh-openstack} Compute (Nova) availability zones (AZs) to install machines on. If this parameter is not set, the installation program relies on the default settings for Nova that the {rh-openstack} administrator configured.
 
 On clusters that use Kuryr, {rh-openstack} Octavia does not support availability zones. Load balancers and, if you are using the Amphora provider driver, {product-title} services that rely on Amphora VMs, are not created according to the value of this property.
 |A list of strings. For example, `["zone-1", "zone-2"]`.
 
 |`controlPlane.platform.openstack.rootVolume.zones`
-|For control plane machines,  the availability zone to install root volumes on. If you do not set this value, the installer selects the default availability zone.
+|For control plane machines,  the availability zone to install root volumes on. If you do not set this value, the installation program selects the default availability zone.
 |A list of strings, for example `["zone-1", "zone-2"]`.
 
 |`controlPlane.platform.openstack.serverGroupPolicy`
@@ -885,7 +885,7 @@ If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is
 |A server group policy to apply to the machine pool. For example, `soft-affinity`.
 
 |`platform.openstack.clusterOSImage`
-|The location from which the installer downloads the {op-system} image.
+|The location from which the installation program downloads the {op-system} image.
 
 You must set this parameter to perform an installation in a restricted network.
 |An HTTP or HTTPS URL, optionally with an SHA-256 checksum.
@@ -974,7 +974,7 @@ Additional Azure configuration parameters are described in the following table:
 |String, for example `production_disk_encryption_set`.
 
 |`compute.platform.azure.osDisk.diskEncryptionSet.subscriptionId`
-|Optional. The ID of a disk encryption set in another Azure subscription. This secondary disk encryption set will be used to encrypt compute machines. By default, the installer will use the disk encryption set from the Azure subscription ID that you provided to the installer prompts.
+|Optional. The ID of a disk encryption set in another Azure subscription. This secondary disk encryption set will be used to encrypt compute machines. By default, the installation program will use the disk encryption set from the Azure subscription ID that you provided to the installation program prompts.
 |String, in the format `00000000-0000-0000-0000-000000000000`.
 
 |`controlPlane.platform.azure.encryptionAtHost`
@@ -990,7 +990,7 @@ Additional Azure configuration parameters are described in the following table:
 |String, for example `production_disk_encryption_set`.
 
 |`controlPlane.platform.azure.osDisk.diskEncryptionSet.subscriptionId`
-|Optional. The ID of a disk encryption set in another Azure subscription. This secondary disk encryption set will be used to encrypt control plane machines. By default, the installer will use the disk encryption set from the Azure subscription ID that you provided to the installer prompts.
+|Optional. The ID of a disk encryption set in another Azure subscription. This secondary disk encryption set will be used to encrypt control plane machines. By default, the installation program will use the disk encryption set from the Azure subscription ID that you provided to the installation program prompts.
 |String, in the format `00000000-0000-0000-0000-000000000000`.
 
 |`controlPlane.platform.azure.osDisk.diskSizeGB`
@@ -1081,18 +1081,13 @@ Additional GCP configuration parameters are described in the following table:
 |The name of the existing VPC that you want to deploy your cluster to.
 |String.
 
+|`platform.gcp.projectID`
+|The name of the GCP project where the installation program installs the cluster. 
+|String.
+
 |`platform.gcp.region`
 |The name of the GCP region that hosts your cluster.
 |Any valid region name, such as `us-central1`.
-
-|`platform.gcp.type`
-|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type].
-|The GCP machine type.
-
-|`platform.gcp.zones`
-|The availability zones where the installation program creates machines for the specified MachinePool.
-|A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
-link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 
 |`platform.gcp.controlPlaneSubnet`
 |The name of the existing subnet in your VPC that you want to deploy your control plane machines to.
@@ -1108,15 +1103,48 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 ====
 The `licenses` parameter is a deprecated field and nested virtualization is enabled by default. It is not recommended to use this field.
 ====
-|Any license available with the link:https://cloud.google.com/compute/docs/reference/rest/v1/licenses/list[license API], such as the license to enable link:https://cloud.google.com/compute/docs/instances/nested-virtualization/overview[nested virtualization]. You cannot use this parameter with a mechanism that generates pre-built images. Using a license URL forces the installer to copy the source image before use.
+|Any license available with the link:https://cloud.google.com/compute/docs/reference/rest/v1/licenses/list[license API], such as the license to enable link:https://cloud.google.com/compute/docs/instances/nested-virtualization/overview[nested virtualization]. You cannot use this parameter with a mechanism that generates pre-built images. Using a license URL forces the installation program to copy the source image before use.
 
-|`platform.gcp.osDisk.diskSizeGB`
+|`platform.gcp.defaultMachinePlatform.zones`
+|The availability zones where the installation program creates machines.
+|A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
+link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
+
+|`platform.gcp.defaultMachinePlatform.osDisk.diskSizeGB`
 |The size of the disk in gigabytes (GB).
 |Any size between 16 GB and 65536 GB.
 
-|`platform.gcp.osDisk.diskType`
-|The type of disk.
-|Either the default `pd-ssd` or the `pd-standard` disk type. The control plane nodes must be the `pd-ssd` disk type. The worker nodes can be either type.
+|`platform.gcp.defaultMachinePlatform.osDisk.diskType`
+|The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type].
+|Either the default `pd-ssd` or the `pd-standard` disk type. The control plane nodes must be the `pd-ssd` disk type. Compute nodes can be either type.
+
+|`platform.gcp.defaultMachinePlatform.tags`
+|Optional. Additional network tags to add to the control plane and compute machines.
+|One or more strings, for example `network-tag1``.
+
+|`platform.gcp.defaultMachinePlatform.type`
+|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for control plane and compute machines.
+|The GCP machine type, for example `n1-standard-4`. 
+
+|`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey.name`
+|The name of the customer managed encryption key to be used for machine disk encryption.
+|The encryption key name.
+
+|`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey.keyRing`
+|The name of the Key Management Service (KMS) key ring to which the KMS key belongs.
+|The KMS key ring name.
+
+|`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey.location`
+|The link:https://cloud.google.com/kms/docs/locations[GCP location] in which the KMS key ring exists.
+|The GCP location.
+
+|`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey.projectID`
+|The ID of the project in which the KMS key ring exists. This value defaults to the value of the `platform.gcp.projectID` parameter if it is not set.
+|The GCP project ID.
+
+|`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKeyServiceAccount`
+|The GCP service account used for the encryption request for control plane and compute machines. If absent, the Compute Engine default service account is used. For more information about GCP service accounts, see Google's documentation on link:https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account[service accounts].
+|The GCP service account email, for example `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
 
 |`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.name`
 |The name of the customer managed encryption key to be used for control plane machine disk encryption.
@@ -1127,21 +1155,37 @@ The `licenses` parameter is a deprecated field and nested virtualization is enab
 |The KMS key ring name.
 
 |`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.location`
-|For control plane machines, the GCP location in which the key ring exists. For more information on KMS locations, see Google's documentation on link:https://cloud.google.com/kms/docs/locations[Cloud KMS locations].
+|For control plane machines, the GCP location in which the key ring exists. For more information about KMS locations, see Google's documentation on link:https://cloud.google.com/kms/docs/locations[Cloud KMS locations].
 |The GCP location for the key ring.
 
 |`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.projectID`
 |For control plane machines, the ID of the project in which the KMS key ring exists. This value defaults to the VM project ID if not set.
 |The GCP project ID.
 
-////
-`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKeyServiceAccount`
+|`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKeyServiceAccount`
+|The GCP service account used for the encryption request for control plane machines. If absent, the Compute Engine default service account is used. For more information about GCP service accounts, see Google's documentation on link:https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account[service accounts].
+|The GCP service account email, for example `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
 
-The GCP Compute Engine System service account used for the encryption request for the given KMS key. The Compute Engine default service account is always used for control plane machines during installation, which follows this pattern: `service-<project_number>@compute-system.iam.gserviceaccount.com`. The default service account must have access to the KMS key specified for the control plane machines. The custom service account defined is available for use during post-installation operations. For more information on GCP service accounts, see Google's documentation on link:https://cloud.google.com/iam/docs/service-accounts#types[Types of service accounts].
+|`controlPlane.platform.gcp.osDisk.diskSizeGB`
+|The size of the disk in gigabytes (GB). This value applies to control plane machines.
+|Any integer between 16 and 65536.
 
-The GCP Compute Engine System service account email, like `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
-////
-// kmsKeyServiceAccount not yet fully supported in 4.7. Re-add when more stable.
+|`controlPlane.platform.gcp.osDisk.diskType`
+|The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type] for control plane machines.
+|Control plane machines must use the `pd-ssd` disk type, which is the default.
+
+|`controlPlane.platform.gcp.tags`
+|Optional. Additional network tags to add to the control plane machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.tags` parameter for control plane machines.
+|One or more strings, for example `control-plane-tag1`.
+
+|`controlPlane.platform.gcp.type`
+|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for control plane machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter. 
+|The GCP machine type, for example `n1-standard-4`.
+
+|`controlPlane.platform.gcp.zones`
+|The availability zones where the installation program creates control plane machines.
+|A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
+link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 
 |`compute.platform.gcp.osDisk.encryptionKey.kmsKey.name`
 |The name of the customer managed encryption key to be used for compute machine disk encryption.
@@ -1152,21 +1196,38 @@ The GCP Compute Engine System service account email, like `<service_account_name
 |The KMS key ring name.
 
 |`compute.platform.gcp.osDisk.encryptionKey.kmsKey.location`
-|For compute machines, the GCP location in which the key ring exists. For more information on KMS locations, see Google's documentation on link:https://cloud.google.com/kms/docs/locations[Cloud KMS locations].
+|For compute machines, the GCP location in which the key ring exists. For more information about KMS locations, see Google's documentation on link:https://cloud.google.com/kms/docs/locations[Cloud KMS locations].
 |The GCP location for the key ring.
 
 |`compute.platform.gcp.osDisk.encryptionKey.kmsKey.projectID`
 |For compute machines, the ID of the project in which the KMS key ring exists. This value defaults to the VM project ID if not set.
 |The GCP project ID.
 
-////
-`compute.platform.gcp.osDisk.encryptionKey.kmsKeyServiceAccount`
+|`compute.platform.gcp.osDisk.encryptionKey.kmsKeyServiceAccount`
+|The GCP service account used for the encryption request for compute machines. If this value is not set, the Compute Engine default service account is used. For more information about GCP service accounts, see Google's documentation on link:https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account[service accounts].
+|The GCP service account email, for example `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
 
-For compute machines, the GCP Compute Engine System service account used for the encryption request for the given KMS key. If left undefined, the Compute Engine default service account is used, which follows this pattern: `service-<project_number>@compute-system.iam.gserviceaccount.com`. For more information on GCP service accounts, see Google's documentation on link:https://cloud.google.com/iam/docs/service-accounts#types[Types of service accounts].
+|`compute.platform.gcp.osDisk.diskSizeGB`
+|The size of the disk in gigabytes (GB). This value applies to compute machines.
+|Any integer between 16 and 65536.
 
-The GCP Compute Engine System service account email, like `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
-////
-// kmsKeyServiceAccount not yet fully supported in 4.7. Re-add when more stable.
+|`compute.platform.gcp.osDisk.diskType`
+|The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type] for compute machines.
+|Either the default `pd-ssd` or the `pd-standard` disk type.
+
+|`compute.platform.gcp.tags`
+|Optional. Additional network tags to add to the compute machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.tags` parameter for compute machines.
+|One or more strings, for example `compute-network-tag1`.
+
+|`compute.platform.gcp.type`
+|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for compute machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter. 
+|The GCP machine type, for example `n1-standard-4`.
+
+|`compute.platform.gcp.zones`
+|The availability zones where the installation program creates compute machines.
+|A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
+link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
+
 |====
 
 endif::gcp[]
@@ -1200,7 +1261,7 @@ Additional IBM Cloud VPC configuration parameters are described in the following
 |====
 [.small]
 --
-1. Whether you define an existing resource group, or if the installer creates one, determines how the resource group is treated when the cluster is uninstalled. If you define a resource group, the installer removes all of the installer-provisioned resources, but leaves the resource group alone; if a resource group is created as part of the installation, the installer removes all of the installer provisioned resources and the resource group.
+1. Whether you define an existing resource group, or if the installation program creates one, determines how the resource group is treated when the cluster is uninstalled. If you define a resource group, the installation program removes all of the installer-provisioned resources, but leaves the resource group alone; if a resource group is created as part of the installation, the installation program removes all of the installer-provisioned resources and the resource group.
 2. To determine which profile best meets your needs, see https://cloud.ibm.com/docs/vpc?topic=vpc-profiles&interface=ui[Instance Profiles] in the IBM documentation.
 --
 endif::ibm-cloud[]
@@ -1391,7 +1452,7 @@ in vSphere.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
 |`platform.vsphere.resourcePool`
-|Optional. The absolute path of an existing resource pool where the installer creates the virtual machines. If you do not specify a value, resources are installed in the root of the cluster `/<datacenter_name>/host/<cluster_name>/Resources`.
+|Optional. The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
 |String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
 |`platform.vsphere.network`
@@ -1426,7 +1487,7 @@ Optional VMware vSphere machine pool configuration parameters are described in t
 |Parameter|Description|Values
 
 |`platform.vsphere.clusterOSImage`
-|The location from which the installer downloads the {op-system} image. You must set this parameter to perform an installation in a restricted network.
+|The location from which the installation program downloads the {op-system} image. You must set this parameter to perform an installation in a restricted network.
 |An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, `\https://mirror.openshift.com/images/rhcos-<version>-vmware.<architecture>.ova`.
 
 |`platform.vsphere.osDisk.diskSizeGB`
@@ -1528,7 +1589,7 @@ Additional Alibaba Cloud configuration parameters are described in the following
 |String.
 
 |`platform.alibabacloud.resourceGroupID`
-|The ID of an already existing resource group where the cluster will be installed. If empty, the installer will create a new resource group for the cluster.
+|The ID of an already existing resource group where the cluster will be installed. If empty, the installation program will create a new resource group for the cluster.
 |String.
 
 |`platform.alibabacloud.tags`
@@ -1536,11 +1597,11 @@ Additional Alibaba Cloud configuration parameters are described in the following
 |Object.
 
 |`platform.alibabacloud.vpcID`
-|The ID of an already existing VPC where the cluster should be installed. If empty, the installer will create a new VPC for the cluster.
+|The ID of an already existing VPC where the cluster should be installed. If empty, the installation program will create a new VPC for the cluster.
 |String.
 
 |`platform.alibabacloud.vswitchIDs`
-|The ID list of already existing VSwitches where cluster resources will be created. The existing VSwitches can only be used when also using existing VPC. If empty, the installer will create new VSwitches for the cluster.
+|The ID list of already existing VSwitches where cluster resources will be created. The existing VSwitches can only be used when also using existing VPC. If empty, the installation program will create new VSwitches for the cluster.
 |String list.
 
 |`platform.alibabacloud.defaultMachinePlatform.imageID`
@@ -1564,7 +1625,7 @@ Additional Alibaba Cloud configuration parameters are described in the following
 |String.
 
 |`platform.alibabacloud.privateZoneID`
-|The ID of an existing private zone into which to add DNS records for the cluster's internal API. An existing private zone can only be used when also using existing VPC. The private zone must be associated with the VPC containing the subnets. Leave the private zone unset to have the installer create the private zone on your behalf.
+|The ID of an existing private zone into which to add DNS records for the cluster's internal API. An existing private zone can only be used when also using existing VPC. The private zone must be associated with the VPC containing the subnets. Leave the private zone unset to have the installation program create the private zone on your behalf.
 |String.
 
 |====

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -55,6 +55,9 @@ controlPlane: <2> <3>
             keyRing: test-machine-keys
             location: global
             projectID: project-id
+      tags: <6>
+      - control-plane-tag1
+      - control-plane-tag2
   replicas: 3
 compute: <2> <3>
 - hyperthreading: Enabled <4>
@@ -74,6 +77,9 @@ compute: <2> <3>
             keyRing: test-machine-keys
             location: global
             projectID: project-id
+        tags: <6>
+        - compute-tag1
+        - compute-tag2
   replicas: 3
 metadata:
   name: test-cluster <1>
@@ -100,36 +106,31 @@ platform:
   gcp:
     projectID: openshift-production <1>
     region: us-central1 <1>
+    defaultMachinePlatform:
+      tags: <6>
+      - global-tag1
+      - global-tag2
 ifdef::vpc,restricted[]
-    network: existing_vpc <6>
-    controlPlaneSubnet: control_plane_subnet <7>
-    computeSubnet: compute_subnet <8>
+    network: existing_vpc <7>
+    controlPlaneSubnet: control_plane_subnet <8>
+    computeSubnet: compute_subnet <9>
 endif::vpc,restricted[]
 ifndef::restricted[]
 pullSecret: '{"auths": ...}' <1>
 endif::restricted[]
 ifdef::restricted[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <9>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <10>
 endif::restricted[]
 ifndef::vpc,restricted[]
 ifndef::openshift-origin[]
-fips: false <6>
-sshKey: ssh-ed25519 AAAA... <7>
+fips: false <7>
+sshKey: ssh-ed25519 AAAA... <8>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <6>
+sshKey: ssh-ed25519 AAAA... <7>
 endif::openshift-origin[]
 endif::vpc,restricted[]
 ifdef::vpc[]
-ifndef::openshift-origin[]
-fips: false <9>
-sshKey: ssh-ed25519 AAAA... <10>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <9>
-endif::openshift-origin[]
-endif::vpc[]
-ifdef::restricted[]
 ifndef::openshift-origin[]
 fips: false <10>
 sshKey: ssh-ed25519 AAAA... <11>
@@ -137,22 +138,31 @@ endif::openshift-origin[]
 ifdef::openshift-origin[]
 sshKey: ssh-ed25519 AAAA... <10>
 endif::openshift-origin[]
+endif::vpc[]
+ifdef::restricted[]
+ifndef::openshift-origin[]
+fips: false <11>
+sshKey: ssh-ed25519 AAAA... <12>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+sshKey: ssh-ed25519 AAAA... <11>
+endif::openshift-origin[]
 endif::restricted[]
 ifdef::private[]
 ifndef::openshift-origin[]
-publish: Internal <11>
+publish: Internal <12>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-publish: Internal <10>
+publish: Internal <11>
 endif::openshift-origin[]
 endif::private[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-additionalTrustBundle: | <12>
+additionalTrustBundle: | <13>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <13>
+imageContentSources: <14>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -161,11 +171,11 @@ imageContentSources: <13>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-additionalTrustBundle: | <11>
+additionalTrustBundle: | <12>
   -----BEGIN CERTIFICATE-----
   <MY_TRUSTED_CA_CERT>
   -----END CERTIFICATE-----
-imageContentSources: <12>
+imageContentSources: <13>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -188,30 +198,17 @@ capabilities:
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger machine types, such as `n1-standard-8`, for your machines if you disable simultaneous multithreading.
 ====
-<5> Optional: The custom encryption key section to encrypt both virtual machines and persistent volumes. Your default compute service account must have the permissions granted to use your KMS key and have the correct IAM role assigned. The default service account name follows the `service-<project_number>@compute-system.iam.gserviceaccount.com` pattern. For more information on granting the correct permissions for your service account, see "Machine management" -> "Creating machine sets" -> "Creating a machine set on GCP".
+<5> Optional: The custom encryption key section to encrypt both virtual machines and persistent volumes. Your default compute service account must have the permissions granted to use your KMS key and have the correct IAM role assigned. The default service account name follows the `service-<project_number>@compute-system.iam.gserviceaccount.com` pattern. For more information about granting the correct permissions for your service account, see "Machine management" -> "Creating machine sets" -> "Creating a machine set on GCP".
+<6> Optional: A set of network tags to apply to the control plane or compute machine sets. The `platform.gcp.defaultMachinePlatform.tags` parameter will apply to both control plane and compute machines. If the `compute.platform.gcp.tags` or `controlPlane.platform.gcp.tags` parameters are set, they override the `platform.gcp.defaultMachinePlatform.tags` parameter.
 ifdef::vpc,restricted[]
-<6> Specify the name of an existing VPC.
-<7> Specify the name of the existing subnet to deploy the control plane machines to. The subnet must belong to the VPC that you specified.
-<8> Specify the name of the existing subnet to deploy the compute machines to. The subnet must belong to the VPC that you specified.
+<7> Specify the name of an existing VPC.
+<8> Specify the name of the existing subnet to deploy the control plane machines to. The subnet must belong to the VPC that you specified.
+<9> Specify the name of the existing subnet to deploy the compute machines to. The subnet must belong to the VPC that you specified.
 endif::vpc,restricted[]
 ifdef::restricted[]
-<9> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
+<10> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
 endif::restricted[]
 ifdef::vpc[]
-ifndef::openshift-origin[]
-<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
-+
-[IMPORTANT]
-====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
-====
-<10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<9> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
-endif::vpc[]
-ifdef::restricted[]
 ifndef::openshift-origin[]
 <10> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
@@ -224,19 +221,33 @@ endif::openshift-origin[]
 ifdef::openshift-origin[]
 <10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
-endif::restricted[]
-ifndef::vpc,restricted[]
+endif::vpc[]
+ifdef::restricted[]
 ifndef::openshift-origin[]
-<6> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
-<7> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<6> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<11> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+endif::openshift-origin[]
+endif::restricted[]
+ifndef::vpc,restricted[]
+ifndef::openshift-origin[]
+<7> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
+<8> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<7> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 endif::vpc,restricted[]
 +
@@ -246,20 +257,20 @@ For production {product-title} clusters on which you want to perform installatio
 ====
 ifdef::private[]
 ifndef::openshift-origin[]
-<11> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
+<12> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<10> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
+<11> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
 endif::openshift-origin[]
 endif::private[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-<12> Provide the contents of the certificate file that you used for your mirror registry.
-<13> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<13> Provide the contents of the certificate file that you used for your mirror registry.
+<14> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<11> Provide the contents of the certificate file that you used for your mirror registry.
-<12> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<12> Provide the contents of the certificate file that you used for your mirror registry.
+<13> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]
 

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -25,6 +25,9 @@ controlPlane: <2>
       zones:
       - us-central1-a
       - us-central1-c
+      tags: <5>
+      - control-plane-tag1
+      - control-plane-tag2
   replicas: 3
 compute: <2>
 - hyperthreading: Enabled <3>
@@ -35,6 +38,9 @@ compute: <2>
       zones:
       - us-central1-a
       - us-central1-c
+      tags: <5>
+      - compute-tag1
+      - compute-tag2
   replicas: 0
 metadata:
   name: test-cluster
@@ -54,17 +60,21 @@ endif::openshift-origin[]
   - 172.30.0.0/16
 platform:
   gcp:
-    projectID: openshift-production <5>
-    region: us-central1 <6>
+    defaultMachinePlatform:
+      tags: <5>
+      - global-tag1
+      - global-tag2
+    projectID: openshift-production <6>
+    region: us-central1 <7>
 pullSecret: '{"auths": ...}'
 ifndef::openshift-origin[]
-fips: false <7>
-sshKey: ssh-ed25519 AAAA... <8>
-publish: Internal <9>
+fips: false <8>
+sshKey: ssh-ed25519 AAAA... <9>
+publish: Internal <10>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <7>
-publish: Internal <8>
+sshKey: ssh-ed25519 AAAA... <8>
+publish: Internal <9>
 endif::openshift-origin[]
 capabilities:
   baselineCapabilitySet: None
@@ -80,19 +90,20 @@ capabilities:
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger machine types, such as `n1-standard-8`, for your machines if you disable simultaneous multithreading.
 ====
-<5> Specify the main project where the VM instances reside.
-<6> Specify the region that your VPC network is in.
+<5> Optional: A set of network tags to apply to the control plane or compute machine sets. The `platform.gcp.defaultMachinePlatform.tags` parameter applies to both control plane and compute machines. If the `compute.platform.gcp.tags` or `controlPlane.platform.gcp.tags` parameters are set, they override the `platform.gcp.defaultMachinePlatform.tags` parameter.
+<6> Specify the main project where the VM instances reside.
+<7> Specify the region that your VPC network is in.
 ifndef::openshift-origin[]
-<7> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<8> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
-<8> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<9> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<7> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<8> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 +
 [NOTE]
@@ -100,10 +111,10 @@ endif::openshift-origin[]
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 ifndef::openshift-origin[]
-<9> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
+<10> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
 To use a shared VPC in a cluster that uses infrastructure that you provision, you must set `publish` to `Internal`. The installation program will no longer be able to access the public DNS zone for the base domain in the host project.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<8> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
+<9> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
 To use a shared VPC in a cluster that uses infrastructure that you provision, you must set `publish` to `Internal`. The installation program will no longer be able to access the public DNS zone for the base domain in the host project.
 endif::openshift-origin[]


### PR DESCRIPTION
[OSDOCS-3939](https://issues.redhat.com//browse/OSDOCS-3939): [GCP] Enable user specified networking tags

4.12

Dev Jira: https://issues.redhat.com/browse/CORS-2209
Docs Jira: https://issues.redhat.com/browse/OSDOCS-3939

[Doc preview: config parameters](https://50178--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-network-customizations.html#installation-configuration-parameters-additional-gcp_installing-gcp-network-customizations)
[Doc preview: sample yaml file](https://50178--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-network-customizations.html#installation-gcp-config-yaml_installing-gcp-network-customizations)
[Doc preview: sample yaml for UPI Shared VPC](https://50178--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-gcp-user-infra-shared-vpc-config-yaml_installing-gcp-user-infra-vpc)

QE review and Peer review completed.
