### PR TITLE
Fix typo concerning AWS Route Tables

### DIFF
--- a/modules/ccs-aws-provisioned.adoc
+++ b/modules/ccs-aws-provisioned.adoc
@@ -65,7 +65,7 @@ Customers should expect to see one VPC per cluster. Additionally, the VPC needs 
 
 * *Subnets*: Two subnets for a cluster with a single availability zone, or six subnets for a cluster with multiple availability zones.
 
-* *Router tables*: One router table per private subnet, and one additional table per cluster.
+* *Route tables*: One route table per private subnet, and one additional table per cluster.
 
 * *Internet gateways*: One Internet Gateway per cluster.
 

--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -63,7 +63,7 @@ Customers should expect to see one VPC per cluster. Additionally, the VPC will n
 
 * *Subnets*: Two subnets for a cluster with a single availability zone, or six subnets for a cluster with multiple availability zones.
 
-* *Router tables*: One router table per private subnet, and one additional table per cluster.
+* *Route tables*: One route table per private subnet, and one additional table per cluster.
 
 * *Internet gateways*: One Internet Gateway per cluster.
 


### PR DESCRIPTION
Just fixing a typo as the AWS resources are called Route Tables, not Router Tables. https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html

Link to docs preview:
https://50836--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#rosa-vpc_prerequisites