### PR TITLE
GH#50503: Product Name and Link Fixes (Accessing Web Console page)

### DIFF
--- a/modules/enabling-multi-cluster-console.adoc
+++ b/modules/enabling-multi-cluster-console.adoc
@@ -12,7 +12,7 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 .Prerequisites
 * Your cluster must be using the latest version of {product-title}.
-* You must have link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/install/index[Red Hat Advanced Cluster Management (ACM) for Kubernetes 2.5] or the link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/multicluster_engine/index[multiculster engine (MCE) Operator] installed.
+* You must have link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/install/index[{rh-rhacm-first}] or the link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/multicluster_engine/index[multicluster engine for Kubernetes (MCE)] installed.
 * You must have administrator privileges.
 
 [WARNING]
@@ -24,7 +24,7 @@ Do not set this feature gate on production clusters. You will not be able to upg
 
 . Log in to the {product-title} web console using your credentials.
 
-. Enable ACM in the administrator perspective by navigating from *Administration* -> *Cluster Settings* -> *Configuration* -> *Console* `console.operator.openshift.io` -> *Console Plugins* and click *Enable* for `acm`.
+. Enable {rh-rhacm} in the administrator perspective by navigating from *Administration* -> *Cluster Settings* -> *Configuration* -> *Console* `console.operator.openshift.io` -> *Console Plugins* and click *Enable* for `acm`.
 
 . A pop-up window will appear notifying you that updating the enablement of this console plug-in will prompt for the console to be refreshed once it has been updated. Select `Enable` and click *Save*.
 

--- a/modules/multi-cluster-about.adoc
+++ b/modules/multi-cluster-about.adoc
@@ -6,4 +6,4 @@
 [id="multi-cluster-about_{context}"]
 = Multicluster console
 
-The multicluster console provides a single interface with consistent design for the hybrid cloud console. If you enable the feature, you can switch between Advanced Cluster Management (ACM) and the cluster console in the same browser tab. It provides a simplified and consistent design that allows for shared components.
+The multicluster console provides a single interface with consistent design for the hybrid cloud console. If you enable the feature, you can switch between {rh-rhacm-first} and the cluster console in the same browser tab. It provides a simplified and consistent design that allows for shared components.


### PR DESCRIPTION
4.11 only

#50503

This fix updates and repairs a few external links so that they lead to the appropriate destination. It also changes mentions of Advanced Cluster Manager to its correct name (Red Hat Advanced Cluster Management) per the official names list.

Preview: https://50773--docspreview.netlify.app/openshift-enterprise/latest/web_console/web-console.html