### PR TITLE
GH#47776: Fixing secrets chart

### DIFF
--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -72,10 +72,6 @@ Tested Cloud Platforms for {product-title} 4.x: Amazon Web Services, Microsoft A
 | 12,000
 | 12,000
 
-| Number of secrets
-| 40,000
-| 40,000
-
 | Number of custom resource definitions (CRD)
 | There is no default value.
 | 512 ^[7]^


### PR DESCRIPTION
For versions 4.10+ 
Fixes Issue #47776

Description: There is a duplicate of the `Number of Secrets` in this chart. Removing the older one, but will check with Eng and QE to confirm. I believe the correct column is on [Line 46](https://github.com/openshift/openshift-docs/pull/50728/files#diff-c4975d9316c93e0d71b870bbc1d2b30363395b69de430810d603ba18ae37ab9dR47)

Preview: [Scalability and Performance -> OpenShift Container Platform tested cluster maximums for major releases](https://50728--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html#cluster-maximums-major-releases_object-limits)