### PR TITLE
BZ#2123004: Downstream docs showing older & unsupported versions in installation matrix

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -68,9 +68,7 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.7
-:mtc-version-z: 1.7.1
-:mtc-legacy-version: 1.5
-:mtc-legacy-version-z: 1.5.5
+:mtc-version-z: 1.7
 // builds (Valid only in 4.11 and later)
 :builds-v2title: Builds for Red Hat OpenShift
 :builds-v2shortname: OpenShift Builds v2

--- a/migration_toolkit_for_containers/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/mtc-release-notes.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 The release notes for {mtc-full} ({mtc-short}) describe new features and enhancements, deprecated features, and known issues.
 
-The {mtc-short}) enables you to migrate application workloads between {product-title} clusters at the granularity of a namespace.
+The {mtc-short} enables you to migrate application workloads between {product-title} clusters at the granularity of a namespace.
 
 You can migrate from xref:../migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.adoc[{product-title} 3 to {product-version}] and between {product-title} 4 clusters.
 

--- a/modules/migration-compatibility-guidelines.adoc
+++ b/modules/migration-compatibility-guidelines.adoc
@@ -25,7 +25,7 @@ remote cluster:: A source or destination cluster for a migration that runs Veler
 .{mtc-short} compatibility: Migrating from a legacy platform
 |===
 ||{product-title} 4.5 or earlier |{product-title} 4.6 later
-|Latest {mtc-short} version a|{mtc-short} {mtc-version}.z
+|Stable {mtc-short} version a|{mtc-short} {mtc-version}._z_
 
 Legacy {mtc-version} operator: Install manually with the `operator.yml` file.
 [IMPORTANT]
@@ -36,13 +36,6 @@ This cluster cannot be the control cluster.
 |{mtc-short} {mtc-version}.z
 
 Install with OLM, release channel `release-v1.7`
-|Stable {mtc-short} version |{mtc-short} 1.5
-
-Legacy 1.5 operator: Install manually with the `operator.yml` file.
-
-|{mtc-short} 1.6.z
-
-Install with OLM, release channel `release-v1.6`
 |===
 
 [NOTE]

--- a/modules/migration-installing-legacy-operator.adoc
+++ b/modules/migration-installing-legacy-operator.adoc
@@ -41,40 +41,20 @@ endif::[]
 $ sudo podman login registry.redhat.io
 ----
 
-. Download the `operator.yml` file:
-
-.. For the stable version, enter the following command:
+. Download the `operator.yml` file by entering the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/operator.yml ./
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/operator.yml ./
 ----
 
-.. For the latest version, enter the following command:
+. Download the `controller.yml` file by entering the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/operator.yml ./
-----
-
-. Download the `controller.yml` file:
-
-.. For the stable version, enter the following command:
-+
-[source,terminal,subs="attributes+"]
-----
-$ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/controller.yml ./
-----
-
-.. For the latest version, enter the following command:
-+
-[source,terminal,subs="attributes+"]
-----
-$ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/controller.yml ./
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/controller.yml ./
 ----
 
 ifdef::installing-restricted-3-4,installing-mtc-restricted[]

--- a/modules/migration-migrating-on-prem-to-cloud.adoc
+++ b/modules/migration-migrating-on-prem-to-cloud.adoc
@@ -29,7 +29,7 @@ A service created on the destination cluster exposes the source cluster's API to
 +
 [source,terminal,subs=attributes+]
 ----
-$ podman cp $(podman create registry.redhat.io/rhmtc/openshift-migration-controller-rhel8:v{mtc-version-z}):/crane ./
+$ podman cp $(podman create registry.redhat.io/rhmtc/openshift-migration-controller-rhel8:v{mtc-version}):/crane ./
 ----
 . Log in remotely to a node on the source cluster and a node on the destination cluster.
 

--- a/modules/migration-upgrading-mtc-with-legacy-operator.adoc
+++ b/modules/migration-upgrading-mtc-with-legacy-operator.adoc
@@ -31,22 +31,12 @@ endif::[]
 $ sudo podman login registry.redhat.io
 ----
 
-. Download the `operator.yml` file:
-
-.. For the stable version, enter the following command:
+. Download the `operator.yml` file by entering the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/operator.yml ./
-----
-
-.. For the latest version, enter the following command:
-+
-[source,terminal,subs="attributes+"]
-----
-$ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/operator.yml ./
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/operator.yml ./
 ----
 
 . Replace the {mtc-full} Operator:


### PR DESCRIPTION
MTC 1.7.x : OCP 4.2+

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2123004

Previews:
Compatibility guidelines table: http://file.emea.redhat.com/rhoch/mtc_remove_older/migration_toolkit_for_containers/installing-mtc.html#migration-compatibility-guidelines_installing-mtc

Legacy installation (non-restricted), steps 2 and 3: http://file.emea.redhat.com/rhoch/mtc_remove_older/migration_toolkit_for_containers/installing-mtc.html#migration-installing-legacy-operator_installing-mtc

Legacy installation (restricted), steps 2 and 3: 
http://file.emea.redhat.com/rhoch/mtc_remove_older/migration_toolkit_for_containers/installing-mtc-restricted.html#migration-installing-legacy-operator_installing-mtc-restricted 

Upgrading legacy, step 2:

http://file.emea.redhat.com/rhoch/mtc_remove_older/migration_toolkit_for_containers/upgrading-mtc.html#migration-upgrading-mtc-with-legacy-operator_upgrading-mtc 