### PR TITLE
OSDOCS-4149: Addded asia-south2 to supported GCP regions

### DIFF
--- a/modules/installation-gcp-regions.adoc
+++ b/modules/installation-gcp-regions.adoc
@@ -16,6 +16,7 @@ regions:
 * `asia-northeast2` (Osaka, Japan)
 * `asia-northeast3` (Seoul, South Korea)
 * `asia-south1` (Mumbai, India)
+* `asia-south2` (Delhi, India)
 * `asia-southeast1` (Jurong West, Singapore)
 * `asia-southeast2` (Jakarta, Indonesia)
 * `australia-southeast1` (Sydney, Australia)


### PR DESCRIPTION
Version(s):
4.10 

Issue:
This PR addresses [OSDOCS-4149](https://issues.redhat.com/browse/OSDOCS-4149).

Link to docs preview:
[Supported GCP regions](http://file.rdu.redhat.com/mpytlak/osdocs-4149/installing/installing_gcp/installing-gcp-account.html#installation-gcp-regions_installing-gcp-account).