### PR TITLE
[SRVKE-528]: Add broker class config docs

### DIFF
--- a/modules/serverless-channel-default.adoc
+++ b/modules/serverless-channel-default.adoc
@@ -6,18 +6,11 @@
 [id="serverless-channel-default_{context}"]
 = Configuring the default channel implementation
 
-The `default-ch-webhook` config map can be used to specify the default channel implementation of Knative Eventing. The default channel implementation can be specified for the entire cluster, as well as for one or more namespaces. Currently the `InMemoryChannel` and `KafkaChannel` channel types are supported.
+You can use the `default-ch-webhook` config map to specify the default channel implementation of Knative Eventing. You can specify the default channel implementation for the entire cluster or for one or more namespaces. Currently the `InMemoryChannel` and `KafkaChannel` channel types are supported.
 
 .Prerequisites
 
-ifdef::openshift-enterprise[]
-* You have cluster administrator permissions on {product-title}.
-endif::[]
-
-ifdef::openshift-dedicated,openshift-rosa[]
-* You have cluster or dedicated administrator permissions on {product-title}.
-endif::[]
-
+* You have administrator permissions on {product-title}.
 * You have installed the {ServerlessOperatorName} and Knative Eventing on your cluster.
 * If you want to use Kafka channels as the default channel implementation, you must also install the `KnativeKafka` CR on your cluster.
 

--- a/modules/serverless-create-broker-kn.adoc
+++ b/modules/serverless-create-broker-kn.adoc
@@ -16,11 +16,11 @@ Brokers can be used in combination with triggers to deliver events from an event
 
 .Procedure
 
-* Create the `default` broker:
+* Create a broker:
 +
 [source,terminal]
 ----
-$ kn broker create default
+$ kn broker create <broker_name>
 ----
 
 .Verification

--- a/modules/serverless-global-config-broker-class-default.adoc
+++ b/modules/serverless-global-config-broker-class-default.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+//  * serverless/admin_guide/serverless-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-global-config-broker-class-default_{context}"]
+= Configuring the default broker class
+
+You can use the `config-br-defaults` config map to specify default broker class settings for Knative Eventing. You can specify the default broker class for the entire cluster or for one or more namespaces. Currently the `MTChannelBasedBroker` and `Kafka` broker types are supported.
+
+.Prerequisites
+
+* You have administrator permissions on {product-title}.
+* You have installed the {ServerlessOperatorName} and Knative Eventing on your cluster.
+* If you want to use Kafka broker as the default broker implementation, you must also install the `KnativeKafka` CR on your cluster.
+
+.Procedure
+
+* Modify the `KnativeEventing` custom resource to add configuration details for the `config-br-defaults` config map:
++
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  defaultBrokerClass: Kafka <1>
+  config: <2>
+    config-br-defaults: <3>
+      default-br-config: |
+        clusterDefault: <4>
+          brokerClass: Kafka
+          apiVersion: v1
+          kind: ConfigMap
+          name: kafka-broker-config <5>
+          namespace: knative-eventing <6>
+        namespaceDefaults: <7>
+          my-namespace:
+            brokerClass: MTChannelBasedBroker
+            apiVersion: v1
+            kind: ConfigMap
+            name: config-br-default-channel <8>
+            namespace: knative-eventing <9>
+...
+----
+<1> The default broker class for Knative Eventing.
+<2> In `spec.config`, you can specify the config maps that you want to add modified configurations for.
+<3> The `config-br-defaults` config map specifies the default settings for any broker that does not specify `spec.config` settings or a broker class.
+<4> The cluster-wide default broker class configuration. In this example, the default broker class implementation for the cluster is `Kafka`.
+<5> The `kafka-broker-config` config map specifies default settings for the Kafka broker. See "Configuring Kafka broker settings" in the "Additional resources" section.
+<6> The namespace where the `kafka-broker-config` config map exists.
+<7> The namespace-scoped default broker class configuration. In this example, the default broker class implementation for the `my-namespace` namespace is `MTChannelBasedBroker`. You can specify default broker class implementations for multiple namespaces.
+<8> The `config-br-default-channel` config map specifies the default backing channel for the broker. See "Configuring the default broker backing channel" in the "Additional resources" section.
+<9> The namespace where the `config-br-default-channel` config map exists.
++
+[IMPORTANT]
+====
+Configuring a namespace-specific default overrides any cluster-wide settings.
+====

--- a/serverless/admin_guide/serverless-configuration.adoc
+++ b/serverless/admin_guide/serverless-configuration.adoc
@@ -15,6 +15,12 @@ The `spec.config` in the Knative custom resources have one `<name>` entry for ea
 // Knative Eventing
 include::modules/serverless-channel-default.adoc[leveloffset=+1]
 include::modules/serverless-broker-backing-channel-default.adoc[leveloffset=+1]
+include::modules/serverless-global-config-broker-class-default.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../serverless/admin_guide/serverless-kafka-admin.adoc#serverless-kafka-broker-configmap_serverless-kafka-admin[Configuring Kafka broker settings]
+* xref:../../serverless/admin_guide/serverless-configuration.adoc#serverless-broker-backing-channel-default_serverless-configuration[Configuring the default broker backing channel]
 
 // Knative Serving
 //autoscaling

--- a/serverless/develop/serverless-using-brokers.adoc
+++ b/serverless/develop/serverless-using-brokers.adoc
@@ -47,6 +47,7 @@ include::modules/serverless-describe-broker-kn.adoc[leveloffset=+2]
 [id="additional-resources_serverless-using-brokers"]
 [role="_additional-resources"]
 == Additional resources
+* xref:../../serverless/admin_guide/serverless-configuration.adoc#serverless-global-config-broker-class-default_serverless-configuration[Configuring the default broker class]
 * xref:../../serverless/develop/serverless-triggers.adoc#serverless-triggers[Triggers]
 xref:../../serverless/discover/knative-event-sources.adoc#knative-event-sources[Event sources]
 * xref:../../serverless/develop/serverless-event-delivery.adoc#serverless-event-delivery[Event delivery]


### PR DESCRIPTION
Version(s):
OCP 4.6+

Issue:
https://issues.redhat.com/browse/SRVKE-528

Link to docs preview:
- https://50821--docspreview.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-configuration.html#serverless-global-config-broker-class-default_serverless-configuration
- https://50821--docspreview.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-configuration.html#serverless-channel-default_serverless-configuration