### PR TITLE
RHDEVDOCS-4311- Add available component and log level values for monitoring log level settings

### DIFF
--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -52,8 +52,11 @@ data:
     <component>: <1>
       logLevel: <log_level> <2>
 ----
-<1> The monitoring component that you are applying a log level to.
-<2> The log level to apply to the component.
+<1> The monitoring stack component for which you are setting a log level.
+For default platform monitoring, available component values are `prometheusK8s`, `alertmanagerMain`, `prometheusOperator`, and `thanosQuerier`.
+<2> The log level to set for the component.
+The available values are `error`, `warn`, `info`, and `debug`. 
+The default value is `info`.
 
 ** *To set a log level for a component in the `openshift-user-workload-monitoring` project*:
 .. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
@@ -77,8 +80,11 @@ data:
     <component>: <1>
       logLevel: <log_level> <2>
 ----
-<1> The monitoring component that you are applying a log level to.
-<2> The log level to apply to the component.
+<1> The monitoring stack component for which you are setting a log level.
+For user workload monitoring, available component values are `prometheus`, `prometheusOperator`, and `thanosRuler`.
+<2> The log level to set for the component.
+The available values are `error`, `warn`, `info`, and `debug`. 
+The default value is `info`.
 
 . Save the file to apply the changes. The pods for the component restarts automatically when you apply the log-level change.
 +


### PR DESCRIPTION
Summary: This PR adds available component and log level values for monitoring log level config map settings.

- Aligned team: DevTools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4311
- Direct link to doc preview (RH VPN access required): http://file.rdu.redhat.com/bburt/RHDEVDOCS-4311-add-available-component-values-for-monitoring-log-levels/monitoring/configuring-the-monitoring-stack.html#setting-log-levels-for-monitoring-components_configuring-the-monitoring-stack
- SME review: n/a
- QE review: @juzhao 
- Peer review: @rolfedh 