### PR TITLE
OSDOCS-4154 Adding AWS Marketplace install content [4.9]

### DIFF
--- a/installing/installing_aws/installing-aws-account.adoc
+++ b/installing/installing_aws/installing-aws-account.adoc
@@ -26,6 +26,8 @@ include::modules/installation-aws-iam-user.adoc[leveloffset=+1]
 
 include::modules/installation-aws-permissions-iam-roles.adoc[leveloffset=+1]
 
+include::modules/installation-aws-marketplace.adoc[leveloffset=+1]
+
 include::modules/installation-aws-regions.adoc[leveloffset=+1]
 
 == Next steps

--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -33,6 +33,8 @@ include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
+include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]
+
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]

--- a/installing/installing_aws/installing-aws-government-region.adoc
+++ b/installing/installing_aws/installing-aws-government-region.adoc
@@ -38,6 +38,8 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-aws-upload-custom-rhcos-ami.adoc[leveloffset=+1]
 
+include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]
+
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]

--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -25,7 +25,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 ====
 If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
-* You downloaded the AWS CLI and installed it on your computer. See link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or Unix)] in the AWS documentation.
+* You downloaded the AWS CLI and installed it on your computer. See link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or UNIX)] in the AWS documentation.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
@@ -53,6 +53,8 @@ include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-user-infra-requirements.adoc[leveloffset=+1]
 
 include::modules/installation-aws-permissions.adoc[leveloffset=+2]
+
+include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 

--- a/modules/installation-aws-marketplace-subscribe.adoc
+++ b/modules/installation-aws-marketplace-subscribe.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-customizations.adoc
+// * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-user-infra.adoc
+
+ifeval::["{context}" == "installing-aws-customizations"]
+:ipi:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:ipi:
+:gov-region:
+endif::[]
+ifeval::["{context}" == "installing-aws-user-infra"]
+:upi:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="installation-aws-marketplace-subscribe_{context}"]
+= Obtaining an AWS Marketplace image
+If you are deploying an {product-title} cluster using an AWS Marketplace image, you must first subscribe through AWS. Subscribing to the offer provides you with the AMI ID that the installation program uses to deploy worker nodes.
+
+[NOTE]
+====
+Deploying an {product-title} cluster using an AWS Marketplace image is not supported in the secret regions or China regions. 
+====
+
+.Prerequisites
+
+* You have an AWS account to purchase the offer. This account does not have to be the same account that is used to install the cluster.
+
+.Procedure
+
+. Complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace].
+ifdef::ipi[]
+. Record the AMI ID for your specific region. As part of the installation process, you must update the `install-config.yaml` file with this value before deploying the cluster.
+endif::ipi[]
+ifdef::upi[]
+. Record the AMI ID for your specific region. If you use the CloudFormation template to deploy your worker nodes, you must update the `worker0.type.properties.ImageID` parameter with this value.
+endif::upi[]
+
+ifdef::ipi[]
+.Sample `install-config.yaml` file with AWS Marketplace worker nodes
+
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com
+compute:
+- hyperthreading: Enabled
+  name: worker
+  platform:
+    aws:
+      amiID: ami-06c4d345f7c207239 <1>
+      type: m5.4xlarge
+  replicas: 3
+metadata:
+  name: test-cluster
+platform:
+  aws:
+ifndef::gov-region[]
+    region: us-east-2 <2>
+endif::gov-region[]
+ifdef::gov-region[]
+    region: us-gov-west-1 <2>
+endif::gov-region[]
+sshKey: ssh-ed25519 AAAA...
+pullSecret: '{"auths": ...}'
+----
+<1> The AMI ID from your AWS Marketplace subscription.
+<2> Your AMI ID is associated with a specific AWS region. When creating the installation configuration file, ensure that you select the same AWS region that you specified when configuring your subscription.
+endif::ipi[]
+
+ifeval::["{context}" == "installing-aws-customizations"]
+:!ipi:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:!ipi:
+:!gov-region:
+endif::[]
+ifeval::["{context}" == "installing-aws-user-infra"]
+:!upi:
+endif::[]

--- a/modules/installation-aws-marketplace.adoc
+++ b/modules/installation-aws-marketplace.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-account.adoc
+
+:_content-type: CONCEPT
+[id="installation-aws-marketplace_{context}"]
+= Supported AWS Marketplace regions
+
+Installing an {product-title} cluster using an AWS Marketplace image is available to customers who purchase the offer in North America.
+
+While the offer must be purchased in North America, you can deploy the cluster to any of the following supported partitions:
+
+* Public
+* GovCloud
+
+[NOTE]
+====
+Deploying a {product-title} cluster using an AWS Marketplace image is not supported for the AWS secret regions or China regions.
+====

