### PR TITLE
etcd recommendations improvements for 4.11+

### DIFF
--- a/modules/openshift-cluster-maximums-environment.adoc
+++ b/modules/openshift-cluster-maximums-environment.adoc
@@ -15,8 +15,8 @@ AWS cloud platform:
 | r5.4xlarge
 | 16
 | 128
-| io1
-| 220 / 3000
+| gp3
+| 220
 | 3
 | us-west-2
 
@@ -24,7 +24,7 @@ AWS cloud platform:
 | m5.12xlarge
 | 48
 | 192
-| gp2
+| gp3
 | 100
 | 3
 | us-west-2
@@ -33,7 +33,7 @@ AWS cloud platform:
 | m5.4xlarge
 | 16
 | 64
-| gp2
+| gp3
 | 500 ^[4]^
 | 1
 | us-west-2
@@ -42,7 +42,7 @@ AWS cloud platform:
 | m5.2xlarge
 | 8
 | 32
-| gp2
+| gp3
 | 100
 | 3/25/250/500 ^[5]^
 | us-west-2
@@ -50,7 +50,7 @@ AWS cloud platform:
 |===
 [.small]
 --
-1. io1 disks with 3000 IOPS are used for master/etcd nodes as etcd is I/O intensive and latency sensitive.
+1. `gp3` disks with a baseline performance of 3000 IOPS and 125 MiB/s are used for master/etcd nodes as etcd is I/O intensive and latency sensitive and `gp3` volumes do not use burst performance.
 2. Infra nodes are used to host Monitoring, Ingress, and Registry components to ensure they have enough resources to run at large scale.
 3. Workload node is dedicated to run performance and scalability workload generators.
 4. Larger disk size is used so that there is enough space to store the large amounts of data that is collected during the performance and scalability test run.

--- a/modules/recommended-etcd-practices.adoc
+++ b/modules/recommended-etcd-practices.adoc
@@ -16,7 +16,19 @@ For large and dense clusters, etcd can suffer from poor performance if the keysp
 
 For more information about defragmenting etcd, see the "Defragmenting etcd data" section.
 
-Because etcd writes data to disk and persists proposals on disk, its performance depends on disk performance. Slow disks and disk activity from other processes can cause long fsync latencies. Those latencies can cause etcd to miss heartbeats, not commit new proposals to the disk on time, and ultimately experience request timeouts and temporary leader loss. Run etcd on machines that are backed by SSD or NVMe disks with low latency and high throughput. Consider single-level cell (SLC) solid-state drives (SSDs), which provide 1 bit per memory cell, are durable and reliable, and are ideal for write-intensive workloads.
+Because etcd writes data to disk and persists proposals on disk, its performance depends on disk performance.
+Etcd requires a low latency block device for optimal performance and stability because the concensus protocol depends on persistently storing metadata to a log using Write-Ahead Logging (WAL). Slow disks and disk activity from other processes can cause long `fsync` latencies.
+
+Those latencies can cause etcd to miss heartbeats, not commit new proposals to the disk on time, and ultimately experience request timeouts and temporary leader loss. High write latencies also lead to an OpenShift API slowness, therefore the performance of the whole cluster would be affected.
+
+[IMPORTANT]
+====
+It is not recommended to co-locate other workloads in the Control Plane nodes.
+====
+
+It is recommended to run etcd on a block device able to write at least 50 IOPS of 8000 bytes in lengthy sequentially with a latency of 20ms. Etcd uses `fdatasync` to synchronize each write it performs in the WAL and sequential 500 IOPS of 8000 bytes for heavily loaded clusters at 2ms. A benchmarking tool can be used to obtain these metrics.
+
+It is recommended to run etcd on machines that are backed by SSD or NVMe disks with low latency and high throughput. Consider single-level cell (SLC) solid-state drives (SSDs), which provide 1 bit per memory cell, are durable and reliable, and are ideal for write-intensive workloads.
 
 The following hard disk features provide optimal etcd performance:
 
@@ -26,11 +38,7 @@ The following hard disk features provide optimal etcd performance:
 * Solid state drives as a minimum selection, however NVMe drives are preferred.
 * Server-grade hardware from various manufacturers for increased reliability.
 * RAID 0 technology for increased performance.
-* Dedicated etcd drives. Do not place log files or other heavy workloads on etcd drives. 
-
-Avoid NAS or SAN setups, and spinning drives. Always benchmark using utilities such as `fio`. Continuously monitor the cluster performance as it increases.
-
-IMPORTANT: Avoid using the Network File System (NFS) protocol.
+* Dedicated etcd drives. Do not place log files or other heavy workloads on etcd drives.
 
 Some key metrics to monitor on a deployed {product-title} cluster are p99 of etcd disk write ahead log duration and the number of etcd leader changes. Use Prometheus to track these metrics.
 
@@ -64,7 +72,7 @@ $ sudo docker run --volume /var/lib/etcd:/var/lib/etcd:Z quay.io/openshift-scale
 ----
 --
 
-The output reports whether the disk is fast enough to host etcd by comparing the 99th percentile of the fsync metric captured from the run to see if it is less than 10 ms.
+The output reports whether the disk is fast enough to host etcd by comparing the 99th percentile of the fsync metric captured from the run to see if it is less than 20 ms.
 
 Because etcd replicates the requests among all the members, its performance strongly depends on network input/output (I/O) latency. High network latencies result in etcd heartbeats taking longer than the election timeout, which results in leader elections that are disruptive to the cluster. A key metric to monitor on a deployed {product-title} cluster is the 99th percentile of etcd network peer latency on each etcd cluster member. Use Prometheus to track the metric.
 


### PR DESCRIPTION
This is a clone of #50250 to commit the changes against the `main` branch, but also allow for peer review and edits as needed. Some text has been altered from the original PR to adhere to IBM style guide standards.

Version(s):
4.11+ 

While this data is specific to 4.11, it will provide a good baseline for 4.12 until updated metrics are obtained after release. 

Link to docs preview:
[Recommended etcd practices](http://file.rdu.redhat.com/antaylor/etcd-improvements-4.11/scalability_and_performance/recommended-host-practices.html#recommended-etcd-practices_recommended-host-practices)
[Planning your environment according to object maximums](http://file.rdu.redhat.com/antaylor/etcd-improvements-4.11/scalability_and_performance/planning-your-environment-according-to-object-maximums.html#cluster-maximums-environment_object-limits)

Additional information:
None at this time.