### PR TITLE
TELCODOCS-321: D/S Docs & RN: METAL-1 (MPINSTALL-72) Metal Day 1 Networking

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -44,12 +44,6 @@ include::modules/ipi-install-modifying-install-config-for-dual-stack-network.ado
 
 include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-[id="additional-resources_relnotes"]
-.Additional resources
-
-* xref:../../release_notes/ocp-4-11-release-notes.adoc#ocp-4-11-known-issues[OpenShift Container Platform 4.11 release notes]
-
 include::modules/ipi-install-configure-multiple-cluster-nodes.adoc[leveloffset=+2]
 
 include::modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc[leveloffset=+2]

--- a/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -6,55 +6,100 @@
 [id="configuring-host-network-interfaces-in-the-install-config-yaml-file_{context}"]
 = Optional: Configuring host network interfaces
 
-During installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState. To use the `networkConfig` configuration setting, you must provide an NMState YAML configuration.
+Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState.
 
-See link:https://nmstate.io/examples.html#interfaces-ethernet[NMState] for additional examples of the NMState syntax.
+The most common use case for this functionality is to specify a static IP address on the `baremetal` network, but you can also configure other networks such as a storage network. This functionality supports other NMState features such as VLAN, VXLAN, bridges, bonds, routes, MTU, and DNS resolver settings.
 
-.Example
+.Prequisites
+
+* Configure a `PTR` DNS record with a valid hostname for each node with a static IP address.
+* Install the NMState CLI (`nmstate`).
+
+.Procedure
+
+. Optional: Consider testing the NMState syntax with `nmstatectl gc` before including it in the `install-config.yaml` file, because the installer will not check the NMState YAML syntax.
++
+[NOTE]
+====
+Errors in the YAML syntax might result in a failure to apply the network configuration. Additionally, maintaining the validated YAML syntax is useful when applying changes using Kubernetes NMState after deployment or when expanding the cluster.
+====
+
+
+.. Create an NMState YAML file:
++
 [source,yaml]
 ----
-  hosts:
-        - name: openshift-master-0
-          role: master
-          bmc:
-            address: redfish+http://<out-of-band-ip>/redfish/v1/Systems/
-            username: <user>
-            password: <password>
-            disableCertificateVerification: null
-          bootMACAddress: <NIC1_mac_address>
-          bootMode: UEFI
-          rootDeviceHints:
-            deviceName: "/dev/sda"
-          networkConfig: <1>
-            interfaces:
-            - name: <NIC1_name>
-              type: ethernet
-              state: up
-              ipv4:
-                address:
-                - ip: "<IP_address>"
-                  prefix-length: 24
-                enabled: true
-            dns-resolver:
-              config:
-                server:
-                - <DNS_IP_address>
-            routes:
-              config:
-              - destination: 0.0.0.0/0
-                next-hop-address: <IP_address>
-                next-hop-interface: <NIC1_name>
+interfaces:
+- name: <nic1_name> <1>
+  type: ethernet
+  state: up
+  ipv4:
+    address:
+    - ip: <ip_address> <1>
+      prefix-length: 24
+    enabled: true
+dns-resolver:
+  config:
+    server:
+    - <dns_ip_address> <1>
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: <next_hop_ip_address> <1>
+    next-hop-interface: <next_hop_nic1_name> <1>
 ----
-<1> Add NMState YAML syntax to configure host interfaces.
++
+<1> Replace `<nic1_name>`, `<ip_address>`, `<dns_ip_address>`, `<next_hop_ip_address>` and `<next_hop_nic1_name>` with appropriate values.
 
-[TIP]
-====
-Consider saving the `networkConfig` YAML syntax to a file and testing it using the NMState command line interface before including it in the `install-config.yaml` file, because the installer will not check the NMState YAML syntax. Execute `nmstatectl gc <yaml-config>` to test the syntax. Errors in the YAML syntax might result in a failure to apply the network configuration. Additionally, maintaining the validated YAML syntax is useful when applying changes using Kubernetes NMState after deployment or when expanding the cluster.
-====
+.. Test the configuration file by running the following command:
++
+[source,terminal]
+----
+$ nmstatectl gc <nmstate_yaml_file>
+----
++
+Replace `<nmstate_yaml_file>` with the configuration file name.
 
-The most common use case for this functionality is to specify a static IP address on the `baremetal` network, but you can also configure other networks such as a storage network. This functionality will also support other NMState features such as VLAN, VXLAN, bridges, bonds, routes, MTU, and DNS resolver settings.
-
+. Use the `networkConfig` configuration setting by adding the NMState configuration to hosts within the `install-config.yaml` file:
++
+[source,yaml]
+----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish+http://<out_of_band_ip>/redfish/v1/Systems/
+          username: <user>
+          password: <password>
+          disableCertificateVerification: null
+        bootMACAddress: <NIC1_mac_address>
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: "/dev/sda"
+        networkConfig: <1>
+          interfaces:
+          - name: <nic1_name> <2>
+            type: ethernet
+            state: up
+            ipv4:
+              address:
+              - ip: <ip_address> <2>
+                prefix-length: 24
+              enabled: true
+          dns-resolver:
+            config:
+              server:
+              - <dns_ip_address> <2>
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-address: <next_hop_ip_address> <2>
+              next-hop-interface: <next_hop_nic1_name> <2>
+----
+<1> Add the NMState YAML syntax to configure the host interfaces.
+<2> Replace `<nic1_name>`, `<ip_address>`, `<dns_ip_address>`, `<next_hop_ip_address>` and `<next_hop_nic1_name>` with appropriate values.
++
 [IMPORTANT]
 ====
-Once deployed, you cannot modify the `networkConfig` configuration setting of `install-config.yaml` file to make changes to the host network interface. Use the Kubernetes NMState Operator to make changes to the host network interface after deployment.
+After deploying the cluster, you cannot modify the `networkConfig` configuration setting of `install-config.yaml` file to make changes to the host network interface. Use the Kubernetes NMState Operator to make changes to the host network interface after deployment.
 ====


### PR DESCRIPTION
Creates a 4.11-specific PR because https://github.com/openshift/openshift-docs/pull/49724 could not be cherry-picked.

Fixes: [TELCODOCS-321](https://issues.redhat.com//browse/TELCODOCS-321)

See https://issues.redhat.com/browse/TELCODOCS-321 for additional details.

Preview URL: http://jowilkin.com:8080/TELCODOCS-321-4.11/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow

For release(s): 4.11
Signed-off-by: John Wilkins <jowilkin@redhat.com>
