### PR TITLE
OSDOCS-3801: Add OVN-Kubernetes internal subnet configuration

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -289,6 +289,22 @@ endif::ibm-cloud[]
 ====
  While migrating egress traffic, you can expect some disruption to workloads and service traffic until the Cluster Network Operator (CNO) successfully rolls out the changes.
 ====
+
+|`v4InternalSubnet`
+|
+If your existing network infrastructure overlaps with the `100.64.0.0/16` IPv4 subnet, you can specify a different IP address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster.
+
+For example, if the `clusterNetwork.cidr` is `10.128.0.0/14` and the `clusterNetwork.hostPrefix` is `/23`, then the maximum number of nodes is `2^(23-14)=128`. An IP address is also required for the gateway, network, and broadcast addresses. Therefore the internal IP address range must be at least a `/24`.
+
+This field cannot be changed after installation.
+|The default value is `100.64.0.0/16`.
+
+|`v6InternalSubnet`
+|
+If your existing network infrastructure overlaps with the `fd98::/48` IPv6 subnet, you can specify a different IP address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster.
+
+This field cannot be changed after installation.
+| The default value is `fd98::/48`.
 |====
 
 ifdef::ibm-cloud[]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-3801

Preview: https://50264--docspreview.netlify.app/openshift-enterprise/latest/networking/cluster-network-operator.html#nw-operator-cr-cno-object_cluster-network-operator

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

TODO: Squash commits

