### PR TITLE
Added version selector logic for OKD docs

### DIFF
--- a/_javascripts/page-loader.js
+++ b/_javascripts/page-loader.js
@@ -48,9 +48,17 @@ function versionSelector(list) {
       newVersion +
       fileRequested;
   } else {
+    //if distro key is openshift enterprise
+    if (dk == "openshift-enterprise") {
     newLink = "https://docs.openshift.com/container-platform/" +
       newVersion +
       fileRequested;
+    }
+    else if (dk == "openshift-origin"){
+      newLink = "https://docs.okd.io/" +
+      newVersion +
+      fileRequested;
+    }
   }
 
   // without doing async loads, there is no way to know if the path actually
@@ -68,8 +76,15 @@ function versionSelector(list) {
         list.value = currentVersion;
         if(confirm("This page doesn't exist in version " + newVersion + ". Click OK to search the " + newVersion + " docs OR Cancel to stay on this page.")) {
           if (['3.65', '3.66', '3.67', '3.68', '3.69', '3.70', '3.71'].contains(newVersion)) {
-          window.location = "https://google.com/search?q=site:https://docs.openshift.com/acs/" + newVersion + " " + document.title;} else {
-            window.location = "https://google.com/search?q=site:https://docs.openshift.com/enterprise/" + newVersion + " " + document.title;
+            window.location = "https://google.com/search?q=site:https://docs.openshift.com/acs/" + newVersion + " " + document.title;}
+          else {
+            if (dk == "openshift-enterprise"){
+              window.location = "https://google.com/search?q=site:https://docs.openshift.com/enterprise/" + newVersion + " " + document.title;
+            } else {
+              if (dk == "openshift-origin"){
+                window.location = "https://google.com/search?q=site:https://docs.okd.io/" + newVersion + " " + document.title;
+              }
+            }
           }
         } else {
           // do nothing, user doesn't want to search


### PR DESCRIPTION
Discussion at https://coreos.slack.com/archives/C85JYPHL3/p1663710050341149

We want to add version selector dropdown for OKD docs. To do this, 
1. We first need to modify the JavaScript code to handle the version selector menu. (This PR)
2. Then, we need to include the version selector component in the template. https://github.com/openshift/openshift-docs/pull/50630 

