### PR TITLE
Updated prerequisite to AWS S3 compatible bucket for log storage.

### DIFF
--- a/modules/cluster-logging-loki-deploy.adoc
+++ b/modules/cluster-logging-loki-deploy.adoc
@@ -8,7 +8,7 @@ You can use the {product-title} web console to deploy the LokiStack.
 .Prerequisites
 
 * {logging-title-uc} Operator 5.5 and later
-* AWS S3 bucket for log storage
+* AWS S3 compatible bucket for log storage
 
 .Procedure
 


### PR DESCRIPTION
Updated prerequisite to AWS S3 compatible bucket for log storage.

Version(s): 4.10+

Issue: https://github.com/openshift/openshift-docs/issues/50537

https://50531--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-loki.html#logging-loki-deploy_cluster-logging-loki


QE needed