### PR TITLE
OCPBUGS-848 - Adding clarity for Red Hat support of Redfish firmware combinations

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -6,23 +6,25 @@
 [id='ipi-install-firmware-requirements-for-installing-with-virtual-media_{context}']
 = Firmware requirements for installing with virtual media
 
-The installer for installer-provisioned {product-title} clusters validates the hardware and firmware compatibility with Redfish virtual media. The following table lists supported firmware for installer-provisioned {product-title} clusters deployed with Redfish virtual media.
+The installer for installer-provisioned {product-title} clusters validates the hardware and firmware compatibility with Redfish virtual media. The following table lists the minimum firmware versions tested and verified to work for installer-provisioned {product-title} clusters deployed by using Redfish virtual media.
 
 .Firmware compatibility for Redfish virtual media
 [frame="topbot", options="header"]
 |====
-|Hardware| Model | Management | Firmware Versions
-| HP | 10th Generation | iLO5 | 2.63
+|Hardware| Model | Management | Firmware versions
+| HP | 10th Generation | iLO5 | 2.63 or later
 
-.2+| Dell | 14th Generation | iDRAC 9 | v4.20.20.20 - 04.40.00.00
+.2+| Dell | 14th Generation | iDRAC 9 | v4.20.20.20 - v4.40.00.00 only
 
-| 13th Generation .2+| iDRAC 8 | v2.75.75.75+
+| 13th Generation .2+| iDRAC 8 | v2.75.75.75 or later
 
 |====
 
 [NOTE]
 ====
-See the hardware documentation for the nodes or contact the hardware vendor for information on updating the firmware.
+Red Hat does not test every combination of firmware, hardware, or other third-party components. For further information about third-party support, see link:https://access.redhat.com/third-party-software-support[Red Hat third-party support policy].
+
+See the hardware documentation for the nodes or contact the hardware vendor for information about updating the firmware.
 
 For HP servers, Redfish virtual media is not supported on 9th generation systems running iLO4, because Ironic does not support iLO4 with virtual media.
 


### PR DESCRIPTION
OCPBUGS#848: Adding a note saying Red Hat does not test every combination of firmware and hardware or other third-party components and directing users to Red Hat's third-party software support policy.

Version(s):
4.8+

Issue: https://issues.redhat.com/browse/OCPBUGS-848

Link to docs preview: http://file.emea.redhat.com/rohennes/OCPBUGS-848-clarify-IPI-support/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites
