### PR TITLE
OSDOCS-4183: add enabling serial console

### DIFF
--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -118,25 +118,33 @@ include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-machines-advanced.adoc[leveloffset=+2]
 
-include::modules/installation-user-infra-machines-advanced-customizing-iso-or-pxe.adoc[leveloffset=+4]
+include::modules/installation-user-infra-machines-advanced-console-configuration.adoc[leveloffset=+3]
+
+include::modules/installation-user-infra-machines-advanced-enabling-serial-console.adoc[leveloffset=+3]
+
+include::modules/installation-user-infra-machines-advanced-customizing-iso-or-pxe.adoc[leveloffset=+3]
 
 :boot-media: ISO image
 :boot: iso
-include::modules/installation-user-infra-machines-advanced-customizing-live.adoc[leveloffset=+4]
+include::modules/installation-user-infra-machines-advanced-customizing-live.adoc[leveloffset=+3]
 
-include::modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc[leveloffset=+5]
+include::modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc[leveloffset=+4]
 
-include::modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc[leveloffset=+5]
+include::modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc[leveloffset=+4]
+
+include::modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc[leveloffset=+4]
 :boot-media!:
 :boot!:
 
 :boot-media: PXE environment
 :boot: pxe
-include::modules/installation-user-infra-machines-advanced-customizing-live.adoc[leveloffset=+4]
+include::modules/installation-user-infra-machines-advanced-customizing-live.adoc[leveloffset=+3]
 
-include::modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc[leveloffset=+5]
+include::modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc[leveloffset=+4]
 
-include::modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc[leveloffset=+5]
+include::modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc[leveloffset=+4]
+
+include::modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc[leveloffset=+4]
 :boot-media!:
 :boot!:
 

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -133,25 +133,33 @@ include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-machines-advanced.adoc[leveloffset=+2]
 
-include::modules/installation-user-infra-machines-advanced-customizing-iso-or-pxe.adoc[leveloffset=+4]
+include::modules/installation-user-infra-machines-advanced-console-configuration.adoc[leveloffset=+3]
+
+include::modules/installation-user-infra-machines-advanced-enabling-serial-console.adoc[leveloffset=+3]
+
+include::modules/installation-user-infra-machines-advanced-customizing-iso-or-pxe.adoc[leveloffset=+3]
 
 :boot-media: ISO image
 :boot: iso
-include::modules/installation-user-infra-machines-advanced-customizing-live.adoc[leveloffset=+4]
+include::modules/installation-user-infra-machines-advanced-customizing-live.adoc[leveloffset=+3]
 
-include::modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc[leveloffset=+5]
+include::modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc[leveloffset=+4]
 
-include::modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc[leveloffset=+5]
+include::modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc[leveloffset=+4]
+
+include::modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc[leveloffset=+4]
 :boot-media!:
 :boot!:
 
 :boot-media: PXE environment
 :boot: pxe
-include::modules/installation-user-infra-machines-advanced-customizing-live.adoc[leveloffset=+4]
+include::modules/installation-user-infra-machines-advanced-customizing-live.adoc[leveloffset=+3]
 
-include::modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc[leveloffset=+5]
+include::modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc[leveloffset=+4]
 
-include::modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc[leveloffset=+5]
+include::modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc[leveloffset=+4]
+
+include::modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc[leveloffset=+4]
 :boot-media!:
 :boot!:
 

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -139,25 +139,33 @@ include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-machines-advanced.adoc[leveloffset=+2]
 
-include::modules/installation-user-infra-machines-advanced-customizing-iso-or-pxe.adoc[leveloffset=+4]
+include::modules/installation-user-infra-machines-advanced-console-configuration.adoc[leveloffset=+3]
+
+include::modules/installation-user-infra-machines-advanced-enabling-serial-console.adoc[leveloffset=+3]
+
+include::modules/installation-user-infra-machines-advanced-customizing-iso-or-pxe.adoc[leveloffset=+3]
 
 :boot-media: ISO image
 :boot: iso
-include::modules/installation-user-infra-machines-advanced-customizing-live.adoc[leveloffset=+4]
+include::modules/installation-user-infra-machines-advanced-customizing-live.adoc[leveloffset=+3]
 
