### PR TITLE
GI:46001 fixed typo for table header in compatibility guidelines section

### DIFF
--- a/modules/migration-compatibility-guidelines.adoc
+++ b/modules/migration-compatibility-guidelines.adoc
@@ -24,7 +24,7 @@ remote cluster:: A source or destination cluster for a migration that runs Veler
 [cols="1,2,2", options="header"]
 .{mtc-short} compatibility: Migrating from a legacy platform
 |===
-||{product-title} 4.5 or earlier |{product-title} 4.6 later
+||{product-title} 4.5 or earlier |{product-title} 4.6 or later
 |Stable {mtc-short} version a|{mtc-short} {mtc-version}._z_
 
 Legacy {mtc-version} operator: Install manually with the `operator.yml` file.


### PR DESCRIPTION
This PR is a typo fix for a header in Table 1 of the "Installing MTC" page. The title of the second column header has been changed from "OpenShift Container Platform 4.6 later" to "OpenShift Container Platform 4.6 or later".

Version(s):
4.6+

Issue:
https://github.com/openshift/openshift-docs/issues/46001

Link to docs preview:
https://50402--docspreview.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc.html