### PR TITLE
[RHACS] Add how to view Dockerfile line that adds CVE

### DIFF
--- a/modules/identify-container-image-layer-that-introduces-vulnerabilities.adoc
+++ b/modules/identify-container-image-layer-that-introduces-vulnerabilities.adoc
@@ -11,8 +11,7 @@ Use the *Vulnerability Management* view to identify vulnerable components and th
 
 .Procedure
 
-. Navigate to the RHACS portal and click *Vulnerability Management* from the navigation menu.
-. Select an image from the *Top Riskiest Images* widget.
-. In the *Image* details view, select the *Dockerfile* tab under the *Image Findings* section.
-. In the *Dockerfile* tab under the *Image Findings* section, select the expand icon to see a summary of image components.
+. Navigate to the {product-title-short} portal and click *Vulnerability Management* from the navigation menu.
+. Select an image from either the *Top Riskiest Images* widget or click the *Images* button at the top of the Dashboard and select an image.
+. In the *Image* details view, next to *Dockerfile*, select the expand icon to see a summary of image components.
 . Select the expand icon for specific components to get more details about the CVEs affecting the selected component.

--- a/modules/identify-dockerfile-line-component-cve.adoc
+++ b/modules/identify-dockerfile-line-component-cve.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-vulnerabilities.adoc
+// * operating/examine-images-for-vulnerabilities.adoc
+:_content-type: PROCEDURE
+[id="identify-dockerfile-line-component-cve_{context}"]
+= Identifying the Dockerfile line in an image that adds a component with a CVE
+
+[role="_abstract"]
+You can identify the specific Dockerfile line in an image that adds a component that has been identified as having a CVE. 
+
+.Procedure
+
+To view the problematic line:
+
+. Navigate to the {product-title-short} portal and click *Vulnerability Management* from the navigation menu.
+. Select an image from either the *Top Riskiest Images* widget or click the *Images* button at the top of the Dashboard and select an image.
+. In the *Image* details view, under *Image Findings*, CVEs are listed in the *Observed CVEs*, *Deferred CVEs*, and *False positive CVEs* tabs.
+. Locate the CVE you want to examine further. In the *Affected Components* column, click on the *<number> Components* link to view a list of components affected by the CVE. You can perform the following actions in this window:
+* Select the expand icon next to a specific component to view the Dockerfile line in the image where the component was added that contains the CVE. To address the CVE, you need to change this line in the Dockerfile; for example, you can upgrade the component. 
+* Click the name of the component to go to the *Component Summary* page and view more information about the component. 
+

--- a/modules/view-dockerfile-for-image.adoc
+++ b/modules/view-dockerfile-for-image.adoc
@@ -9,7 +9,7 @@
 Use the *Vulnerability Management* view to find the root cause of vulnerabilities in an image.
 You can view the Dockerfile and find exactly which command in the Dockerfile introduced the vulnerabilities and all components that are associated with that single command.
 
-The Dockerfile tab shows information about:
+The Dockerfile section shows information about:
 
 * All the layers in the Dockerfile
 * The instructions and their value for each layer
@@ -21,9 +21,10 @@ If there are any CVEs in those components, you can select the expand icon for an
 
 .Procedure
 
-. Navigate to the RHACS portal and click *Vulnerability Management* from the navigation menu.
-. Select an image from the *Top Riskiest Images* widget.
-. In the *Image* details view, select the *Dockerfile* tab under the *Image Findings* section.
+. Navigate to the {product-title-short} portal and click *Vulnerability Management* from the navigation menu.
+. Select an image from either the *Top Riskiest Images* widget or click the *Images* button at the top of the Dashboard and select an image.
+. In the *Image* details view, next to *Dockerfile*, select the expand icon to see a summary of instructions, values, creation date, and components.
+. Select the expand icon for an individual component to view more information.
 
 //[role="_additional-resources"]
 //.Additional resources

--- a/operating/examine-images-for-vulnerabilities.adoc
+++ b/operating/examine-images-for-vulnerabilities.adoc
@@ -67,6 +67,8 @@ include::modules/view-dockerfile-for-image.adoc[leveloffset=+1]
 
 include::modules/identify-container-image-layer-that-introduces-vulnerabilities.adoc[leveloffset=+1]
 
+include::modules/identify-dockerfile-line-component-cve.adoc[leveloffset=+1]
+
 include::modules/identify-operating-system-of-the-base-image.adoc[leveloffset=+1]
 
 include::modules/disable-language-specific-vulnerability-scanning.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):

- merge to `rhacs-docs-3.72.0`
- cherry pick to `rhacs`

Labels: 

- `RHACS`
- `RHACS/next`

[Issue](https://issues.redhat.com/browse/ROX-12093)

Link to docs preview:

Added section:

- [Identifying the Dockerfile line in an image that adds a component with a CVE  ](https://openshift-docs-10jux45h1-kcarmichael08.vercel.app/openshift-acs/master/operating/examine-images-for-vulnerabilities.html#identify-dockerfile-line-component-cve_examine-images-for-vulnerabilities)

Minor changes to match screens/make instructions clear:

- [Viewing Dockerfile for an image](https://openshift-docs-10jux45h1-kcarmichael08.vercel.app/openshift-acs/master/operating/examine-images-for-vulnerabilities.html#viewing-dockerfile-for-image_examine-images-for-vulnerabilities)
- [Identifying the container image layer that introduces vulnerabilities](https://openshift-docs-10jux45h1-kcarmichael08.vercel.app/openshift-acs/master/operating/examine-images-for-vulnerabilities.html#identify-container-image-layer-that-introduces-vulnerabilities_examine-images-for-vulnerabilities)
