### PR TITLE
GitHub-39899: Removing reference to the sub claim

### DIFF
--- a/modules/identity-provider-oidc-CR.adoc
+++ b/modules/identity-provider-oidc-CR.adoc
@@ -43,9 +43,7 @@ identity name. It is also used to build the redirect URL.
 client must be allowed to redirect to
 `\https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>`.
 <4> Reference to an {product-title} `Secret` object containing the client secret.
-<5> List of claims to use as the identity. First non-empty claim is used. At
-least one claim is required. If none of the listed claims have a value,
-authentication fails. For example, this uses the value of the `sub` claim in the returned `id_token` as the user's identity.
+<5> The list of claims to use as the identity. The first non-empty claim is used.
 <6> link:https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier[Issuer Identifier]
 described in the OpenID spec. Must use `https` without query or fragment
 component.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.6-4.9

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
GH #39899

Link to docs preview:
http://file.rdu.redhat.com/~ahoffer/2022/github-39899/authentication/identity_providers/configuring-oidc-identity-provider.html#identity-provider-oidc-CR_configuring-oidc-identity-provider

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
Uses the wording already merged in #40702, bringing back to 4.6-4.9.


