### PR TITLE
TELCODOCS-422 RN for MetalLB node selector

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -74,6 +74,12 @@ For more information, see xref:../installing/installing-troubleshooting.adoc#ins
 [id="ocp-4-12-networking"]
 === Networking
 
+[id="ocp-4-12-announce-IP-from-node-subset-metallb"]
+==== Advertise MetalLB from a given address pool from a subset of nodes
+With this update, in BGP mode, you can use the node selector to advertise the MetalLB service from a subset of nodes, using a specific pool of IP addresses. This feature was introduced as a Technology Preview feature in {product-title} 4.11 and is now generally available in {product-title} 4.12 for BGP mode only. L2 mode remains a Technology Preview feature.
+
+For more information, see xref:../networking/metallb/about-advertising-ipaddresspool.adoc#nw-metallb-advertise-ip-pools-to-node-subset_about-advertising-ip-address-pool[Advertising an IP address pool from a subset of nodes].
+
 [id="ocp-4-12-storage"]
 === Storage
 


### PR DESCRIPTION
[TELCODOCS-422](https://issues.redhat.com//browse/TELCODOCS-422): You can use the node selector specification to advertise MetalLB from an IP address from a given IP address pool, and from a specific set of nodes. This was introduced in BGP/L2 mode as TP in 4.11. With this update, BGP mode only is going GA. L2 mode is still TP.

Version(s): 4.12

Issue: https://issues.redhat.com/browse/TELCODOCS-422

Link to docs preview: http://file.emea.redhat.com/rohennes/TELCODOCS-422-RN-metal-node-selector/release_notes/ocp-4-12-release-notes.html#ocp-4-12-acannounce-IP-from-node-subset-metallb