-include::modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc[leveloffset=+5]
+include::modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc[leveloffset=+4]
 
-include::modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc[leveloffset=+5]
+include::modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc[leveloffset=+4]
+
+include::modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc[leveloffset=+4]
 :boot-media!:
 :boot!:
 
 :boot-media: PXE environment
 :boot: pxe
-include::modules/installation-user-infra-machines-advanced-customizing-live.adoc[leveloffset=+4]
+include::modules/installation-user-infra-machines-advanced-customizing-live.adoc[leveloffset=+3]
 
-include::modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc[leveloffset=+5]
+include::modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc[leveloffset=+4]
 
-include::modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc[leveloffset=+5]
+include::modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc[leveloffset=+4]
+
+include::modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc[leveloffset=+4]
 :boot-media!:
 :boot!:
 

--- a/modules/installation-user-infra-machines-advanced-console-configuration.adoc
+++ b/modules/installation-user-infra-machines-advanced-console-configuration.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies
+//
+// * installing/installing_bare_metal/installing-bare-metal.adoc
+// * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+// * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+
+:_content-type: CONCEPT
+[id="installation-user-infra-machines-advanced-console-configuration_{context}"]
+= Default console configuration
+
+{op-system-first} nodes installed from an {product-title} {product-version} boot image use a default console that is meant to accomodate most virtualized and bare metal setups. Different cloud and virtualization platforms may use different default settings depending on the chosen architecture. Bare metal installations use the kernel default settings which typically means the graphical console is the primary console and the serial console is disabled.
+
+The default consoles may not match your specific hardware configuration or you might have specific needs that require you to adjust the default console. For example:
+
+* You want to access the emergency shell on the console for debugging purposes.
+* Your cloud platform does not provide interactive access to the graphical console, but provides a serial console.
+* You want to enable multiple consoles.
+
+Console configuration is inherited from the boot image. This means that new nodes in existing clusters are unaffected by changes to the default console.
+
+You can configure the console for bare metal installations in the following ways:
+
+* Using `coreos-installer` manually on the command line.
+* Using the `coreos-installer iso customize` or `coreos-installer pxe customize` subcommands with the `--dest-console` option to create a custom image that automates the process.
+
+[NOTE]
+====
+For advanced customization, perform console configuration using the `coreos-installer iso` or `coreos-installer pxe` subcommands, and not kernel arguments.
+====

