### PR TITLE
OSDOCS-4147: Added Melbourne, Australia (australia-southeast2) to sup…

### DIFF
--- a/modules/installation-gcp-regions.adoc
+++ b/modules/installation-gcp-regions.adoc
@@ -19,6 +19,7 @@ regions:
 * `asia-southeast1` (Jurong West, Singapore)
 * `asia-southeast2` (Jakarta, Indonesia)
 * `australia-southeast1` (Sydney, Australia)
+* `australia-southeast2` (Melbourne, Australia)
 * `europe-central2` (Warsaw, Poland)
 * `europe-north1` (Hamina, Finland)
 * `europe-southwest1` (Madrid, Spain)


### PR DESCRIPTION
Version(s):
4.10

Issue:
This issue addresses [OSDOCS-4147](https://issues.redhat.com/browse/OSDOCS-4147).

Link to docs preview:
[Supported GCP regions](http://file.rdu.redhat.com/mpytlak/osdocs-4147/installing/installing_gcp/installing-gcp-account.html#installation-gcp-regions_installing-gcp-account)