### PR TITLE
GH#49000: Updating erroneous release note entry

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2456,26 +2456,7 @@ openshift.io/scc: hostmount-anyuid
 
 * There is a known issue on Nutanix where persistent volumes (PVs) created by a cluster are not cleaned up by the  `destroy cluster` command. As a workaround for this issue, you need to clean up the PVs manually. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2108700[*BZ#2108700*])
 
-* There is currently a known issue when creating and editing `egressqos` with incorect syntax or values success. The incorrect values in `egressqos` should not be able to be created successfully. As a workaround, use
-+
-[source,terminal]
-
-----
-diff --git a/go-controller/pkg/crd/egressqos/v1/types.go b/go-controller/pkg/crd/egressqos/v1/types.go
-index a90ab14ff..f7f6f1a71 100644
---- a/go-controller/pkg/crd/egressqos/v1/types.go
-+++ b/go-controller/pkg/crd/egressqos/v1/types.go
-@@ -59,6 +59,7 @@ type EgressQoSRule struct {
-        // This field is optional, and in case it is not set the rule is applied
-        // to all egress traffic regardless of the destination.
-        // +optional
-+       // +kubebuilder:validation:Format="cidr"
-        DstCIDR *string `json:"dstCIDR,omitempty"`
-
-        // PodSelector applies the QoS rule only to the pods in the namespace whose label
-----
-
-+
+* There is currently a known issue when creating and editing `egressqos` with incorrect syntax or values success. The incorrect values in `egressqos` should not create successfully. There is currently no workaround for this issue.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097579[*BZ#2097579*])
 
 [id="ocp-4-11-asynchronous-errata-updates"]


### PR DESCRIPTION
Applies only to 4.11

#49000

SME and QE approved.

This fix updates a release note entry for 4.11 that documented the output of a git diff command as a workaround for a specific issue. There is actually no workaround for this issue, so the entry was updated accordingly.

Preview: https://50650--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html