### PR TITLE
Updates to the Getting started section of the OCP 4.11 docs

### DIFF
--- a/applications/connecting_applications_to_services/getting-started-with-service-binding.adoc
+++ b/applications/connecting_applications_to_services/getting-started-with-service-binding.adoc
@@ -17,7 +17,7 @@ The {servicebinding-title} manages the data plane for workloads and backing serv
 * You have access to an {product-title} cluster using an account with `cluster-admin` permissions.
 * You have installed the `oc` CLI.
 * You have installed {servicebinding-title} from OperatorHub.
-* You have installed the Crunchy Postgres for Kubernetes Operator from OperatorHub using the *v5* Update channel. The installed Operator is available in an appropriate namespace, such as the `my-petclinic` namespace.
+* You have installed the 5.1.2 version of the Crunchy Postgres for Kubernetes Operator from OperatorHub using the *v5* Update channel. The installed Operator is available in an appropriate namespace, such as the `my-petclinic` namespace.
 +
 [NOTE]
 ====
@@ -33,6 +33,8 @@ include::modules/sbo-deploying-the-spring-petclinic-sample-application.adoc[leve
 //Connecting the Spring PetClinic sample application to the PostgreSQL database service
 include::modules/sbo-connecting-spring-petclinic-sample-app-to-postgresql-database-service.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+[id="additional-resources_getting-started-sbo"]
 == Additional Resources
 * xref:../../applications/connecting_applications_to_services/installing-sbo.adoc#installing-sbo[Installing Service Binding Operator].
 * xref:../../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating applications using the Developer perspective].

--- a/modules/sbo-creating-a-postgresql-database-instance.adoc
+++ b/modules/sbo-creating-a-postgresql-database-instance.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * /applications/connecting_applications_to_services/getting-started-with-service-binding.adoc
+
 :_content-type: PROCEDURE
 [id="sbo-creating-a-postgresql-database-instance_{context}"]
 = Creating a PostgreSQL database instance
@@ -18,8 +22,8 @@ kind: PostgresCluster
 metadata:
   name: hippo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-ha:centos8-13.4-0
-  postgresVersion: 13
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.4-0
+  postgresVersion: 14
   instances:
     - name: instance1
       dataVolumeClaimSpec:
@@ -30,7 +34,7 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.33-2
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.38-0
       repos:
       - name: repo1
         volume:
@@ -40,17 +44,6 @@ spec:
             resources:
               requests:
                 storage: 1Gi
-      - name: repo2
-        volume:
-          volumeClaimSpec:
-            accessModes:
-            - "ReadWriteOnce"
-            resources:
-              requests:
-                storage: 1Gi
-  proxy:
-    pgBouncer:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-2
 EOD
 ----
 +
@@ -76,11 +69,10 @@ The output, which takes a few minutes to display, verifies that the database is 
 .Example output
 [source,terminal]
 ----
-NAME                               READY   STATUS    RESTARTS   AGE
-hippo-backup-nqjg-2rq94            1/1     Running   0          35s
-hippo-instance1-nw92-0             3/3     Running   0          112s
-hippo-pgbouncer-57b98f4476-znsk5   2/2     Running   0          112s
-hippo-repo-host-0                  1/1     Running   0          112s
+NAME                                     READY    STATUS      RESTARTS   AGE
+hippo-backup-9rxm-88rzq                   0/1     Completed   0          2m2s
+hippo-instance1-6psd-0                    4/4     Running     0          3m28s
+hippo-repo-host-0                         2/2     Running     0          3m28s
 ----
 +
 After the database is configured, you can deploy the sample application and connect it to the database service.

--- a/modules/sbo-deploying-the-spring-petclinic-sample-application.adoc
+++ b/modules/sbo-deploying-the-spring-petclinic-sample-application.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * /applications/connecting_applications_to_services/getting-started-with-service-binding.adoc
+
 :_content-type: PROCEDURE
 [id="sbo-deploying-the-spring-petclinic-sample-application_{context}"]
 = Deploying the Spring PetClinic sample application
@@ -92,5 +96,20 @@ spring-petclinic-5b4c7999d4-wzdtz   0/1     CrashLoopBackOff   4 (13s ago)   2m2
 ----
 +
 At this stage, the pod fails to start. If you try to interact with the application, it returns errors.
++
+. Expose the service to create a route for your application:
++
+[source,terminal]
+----
+$ oc expose service spring-petclinic -n my-petclinic
+----
++
+The output verifies that the `spring-petclinic` service is exposed and a route for the Spring PetClinic sample application is created:
++
+.Example output
+[source,terminal]
+----
+route.route.openshift.io/spring-petclinic exposed
+----
 
 You can now use the {servicebinding-title} to connect the application to the database service.


### PR DESCRIPTION
[RHDEVDOCS-4459](https://issues.redhat.com/browse/RHDEVDOCS-4459): [SB] Updates to the SBO Getting started section of OCP 4.11 docs

- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: enterprise-`4.11` and later
- **JIRA issues**: [RHDEVDOCS-4459](https://issues.redhat.com/browse/RHDEVDOCS-4459)
- **Preview pages**: [Getting started with service binding - Prerequisites section](https://50500--docspreview.netlify.app/openshift-enterprise/latest/applications/connecting_applications_to_services/getting-started-with-service-binding.html), [Deploying the Spring PetClinic sample application](https://50500--docspreview.netlify.app/openshift-enterprise/latest/applications/connecting_applications_to_services/getting-started-with-service-binding.html#sbo-deploying-the-spring-petclinic-sample-application_getting-started-with-service-binding), [Connecting the Spring PetClinic sample application to the PostgreSQL database service](https://50500--docspreview.netlify.app/openshift-enterprise/latest/applications/connecting_applications_to_services/getting-started-with-service-binding.html#connecting-the-spring-petclinic-sample-application-to-the-postgresql-database-service)
- **SME Review**: Completed by @dperaza4dustbit
- **QE review**: Completed by @pmacik 
- **Peer-review**: Completed by @gabriel-rh 