### PR TITLE
[RHACS] Added legend info for Network Graph

### DIFF
--- a/modules/network-graph-view.adoc
+++ b/modules/network-graph-view.adoc
@@ -11,7 +11,7 @@ The network graph provides visibility and control over:
 * The allowed network connections, as defined by the Kubernetes network policies.
 * The active communications paths among namespaces and deployments.
 
-In the menu bar, choose the cluster for which to view information and at least one namespace.
+In the menu bar, choose the cluster for which you want to view information and at least one namespace.
 
 In the *Network Graph* view, you can configure the type of connections you want to see.
 In the *Flows* section (upper left), select:
@@ -20,25 +20,19 @@ In the *Flows* section (upper left), select:
 * *Allowed* to view only allowed network connections.
 * *All* to view both active and allowed network connections.
 
-In the network graph, each circle represents a deployment, each surrounding box represents a Kubernetes namespace, and each thick line represents connection between namespaces.
-You can hover over these items to view more details. Clicking on an item such as a deployment or a namespace opens a window that displays additional information. The window can be expanded and collapsed by selecting the arrow in the blue bar.
+In the *Network Graph*, click *Legend* to view information about the symbols in use and their meaning. The legend shows explanatory text for symbols representing namespaces, deployments, and connections on the network graph.
 
-To understand the meaning of other symbols in the network graph, move your mouse over other symbols in the legend (lower left) to view the tooltip indicating the meaning of those symbols.
+Clicking on an item in the *Network Graph*, such as a deployment or a namespace, opens a window that displays additional information. You can expand and collapse the window by selecting the arrow in the blue bar.
 
 When you hover over:
 
-* a connection, you see information about the network flow, which includes active connections, port numbers and protocols in use.
+* a connection, you see information about the network flow, which includes active connections, port numbers, and protocols in use.
 * a deployment, you see information about ingress and egress connections, protocols, port numbers in use, and the direction of the network traffic between deployments.
-
-[NOTE]
-====
-You need {product-title} version 3.0.47 or newer to see information about ingress and egress connections, protocols, port numbers, and the direction of the network traffic.
-====
 
 [discrete]
 == Allowed network connections
 
-{product-title} processes all network policies in each secured cluster to show you which deployments can contact each other, and which can reach external networks.
+{product-title} processes all network policies in each secured cluster to show you which deployments can contact each other and which can reach external networks.
 
 The network graph shows possible network connections as dashed lines.
 
@@ -59,26 +53,16 @@ The *Network Flows* details panel show both anomalous and baseline flows.
 From this panel, you can:
 
 * Mark network flows from the baseline as anomalous by selecting *Mark as Anomalous*.
-* Add network flows to baseline from the anomalous flows by selecting *Add to Baseline*.
-
-[NOTE]
-====
-To use the *Network baseline* feature, you must use {product-title} version 3.0.54 or newer.
-====
+* Add network flows to the baseline from the anomalous flows by selecting *Add to Baseline*.
 
 [discrete]
 == External entities and connections
 
-The *Network Graph* view shows information about network connections between managed clusters and external sources.
-{product-title} also automatically discovers and highlights public CIDR (Classless Inter-Domain	Routing) addresses blocks, such as Google Cloud, AWS, Azure, Oracle Cloud, and Cloudflare.
-Using this information, you can identify deployments with active external connections and if they are making or receiving unauthorized connections from outside of your network.
+The *Network Graph* view shows network connections between managed clusters and external sources.
+In addition, {product-title} automatically discovers and highlights public Classless Inter-Domain Routing (CIDR) address blocks, such as Google Cloud, AWS, Azure, Oracle Cloud, and Cloudflare.
+Using this information, you can identify deployments with active external connections and determine if they are making or receiving unauthorized connections from outside your network.
 
-[NOTE]
-====
-You need {product-title} version 3.0.52 or newer to see information about active external connections.
-====
-
-By default, the external connections point to a common *External Entities* box, and different CIDR addresses blocks in the *Network Graph* view.
+By default, the external connections point to a common *External Entities* box and different CIDR address blocks in the *Network Graph* view.
 However, you can choose not to show auto-discovered CIDR blocks.
 
 {product-title} includes IP ranges for the following cloud providers:
@@ -91,4 +75,3 @@ However, you can choose not to show auto-discovered CIDR blocks.
 
 {product-title} fetches and updates the cloud providers' IP ranges every 7 days.
 If you are using offline mode,  you can update these ranges by installing new support packages.
-//Link to offline docs

--- a/operating/manage-network-policies.adoc
+++ b/operating/manage-network-policies.adoc
@@ -20,6 +20,10 @@ To support network policy enforcement, {product-title} provides:
 
 include::modules/network-graph-view.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../configuration/enable-offline-mode.adoc#update-kernel-support-packages_enable-offline-mode[Updating kernel support packages in offline mode]
+
 include::modules/view-network-policies.adoc[leveloffset=+2]
 
 include::modules/configure-cidr-blocks.adoc[leveloffset=+2]


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-12089

Merge into `rhacs-docs-3.72.0`

- Removed old admonitions which are not required anymore.
- Fixed a few sentences
- Added additional link 

Preview: https://openshift-docs-git-rox-12089-gnelson.vercel.app/openshift-acs/master/operating/manage-network-policies.html#network-graph-view_manage-network-policies

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
