### PR TITLE
SRVKE-802: Add KafkaSource SASL docs

### DIFF
--- a/modules/serverless-kafka-sasl-channels.adoc
+++ b/modules/serverless-kafka-sasl-channels.adoc
@@ -14,7 +14,7 @@ _Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for au
 * The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR are installed on your {product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 * You have a username and password for a Kafka cluster.
-* You have chosen the SASL mechanism to use, for example `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
+* You have chosen the SASL mechanism to use, for example, `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
 * If TLS is enabled, you also need the `ca.crt` certificate file for the Kafka cluster.
 * Install the OpenShift CLI (`oc`).
 

--- a/modules/serverless-kafka-sasl-source.adoc
+++ b/modules/serverless-kafka-sasl-source.adoc
@@ -1,10 +1,10 @@
-// Module is included in the following assemblies:
+// Module included in the following assemblies:
 //
 // * serverless/admin_guide/serverless-kafka-admin.adoc
 
 :_content-type: PROCEDURE
-[id="serverless-kafka-broker-sasl-default-config_{context}"]
-= Configuring SASL authentication for Kafka brokers
+[id="serverless-kafka-sasl-source_{context}"]
+= Configuring SASL authentication for Kafka sources
 
 _Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for authentication. If you use SASL authentication on your cluster, users must provide credentials to Knative for communicating with the Kafka cluster, otherwise events cannot be produced or consumed.
 
@@ -16,46 +16,53 @@ _Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for au
 * You have a username and password for a Kafka cluster.
 * You have chosen the SASL mechanism to use, for example, `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
 * If TLS is enabled, you also need the `ca.crt` certificate file for the Kafka cluster.
-* Install the OpenShift CLI (`oc`).
+* You have installed the OpenShift (`oc`) CLI.
 
 .Procedure
 
-. Create the certificate files as a secret in the `knative-eventing` namespace:
-+
-[source,terminal]
-----
-$ oc create secret -n knative-eventing generic <secret_name> \
-  --from-literal=protocol=SASL_SSL \
-  --from-literal=sasl.mechanism=<sasl_mechanism> \
-  --from-file=ca.crt=caroot.pem \
-  --from-literal=password="SecretPassword" \
-  --from-literal=user="my-sasl-user"
-----
-** Use the key names `ca.crt`, `password`, and `sasl.mechanism`. Do not change them.
-** If you want to use SASL with public CA certificates, you must use the `tls.enabled=true` flag, rather than the `ca.crt` argument, when creating the secret. For example:
+. Create the certificate files as secrets in your chosen namespace:
 +
 [source,terminal]
 ----
 $ oc create secret -n <namespace> generic <kafka_auth_secret> \
-  --from-literal=tls.enabled=true \
+  --from-file=ca.crt=caroot.pem \
   --from-literal=password="SecretPassword" \
-  --from-literal=saslType="SCRAM-SHA-512" \
+  --from-literal=saslType="SCRAM-SHA-512" \ <1>
   --from-literal=user="my-sasl-user"
 ----
+<1> The SASL type can be `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
 
-. Edit the `KnativeKafka` CR and add a reference to your secret in the `broker` spec:
+. Create or modify your Kafka source so that it contains the following `spec` configuration:
 +
 [source,yaml]
 ----
-apiVersion: operator.serverless.openshift.io/v1alpha1
-kind: KnativeKafka
+apiVersion: sources.knative.dev/v1beta1
+kind: KafkaSource
 metadata:
-  namespace: knative-eventing
-  name: knative-kafka
+  name: example-source
 spec:
-  broker:
-    enabled: true
-    defaultConfig:
-      authSecretName: <secret_name>
+...
+  net:
+    sasl:
+      enable: true
+      user:
+        secretKeyRef:
+          name: <kafka_auth_secret>
+          key: user
+      password:
+        secretKeyRef:
+          name: <kafka_auth_secret>
+          key: password
+      saslType:
+        secretKeyRef:
+          name: <kafka_auth_secret>
+          key: saslType
+    tls:
+      enable: true
+      caCert: <1>
+        secretKeyRef:
+          name: <kafka_auth_secret>
+          key: ca.crt
 ...
 ----
+<1> The `caCert` spec is not required if you are using a public cloud Kafka service, such as Red Hat OpenShift Streams for Apache Kafka.

--- a/serverless/admin_guide/serverless-kafka-admin.adoc
+++ b/serverless/admin_guide/serverless-kafka-admin.adoc
@@ -46,6 +46,7 @@ include::modules/serverless-kafka-broker-tls-default-config.adoc[leveloffset=+2]
 include::modules/serverless-kafka-broker-sasl-default-config.adoc[leveloffset=+2]
 include::modules/serverless-kafka-tls-channels.adoc[leveloffset=+2]
 include::modules/serverless-kafka-sasl-channels.adoc[leveloffset=+2]
+include::modules/serverless-kafka-sasl-source.adoc[leveloffset=+2]
 
 include::modules/serverless-kafka-broker-configmap.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
OCP 4.6+

Issue:
https://issues.redhat.com/browse/SRVKE-802

Link to docs preview:
https://50877--docspreview.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-kafka-admin.html#serverless-kafka-sasl-source_serverless-kafka-admin