### PR TITLE
BZ2102393 fixing strings in procedure

### DIFF
--- a/modules/gitops-creating-an-application-by-using-the-oc-tool.adoc
+++ b/modules/gitops-creating-an-application-by-using-the-oc-tool.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * configuring-an-openshift-cluster-with-argo-cd.adoc
-// * depoying-an-application-with-argo-cd.adoc
+// * configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
+// * deploying-a-spring-boot-application-with-argo-cd.adoc
 
 ifeval::["{context}" == "configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations"]
 :cluster:
@@ -26,7 +26,7 @@ $ git clone git@github.com:redhat-developer/openshift-gitops-getting-started.git
 ----
 
 . Create the application:
-ifdef::app[]
+ifndef::app[]
 +
 [source,terminal]
 ----
@@ -51,7 +51,7 @@ $ oc get application -n openshift-gitops
 
 . Add a label to the namespace your application is deployed in so that the Argo CD instance in the `openshift-gitops` namespace can manage it:
 
-ifdef::app[]
+ifndef::app[]
 +
 [source,terminal]
 ----


### PR DESCRIPTION
BZ#2102393, [DDF] "This is the wrong file. It should be the app.yaml"

PR applies to : 4.7+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2102393

Link to docs preview:
http://file.rdu.redhat.com/shdiaz/BZ2102393_2/cicd/gitops/deploying-a-spring-boot-application-with-argo-cd.html#creating-an-application-by-using-the-oc-tool_deploying-a-spring-boot-application-with-argo-cd

@stevsmit, please take a look

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
