### PR TITLE
OSDOCS-4117: Installing an IBM Cloud VPC cluster into an existing VPC

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -260,6 +260,8 @@ Topics:
     File: installing-ibm-cloud-customizations
   - Name: Installing a cluster on IBM Cloud VPC with network customizations
     File: installing-ibm-cloud-network-customizations
+  - Name: Installing a cluster on IBM Cloud VPC into an existing VPC
+    File: installing-ibm-cloud-vpc
   - Name: Uninstalling a cluster on IBM Cloud VPC
     File: uninstalling-cluster-ibm-cloud
 - Name: Installing on Nutanix

--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Before you install {product-title}, decide what kind of installation process to follow and make sure you that you have all of the required resources to prepare the cluster for users.
+Before you install {product-title}, decide what kind of installation process to follow and verify that you have all of the required resources to prepare the cluster for users.
 
 [id="installing-preparing-selecting-cluster-type"]
 == Selecting a cluster installation type
@@ -37,7 +37,7 @@ endif::openshift-origin[]
 * Bare metal or other platform agnostic infrastructure
 // might want a note about single node here
 
-You can deploy an {product-title} 4 cluster to both on-premise hardware and to cloud hosting services, but all of the machines in a cluster must be in the same datacenter or cloud hosting service.
+You can deploy an {product-title} 4 cluster to both on-premise hardware and to cloud hosting services, but all of the machines in a cluster must be in the same data center or cloud hosting service.
 
 If you want to use {product-title} but do not want to manage the cluster yourself, you have several managed service options. If you want a cluster that is fully managed by Red Hat, you can use link:https://www.openshift.com/products/dedicated/[OpenShift Dedicated] or link:https://www.openshift.com/products/online/[OpenShift Online]. You can also use OpenShift as a managed service on Azure, AWS, IBM Cloud VPC, or Google Cloud. For more information about managed services, see the link:https://www.openshift.com/products[OpenShift Products] page.
 
@@ -234,7 +234,7 @@ ifndef::openshift-origin[]
 |
 |
 |
-|
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc#installing-ibm-cloud-vpc[&#10003;]
 |
 |
 
@@ -391,7 +391,7 @@ ifdef::openshift-origin[]
 |
 |
 |
-|
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc#installing-ibm-cloud-vpc[&#10003;]
 |
 |
 

--- a/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 In environments where the cloud identity and access management (IAM) APIs are not reachable, you must put the Cloud Credential Operator (CCO) into manual mode before you install the cluster.
 
-:FeatureName: IBM Cloud VPC using installer-provisioned infrastructure
-include::snippets/technology-preview.adoc[]
-
 include::modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 Before you can install {product-title}, you must configure an IBM Cloud account.
 
-:FeatureName: IBM Cloud VPC using installer-provisioned infrastructure
-include::snippets/technology-preview.adoc[]
-
 [id="prerequisites_installing-ibm-cloud-account"]
 == Prerequisites
 

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
@@ -11,9 +11,6 @@ customized network configuration on infrastructure that the installation program
 
 You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
 
-:FeatureName: IBM Cloud VPC using installer-provisioned infrastructure
-include::snippets/technology-preview.adoc[]
-
 [id="prerequisites_installing-ibm-cloud-network-customizations"]
 == Prerequisites
 

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
@@ -1,14 +1,14 @@
 :_content-type: ASSEMBLY
-[id="installing-ibm-cloud-customizations"]
-= Installing a cluster on IBM Cloud VPC with customizations
+[id="installing-ibm-cloud-vpc"]
+= Installing a cluster on IBM Cloud VPC into an existing VPC
 include::_attributes/common-attributes.adoc[]
-:context: installing-ibm-cloud-customizations
+:context: installing-ibm-cloud-vpc
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a customized cluster on infrastructure that the installation program provisions on IBM Cloud VPC. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
+In {product-title} version {product-version}, you can install a cluster into an existing Virtual Private Cloud (VPC) on IBM Cloud VPC. The installation program provisions the rest of the required infrastructure, which you can then further customize. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
-[id="prerequisites_installing-ibm-cloud-customizations"]
+[id="prerequisites_installing-ibm-cloud-vpc"]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
@@ -16,6 +16,8 @@ In {product-title} version {product-version}, you can install a customized clust
 * You xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[configured an IBM Cloud account] to host the cluster.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 * You configured the `ccoctl` utility before you installed the cluster. For more information, see xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud VPC].
