### PR TITLE
[enterprise-4.10]GH#46935: Fix indentation in the sample remediation template YAML file

### DIFF
--- a/modules/eco-poison-pill-operator-about.adoc
+++ b/modules/eco-poison-pill-operator-about.adoc
@@ -67,15 +67,15 @@ The `PoisonPillRemediationTemplate` CR resembles the following YAML file:
 apiVersion: poison-pill.medik8s.io/v1alpha1
 kind: PoisonPillRemediationTemplate
 metadata:
-creationTimestamp: "2022-03-02T08:02:40Z"
-generation: 1
-name: poison-pill-default-template
-namespace: openshift-operators
-resourceVersion: "596469"
-uid: 5d29e437-c485-48fa-ba9e-0354649afd31
+  creationTimestamp: "2022-03-02T08:02:40Z"
+  generation: 1
+  name: poison-pill-default-template
+  namespace: openshift-operators
+  resourceVersion: "596469"
+  uid: 5d29e437-c485-48fa-ba9e-0354649afd31
 spec:
-template:
-spec:
-remediationStrategy: NodeDeletion <1>
+  template:
+    spec:
+      remediationStrategy: NodeDeletion <1>
 ----
 <1> Specifies the remediation strategy. The default remediation strategy is `NodeDeletion`.


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/46935: Fixes indentation in the sample remediation template YAML

Version(s):
OpenShift 4.10 only

Issue:
https://github.com/openshift/openshift-docs/issues/46935

Link to docs preview:
http://file.rdu.redhat.com/avbhatt/issue-46935/nodes/nodes/eco-poison-pill-operator.html#understanding-poison-pill-remediation-template-config_poison-pill-operator-remediate-nodes
