### PR TITLE
Adds base64 encoded note to access key id and access key secret

### DIFF
--- a/modules/cluster-logging-loki-deploy.adoc
+++ b/modules/cluster-logging-loki-deploy.adoc
@@ -54,13 +54,15 @@ metadata:
   name: logging-loki-s3
   namespace: openshift-logging
 data:
-  access_key_id: QUtJQUlPU0ZPRE5ON0VYQU1QTEUK
-  access_key_secret: d0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWQo=
-  bucketnames: czMtYnVja2V0LW5hbWU= <1>
-  endpoint: aHR0cHM6Ly9zMy5ldS1jZW50cmFsLTEuYW1hem9uYXdzLmNvbQ== <2>
+  access_key_id: QUtJQUlPU0ZPRE5ON0VYQU1QTEUK <1>
+  access_key_secret: d0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWQo= <2>
+  bucketnames: czMtYnVja2V0LW5hbWU= <3>
+  endpoint: aHR0cHM6Ly9zMy5ldS1jZW50cmFsLTEuYW1hem9uYXdzLmNvbQ== <4>
 ----
-<1> Base64-encoded bucket name
-<2> Base64-encoded S3 API endpoint
+<1> Base64-encoded access key id
+<2> Base64-encoded access key secret
+<3> Base64-encoded bucket name
+<4> Base64-encoded S3 API endpoint
 +
 . Create the `LokiStack` custom resource:
 +


### PR DESCRIPTION
Adds base64 encoded note to access key id and access key secret

Issue: https://github.com/openshift/openshift-docs/issues/49432

Versions: 4.10+

Preview: 
https://50531--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-loki.html#logging-loki-deploy_cluster-logging-loki

Needs QE review. 