+
+include::modules/installation-custom-ibm-cloud-vpc.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
@@ -31,10 +33,6 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-ibm-cloud-config-yaml.adoc[leveloffset=+2]
 
-//.Additional resources
-
-//* ../../machine_management/creating_machinesets/creating-machineset-ibm-cloud.adoc#machineset-enabling-customer-managed-encryption_creating-machineset-ibm-cloud[Enabling customer-managed encryption keys for a compute machine set]
-
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/manually-create-iam-ibm-cloud.adoc[leveloffset=+1]
@@ -46,19 +44,18 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_installing-ibm-cloud-customizations-console"]
+[id="additional-resources_installing-ibm-cloud-vpc-console"]
 .Additional resources
 * xref:../../web_console/web-console.adoc#web-console[Accessing the web console]
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_installing-ibm-cloud-customizations-telemetry"]
+[id="additional-resources_installing-ibm-cloud-vpc-telemetry"]
 .Additional resources
 * xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 
-[id="next-steps_installing-ibm-cloud-customizations"]
+[id="next-steps_installing-ibm-cloud-vpc"]
 == Next steps
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* Optional: xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[Opt out of remote health reporting].

--- a/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The installation workflows documented in this section are for IBM Cloud VPC infrastructure environments. IBM Cloud Classic is not supported at this time. For more information on the difference between Classic and VPC infrastructures, see IBM's link:https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure[documentation].
+The installation workflows documented in this section are for IBM Cloud VPC infrastructure environments. IBM Cloud Classic is not supported at this time. For more information about the difference between Classic and VPC infrastructures, see the IBM link:https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure[documentation].
 
 [id="prerequisites_preparing-to-install-on-ibm-cloud"]
 == Prerequisites
@@ -14,9 +14,6 @@ The installation workflows documented in this section are for IBM Cloud VPC infr
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-
-:FeatureName: IBM Cloud using installer-provisioned infrastructure
-include::snippets/technology-preview.adoc[]
 
 [id="requirements-for-installing-ocp-on-ibm-cloud"]
 == Requirements for installing {product-title} on IBM Cloud VPC
@@ -40,6 +37,8 @@ You can install a cluster on IBM Cloud VPC infrastructure that is provisioned by
 * **xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[Installing a customized cluster on IBM Cloud VPC]**: You can install a customized cluster on IBM Cloud VPC infrastructure that the installation program provisions. The installation program allows for some customization to be applied at the installation stage. Many other customization options are available xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[post-installation].
 
 * **xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc#installing-ibm-cloud-network-customizations[Installing a cluster on IBM Cloud VPC with network customizations]**: You can customize your {product-title} network configuration during installation, so that your cluster can coexist with your existing IP address allocations and adhere to your network requirements.
+
+* **xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc#installing-ibm-cloud-vpc[Installing a cluster on IBM Cloud VPC into an existing VPC]**: You can install {product-title} on an existing IBM  Virtual Private Cloud (VPC). You can use this installation method if you have constraints set by the guidelines of your company, such as limits when creating new accounts or infrastructure.
 
 [id="next-steps_preparing-to-install-on-ibm-cloud"]
 == Next steps

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -29,6 +29,7 @@
 // * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/install_config/installing-restricted-networks-preparations.adoc
 // * installing/installing_vmc/installing-vmc-user-infra.adoc
 // * installing/installing_vmc/installing-vmc.adoc

--- a/modules/cli-logging-in-kubeadmin.adoc
+++ b/modules/cli-logging-in-kubeadmin.adoc
@@ -30,6 +30,7 @@
 // * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
 // * installing/installing_openstack/installing-openstack-installer.adoc

--- a/modules/cluster-entitlements.adoc
+++ b/modules/cluster-entitlements.adoc
@@ -14,6 +14,7 @@
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc

--- a/modules/cluster-telemetry.adoc
+++ b/modules/cluster-telemetry.adoc
@@ -59,6 +59,7 @@
 // * installing/installing_gcp/installing-gcp-network-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_vmc/installing-vmc-network-customizations.adoc
 // * installing/installing_vmc/installing-vmc-customizations.adoc
 // * installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -26,6 +26,7 @@
 // * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -124,6 +125,10 @@ ifeval::["{context}" == "installing-ibm-cloud-customizations"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
 :ibm-cloud:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:ibm-cloud:
+:ibm-cloud-vpc:
 endif::[]
 ifeval::["{context}" == "installing-openstack-installer-custom"]
 :osp:
