### PR TITLE
OSDOCS-2609: Fixed the order of CLI commands

### DIFF
--- a/modules/rosa-installing.adoc
+++ b/modules/rosa-installing.adoc
@@ -79,25 +79,6 @@ $ rosa completion bash | sudo tee /etc/bash_completion.d/rosa
 $ source /etc/bash_completion.d/rosa
 ----
 
-. Enter the following command to verify that your AWS account has the necessary permissions.
-+
-[source,terminal]
-----
-$ rosa verify permissions
-----
-+
-.Example output
-[source,terminal]
-----
-I: Validating SCP policies...
-I: AWS SCP policies ok
-----
-+
-[NOTE]
-====
-This command verifies permissions only for ROSA clusters that do not use the AWS Security Token Service (STS).
-====
-
 . Log in to your Red Hat account with `rosa`.
 +
 .. Enter the following command.
@@ -121,6 +102,25 @@ To login to your Red Hat account, get an offline access token at https://console
 ----
 I: Logged in as 'rh-rosa-user' on 'https://api.openshift.com'
 ----
+
+. Enter the following command to verify that your AWS account has the necessary permissions.
++
+[source,terminal]
+----
+$ rosa verify permissions
+----
++
+.Example output
+[source,terminal]
+----
+I: Validating SCP policies...
+I: AWS SCP policies ok
+----
++
+[NOTE]
+====
+This command verifies permissions only for ROSA clusters that do not use the AWS Security Token Service (STS).
+====
 
 . Verify that your AWS account has the necessary quota to deploy an {product-title} cluster.
 +


### PR DESCRIPTION
Version(s):
Enterprise-4.11+ 

Issue:
[OSDOCS-2609](https://issues.redhat.com/browse/OSDOCS-2609)

Link to docs preview:

- **[ROSA](https://50529--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-installing-rosa.html#rosa-installing-and-configuring-the-rosa-cli_rosa-installing-cli)**

Additional information:
Reordered the list of `rosa` CLI commands. Previously, executing `rosa verify permissions` before `rosa login` generated an error.