### PR TITLE
BZ1982550_f fixing footnote numbering for Customer Portal

### DIFF
--- a/modules/configuring-ovs-log-level-permanently.adoc
+++ b/modules/configuring-ovs-log-level-permanently.adoc
@@ -25,7 +25,7 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: master  <.>
+    machineconfiguration.openshift.io/role: master  <1>
   name: 99-change-ovs-loglevel
 spec:
   config:
@@ -36,13 +36,13 @@ spec:
       - dropins:
         - contents: |
             [Service]
-              ExecStartPost=-/usr/bin/ovs-appctl vlog/set syslog:dbg  <.>
+              ExecStartPost=-/usr/bin/ovs-appctl vlog/set syslog:dbg  <2>
               ExecReload=-/usr/bin/ovs-appctl vlog/set syslog:dbg
           name: 20-ovs-vswitchd-restart.conf
         name: ovs-vswitchd.service
 ----
-<.> After you perform this procedure to configure control plane nodes, repeat the procedure and set the role to `worker` to configure worker nodes.
-<.> Set the `syslog:<log_level>` value. Log levels are `off`, `emer`, `err`, `warn`, `info`, or `dbg`. Setting the value to `off` filters out all log messages.
+<1> After you perform this procedure to configure control plane nodes, repeat the procedure and set the role to `worker` to configure worker nodes.
+<2> Set the `syslog:<log_level>` value. Log levels are `off`, `emer`, `err`, `warn`, `info`, or `dbg`. Setting the value to `off` filters out all log messages.
 
 . Apply the machine config:
 +

--- a/modules/developer-cli-odo-ref-build-images.adoc
+++ b/modules/developer-cli-odo-ref-build-images.adoc
@@ -12,12 +12,12 @@ components:
 - image:
     imageName: quay.io/myusername/myimage
     dockerfile:
-      uri: ./Dockerfile <.>
-      buildContext: ${PROJECTS_ROOT} <.>
+      uri: ./Dockerfile <1>
+      buildContext: ${PROJECTS_ROOT} <2>
   name: component-built-from-dockerfile
 ----
-<.> The `uri` field indicates the relative path of the Dockerfile to use, relative to the directory containing the `devfile.yaml`. The devfile specification indicates that `uri` could also be an HTTP URL, but this case is not supported by odo yet.
-<.> The `buildContext` indicates the directory used as build context. The default value is `+${PROJECTS_ROOT}+`.
+<1> The `uri` field indicates the relative path of the Dockerfile to use, relative to the directory containing the `devfile.yaml`. The devfile specification indicates that `uri` could also be an HTTP URL, but this case is not supported by odo yet.
+<2> The `buildContext` indicates the directory used as build context. The default value is `+${PROJECTS_ROOT}+`.
 
 For each image component, odo executes either `podman` or `docker` (the first one found, in this order), to build the image with the specified Dockerfile, build context, and arguments.
 

--- a/modules/developer-cli-odo-ref-catalog.adoc
+++ b/modules/developer-cli-odo-ref-catalog.adoc
@@ -49,9 +49,9 @@ $ odo catalog describe component nodejs
 .Example output
 [source,terminal]
 ----
-* Registry: DefaultDevfileRegistry <.>
+* Registry: DefaultDevfileRegistry <1>
 
-Starter Projects: <.>
+Starter Projects: <2>
 ---
 name: nodejs-starter
 attributes: {}
@@ -68,8 +68,8 @@ projectsource:
   zip: null
   custom: null
 ----
-<.> _Registry_ is the registry from which the devfile is retrieved.
-<.> _Starter projects_ are sample projects in the same language and framework of the devfile, that can help you start a new project.
+<1> _Registry_ is the registry from which the devfile is retrieved.
+<2> _Starter projects_ are sample projects in the same language and framework of the devfile, that can help you start a new project.
 
 
 See `odo create` for more information on creating a project from a starter project.

--- a/modules/migration-mtc-cr-manifests.adoc
+++ b/modules/migration-mtc-cr-manifests.adoc
@@ -132,20 +132,20 @@ metadata:
   labels:
     migplan: <migplan>
 spec:
