### PR TITLE
OSDOCS-4201: Created a page about deleting clusters

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -93,6 +93,10 @@ Topics:
   File: creating-a-gcp-cluster
 - Name: Configuring your identity providers
   File: config-identity-providers
+- Name: Revoking privileges and access to an OpenShift Dedicated cluster  
+  File: osd-revoking-cluster-privileges
+- Name: Deleting an OpenShift Dedicated cluster
+  File: osd-deleting-a-cluster
 ---
 Name: Cluster administration
 Dir: osd_cluster_admin

--- a/osd_install_access_delete_cluster/osd-deleting-a-cluster.adoc
+++ b/osd_install_access_delete_cluster/osd-deleting-a-cluster.adoc
@@ -1,0 +1,12 @@
+:_content-type: ASSEMBLY
+[id="osd-deleting-a-cluster"]
+= Deleting an {product-title} cluster
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: osd-deleting-a-cluster
+
+toc::[]
+
+[role="_abstract"]
+As cluster owner, you can delete your {product-title} clusters.
+
+include::modules/deleting-cluster.adoc[leveloffset=+1]

--- a/osd_install_access_delete_cluster/osd-revoking-cluster-privileges.adoc
+++ b/osd_install_access_delete_cluster/osd-revoking-cluster-privileges.adoc
@@ -1,0 +1,13 @@
+:_content-type: ASSEMBLY
+[id=" osd-revoking-cluster-privileges"]
+= Revoking privileges and access to an {product-title} cluster
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: osd-revoking-cluster-privileges
+
+toc::[]
+
+[role="_abstract"]
+As cluster owner, you can revoke admin privileges and user access to a {product-title} cluster.
+
+include::modules/osd-revoke-admin-privileges.adoc[leveloffset=+1]
+include::modules/osd-revoke-user-access.adoc[leveloffset=+1]


### PR DESCRIPTION
Status:
**Editing**

Version(s):
Enterprise-4.11

Issue:
[OSDOCS-4201](https://issues.redhat.com/browse/OSDOCS-4201)

Link to docs preview:
- **OSD**
    - **[Revoking privileges and access to an OpenShift Dedicated cluster](https://50875--docspreview.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/osd-revoking-cluster-privileges.html)** 
    - **[Deleting an OpenShift Dedicated Cluster](https://50875--docspreview.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/osd-deleting-a-cluster.html)**

Additional information:
Create a new assembly that combines three existing modules. These modules cover revoking privileges and access to clusters as well as deleting the clusters.