### PR TITLE
BZ2102828: Cu requires guidance on windows container Vs OCP windows node version compatibility and best dev practices to avoid compatibility issues.

### DIFF
--- a/modules/windows-pod-placement.adoc
+++ b/modules/windows-pod-placement.adoc
@@ -7,6 +7,14 @@
 
 Before deploying your Windows workloads to the cluster, you must configure your Windows node scheduling so pods are assigned correctly. Since you have a machine hosting your Windows node, it is managed the same as a Linux-based node. Likewise, scheduling a Windows pod to the appropriate Windows node is completed similarly, using mechanisms like taints, tolerations, and node selectors.
 
-With multiple operating systems, and the ability to run multiple Windows OS variants, in the same cluster, you must map your Windows pods to a base Windows OS variant by using a `RuntimeClass`. For example, if you have multiple Windows nodes running on different Windows Server container versions, the cluster could schedule your Windows pods to an incompatible Windows OS variant. You must have `RuntimeClass` objects configured for each Windows OS variant on your cluster. Using a `RuntimeClass` object is also recommended if you have only one Windows OS variant available in your cluster.
+With multiple operating systems, and the ability to run multiple Windows OS variants in the same cluster, you must map your Windows pods to a base Windows OS variant by using a `RuntimeClass` object. For example, if you have multiple Windows nodes running on different Windows Server container versions, the cluster could schedule your Windows pods to an incompatible Windows OS variant. You must have `RuntimeClass` objects configured for each Windows OS variant on your cluster. Using a `RuntimeClass` object is also recommended if you have only one Windows OS variant available in your cluster.
 
 For more information, see Microsoft's documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/update-containers#host-and-container-version-compatibility[Host and container version compatibility].
+
+[IMPORTANT]
+====
+The container base image must be the same Windows OS version and build number that is running on the node where the conainer is to be scheduled. 
+
+Also, if you upgrade the Windows nodes from one version to another, for example going from 20H2 to 2022, you must upgrade your container base image to match the new version. For more information, see link:https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-2022%2Cwindows-11-21H2[Windows container version compatibility].
+====
+


### PR DESCRIPTION
** New PR replacing https://github.com/openshift/openshift-docs/pull/49446, which had issues in the topic map **

https://bugzilla.redhat.com/show_bug.cgi?id=2102828

Preview:[ Windows pod placement: Important note](http://file.rdu.redhat.com/mburke/BZ-2102828/windows_containers/scheduling-windows-workloads.html#windows-pod-placement_scheduling-windows-workloads)

