### PR TITLE
[RHACS] Update docs with correct variable info for wildcard Prometheus monitoring

### DIFF
--- a/modules/enable-monitoring-customize-port.adoc
+++ b/modules/enable-monitoring-customize-port.adoc
@@ -22,7 +22,7 @@ $ oc -n stackrox set env deploy/central ROX_METRICS_PORT=<value> <1>
 You can specify the `<value>` for the `ROX_METRICS_PORT` environment variable as:
 
 * `disabled` to disable monitoring.
-* `<port_number>` to bind it to a wildcard address.
+* `:<port_number>` to bind it to a wildcard address.
 * `<address>:<port_number>` to use specific address and port number.
 You can also specify an IPv6 address by using square brackets, for example, `[2001:db8::1234]:9090`.
 ====


### PR DESCRIPTION
Version(s):

Merge to:
- `rhacs-docs`

Cherry pick to:
- `rhacs-docs-3.72`
- `rhacs-docs-3.71`
- `rhacs-docs-3.70`

[Issue](https://issues.redhat.com/browse/ROX-12478)

[Link to docs preview](https://openshift-docs-fx9jsxesm-kcarmichael08.vercel.app/openshift-acs/master/configuration/monitor-acs.html)
