### PR TITLE
[enterprise-4.10] GH#50050 - Fixing mirrors link in scaling docs 

### DIFF
--- a/modules/ztp-acm-adding-images-to-mirror-registry.adoc
+++ b/modules/ztp-acm-adding-images-to-mirror-registry.adoc
@@ -20,7 +20,7 @@ The {op-system} images might not change with every release of {product-title}. Y
 .Procedure
 
 . Log in to the mirror host.
-. Obtain the {op-system} ISO and RootFS images from link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/[mirror.openshift.com], for example:
+. Obtain the {op-system} ISO and RootFS images from link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/latest/[mirror.openshift.com], for example:
 
 .. Export the required image names and {product-title} version as environment variables:
 +


### PR DESCRIPTION
For version 4.10
Fixes issue #50050 

Description: Adding latest mirrors like to 4.10 scaling docs 

Preview: [Scalability and Performance -> Deploying distributed units at scale in a disconnected environment -> Adding RHCOS and RootFS images to the disconnected mirror host](https://kelbrown20.github.io/bug-fix-previews/gh-fixing-mirrors-link-in-scaling-4.10/scalability_and_performance/ztp-deploying-disconnected.html#ztp-acm-adding-images-to-mirror-registry_ztp-deploying-disconnected)