### PR TITLE
[enterprise-4.9] Downstream docs showing older & unsupported versions in installation matrix

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -60,9 +60,7 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.7
-:mtc-version-z: 1.7.1
-:mtc-legacy-version: 1.5
-:mtc-legacy-version-z: 1.5.5
+:mtc-version-z: 1.7
 //gitops
 :gitops-title: Red Hat OpenShift GitOps
 :gitops-shortname: GitOps

--- a/migration_toolkit_for_containers/about-mtc.adoc
+++ b/migration_toolkit_for_containers/about-mtc.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The {mtc-full} ({mtc-short}) enables you to migrate stateful application workloads between {product-title} 4 clusters at the granularity of a namespace.
+The {mtc-full} ({mtc-short} enables you to migrate stateful application workloads between {product-title} 4 clusters at the granularity of a namespace.
 
 [NOTE]
 ====

--- a/modules/migration-compatibility-guidelines.adoc
+++ b/modules/migration-compatibility-guidelines.adoc
@@ -25,7 +25,7 @@ remote cluster:: A source or destination cluster for a migration that runs Veler
 .{mtc-short} compatibility: Migrating from a legacy platform
 |===
 ||{product-title} 4.5 or earlier |{product-title} 4.6 later
-|Latest {mtc-short} version a|{mtc-short} {mtc-version}.z
+|Stable {mtc-short} version a|{mtc-short} {mtc-version}.z
 
 Legacy {mtc-version} operator: Install manually with the `operator.yml` file.
 [IMPORTANT]
@@ -36,13 +36,6 @@ This cluster cannot be the control cluster.
 |{mtc-short} {mtc-version}.z
 
 Install with OLM, release channel `release-v1.7`
-|Stable {mtc-short} version |{mtc-short} 1.5
-
-Legacy 1.5 operator: Install manually with the `operator.yml` file.
-
-|{mtc-short} 1.6.z
-
-Install with OLM, release channel `release-v1.6`
 |===
 
 [NOTE]

--- a/modules/migration-installing-legacy-operator.adoc
+++ b/modules/migration-installing-legacy-operator.adoc
@@ -41,40 +41,20 @@ endif::[]
 $ sudo podman login registry.redhat.io
 ----
 
-. Download the `operator.yml` file:
-
-.. For the stable version, enter the following command:
+. Download the `operator.yml` file by entering the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/operator.yml ./
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/operator.yml ./
 ----
 
-.. For the latest version, enter the following command:
+. Download the `controller.yml` file by entering the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/operator.yml ./
-----
-
-. Download the `controller.yml` file:
-
-.. For the stable version, enter the following command:
-+
-[source,terminal,subs="attributes+"]
-----
-$ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/controller.yml ./
-----
-
-.. For the latest version, enter the following command:
-+
-[source,terminal,subs="attributes+"]
-----
-$ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/controller.yml ./
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/controller.yml ./
 ----
 
 ifdef::installing-restricted-3-4,installing-mtc-restricted[]

--- a/modules/migration-upgrading-mtc-with-legacy-operator.adoc
+++ b/modules/migration-upgrading-mtc-with-legacy-operator.adoc
@@ -31,22 +31,12 @@ endif::[]
 $ sudo podman login registry.redhat.io
 ----
 
-. Download the `operator.yml` file:
-
-.. For the stable version, enter the following command:
+. Download the `operator.yml` file by entering the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/operator.yml ./
-----
-
-.. For the latest version, enter the following command:
-+
-[source,terminal,subs="attributes+"]
-----
-$ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version-z}):/operator.yml ./
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/operator.yml ./
 ----
 
 . Replace the {mtc-full} Operator:


### PR DESCRIPTION
Cherry picked from https://github.com/openshift/openshift-docs/commit/8cf9372509ce25160fa4a46ce4895f55eb80ce69 in https://github.com/openshift/openshift-docs/pull/50239