### PR TITLE
OSDOCS-3673.2-Private Link Warning

### DIFF
--- a/modules/osd-aws-privatelink-about.adoc
+++ b/modules/osd-aws-privatelink-about.adoc
@@ -5,3 +5,8 @@
 A {product-title} cluster can be created without any requirements on public subnets, internet gateways, or network address translation (NAT) gateways. In this configuration, Red Hat uses AWS PrivateLink to manage and monitor a cluster to avoid all public ingress network traffic. Without a public subnet, it is not possible to configure an application router as public. Configuring private application routers is the only option.
 
 For more information, see link:https://aws.amazon.com/privatelink/[AWS PrivateLink] on the AWS website.
+
+[IMPORTANT]
+====
+You can only make a PrivateLink cluster at installation time. You cannot change a cluster to PrivateLink after installation.
+====


### PR DESCRIPTION
Version(s):
Enterprise-4.11

Issue:
Continuation of [OSDOCS-3673](https://issues.redhat.com/browse/OSDOCS-3673).

Link to docs preview:
[Creating a PrivateLink cluster on ROSA](https://50823--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.html)

Additional information:
Added an important note that PrivateLink clusters can only be created when the cluster is being configured. Not on an existing cluster.