-  analyzeImageCount: true <.>
-  analyzeK8SResources: true <.>
-  analyzePVCapacity: true <.>
-  listImages: false <.>
-  listImagesLimit: 50 <.>
+  analyzeImageCount: true <1>
+  analyzeK8SResources: true <2>
+  analyzePVCapacity: true <3>
+  listImages: false <4>
+  listImagesLimit: 50 <5>
   migPlanRef:
     name: <migplan>
     namespace: openshift-migration
 ----
-<.> Optional: Returns the number of images.
-<.> Optional: Returns the number, kind, and API version of the Kubernetes resources.
-<.> Optional: Returns the PV capacity.
-<.> Returns a list of image names. The default is `false` so that the output is not excessively long.
-<.> Optional: Specify the maximum number of image names to return if `listImages` is `true`.
+<1> Optional: Returns the number of images.
+<2> Optional: Returns the number, kind, and API version of the Kubernetes resources.
+<3> Optional: Returns the PV capacity.
+<4> Returns a list of image names. The default is `false` so that the output is not excessively long.
+<5> Optional: Specify the maximum number of image names to return if `listImages` is `true`.
 
 [id="migcluster_{context}"]
 == MigCluster

--- a/modules/nw-egress-router-pod-ovn.adoc
+++ b/modules/nw-egress-router-pod-ovn.adoc
@@ -31,13 +31,13 @@ kind: Pod
 metadata:
   name: egress-router-pod
   annotations:
-    k8s.v1.cni.cncf.io/networks: egress-router-redirect  <.>
+    k8s.v1.cni.cncf.io/networks: egress-router-redirect  <1>
 spec:
   containers:
     - name: egress-router-pod
       image: {egress-pod-image-name}
 ----
-<.> The specified network must match the name of the network attachment definition. You can specify a namespace, interface name, or both, by replacing the values in the following pattern: `<namespace>/<network>@<interface>`. By default, Multus adds a secondary network interface to the pod with a name such as `net1`, `net2`, and so on.
+<1> The specified network must match the name of the network attachment definition. You can specify a namespace, interface name, or both, by replacing the values in the following pattern: `<namespace>/<network>@<interface>`. By default, Multus adds a secondary network interface to the pod with a name such as `net1`, `net2`, and so on.
 
 // Clear temporary attributes
 :!router-type:

--- a/modules/oadp-installing-dpa.adoc
+++ b/modules/oadp-installing-dpa.adoc
@@ -52,42 +52,42 @@ spec:
   configuration:
     velero:
       defaultPlugins:
-        - openshift <.>
+        - openshift <1>
         - aws
     restic:
-      enable: true <.>
+      enable: true <2>
       podConfig:
-        nodeSelector: <node selector> <.>
+        nodeSelector: <node selector> <3>
   backupLocations:
     - name: default
       velero:
         provider: {provider}
         default: true
         objectStorage:
-          bucket: <bucket_name> <.>
-          prefix: <prefix> <.>
+          bucket: <bucket_name> <4>
+          prefix: <prefix> <5>
         config:
           region: <region>
           profile: "default"
         credential:
           key: cloud
-          name: {credentials} <.>
-  snapshotLocations: <.>
+          name: {credentials} <6>
+  snapshotLocations: <7>
     - name: default
       velero:
         provider: {provider}
         config:
-          region: <region> <.>
+          region: <region> <8>
           profile: "default"
 ----
-<.> The `openshift` plug-in is mandatory.
-<.> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<.> Specify the node selector to be supplied to Restic podSpec.
-<.> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<.> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
-<.> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<.> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
-<.> The snapshot location must be in the same region as the PVs.
+<1> The `openshift` plug-in is mandatory.
+<2> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<3> Specify the node selector to be supplied to Restic podSpec.
+<4> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<5> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<6> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<7> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
+<8> The snapshot location must be in the same region as the PVs.
 endif::[]
 ifdef::installing-oadp-azure[]
 +
