### PR TITLE
Adds notes for 4.11.5 release

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2608,3 +2608,32 @@ $ oc adm release info 4.11.4 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-5"]
+=== RHSA-2022:6536 - {product-title} 4.11.5 bug fix and security update
+
+Issued: 2022-09-20
+
+{product-title} release 4.11.5, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:6536[RHSA-2022:6536] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:6535[RHBA-2022:6535] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.5 --pullspecs
+----
+
+[id="ocp-4-11-5-known-issues"]
+==== Known issues
+
+* Sharding the default Ingress Controller breaks the {product-title} factory routes such as `canary`, `oauth`, and `console`. As a workaround, you can manually add matching labels and expressions to the routes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2024946[*BZ#2024946*])
+
+[id="ocp-4-11-5-bug-fixes"]
+==== Bug fixes
+
+* Previously, an update of the `routeSelector` cleared the route status of the Ingress Controller prior to the router deployment. As a result, the route status repopulated incorrectly. With this update, the route status is cleared with a `routeSelector` update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2110528[*BZ#2110528*])
+
+[id="ocp-4-11-5-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for tomorrow's 4.11.5 release

Issue:
[OSDOCS-4143](https://issues.redhat.com/browse/OSDOCS-4143)

Link to docs preview:
https://50540--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-5

Additional information:
Links will not work yet!

<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
