### PR TITLE
[virt] commenting out known issue

### DIFF
--- a/virt/virt-4-9-release-notes.adoc
+++ b/virt/virt-4-9-release-notes.adoc
@@ -174,8 +174,8 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 [id="virt-4-9-known-issues"]
 == Known issues
 
-* Updating to {VirtProductName} 4.9.6 causes some virtual machines (VMs) to get stuck in a live migration loop. This occurs if the `spec.volumes.containerDisk.path` field in the VM manifest is set to a relative path.
-** As a workaround, delete and recreate the VM manifest, setting the value of the `spec.volumes.containerDisk.path` field to an absolute path. You can then update {VirtProductName}.
+//* Updating to {VirtProductName} 4.9.6 causes some virtual machines (VMs) to get stuck in a live migration loop. This occurs if the `spec.volumes.containerDisk.path` field in the VM manifest is set to a relative path.
+//** As a workaround, delete and recreate the VM manifest, setting the value of the `spec.volumes.containerDisk.path` field to an absolute path. You can then update {VirtProductName}.
 // no public BZ
 
 //BZ-2007397


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.9 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.11) and future versions: 4.11+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.6-4.8): 4.6, 4.7, 4.8 --->

Issue: no issue
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/pousley/revert-pr-50276/virt/virt-4-9-release-notes.html#virt-4-9-known-issues
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. -->

<!-- NOTE:
Automatic preview functionality is currently not available.
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview for PRs that update the rendered build in any way.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information: I erroneously merged https://github.com/openshift/openshift-docs/pull/50276 and am commenting out the lines that PR added. To be uncommented when 4.9.6 releases. 🤦 
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
