### PR TITLE
[RHACS] Clarify adding rules for OCP users in ACS

### DIFF
--- a/modules/configure-ocp-oauth-identity-provider.adoc
+++ b/modules/configure-ocp-oauth-identity-provider.adoc
@@ -25,25 +25,33 @@ To integrate the built-in {ocp} OAuth server as an identity provider for {produc
 For security, Red Hat recommends first setting the *Minimum access role* to *None* while you complete setup. Later, you can return to the *Access Control* page to set up more tailored access rules based on user metadata from your identity provider.
 ====
 
-. To add access rules for users and groups accessing {product-title-short}, click *Add new rule* in the *Rules* section. For example:
-.. To give the *Admin* role to a user called `administrator`, you can use the following key-value pairs to create access rules:
+. Optional: To add access rules for users and groups accessing {product-title-short}, click *Add new rule* in the *Rules* section, then enter the rule information and click *Save*. You will need attributes for the user or group so that you can configure access. 
 +
-|===
-| *Key* | *Value*
-|Name
-|administrator
-|Role
-|Admin
-|===
-.. If you are using the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/authentication_and_authorization/index#configuring-htpasswd-identity-provider[HTPasswd Identity Provider] with the username `UserA` that is part of the group `GroupA`, you can use the following key-value pairs to create access rules:
+[TIP]
+====
+Group mappings are more robust because groups are usually associated with teams or permissions sets and require modification less often than users.
+====
 +
-|===
-| *Key* | *Value*
-|Name
-|UserA
-|Group
-|GroupA
-|UserID
-|<UUID>
-|===
-. Click *Save*.
+
+To get user information in {ocp}, you can use one of the following methods:
++
+--
+* Click *User Management* -> *Users* -> *<username*> -> *YAML*.
+* Access the `k8s/cluster/user.openshift.io\~v1~User/<username>/yaml` file and note the values for `name`, `uid` (`userid` in {product-title-short}), and `groups`. 
+* Use the {ocp} API as described in the _{ocp} API reference_.
+--
++
+The following configuration example describes how to configure rules for an *Admin* role with the following attributes:
++
+--
+** `name`: `administrator`
+** `groups`: `["system:authenticated", "system:authenticated:oauth", "myAdministratorsGroup"]`
+** `uid`: `12345-00aa-1234-123b-123fcdef1234`
+--
++
+You can add a rule for this administrator role using one of the following steps:
++
+** To configure a rule for a name, select `name` from the *Key* drop-down list, enter `administrator` in the *Value* field, then select *Administrator* under *Role*.
+** To configure a rule for a group, select `groups` from the *Key* drop-down list, enter `myAdministratorsGroup` in the *Value* field, then select *Admin* under *Role*.
+** To configure a rule for a user name, select `userid` from the *Key* drop-down list, enter `12345-00aa-1234-123b-123fcdef1234` in the *Value* field, then select *Admin* under *Role*.
+

--- a/operating/manage-user-access/configure-ocp-oauth.adoc
+++ b/operating/manage-user-access/configure-ocp-oauth.adoc
@@ -20,7 +20,6 @@ include::modules/configure-ocp-oauth-identity-provider.adoc[leveloffset=+1]
 ----
 $ oc -n stackrox set env deploy/central ROX_ENABLE_OPENSHIFT_AUTH=true
 ----
-* For access rules, you should use the key `Name` to reference the user name that the {ocp} OAuth server returns.
 * For access rules, the {ocp} OAuth server does not return the key `Email`.
 ====
 


### PR DESCRIPTION
Version(s):

Merge to:
- `rhacs-docs-3.72`

Cherry pick to:
- `rhacs-docs`
- `rhacs-docs-3.71`

[Issue](https://issues.redhat.com/browse/ROX-12300)

[Link to docs preview](https://openshift-docs-l4g66xs0j-kcarmichael08.vercel.app/openshift-acs/master/operating/manage-user-access/configure-ocp-oauth.html)

Reviewed/approved by Eng (ACS has no QE)
