### PR TITLE
OSDOCS-4151: Adding section on using custom machine types

### DIFF
--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -33,6 +33,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_gcp/installing-gcp-network-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-network-customizations.adoc
@@ -40,6 +40,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_gcp/installing-gcp-private.adoc
+++ b/installing/installing_gcp/installing-gcp-private.adoc
@@ -37,6 +37,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -61,6 +61,7 @@ This section describes the requirements for deploying {product-title} on user-pr
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-user-infra-config-host-project-vpc.adoc[leveloffset=+1]
 include::modules/installation-gcp-dns.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -56,6 +56,7 @@ This section describes the requirements for deploying {product-title} on user-pr
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
 include::modules/installation-disk-partitioning-upi-templates.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -33,6 +33,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -44,6 +44,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -63,6 +63,7 @@ This section describes the requirements for deploying {product-title} on user-pr
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
 include::modules/installation-disk-partitioning-upi-templates.adoc[leveloffset=+2]

--- a/modules/installation-using-gcp-custom-machine-types.adoc
+++ b/modules/installation-using-gcp-custom-machine-types.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+// * installing/installing_gcp/installing-gcp-network-customizations.adoc
+// * installing/installing_gcp/installing-gcp-private.adoc
+// * installing/installing_gcp/installing-gcp-vpc.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+// * installing/installing_gcp/installing-gcp-user-infra.adoc
+// * installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp.adoc
+
+ifeval::["{context}" == "installing-gcp-customizations"]
+:ipi:
+endif::[]
+ifeval::["{context}" == "installing-gcp-network-customizations"]
+:ipi:
+endif::[]
+ifeval::["{context}" == "installing-gcp-private"]
+:ipi:
+endif::[]
+ifeval::["{context}" == "installing-gcp-vpc"]
+:ipi:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-gcp-installer-provisioned"]
+:ipi:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="installation-custom-machine-types_{context}"]
+= Using custom machine types
+Using a custom machine type to install a {product-title} cluster is supported.
+
+Consider the following when using a custom machine type:
+
+* Similar to predefined instance types, custom machine types must meet the minimum resource requirements for control plane and compute machines. For more information, see "Minimum resource requirements for cluster installation".
+* The name of the custom machine type must adhere to the following syntax:
++
+--
+`custom-<number_of_cpus>-<amount_of_memory_in_mb>`
+
+For example, `custom-6-20480`.
+--
+
+ifdef::ipi[]
+As part of the installation process, you specify the custom machine type in the `install-config.yaml` file.
+
+.Sample `install-config.yaml` file with a custom machine type
+
+[source,yaml]
+----
+compute:
+- architecture: amd64
+  hyperthreading: Enabled
+  name: worker
+  platform:
+    gcp:
+      type: custom-6-20480
+  replicas: 2
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform:
+    gcp:
+      type: custom-6-20480
+  replicas: 3
+----
+endif::ipi[]
+
+ifeval::["{context}" == "installing-gcp-customizations"]
+:!ipi:
+endif::[]
+ifeval::["{context}" == "installing-gcp-network-customizations"]
+:!ipi:
+endif::[]
+ifeval::["{context}" == "installing-gcp-private"]
+:!ipi:
+endif::[]
+ifeval::["{context}" == "installing-gcp-vpc"]
+:!ipi:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-gcp-installer-provisioned"]
+:!ipi:
+endif::[]


### PR DESCRIPTION
Version(s):
4.8+

Issue:
This PR addresses [OSDOCS-4151](https://issues.redhat.com/browse/OSDOCS-4151), which was created a part of this Slack [thread](https://coreos.slack.com/archives/C01V1DP387R/p1663318153713369).

Link to docs preview:
[Using custom machine types](https://50943--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-custom-machine-types_installing-gcp-customizations)

QE review:
PR is QE approved.