### PR TITLE
OSDOCS-4046: Updated SD Life Cycle

### DIFF
--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -3,29 +3,15 @@
 // * osd_architecture/osd_policy/osd-life-cycle.adoc
 // * rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
 
-[id="rosa-life-cycle-dates_{context}"]
+[id="sd-life-cycle-dates_{context}"]
 = Life cycle dates
 
 [options="header"]
 |===
 |Version    |General availability   |End of life
+|4.11       |Aug 10, 2022           |Jun 10, 2023
 |4.10       |Mar 10, 2022           |Jan 10, 2023
 |4.9        |Oct 18, 2021           |Sep 28, 2022
 |4.8        |Jul 27, 2021           |Aug 31, 2022
-
-ifeval::["{product-title}" == "OpenShift Dedicated"]
-|4.7        |Feb 24, 2021           |Dec 17, 2021 footnote:[4.7 minor version follows previous Y-1 life cycle]
-|4.6        |Oct 27, 2020           |Aug 26, 2021
-|4.5        |Sep 23, 2020           |Mar 26, 2021
-|4.4        |Sep 15, 2020           |Nov 26, 2020
-|4.3        |Feb 19, 2020           |Oct 23, 2020
-|4.2        |Nov 12, 2019           |Oct 15, 2020
-|4.1        |Jun 11, 2019           |Mar 20, 2020
-|3.11       |Oct 10, 2018           |Jul 31, 2021 footnote:[https://access.redhat.com/articles/5254001]
-endif::[]
-
-ifeval::["{product-title}" == "Red Hat OpenShift Service on AWS"]
-|4.7        |Mar 24, 2021           |Dec 17, 2021 footnote:[4.7 minor version follows previous Y-1 life cycle]
-endif::[]
 
 |===


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-4046](https://issues.redhat.com/browse/OSDOCS-4046)

Link to docs preview:

- **[ROSA](https://50512--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html#sd-life-cycle-dates_rosa-life-cycle)**
- **[OSD](https://50512--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-life-cycle.html#sd-life-cycle-dates_osd-life-cycle)**

Additional information:
This PR adds the new version of OpenShift that is supported and removes unrelated ones.