### PR TITLE
OSDOCS4193: small typo fix

### DIFF
--- a/modules/migration-compatibility-guidelines.adoc
+++ b/modules/migration-compatibility-guidelines.adoc
@@ -33,7 +33,7 @@ Legacy {mtc-version} operator: Install manually with the `operator.yml` file.
 This cluster cannot be the control cluster.
 ====
 
-|{mtc-short} {mtc-version}.z
+|{mtc-short} {mtc-version}._z_
 
 Install with OLM, release channel `release-v1.7`
 |===


### PR DESCRIPTION
4.6+

https://issues.redhat.com/browse/OSDOCS-4193 

This fix italicizes the "z" in a version number to match the same version number mentioned in the adjacent table cell.

Preview: https://50776--docspreview.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc.html