@@ -103,27 +103,27 @@ spec:
     velero:
       defaultPlugins:
         - azure
-        - openshift <.>
+        - openshift <1>
     restic:
-      enable: true <.>
+      enable: true <2>
       podConfig:
-        nodeSelector: <node selector> <.>
+        nodeSelector: <node selector> <3>
   backupLocations:
     - velero:
         config:
-          resourceGroup: <azure_resource_group> <.>
-          storageAccount: <azure_storage_account_id> <.>
-          subscriptionId: <azure_subscription_id> <.>
+          resourceGroup: <azure_resource_group> <4>
+          storageAccount: <azure_storage_account_id> <5>
+          subscriptionId: <azure_subscription_id> <6>
           storageAccountKeyEnvVar: AZURE_STORAGE_ACCOUNT_ACCESS_KEY
         credential:
           key: cloud
-          name: {credentials}  <.>
+          name: {credentials}  <7>
         provider: {provider}
         default: true
         objectStorage:
-          bucket: <bucket_name> <.>
-          prefix: <prefix> <.>
-  snapshotLocations: <.>
+          bucket: <bucket_name> <8>
+          prefix: <prefix> <9>
+  snapshotLocations: <10>
     - velero:
         config:
           resourceGroup: <azure_resource_group>
@@ -132,16 +132,16 @@ spec:
         name: default
         provider: {provider}
 ----
-<.> The `openshift` plug-in is mandatory.
-<.> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<.> Specify the node selector to be supplied to Restic podSpec.
-<.> Specify the Azure resource group.
-<.> Specify the Azure storage account ID.
-<.> Specify the Azure subscription ID.
-<.> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<.> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<.> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
-<.> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
+<1> The `openshift` plug-in is mandatory.
+<2> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<3> Specify the node selector to be supplied to Restic podSpec.
+<4> Specify the Azure resource group.
+<5> Specify the Azure storage account ID.
+<6> Specify the Azure subscription ID.
+<7> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<8> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<9> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<10> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
 endif::[]
 ifdef::installing-oadp-gcp[]
 +
@@ -157,37 +157,37 @@ spec:
     velero:
       defaultPlugins:
         - gcp
-        - openshift <.>
+        - openshift <1>
     restic:
-      enable: true <.>
+      enable: true <2>
       podConfig:
-        nodeSelector: <node selector> <.>
+        nodeSelector: <node selector> <3>
   backupLocations:
     - velero:
         provider: {provider}
         default: true
         credential:
           key: cloud
-          name: {credentials} <.>
+          name: {credentials} <4>
         objectStorage:
-          bucket: <bucket_name> <.>
-          prefix: <prefix> <.>
-  snapshotLocations: <.>
+          bucket: <bucket_name> <5>
+          prefix: <prefix> <6>
+  snapshotLocations: <7>
     - velero:
         provider: {provider}
         default: true
         config:
           project: <project>
-          snapshotLocation: us-west1 <.>
+          snapshotLocation: us-west1 <8>
 ----
-<.> The `openshift` plug-in is mandatory.
-<.> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<.> Specify the node selector to be supplied to Restic podSpec.
-<.> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<.> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<.> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
-<.> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
-<.> The snapshot location must be in the same region as the PVs.
+<1> The `openshift` plug-in is mandatory.
+<2> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<3> Specify the node selector to be supplied to Restic podSpec.
+<4> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<5> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<6> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<7> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
+<8> The snapshot location must be in the same region as the PVs.
 endif::[]
 ifdef::installing-oadp-mcg[]
 +
@@ -203,35 +203,35 @@ spec:
     velero:
       defaultPlugins:
         - aws
-        - openshift <.>
+        - openshift <1>
     restic:
-      enable: true <.>
+      enable: true <2>
       podConfig:
-        nodeSelector: <node selector> <.>
+        nodeSelector: <node selector> <3>
   backupLocations:
     - velero:
         config:
           profile: "default"
           region: minio
