### PR TITLE
Added missing 3.72 version

### DIFF
--- a/_javascripts/page-loader.js
+++ b/_javascripts/page-loader.js
@@ -42,7 +42,7 @@ function versionSelector(list) {
     newLink = "https://docs.openshift.com/enterprise/" +
       newVersion +
       fileRequested;
-  } else if (['3.65', '3.66', '3.67', '3.68', '3.69', '3.70', '3.71'].contains(newVersion)) {
+  } else if (['3.65', '3.66', '3.67', '3.68', '3.69', '3.70', '3.71', '3.72'].contains(newVersion)) {
     // check and handle links for RHACS versions
     newLink = "https://docs.openshift.com/acs/" +
       newVersion +
@@ -75,7 +75,7 @@ function versionSelector(list) {
       if(jqXHR.status == 404) {
         list.value = currentVersion;
         if(confirm("This page doesn't exist in version " + newVersion + ". Click OK to search the " + newVersion + " docs OR Cancel to stay on this page.")) {
-          if (['3.65', '3.66', '3.67', '3.68', '3.69', '3.70', '3.71'].contains(newVersion)) {
+          if (['3.65', '3.66', '3.67', '3.68', '3.69', '3.70', '3.71', '3.72'].contains(newVersion)) {
             window.location = "https://google.com/search?q=site:https://docs.openshift.com/acs/" + newVersion + " " + document.title;}
           else {
             if (dk == "openshift-enterprise"){


### PR DESCRIPTION

![Sep-28-2022 11-51-47](https://user-images.githubusercontent.com/23069445/192669443-5d49c98f-3b53-4984-9361-710f2c0d9010.gif)

> version dropdown is glitchy. If i’m on the 3.71 version and select 3.72, i’m able to select 3.72, but it switches back to 3.71.

This is to resolve the version picker bug.