--- a/modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies
+//
+// * installing/installing_bare_metal/installing-bare-metal.adoc
+// * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+// * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+
+:_content-type: PROCEDURE
+[id="installation-user-infra-machines-advanced-customizing-live-{boot}-serial-console_{context}"]
+= Modifying a live install {boot-media} to enable the serial console
+
+On clusters installed with {product-title} 4.12 and above, the serial console is disabled by default and all output is written to the graphical console. You can enable the serial console with the following procedure.
+
+.Procedure
+
+. Download the `coreos-installer` binary from the link:https://mirror.openshift.com/pub/openshift-v4/clients/coreos-installer/latest/[`coreos-installer` image mirror] page.
+
+ifeval::["{boot-media}" == "ISO image"]
+. Retrieve the {op-system} ISO image from the link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/[{op-system} image mirror] page and run the following command to customize the ISO image to enable the serial console to receive output:
++
+[source,terminal]
+----
+$ coreos-installer iso customize rhcos-<version>-live.x86_64.iso \
+  --dest-ignition <path> \//<1>
+  --dest-console tty0 \//<2>
+  --dest-console ttyS0,<options> \//<3>
+  --dest-device /dev/sda <4>
+----
++
+<1> The location of the Ignition config to install.
+<2> The desired secondary console. In this case, the graphical console. Omitting this option will disable the graphical console.
+<3> The desired primary console. In this case, the serial console. The `options` field defines the baud rate and other settings. A common value for this field is `115200n8`. If no options are provided, the default kernel value of `9600n8` is used. For more information on the format of this option, see the link:https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html[Linux kernel serial console] documentation.
+<4> The specified disk to install to. In this case, `/dev/sda`. If you omit this option, the {boot-media} automatically runs the installation program which will fail unless you also specify the `coreos.inst.install_dev` kernel argument.
++
+[NOTE]
+====
+The `--dest-console` option affects the installed system and not the live ISO system. To modify the console for a live ISO system, use the `--live-karg-append` option and specify the console with `console=`.
+====
++
+Your customizations are applied and affect every subsequent boot of the {boot-media}.
+
+. Optional: To remove the {boot-media} customizations and return the image to its original state, run the following command:
++
+[source,terminal]
+----
+$ coreos-installer iso reset rhcos-<version>-live.x86_64.iso
+----
++
+You can now recustomize the live {boot-media} or use it in its original state.
+
+endif::[]
+
+ifeval::["{boot-media}" == "PXE environment"]
+. Retrieve the {op-system} `kernel`, `initramfs` and `rootfs` files from the link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/[{op-system} image mirror] page and the Ignition config file, and then run the following command to create a new customized `initramfs` file that enables the serial console to receive output:
++
+[source,terminal]
+----
+$ coreos-installer pxe customize rhcos-<version>-live-initramfs.x86_64.img \
+  --dest-ignition <path> \//<1>
+  --dest-console tty0 \//<2>
+  --dest-console ttyS0,<options> \//<3>
+  --dest-device /dev/sda \//<4>
+  -o rhcos-<version>-custom-initramfs.x86_64.img
+----
++
+<1> The location of the Ignition config to install.
+<2> The desired secondary console. In this case, the graphical console. Omitting this option will disable the graphical console.
+<3> The desired primary console. In this case, the serial console. The `options` field defines the baud rate and other settings. A common value for this field is `115200n8`. If no options are provided, the default kernel value of `9600n8` is used. For more information on the format of this option, see the link:https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html[Linux kernel serial console] documentation.
+<4> The specified disk to install to. In this case, `/dev/sda`. If you omit this option, the {boot-media} automatically runs the installer which will fail unless you also specify the `coreos.inst.install_dev` kernel argument.
++
+Your customizations are applied and affect every subsequent boot of the {boot-media}.
+endif::[]

--- a/modules/installation-user-infra-machines-advanced-enabling-serial-console.adoc
+++ b/modules/installation-user-infra-machines-advanced-enabling-serial-console.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bare_metal/installing-bare-metal.adoc
+// * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+// * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+
+:_content-type: PROCEDURE
+[id="installation-user-infra-machines-advanced-enabling-serial-console_{context}"]
+= Enabling the serial console for PXE and ISO installations
+
+By default, the {op-system-first} serial console is disabled and all output is written to the graphical console. You can enable the serial console for an ISO installatiand reconfigure the bootloader so that output is sent to both the serial console and the graphical console.
+
+.Procedure
+
+. Boot the ISO installer.
+
+. Run the `coreos-installer` command to install the system, adding the `--console` option once to specify the graphical console, and a second time to specify the serial console:
++
+[source,terminal]
+----
+$ coreos-installer install \
+  --console=tty0 \//<1>
+  --console=ttyS0,<options> \//<2>
+  --ignition-url=http://host/worker.ign /dev/sda
+----
++
+<1> The desired secondary console. In this case, the graphical console. Omitting this option will disable the graphical console.
+<2> The desired primary console. In this case the serial console. The `options` field defines the baud rate and other settings. A common value for this field is `11520n8`. If no options are provided, the default kernel value of `9600n8` is used. For more information on the format of this option, see link:https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html[Linux kernel serial console] documentation.
++
+. Reboot into the installed system.
++
+[NOTE]
+====
+A similar outcome can be obtained by using the `coreos-installer install --append-karg` option, and specifying the console with `console=`. However, this will only set the console for the kernel and not the bootloader.
+====
+
+To configure a PXE installation, make sure the `coreos.inst.install_dev` kernel command line option is omitted, and use the shell prompt to run `coreos-installer` manually using the above ISO installation procedure.
+

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -201,7 +201,7 @@ or other boot options.
 +
 [NOTE]
 ====
