### PR TITLE
Adding .png image format req

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -835,6 +835,10 @@ If a documentation change is due to a Bugzilla bug or Jira issue, the bug/issue 
 
 == Images
 
+=== Image format
+
+Use `*.png` format images.
+
 === Block images
 
 To include a block image (an image on its own line):


### PR DESCRIPTION
Adds `*.png` image format mandate for OCP docs screenshots and diagrams.