### PR TITLE
[enterprise-4.8] Issue #48197 removed PAO from origin topic map

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2002,7 +2002,7 @@ Topics:
   Distros: openshift-origin,openshift-enterprise
 - Name: Performance Addon Operator for low latency nodes
   File: cnf-performance-addon-operator-for-low-latency-nodes
-  Distros: openshift-origin,openshift-enterprise
+  Distros: openshift-enterprise
 - Name: Creating a performance profile
   File: cnf-create-performance-profiles
   Distros: openshift-origin,openshift-enterprise


### PR DESCRIPTION
Version(s):
4.8 manual cherry pick of https://github.com/openshift/openshift-docs/pull/49332