@@ -292,9 +297,16 @@ You can customize your installation configuration based on the requirements of y
 // https://bugzilla.redhat.com/show_bug.cgi?id=2020416
 // Once BM UPI supports dual-stack, uncomment all the following conditionals and blocks
 
-If you use the OVN-Kubernetes cluster network provider, both IPv4 and IPv6 address families are supported.
+* If you use the OVN-Kubernetes cluster network provider, both IPv4 and IPv6 address families are supported.
 
-If you use the OpenShift SDN cluster network provider, only the IPv4 address family is supported.
+* If you use the OpenShift SDN cluster network provider, only the IPv4 address family is supported.
+
+ifdef::ibm-cloud[]
+[NOTE]
+====
+IBM Cloud VPC does not support IPv6 address families.
+====
+endif::ibm-cloud[]
 
 If you configure your cluster to use both IP address families, review the following requirements:
 
@@ -303,7 +315,7 @@ If you configure your cluster to use both IP address families, review the follow
 * Both IP families must have the default gateway.
 
 * You must specify IPv4 and IPv6 addresses in the same order for all network configuration parameters. For example, in the following configuration IPv4 addresses are listed before IPv6 addresses.
-+
+
 [source,yaml]
 ----
 networking:
@@ -688,7 +700,7 @@ Optional AWS configuration parameters are described in the following table:
 such as `io1`.
 
 |`compute.platform.aws.rootVolume.kmsKeyARN`
-|The Amazon Resource Name (key ARN) of a KMS key. This is required to encrypt OS volumes of worker nodes with a specific KMS key.
+|The Amazon Resource Name (key ARN) of a KMS key. This is required to encrypt operating system volumes of worker nodes with a specific KMS key.
 |Valid link:https://docs.aws.amazon.com/kms/latest/developerguide/find-cmk-id-arn.html[key ID or the key ARN].
 
 |`compute.platform.aws.type`
@@ -717,7 +729,7 @@ endif::openshift-origin[]
 
 
 |`controlPlane.platform.aws.amiID`
-|The AWS AMI used to boot control plane machines for the cluster.  This is required for regions that require a custom {op-system} AMI.
+|The AWS AMI used to boot control plane machines for the cluster. This is required for regions that require a custom {op-system} AMI.
 |Any published or custom {op-system} AMI that belongs to the set AWS region. See _{op-system} AMIs for AWS infrastructure_ for available AMI IDs.
 
 |`controlPlane.platform.aws.iamRole`
@@ -725,7 +737,7 @@ endif::openshift-origin[]
 |The name of a valid AWS IAM role.
 
 |`controlPlane.platform.aws.rootVolume.kmsKeyARN`
-|The Amazon Resource Name (key ARN) of a KMS key. This is required to encrypt OS volumes of control plane nodes with a specific KMS key.
+|The Amazon Resource Name (key ARN) of a KMS key. This is required to encrypt operating system volumes of control plane nodes with a specific KMS key.
 |Valid link:https://docs.aws.amazon.com/kms/latest/developerguide/find-cmk-id-arn.html[key ID and the key ARN].
 
 |`controlPlane.platform.aws.type`
@@ -972,7 +984,7 @@ Additional Azure configuration parameters are described in the following table:
 |`Enabled`, `Disabled`. The default is `Disabled`.
 
 |`compute.platform.azure.osDisk.diskEncryptionSet.resourceGroup`
-|The name of the Azure resource group that contains the disk encryption set from the installation prerequisites. This resource group should be different than the resource group where you install the cluster to avoid deleting your Azure encryption key when the cluster is destroyed. This value is only necessary if you intend to install the cluster with user-managed disk encryption.
+|The name of the Azure resource group that contains the disk encryption set from the installation prerequisites. This resource group should be different from the resource group where you install the cluster to avoid deleting your Azure encryption key when the cluster is destroyed. This value is only necessary if you intend to install the cluster with user-managed disk encryption.
 |String, for example `production_encryption_resource_group`.
 
 |`compute.platform.azure.osDisk.diskEncryptionSet.name`
@@ -988,7 +1000,7 @@ Additional Azure configuration parameters are described in the following table:
 |`true` or `false`. The default is `false`.
 
 |`controlPlane.platform.azure.osDisk.diskEncryptionSet.resourceGroup`
