### PR TITLE
CNV-20429: Updated latency check documentation

### DIFF
--- a/modules/virt-measuring-latency-vm-secondary-network.adoc
+++ b/modules/virt-measuring-latency-vm-secondary-network.adoc
@@ -54,38 +54,16 @@ rules:
       - create
       - update
       - patch
-  - apiGroups: [ "" ]
-    resources: [ "namespaces" ]
-    verbs:
-      - get
-      - list
-      - create
       - delete
-      - watch
-  - apiGroups: [ "" ]
-    resources: [ "serviceaccounts" ]
-    verbs:
-      - get
-      - list
-      - create
   - apiGroups: [ "rbac.authorization.k8s.io" ]
     resources:
       - roles
       - rolebindings
-      - clusterrolebindings
     verbs:
       - get
       - list
       - create
       - delete
-  - apiGroups: [ "rbac.authorization.k8s.io" ]
-    resources:
-      - clusterroles
-    verbs:
-      - get
-      - list
-      - create
-      - bind
   - apiGroups: [ "batch" ]
     resources: [ "jobs" ]
     verbs:
@@ -118,15 +96,25 @@ subjects:
 $ oc apply -f <framework_manifest>.yaml
 ----
 
-. Create a configuration file that contains the `ClusterRole` and `Role` objects with permissions that the checkup requires for cluster access:
+. Create a manifest file that contains the `ServiceAccount`, `Role`, and `RoleBinding` objects with permissions that the checkup requires for cluster access:
 +
-.Example cluster role manifest file
+.Example role manifest file
+[%collapsible]
+====
 [source,yaml]
 ----
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vm-latency-checkup-sa
+  namespace: <target_namespace> <1>
+---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: kubevirt-vm-latency-checker
+  namespace: <target_namespace>
 rules:
 - apiGroups: ["kubevirt.io"]
   resources: ["virtualmachineinstances"]
@@ -137,7 +125,22 @@ rules:
 - apiGroups: ["k8s.cni.cncf.io"]
   resources: ["network-attachment-definitions"]
   verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubevirt-vm-latency-checker
+  namespace: <target_namespace>
+subjects:
+- kind: ServiceAccount
+  name: vm-latency-checkup-sa
+roleRef:
+  kind: Role
+  name: kubevirt-vm-latency-checker
+  apiGroup: rbac.authorization.k8s.io
 ----
+====
+<1> Specify the namespace where the checkup is to be executed. This must be an existing namespace where the `NetworkAttachmentDefinition` object resides.
 
 . Apply the checkup roles manifest:
 +
@@ -154,24 +157,28 @@ $ oc apply -f <latency_roles>.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubevirt-vm-latency-checkup
-  namespace: kiagnose
+  name: kubevirt-vm-latency-checkup-config
+  namespace: <target_namespace> <1>
 data:
-  spec.image: registry.redhat.io/container-native-virtualization/vm-network-latency-checkup:v4.11.0
-  spec.timeout: 10m
-  spec.clusterRoles: |
-    kubevirt-vmis-manager
-  spec.param.network_attachment_definition_namespace: "default" <1>
-  spec.param.network_attachment_definition_name: "bridge-network" <2>
-  spec.param.max_desired_latency_milliseconds: "10" <3>
-  spec.param.sample_duration_seconds: "5" <4>
+  spec.image: registry.redhat.io/container-native-virtualization/vm-network-latency-checkup:v4.12.0
+  spec.timeout: 5m
+  spec.serviceAccountName: vm-latency-checkup-sa
+  spec.param.network_attachment_definition_namespace: <target_namespace> <2>
+  spec.param.network_attachment_definition_name: "bridge-network" <3>
+  spec.param.max_desired_latency_milliseconds: "10" <4>
+  spec.param.sample_duration_seconds: "5" <5>
+  spec.param.source_node: "worker1" <6>
+  spec.param.target_node: "worker2" <7>
 ----
-<1> The namespace where the `NetworkAttachmentDefinition` object resides.
-<2> The name of the `NetworkAttachmentDefinition` object.
-<3> Optional: The maximum desired latency, in milliseconds, between the virtual machines. If the measured latency exceeds this value, the check fails.
-<4> Optional: The duration of the latency check, in seconds.
+<1> The namespace where the checkup is to be executed. This must be an existing namespace where the `NetworkAttachmentDefinition` object resides.
+<2> The namespace where the `NetworkAttachmentDefinition` object resides.
+<3> The name of the `NetworkAttachmentDefinition` object.
+<4> Optional: The maximum desired latency, in milliseconds, between the virtual machines. If the measured latency exceeds this value, the checkup fails.
+<5> Optional: The duration of the latency check, in seconds.
+<6> Optional: When specified, latency is measured from this node to the target node. If the source node is specified, the `spec.param.target_node` field cannot be empty.
+<7> Optional: When specified, latency is measured from the source node to this node.
 
