### PR TITLE
[enterprise-4.8] added release notes

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,7 +23,11 @@ include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 
+include::modules/gitops-release-notes-1-6-1.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-6-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-5-6.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-5-5.adoc[leveloffset=+1]
 
@@ -36,6 +40,8 @@ include::modules/gitops-release-notes-1-5-2.adoc[leveloffset=+1]
 include::modules/gitops-release-notes-1-5-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-5-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-4-12.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-1.adoc[leveloffset=+1]
 

--- a/modules/gitops-release-notes-1-4-12.adoc
+++ b/modules/gitops-release-notes-1-4-12.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-4-12_{context}"]
+= Release notes for {gitops-title} 1.4.12
+
+{gitops-title} 1.4.12 is now available on {product-title} 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-4-12_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, in a large set of applications the application controllers were restarted multiple times due to the unresponsiveness of liveness probes. This update fixes the issue by removing the liveness probe in the application controller `StatefulSet` object. link:https://issues.redhat.com/browse/GITOPS-2153[GITOPS-2153]
+
+* Before this update, the RHSSO certificate cannot be validated when it is set up with a certificate which is not signed by certificate authorities. This update fixes the issue and now you can provide a custom certificate which will be used in verifying the Keycloak's TLS certificate when communicating with it. You can add the `rootCA` to the Argo CD custom resource `.spec.keycloak.rootCA` field. The Operator reconciles this change and updates the `oidc.config` field in the `argocd-cm` `ConfigMap` with the PEM-encoded root certificate. link:https://issues.redhat.com/browse/GITOPS-2214[GITOPS-2214]
++
+[NOTE]
+====
+Restart the Argo CD server pod after updating the `.spec.keycloak.rootCA` field.
+====
++
+For example: 
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: basic
+spec:
+  sso:
+    provider: keycloak
+    keycloak:
+     rootCA: |
+       ---- BEGIN CERTIFICATE ----
+       This is a dummy certificate
+       Please place this section with appropriate rootCA
+       ---- END CERTIFICATE ----
+  server:
+    route:
+      enabled: true
+----
+
+* Before this update, a terminating namespace that was managed by Argo CD would block the creation of roles and other configuration of other managed namespaces. This update fixes this issue. link:https://issues.redhat.com/browse/GITOPS-2277[GITOPS-2277]
+
+* Before this update, the Dex pods failed to start with `CreateContainerConfigError` when an SCC of `anyuid` was assigned to the Dex `ServiceAccount` resource. This update fixes this issue by assigning a default user id to the Dex container. link:https://issues.redhat.com/browse/GITOPS-2235[GITOPS-2235]

--- a/modules/gitops-release-notes-1-5-6.adoc
+++ b/modules/gitops-release-notes-1-5-6.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-5-6_{context}"]
+= Release notes for {gitops-title} 1.5.6
+
+{gitops-title} 1.5.6 is now available on {product-title} 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-5-6_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, in a large set of applications the application controllers were restarted multiple times due to the unresponsiveness of liveness probes. This update fixes the issue by removing the liveness probe in the application controller `StatefulSet` object. link:https://issues.redhat.com/browse/GITOPS-2153[GITOPS-2153]
+
+* Before this update, the RHSSO certificate cannot be validated when it is set up with a certificate which is not signed by certificate authorities. This update fixes the issue and now you can provide a custom certificate which will be used in verifying the Keycloak's TLS certificate when communicating with it. You can add the `rootCA` to the Argo CD custom resource `.spec.keycloak.rootCA` field. The Operator reconciles this change and updates the `oidc.config` field in the `argocd-cm` `ConfigMap` with the PEM-encoded root certificate. link:https://issues.redhat.com/browse/GITOPS-2214[GITOPS-2214]
++
+[NOTE]
+====
+Restart the Argo CD server pod after updating the `.spec.keycloak.rootCA` field.
+====
++
+For example: 
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: basic
+spec:
+  sso:
+    provider: keycloak
+    keycloak:
+     rootCA: |
+       ---- BEGIN CERTIFICATE ----
+       This is a dummy certificate
+       Please place this section with appropriate rootCA
+       ---- END CERTIFICATE ----
+  server:
+    route:
+      enabled: true
+----
+
+* Before this update, a terminating namespace that was managed by Argo CD would block the creation of roles and other configuration of other managed namespaces. This update fixes this issue. link:https://issues.redhat.com/browse/GITOPS-2277[GITOPS-2277]
+
+* Before this update, the Dex pods failed to start with `CreateContainerConfigError` when an SCC of `anyuid` was assigned to the Dex `ServiceAccount` resource. This update fixes this issue by assigning a default user id to the Dex container. link:https://issues.redhat.com/browse/GITOPS-2235[GITOPS-2235]

--- a/modules/gitops-release-notes-1-6-1.adoc
+++ b/modules/gitops-release-notes-1-6-1.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-6-1_{context}"]
+= Release notes for {gitops-title} 1.6.1
+
+{gitops-title} 1.6.1 is now available on {product-title} 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-6-1_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, in a large set of applications the application controllers were restarted multiple times due to the unresponsiveness of liveness probes. This update fixes the issue by removing the liveness probe in the application controller `StatefulSet` object. link:https://issues.redhat.com/browse/GITOPS-2153[GITOPS-2153]
+
+* Before this update, the RHSSO certificate cannot be validated when it is set up with a certificate which is not signed by certificate authorities. This update fixes the issue and now you can provide a custom certificate which will be used in verifying the Keycloak's TLS certificate when communicating with it. You can add the `rootCA` to the Argo CD custom resource `.spec.keycloak.rootCA` field. The Operator reconciles this change and updates the `oidc.config` field in the `argocd-cm` `ConfigMap` with the PEM-encoded root certificate. link:https://issues.redhat.com/browse/GITOPS-2214[GITOPS-2214]
++
+[NOTE]
+====
+Restart the Argo CD server pod after updating the `.spec.keycloak.rootCA` field.
+====
++
+For example: 
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: basic
+spec:
+  sso:
+    provider: keycloak
+    keycloak:
+     rootCA: |
+       ---- BEGIN CERTIFICATE ----
+       This is a dummy certificate
+       Please place this section with appropriate rootCA
+       ---- END CERTIFICATE ----
+  server:
+    route:
+      enabled: true
+----
+
+* Before this update, a terminating namespace that was managed by Argo CD would block the creation of roles and other configuration of other managed namespaces. This update fixes this issue. link:https://issues.redhat.com/browse/GITOPS-2277[GITOPS-2277]
+
+* Before this update, the Dex pods failed to start with `CreateContainerConfigError` when an SCC of `anyuid` was assigned to the Dex `ServiceAccount` resource. This update fixes this issue by assigning a default user id to the Dex container. link:https://issues.redhat.com/browse/GITOPS-2235[GITOPS-2235] 


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise- 4.8

JIRA issue:
https://issues.redhat.com/browse/RHDEVDOCS-4445

Preview pages: https://50294--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html

SME+QE review: @wtam2018
Peer-review: @gabriel-rh