### PR TITLE
BZ2103610 fixing taints, 9 BZs total

### DIFF
--- a/modules/nodes-scheduler-taints-tolerations-about.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-about.adoc
@@ -16,14 +16,10 @@ You apply taints to a node through the `Node` specification (`NodeSpec`) and app
 [source,yaml]
 ----
 spec:
-....
-  template:
-....
-    spec:
-      taints:
-      - effect: NoExecute
-        key: key1
-        value: value1
+  taints:
+  - effect: NoExecute
+    key: key1
+    value: value1
 ....
 ----
 
@@ -31,16 +27,12 @@ spec:
 [source,yaml]
 ----
 spec:
-....
-  template:
-....
-    spec:
-      tolerations:
-      - key: "key1"
-        operator: "Equal"
-        value: "value1"
-        effect: "NoExecute"
-        tolerationSeconds: 3600
+  tolerations:
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoExecute"
+    tolerationSeconds: 3600
 ....
 ----
 
@@ -148,16 +140,12 @@ You can specify how long a pod can remain bound to a node before being evicted b
 [source,yaml]
 ----
 spec:
-....
-  template:
-....
-    spec:
-      tolerations:
-      - key: "key1"
-        operator: "Equal"
-        value: "value1"
-        effect: "NoExecute"
-        tolerationSeconds: 3600
+  tolerations:
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoExecute"
+    tolerationSeconds: 3600
 ----
 
 Here, if this pod is running but does not have a matching toleration, the pod stays bound to the node for 3,600 seconds and then be evicted. If the taint is removed before that time, the pod is not evicted.
@@ -204,19 +192,15 @@ $ oc adm taint nodes node1 key2=value2:NoSchedule
 [source,yaml]
 ----
 spec:
-....
-  template:
-....
-    spec:
-      tolerations:
-      - key: "key1"
-        operator: "Equal"
-        value: "value1"
-        effect: "NoSchedule"
-      - key: "key1"
-        operator: "Equal"
-        value: "value1"
-        effect: "NoExecute"
+  tolerations:
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoSchedule"
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoExecute"
 ----
 
 In this case, the pod cannot be scheduled onto the node, because there is no toleration matching the third taint. The pod continues running if it is already running on the node when the taint is added, because the third taint is the only
@@ -269,19 +253,15 @@ For more information, see link:https://kubernetes.io/docs/concepts/architecture/
 [source,yaml]
 ----
 spec:
-....
-  template:
-....
-    spec:
-      tolerations:
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-        effect: NoExecute
-        tolerationSeconds: 300 <1>
-      - key: node.kubernetes.io/unreachable
-        operator: Exists
-        effect: NoExecute
-        tolerationSeconds: 300
+  tolerations:
+  - key: node.kubernetes.io/not-ready
+    operator: Exists
+    effect: NoExecute
+    tolerationSeconds: 300 <1>
+  - key: node.kubernetes.io/unreachable
+    operator: Exists
+    effect: NoExecute
+    tolerationSeconds: 300
 ----
 
 <1> These tolerations ensure that the default pod behavior is to remain bound for five minutes after one of these node conditions problems is detected.
@@ -305,10 +285,6 @@ Pods with this toleration are not removed from a node that has taints.
 [source,yaml]
 ----
 spec:
-....
-  template:
-....
-    spec:
-      tolerations:
-      - operator: "Exists"
+  tolerations:
+  - operator: "Exists"
 ----

--- a/modules/nodes-scheduler-taints-tolerations-adding-machineset.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-adding-machineset.adoc
@@ -17,16 +17,12 @@ You can add taints to nodes using a machine set. All nodes associated with the `
 [source,yaml]
 ----
 spec:
-....
-  template:
-....
-    spec:
-      tolerations:
-      - key: "key1" <1>
-        value: "value1"
-        operator: "Equal"
-        effect: "NoExecute"
-        tolerationSeconds: 3600 <2>
+  tolerations:
+  - key: "key1" <1>
+    value: "value1"
+    operator: "Equal"
+    effect: "NoExecute"
+    tolerationSeconds: 3600 <2>
 ----
 <1> The toleration parameters, as described in the *Taint and toleration components* table.
 <2> The `tolerationSeconds` parameter specifies how long a pod is bound to a node before being evicted.

--- a/modules/nodes-scheduler-taints-tolerations-adding.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-adding.adoc
@@ -17,16 +17,12 @@ You add tolerations to pods and taints to nodes to allow the node to control whi
 [source,yaml]
 ----
 spec:
-....
-  template:
-....
-    spec:
-      tolerations:
-      - key: "key1" <1>
-        value: "value1"
-        operator: "Equal"
-        effect: "NoExecute"
-        tolerationSeconds: 3600 <2>
+  tolerations:
+  - key: "key1" <1>
+    value: "value1"
+    operator: "Equal"
+    effect: "NoExecute"
+    tolerationSeconds: 3600 <2>
 ----
 <1> The toleration parameters, as described in the *Taint and toleration components* table.
 <2> The `tolerationSeconds` parameter specifies how long a pod can remain bound to a node before being evicted.
@@ -36,16 +32,12 @@ For example:
 .Sample pod configuration file with an Exists operator
 [source,yaml]
 ----
-spec:
-....
-  template:
-....
-    spec:
-      tolerations:
-      - key: "key1"
-        operator: "Exists" <1>
-        effect: "NoExecute"
-        tolerationSeconds: 3600
+spec: 
+   tolerations:
+    - key: "key1"
+      operator: "Exists" <1>
+      effect: "NoExecute"
+      tolerationSeconds: 3600
 ----
 <1> The `Exists` operator does not take a `value`.
 +


### PR DESCRIPTION
This bug includes eight others and addresses an incorrect example in three modules. QE confirmed the reporter as correct in the first (#10) ticket.

Version(s):
  * PR applies to: 4.8+

Issues:
This fix (applied in three modules and several sections) is in reference to:

https://bugzilla.redhat.com/show_bug.cgi?id=2103610
https://bugzilla.redhat.com/show_bug.cgi?id=2103611
https://bugzilla.redhat.com/show_bug.cgi?id=2103612
https://bugzilla.redhat.com/show_bug.cgi?id=2103613
https://bugzilla.redhat.com/show_bug.cgi?id=2103614
https://bugzilla.redhat.com/show_bug.cgi?id=2103615
https://bugzilla.redhat.com/show_bug.cgi?id=2103616
https://bugzilla.redhat.com/show_bug.cgi?id=2103617
https://bugzilla.redhat.com/show_bug.cgi?id=2103618

Links to docs preview (not in order of bugs, in order they occur in docs for easier viewing):
https://50662--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations

https://50662--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-about-seconds_nodes-scheduler-taints-tolerations

https://50662--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-about-multiple_nodes-scheduler-taints-tolerations

https://50662--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-about-taintBasedEvictions_nodes-scheduler-taints-tolerations

https://50662--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-adding_nodes-scheduler-taints-tolerations

https://50662--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-adding-machineset_nodes-scheduler-taints-tolerations

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
