### PR TITLE
adding DDF module

### DIFF
--- a/modules/providing-direct-documentation-feedback.adoc
+++ b/modules/providing-direct-documentation-feedback.adoc
@@ -1,0 +1,24 @@
+:_module-type: CONCEPT
+
+[id="providing-direct-documentation-feedback_{context}"]
+= Providing feedback on Red Hat documentation
+
+[role="_abstract"]
+We appreciate your feedback on our technical content and encourage you to tell us what you think.
+If you'd like to add comments, provide insights, correct a typo, or even ask a question, you can do so directly in the documentation.
+
+[NOTE]
+====
+You must have a Red Hat account and be logged in to the customer portal.
+====
+
+To submit documentation feedback from the customer portal, do the following:
+
+. Select the *Multi-page HTML* format.
+. Click the *Feedback* button at the top-right of the document.
+. Highlight the section of text where you want to provide feedback.
+. Click the *Add Feedback* dialog next to your highlighted text.
+. Enter your feedback in the text box on the right of the page and then click *Submit*.
+
+We automatically create a tracking issue each time you submit feedback.
+Open the link that is displayed after you click *Submit* and start watching the issue or add more comments.


### PR DESCRIPTION
This is a copy of the [DDF module](https://github.com/redhat-documentation/mw-shared-modules/blob/master/runtimes-common/proc_providing_direct_documentation_feedback.adoc) that all of runtimes uses. I've updated the module type attribute to meet the repo guidelines. If we're successful, it'll be automatically injected into the `master.adoc` files that drive the PV1 titles, so the list of where the module's used is not currently necessary.

4.6+