### PR TITLE
OSSMDOC-666: Add link to persistent storage docs.

### DIFF
--- a/distr_tracing/distr_tracing_install/distr-tracing-deploying-jaeger.adoc
+++ b/distr_tracing/distr_tracing_install/distr-tracing-deploying-jaeger.adoc
@@ -66,6 +66,10 @@ include::modules/distr-tracing-accessing-jaeger-console.adoc[leveloffset=+2]
 
 include::modules/distr-tracing-deployment-best-practices.adoc[leveloffset=+2]
 
+ifdef::openshift-enterprise,openshift-dedicated[]
+For information about configuring persistent storage, see xref:../../storage/understanding-persistent-storage.adoc[Understanding persistent storage] and the appropriate configuration topic for your chosen storage option.
+endif::[]
+
 include::modules/distr-tracing-config-default.adoc[leveloffset=+2]
 
 include::modules/distr-tracing-config-jaeger-collector.adoc[leveloffset=+2]

--- a/modules/jaeger-deployment-best-practices.adoc
+++ b/modules/jaeger-deployment-best-practices.adoc
@@ -2,7 +2,7 @@
 This module included in the following assemblies:
 *  /jaeger/jaeger_install/rhbjaeger-deploying.adoc
 ////
-:pantheon-module-type: CONCEPT
+:_content-type: CONCEPT
 [id="jager-deployment-best-practices_{context}"]
 = Deployment best practices
 

--- a/modules/jaeger-features.adoc
+++ b/modules/jaeger-features.adoc
@@ -4,7 +4,7 @@ This module included in the following assemblies:
 -service_mesh/v2x/ossm-architecture.adoc
 -rhbjaeger-architecture.adoc
 ////
-:pantheon-module-type: CONCEPT
+:_content-type: CONCEPT
 [id="jaeger-features_{context}"]
 = Jaeger features
 

--- a/modules/jaeger-install-overview.adoc
+++ b/modules/jaeger-install-overview.adoc
@@ -2,7 +2,7 @@
 This module included in the following assemblies:
 - rhbjaeger-installation.adoc
 ////
-:pantheon-module-type: CONCEPT
+:_content-type: CONCEPT
 
 [id="jaeger-install-overview_{context}"]
 = Jaeger installation overview

--- a/modules/jaeger-removing-instance-cli.adoc
+++ b/modules/jaeger-removing-instance-cli.adoc
@@ -2,7 +2,7 @@
 This module included in the following assemblies:
 - rhbjaeger-installation.adoc
 ////
-:pantheon-module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="jaeger-removing-cli_{context}"]
 = Removing a Jaeger instance from the CLI
 

--- a/modules/jaeger-removing-instance.adoc
+++ b/modules/jaeger-removing-instance.adoc
@@ -2,7 +2,7 @@
 This module included in the following assemblies:
 - rhbjaeger-removing.adoc
 ////
-:pantheon-module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="jaeger-removing_{context}"]
 = Removing a Jaeger instance using the web console
 

--- a/modules/jaeger-sidecar-automatic.adoc
+++ b/modules/jaeger-sidecar-automatic.adoc
@@ -2,7 +2,7 @@
 This module included in the following assemblies:
 - rhbjaeger-deploying.adoc
 ////
-:pantheon-module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="jaeger-sidecar-automatic_{context}"]
 = Automatically injecting sidecars
 

--- a/modules/jaeger-sidecar-manual.adoc
+++ b/modules/jaeger-sidecar-manual.adoc
@@ -2,7 +2,7 @@
 This module included in the following assemblies:
 - rhbjaeger-deploying.adoc
 ////
-:pantheon-module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="jaeger-sidecar-manual_{context}"]
 = Manually injecting sidecars
 

--- a/modules/jaeger-upgrading-es.adoc
+++ b/modules/jaeger-upgrading-es.adoc
@@ -2,7 +2,7 @@
 This module included in the following assemblies:
 - jaeger_install/rhbjaeger-updating
 ////
-:pantheon-module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="upgrading_es5_es6_{context}"]
 = Upgrading from Elasticsearch 5 to Elasticsearch 6
 

--- a/service_mesh/v2x/ossm-reference-jaeger.adoc
+++ b/service_mesh/v2x/ossm-reference-jaeger.adoc
@@ -18,6 +18,10 @@ include::modules/ossm-configuring-external-jaeger.adoc[leveloffset=+1]
 
 include::modules/distr-tracing-deployment-best-practices.adoc[leveloffset=+2]
 
+ifdef::openshift-enterprise,openshift-dedicated[]
+For information about configuring persistent storage, see xref:../../storage/understanding-persistent-storage.adoc[Understanding persistent storage] and the appropriate configuration topic for your chosen storage option.
+endif::[]
+
 include::modules/distr-tracing-config-security-ossm.adoc[leveloffset=+2]
 
 include::modules/distr-tracing-config-security-ossm-web.adoc[leveloffset=+3]
@@ -32,7 +36,7 @@ include::modules/distr-tracing-config-sampling.adoc[leveloffset=+2]
 
 include::modules/distr-tracing-config-storage.adoc[leveloffset=+2]
 
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-dedicated[]
 For more information about configuring Elasticsearch with {product-title}, see xref:../../logging/config/cluster-logging-log-store.adoc[Configuring the log store] or xref:../../distr_tracing/distr_tracing_install/distr-tracing-deploying-jaeger.adoc[Configuring and deploying distributed tracing].
 
 //TO DO For information about connecting to an external Elasticsearch instance, see xref:../../distr_tracing/distr_tracing_install/distr-tracing-deploying-jaeger.adoc#jaeger-config-external-es_jaeger-deploying[Connecting to an existing Elasticsearch instance].


### PR DESCRIPTION
Version(s): 4.6 - 4.12

Issue: [OSSMDOC-666](https://issues.redhat.com/browse/OSSMDOC-666)
(Also cleans up some content type metadata in outdated format)

Link to docs preview:  Link inserted after the Best Practices topic
http://file.bos.redhat.com/jstickle/OSSMDOC-666/distr_tracing/distr_tracing_install/distr-tracing-deploying-jaeger.html#distr-tracing-deployment-best-practices_deploying-distr-tracing-platform
http://file.bos.redhat.com/jstickle/OSSMDOC-666/service_mesh/v2x/ossm-reference-jaeger.html#distr-tracing-deployment-best-practices_jaeger-config-reference


Additional information:
QE review: jkandasa, iblancasa
Peer review: sheriff-rh
