### PR TITLE
[RHACS] Added procedure: Creating additional routes ROX11325

### DIFF
--- a/modules/configure-ocp-oauth-identity-provider.adoc
+++ b/modules/configure-ocp-oauth-identity-provider.adoc
@@ -10,15 +10,20 @@ To integrate the built-in {ocp} OAuth server as an identity provider for {produc
 
 .Prerequisites
 * You must have the `AuthProvider` permission to configure identity providers in {product-title-short}.
-* You must have already configured users and groups in {ocp} OAuth server through an identity provider. For information about identity provider requirements, see "Understanding identity provider configuration" in the "Additional resources" section.
+* You must have already configured users and groups in {ocp} OAuth server through an identity provider. For information about the identity provider requirements, see link:https://docs.openshift.com/container-platform/4.9/authentication/understanding-identity-provider.html[Understanding identity provider configuration].
+
+[NOTE]
+====
+The following procedure configures only a single main route named `central` for the {ocp} OAuth server.
+====
 
 .Procedure
 . On the {product-title-short} portal, navigate to *Platform Configuration* -> *Access Control*.
 . Click *Create auth provider* and select *Auth0* from the drop-down list.
 . Enter a name for the authentication provider in the *Name* field.
 . Enter the *Auth0 tenant*, or the container where your `Auth0` data is configured and stored. The *Auth0 tenant* is in the form of a domain name (for example, `your-tenant.auth0.com`).
-. Enter the *Client ID*, or the unique identifier that you are using for authentication of your application. 
-. Assign a *Minimum access role* for users that access {product-title-short} using the selected identity provider. A user must have the permissions granted to this role or a role with higher permissions to log in to {product-title-short}. 
+. Enter the *Client ID*, or the unique identifier that you are using for authentication of your application.
+. Assign a *Minimum access role* for users that access {product-title-short} using the selected identity provider. A user must have the permissions granted to this role or a role with higher permissions to log in to {product-title-short}.
 +
 [TIP]
 ====

--- a/modules/create-additional-routes-ocp-oauth.adoc
+++ b/modules/create-additional-routes-ocp-oauth.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-user-access/configure-ocp-oauth.adoc
+:_module-type: PROCEDURE
+[id="create-additional-routes-ocp-oauth_{context}"]
+= Creating additional routes for {ocp} OAuth server
+
+When you configure {ocp} OAuth server as an identity provider by using {product-title} portal, {product-title-short} configures only a single route for the OAuth server.
+However, you can create additional routes by specifying them as annotations in the Central custom resource.
+
+.Prerequisites
+
+* You must have configured link:https://docs.openshift.com/container-platform/4.11/authentication/using-service-accounts-as-oauth-client.html#service-accounts-as-oauth-clients_using-service-accounts-as-oauth-client[Service accounts as OAuth clients] for your {ocp} OAuth server.
+
+.Procedure
+
+* If you installed {product-title-short} using the {product-title-short} Operator:
+. Create a `CENTRAL_ADDITIONAL_ROUTES` environment variable that contains a patch for the Central custom resource:
++
+[source,terminal]
+----
+$ CENTRAL_ADDITIONAL_ROUTES='
+spec:
+  central:
+    exposure:
+      loadBalancer:
+        enabled: false
+        port: 443
+      nodePort:
+        enabled: false
+      route:
+        enabled: true
+    persistence:
+      persistentVolumeClaim:
+        claimName: stackrox-db
+  customize:
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirecturi.main: sso/providers/openshift/callback <1>
+      serviceaccounts.openshift.io/oauth-redirectreference.main: "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"central\"}}" <2>
+      serviceaccounts.openshift.io/oauth-redirecturi.second: sso/providers/openshift/callback <3>
+      serviceaccounts.openshift.io/oauth-redirectreference.second: "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"second-central\"}}" <4>
+'
+----
+<1> The redirect URI for setting the main route.
+<2> The redirect URI reference for the main route.
+<3> The redirect for setting the second route.
+<4> The redirect reference for the second route.
+
+. Apply the `CENTRAL_ADDITIONAL_ROUTES` patch to the Central custom resource:
++
+[source,terminal]
+----
+$ oc patch centrals.platform.stackrox.io \
+  -n <namespace> \ <1>
+  <custom-resource> \ <2>
+  --patch "$CENTRAL_ADDITIONAL_ROUTES" \
+  --type=merge
+----
+<1> Replace `<namespace>` with the name of the project that contains the Central custom resource.
+<2> Replace `<custom-resource>` with the name of the Central custom resource.
+
+* Or, if you installed {product-title-short} using Helm:
+. Add the following annotations to your `values-public.yaml` file:
++
+[source,yaml]
+----
+customize:
+  central:
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirecturi.main: sso/providers/openshift/callback <1>
+      serviceaccounts.openshift.io/oauth-redirectreference.main: "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"central\"}}" <2>
+      serviceaccounts.openshift.io/oauth-redirecturi.second: sso/providers/openshift/callback <3>
+      serviceaccounts.openshift.io/oauth-redirectreference.second: "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"second-central\"}}" <4>
+----
+<1> The redirect for setting the main route.
+<2> The redirect reference for the main route.
+<3> The redirect for setting the second route.
+<4> The redirect reference for the second route.
+. Apply the custom annotations to the Central custom resource by using `helm upgrade`:
++
+[source,terminal]
+----
+$ helm upgrade -n stackrox \
+  stackrox-central-services rhacs/central-services \
+  -f <path_to_values_public.yaml> <1>
+----
+<1> Specify the path of the `values-public.yaml` configuration file using the `-f` option.

--- a/operating/manage-user-access/configure-ocp-oauth.adoc
+++ b/operating/manage-user-access/configure-ocp-oauth.adoc
@@ -13,7 +13,7 @@ include::modules/configure-ocp-oauth-identity-provider.adoc[leveloffset=+1]
 
 [IMPORTANT]
 ====
-* If you use a custom TLS certificate for {ocp} OAuth server, you must add the CA’s root certificate to {product-title} as a trusted root CA. Otherwise, Central cannot connect to the {ocp} OAuth server.
+* If you use a custom TLS certificate for {ocp} OAuth server, you must add the root certificate of the CA to {product-title} as a trusted root CA. Otherwise, Central cannot connect to the {ocp} OAuth server.
 * To enable the {ocp} OAuth server integration when installing {product-title} using the `roxctl` CLI, set the `ROX_ENABLE_OPENSHIFT_AUTH` environment variable to `true` in Central:
 +
 [source,terminal]
@@ -26,6 +26,12 @@ $ oc -n stackrox set env deploy/central ROX_ENABLE_OPENSHIFT_AUTH=true
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/authentication_and_authorization/understanding-identity-provider[Understanding identity provider configuration]
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/authentication_and_authorization/configuring-identity-providers#configuring-ldap-identity-provider[Configuring an LDAP identity provider]
-* xref:../../configuration/add-trusted-ca.adoc[Adding trusted certificate authorities ]
+* link:https://docs.openshift.com/container-platform/4.9/authentication/identity_providers/configuring-ldap-identity-provider.html[Configuring an LDAP identity provider]
+* xref:../../configuration/add-trusted-ca.adoc#add-trusted-ca[Adding trusted certificate authorities]
+
+include::modules/create-additional-routes-ocp-oauth.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.openshift.com/container-platform/4.11/authentication/using-service-accounts-as-oauth-client.html#service-accounts-as-oauth-clients_using-service-accounts-as-oauth-client[Service accounts as OAuth clients]
+* link:https://docs.openshift.com/container-platform/4.11/authentication/using-service-accounts-as-oauth-client.html#redirect-uris-for-service-accounts_using-service-accounts-as-oauth-client[Redirect URIs for service accounts as OAuth clients]


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-11325

Applies to:
- `rhacs-docs-3.69` (EOL: not needed anymore)
- `rhacs-docs-3.70`
- `rhacs-docs-3.71`
- `rhacs-docs-3.72`

Added procedure to create additional routes for OpenShift Container Platform OAuth server.

Preview: https://openshift-docs-git-rox11325-gnelson.vercel.app/openshift-acs/master/operating/manage-user-access/configure-ocp-oauth.html#create-additional-routes-ocp-oauth_configure-ocp-oauth