### PR TITLE
RHDEVDOCS-4175 Document that all S2I tasks are failing and the solution

### DIFF
--- a/modules/op-release-notes-1-7.adoc
+++ b/modules/op-release-notes-1-7.adoc
@@ -409,7 +409,17 @@ time="2022-03-04T09:47:57Z" level=error msg="error writing \"0 0 4294967295\\n\"
 time="2022-03-04T09:47:57Z" level=error msg="(unable to determine exit status)"
 ----
 +
-With this update, the `pipelines-scc` security context constraint (SCC) is compatible with the `SETFCAP` capability necessary for S2I and Buildah clustertasks. As a result, the S2I build tasks run successfully.
+With this update, the `pipelines-scc` security context constraint (SCC) is compatible with the `SETFCAP` capability necessary for `Buildah` and `S2I` cluster tasks. As a result, the `Buildah` and `S2I` build tasks can run successfully.
++
+To successfully run the `Buildah` cluster task and `S2I` build tasks for applications written in various languages and frameworks, add the following snippet for appropriate `steps` objects such as `build` and `push`:
++
+[source,yaml]
+----
+securityContext:
+  capabilities:
+    add: ["SETFCAP"]
+----
++
 // https://issues.redhat.com/browse/SRVKP-2091
 
 

--- a/modules/op-release-notes-1-8.adoc
+++ b/modules/op-release-notes-1-8.adoc
@@ -494,13 +494,23 @@ This update fixes the issue. It passes the namespace-based configuration to the 
 
 * Before this update, all S2I build tasks failed with an error similar to the following message:
 +
+[source,terminal]
 ----
 Error: error writing "0 0 4294967295\n" to /proc/22/uid_map: write /proc/22/uid_map: operation not permitted
 time="2022-03-04T09:47:57Z" level=error msg="error writing \"0 0 4294967295\\n\" to /proc/22/uid_map: write /proc/22/uid_map: operation not permitted"
 time="2022-03-04T09:47:57Z" level=error msg="(unable to determine exit status)"
 ----
 +
-With this update, the `pipelines-scc` security context constraint (SCC) is compatible with the `SETFCAP` capability necessary for S2I and Buildah cluster tasks. As a result, the S2I build tasks run successfully.
+With this update, the `pipelines-scc` security context constraint (SCC) is compatible with the `SETFCAP` capability necessary for `Buildah` and `S2I` cluster tasks. As a result, the `Buildah` and `S2I` build tasks can run successfully.
++
+To successfully run the `Buildah` cluster task and `S2I` build tasks for applications written in various languages and frameworks, add the following snippet for appropriate `steps` objects such as `build` and `push`:
++
+[source,yaml]
+----
+securityContext:
+  capabilities:
+    add: ["SETFCAP"]
+----
 +
 // (borrowed from 1.7.2 release notes) https://issues.redhat.com/browse/SRVKP-2091
 // Piyush Garg


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`, `enterprise-4.12`
- **JIRA issues**: [RHDEVDOCS-4175 Document that all S2I build tasks are failing and solutions](https://issues.redhat.com/browse/RHDEVDOCS-4175)
- **Preview pages**: See the `Fixed issues` subsection in the 1.7.2 and 1.8 sections:
  - **1.8**: http://file.pnq.redhat.com/sosarkar/4175-S2I-tasks-failing/cicd/pipelines/op-release-notes.html#fixed-issues-1-8_op-release-notes
  - **1.7.2**: http://file.pnq.redhat.com/sosarkar/4175-S2I-tasks-failing/cicd/pipelines/op-release-notes.html#fixed-issues-1-7-2_op-release-notes
- **SME review**: @piyush-garg          
- **QE review**: Not necessary as this is a very minor change that doesn't affect any procedure.
- **Peer-review**: TBD  