### PR TITLE
[RHACS] Added RHEL 9 for image scanning

### DIFF
--- a/modules/scanning-images.adoc
+++ b/modules/scanning-images.adoc
@@ -73,7 +73,7 @@ Scanner identifies vulnerabilities in images that contain the following Linux di
 | `debian:9`, `debian:10`, `debian:11`, `debian:unstable`
 
 | link:https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux[{op-system-base-full}]
-| `rhel:6`, `rhel:7`, `rhel:8`
+| `rhel:6`, `rhel:7`, `rhel:8`, `rhel:9`
 
 | link:http://releases.ubuntu.com/[Ubuntu]
 | `ubuntu:14.04`, `ubuntu:16.04`, `ubuntu:18.04`, `ubuntu:20.04`, `ubuntu:21.10`, `ubuntu:22.04`


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-12528 

Preview: https://openshift-docs-git-rox12528-gnelson.vercel.app/openshift-acs/master/operating/examine-images-for-vulnerabilities.html#supported-operating-systems

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