-          s3Url: <url> <.>
+          s3Url: <url> <4>
           insecureSkipTLSVerify: "true"
           s3ForcePathStyle: "true"
         provider: {provider}
         default: true
         credential:
           key: cloud
-          name: {credentials} <.>
+          name: {credentials} <5>
         objectStorage:
-          bucket: <bucket_name> <.>
-          prefix: <prefix> <.>
+          bucket: <bucket_name> <6>
+          prefix: <prefix> <7>
 ----
-<.> The `openshift` plug-in is mandatory.
-<.> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<.> Specify the node selector to be supplied to Restic podSpec.
-<.> Specify the URL of the S3 endpoint.
-<.> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<.> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<.> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<1> The `openshift` plug-in is mandatory.
+<2> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<3> Specify the node selector to be supplied to Restic podSpec.
+<4> Specify the URL of the S3 endpoint.
+<5> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<6> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<7> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
 ifdef::installing-oadp-ocs[]
 +
@@ -246,35 +246,35 @@ spec:
   configuration:
     velero:
       defaultPlugins:
-        - kubevirt <.>
-        - gcp <.>
-        - csi <.>
-        - openshift <.>
+        - kubevirt <1>
+        - gcp <2>
+        - csi <3>
+        - openshift <4>
     restic:
-      enable: true <.>
+      enable: true <5>
       podConfig:
-        nodeSelector: <node selector> <.>
+        nodeSelector: <node selector> <6>
   backupLocations:
     - velero:
-        provider: {provider} <.>
+        provider: {provider} <7>
         default: true
         credential:
           key: cloud
-          name: <default_secret> <.>
+          name: <default_secret> <8>
         objectStorage:
-          bucket: <bucket_name> <.>
-          prefix: <prefix> <.>
+          bucket: <bucket_name> <9>
+          prefix: <prefix> <10>
 ----
-<.> Optional: The `kubevirt` plug-in is used with {VirtProductName}.
-<.> Specify the default plug-in for the backup provider, for example, `gcp`, if appropriate.
-<.> Specify the `csi` default plug-in if you use CSI snapshots to back up PVs. The `csi` plug-in uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
-<.> The `openshift` plug-in is mandatory.
-<.> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<.> Specify the node selector to be supplied to Restic podSpec
-<.> Specify the backup provider.
-<.> If you use a default plug-in for the backup provider, you must specify the correct default name for the `Secret`, for example, `cloud-credentials-gcp`. If you specify a custom name, the custom name is used for the backup location. If you do not specify a `Secret` name, the default name is used.
-<.> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<.> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<1> Optional: The `kubevirt` plug-in is used with {VirtProductName}.
+<2> Specify the default plug-in for the backup provider, for example, `gcp`, if appropriate.
+<3> Specify the `csi` default plug-in if you use CSI snapshots to back up PVs. The `csi` plug-in uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
+<4> The `openshift` plug-in is mandatory.
+<5> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<6> Specify the node selector to be supplied to Restic podSpec
+<7> Specify the backup provider.
+<8> If you use a default plug-in for the backup provider, you must specify the correct default name for the `Secret`, for example, `cloud-credentials-gcp`. If you specify a custom name, the custom name is used for the backup location. If you do not specify a `Secret` name, the default name is used.
+<9> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<10> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
 ifdef::virt-installing-configuring-oadp[]
 +
@@ -289,35 +289,35 @@ spec:
   configuration:
     velero:
       defaultPlugins:
-        - kubevirt <.>
-        - gcp <.>
-        - csi <.>
-        - openshift <.>
+        - kubevirt <1>
+        - gcp <2>
+        - csi <3>
+        - openshift <4>
     restic:
-      enable: true <.>
+      enable: true <5>
       podConfig:
-        nodeSelector: <node selector> <.>
+        nodeSelector: <node selector> <6>
   backupLocations:
     - velero:
-        provider: {provider} <.>
+        provider: {provider} <7>
         default: true
         credential:
           key: cloud
-          name: <default_secret> <.>
+          name: <default_secret> <8>
         objectStorage:
