### PR TITLE
[RHACS] Fixed permission related docs bug

### DIFF
--- a/backup_and_restore/backing-up-acs.adoc
+++ b/backup_and_restore/backing-up-acs.adoc
@@ -27,4 +27,8 @@ You can use the `roxctl` CLI to take the backups by using the `backup` command. 
 
 include::modules/on-demand-backups-roxctl-api.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../operating/manage-user-access/manage-role-based-access-control-3630.adoc#rbac-system-roles-3630_manage-role-based-access-control[System roles]
+
 include::modules/on-demand-backups-roxctl-admin-pass.adoc[leveloffset=+2]

--- a/modules/on-demand-backups-roxctl-api.adoc
+++ b/modules/on-demand-backups-roxctl-api.adoc
@@ -10,10 +10,8 @@ You can back up the entire database of {product-title} by using an API token.
 
 .Prerequisites
 
-* You must have an API token with `read` permission for all resources of {product-title}.
-You can assign the *Analyst* system role to grant this level of access. The *Analyst* role has `read` permissions for all resources.
+* You must have an API token with the `Admin` role.
 * You must have installed the `roxctl` CLI.
-//TODO: Add link to the system role topic.
 
 .Procedure
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-12683

Merge into: `rhacs-docs`

Cherry pick into:
- `rhacs-docs-3.72`
- `rhacs-docs-3.71`
- `rhacs-docs-3.70`
- `rhacs-docs-3.69`

Preview: https://openshift-docs-git-rox12683-gnelson.vercel.app/openshift-acs/master/backup_and_restore/backing-up-acs.html#on-demand-backups-roxctl-api_backing-up-acs