### PR TITLE
Add an example aws command for querying valid AMI images 4.6 to 4.10

### DIFF
--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
@@ -13,7 +13,14 @@ You can create a Windows `MachineSet` object to serve a specific purpose in your
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
 * You are using a supported Windows Server as the operating system image with the Docker-formatted container runtime add-on enabled.
-
++
+Use the following `aws` command to query valid AMI images:
++
+[source,terminal]
+----
+$ aws ec2 describe-images --region <aws region name> --filters "Name=name,Values=Windows_Server-2019*English*Full*Containers*" "Name=is-public,Values=true" --query "reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}" --output table
+----
++
 [IMPORTANT]
 ====
 Currently, the Docker-formatted container runtime is used in Windows nodes. Kubernetes is deprecating Docker as a container runtime; you can reference the Kubernetes documentation for more information in link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Docker deprecation]. Containerd will be the new supported container runtime for Windows nodes in a future release of Kubernetes.


### PR DESCRIPTION
This PR is to avoid a merge error in 4.6 and 4.10 with this PR: https://github.com/openshift/openshift-docs/pull/50802

Merging to 4.6, because main is different. CP 4.7 to 4.10. 4.11+ is different.