-|The name of the Azure resource group that contains the disk encryption set from the installation prerequisites. This resource group should be different than the resource group where you install the cluster to avoid deleting your Azure encryption key when the cluster is destroyed. This value is only necessary if you intend to install the cluster with user-managed disk encryption.
+|The name of the Azure resource group that contains the disk encryption set from the installation prerequisites. This resource group should be different from the resource group where you install the cluster to avoid deleting your Azure encryption key when the cluster is destroyed. This value is only necessary if you intend to install the cluster with user-managed disk encryption.
 |String, for example `production_encryption_resource_group`.
 
 |`controlPlane.platform.azure.osDisk.diskEncryptionSet.name`
@@ -1088,7 +1100,7 @@ Additional GCP configuration parameters are described in the following table:
 |String.
 
 |`platform.gcp.projectID`
-|The name of the GCP project where the installation program installs the cluster. 
+|The name of the GCP project where the installation program installs the cluster.
 |String.
 
 |`platform.gcp.region`
@@ -1130,7 +1142,7 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 
 |`platform.gcp.defaultMachinePlatform.type`
 |The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for control plane and compute machines.
-|The GCP machine type, for example `n1-standard-4`. 
+|The GCP machine type, for example `n1-standard-4`.
 
 |`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey.name`
 |The name of the customer managed encryption key to be used for machine disk encryption.
@@ -1185,7 +1197,7 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |One or more strings, for example `control-plane-tag1`.
 
 |`controlPlane.platform.gcp.type`
-|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for control plane machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter. 
+|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for control plane machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter.
 |The GCP machine type, for example `n1-standard-4`.
 
 |`controlPlane.platform.gcp.zones`
@@ -1226,7 +1238,7 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |One or more strings, for example `compute-network-tag1`.
 
 |`compute.platform.gcp.type`
-|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for compute machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter. 
+|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for compute machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter.
 |The GCP machine type, for example `n1-standard-4`.
 
 |`compute.platform.gcp.zones`
@@ -1249,12 +1261,23 @@ Additional IBM Cloud VPC configuration parameters are described in the following
 |Parameter|Description|Values
 
 |`platform.ibmcloud.resourceGroupName`
+ifndef::ibm-cloud-vpc[]
 |The name of an existing resource group to install your cluster to. This resource group must only be used for this specific cluster because the cluster components assume ownership of all of the resources in the resource group. If undefined, a new resource group is created for the cluster. [^1^]
+endif::ibm-cloud-vpc[]
+ifdef::ibm-cloud-vpc[]
+|The name of an existing resource group. The existing VPC and subnets should be in this resource group. Cluster installation resources are created in this resource group.
+endif::ibm-cloud-vpc[]
+
 |String, for example `existing_resource_group`.
 
 |`platform.ibmcloud.dedicatedHosts.profile`
 |The new dedicated host to create. If you specify a value for `platform.ibmcloud.dedicatedHosts.name`, this parameter is not required.
+ifndef::ibm-cloud-vpc[]
 |Valid IBM Cloud VPC dedicated host profile, such as `cx2-host-152x304`. [^2^]
+endif::ibm-cloud-vpc[]
+ifdef::ibm-cloud-vpc[]
+|Valid IBM Cloud VPC dedicated host profile, such as `cx2-host-152x304`. [^1^]
+endif::ibm-cloud-vpc[]
 
 |`platform.ibmcloud.dedicatedHosts.name`
 |An existing dedicated host. If you specify a value for `platform.ibmcloud.dedicatedHosts.profile`, this parameter is not required.
@@ -1262,13 +1285,35 @@ Additional IBM Cloud VPC configuration parameters are described in the following
 
 |`platform.ibmcloud.type`
 |The instance type for all IBM Cloud VPC machines.
+ifndef::ibm-cloud-vpc[]
 |Valid IBM Cloud VPC instance type, such as `bx2-8x32`. [^2^]
+endif::ibm-cloud-vpc[]
+ifdef::ibm-cloud-vpc[]
+|Valid IBM Cloud VPC instance type, such as `bx2-8x32`. [^1^]
+endif::ibm-cloud-vpc[]
+
+|`platform.ibmcloud.vpcName`
+| The name of the existing VPC that you want to deploy your cluster to.
+| String
+
+|`platform.ibmcloud.controlPlaneSubnets`
+| The name(s) of the existing subnet(s) in your VPC that you want to deploy your control plane machines to. Specify a subnet for each availability zone.
+| String array
+
+|`platform.ibmcloud.computeSubnets`
+| The name(s) of the existing subnet(s) in your VPC that you want to deploy your compute machines to. Specify a subnet for each availability zone. Subnet IDs are not supported.
+| String array
 
 |====
 [.small]
 --
