### PR TITLE
SRVKS-951: Add internal TLS enablement docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3624,6 +3624,8 @@ Topics:
 - Name: Security
   Dir: security
   Topics:
+  - Name: Configuring TLS authentication
+    File: serverless-config-tls
   - Name: Configuring JSON Web Token authentication for Knative services
     File: serverless-ossm-with-kourier-jwt
   - Name: Configuring a custom domain for a Knative service

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -166,14 +166,14 @@ Topics:
 - Name: Upgrading OpenShift Dedicated
   File: osd-upgrades
   Distros: openshift-dedicated
----  
+---
 Name: CI/CD
 Dir: cicd
 Distros: openshift-dedicated
 Topics:
 - Name: Builds
   Dir: builds
-  Distros: openshift-dedicated 
+  Distros: openshift-dedicated
   Topics:
   - Name: Setting up additional trusted certificate authorities for builds
     File: setting-up-trusted-ca
@@ -355,6 +355,8 @@ Topics:
 - Name: Security
   Dir: security
   Topics:
+  - Name: Configuring TLS authentication
+    File: serverless-config-tls
   - Name: Configuring JSON Web Token authentication for Knative services
     File: serverless-ossm-with-kourier-jwt
   - Name: Configuring a custom domain for a Knative service

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -554,6 +554,8 @@ Topics:
 - Name: Security
   Dir: security
   Topics:
+  - Name: Configuring TLS authentication
+    File: serverless-config-tls
   - Name: Configuring JSON Web Token authentication for Knative services
     File: serverless-ossm-with-kourier-jwt
   - Name: Configuring a custom domain for a Knative service

--- a/modules/serverless-domain-mapping-custom-tls-cert.adoc
+++ b/modules/serverless-domain-mapping-custom-tls-cert.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * serverless/security/serverless-custom-domains.adoc
+// * /serverless/security/serverless-custom-domains.adoc
+// * /serverless/security/serverless-config-tls.adoc
 
 :_content-type: PROCEDURE
 [id="serverless-domain-mapping-custom-tls-cert_{context}"]

--- a/modules/serverless-enabling-tls-internal-traffic.adoc
+++ b/modules/serverless-enabling-tls-internal-traffic.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * /serverless/security/serverless-config-tls.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-enabling-tls-internal-traffic_{context}"]
+= Enabling TLS authentication for internal traffic
+
+{ServerlessProductName} supports TLS edge termination by default, so that HTTPS traffic from end users is encrypted. However, internal traffic behind the OpenShift route is forwarded to applications by using plain data. By enabling TLS for internal traffic, the traffic sent between components is encrypted, which makes this traffic more secure.
+
+[NOTE]
+====
+If you want to enable internal TLS with a {SMProductName} integration, you must enable {SMProductShortName} with mTLS instead of the internal encryption explained in the following procedure.
+====
+
+:FeatureName: Internal TLS encryption support
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have installed the OpenShift (`oc`) CLI.
+
+.Procedure
+
+. Create a Knative service that includes the `internal-encryption: "true"` field in the spec:
++
+[source,yaml]
+----
+...
+spec:
+  config:
+    network:
+      internal-encryption: "true"
+...
+----
+
+. Restart the activator pods in the `knative-serving` namespace to load the certificates:
++
+[source,terminal]
+----
+$ oc delete pod -n knative-serving --selector app=activator
+----

