### PR TITLE
[OSDOCS-3207] added note about unsupported ingress operator to AWS PrivateLink

### DIFF
--- a/modules/osd-aws-privatelink-about.adoc
+++ b/modules/osd-aws-privatelink-about.adoc
@@ -2,6 +2,6 @@
 [id="osd-aws-privatelink-about.adoc_{context}"]
 = Understanding AWS PrivateLink
 
-A {product-title} cluster can be created without any requirements on public subnets, internet gateways, or network address translation (NAT) gateways. In this configuration, Red Hat uses AWS PrivateLink to manage and monitor a cluster in order to avoid all public ingress network traffic.
+A {product-title} cluster can be created without any requirements on public subnets, internet gateways, or network address translation (NAT) gateways. In this configuration, Red Hat uses AWS PrivateLink to manage and monitor a cluster to avoid all public ingress network traffic. Without a public subnet, it is not possible to configure an application router as public. Configuring private application routers is the only option.
 
 For more information, see link:https://aws.amazon.com/privatelink/[AWS PrivateLink] on the AWS website.


### PR DESCRIPTION
added note about unsupported ingress operator to AWS PrivateLink

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-3207

Link to docs preview:
http://file.rdu.redhat.com/aldiaz/OSDOCS-3207/rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.html

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