--- a/modules/installation-creating-aws-worker.adoc
+++ b/modules/installation-creating-aws-worker.adoc
@@ -88,13 +88,13 @@ config files for the cluster.
 file metadata, which has the format `<cluster-name>-<random-string>`.
 <3> Current {op-system-first} AMI to use for the worker nodes.
 <4> Specify an `AWS::EC2::Image::Id` value.
-<5> A subnet, preferably private, to launch the worker nodes on.
+<5> A subnet, preferably private, to start the worker nodes on.
 <6> Specify a subnet from the `PrivateSubnets` value from the output of the
 CloudFormation template for DNS and load balancing.
 <7> The worker security group ID to associate with worker nodes.
 <8> Specify the `WorkerSecurityGroupId` value from the output of the
 CloudFormation template for the security group and roles.
-<9> The location to fetch bootstrap Ignition config file from.
+<9> The location to fetch the bootstrap Ignition config file from.
 <10> Specify the generated Ignition config location,
 `https://api-int.<cluster_name>.<domain_name>:22623/config/worker`.
 <11> Base64 encoded certificate authority string to use.
@@ -180,11 +180,11 @@ the CloudFormation template for the security group and roles.
 section of this topic and save it as a YAML file on your computer. This template
 describes the networking objects and load balancers that your cluster requires.
 
-. If you specified an `m5` instance type as the value for `WorkerInstanceType`,
-add that instance type to the `WorkerInstanceType.AllowedValues` parameter
-in the CloudFormation template.
+. Optional: If you specified an `m5` instance type as the value for `WorkerInstanceType`, add that instance type to the `WorkerInstanceType.AllowedValues` parameter in the CloudFormation template.
 
-. Launch the CloudFormation template to create a stack of AWS resources that represent a worker node:
+. Optional: If you are deploying with an AWS Marketplace image, update the `Worker0.type.properties.ImageID` parameter with the AMI ID that you obtained from your subscription.
+
+. Use the CloudFormation template to create a stack of AWS resources that represent a worker node:
 +
 [IMPORTANT]
 ====

--- a/modules/nw-sriov-networknodepolicy-object.adoc
+++ b/modules/nw-sriov-networknodepolicy-object.adoc
@@ -80,7 +80,8 @@ When `linkType` is set to `ib`, `isRdma` is automatically set to `true` by the S
 +
 Do not set `linkType` to `eth` for `SriovNetworkNodePolicy`, because this can lead to an incorrect number of available devices reported by the device plug-in.
 
-<18> Optional: To enable hardware offloading, the `eSwitchMode` field must be set to `switchdev`.
+//Commenting out as there doesn't seem to be a callout for this annotation 9/20/2022
+//<18> Optional: To enable hardware offloading, the `eSwitchMode` field must be set to `switchdev`.
 
 [id="sr-iov-network-node-configuration-examples_{context}"]
 == SR-IOV network node configuration examples


### PR DESCRIPTION
[OSDOCS-4154](https://issues.redhat.com//browse/OSDOCS-4154)
4.9 backport for https://issues.redhat.com/browse/OSDOCS-3030

This is a continuation of https://github.com/openshift/openshift-docs/pull/48413

Version(s)
4.9

Doc preview:
[Configuring an AWS account](https://bscott-rh.github.io/openshift-docs/OSDOCS-4154/installing/installing_aws/installing-aws-account.html#installation-aws-marketplace_installing-aws-account)
[Installing on AWS with customizations](https://bscott-rh.github.io/openshift-docs/OSDOCS-4154/installing/installing_aws/installing-aws-customizations.html#installation-aws-marketplace-subscribe_installing-aws-customizations)
[Installing on AWS on government or secret regions](https://bscott-rh.github.io/openshift-docs/OSDOCS-4154/installing/installing_aws/installing-aws-government-region.html#installation-aws-marketplace-subscribe_installing-aws-government-region)
[Creating the worker nodes in AWS](https://bscott-rh.github.io/openshift-docs/OSDOCS-4154/installing/installing_aws/installing-aws-user-infra.html#installation-creating-aws-worker_installing-aws-user-infra)