### PR TITLE
BZ2097052 fixing missing variable in quay argument

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -67,7 +67,7 @@ $ oc adm release extract \
 --credentials-requests \
 --cloud=aws \
 --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
---quay.io/<path_to>/ocp-release:<version>
+--from=quay.io/<path_to>/ocp-release:<version>
 ----
 endif::aws-sts[]
 ifdef::google-cloud-platform[]

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -88,7 +88,7 @@ This command also creates a YAML configuration file in `/<path_to_ccoctl_output_
 $ oc adm release extract --credentials-requests \
 --cloud=aws \
 --to=<path_to_directory_with_list_of_credentials_requests>/credrequests <1>
---quay.io/<path_to>/ocp-release:<version>
+--from=quay.io/<path_to>/ocp-release:<version>
 ----
 +
 <1> `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.


### PR DESCRIPTION
QE tested and confirmed a missing portion of the quay argument in the following procedures, so the argument has been corrected in these two small modules.

Version(s):
  * PR applies to: 4.8+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2097052

Link to docs preview:
https://50598--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#sts-mode-create-aws-resources-ccoctl

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->


<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