-1. Whether you define an existing resource group, or if the installation program creates one, determines how the resource group is treated when the cluster is uninstalled. If you define a resource group, the installation program removes all of the installer-provisioned resources, but leaves the resource group alone; if a resource group is created as part of the installation, the installation program removes all of the installer-provisioned resources and the resource group.
+ifndef::ibm-cloud-vpc[]
+1. Whether you define an existing resource group, or if the installation program creates one, determines how the resource group is treated when the cluster is uninstalled. If you define a resource group, the installation program removes all of the installer-provisioned resources, but leaves the resource group alone; if a resource group is created as part of the installation, the installation program removes all of the installer provisioned resources and the resource group.
 2. To determine which profile best meets your needs, see https://cloud.ibm.com/docs/vpc?topic=vpc-profiles&interface=ui[Instance Profiles] in the IBM documentation.
+endif::ibm-cloud-vpc[]
+ifdef::ibm-cloud-vpc[]
+1. To determine which profile best meets your needs, see https://cloud.ibm.com/docs/vpc?topic=vpc-profiles&interface=ui[Instance Profiles] in the IBM documentation.
+endif::ibm-cloud-vpc[]
 --
 endif::ibm-cloud[]
 
@@ -1446,7 +1491,7 @@ in vSphere.
 |String
 
 |`platform.vsphere.datacenter`
-|The name of the datacenter to use in the vCenter instance.
+|The name of the data center to use in the vCenter instance.
 |String
 
 |`platform.vsphere.defaultDatastore`
@@ -1454,7 +1499,7 @@ in vSphere.
 |String
 
 |`platform.vsphere.folder`
-|Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the datacenter virtual machine folder.
+|Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
 |`platform.vsphere.resourcePool`
@@ -1591,7 +1636,7 @@ Additional Alibaba Cloud configuration parameters are described in the following
 |Parameter|Description|Values
 
 |`platform.alibabacloud.region`
-|Required.The Alibaba Cloud region where the cluster will be created.
+|Required. The Alibaba Cloud region where the cluster will be created.
 |String.
 
 |`platform.alibabacloud.resourceGroupID`
