### PR TITLE
TELCODOCS-860 RN [4.11.3]: MGMT-10404 Use boot-artifacts API to fetch rootfs in minimal-iso (assisted-image-service)

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -976,10 +976,6 @@ Before this release, you could not configure this setting.
 You can now configure the retention time period for Thanos Ruler data in user-defined projects.
 Before this release, you could not change the default value of `24h`.
 
-[id="ocp-4-11-scalability-and-performance"]
-=== Scalability and performance
-Beginning with {product-title} 4.11, users no longer need to set the Root FS image URL (`rootFSUrl`) in the `agent_service_config.yaml` file. The `rootFSUrl` is now handled automatically.
-
 [id=ocp-4-11-workload-hints-for-nto]
 ==== Workload hints for the Node Tuning Operator
 {product-title} 4.11 supports a hinting mechanism for the Node Tuning Operator that can tune `PerformanceProfile` to meet the demands of different industry environments. In this release, workload hints are available for `highPowerConsumption` (very low latency at the cost of increased power consumption) and `realtime` (priority given to optimum latency). A combination of true/false settings for these hints can be used to deal with application-specific workload profiles and requirements.
@@ -2580,6 +2576,14 @@ You can view the container images in this release by running the following comma
 ----
 $ oc adm release info 4.11.3 --pullspecs
 ----
+
+[id="ocp-4-11-3-features"]
+==== Features
+
+[id="ocp-4-11-3-scalability-and-performance"]
+=== Scalability and performance
+
+Beginning with {product-title} 4.11.3, users no longer need to set the Root FS image URL (`rootFSUrl`) in the `agent_service_config.yaml` file. The `rootFSUrl` is now handled automatically.
 
 [id="ocp-4-11-3-updating"]
 ==== Updating


### PR DESCRIPTION
Fixes: [TELCODOCS-860](https://issues.redhat.com/browse/TELCODOCS-860)

For: Version 4.11.3+

Signed-off-by: Katie Tothill ktothill@redhat.com