### PR TITLE
Only run the autopreview logic on pull requests

### DIFF
--- a/autopreview.sh
+++ b/autopreview.sh
@@ -3,11 +3,12 @@ set -ev
 
 #ALLOWED_USERS=("aireilly" "mburke5678" "vikram-redhat" "abrennan89" "ahardin-rh" "kalexand-rh" "adellape" "bmcelvee" "ousleyp" "lamek" "JStickler" "rh-max" "bergerhoffer" "sheriff-rh" "jboxman" "bobfuru" "aburdenthehand" "boczkowska" "Preeticp" "neal-timpe" "codyhoag" "apinnick" "bgaydosrh" "lmandavi" "maxwelldb" "pneedle-rh" "lbarbeevargas" "jeana-redhat" "RichardHoch" "johnwilkins" "sjhala-ccs" "mgarrellRH" "SNiemann15" "sfortner-RH" "jonquilwilliams" "ktania46" "wking" "
 #jc-berger" "rishumehra" "iranzo" "abhatt-rh" "@mohit-sheth" "stoobie" "emarcusRH" "kquinn1204" "mikemckiernan" "skrthomas" "sagidlow" "rolfedh")
-USERNAME=${TRAVIS_PULL_REQUEST_SLUG::-15}
-COMMIT_HASH="$(git rev-parse @~)"
-mapfile -t FILES_CHANGED < <(git diff --name-only "$COMMIT_HASH")
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then #to make sure it only runs on PRs and not all merges
+    USERNAME=${TRAVIS_PULL_REQUEST_SLUG::-15}
+    COMMIT_HASH="$(git rev-parse @~)"
+    mapfile -t FILES_CHANGED < <(git diff --name-only "$COMMIT_HASH")
+
     if [ "${TRAVIS_PULL_REQUEST_BRANCH}" != "main" ] ; then # to make sure it does not run for direct main changes
         if [[ " ${FILES_CHANGED[*]} " = *".adoc"* ]] || [[ " ${FILES_CHANGED[*]} " = *"_topic_map.yml"* ]] || [[ " ${FILES_CHANGED[*]} " = *"_distro_map.yml"* ]] ; then # to make sure this doesn't run for general modifications
             if [ "$USERNAME" != "openshift-cherrypick-robot" ] ; then # to make sure it doesn't run for USERNAME openshift-cherrypick-robot


### PR DESCRIPTION
Currently the `autopreview.sh` script tries to get Author name even for merges, PS: https://app.travis-ci.com/github/openshift/openshift-docs/jobs/582583546#L140 

- Merge in `main`
- Cherrypick in `enterprise-4.11`
- Cherrypick in `enterprise-4.12`

Moving those lines inside the check fixes the issue.