@@ -1765,6 +1810,10 @@ ifeval::["{context}" == "installing-ibm-cloud-customizations"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
 :!ibm-cloud:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:!ibm-cloud:
+:!ibm-cloud-vpc:
 endif::[]
 ifeval::["{context}" == "installing-openstack-installer-custom"]
 :!osp:

--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -28,6 +28,7 @@
 // * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc

--- a/modules/installation-custom-ibm-cloud-vpc.adoc
+++ b/modules/installation-custom-ibm-cloud-vpc.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-ibm-cloud-vpc.adoc
+
+:_content-type: CONCEPT
+[id="installation-custom-ibm-cloud-vpc_{context}"]
+= About using a custom VPC
+
+In {product-title} {product-version}, you can deploy a cluster into the subnets of an existing IBM Virtual Private Cloud (VPC). Deploying {product-title} into an existing VPC can help you avoid limit constraints in new accounts or more easily abide by the operational constraints that your company's guidelines set. If you cannot obtain the infrastructure creation permissions that are required to create the VPC yourself, use this installation option.
+
+Because the installation program cannot know what other components are in your existing subnets, it cannot choose subnet CIDRs and so forth. You must configure networking for the subnets to which you will install the cluster.
+
+[id="installation-custom-ibm-cloud-vpc-requirements_{context}"]
+== Requirements for using your VPC
+
+You must correctly configure the existing VPC and its subnets before you install the cluster. The installation program does not create the following components:
+
+* NAT gateways
+* Subnets
+* Route tables
+* VPC network
+
+The installation program cannot:
+
+* Subdivide network ranges for the cluster to use
+* Set route tables for the subnets
+* Set VPC options like DHCP
+
+include::snippets/custom-dns-server.adoc[]
+
+[id="installation-custom-ibm-cloud-vpc-validation_{context}"]
+== VPC validation
+
+The VPC and all of the subnets must be in an existing resource group. The cluster is deployed to this resource group.
+
+As part of the installation, specify the following in the `install-config.yaml` file:
+
+* The name of the resource group
+* The name of VPC
+* The subnets for control plane machines and compute machines
+
+To ensure that the subnets that you provide are suitable, the installation program confirms the following:
+
+* All of the subnets that you specify exist.
+* For each availability zone in the region, you specify:
+** One subnet for control plane machines.
+** One subnet for compute machines.
+* The machine CIDR that you specified contains the subnets for the compute machines and control plane machines.
+
+[NOTE]
+====
+Subnet IDs are not supported.
+====
+
+[id="installation-custom-ibm-cloud-vpc-isolation_{context}"]
+== Isolation between clusters
+
+If you deploy {product-title} to an existing network, the isolation of cluster services is reduced in the following ways:
+
+* You can install multiple {product-title} clusters in the same VPC.
+
+* ICMP ingress is allowed to the entire network.
+
+* TCP port 22 ingress (SSH) is allowed to the entire network.
+
+* Control plane TCP 6443 ingress (Kubernetes API) is allowed to the entire network.
+
+* Control plane TCP 22623 ingress (MCS) is allowed to the entire network.

--- a/modules/installation-ibm-cloud-config-yaml.adoc
+++ b/modules/installation-ibm-cloud-config-yaml.adoc
@@ -2,12 +2,16 @@
 //
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 
 ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
 :with-networking:
 endif::[]
-ifeval::["{context}" != "installing-ibm-cloud-network-customizations"]
+ifeval::["{context}" == "installing-ibm-cloud-customizations"]
 :without-networking:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:vpc:
 endif::[]
 
 :_content-type: REFERENCE
@@ -18,9 +22,10 @@ You can customize the `install-config.yaml` file to specify more details about y
 
 [IMPORTANT]
 ====
-This sample YAML file is provided for reference only. You must obtain your `install-config.yaml` file by using the installation program and modify it.
+This sample YAML file is provided for reference only. You must obtain your `install-config.yaml` file by using the installation program and then modify it.
 ====
 
+ifdef::with-networking,without-networking[]
 [source,yaml]
 ----
 apiVersion: v1
@@ -79,33 +84,132 @@ capabilities:
 <1> Required. The installation program prompts you for this value.
 <2> If you do not provide these parameters and values, the installation program provides the default value.
 <3> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
-<4> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
+<4> Enables or disables simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
 +
 [IMPORTANT]
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger machine types, such as `n1-standard-8`, for your machines if you disable simultaneous multithreading.
 ====
 ifndef::openshift-origin[]
-<5> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<5> Enables or disables FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
-<6> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<6> Optional: provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<5> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<5> Optional: provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 +
 [NOTE]
 ====
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
+endif::with-networking,without-networking[]
+
+ifdef::vpc[]
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com <1>
+controlPlane: <2> <3>
+  hyperthreading: Enabled <4>
+  name: master
+  platform:
+    ibm-cloud: {}
+  replicas: 3
+compute: <2> <3>
+- hyperthreading: Enabled <4>
+  name: worker
+  platform:
+    ibmcloud: {}
+  replicas: 3
+metadata:
+  name: test-cluster <1>
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 <5>
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
+  networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  ibmcloud:
+    region: eu-gb <1>
+    resourceGroupName: eu-gb-example-network-rg <6>
+    vpcName: eu-gb-example-network-1 <7>
+    controlPlaneSubnets: <8>
+      - eu-gb-example-network-1-cp-eu-gb-1
+      - eu-gb-example-network-1-cp-eu-gb-2
+      - eu-gb-example-network-1-cp-eu-gb-3
+    computeSubnets: <9>
+      - eu-gb-example-network-1-compute-eu-gb-1
+      - eu-gb-example-network-1-compute-eu-gb-2
+      - eu-gb-example-network-1-compute-eu-gb-3
+credentialsMode: Manual
+publish: External
+pullSecret: '{"auths": ...}' <1>
+ifndef::openshift-origin[]
+fips: false <10>
+sshKey: ssh-ed25519 AAAA... <11>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+sshKey: ssh-ed25519 AAAA... <10>
+endif::openshift-origin[]
+capabilities:
+  baselineCapabilitySet: None
+  additionalEnabledCapabilities:
+  - openshift-samples
+----
+<1> Required. The installation program prompts you for this value.
+<2> If you do not provide these parameters and values, the installation program provides the default value.
+<3> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
+<4> Enables or disables simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
++
+[IMPORTANT]
+====
+If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger machine types, such as `n1-standard-8`, for your machines if you disable simultaneous multithreading.
+====
+<5> The machine CIDR must contain the subnets for the compute machines and control plane machines.
+<6> The name of an existing resource group. The existing VPC and subnets should be in this resource group. The cluster is deployed to this resource group.
+<7> Specify the name of an existing VPC.
+<8> Specify the name of the existing subnets to which to deploy the control plane machines. The subnets must belong to the VPC that you specified. Specify a subnet for each availability zone in the region.
+<9> Specify the name of the existing subnets to which to deploy the compute machines. The subnets must belong to the VPC that you specified. Specify a subnet for each availability zone in the region.
+ifndef::openshift-origin[]
+<10> Enables or disables FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
+<11> Optional: provide the `sshKey` value that you use to access the machines in your cluster.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<10> Optional: provide the `sshKey` value that you use to access the machines in your cluster.
+endif::openshift-origin[]
++
+[NOTE]
+====
+For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
+====
+endif::vpc[]
+
 
 ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
 :!with-networking:
 endif::[]
-ifeval::["{context}" != "installing-ibm-cloud-customizations"]
+ifeval::["{context}" == "installing-ibm-cloud-customizations"]
 :!without-networking:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:!vpc:
 endif::[]

--- a/modules/installation-ibm-cloud-export-variables.adoc
+++ b/modules/installation-ibm-cloud-export-variables.adoc
@@ -1,7 +1,18 @@
 // Module included in the following assemblies:
 //
-// installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
+
+ifeval::["{context}" == "installing-ibm-cloud-customizations"]
+:ibm-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
+:ibm-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:ibm-vpc:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="installation-ibm-cloud-export-variables_{context}"]
@@ -9,20 +20,32 @@
 
 You must set the IBM Cloud VPC API key you created as a global variable; the installation program ingests the variable during startup to set the API key.
 
