### PR TITLE
WINC adding Serverless as a limitation

### DIFF
--- a/modules/windows-containers-release-notes-limitations.adoc
+++ b/modules/windows-containers-release-notes-limitations.adoc
@@ -13,6 +13,7 @@ Note the following limitations when working with Windows nodes managed by the WM
 ** OpenShift Pipelines
 ** OpenShift Service Mesh
 ** OpenShift monitoring of user-defined projects
+** {ServerlessProductName}
 
 * The following Red Hat features are not supported on Windows nodes:
 ** link:https://access.redhat.com/documentation/en-us/cost_management_service/2022/html/getting_started_with_cost_management/assembly-introduction-cost-management?extIdCarryOver=true&sc_cid=701f2000001OH74AAG#about-cost-management_getting-started[Red Hat cost management]


### PR DESCRIPTION
Adding OpenShift Serverless as a WINC Known Limitation, per @Anandnatraj in https://github.com/openshift/openshift-docs/pull/49845#issuecomment-1240014777

Preview: [Known Limitations](http://file.rdu.redhat.com/mburke/winc-add-serverless-limitation/windows_containers/windows-containers-release-notes-6-x.html#windows-containers-release-notes-limitations_windows-containers-release-notes) in release notes. Module is also in the [Understanding Windows container workloads](http://file.rdu.redhat.com/mburke/winc-add-serverless-limitation/windows_containers/windows-containers-release-notes-6-x.html#windows-containers-release-notes-limitations_windows-containers-release-notes) assembly