### PR TITLE
modules/understanding-upgrade-channels: Drop nightly discussions

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -18,18 +18,6 @@ The `candidate-{product-version}` channel contains candidate builds for a z-stre
 
 You can use the `candidate-{product-version}` channel to update from a previous minor version of {product-title}.
 
-[NOTE]
-====
-Release candidates differ from the nightly builds. Nightly builds are available for early access to features, but updating to or from nightly builds is neither recommended nor supported. Nightly builds are not available in any upgrade channel. You can reference the {product-title}
-ifdef::openshift-origin[]
-link:https://origin-release.apps.ci.l2s4.p1.openshiftapps.com/[release statuses]
-endif::[]
-ifndef::openshift-origin[]
-link:https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/[release statuses]
-endif::[]
-for more build information.
-====
-
 [id="fast-version-channel_{context}"]
 == fast-{product-version} channel
 


### PR DESCRIPTION
We've had this section since back in 42c10066ed (#18944), but there are a few wrinkles around nightlies:

* The canonical release controller URIs are now given [here][1], and they prefer [this][2] and similar pretty URIs instead of the `l2s4` business in the paragraph I'm removing.

* On the release controllers, all single-arch nightlies list CI-registry pullspecs, [e.g.][3]:

        oc adm release extract --tools registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2022-09-16-035656

* CI-registry access [requires Red Hat single-sign-on][4] and [membership in the Red Hat Rover group or similar][5].  This is not a customer-facing option.

* ART promotes a subset of release-controller-accepted nightlies are promoted to the mirrors like [this][6].  These have `quay.io/` pullspecs and are customer-accessible.

* But ART stops promoting 4.y nightlies to the mirrors when they release the first feature candidate for the 4.y (4.y.0-fc.#).  And beginning in 4.12, ART is no longer pushing nightlies to mirrors at all, since we started cutting sprintly builds (engineering candidates):

    ```console
    $ w3m -dump -cols 200 https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp-dev-preview/ | grep '4[.]12[.]'
     4.12.0-0.nightly-2022-07-02-041854  —    -
     4.12.0-0.nightly-2022-07-05-083442  —    -
     4.12.0-0.nightly-2022-07-05-155211  —    -
     4.12.0-0.nightly-2022-07-05-191634  —    -
     4.12.0-0.nightly-2022-07-05-225149  —    -
     4.12.0-0.nightly-2022-07-06-023534  —    -
     4.12.0-0.nightly-2022-07-06-061520  —    -
     4.12.0-0.nightly-2022-07-06-094950  —    -
     4.12.0-0.nightly-2022-07-06-134516  —    -
     4.12.0-0.nightly-2022-07-06-221008  —    -
     4.12.0-0.nightly-2022-07-07-092951  —    -
     4.12.0-0.nightly-2022-07-07-144231  —    -
     4.12.0-0.nightly-2022-07-11-054352  —    -
     4.12.0-0.nightly-2022-07-25-055755  —    -
     4.12.0-ec.0                         —    -
     4.12.0-ec.1                         —    -
     4.12.0-ec.2                         —    -
     4.12.0-ec.3                         —    -
    ```

Removing the nightly reference avoids sending customers down this not-very-useful-for-them rabbit hole.  [This][7] is a more reliable location for learning about things outside of candidate channels, but we don't need to link to that or discuss it from the upgrade-channel documentation.

[1]: https://docs.ci.openshift.org/docs/getting-started/useful-links/#services
[2]: https://amd64.ocp.releases.ci.openshift.org/
[3]: https://amd64.ocp.releases.ci.openshift.org/releasestream/4.12.0-0.nightly/release/4.12.0-0.nightly-2022-09-16-035656
[4]: https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/#how-do-i-log-in-to-pull-images-that-require-authentication
[5]: https://docs.ci.openshift.org/docs/how-tos/rbac/#rover-groups
[6]: https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp-dev-preview/
[7]: https://console.redhat.com/openshift/install/pre-release

Version(s): 4.6+