### PR TITLE
OSDOCS-4201.1: Removed 'deletion' references from Topic Map

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -83,7 +83,7 @@ Topics:
 - Name: Getting started with OpenShift Dedicated
   File: osd-getting-started
 ---
-Name: Installing, accessing, and deleting OpenShift Dedicated clusters
+Name: Installing and accessing OpenShift Dedicated clusters
 Dir: osd_install_access_delete_cluster
 Distros: openshift-dedicated
 Topics:

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -126,7 +126,7 @@ Topics:
 - Name: Getting started with ROSA
   File: rosa-getting-started
 ---
-Name: Installing, accessing, and deleting ROSA clusters
+Name: Installing and accessing ROSA clusters
 Dir: rosa_install_access_delete_clusters
 Distros: openshift-rosa
 Topics:


### PR DESCRIPTION
Version(s):
Enterprise-4.11

Issue:
[OSDOCS-4201](https://issues.redhat.com/browse/OSDOCS-4201)

Link to docs preview:

- [OSD](https://file.rdu.redhat.com/eponvell/OSDOCS-4201-1_Fix-ROSA-OSD-Topic-Map/dedicated/welcome/index.html)
- [ROSA](https://file.rdu.redhat.com/eponvell/OSDOCS-4201-1_Fix-ROSA-OSD-Topic-Map/rosa/welcome/index.html)

Additional information:
Removed "deleting" from the topic map for OSD and ROSA. This will be added back once the instructions for deleting the clusters is created.