### PR TITLE
travis build: make the wget vale zip step resilient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,12 @@ jobs:
       before_script:
         - gem install asciidoctor
       script:
-        - wget https://github.com/errata-ai/vale/releases/download/v2.20.1/vale_2.20.1_Linux_64-bit.tar.gz
+        - travis_retry wget https://github.com/errata-ai/vale/releases/download/v2.20.1/vale_2.20.1_Linux_64-bit.tar.gz --retry-connrefused
         - mkdir bin && tar -xvzf vale_2.20.1_Linux_64-bit.tar.gz -C bin
         - export PATH=./bin:"$PATH"
-        - vale sync # pull down VRH rules package
+        - travis_retry vale sync # pull down VRH rules package
         - chmod +x ./scripts/check-with-vale.sh
-        - ./scripts/check-with-vale.sh $TRAVIS_PULL_REQUEST $TRAVIS_PULL_REQUEST_SHA
+        - travis_retry ./scripts/check-with-vale.sh $TRAVIS_PULL_REQUEST $TRAVIS_PULL_REQUEST_SHA
     # Commenting out to disable auto-merging of PRs
     # - stage: automerge
     #   if: env(PR_AUTHOR)=openshift-cherrypick-robot


### PR DESCRIPTION
Currently, the `wget vale` step can cause the entire build to fail. We can make the wget step more resilient by passing the following `wget` param and using `travis_retry`:

* Retry refused connections and similar fatal errors (`--retry-connrefused`)

Merge to main, CP to ~enterprise-4.8+~ enterprise-4.10+