### PR TITLE
OSDOCS-4146: Added step to remove manifests that define control plane…

### DIFF
--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -166,6 +166,15 @@ $ rm -f <installation_directory>/openshift/99_openshift-cluster-api_master-machi
 By removing these files, you prevent the cluster from automatically generating control plane machines.
 endif::aws,azure,ash,gcp[]
 
+ifdef::aws[]
+. Remove the Kubernetes manifest files that define the control plane machineset:
++
+[source,terminal]
+----
+$ rm -f <installation_directory>/openshift/99_openshift-machine-api_master-control-plane-machine-set.yaml
+----
+endif::aws[]
+
 ifdef::gcp[]
 ifndef::user-infra-vpc[]
 . Optional: If you do not want the cluster to provision compute machines, remove
@@ -182,8 +191,7 @@ ifdef::aws,azure,ash,gcp[]
 $ rm -f <installation_directory>/openshift/99_openshift-cluster-api_worker-machineset-*.yaml
 ----
 +
-Because you create and manage the worker machines yourself, you do not need
-to initialize these machines.
+Because you create and manage the worker machines yourself, you do not need to initialize these machines.
 endif::aws,azure,ash,gcp[]
 
 ifdef::osp,vsphere,vmc[]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
This PR addresses [OSDOCS-4146](https://issues.redhat.com/browse/OSDOCS-4146). Updated the procedure on creating the Kubernetes manifest and Ignition config files to include a new step for removing the manifests that define the control plane machineset, which was introduced in [CORS-2128](https://issues.redhat.com/browse/CORS-2128).

QE review:
Approved

Link to docs preview:
Installing a cluster on user-provisioned infrastructure in AWS by using CloudFormation templates > [Creating the Kubernetes manifest and Ignition config files](https://50657--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-user-infra-generate-k8s-manifest-ignition_installing-aws-user-infra)