### PR TITLE
RHDEVDOCS-3177 Tracker for 1861266 - [DOCS] New USE_JAVA_VERSION vari…

### DIFF
--- a/modules/images-other-jenkins-agent-env-var.adoc
+++ b/modules/images-other-jenkins-agent-env-var.adoc
@@ -50,4 +50,10 @@ JVM threads.
 |Specifies additional options for the Jenkins JVM. These options are appended to all other options, including the Java options above, and can be used to override any of them, if necessary. Separate each additional option with a space and if any option contains space characters, escape them with a backslash.
 |Example settings: `-Dfoo -Dbar`; `-Dfoo=first\ value -Dbar=second\ value`
 
+|`USE_JAVA_VERSION`
+|Specifies the version of Java version to use to run the agent in its container. The container base image has two versions of java installed: `java-11` and `java-1.8.0`. If you extend the container base image, you can specify any alternative version of java using its associated suffix.
+|The default value is `java-11`.
+
+Example setting: `java-1.8.0`
+
 |===


### PR DESCRIPTION
…able not documented

- Aligned team: Dev Tools
- For branches: 4.6+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3177
- Direct link to doc preview: https://50560--docspreview.netlify.app/openshift-enterprise/latest/cicd/jenkins/images-other-jenkins-agent.html#images-other-jenkins-agent-env-var_images-other-jenkins-agent
- SME review: @akram (approved)
- QE review: @jitendar-singh (approved)
- Peer review: @jc-berger (approved)
- All reviews complete. Please merge now.
