### PR TITLE
Added version selector number for RHACS 3.72

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -119,6 +119,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="3.72">3.72</option>
               <option value="3.71">3.71</option>
               <option value="3.70">3.70</option>
               <option value="3.69">3.69</option>


### PR DESCRIPTION
Currently, version number is not showing up in 3.72 docs. This PR fixes the issue.

Should be part of https://github.com/openshift/openshift-docs/pull/50838