-. Create the config map in the framework’s namespace:
+. Apply the config map manifest in the framework’s namespace:
 +
 [source,terminal]
 ----
@@ -196,12 +203,12 @@ spec:
       restartPolicy: Never
       containers:
         - name: framework
-          image: registry.redhat.io/container-native-virtualization/checkup-framework:v4.11.0
+          image: registry.redhat.io/container-native-virtualization/checkup-framework:v4.12.0
           env:
             - name: CONFIGMAP_NAMESPACE
-              value: kiagnose
+              value: <target_namespace>
             - name: CONFIGMAP_NAME
-              value: kubevirt-vm-latency-checkup
+              value: kubevirt-vm-latency-checkup-config
 ----
 
 . Apply the `Job` manifest. The checkup uses the ping utility to verify connectivity and measure latency.
@@ -215,14 +222,14 @@ $ oc apply -f <latency_job>.yaml
 +
 [source,terminal]
 ----
-$ oc wait --for=condition=complete --timeout=10m job.batch/kubevirt-vm-latency-checkup -n kiagnose
+$ oc wait job kubevirt-vm-latency-checkup -n kiagnose --for condition=complete --timeout 6m
 ----
 
-. Review the results of the latency checkup by retrieving the status of the `ConfigMap` object. If the measured latency is greater than the value of the `spec.param.max_desired_latency_milliseconds` attribute, the checkup fails and returns an error.
+. Review the results of the latency checkup by retrieving the status of the `ConfigMap` object. If the maximum measured latency is greater than the value of the `spec.param.max_desired_latency_milliseconds` attribute, the checkup fails and returns an error.
 +
 [source,terminal]
 ----
-$ oc get configmap kubevirt-vm-latency-checkup -n kiagnose -o yaml
+$ oc get configmap kubevirt-vm-latency-checkup-config -n <target_namespace> -o yaml
 ----
 +
 .Example output config map (success)
@@ -231,24 +238,51 @@ $ oc get configmap kubevirt-vm-latency-checkup -n kiagnose -o yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubevirt-vm-latency-checkup
-  namespace: kiagnose
-...
+  name: kubevirt-vm-latency-checkup-config
+  namespace: <target_namespace>
+data:
+  spec.image: registry.redhat.io/container-native-virtualization/vm-network-latency-checkup:v4.12.0
+  spec.timeout: 5m
+  spec.serviceAccountName: vm-latency-checkup-sa
+  spec.param.network_attachment_definition_namespace: <target_namespace>
+  spec.param.network_attachment_definition_name: "bridge-network"
+  spec.param.max_desired_latency_milliseconds: "10"
+  spec.param.sample_duration_seconds: "5"
+  spec.param.source_node: "worker1"
+  spec.param.target_node: "worker2"
   status.succeeded: "true"
   status.failureReason: ""
-  status.result.minLatencyNanoSec: 2000
-  status.result.maxLatencyNanoSec: 3000
-  status.result.avgLatencyNanoSec: 2500
-  status.results.measurementDurationSec: 300
-...
+  status.completionTimestamp: "2022-01-01T09:00:00Z"
+  status.startTimestamp: "2022-01-01T09:00:07Z"
+  status.result.avgLatencyNanoSec: "177000"
+  status.result.maxLatencyNanoSec: "244000" <1>
+  status.result.measurementDurationSec: "5"
+  status.result.minLatencyNanoSec: "135000"
+  status.result.sourceNode: "worker1"
+  status.result.targetNode: "worker2"
+----
+<1> The maximum measured latency in nanoseconds.
+
+. Optional: To view the detailed job log in case of checkup failure, use the following command:
++
+[source,terminal]
+----
+$ oc logs job.batch/kubevirt-vm-latency-checkup -n kiagnose
 ----
 
-. Delete the framework and checkup resources that you previously created. This includes the job, config map, cluster role, and framework manifest files.
+. Delete the job and config map resources that you previously created.
 +
-[NOTE]
-====
-Do not delete the framework and cluster role manifest files if you plan to run another checkup.
-====
+[source,terminal]
+----
+$ oc delete job -n kiagnose kubevirt-vm-latency-checkup
+----
++
+[source,terminal]
+----
+$ oc delete config-map -n <target_namespace> kubevirt-vm-latency-checkup-config
+----
+
+. Optional: If you do not plan to run another checkup, delete the checkup role and framework manifest files.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: [CNV-20429](https://issues.redhat.com//browse/CNV-20429)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/sjhala/cnv-20429/virt/logging_events_monitoring/virt-running-cluster-checkups.html#virt-measuring-latency-vm-secondary-network_virt-running-cluster-checkups
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. -->

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
