### PR TITLE
TELCODOCS#842 - release note - Ironic now uses RHEL 9 base image

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -137,6 +137,13 @@ In {product-title} {product-version}, the `propagateUserTags` parameter is a fla
 
 For more information, see xref:../installing/installing_aws/installing-aws-network-customizations.html#installation-configuration-parameters_installing-aws-network-customizations[Optional configuration parameters].
 
+[id="ocp-4-12-ironic-base-image-rhel-9"]
+==== Ironic container images use RHEL 9 base image
+In earlier versions of {product-title}, Ironic container images used {op-system-base-full} 8 as the base image. From {product-title} {product-version}, Ironic container images use {op-system-base} 9 as the base image. The {op-system-base} 9 base image adds support for CentOS Stream 9, Python 3.8, and Python 3.9 in Ironic components. 
+
+For more information about the Ironic provisioning service, see xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc[Deploying installer-provisioned clusters on bare metal].
+
+[id="ocp-4-12-post-installation"]
 === Post-installation configuration
 
 [id="ocp-4-12-web-console"]


### PR DESCRIPTION
[TELCODOCS-842](https://issues.redhat.com//browse/TELCODOCS-842): The Ironic container image is using RHEL 9 as a base image as opposed to RHEL 8 in prior versions. 

Version(s):
4.12

Issue: https://issues.redhat.com/browse/TELCODOCS-842

Link to docs preview: https://50208--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-ironic-base-image-rhel-9

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
