### PR TITLE
Revert "OSDOCS-3807.2: Fixed a needlessly complicated attributes sect…

### DIFF
--- a/cicd/builds/setting-up-trusted-ca.adoc
+++ b/cicd/builds/setting-up-trusted-ca.adoc
@@ -1,8 +1,12 @@
 :_content-type: ASSEMBLY
 [id="setting-up-trusted-ca"]
 = Setting up additional trusted certificate authorities for builds
+ifndef::openshift-dedicated,openshift-rosa[]
 include::_attributes/common-attributes.adoc[]
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
+endif::[]
 :context: setting-up-trusted-ca
 
 toc::[]


### PR DESCRIPTION
…ion."

This reverts commit 2711adb8bcf1e206e46ea6831a8a149f8f9ad584.

This is breaking the portal builds in the CICD book.

@EricPonvelle, FYI