### PR TITLE
GH#50168 - Fixing multicluster console link

### DIFF
--- a/modules/enabling-multi-cluster-console.adoc
+++ b/modules/enabling-multi-cluster-console.adoc
@@ -12,7 +12,7 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 .Prerequisites
 * Your cluster must be using the latest version of {product-title}.
-* You must have link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/install/index[Red Hat Advanced Cluster Management (ACM) for Kubernetes 2.5] or the link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/multicluster_engine_operator/index[multiculster engine (MCE) Operator] installed.
+* You must have link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/install/index[Red Hat Advanced Cluster Management (ACM) for Kubernetes 2.5] or the link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/multicluster_engine/index[multiculster engine (MCE) Operator] installed.
 * You must have administrator privileges.
 
 [WARNING]


### PR DESCRIPTION
For versions 4.10+ 
Fixes issue: #50168

Description: Fixes 404 link in multicluster console docs 

Preview: 
[Web console -> Accessing the Web Console -> Multicluster Console ](https://kelbrown20.github.io/bug-fix-previews/GH50168-web-console-link/web_console/web-console.html#multi-cluster-about_web-console)