### PR TITLE
OSDOCS-4202: correct typo in grace-period usage

### DIFF
--- a/modules/storage-multi-attach-error.adoc
+++ b/modules/storage-multi-attach-error.adoc
@@ -35,7 +35,7 @@ If you encounter a multi-attach error message with an RWO volume, force delete t
 +
 [source,terminal]
 ----
-$ oc delete pod <old_pod> --force=true --grace-period=0s
+$ oc delete pod <old_pod> --force=true --grace-period=0
 ----
 +
 This command deletes the volumes stuck on shutdown or crashed nodes after six minutes.


### PR DESCRIPTION
Version(s):
* All

Issue:

This corrects a typo in the usage of the `--grace-period` argument. `0s` is not a valid value, and should be `0`. 
Refs [OSDOCS-4202](https://issues.redhat.com//browse/OSDOCS-4202)

