### PR TITLE
BZ-2058453: Add procedure to pause MHC using the web console

### DIFF
--- a/modules/machine-health-checks-pausing-web-console.adoc
+++ b/modules/machine-health-checks-pausing-web-console.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+
+// * updating/updating-cluster-within-minor.adoc
+
+:_content-type: PROCEDURE
+[id="machine-health-checks-pausing-web-console_{context}"]
+= Pausing a MachineHealthCheck resource by using the web console
+
+During the upgrade process, nodes in the cluster might become temporarily unavailable. In the case of worker nodes, the machine health check might identify such nodes as unhealthy and reboot them. To avoid rebooting such nodes, pause all the `MachineHealthCheck` resources before updating the cluster.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+. Navigate to *Compute* -> *MachineHealthChecks*.
+. To pause the machine health checks, add the `cluster.x-k8s.io/paused=""` annotation to each `MachineHealthCheck` resource. For example, to add the annotation to the `machine-api-termination-handler` resource, complete the following steps:
+.. Click the Options menu {kebab} next to the `machine-api-termination-handler` and click *Edit annotations*.
+.. In the *Edit annotations* dialog, click *Add more*.
+.. In the *Key* and *Value* fields, add `cluster.x-k8s.io/paused` and `""` values, respectively, and click *Save*.

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -33,7 +33,7 @@ xref:../updating/preparing-eus-eus-upgrade.adoc#preparing-eus-eus-upgrade[Prepar
 xref:../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[Updating a cluster using the web console]: You can update an {product-title} cluster by using the web console. The following steps update a cluster within a minor version. You can use the same instructions for updating a cluster between minor versions.
 
 * xref:../updating/updating-cluster-within-minor.adoc#update-using-custom-machine-config-pools-canary_updating-cluster-within-minor[Performing a canary rollout update]
-* xref:../updating/updating-cluster-within-minor.adoc#machine-health-checks-pausing_updating-cluster-within-minor[Pausing a MachineHealthCheck resource]
+* xref:../updating/updating-cluster-within-minor.adoc#machine-health-checks-pausing-web-console_updating-cluster-within-minor[Pausing a MachineHealthCheck resource]
 * xref:../updating/updating-cluster-within-minor.adoc#update-single-node-openshift_updating-cluster-within-minor[About updating {product-title} on a single-node cluster]
 * xref:../updating/updating-cluster-within-minor.adoc#update-upgrading-web_updating-cluster-within-minor[Updating a cluster by using the web console]
 * xref:../updating/updating-cluster-within-minor.adoc#update-changing-update-server-web_updating-cluster-within-minor[Changing the update server by using the web console]

--- a/updating/updating-cluster-within-minor.adoc
+++ b/updating/updating-cluster-within-minor.adoc
@@ -49,7 +49,7 @@ include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
 * xref:../installing/installing_azure/manually-creating-iam-azure.adoc[Manually creating IAM for Azure]
 * xref:../installing/installing_gcp/manually-creating-iam-gcp.adoc[Manually creating IAM for GCP]
 
-include::modules/machine-health-checks-pausing.adoc[leveloffset=+1]
+include::modules/machine-health-checks-pausing-web-console.adoc[leveloffset=+1]
 
 include::modules/updating-sno.adoc[leveloffset=+1]
 


### PR DESCRIPTION
BZ-2058453: This PR adds a procedure for pausing `MachineHealthCheck` (MHC) using the web console. It also updates the relevant assemblies (_Updating a cluster using the web console_ and _Updating clusters overview_) to include/xref this procedure.

Version(s): OpenShift 4.9+ (4.9 and later)

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2058453

Link to docs preview:

- http://file.rdu.redhat.com/avbhatt/bz-2058453/updating/updating-cluster-within-minor.html#machine-health-checks-pausing-web-console_updating-cluster-within-minor (Updated the `include` to reflect the new module)
- http://file.rdu.redhat.com/avbhatt/bz-2058453/updating/index.html#updating-clusters-overview-update-cluster-using-web-console (Updated the `xref` to point to the new module)

**Review status**:

- SME reviewed
- QE approved 