-.Prerequisties
+.Prerequisites
 
 * You have created either a user API key or service ID API key for your IBM Cloud account.
 
 .Procedure
 
 * Export your IBM Cloud VPC API key as a global variable:
+ifdef::ibm-vpc[]
 +
 [source,terminal]
 ----
 $ export IC_API_KEY=<api_key>
 ----
+endif::ibm-vpc[]
 
 [IMPORTANT]
 ====
 You must set the variable name exactly as specified; the installation program expects the variable name to be present during startup.
 ====
+
+ifeval::["{context}" == "installing-ibm-cloud-customizations"]
+:!ibm-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
+:!ibm-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:!ibm-vpc:
+endif::[]

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -19,6 +19,7 @@
 // * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -97,6 +98,9 @@ ifeval::["{context}" == "installing-ibm-cloud-customizations"]
 :ibm-cloud:
 endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
+:ibm-cloud:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
 :ibm-cloud:
 endif::[]
 ifeval::["{context}" == "installing-openstack-installer-custom"]
@@ -235,7 +239,7 @@ endif::rhv[]
 ifdef::alibabacloud-default,alibabacloud-custom[]
 ... Specify *alibabacloud* as the platform to target.
 ... Specify the region to deploy the cluster to.
-... Specify the base domain to deploy the cluster to.  All DNS records will be sub-domains of this base and will also include the cluster name.
+... Specify the base domain to deploy the cluster to. All DNS records will be sub-domains of this base and will also include the cluster name.
 ... Specify a descriptive name for your cluster.
 endif::alibabacloud-default,alibabacloud-custom[]
 ifdef::aws[]
@@ -294,7 +298,7 @@ ifdef::vsphere,vmc[]
 ... Specify the user name and password for the vCenter account that has the required permissions to create the cluster.
 +
 The installation program connects to your vCenter instance.
-... Select the datacenter in your vCenter instance to connect to.
+... Select the data center in your vCenter instance to connect to.
 ... Select the default vCenter datastore to use.
 ... Select the vCenter cluster to install the {product-title} cluster in. The installation program uses the root resource pool of the vSphere cluster as the default resource pool.
 ... Select the network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
@@ -656,6 +660,9 @@ ifeval::["{context}" == "installing-ibm-cloud-customizations"]
 :!ibm-cloud:
 endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
+:!ibm-cloud:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
 :!ibm-cloud:
 endif::[]
 ifeval::["{context}" == "installing-openstack-installer-custom"]

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -21,6 +21,8 @@
 // * installing/installing_gcp/installing-gcp-default.adoc
 // * installing/installing_gcp/installing-gcp-vpc.adoc
 // * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+// * installing/installing_gcp/installing-ibm-cloud-customizations.adoc
