### PR TITLE
[enterprise-4.7] Issue #48197 removed PAO from origin topic map

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1892,7 +1892,7 @@ Topics:
   Distros: openshift-origin,openshift-enterprise
 - Name: Performance Addon Operator for low latency nodes
   File: cnf-performance-addon-operator-for-low-latency-nodes
-  Distros: openshift-origin,openshift-enterprise
+  Distros: openshift-enterprise
 - Name: Optimizing data plane performance with the Intel vRAN Dedicated Accelerator ACC100
   File: cnf-optimize-data-performance-acc100
 - Name: Provisioning and deploying a distributed unit (DU)


### PR DESCRIPTION
Version(s):
4.7 manual cherry pick of https://github.com/openshift/openshift-docs/pull/49332