### PR TITLE
Clarifying the behavior of PSA sync

### DIFF
--- a/modules/security-context-constraints-psa-opting.adoc
+++ b/modules/security-context-constraints-psa-opting.adoc
@@ -8,18 +8,18 @@
 
 You can enable or disable automatic pod security admission synchronization for most namespaces.
 
-[NOTE]
+[IMPORTANT]
 ====
-By default, user-created namespaces that have the prefix `openshift-` have pod security admission label synchronization disabled.
+Namespaces that are defined as part of the cluster payload have pod security admission synchronization disabled permanently. These namespaces include:
 
-Namespaces that the installer creates have pod security admission label synchronization disabled permanently. These namespaces include:
-
-* All namespaces that are prefixed with `openshift-`, except for `openshift-operators`
 * `default`
 * `kube-node-lease`
 * `kube-system`
 * `kube-public`
 * `openshift`
+* All system-created namespaces that are prefixed with `openshift-`, except for `openshift-operators`
+
+By default, all namespaces that have an `openshift-` prefix are not synchronized. You can enable synchronization for any user-created [x-]`openshift-*` namespaces. You cannot enable synchronization for any system-created [x-]`openshift-*` namespaces, except for `openshift-operators`.
 ====
 
 .Procedure

--- a/modules/security-context-constraints-psa-synchronization.adoc
+++ b/modules/security-context-constraints-psa-synchronization.adoc
@@ -10,26 +10,13 @@
 
 In addition to the global pod security admission control configuration, a controller exists that applies pod security admission control `warn` and `audit` labels to namespaces according to the SCC permissions of the service accounts that are in a given namespace.
 
+[IMPORTANT]
+====
+Namespaces that are defined as part of the cluster payload have pod security admission synchronization disabled permanently. You can enable pod security admission synchronization on other namespaces as necessary.
+====
+
 The controller examines `ServiceAccount` object permissions to use security context constraints in each namespace. Security context constraints (SCCs) are mapped to pod security profiles based on their field values; the controller uses these translated profiles. Pod security admission `warn` and `audit` labels are set to the most privileged pod security profile found in the namespace to prevent warnings and audit logging as pods are created.
 
 Namespace labeling is based on consideration of namespace-local service account privileges.
 
 Applying pods directly might use the SCC privileges of the user who runs the pod. However, user privileges are not considered during automatic labeling.
-
-[IMPORTANT]
-====
-Namespaces that have an `openshift-` name prefix and were not created by the system during the installation are not synchronized by default.
-
-Namespaces that have the `openshift-` prefix are typically system namespaces; by convention, a controller should exist to manage them.
-
-You can enable SCC synchronization in namespaces that have the `openshift-` prefix by setting the value of the `security.openshift.io/scc.podSecurityLabelSync` label to `true`.
-
-Namespaces that are defined as part of the cluster payload have pod security admission synchronization disabled permanently. These namespaces include:
-
-* All namespaces that are prefixed with `openshift-`, except for `openshift-operators`
-* `default`
-* `kube-node-lease`
-* `kube-system`
-* `kube-public`
-* `openshift`
-====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.11+

Issue:
N/A

Link to docs preview:
http://file.rdu.redhat.com/~ahoffer/2022/psa-clarifications/authentication/understanding-and-managing-pod-security-admission.html#security-context-constraints-psa-synchronization_understanding-and-managing-pod-security-admission

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
