### PR TITLE
OCPBUGS-1507 making updates for --offlined-cpu-count

### DIFF
--- a/modules/cnf-performance-profile-creator-arguments.adoc
+++ b/modules/cnf-performance-profile-creator-arguments.adoc
@@ -47,6 +47,22 @@ Default: `log`.
 
 When the user runs the tool with the wrapper script `must-gather` is supplied by the script itself and the user must not specify it.
 
+| `offlined-cpu-count`
+a| Number of offlined CPUs.
+
+[NOTE]
+====
+This must be a natural number greater than 0. If not enough logical processors are offlined then error messages are logged. The messages are:
+[source,terminal]
+----
+Error: failed to compute the reserved and isolated CPUs: please ensure that reserved-cpu-count plus offlined-cpu-count should be in the range [0,1]
+----
+[source,terminal]
+----
+Error: failed to compute the reserved and isolated CPUs: please specify the offlined CPU count in the range [0,1]
+----
+====
+
 | `power-consumption-mode`
 a|The power consumption mode.
 

--- a/modules/cnf-running-the-performance-creator-profile-offline.adoc
+++ b/modules/cnf-running-the-performance-creator-profile-offline.adoc
@@ -134,25 +134,25 @@ Options:
    -h                 help for run-perf-profile-creator.sh
    -p                 Node Tuning Operator image <1>
    -t                 path to a must-gather tarball <2>
-
 A tool that automates creation of Performance Profiles
 
-   Usage:
-     performance-profile-creator [flags]
+Usage:
+  performance-profile-creator [flags]
 
-   Flags:
-         --disable-ht                        Disable Hyperthreading
-     -h, --help                              help for performance-profile-creator
-         --info string                       Show cluster information; requires --must-gather-dir-path, ignore the other arguments. [Valid values: log, json] (default "log")
-         --mcp-name string                   MCP name corresponding to the target machines (required)
-         --must-gather-dir-path string       Must gather directory path (default "must-gather")
-         --power-consumption-mode string     The power consumption mode.  [Valid values: default, low-latency, ultra-low-latency] (default "default")
-         --profile-name string               Name of the performance profile to be created (default "performance")
-         --reserved-cpu-count int            Number of reserved CPUs (required)
-         --rt-kernel                         Enable Real Time Kernel (required)
-         --split-reserved-cpus-across-numa   Split the Reserved CPUs across NUMA nodes
-         --topology-manager-policy string    Kubelet Topology Manager Policy of the performance profile to be created. [Valid values: single-numa-node, best-effort, restricted] (default "restricted")
-         --user-level-networking             Run with User level Networking(DPDK) enabled
+Flags:
+      --disable-ht                        Disable Hyperthreading
+  -h, --help                              help for performance-profile-creator
+      --info string                       Show cluster information; requires --must-gather-dir-path, ignore the other arguments. [Valid values: log, json] (default "log")
+      --mcp-name string                   MCP name corresponding to the target machines (required)
+      --must-gather-dir-path string       Must gather directory path (default "must-gather")
+      --offlined-cpu-count int            Number of offlined CPUs
+      --power-consumption-mode string     The power consumption mode.  [Valid values: default, low-latency, ultra-low-latency] (default "default")
+      --profile-name string               Name of the performance profile to be created (default "performance")
+      --reserved-cpu-count int            Number of reserved CPUs (required)
+      --rt-kernel                         Enable Real Time Kernel (required)
+      --split-reserved-cpus-across-numa   Split the Reserved CPUs across NUMA nodes
+      --topology-manager-policy string    Kubelet Topology Manager Policy of the performance profile to be created. [Valid values: single-numa-node, best-effort, restricted] (default "restricted")
+      --user-level-networking             Run with User level Networking(DPDK) enabled
 ----
 +
 [NOTE]

--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -67,6 +67,7 @@ Flags:
       --info string                       Show cluster information; requires --must-gather-dir-path, ignore the other arguments. [Valid values: log, json] (default "log")
       --mcp-name string                   MCP name corresponding to the target machines (required)
       --must-gather-dir-path string       Must gather directory path (default "must-gather")
+      --offlined-cpu-count int            Number of offlined CPUs
       --power-consumption-mode string     The power consumption mode.  [Valid values: default, low-latency, ultra-low-latency] (default "default")
       --profile-name string               Name of the performance profile to be created (default "performance")
       --reserved-cpu-count int            Number of reserved CPUs (required)
@@ -109,7 +110,7 @@ The `info` option requires a value which specifies the output format. Possible v
 +
 [source,terminal,subs="attributes+"]
 ----
-$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-operator:v{product-version} --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true --split-reserved-cpus-across-numa=false --topology-manager-policy=single-numa-node --must-gather-dir-path /must-gather  --power-consumption-mode=ultra-low-latency > my-performance-profile.yaml
+$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-operator:vBranch Build --mcp-name=worker-cnf --reserved-cpu-count=4 --rt-kernel=true --split-reserved-cpus-across-numa=false --must-gather-dir-path /must-gather --power-consumption-mode=ultra-low-latency --offlined-cpu-count=6 > my-performance-profile.yaml
 ----
 +
 [NOTE]
@@ -138,26 +139,21 @@ kind: PerformanceProfile
 metadata:
   name: performance
 spec:
-  additionalKernelArgs:
-  - nmi_watchdog=0
-  - audit=0
-  - mce=off
-  - processor.max_cstate=1
-  - intel_idle.max_cstate=0
-  - idle=poll
   cpu:
-    isolated: "1,3,5,7,9,11,13,15,17,19-39,41,43,45,47,49,51,53,55,57"
-    reserved: "0,2,4,6,8,10,12,14,16,18,40,42,44,46,48,50,52,54,56,58"
-    offlined: "59-79"
+    isolated: 2-39,48-79
+    offlined: 42-47
+    reserved: 0-1,40-41
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
   numa:
-    topologyPolicy: single-numa-node
+    topologyPolicy: restricted
   realTimeKernel:
     enabled: true
   workloadHints:
     highPowerConsumption: true
-    realtime: true
+    realTime: true
 ----
 
 . Apply the generated profile:


### PR DESCRIPTION
OCPBUGS-1507: PPC documentation missing offlined parameter

Version(s):
  * PR applies only to a specific single version: 4.11

Issue: 

- https://issues.redhat.com/browse/OCPBUGS-1507

Link to docs preview: 

- http://file.emea.redhat.com/kquinn/OCPBUGS-1507/scalability_and_performance/cnf-create-performance-profiles.html
- https://50795--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-create-performance-profiles.html

NOTES: Dev and QE review complete 
