### PR TITLE
[OSDOCS-2344] removed mentions of --delete-stack as it has been deprecated

### DIFF
--- a/modules/rosa-deleting-cluster.adoc
+++ b/modules/rosa-deleting-cluster.adoc
@@ -108,7 +108,7 @@ ifndef::sts[]
 +
 [source, terminal]
 ----
-$ rosa init --delete-stack
+$ rosa init --delete
 ----
 endif::sts[]
 

--- a/modules/rosa-initialize.adoc
+++ b/modules/rosa-initialize.adoc
@@ -38,7 +38,7 @@ $ rosa init [arguments]
 |--region
 |The AWS region (string) in which to verify quota and permissions. This value overrides the `AWS_REGION` environment variable only when running the `init` command, but it does not change your AWS CLI configuration.
 
-|--delete-stack
+|--delete
 |Deletes the stack template that is applied to your AWS account during the `init` command.
 
 |--client-id

--- a/modules/rosa-troubleshooting-osdccsadmin-deployment.adoc
+++ b/modules/rosa-troubleshooting-osdccsadmin-deployment.adoc
@@ -20,7 +20,7 @@ To fix this issue:
 +
 [source,terminal]
 ----
-$ rosa init --delete-stack
+$ rosa init --delete
 ----
 
 . Reinitialize your account:


### PR DESCRIPTION
[OSDOCS-2344] removed mentions of --delete-stack as it has been deprecated

Version(s):
4.10+

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
https://issues.redhat.com/browse/OSDOCS-2344

Link to docs preview:
https://50566--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-deleting-cluster.html#rosa-deleting-cluster_rosa-deleting-cluster

https://50566--docspreview.netlify.app/openshift-rosa/latest/rosa_cli/rosa-get-started-cli.html#rosa-init_rosa-getting-started-cli

https://50566--docspreview.netlify.app/openshift-rosa/latest/rosa_support/rosa-troubleshooting-deployments.html#rosa-troubleshooting-deployment-failure-osdccsadmin_rosa-troubleshooting-cluster-deployments

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->


<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
