### PR TITLE
[GH#50385]: Bug fix for CLI doc prereqs

### DIFF
--- a/modules/serverless-installing-cli-web-console.adoc
+++ b/modules/serverless-installing-cli-web-console.adoc
@@ -11,7 +11,7 @@ Using the {product-title} web console provides a streamlined and intuitive user 
 .Prerequisites
 
 * You have logged in to the {product-title} web console.
-* The {ServerlessOperatorName} is installed on your {product-title} cluster.
+* The {ServerlessOperatorName} and Knative Serving are installed on your {product-title} cluster.
 +
 [IMPORTANT]
 ====
@@ -22,6 +22,8 @@ If *libc* is not available, you might see the following error when you run CLI c
 $ kn: No such file or directory
 ----
 ====
+
+* If you want to use the verification steps for this procedure, you must install the OpenShift (`oc`) CLI.
 
 .Procedure
 
@@ -41,4 +43,33 @@ $ tar -xf <file>
 [source,terminal]
 ----
 $ echo $PATH
+----
+
+.Verification
+
+* Run the following commands to check that the correct Knative CLI resources and route have been created:
++
+[source,terminal]
+----
+$ oc get ConsoleCLIDownload
+----
++
+.Example output
+[source,terminal]
+----
+NAME                  DISPLAY NAME                                             AGE
+kn                    kn - OpenShift Serverless Command Line Interface (CLI)   2022-09-20T08:41:18Z
+oc-cli-downloads      oc - OpenShift Command Line Interface (CLI)              2022-09-20T08:00:20Z
+----
++
+[source,terminal]
+----
+$ oc get route -n openshift-serverless
+----
++
+.Example output
+[source,terminal]
+----
+NAME   HOST/PORT                                  PATH   SERVICES                      PORT       TERMINATION     WILDCARD
+kn     kn-openshift-serverless.apps.example.com          knative-openshift-metrics-3   http-cli   edge/Redirect   None
 ----

--- a/serverless/cli_tools/installing-kn.adoc
+++ b/serverless/cli_tools/installing-kn.adoc
@@ -20,11 +20,10 @@ endif::[]
 ====
 If you try to use an older version of the Knative (`kn`) CLI with a newer {ServerlessProductName} release, the API is not found and an error occurs.
 
-For example, if you use the 1.16.0 release of the Knative (`kn`) CLI, which uses version 0.22.0, with the 1.17.0 {ServerlessProductName} release, which uses the 0.23.0 versions of the Knative Serving and Knative Eventing APIs, the CLI does not work because it continues to look for the outdated 0.22.0 API versions.
+For example, if you use the 1.23.0 release of the Knative (`kn`) CLI, which uses version 1.2, with the 1.24.0 {ServerlessProductName} release, which uses the 1.3 versions of the Knative Serving and Knative Eventing APIs, the CLI does not work because it continues to look for the outdated 1.2 API versions.
 
 Ensure that you are using the latest Knative (`kn`) CLI version for your {ServerlessProductName} release to avoid issues.
 ====
-// need to update this note, out of scope for this PR
 
 include::modules/serverless-installing-cli-web-console.adoc[leveloffset=+1]
 include::modules/serverless-installing-cli-linux-rpm-package-manager.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixed bug, cleaned up note and added verification steps.

Version(s):
OCP 4.6+

Issue:
Fixes https://github.com/openshift/openshift-docs/issues/50385

Link to docs preview:
https://50597--docspreview.netlify.app/openshift-enterprise/latest/serverless/cli_tools/installing-kn.html#installing-cli-web-console_installing-kn