### PR TITLE
CSS tweaks for earlier branches, fix CSS typos

### DIFF
--- a/_stylesheets/print.css
+++ b/_stylesheets/print.css
@@ -345,10 +345,6 @@ a {
     break-inside: avoid
 }
 
-$a:after>img {
-    content: "";
-}
-
 .entry iframe,
 ins {
     display: none;
@@ -452,12 +448,13 @@ div.title {
     display: none !important;
 }
 
-overflow-y: hidden;
-overflow-x: hidden;
-
 * {
     -webkit-box-shadow: none !important;
     -webkit-print-color-adjust: exact;
     box-shadow: none !important;
     text-shadow: none !important;
+}
+
+.breadcrumb {
+    display: none;
 }

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -236,7 +236,7 @@
           </div>
         </div>
       </div>
-      <div class="print-logo">
+      <div class="print-logo" style="display:none;">
         <img src="https://www.redhat.com/cms/managed-files/Logo-Red_Hat-OpenShift-A-Standard-RGB_0_0.svg" alt="print logo"/>
       </div>
       <div class="col-xs-12 col-sm-9 col-md-9 main">


### PR DESCRIPTION
* Fixes breadcrumbs being displayed in the print preview for 4.7, 4.8.
* cleans up some css typos.
* Adds `style="display:none;"` to `div class="print-logo"` so that even if the css doesn't load, the print logo is not displayed. 

Merge to main, CP to enterprise-4.1.

Preview: http://file.emea.redhat.com/aireilly/css-tweak/welcome/index.html