### PR TITLE
TELCODOCS-321: D/S Docs & RN: METAL-1 (MPINSTALL-72) Metal Day 1 Networking

### DIFF
--- a/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
+++ b/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
@@ -34,13 +34,11 @@ oc edit provisioning
     resourceVersion: "551591"
     uid: f76e956f-24c6-4361-aa5b-feaf72c5b526
   spec:
-    preProvisioningOSDownloadURLs: {}
     provisioningDHCPRange: 172.22.0.10,172.22.0.254
     provisioningIP: 172.22.0.3
     provisioningInterface: enp1s0
     provisioningNetwork: Managed
     provisioningNetworkCIDR: 172.22.0.0/24
-    provisioningOSDownloadURL: http://192.168.111.1/images/rhcos-<version>.<architecture>.qcow2.gz?sha256=<sha256>
     virtualMediaViaExternalNetwork: true <1>
   status:
     generations:
@@ -61,7 +59,6 @@ oc edit provisioning
 ----
 +
 <1> Add `virtualMediaViaExternalNetwork: true` to the `provisioning` CR.
-
 
 . If the image URL exists, edit the `machineset` to use the API VIP address. This step only applies to clusters installed in versions 4.9 or earlier.
 +

--- a/modules/nw-enabling-a-provisioning-network-after-installation.adoc
+++ b/modules/nw-enabling-a-provisioning-network-after-installation.adoc
@@ -38,7 +38,7 @@ $ oc get provisioning -o yaml > enable-provisioning-nw.yaml
 $ vim ~/enable-provisioning-nw.yaml
 ----
 +
-Scroll down to the `provisioningNetwork` configuration setting and change it from `Disabled` to `Managed`. Then, add the `provisioningOSDownloadURL`, `provisioningIP`, `provisioningNetworkCIDR`, `provisioningDHCPRange`, `provisioningInterface`, and `watchAllNameSpaces` configuration settings after the `provisioningNetwork` setting. Provide appropriate values for each setting.
+Scroll down to the `provisioningNetwork` configuration setting and change it from `Disabled` to `Managed`. Then, add the `provisioningIP`, `provisioningNetworkCIDR`, `provisioningDHCPRange`, `provisioningInterface`, and `watchAllNameSpaces` configuration settings after the `provisioningNetwork` setting. Provide appropriate values for each setting.
 +
 [source,yaml]
 ----
@@ -50,27 +50,24 @@ items:
     name: provisioning-configuration
   spec:
     provisioningNetwork: <1>
-    provisioningOSDownloadURL: <2>
-    provisioningIP: <3>
-    provisioningNetworkCIDR: <4>
-    provisioningDHCPRange: <5>
-    provisioningInterface: <6>
-    watchAllNameSpaces: <7>
+    provisioningIP: <2>
+    provisioningNetworkCIDR: <3>
+    provisioningDHCPRange: <4>
+    provisioningInterface: <5>
+    watchAllNameSpaces: <6>
 ----
 +
 <1> The `provisioningNetwork` is one of `Managed`, `Unmanaged`, or `Disabled`. When set to `Managed`, Metal3 manages the provisioning network and the CBO deploys the Metal3 pod with a configured DHCP server. When set to `Unmanaged`, the system administrator configures the DHCP server manually.
 +
-<2> The `provisioningOSDownloadURL` is a valid HTTPS URL with a valid sha256 checksum that enables the Metal3 pod to download a qcow2 operating system image ending in `.qcow2.gz` or `.qcow2.xz`. This field is required whether the provisioning network is `Managed`, `Unmanaged`, or `Disabled`. For example: `\http://192.168.0.1/images/{op-system-lowercase}-_<version>_.x86_64.qcow2.gz?sha256=_<sha>_`.
+<2> The `provisioningIP` is the static IP address that the DHCP server and ironic use to provision the network. This static IP address must be within the `provisioning` subnet, and outside of the DHCP range. If you configure this setting, it must have a valid IP address even if the `provisioning` network is `Disabled`. The static IP address is bound to the metal3 pod. If the metal3 pod fails and moves to another server, the static IP address also moves to the new server.
 +
-<3> The `provisioningIP` is the static IP address that the DHCP server and ironic use to provision the network. This static IP address must be within the `provisioning` subnet, and outside of the DHCP range. If you configure this setting, it must have a valid IP address even if the `provisioning` network is `Disabled`. The static IP address is bound to the metal3 pod. If the metal3 pod fails and moves to another server, the static IP address also moves to the new server.
+<3> The Classless Inter-Domain Routing (CIDR) address. If you configure this setting, it must have a valid CIDR address even if the `provisioning` network is `Disabled`. For example: `192.168.0.1/24`.
 +
-<4> The Classless Inter-Domain Routing (CIDR) address. If you configure this setting, it must have a valid CIDR address even if the `provisioning` network is `Disabled`. For example: `192.168.0.1/24`.
+<4> The DHCP range. This setting is only applicable to a `Managed` provisioning network. Omit this configuration setting if the `provisioning` network is `Disabled`. For example: `192.168.0.64, 192.168.0.253`.
 +
-<5> The DHCP range. This setting is only applicable to a `Managed` provisioning network. Omit this configuration setting if the `provisioning` network is `Disabled`. For example: `192.168.0.64, 192.168.0.253`.
+<5> The NIC name for the `provisioning` interface on cluster nodes. The `provisioningInterface` setting is only applicable to `Managed` and `Unmanaged` provisioning networks. Omit the `provisioningInterface` configuration setting if the `provisioning` network is `Disabled`. Omit the `provisioningInterface` configuration setting to use the `bootMACAddress` configuration setting instead.
 +
-<6> The NIC name for the `provisioning` interface on cluster nodes. The `provisioningInterface` setting is only applicable to `Managed` and `Unmanaged` provisioning networks. Omit the `provisioningInterface` configuration setting if the `provisioning` network is `Disabled`. Omit the `provisioningInterface` configuration setting to use the `bootMACAddress` configuration setting instead.
-+
-<7> Set this setting to `true` if you want metal3 to watch namespaces other than the default `openshift-machine-api` namespace. The default value is `false`.
+<6> Set this setting to `true` if you want metal3 to watch namespaces other than the default `openshift-machine-api` namespace. The default value is `false`.
 
 . Save the changes to the provisioning CR file.
 


### PR DESCRIPTION
Removes  provisioningOSDownloadURL and preProvisioningOSDownloadURL from the docs.

Fixes: [TELCODOCS-321](https://issues.redhat.com//browse/TELCODOCS-321)

See https://issues.redhat.com/browse/TELCODOCS-321 for additional details.

Preview URL: http://jowilkin.com:8080/TELCDOCS-321-download-urls/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.html#enabling-a-provisioning-network-after-installation_ipi-install-post-installation-configuration and http://jowilkin.com:8080/TELCDOCS-321-download-urls/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-to-deploy-with-virtual-media-on-the-baremetal-network_ipi-install-expanding

For release(s): 4.12, 4.11, 4.10
Signed-off-by: John Wilkins <jowilkin@redhat.com>