--- a/modules/serverless-enabling-tls-local-services.adoc
+++ b/modules/serverless-enabling-tls-local-services.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * /serverless/security/serverless-config-tls.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-enabling-tls-local-services_{context}"]
+= Enabling TLS authentication for cluster local services
+
+For cluster local services, the Kourier local gateway `kourier-internal` is used. If you want to use TLS traffic against the Kourier local gateway, you must configure your own server certificates in the local gateway.
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have administrator permissions.
+* You have installed the OpenShift (`oc`) CLI.
+
+.Procedure
+
+. Deploy server certificates in the `knative-serving-ingress` namespace:
++
+[source,terminal]
+----
+$ export san="knative"
+----
++
+[NOTE]
+====
+Subject Alternative Name (SAN) validation is required so that these certificates can serve the request to `<app_name>.<namespace>.svc.cluster.local`.
+====
+
+. Generate a root key and certificate:
++
+[source,terminal]
+----
+$ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
+    -subj '/O=Example/CN=Example' \
+    -keyout ca.key \
+    -out ca.crt
+----
+
+. Generate a server key that uses SAN validation:
++
+[source,terminal]
+----
+$ openssl req -out tls.csr -newkey rsa:2048 -nodes -keyout tls.key \
+  -subj "/CN=Example/O=Example" \
+  -addext "subjectAltName = DNS:$san"
+----
+
+. Create server certificates:
++
+[source,terminal]
+----
+$ openssl x509 -req -extfile <(printf "subjectAltName=DNS:$san") \
+  -days 365 -in tls.csr \
+  -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt
+----
+
+. Configure a secret for the Kourier local gateway:
+.. Deploy a secret in `knative-serving-ingress` namespace from the certificates created by the previous steps:
++
+[source,terminal]
+----
+$ oc create -n knative-serving-ingress secret tls server-certs \
+    --key=tls.key \
+    --cert=tls.crt --dry-run=client -o yaml | oc apply -f -
+----
+
+.. Update the `KnativeServing` custom resource (CR) spec to use the secret that was created by the Kourier gateway:
++
+.Example KnativeServing CR
+[source,yaml]
+----
+...
+spec:
+  config:
+    kourier:
+      cluster-cert-secret: server-certs
+...
+----
+
+The Kourier controller sets the certificate without restarting the service, so that you do not need to restart the pod.
+
+You can access the Kourier internal service with TLS through port `443` by mounting and using the `ca.crt` from the client.

--- a/modules/serverless-kafka-broker-tls-default-config.adoc
+++ b/modules/serverless-kafka-broker-tls-default-config.adoc
@@ -1,6 +1,7 @@
 // Module is included in the following assemblies:
 //
 // * serverless/admin_guide/serverless-kafka-admin.adoc
+// * /serverless/security/serverless-config-tls.adoc
 
 :_content-type: PROCEDURE
 [id="serverless-kafka-broker-tls-default-config_{context}"]

--- a/modules/serverless-kafka-tls-channels.adoc
+++ b/modules/serverless-kafka-tls-channels.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * serverless/admin_guide/serverless-kafka-admin.adoc
+// * /serverless/admin_guide/serverless-kafka-admin.adoc
+// * /serverless/security/serverless-config-tls.adoc
 
 :_content-type: PROCEDURE
 [id="serverless-kafka-tls-channels_{context}"]

--- a/serverless/security/serverless-config-tls.adoc
+++ b/serverless/security/serverless-config-tls.adoc
@@ -1,0 +1,29 @@
+:_content-type: ASSEMBLY
+[id="serverless-config-tls"]
+= Configuring TLS authentication
+include::_attributes/common-attributes.adoc[]
+:context: serverless-config-tls
+
+toc::[]
+
+You can use _Transport Layer Security_ (TLS) to encrypt Knative traffic and for authentication.
+
+TLS is the only supported method of traffic encryption for Knative Kafka. Red Hat recommends using both SASL and TLS together for Knative Kafka resources.
+
+[NOTE]
+====
+If you want to enable internal TLS with a {SMProductName} integration, you must enable {SMProductShortName} with mTLS instead of the internal encryption explained in the following procedure. See the documentation for xref:../../serverless/admin_guide/serverless-ossm-setup.adoc#serverless-ossm-enabling-serving-metrics_serverless-ossm-setup[Enabling Knative Serving metrics when using Service Mesh with mTLS].
+====
+
+include::modules/serverless-enabling-tls-internal-traffic.adoc[leveloffset=+1]
+include::modules/serverless-enabling-tls-local-services.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../serverless/admin_guide/serverless-ossm-setup.adoc#serverless-ossm-enabling-serving-metrics_serverless-ossm-setup[Enabling Knative Serving metrics when using Service Mesh with mTLS]
+
+include::modules/serverless-domain-mapping-custom-tls-cert.adoc[leveloffset=+1]
+
+// TLS for kafka
+include::modules/serverless-kafka-broker-tls-default-config.adoc[leveloffset=+1]
+include::modules/serverless-kafka-tls-channels.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
OCP 4.6+ except 4.7, OSD, ROSA

Issue:
https://issues.redhat.com/browse/SRVKS-951

Link to docs preview:
- OCP: https://50404--docspreview.netlify.app/openshift-enterprise/latest/serverless/security/serverless-config-tls.html
- OSD: https://50404--docspreview.netlify.app/openshift-dedicated/latest/serverless/security/serverless-config-tls.html
- ROSA: https://50404--docspreview.netlify.app/openshift-rosa/latest/serverless/security/serverless-config-tls.html