### PR TITLE
BZ#2126531: Downstream docs show literal "mtc-legacy-version-z" instead of "1.7"

### DIFF
--- a/modules/migration-upgrading-mtc-with-legacy-operator.adoc
+++ b/modules/migration-upgrading-mtc-with-legacy-operator.adoc
@@ -24,7 +24,7 @@ endif::[]
 
 .Procedure
 
-. Log in to `registry.redhat.io` with your Red Hat Customer Portal credentials:
+. Log in to `registry.redhat.io` with your Red Hat Customer Portal credentials by entering the following command:
 +
 [source,terminal]
 ----
@@ -39,43 +39,43 @@ $ sudo podman cp $(sudo podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/operator.yml ./
 ----
 
-. Replace the {mtc-full} Operator:
+. Replace the {mtc-full} Operator by entering the following command:
 +
 [source,terminal]
 ----
 $ oc replace --force -f operator.yml
 ----
 
-. Scale the `migration-operator` deployment to `0` to stop the deployment:
+. Scale the `migration-operator` deployment to `0` to stop the deployment by entering the following command:
 +
 [source,terminal]
 ----
 $ oc scale -n openshift-migration --replicas=0 deployment/migration-operator
 ----
 
-. Scale the `migration-operator` deployment to `1` to start the deployment and apply the changes:
+. Scale the `migration-operator` deployment to `1` to start the deployment and apply the changes by entering the following command:
 +
 [source,terminal]
 ----
 $ oc scale -n openshift-migration --replicas=1 deployment/migration-operator
 ----
 
-. Verify that the `migration-operator` was upgraded:
+. Verify that the `migration-operator` was upgraded by entering the following command:
 +
 [source,terminal]
 ----
 $ oc -o yaml -n openshift-migration get deployment/migration-operator | grep image: | awk -F ":" '{ print $NF }'
 ----
 
-. Download the `controller.yml` file:
+. Download the `controller.yml` file by entering the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/controller.yml ./
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/controller.yml ./
 ----
 
-. Create the `migration-controller` object:
+. Create the `migration-controller` object by entering the following command:
 +
 [source,terminal]
 ----
@@ -85,7 +85,7 @@ $ oc create -f controller.yml
 ifdef::upgrading-3-4[]
 . If you have previously added the {product-title} 3 cluster to the {mtc-short} web console, you must update the service account token in the web console because the upgrade process deletes and restores the `openshift-migration` namespace:
 
-.. Obtain the service account token:
+.. Obtain the service account token by entering the following command:
 +
 [source,terminal]
 ----
@@ -98,7 +98,7 @@ $ oc sa get-token migration-controller -n openshift-migration
 .. Click *Update cluster* and then click *Close*.
 endif::[]
 
-. Verify that the {mtc-short} pods are running:
+. Verify that the {mtc-short} pods are running by entering the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
MTC 1.7.4 OCP 4.6+

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2126531

Preview: http://file.emea.redhat.com/rhoch/mtc_literal/migrating_from_ocp_3_to_4/upgrading-3-4.html#migration-upgrading-mtc-with-legacy-operator_upgrading-3-4 (step 7)