-          bucket: <bucket_name> <.>
-          prefix: <prefix> <.>
+          bucket: <bucket_name> <9>
+          prefix: <prefix> <10>
 ----
-<.> The `kubevirt` plug-in is mandatory for {VirtProductName}.
-<.> Specify the plug-in for the backup provider, for example, `gcp`, if it exists.
-<.> The `csi` plug-in is mandatory for backing up PVs with CSI snapshots. The `csi` plug-in uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
-<.> The `openshift` plug-in is mandatory.
-<.> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<.> Specify the node selector to be supplied to Restic podSpec
-<.> Specify the backup provider.
-<.> If you use a default plug-in for the backup provider, you must specify the correct default name for the `Secret`, for example, `cloud-credentials-gcp`. If you specify a custom name, the custom name is used for the backup location. If you do not specify a `Secret` name, the default name is used.
-<.> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<.> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<1> The `kubevirt` plug-in is mandatory for {VirtProductName}.
+<2> Specify the plug-in for the backup provider, for example, `gcp`, if it exists.
+<3> The `csi` plug-in is mandatory for backing up PVs with CSI snapshots. The `csi` plug-in uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
+<4> The `openshift` plug-in is mandatory.
+<5> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<6> Specify the node selector to be supplied to Restic podSpec
+<7> Specify the backup provider.
+<8> If you use a default plug-in for the backup provider, you must specify the correct default name for the `Secret`, for example, `cloud-credentials-gcp`. If you specify a custom name, the custom name is used for the backup location. If you do not specify a `Secret` name, the default name is used.
+<9> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<10> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
 
 . Click *Create*.

--- a/modules/support-starting-an-alternative-image-with-toolbox.adoc
+++ b/modules/support-starting-an-alternative-image-with-toolbox.adoc
@@ -30,13 +30,13 @@ By default, running the `toolbox` command starts a container with the `registry.
 +
 [source,text]
 ----
-REGISTRY=quay.io                <.>
-IMAGE=fedora/fedora:33-x86_64   <.>
-TOOLBOX_NAME=toolbox-fedora-33  <.>
+REGISTRY=quay.io                <1>
+IMAGE=fedora/fedora:33-x86_64   <2>
+TOOLBOX_NAME=toolbox-fedora-33  <3>
 ----
-<.> Optional: Specify an alternative container registry.
-<.> Specify an alternative image to start.
-<.> Optional: Specify an alternative name for the toolbox container.
+<1> Optional: Specify an alternative container registry.
+<2> Specify an alternative image to start.
+<3> Optional: Specify an alternative name for the toolbox container.
 
 . Start a toolbox container with the alternative image:
 +


### PR DESCRIPTION
BZ1982550_f fixing footnote numbering for Customer Portal

Version(s):
  * PR applies to: 4.8+

Issue:
BZ1982550
Also, please close https://github.com/openshift/openshift-docs/pull/47747. This PR replaces it.

Link to docs preview:
https://50852--docspreview.netlify.app/

Specifically:
https://docs.openshift.com/container-platform/4.10/support/troubleshooting/troubleshooting-network-issues.html#configuring-ovs-log-level-permanently_troubleshooting-network-issues
https://docs.openshift.com/container-platform/4.11/cli_reference/developer_cli_odo/odo-cli-reference.html#odo-build-images_odo-cli-reference
https://docs.openshift.com/container-platform/4.7/cli_reference/developer_cli_odo/odo-cli-reference.html#odo-catalog_odo-cli-reference
https://50852--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/deploying-egress-router-ovn-redirection.html#nw-egress-router-ovn-cr_deploying-egress-router-ovn-redirection
https://50852--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-installing-operator_installing-oadp-aws
https://50852--docspreview.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#about-must-gather_gathering-cluster-data
https://50852--docspreview.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#about-toolbox_gathering-cluster-data

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->



<!--- Next steps after opening your PR:

* Ask for peer review from the OpenShift docs team:
  - For Red Hat associates: Ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
    * A link to the PR.
    * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
    * If there is urgency or a deadline for the review.
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.

  Slack is the quickest and preferred way to request a review.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
