### PR TITLE
TELCODCS#835: RN - Ironic API served by proxy server in MB installations with a provisioning network

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -99,6 +99,10 @@ Using the oc-mirror CLI plug-in to mirror file-based catalog Operator images in 
 
 For more information, see xref:../installing/disconnected_install/installing-mirroring-disconnected.adoc#oc-mirror-oci-format_installing-mirroring-disconnected[Mirroring file-based catalog Operator images in OCI format].
 
+[id="ocp-4-12-consistent-address-for-ironicapi"]
+==== Consistent IP address for Ironic API in bare-metal installations without a provisioning network  
+With this update, in bare-metal installations without a provisioning network, the Ironic API service is accessible through a proxy server. This proxy server provides a consistent IP address for the Ironic API service. If the Metal3 pod that contains `metal3-ironic` relocates to another pod, the consistent proxy address ensures constant communication with the Ironic API service.
+
 [id="ocp-4-12-post-installation"]
 === Post-installation configuration
 


### PR DESCRIPTION
[TELCODOCS-835](https://issues.redhat.com//browse/TELCODOCS-835): In bare-metal installations without a provisioning network, the Ironic API service is now accessible on an Apache proxy server. This proxy server provides a consistent IP address for the Iroinc API service and prevents any loss of comms if the Metal3 pod is reclocated.

Version(s): 4.12

Issue: https://issues.redhat.com/browse/TELCODOCS-835

Link to docs preview: https://50241--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-consistent-address-for-ironicapi