### PR TITLE
RHDEVDOCS-4301-5.3.12 - Late release correction

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -153,7 +153,7 @@ include::modules/cluster-logging-loki-tech-preview.adoc[leveloffset=+2]
 * link:https://access.redhat.com/security/cve/CVE-2022-21698[CVE-2022-21698]
 ** link:https://bugzilla.redhat.com/show_bug.cgi?id=2045880[BZ-2045880]
 
-include::modules/cluster-logging-rn-5.3.12.adoc[leveloffset=+1]
+//include::modules/cluster-logging-rn-5.3.12.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-rn-5.3.11.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Correction to https://github.com/openshift/openshift-docs/pull/50663 due to late release of 5.3.12