### PR TITLE
Swaps google identity provider example from github to google.

### DIFF
--- a/modules/config-google-idp.adoc
+++ b/modules/config-google-idp.adoc
@@ -41,7 +41,7 @@ https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp
 For example:
 +
 ----
-https://oauth-openshift.apps.openshift-cluster.example.com/oauth2callback/github
+https://oauth-openshift.apps.openshift-cluster.example.com/oauth2callback/google
 ----
 
 . Configure a Google identity provider using link:https://developers.google.com/identity/protocols/OpenIDConnect[Google's OpenID Connect integration].


### PR DESCRIPTION
Swaps google identity provider example from github to google.

Versions: ROSA. 4.11+

Issue: https://github.com/openshift/openshift-docs/issues/48138

https://50532--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.html#config-google-idp_rosa-sts-config-identity-providers

QE needed