-This configuration does not enable serial console access on machines with a graphical console.  To configure a different console, add one or more `console=` arguments to the `APPEND` line.  For example, add `console=tty0 console=ttyS0` to set the first PC serial port as the primary console and the graphical console as a secondary console.  For more information, see link:https://access.redhat.com/articles/7212[How does one set up a serial terminal and/or console in Red Hat Enterprise Linux?].
+This configuration does not enable serial console access on machines with a graphical console.  To configure a different console, add one or more `console=` arguments to the `APPEND` line.  For example, add `console=tty0 console=ttyS0` to set the first PC serial port as the primary console and the graphical console as a secondary console.  For more information, see link:https://access.redhat.com/articles/7212[How does one set up a serial terminal and/or console in Red Hat Enterprise Linux?] and "Enabling the serial console for PXE and ISO installation" in the "Advanced {op-system} installation configuration" section.
 ====
 
 ifndef::only-pxe[]
@@ -228,7 +228,7 @@ For example, to use DHCP on a NIC that is named `eno1`, set `ip=eno1:dhcp`.
 +
 [NOTE]
 ====
-This configuration does not enable serial console access on machines with a graphical console.  To configure a different console, add one or more `console=` arguments to the `kernel` line.  For example, add `console=tty0 console=ttyS0` to set the first PC serial port as the primary console and the graphical console as a secondary console.  For more information, see link:https://access.redhat.com/articles/7212[How does one set up a serial terminal and/or console in Red Hat Enterprise Linux?].
+This configuration does not enable serial console access on machines with a graphical console.  To configure a different console, add one or more `console=` arguments to the `kernel` line.  For example, add `console=tty0 console=ttyS0` to set the first PC serial port as the primary console and the graphical console as a secondary console.  For more information, see link:https://access.redhat.com/articles/7212[How does one set up a serial terminal and/or console in Red Hat Enterprise Linux?] and "Enabling the serial console for PXE and ISO installation" in the "Advanced {op-system} installation configuration" section.
 ====
 +
 ifndef::openshift-origin[]

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -334,6 +334,9 @@ a|Digest `type-value` of the Ignition config.
 a|`-p`, `--platform <name>`
 a|Override the Ignition platform ID for the installed system.
 
+a|`--console <spec>`
+a|Set the kernel and bootloader console for the installed system. For more information about the format of `<spec>`, see the link:https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html[Linux kernel serial console] documentation.
+
 a|`--append-karg <arg>...`
 a|Append a default kernel argument to the installed system.
 
@@ -398,6 +401,9 @@ a|Remove the embedded Ignition config from an ISO image.
 
 a|`--dest-ignition <path>`
 a|Merge the specified Ignition config file into a new configuration fragment for the destination system.
+
+a|`--dest-console <spec>`
+a|Specify the kernel and bootloader console for the destination system.
 
 a|`--dest-device <path>`
 a|Install and overwrite the specified destination device.
@@ -467,6 +473,9 @@ a|Show the wrapped Ignition config in an image.
 
 a|`--dest-ignition <path>`
 a|Merge the specified Ignition config file into a new configuration fragment for the destination system.
+
+a|`--dest-console <spec>`
+a|Specify the kernel and bootloader console for the destination system.
 
 a|`--dest-device <path>`
 a|Install and overwrite the specified destination device.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/OSDOCS-4183
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

- Default console configuration: http://file.rdu.redhat.com/jdohmann/OSDOCS-4183/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-advanced-console-configuration_installing-bare-metal
- Enabling serial console: http://file.rdu.redhat.com/jdohmann/OSDOCS-4183/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-advanced-enabling-serial-console_installing-bare-metal
- Updated coreos-installer table: http://file.rdu.redhat.com/jdohmann/OSDOCS-4183/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-coreos-installer-options_installing-bare-metal
- Customizing live images
  - ISO: http://file.rdu.redhat.com/jdohmann/OSDOCS-4183/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-advanced-customizing-live-iso-serial-console_installing-bare-metal
  - PXE: http://file.rdu.redhat.com/jdohmann/OSDOCS-4183/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-advanced-customizing-live-pxe-serial-console_installing-bare-metal

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. -->

QE review:
- [x] QE has approved this change.

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
