### PR TITLE
make vale error level = suggestion

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,6 +1,6 @@
 StylesPath = .vale/styles
 
-MinAlertLevel = error
+MinAlertLevel = suggestion
 
 Packages = RedHat
 

--- a/scripts/check-with-vale.sh
+++ b/scripts/check-with-vale.sh
@@ -13,7 +13,7 @@ if [ -n "${FILES}" ] ;
         echo "Read about the error terms that cause the build to fail at https://redhat-documentation.github.io/vale-at-red-hat/docs/reference-guide/termserrors/"
         echo "==============================================================================================================================="
         echo ""
-        vale ${FILES} --minAlertLevel=error --glob='*.adoc' --no-exit
+        vale ${FILES} --glob='*.adoc'
         echo ""
         if [ "$TRAVIS" = true ] ; then
             set -x


### PR DESCRIPTION
Make vale error level = suggestion for ease of use locally. We run vale with `--minAlertLevel=error` in the CI anyway which overrides the vale.ini.