### PR TITLE
[SRVCOM-1949] Add default broker backing channel config settings

### DIFF
--- a/modules/serverless-broker-backing-channel-default.adoc
+++ b/modules/serverless-broker-backing-channel-default.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+//  * serverless/admin_guide/serverless-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-broker-backing-channel-default_{context}"]
+= Configuring the default broker backing channel
+
+If you are using a channel-based broker, you can set the default backing channel type for the broker to either `InMemoryChannel` or `KafkaChannel`.
+
+.Prerequisites
+
+* You have administrator permissions on {product-title}.
+* You have installed the {ServerlessOperatorName} and Knative Eventing on your cluster.
+* You have installed the OpenShift (`oc`) CLI.
+* If you want to use Kafka channels as the default backing channel type, you must also install the `KnativeKafka` CR on your cluster.
+
+.Procedure
+
+. Modify the `KnativeEventing` custom resource (CR) to add configuration details for the `config-br-default-channel` config map:
++
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  config: <1>
+    config-br-default-channel:
+      channel-template-spec: |
+        apiVersion: messaging.knative.dev/v1beta1
+        kind: KafkaChannel <2>
+        spec:
+          numPartitions: 6 <3>
+          replicationFactor: 3 <4>
+----
+<1> In `spec.config`, you can specify the config maps that you want to add modified configurations for.
+<2> The default backing channel type configuration. In this example, the default channel implementation for the cluster is `KafkaChannel`.
+<3> The number of partitions for the Kafka channel that backs the broker.
+<4> The replication factor for the Kafka channel that backs the broker.
+
+. Apply the updated `KnativeEventing` CR:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----

--- a/serverless/admin_guide/serverless-configuration.adoc
+++ b/serverless/admin_guide/serverless-configuration.adoc
@@ -14,6 +14,7 @@ The `spec.config` in the Knative custom resources have one `<name>` entry for ea
 
 // Knative Eventing
 include::modules/serverless-channel-default.adoc[leveloffset=+1]
+include::modules/serverless-broker-backing-channel-default.adoc[leveloffset=+1]
 
 // Knative Serving
 //autoscaling


### PR DESCRIPTION
Version(s):
OCP 4.6+

Issue:
https://issues.redhat.com/browse/SRVCOM-1949

Link to docs preview:
https://50649--docspreview.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-configuration.html#serverless-broker-backing-channel-default_serverless-configuration