### PR TITLE
[enterprise-4.9] BZ2117751: OSDK Remove references to `operator-sdk olm status` 4.8+

### DIFF
--- a/modules/osdk-deploy-olm.adoc
+++ b/modules/osdk-deploy-olm.adoc
@@ -32,15 +32,7 @@ endif::[]
 
 .Procedure
 
-. Check the status of OLM on your cluster by using the following Operator SDK command:
-+
-[source,terminal]
-----
-$ operator-sdk olm status \
-    --olm-namespace=openshift-operator-lifecycle-manager
-----
-
-. Run the Operator on your cluster by using the OLM integration in Operator SDK:
+. Enter the following command to run the Operator on the cluster: 
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s): 4.9

Issue: BZ2117751

Link to docs preview:

Additional information: This is a manual cherry pick of commit cd61e01 xref: #49260
