### PR TITLE
[enterprise-4.6] Issue #48197 removed PAO from origin topic map

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1714,7 +1714,7 @@ Topics:
   File: what-huge-pages-do-and-how-they-are-consumed-by-apps
 - Name: Performance Addon Operator for low latency nodes
   File: cnf-performance-addon-operator-for-low-latency-nodes
-  Distros: openshift-origin,openshift-enterprise,openshift-webscale
+  Distros: openshift-enterprise,openshift-webscale
 - Name: Optimizing data plane performance with Intel devices
   File: cnf-optimize-data-performance-n3000
   Distros: openshift-origin,openshift-enterprise


### PR DESCRIPTION
Version(s):
4.6 manual cherry pick of https://github.com/openshift/openshift-docs/pull/49332