### PR TITLE
[enterprise-4.10] OSDOCS#1516: Updated reference to IBM Cloud VPC account to IBM Cloud …

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -59,7 +59,7 @@ Topics:
  Distros: openshift-enterprise
  Topics:
  - Name: Kubernetes overview
-   File: kubernetes-overview  
+   File: kubernetes-overview
  - Name: OpenShift Container Platform overview
    File: openshift-overview
  - Name: Web console walkthrough
@@ -250,7 +250,7 @@ Topics:
   Topics:
   - Name: Preparing to install on IBM Cloud VPC
     File: preparing-to-install-on-ibm-cloud
-  - Name: Configuring an IBM Cloud account VPC
+  - Name: Configuring an IBM Cloud account
     File: installing-ibm-cloud-account
   - Name: Configuring IAM for IBM Cloud VPC
     File: configuring-iam-ibm-cloud

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc
@@ -1,12 +1,12 @@
 :_content-type: ASSEMBLY
 [id="installing-ibm-cloud-account"]
-= Configuring an IBM Cloud VPC account
+= Configuring an IBM Cloud account
 include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-cloud-account
 
 toc::[]
 
-Before you can install {product-title}, you must configure an IBM Cloud VPC account.
+Before you can install {product-title}, you must configure an IBM Cloud account.
 
 :FeatureName: IBM Cloud VPC using installer-provisioned infrastructure
 include::snippets/technology-preview.adoc[]
@@ -14,7 +14,7 @@ include::snippets/technology-preview.adoc[]
 [id="prerequisites_installing-ibm-cloud-account"]
 == Prerequisites
 
-* You have an IBM Cloud VPC account with a subscription. You cannot install {product-title} on a free or trial IBM Cloud VPC account.
+* You have an IBM Cloud account with a subscription. You cannot install {product-title} on a free or trial IBM Cloud account.
 
 include::modules/quotas-and-limits-ibm-cloud.adoc[leveloffset=+1]
 

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
@@ -16,7 +16,7 @@ include::snippets/technology-preview.adoc[]
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[configured an IBM Cloud VPC account] to host the cluster.
+* You xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[configured an IBM Cloud account] to host the cluster.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 * You configured the `ccoctl` utility before you installed the cluster. For more information, see xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud VPC].
 

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
@@ -19,7 +19,7 @@ include::snippets/technology-preview.adoc[]
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[configured an IBM Cloud VPC account] to host the cluster.
+* You xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[configured an IBM Cloud account] to host the cluster.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 * You configured the `ccoctl` utility before you installed the cluster. For more information, see xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud VPC].
 

--- a/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc
@@ -21,7 +21,7 @@ include::snippets/technology-preview.adoc[]
 [id="requirements-for-installing-ocp-on-ibm-cloud"]
 == Requirements for installing {product-title} on IBM Cloud VPC
 
-Before installing {product-title} on IBM Cloud VPC, you must create a service account and configure an IBM Cloud VPC account. See xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[Configuring an IBM Cloud VPC account] for details about creating an account, enabling API services, configuring DNS, IBM Cloud VPC account limits, and supported IBM Cloud VPC regions.
+Before installing {product-title} on IBM Cloud VPC, you must create a service account and configure an IBM Cloud account. See xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[Configuring an IBM Cloud account] for details about creating an account, enabling API services, configuring DNS, IBM Cloud account limits, and supported IBM Cloud VPC regions.
 
 You must manually manage your cloud credentials when installing a cluster to IBM Cloud VPC. Do this by configuring the Cloud Credential Operator (CCO) for manual mode before you install the cluster. For more information, see xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud VPC].
 
@@ -43,4 +43,4 @@ You can install a cluster on IBM Cloud VPC infrastructure that is provisioned by
 
 [id="next-steps_preparing-to-install-on-ibm-cloud"]
 == Next steps
-* xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[Configuring an IBM Cloud VPC account]
+* xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[Configuring an IBM Cloud account]

--- a/modules/installation-ibm-cloud-creating-api-key.adoc
+++ b/modules/installation-ibm-cloud-creating-api-key.adoc
@@ -6,11 +6,11 @@
 [id="installation-ibm-cloud-creating-api-key_{context}"]
 = Creating an API key
 
-You must create a user API key or a service ID API key for your IBM Cloud VPC account.
+You must create a user API key or a service ID API key for your IBM Cloud account.
 
 .Prerequisites
 
-* You have assigned the required access policies to your IBM Cloud VPC account.
+* You have assigned the required access policies to your IBM Cloud account.
 * You have attached you IAM access policies to an access group, or other appropriate resource.
 
 .Procedure

