### PR TITLE
TELCODOCS-785: RN -  RPS masking with workload hints realTime disabled - WIP

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -298,6 +298,15 @@ For more information about how the migration to OVN-Kubernetes works, see xref:.
 ==== Egress firewall audit logging
 
 For the OVN-Kubernetes network plug-in, egress firewalls support audit logging using the same mechanism that network policy audit logging uses. For more information, see xref:../networking/ovn_kubernetes_network_provider/logging-network-policy.adoc#logging-network-policy[Logging for egress firewall and network policy rules].
+[id="ocp-4-12-rsp-workload-hints"]
+==== Disabling realtime using workload hints removes Receive Packet Steering from the cluster 
+By default, a systemd service sets a Receive Packet Steering (RPS) mask for virtual network interfaces in the cluster. The RPS mask routes interrupt requests from virtual network interfaces according to the list of reserved CPUs defined in the performance profile. A crio hook script also sets an RPS mask for all virtual network devices at the container level.
+
+With this update, if you set `spec.workloadHints.realTime` in the performance profile to `False`, the system also disables both the systemd service and the crio hook script which set the RPS mask. The system disables these RPS functions because RPS is typically relevant to use cases requiring low-latency, realtime workloads only.
+
+To retain RPS functions even when you set `spec.workloadHints.realTime` to `False`, see the __RPS Settings__ section of the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/5532341[Performance addons operator advanced configuration].
+
+For more information about configuring workload hints, see xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#cnf-understanding-workload-hints_cnf-master[Understanding workload hints].
 
 [id="ocp-4-12-storage"]
 === Storage


### PR DESCRIPTION
[TELCODOCS-785](https://issues.redhat.com//browse/TELCODOCS-785): When you set `spec.workloadHints.realTime` to `False` in a performance profile, any RPS settings applied in the cluster are removed. 

Version(s): 
4.12+ 

Issue: 
https://issues.redhat.com/browse/TELCODOCS-785

Link to docs preview: 
http://file.emea.redhat.com/rohennes/TELCODOCS-785-RN-RPS-workload-hints/release_notes/ocp-4-12-release-notes.html#ocp-4-12-rsp-workload-hints
