### PR TITLE
OCPBUGS-1651 making clarification for L2 etp behaviour

### DIFF
--- a/modules/nw-metallb-bgp.adoc
+++ b/modules/nw-metallb-bgp.adoc
@@ -45,11 +45,9 @@ However, you can configure MetalLB to start BGP sessions with peers that belong 
 
 * All the nodes with a `speaker` pod that advertises the load balancer IP address can receive traffic for the service.
 
-** If the external traffic policy for the service is set to `cluster`, then all the `speaker` pods advertise the `203.0.113.200` load balancer IP address and all the nodes with a `speaker` pod can receive traffic for the service.
-At least one endpoint for the service must be in the `Ready` condition. The host prefix is advertised to the router peer only if the external traffic policy is set to `cluster`.
+** If the external traffic policy for the service is set to `cluster`, all the nodes where a speaker pod is running advertise the `203.0.113.200` load balancer IP address and all the nodes with a `speaker` pod can receive traffic for the service. The host prefix is advertised to the router peer only if the external traffic policy is set to cluster. 
 
-** If the external traffic policy for the service is set to `local`, then only the `speaker` pods that are on the same node as an endpoint in the `Ready` condition for the service can advertise the load balancer IP address. Only those nodes can receive traffic for the service.
-In the preceding graphic, nodes 2 and 3 would advertise `203.0.113.200`.
+** If the external traffic policy for the service is set to `local`, then all the nodes where a `speaker` pod is running and at least an endpoint of the service is running can advertise the `203.0.113.200` load balancer IP address. Only those nodes can receive traffic for the service. In the preceding graphic, nodes 2 and 3 would advertise `203.0.113.200`.
 
 * You can configure MetalLB to control which `speaker` pods start BGP sessions with specific BGP peers by specifying a node selector when you add a BGP peer custom resource.
 

--- a/modules/nw-metallb-layer2.adoc
+++ b/modules/nw-metallb-layer2.adoc
@@ -45,6 +45,10 @@ The `speaker` pod that announces the external IP address must be on the same nod
 * Client traffic is routed to the host network and connects to the `192.168.100.200` IP address.
 After traffic enters the node, the service proxy sends the traffic to the application pod on the same node or another node according to the external traffic policy that you set for the service.
 
+** If the external traffic policy for the service is set to `cluster`, the node that advertises the `192.168.100.200` load balancer IP address is selected from the nodes where a `speaker` pod is running. Only that node can receive traffic for the service.
+
+** If the external traffic policy for the service is set to `local`, the node that announces the `192.168.100.200` load balancer IP address is selected from the nodes where a `speaker` pod is running and at least an endpoint of the service. Only that node can receive traffic for the service. In the preceding graphic, either node 1 or 3 would advertise `192.168.100.200`.
+
 * If node 1 becomes unavailable, the external IP address fails over to another node.
 On another node that has an instance of the application pod and service endpoint, the `speaker` pod begins to announce the external IP address, `192.168.100.200` and the new node receives the client traffic.
 In the diagram, the only candidate is node 3.


### PR DESCRIPTION
OCPBUGS-1651: Update MetalLB to clarify the impact of the externalTrafficPolicy (etp) settings (cluster or local) on BGP and L2 advertisements

Version(s): PR applies only to a specific single version: 4.10

Issue: https://issues.redhat.com/browse/OCPBUGS-1651
Link to docs preview:

http://file.emea.redhat.com/kquinn/OCPBUGS-1651/networking/metallb/about-metallb.html#nw-metallb-layer2_about-metallb-and-metallb-operator

http://file.emea.redhat.com/kquinn/OCPBUGS-1651/networking/metallb/about-metallb.html#nw-metallb-bgp_about-metallb-and-metallb-operator

NOTES: Dev, QE and peer review complete 
This content was already reviewed as part of https://github.com/openshift/openshift-docs/pull/45516 so not 100% sure peer review is needed but in case 