--- a/modules/installation-ibm-cloud-export-variables.adoc
+++ b/modules/installation-ibm-cloud-export-variables.adoc
@@ -11,7 +11,7 @@ You must set the IBM Cloud VPC API key you created as a global variable; the ins
 
 .Prerequisties
 
-* You have created either a user API key or service ID API key for your IBM Cloud VPC account.
+* You have created either a user API key or service ID API key for your IBM Cloud account.
 
 .Procedure
 

--- a/modules/installation-ibm-cloud-iam-policies-api-key.adoc
+++ b/modules/installation-ibm-cloud-iam-policies-api-key.adoc
@@ -6,14 +6,14 @@
 [id="installation-ibm-cloud-iam-policies-api-key_{context}"]
 = IBM Cloud VPC IAM Policies and API Key
 
-To install {product-title} into your IBM Cloud VPC account, the installation program requires an IAM API key, which provides authentication and authorization to access IBM Cloud service APIs. You can use an existing IAM API key that contains the required policies or create a new one.
+To install {product-title} into your IBM Cloud account, the installation program requires an IAM API key, which provides authentication and authorization to access IBM Cloud service APIs. You can use an existing IAM API key that contains the required policies or create a new one.
 
 For an IBM Cloud IAM overview, see the IBM Cloud link:https://cloud.ibm.com/docs/account?topic=account-iamoverview[documentation].
 
 [id="required-access-policies-ibm-cloud_{context}"]
 == Required access policies
 
-You must assign the required access policies to your IBM Cloud VPC account.
+You must assign the required access policies to your IBM Cloud account.
 
 .Required access policies
 [cols="1,2,2,2,3",options="header"]

--- a/modules/quotas-and-limits-ibm-cloud.adoc
+++ b/modules/quotas-and-limits-ibm-cloud.adoc
@@ -6,7 +6,7 @@
 [id="quotas-and-limits-ibm-cloud_{context}"]
 = Quotas and limits on IBM Cloud VPC
 
-The {product-title} cluster uses a number of IBM Cloud VPC components, and the default quotas and limits affect your ability to install {product-title} clusters. If you use certain cluster configurations, deploy your cluster in certain regions, or run multiple clusters from your account, you might need to request additional resources for your IBM Cloud VPC account.
+The {product-title} cluster uses a number of IBM Cloud VPC components, and the default quotas and limits affect your ability to install {product-title} clusters. If you use certain cluster configurations, deploy your cluster in certain regions, or run multiple clusters from your account, you might need to request additional resources for your IBM Cloud account.
 
 For a comprehensive list of the default IBM Cloud VPC quotas and service limits, see IBM Cloud's documentation for link:https://cloud.ibm.com/docs/vpc?topic=vpc-quotas[Quotas and service limits].
 
@@ -80,7 +80,7 @@ For more information, see IBM Cloud's documentation on link:https://cloud.ibm.co
 |19 per region
 |===
 
-If you plan to exceed the resources stated in the table, you must increase your IBM Cloud VPC account quota.
+If you plan to exceed the resources stated in the table, you must increase your IBM Cloud account quota.
 
 [discrete]
 == Block Storage Volumes


### PR DESCRIPTION
Version(s):
4.10

This is a continuation of https://github.com/openshift/openshift-docs/pull/50595.

I was unable to resolve the 4.10 merge conflict by cherry picking the commit ID of https://github.com/openshift/openshift-docs/pull/50595. Instead, I have manually applied the changes to the 4.10 branch.

Issue:
This issue address [OSDOCS#1516](https://issues.redhat.com/browse/OCPBUGS-1516) explicitly for the 4.10 enterprise branch.

Link to docs preview:

- [Preparing to install on IBM Cloud VPC](http://file.rdu.redhat.com/mpytlak/ocpbugs-1516-410/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.html)
- [Configuring an IBM Cloud account](http://file.rdu.redhat.com/mpytlak/ocpbugs-1516-410/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.html)
- [Installing a cluster on IBM Cloud VPC with customizations](http://file.rdu.redhat.com/mpytlak/ocpbugs-1516-410/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.html)
- [Installing a cluster on IBM Cloud VPC with network customizations](http://file.rdu.redhat.com/mpytlak/ocpbugs-1516-410/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.html)
- [Exporting the IBM Cloud VPC API key](http://file.rdu.redhat.com/mpytlak/ocpbugs-1516-410/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.html#installation-ibm-cloud-export-variables_installing-ibm-cloud-network-customizations)