### PR TITLE
TELCODOCS-938 - Add note clarifying namespace requirements for PolicyGenTemplate CRs

### DIFF
--- a/modules/ztp-creating-the-policygentemplate-cr.adoc
+++ b/modules/ztp-creating-the-policygentemplate-cr.adoc
@@ -8,13 +8,29 @@
 
 Use this procedure to create the `PolicyGenTemplate` custom resource (CR) for your site in your local clone of the Git repository.
 
+.Prerequisites
+
+Ensure that policy namespaces meets the following requirements:
+
+* Namespace names must be prefixed with `ztp`. For example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ztp-common
+----
+
+* Namespaces must not match the namespace of a pre-existing cluster.
+
 .Procedure
 
 . Choose an appropriate example from `out/argocd/example/policygentemplates`. This directory demonstrates a three-level policy framework that represents a well-supported low-latency profile tuned for the needs of 5G Telco DU deployments:
 +
-* A single `common-ranGen.yaml` file that should apply to all types of sites.
-* A set of shared `group-du-*-ranGen.yaml` files, each of which should be common across a set of similar clusters.
-* An example `example-*-site.yaml` that can be copied and updated for each individual site.
+** A single `common-ranGen.yaml` file that applies to all types of sites.
+** A set of shared `group-du-*-ranGen.yaml` files that are common between similar clusters.
+** An example `example-*-site.yaml` file that you can copy and update for each individual site.
 
 . Ensure that the labels defined in your `PolicyGenTemplate` `bindingRules` section correspond to the labels that are defined in the `SiteConfig` files of the clusters you are managing.
 
@@ -26,6 +42,11 @@ Depending on the specific requirements of your clusters, you might need more tha
 ====
 
 . Define all the policy namespaces in a YAML file similar to the example `out/argocd/example/policygentemplates/ns.yaml` file.
++
+[IMPORTANT]
+====
+Ensure that policy namespaces begin with `ztp` and are unique.
+====
 
 . Add all the `PolicyGenTemplate` files and `ns.yaml` file to the `kustomization.yaml` file, similar to the example `out/argocd/example/policygentemplates/kustomization.yaml` file.
 


### PR DESCRIPTION
Add note clarifying namespace requirements for PolicyGenTemplate CRs

Version(s):
Merge to main, cherry-pick to enterprise-4.10, enterprise-4.11, enterprise-4.12

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
https://issues.redhat.com/browse/TELCODOCS-938

Link to docs preview:
http://file.emea.redhat.com/aireilly/td-938/scalability_and_performance/ztp-deploying-disconnected.html#ztp-creating-the-policygentemplate-cr_ztp-deploying-disconnected