### PR TITLE
Remove the admonitions in *Updating the global pull secret*

### DIFF
--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -30,11 +30,6 @@ For more information link:https://access.redhat.com/documentation/en-us/openshif
 ====
 endif::image-pull-secrets[]
 
-[WARNING]
-====
-Cluster resources must adjust to the new pull secret, which can temporarily limit the usability of the cluster.
-====
-
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3641

The warning in https://docs.openshift.com/container-platform/4.10/openshift_images/managing_images/using-image-pull-secrets.html can be removed, as there's no downtime on clusters using 4.7.4 and newer.