### PR TITLE
OSDOCS-4140: Ported routes to OSD/ROSA

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -222,6 +222,13 @@ Topics:
     File: deleting-network-policy
   - Name: Configuring multitenant isolation with network policy
     File: multitenant-network-policy
+- Name: Configuring Routes
+  Dir: routes
+  Topics:
+  - Name: Route configuration
+    File: route-configuration
+  - Name: Secured routes
+    File: secured-routes
 ---
 Name: Applications
 Dir: applications

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -326,6 +326,13 @@ Topics:
     File: deleting-network-policy
   - Name: Configuring multitenant isolation with network policy
     File: multitenant-network-policy
+- Name: Configuring Routes
+  Dir: routes
+  Topics:
+  - Name: Route configuration
+    File: route-configuration
+  - Name: Secured routes
+    File: secured-routes
 ---
 Name: Application development
 Dir: applications

--- a/modules/nw-creating-a-route.adoc
+++ b/modules/nw-creating-a-route.adoc
@@ -47,10 +47,18 @@ $ oc expose pod/hello-openshift
 ----
 $ oc expose svc hello-openshift
 ----
+
+.Verification
+
+* To verify that the `route` resource that you created, run the following command:
 +
-If you examine the resulting `Route` resource, it should look similar to the following:
-+
-.YAML definition of the created unsecured route:
+[source,terminal]
+----
+$ oc get routes -o yaml <name of resource> <1>
+----
+<1> In this example, the route is named `hello-openshift`. 
+
+.Sample YAML definition of the created unsecured route:
 [source,yaml]
 ----
 apiVersion: route.openshift.io/v1

--- a/modules/nw-disabling-hsts.adoc
+++ b/modules/nw-disabling-hsts.adoc
@@ -34,11 +34,11 @@ metadata:
 ----
 ====
 
-* To disable HSTS for every route in a namespace, enter the followinf command:
+* To disable HSTS for every route in a namespace, enter the following command:
 +
 [source,terminal]
 ----
-$ oc annotate <route> --all -n <namespace> --overwrite=true "haproxy.router.openshift.io/hsts_header"="max-age=0"
+$ oc annotate route --all -n <namespace> --overwrite=true "haproxy.router.openshift.io/hsts_header"="max-age=0"
 ----
 
 .Verification

--- a/modules/nw-enabling-hsts-per-route.adoc
+++ b/modules/nw-enabling-hsts-per-route.adoc
@@ -14,7 +14,19 @@ HTTP strict transport security (HSTS) is implemented in the HAProxy template and
 
 .Procedure
 
-* To enable HSTS on a route, add the `haproxy.router.openshift.io/hsts_header` value to the edge-terminated or re-encrypt route:
+* To enable HSTS on a route, add the `haproxy.router.openshift.io/hsts_header` value to the edge-terminated or re-encrypt route. You can use the `oc annotate` tool to do this by running the following command:
++
+[source,terminal]
+----
+$ oc annotate route <rout_name> -n <namespace> --overwrite=true "haproxy.router.openshift.io/hsts_header"="max-age=31536000;\ <1> 
+includeSubDomains;preload"
+----
+<1> In this example, the maximum age is set to `31536000` ms, which is approximately eight and a half hours.
++
+[NOTE]
+====
+In this example, the equal sign (`=`) is in quotes. This is required to properly execute the annotate command. 
+====
 +
 .Example route configured with an annotation
 [source,yaml]

--- a/networking/routes/route-configuration.adoc
+++ b/networking/routes/route-configuration.adoc
@@ -4,16 +4,18 @@
 [id="route-configuration"]
 = Route configuration
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: route-configuration
 
 toc::[]
 
-
 //Creating an insecure route
 include::modules/nw-creating-a-route.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 // Creating a route for router sharding
 include::modules/nw-ingress-sharding-route-configuration.adoc[leveloffset=+1]
+endif::[]
 
 //Creating route timeouts
 include::modules/nw-configuring-route-timeouts.adoc[leveloffset=+1]
@@ -27,6 +29,7 @@ include::modules/nw-enabling-hsts-per-route.adoc[leveloffset=+2]
 //Disabling HTTP strict transport security per-route
 include::modules/nw-disabling-hsts.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 //Enforcing HTTP strict transport security per-domain
 include::modules/nw-enforcing-hsts-per-domain.adoc[leveloffset=+2]
 
@@ -38,7 +41,10 @@ include::modules/nw-throughput-troubleshoot.adoc[leveloffset=+1]
 
 * xref:../../nodes/edge/nodes-edge-remote-workers.adoc#nodes-edge-remote-workers-latency[Latency spikes or temporary reduction in throughput to remote workers]
 
-* xref:../../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration parameters]
+
+* xref:../../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration 
+parameters]
+endif::[]
 
 //Using cookies to keep route statefulness
 include::modules/nw-using-cookies-keep-route-statefulness.adoc[leveloffset=+1]
@@ -49,9 +55,11 @@ include::modules/nw-path-based-routes.adoc[leveloffset=+1]
 
 include::modules/nw-route-specific-annotations.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/nw-route-admission-policy.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-creating-a-route-via-an-ingress.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/nw-ingress-reencrypt-route-custom-cert.adoc[leveloffset=+1]
 

--- a/networking/routes/secured-routes.adoc
+++ b/networking/routes/secured-routes.adoc
@@ -2,6 +2,7 @@
 [id="configuring-default-certificate"]
 = Secured routes
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: secured-routes
 
 toc::[]


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-4140](https://issues.redhat.com/browse/OSDOCS-4140)

Link to docs preview:

**ROSA**
- [Route Configuration](https://50436--docspreview.netlify.app/openshift-rosa/latest/networking/routes/route-configuration.html) 
- [Secured Routes](https://50436--docspreview.netlify.app/openshift-rosa/latest/networking/routes/secured-routes.html)

**OSD**
- [Route Configuration](https://50436--docspreview.netlify.app/openshift-dedicated/latest/networking/routes/route-configuration.html) 
- [Secured Routes](https://50436--docspreview.netlify.app/openshift-dedicated/latest/networking/routes/secured-routes.html)

The following sections are OCP exclusive and removed from ROSA/OSD:

- [Creating a route for Ingress Controller Sharding](https://docs.openshift.com/container-platform/4.11/networking/routes/route-configuration.html#nw-ingress-sharding-route-configuration_route-configuration)
- [Enforcing HTTP Strict Transport Security per-domain](https://docs.openshift.com/container-platform/4.11/networking/routes/route-configuration.html#nw-enforcing-hsts-per-domain_route-configuration)
- [Throughput issue troubleshooting methods](https://docs.openshift.com/container-platform/4.11/networking/routes/route-configuration.html#nw-throughput-troubleshoot_route-configuration)
- [Configuring the route admission policy](https://docs.openshift.com/container-platform/4.11/networking/routes/route-configuration.html#nw-route-admission-policy_route-configuration)
- [Creating a Route using an Ingress Object](https://docs.openshift.com/container-platform/4.11/networking/routes/route-configuration.html#nw-ingress-creating-a-route-via-an-ingress_route-configuration)

Additional information:
Adds the routing books to OSD/ROSA topic maps.