+// * installing/installing_gcp/installing-ibm-cloud-vpc.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -225,6 +227,11 @@ ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
 :ibm-cloud:
 :single-step:
 endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:custom-config:
+:ibm-cloud:
+:single-step:
+endif::[]
 ifeval::["{context}" == "installing-nutanix-installer-provisioned"]
 :custom-config:
 :nutanix:
@@ -357,7 +364,7 @@ ifdef::vsphere,vmc[]
 .. Specify the user name and password for the vCenter account that has the required permissions to create the cluster.
 +
 The installation program connects to your vCenter instance.
-.. Select the datacenter in your vCenter instance to connect to.
+.. Select the data center in your vCenter instance to connect to.
 .. Select the default vCenter datastore to use.
 +
 [NOTE]
@@ -432,7 +439,7 @@ https://ovirtlab.example.com/ovirt-engine/api
 ----
 endif::openshift-origin[]
 +
-.. The installer automatically generates a CA certificate. For `Would you like to use the above certificate to connect to the {rh-virtualization-engine-name}?`, answer `y` or `N`. If you answer `N`, you must install {product-title} in insecure mode.
+.. The installation program automatically generates a CA certificate. For `Would you like to use the above certificate to connect to the {rh-virtualization-engine-name}?`, answer `y` or `N`. If you answer `N`, you must install {product-title} in insecure mode.
 //TODO: Add this sentence with xref after it's OK to add xrefs: For information about insecure mode, see xref:installing-rhv-insecure-mode_installing-rhv-default[].
 .. For `Engine username`, enter the user name and profile of the {rh-virtualization} administrator using this format:
 +
@@ -700,6 +707,11 @@ ifeval::["{context}" == "installing-ibm-cloud-customizations"]
 :!single-step:
 endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
+:!custom-config:
+:!ibm-cloud:
+:!single-step:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
 :!custom-config:
 :!ibm-cloud:
 :!single-step:

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -24,6 +24,7 @@
 // * installing/installing_gcp/installing-gcp-vpc.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
 // * installing/installing_openstack/installing-openstack-installer.adoc

--- a/modules/manually-create-iam-ibm-cloud.adoc
+++ b/modules/manually-create-iam-ibm-cloud.adoc
@@ -2,6 +2,17 @@
 //
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
+
+ifeval::["{context}" == "installing-ibm-cloud-customizations"]
+:ibm-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
+:ibm-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:ibm-vpc:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="manually-create-iam-ibm-cloud_{context}"]
@@ -27,9 +38,10 @@ apiVersion: v1
 baseDomain: cluster1.example.com
 credentialsMode: Manual <1>
 compute:
+ifdef::ibm-vpc[]
 - architecture: amd64
+endif::ibm-vpc[]
   hyperthreading: Enabled
-...
 ----
 <1> This line is added to set the `credentialsMode` parameter to `Manual`.
 
@@ -124,3 +136,13 @@ $ grep resourceGroupName <installation_directory>/manifests/cluster-infrastructu
 .Verification
 
 * Ensure that the appropriate secrets were generated in your cluster's `manifests` directory.
+
+ifeval::["{context}" == "installing-ibm-cloud-customizations"]
+:!ibm-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
+:!ibm-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:!ibm-vpc:
+endif::[]

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -27,6 +27,7 @@
 // * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
 // * installing/installing_openstack/installing-openstack-installer.adoc


### PR DESCRIPTION
Version(s):
4.12+

Issue:
This issue addresses [OSDOCS-4117](https://issues.redhat.com/browse/OSDOCS-4117)

Link to docs preview:

- [Supported installation methods for different platforms](https://50357--docspreview.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#supported-installation-methods-for-different-platforms)
- [Installing a cluster on IBM Cloud VPC into an existing VPC](https://50357--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.html)
- [About using a custom VPC](https://50357--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.html#installation-custom-ibm-cloud-vpc_installing-ibm-cloud-vpc)
- Installation configuration parameters > [Network configuration parameters](https://50357--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.html#installation-configuration-parameters-network_installing-ibm-cloud-vpc)
- Installation configuration parameters > [Additional IBM Cloud VPC configuration parameters](https://50357--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.html#installation-configuration-parameters-additional-ibm-cloud_installing-ibm-cloud-vpc)
- [Sample customized install-config.yaml file for IBM Cloud VPC](https://50357--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.html#installation-ibm-cloud-config-yaml_installing-ibm-cloud-vpc)