### PR TITLE
TELCODOCS 477 CNF-3882 4.12 ACM Topology Aware Lifecycle Manager

### DIFF
--- a/modules/cnf-about-topology-aware-lifecycle-manager-config.adoc
+++ b/modules/cnf-about-topology-aware-lifecycle-manager-config.adoc
@@ -14,5 +14,8 @@ The {cgu-operator-first} manages the deployment of {rh-rhacm-first} policies for
 * The update order of the clusters
 * The set of policies remediated to the cluster
 * The order of policies remediated to the cluster
+* The assignment of a canary cluster
+
+For {sno}, the {cgu-operator-first} can create a backup of a deployment before an upgrade. If the upgrade fails, you can recover the previous version and restore a cluster to a working state without requiring a reprovision of applications.
 
 {cgu-operator} supports the orchestration of the {product-title} y-stream and z-stream updates, and day-two operations on y-streams and z-streams.

--- a/modules/cnf-topology-aware-lifecycle-manager-about-cgu-crs.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-about-cgu-crs.adoc
@@ -16,14 +16,27 @@ The {cgu-operator-first} builds the remediation plan from the `ClusterGroupUpgra
 * Actions to perform before and after the update
 * Update timing
 
-As {cgu-operator} works through remediation of the policies to the specified clusters, the `ClusterGroupUpgrade` CR can have the following states:
+You can control the start time of an update using the `enable` field in the `ClusterGroupUpgrade` CR.
+For example, if you have a scheduled maintenance window of four hours, you can prepare a `ClusterGroupUpgrade` CR with the `enable` field set to `false`.
 
-* `UpgradeNotStarted`
-* `UpgradeCannotStart`
-* `UpgradeNotComplete`
-* `UpgradeTimedOut`
-* `UpgradeCompleted`
-* `PrecachingRequired`
+You can set the timeout by configuring the `spec.remediationStrategy.timeout` setting as follows:
+[source,yaml]
+----
+spec
+  remediationStrategy:
+          maxConcurrency: 1
+          timeout: 240
+----
+
+You can use the `batchTimeoutAction` to determine what happens if an update fails for a cluster.
+You can specify `continue` to skip the failing cluster and continue to upgrade other clusters, or `abort` to stop policy remediation for all clusters.
+Once the timeout elapses, {cgu-operator} removes all `enforce` policies to ensure that no further updates are made to clusters.
+
+To apply the changes, you set the `enabled` field to `true`.
+
+For more information see the "Applying update policies to managed clusters" section.
+
+As {cgu-operator} works through remediation of the policies to the specified clusters, the `ClusterGroupUpgrade` CR can report true or false statuses for a number of conditions.
 
 [NOTE]
 ====
@@ -33,218 +46,424 @@ After {cgu-operator} completes a cluster update, the cluster does not update aga
 * When the cluster changes to non-compliant with the `inform` policy after being updated
 ====
 
-[id="upgrade_not_started"]
-== The UpgradeNotStarted state
+[id="selecting_clusters_{context}"]
+== Selecting clusters
 
-The initial state of the `ClusterGroupUpgrade` CR is `UpgradeNotStarted`.
+{cgu-operator} builds a remediation plan and selects clusters based on the following fields:
 
-{cgu-operator} builds a remediation plan based on the following fields:
-
-* The `clusterSelector` field specifies the labels of the clusters that you want to update.
+* The `clusterLabelSelector` field specifies the labels of the clusters that you want to update. This consists of a list of the standard label selectors from `k8s.io/apimachinery/pkg/apis/meta/v1`. Each selector in the list uses either label value pairs or label expressions. Matches from each selector are added to the final list of clusters along with the matches from the `clusterSelector` field and the `cluster` field.
 * The `clusters` field specifies a list of clusters to update.
 * The `canaries` field specifies the clusters for canary updates.
 * The `maxConcurrency` field specifies the number of clusters to update in a batch.
 
-You can use the `clusters` and the `clusterSelector` fields together to create a combined list of clusters.
+You can use the `clusters`, `clusterLabelSelector`, and `clusterSelector` fields together to create a combined list of clusters.
 
 The remediation plan starts with the clusters listed in the `canaries` field. Each canary cluster forms a single-cluster batch.
+
+.Sample `ClusterGroupUpgrade` CR with the enabled `field` set to `false`
+
+[source,yaml]
+----
+apiVersion: ran.openshift.io/v1alpha1
+kind: ClusterGroupUpgrade
+metadata:
+  creationTimestamp: '2022-11-18T16:27:15Z'
+  finalizers:
+    - ran.openshift.io/cleanup-finalizer
+  generation: 1
+  name: talm-cgu
+  namespace: talm-namespace
+  resourceVersion: '40451823'
+  uid: cca245a5-4bca-45fa-89c0-aa6af81a596c
+Spec:
+  actions:
+    afterCompletion:
+      deleteObjects: true
+    beforeEnable: {}
+  backup: false
+  clusters: <1>
+    - spoke1
+  enable: false <2>
+  managedPolicies: <3>
+    - talm-policy
+  preCaching: false
+  remediationStrategy: <4>
+    canaries: <5>
+        - spoke1
+    maxConcurrency: 2 <6>
+    timeout: 240
+  clusterLabelSelectors: <7>
+    - matchExpressions:
+      - key: label1
+      operator: In
+      values:
+        - value1a
+        - value1b
+  batchTimeoutAction: <8>
+status: <9>
+    computedMaxConcurrency: 2
+    conditions:
+      - lastTransitionTime: '2022-11-18T16:27:15Z'
+        message: All selected clusters are valid
+        reason: ClusterSelectionCompleted
+        status: 'True'
+        type: ClustersSelected <10>
+      - lastTransitionTime: '2022-11-18T16:27:15Z'
+        message: Completed validation
+        reason: ValidationCompleted
+        status: 'True'
+        type: Validated <11>
+      - lastTransitionTime: '2022-11-18T16:37:16Z'
+        message: Not enabled
+        reason: NotEnabled
+        status: 'False'
+        type: Progressing
+    managedPoliciesForUpgrade:
+      - name: talm-policy
+        namespace: talm-namespace
+    managedPoliciesNs:
+      talm-policy: talm-namespace
+    remediationPlan:
+      - - spoke1
+      - - spoke2
+        - spoke3
+    status:
+----
+<1> Defines the list of clusters to update.
+<2> The `enable` field is set to `false`.
+<3> Lists the user-defined set of policies to remediate.
+<4> Defines the specifics of the cluster updates.
+<5> Defines the clusters for canary updates.
+<6> Defines the maximum number of concurrent updates in a batch. The number of remediation batches is the number of canary clusters, plus the number of clusters, except the canary clusters, divided by the maxConcurrency value. The clusters that are already compliant with all the managed policies are excluded from the remediation plan.
+<7> Displays the parameters for selecting clusters.
+<8> Controls what happens if a batch times out. Possible values are `abort` or `continue`. If unspecified, the default is `continue`.
+<9> Displays information about the status of the updates.
+<10> The `ClustersSelected` condition shows that all selected clusters are valid.
+<11> The `Validated` condition shows that all selected clusters have been validated.
 
 [NOTE]
 ====
 Any failures during the update of a canary cluster stops the update process.
 ====
 
-The `ClusterGroupUpgrade` CR transitions to the `UpgradeNotCompleted` state after the remediation plan is successfully created and after the `enable` field is set to `true`. At this point, {cgu-operator} starts to update the non-compliant clusters with the specified managed policies.
+When the remediation plan is successfully created, you can you set the `enable` field to `true` and {cgu-operator} starts to update the non-compliant clusters with the specified managed policies.
 
 [NOTE]
 ====
-You can only make changes to the `spec` fields if the `ClusterGroupUpgrade` CR is either in the `UpgradeNotStarted` or the `UpgradeCannotStart` state.
+You can only make changes to the `spec` fields if the `enable` field of the `ClusterGroupUpgrade` CR is is set to `false`.
 ====
 
-.Sample `ClusterGroupUpgrade` CR in the `UpgradeNotStarted` state
+[id="validating_{context}"]
+== Validating
+
+{cgu-operator} checks that all specified managed policies are available and correct, and uses the `Validated` condition to report the status and reasons as follows:
+
+* `true`
++
+Validation is completed.
+* `false`
++
+Policies are missing or invalid, or an invalid platform image has been specified.
+
+[id="precaching_{context}"]
+== Pre-caching
+
+Clusters might have limited bandwidth to access the container image registry, which can cause a timeout before the updates are completed. You can use pre-caching to avoid this. The container image pre-caching starts when you create a `ClusterGroupUpgrade` CR with the `preCaching` field set to `true`.
+
+{cgu-operator} uses the `PrecacheSpecValid` condition to report status information as follows:
+
+* `true`
++
+The pre-caching spec is valid and consistent.
+* `false`
++
+The pre-caching spec is incomplete.
+
+{cgu-operator} uses the `PrecachingSucceeded` condition to report status information as follows:
+
+* `true`
++
+TALM has concluded the pre-caching process. If pre-caching fails for any cluster, the update fails for that cluster but proceeds for all other clusters. A message informs you if pre-caching has failed for any clusters.
+* `false`
++
+Pre-caching is still in progress for one or more clusters or has failed for all clusters.
+
+For more information see the "Using the container image pre-cache feature" section.
+
+[id="creating_backup_{context}"]
+== Creating a backup
+For {sno}, {cgu-operator} can create a backup of a deployment before an update. If the update fails, you can recover the previous version and restore a cluster to a working state without requiring a reprovision of applications. To use the backup feature you first create a `ClusterGroupUpgrade` CR with the `backup` field set to `true`. To ensure that the contents of the backup are up to date, the backup is not taken until you set the `enable` field in the `ClusterGroupUpgrade` CR to `true`.
+
+{cgu-operator} uses the `BackupSucceeded` condition to report the status and reasons as follows:
+
+* `true`
++
+Backup is completed for all clusters or the backup run has completed but failed for one or more clusters. If backup fails for any cluster, the update fails for that cluster but proceeds for all other clusters.
+* `false`
++
+Backup is still in progress for one or more clusters or has failed for all clusters.
+
+For more information, see the "Creating a backup of cluster resources before upgrade" section.
+
+[id="updating_clusters_{context}"]
+== Updating clusters
+{cgu-operator} enforces the policies following the remediation plan.
+Enforcing the policies for subsequent batches starts immediately after all the clusters of the current batch are compliant with all the managed policies. If the batch times out, {cgu-operator} moves on to the next batch. The timeout value of a batch is the `spec.timeout` field divided by the number of batches in the remediation plan.
+
+{cgu-operator} uses the `Progressing` condition to report the status and reasons as follows:
+
+* `true`
++
+{cgu-operator} is remediating non-compliant policies.
+* `false`
++
+The update is not in progress. Possible reasons for this are:
++
+** All clusters are compliant with all the managed policies.
+** The update has timed out as policy remediation took too long.
+** Blocking CRs are missing from the system or have not yet completed.
+** The `ClusterGroupUpgrade` CR is not enabled.
+** Backup is still in progress.
+
+[NOTE]
+====
+The managed policies apply in the order that they are listed in the `managedPolicies` field in the `ClusterGroupUpgrade` CR. One managed policy is applied to the specified clusters at a time. When a cluster complies with the current policy, the next managed policy is applied to it.
+====
+
+.Sample `ClusterGroupUpgrade` CR in the `Progressing` state
 
 [source,yaml]
 ----
 apiVersion: ran.openshift.io/v1alpha1
 kind: ClusterGroupUpgrade
 metadata:
-  name: cgu-upgrade-complete
-  namespace: default
-spec:
-  clusters: <1>
-  - spoke1
-  enable: false
-  managedPolicies: <2>
-  - policy1-common-cluster-version-policy
-  - policy2-common-nto-sub-policy
-  remediationStrategy: <3>
-    canaries: <4>
-      - spoke1
-    maxConcurrency: 1 <5>
-    timeout: 240
-status: <6>
-  conditions:
-  - message: The ClusterGroupUpgrade CR is not enabled
-    reason: UpgradeNotStarted
-    status: "False"
-    type: Ready
-  copiedPolicies:
-  - cgu-upgrade-complete-policy1-common-cluster-version-policy
-  - cgu-upgrade-complete-policy2-common-nto-sub-policy
-  managedPoliciesForUpgrade:
-  - name: policy1-common-cluster-version-policy
-    namespace: default
-  - name: policy2-common-nto-sub-policy
-    namespace: default
-  placementBindings:
-  - cgu-upgrade-complete-policy1-common-cluster-version-policy
-  - cgu-upgrade-complete-policy2-common-nto-sub-policy
-  placementRules:
-  - cgu-upgrade-complete-policy1-common-cluster-version-policy
-  - cgu-upgrade-complete-policy2-common-nto-sub-policy
-  remediationPlan:
-  - - spoke1
-----
-<1> Defines the list of clusters to update.
-<2> Lists the user-defined set of policies to remediate.
-<3> Defines the specifics of the cluster updates.
-<4> Defines the clusters for canary updates.
-<5> Defines the maximum number of concurrent updates in a batch. The number of remediation batches is the number of canary clusters, plus the number of clusters, except the canary clusters, divided by the `maxConcurrency` value. The clusters that are already compliant with all the managed policies are excluded from the remediation plan.
-<6> Displays information about the status of the updates.
-
-[id="upgrade_cannot_start"]
-== The UpgradeCannotStart state
-
-In the `UpgradeCannotStart` state, the update cannot start because of the following reasons:
-
-* Blocking CRs are missing from the system
-* Blocking CRs have not yet finished
-
-[id="upgrade_not_completed"]
-== The UpgradeNotCompleted state
-
-In the `UpgradeNotCompleted` state, {cgu-operator} enforces the policies following the remediation plan defined in the `UpgradeNotStarted` state.
-
-Enforcing the policies for subsequent batches starts immediately after all the clusters of the current batch are compliant with all the managed policies. If the batch times out, {cgu-operator} moves on to the next batch. The timeout value of a batch  is the `spec.timeout` field divided by the number of batches in the remediation plan.
-
-[NOTE]
-====
-The managed policies apply in the order that they are listed in the `managedPolicies` field in the `ClusterGroupUpgrade` CR. One managed policy is applied to the specified clusters at a time. After the specified clusters comply with the current policy, the next managed policy is applied to the next non-compliant cluster.
-====
-
-.Sample `ClusterGroupUpgrade` CR in the `UpgradeNotCompleted` state
-
-[source,yaml]
-----
-apiVersion: ran.openshift.io/v1alpha1
-kind: ClusterGroupUpgrade
-metadata:
-  name: cgu-upgrade-complete
-  namespace: default
-spec:
+  creationTimestamp: '2022-11-18T16:27:15Z'
+  finalizers:
+    - ran.openshift.io/cleanup-finalizer
+  generation: 1
+  name: talm-cgu
+  namespace: talm-namespace
+  resourceVersion: '40451823'
+  uid: cca245a5-4bca-45fa-89c0-aa6af81a596c
+Spec:
+  actions:
+    afterCompletion:
+      deleteObjects: true
+    beforeEnable: {}
+  backup: false
   clusters:
-  - spoke1
-  enable: true <1>
+    - spoke1
+  enable: true
   managedPolicies:
-  - policy1-common-cluster-version-policy
-  - policy2-common-nto-sub-policy
+    - talm-policy
+  preCaching: true
   remediationStrategy:
-    maxConcurrency: 1
+    canaries:
+        - spoke1
+    maxConcurrency: 2
     timeout: 240
-status: <2>
-  conditions:
-  - message: The ClusterGroupUpgrade CR has upgrade policies that are still non compliant
-    reason: UpgradeNotCompleted
-    status: "False"
-    type: Ready
-  copiedPolicies:
-  - cgu-upgrade-complete-policy1-common-cluster-version-policy
-  - cgu-upgrade-complete-policy2-common-nto-sub-policy
-  managedPoliciesForUpgrade:
-  - name: policy1-common-cluster-version-policy
-    namespace: default
-  - name: policy2-common-nto-sub-policy
-    namespace: default
-  placementBindings:
-  - cgu-upgrade-complete-policy1-common-cluster-version-policy
-  - cgu-upgrade-complete-policy2-common-nto-sub-policy
-  placementRules:
-  - cgu-upgrade-complete-policy1-common-cluster-version-policy
-  - cgu-upgrade-complete-policy2-common-nto-sub-policy
-  remediationPlan:
-  - - spoke1
-  status:
-    currentBatch: 1
-    remediationPlanForBatch: <3>
-      spoke1: 0
+  clusterLabelSelectors:
+    - matchExpressions:
+      - key: label1
+      operator: In
+      values:
+        - value1a
+        - value1b
+  batchTimeoutAction:
+status:
+    clusters:
+      - name: spoke1
+        state: complete
+    computedMaxConcurrency: 2
+    conditions:
+      - lastTransitionTime: '2022-11-18T16:27:15Z'
+        message: All selected clusters are valid
+        reason: ClusterSelectionCompleted
+        status: 'True'
+        type: ClustersSelected
+      - lastTransitionTime: '2022-11-18T16:27:15Z'
+        message: Completed validation
+        reason: ValidationCompleted
+        status: 'True'
+        type: Validated
+      - lastTransitionTime: '2022-11-18T16:37:16Z'
+        message: Remediating non-compliant policies
+        reason: InProgress
+        status: 'True'
+        type: Progressing <1>
+    managedPoliciesForUpgrade:
+      - name: talm-policy
+        namespace: talm-namespace
+    managedPoliciesNs:
+      talm-policy: talm-namespace
+    remediationPlan:
+      - - spoke1
+      - - spoke2
+        - spoke3
+    status:
+      currentBatch: 2
+      currentBatchRemediationProgress:
+        spoke2:
+          state: Completed
+        spoke3:
+          policyIndex: 0
+          state: InProgress
+      currentBatchStartedAt: '2022-11-18T16:27:16Z'
+      startedAt: '2022-11-18T16:27:15Z'
 ----
-<1> The update starts when the value of the `spec.enable` field is `true`.
-<2> The `status` fields change accordingly when the update begins.
-<3> Lists the clusters in the batch and the index of the policy that is being currently applied to each cluster. The index of the policies starts with `0` and the index follows the order of the `status.managedPoliciesForUpgrade` list.
+<1> The `Progressing` fields show that {cgu-operator} is in the process of remediating policies.
 
-[id="upgrade_timed_out"]
-== The UpgradeTimedOut state
+[id="update_status_{context}"]
+== Update status
 
-In the `UpgradeTimedOut` state, {cgu-operator} checks every hour if all the policies for the `ClusterGroupUpgrade` CR are compliant. The checks continue until the `ClusterGroupUpgrade` CR is deleted or the updates are completed.
-The periodic checks allow the updates to complete if they get prolonged due to network, CPU, or other issues. 
+{cgu-operator} uses the `Succeeded` condition to report the status and reasons as follows:
 
-{cgu-operator} transitions to the `UpgradeTimedOut` state in two cases:
+* `true`
++
+All clusters are compliant with the specified managed policies.
+* `false`
++
+Policy remediation failed as there were no clusters available for remediation, or because policy remediation took too long for one of the following reasons:
++
+** The current batch contains canary updates and the cluster in the batch does not comply with all the managed policies within the batch timeout.
+** Clusters did not comply with the managed policies within the `timeout` value specified in the `remediationStrategy` field.
 
-* When the current batch contains canary updates and the cluster in the batch does not comply with all the managed policies within the batch timeout.
-* When the clusters do not comply with the managed policies within the `timeout` value specified in the `remediationStrategy` field.
 
-If the policies are compliant, {cgu-operator} transitions to the `UpgradeCompleted` state.
+.Sample `ClusterGroupUpgrade` CR in the `Succeeded` state
 
-[id="upgrade_completed"]
-== The UpgradeCompleted state
+[source,yaml]
+----
+    apiVersion: ran.openshift.io/v1alpha1
+    kind: ClusterGroupUpgrade
+    metadata:
+      name: cgu-upgrade-complete
+      namespace: default
+    spec:
+      clusters:
+      - spoke1
+      - spoke4
+      enable: true
+      managedPolicies:
+      - policy1-common-cluster-version-policy
+      - policy2-common-pao-sub-policy
+      remediationStrategy:
+        maxConcurrency: 1
+        timeout: 240
+    status:
+      clusters:
+        - name: spoke1
+          state: complete
+        - name: spoke4
+          state: complete
+      conditions:
+      - message: All selected clusters are valid
+        reason: ClusterSelectionCompleted
+        status: "True"
+        type: ClustersSelected
+      - message: Completed validation
+        reason: ValidationCompleted
+        status: "True"
+        type: Validated
+      - message: All clusters are compliant with all the managed policies
+        reason: Completed
+        status: "False"
+        type: Progressing <1>
+      - message: All clusters are compliant with all the managed policies
+        reason: Completed
+        status: "True"
+        type: Succeeded <2>
+      managedPoliciesForUpgrade:
+      - name: policy1-common-cluster-version-policy
+        namespace: default
+      - name: policy2-common-pao-sub-policy
+        namespace: default
+      remediationPlan:
+      - - spoke1
+      - - spoke4
+      status:
+        completedAt: '2022-11-18T16:27:16Z'
+        startedAt: '2022-11-18T16:27:15Z'
 
-In the `UpgradeCompleted` state, the cluster updates are complete.
+----
+<1> In the `Progressing` fields, the status is `false` as the update has completed; clusters are compliant with all the managed policies.
+<2> The `Succeeded` fields show that the validations completed successfully.
+<3> Displays that all the policies are applied to the cluster.
 
-.Sample `ClusterGroupUpgrade` CR in the `UpgradeCompleted` state
+The status field includes a list of clusters and their respective status. The status of a cluster can be `complete` or `timedout`. If a cluster is `timedout`, the `currentPolicy` field shows the name of the policy that was being applied and the status of that policy.
+
+.Sample `ClusterGroupUpgrade` CR in the `timedout` state
 
 [source,yaml]
 ----
 apiVersion: ran.openshift.io/v1alpha1
 kind: ClusterGroupUpgrade
 metadata:
-  name: cgu-upgrade-complete
-  namespace: default
+  creationTimestamp: '2022-11-18T16:27:15Z'
+  finalizers:
+    - ran.openshift.io/cleanup-finalizer
+  generation: 1
+  name: talm-cgu
+  namespace: talm-namespace
+  resourceVersion: '40451823'
+  uid: cca245a5-4bca-45fa-89c0-aa6af81a596c
 spec:
   actions:
     afterCompletion:
-      deleteObjects: true <1>
+      deleteObjects: true
+    beforeEnable: {}
+  backup: false
   clusters:
-  - spoke1
+    - spoke1
+    - spoke2
   enable: true
   managedPolicies:
-  - policy1-common-cluster-version-policy
-  - policy2-common-nto-sub-policy
+    - talm-policy
+  preCaching: false
   remediationStrategy:
-    maxConcurrency: 1
+    maxConcurrency: 2
     timeout: 240
-status: <2>
+status:
+  clusters:
+    - name: spoke1
+      state: complete
+    - currentPolicy: <1>
+        name: talm-policy
+        status: NonCompliant
+      name: spoke2
+      state: timedout
+  computedMaxConcurrency: 2
   conditions:
-  - message: The ClusterGroupUpgrade CR has all clusters compliant with all the managed policies
-    reason: UpgradeCompleted
-    status: "True"
-    type: Ready
+    - lastTransitionTime: '2022-11-18T16:27:15Z'
+      message: All selected clusters are valid
+      reason: ClusterSelectionCompleted
+      status: 'True'
+      type: ClustersSelected
+    - lastTransitionTime: '2022-11-18T16:27:15Z'
+      message: Completed validation
+      reason: ValidationCompleted
+      status: 'True'
+      type: Validated
+    - lastTransitionTime: '2022-11-18T16:37:16Z'
+      message: Policy remediation took too long
+      reason: TimedOut
+      status: 'False'
+      type: Progressing
+    - lastTransitionTime: '2022-11-18T16:37:16Z'
+      message: Policy remediation took too long
+      reason: TimedOut
+      status: 'False'
+      type: Succeeded <2>
   managedPoliciesForUpgrade:
-  - name: policy1-common-cluster-version-policy
-    namespace: default
-  - name: policy2-common-nto-sub-policy
-    namespace: default
+    - name: talm-policy
+      namespace: talm-namespace
+  managedPoliciesNs:
+    talm-policy: talm-namespace
   remediationPlan:
-  - - spoke1
+    - - spoke1
+      - spoke2
   status:
-    remediationPlanForBatch:
-      spoke1: -2 <3>
+        startedAt: '2022-11-18T16:27:15Z'
+        completedAt: '2022-11-18T20:27:15Z'
 ----
-<1> The value of `spec.action.afterCompletion.deleteObjects` field is `true` by default. After the update is completed, {cgu-operator} deletes the underlying {rh-rhacm} objects that were created during the update. This option is to prevent the {rh-rhacm} hub from continuously checking for compliance after a successful update.
-<2> The `status` fields show that the updates completed successfully.
-<3> Displays that all the policies are applied to the cluster.
-
-[id="precaching-required"]
-[discreet]
-== The PrecachingRequired state
-
-In the `PrecachingRequired` state, the clusters need to have images pre-cached before the update can start. For more information about pre-caching, see the "Using the container image pre-cache feature" section.
+<1> If a cluster’s state is `timedout`, the `currentPolicy` field shows the name of the policy and the policy status.
+<2> The status for `succeeded` is `false` and the message indicates that policy remediation took too long.

--- a/modules/cnf-topology-aware-lifecycle-manager-apply-policies.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-apply-policies.adoc
@@ -41,11 +41,13 @@ spec:
   remediationStrategy:
     maxConcurrency: 2 <3>
     timeout: 240 <4>
+  batchTimeoutAction: <5>
 ----
 <1> The name of the policies to apply.
 <2> The list of clusters to update.
 <3> The `maxConcurrency` field signifies the number of clusters updated at the same time.
 <4> The update timeout in minutes.
+<5> Controls what happens if a batch times out. Possible values are `abort` or `continue`. If unspecified, the default is `continue`.
 
 . Create the `ClusterGroupUpgrade` CR by running the following command:
 +
@@ -65,8 +67,8 @@ $ oc get cgu --all-namespaces
 +
 [source,terminal]
 ----
-NAMESPACE   NAME      AGE
-default     cgu-1     8m55s
+NAMESPACE   NAME  AGE  STATE      DETAILS
+default     cgu-1 8m55 NotEnabled Not Enabled
 ----
 
 .. Check the status of the update by running the following command:
@@ -85,10 +87,10 @@ $ oc get cgu -n default cgu-1 -ojsonpath='{.status}' | jq
   "conditions": [
     {
       "lastTransitionTime": "2022-02-25T15:34:07Z",
-      "message": "The ClusterGroupUpgrade CR is not enabled", <1>
-      "reason": "UpgradeNotStarted",
+      "message": "Not enabled", <1>
+      "reason": "NotEnabled",
       "status": "False",
-      "type": "Ready"
+      "type": "Progressing"
     }
   ],
   "copiedPolicies": [
@@ -204,11 +206,21 @@ $ oc get cgu -n default cgu-1 -ojsonpath='{.status}' | jq
   "computedMaxConcurrency": 2,
   "conditions": [ <1>
     {
+      "lastTransitionTime": "2022-02-25T15:33:07Z",
+      "message": "All selected clusters are valid",
+      "reason": "ClusterSelectionCompleted",
+      "status": "True",
+      "type": "ClustersSelected",
+      "lastTransitionTime": "2022-02-25T15:33:07Z",
+      "message": "Completed validation",
+      "reason": "ValidationCompleted",
+      "status": "True",
+      "type": "Validated",
       "lastTransitionTime": "2022-02-25T15:34:07Z",
-      "message": "The ClusterGroupUpgrade CR has upgrade policies that are still non compliant", 
-      "reason": "UpgradeNotCompleted",
-      "status": "False",
-      "type": "Ready"
+      "message": "Remediating non-compliant policies",
+      "reason": "InProgress",
+      "status": "True",
+      "type": "Progressing"
     }
   ],
   "copiedPolicies": [

--- a/modules/cnf-topology-aware-lifecycle-manager-backup-concept.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-backup-concept.adoc
@@ -8,17 +8,37 @@
 
 For {sno}, the {cgu-operator-first} can create a backup of a deployment before an upgrade. If the upgrade fails, you can recover the previous version and restore a cluster to a working state without requiring a reprovision of applications.
 
-The container image backup starts when the `backup` field is set to `true` in the `ClusterGroupUpgrade` CR.
+To use the backup feature you first create a `ClusterGroupUpgrade` CR with the `backup` field set to `true`. To ensure that the contents of the backup are up to date, the backup is not taken until you set the `enable` field in the `ClusterGroupUpgrade` CR to `true`.
 
-The backup process can be in the following statuses:
+{cgu-operator} uses the `BackupSucceeded` condition to report the status and reasons as follows:
 
-`BackupStatePreparingToStart`:: The first reconciliation pass is in progress. The {cgu-operator} deletes any spoke backup namespace and hub view resources that have been created in a failed upgrade attempt.
-`BackupStateStarting`:: The backup prerequisites and backup job are being created.
-`BackupStateActive`:: The backup is in progress.
-`BackupStateSucceeded`:: The backup has succeeded.
-`BackupStateTimeout`:: Artifact backup has been partially done.
-`BackupStateError`:: The backup has ended with a non-zero exit code.
+* `true`
++
+Backup is completed for all clusters or the backup run has completed but failed for one or more clusters. If backup fails for any cluster, the update does not proceed for that cluster.
+* `false`
++
+Backup is still in progress for one or more clusters or has failed for all clusters. The backup process running in the spoke clusters can have the following statuses:
++
+** `PreparingToStart`
++
+The first reconciliation pass is in progress. The {cgu-operator} deletes any spoke backup namespace and hub view resources that have been created in a failed upgrade attempt.
+** `Starting`
++
+The backup prerequisites and backup job are being created.
+** `Active`
++
+The backup is in progress.
+** `Succeeded`
++
+The backup succeeded.
+** `BackupTimeout`
++
+Artifact backup is partially done.
+** `UnrecoverableError`
++
+The backup has ended with a non-zero exit code.
+
 [NOTE]
 ====
-If the backup fails and enters the `BackupStateTimeout` or `BackupStateError` state, the cluster upgrade does not proceed.
+If the backup of a cluster fails and enters the `BackupTimeout` or `UnrecoverableError` state, the cluster update does not proceed for that cluster. Updates to other clusters are not affected and continue.
 ====

--- a/modules/cnf-topology-aware-lifecycle-manager-backup-feature.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-backup-feature.adoc
@@ -50,7 +50,7 @@ nodes:
 
 .Procedure
 
-. Save the contents of the `ClusterGroupUpgrade` CR with the `backup` field set to `true` in the `clustergroupupgrades-group-du.yaml` file:
+. Save the contents of the `ClusterGroupUpgrade` CR with the `backup` and `enable` fields set to `true` in the `clustergroupupgrades-group-du.yaml` file:
 +
 [source,yaml]
 ----
@@ -65,7 +65,7 @@ spec:
   clusters:
   - cnfdb1
   - cnfdb2
-  enable: false
+  enable: true
   managedPolicies:
   - du-upgrade-platform-upgrade
   remediationStrategy:
@@ -101,17 +101,17 @@ $ oc get cgu -n ztp-group-du-sno du-upgrade-4918 -o jsonpath='{.status}'
     ],
     "status": {
         "cnfdb1": "Succeeded",
-        "cnfdb2": "Succeeded"
+        "cnfdb2": "Failed" <1>
     }
 },
 "computedMaxConcurrency": 1,
 "conditions": [
     {
         "lastTransitionTime": "2022-04-05T10:37:19Z",
-        "message": "Backup is completed",
-        "reason": "BackupCompleted",
-        "status": "True",
-        "type": "BackupDone"
+        "message": "Backup failed for 1 cluster", <2>
+        "reason": "PartiallyDone", <3>
+        "status": "True", <4>
+        "type": "Succeeded"
     }
 ],
 "precaching": {
@@ -119,3 +119,7 @@ $ oc get cgu -n ztp-group-du-sno du-upgrade-4918 -o jsonpath='{.status}'
 },
 "status": {}
 ----
+<1> Backup has failed for one cluster.
+<2> The message confirms that the backup failed for one cluster.
+<3> The backup was partially successful.
+<4> The backup process has finished.

--- a/modules/cnf-topology-aware-lifecycle-manager-backup-recovery.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-backup-recovery.adoc
@@ -34,7 +34,7 @@ $ oc delete cgu/du-upgrade-4918 -n ztp-group-du-sno
 +
 [source,terminal]
 ----
-$ oc ostree admin status
+$ ostree admin status
 ----
 .Example outputs
 +

--- a/modules/cnf-topology-aware-lifecycle-manager-policies-concept.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-policies-concept.adoc
@@ -16,4 +16,6 @@ If a spoke cluster does not report any compliant state to {rh-rhacm}, the manage
 * If a policy's `status.status` is missing, {cgu-operator} produces an error.
 * If a cluster's compliance status is missing in the policy's `status.status` field, {cgu-operator} considers that cluster to be non-compliant with that policy.
 
+The `ClusterGroupUpgrade` CR's `batchTimeoutAction` determines what happens if an upgrade fails for a cluster. You can specify `continue` to skip the failing cluster and continue to upgrade other clusters, or specify `abort` to stop the policy remediation for all clusters. Once the timeout elapses, {cgu-operator} removes all enforce policies to ensure that no further updates are made to clusters.
+
 For more information about {rh-rhacm} policies, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html-single/governance/index#policy-overview[Policy overview].

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-concept.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-concept.adoc
@@ -6,23 +6,55 @@
 [id="talo-precache-feature-concept_{context}"]
 = Using the container image pre-cache feature
 
-Clusters might have limited bandwidth to access the container image registry, which can cause a timeout before the updates are completed. 
+Clusters might have limited bandwidth to access the container image registry, which can cause a timeout before the updates are completed.
 
 [NOTE]
 ====
 The time of the update is not set by {cgu-operator}. You can apply the `ClusterGroupUpgrade` CR at the beginning of the update by manual application or by external automation.
 ====
 
-The container image pre-caching starts when the `preCaching` field is set to `true` in the `ClusterGroupUpgrade` CR. After a successful pre-caching process, you can start remediating policies. The remediation actions start when the `enable` field is set to `true`.
+The container image pre-caching starts when the `preCaching` field is set to `true` in the `ClusterGroupUpgrade` CR.
+
+{cgu-operator} uses the `PrecacheSpecValid` condition to report status information as follows:
+
+* `true`
++
+The pre-caching spec is valid and consistent.
+* `false`
++
+The pre-caching spec is incomplete.
+
+{cgu-operator} uses the `PrecachingSucceeded` condition to report status information as follows:
+
+* `true`
++
+TALM has concluded the pre-caching process. If pre-caching fails for any cluster, the update fails for that cluster but proceeds for all other clusters. A message informs you if pre-caching has failed for any clusters.
+* `false`
++
+Pre-caching is still in progress for one or more clusters or has failed for all clusters.
+
+After a successful pre-caching process, you can start remediating policies. The remediation actions start when the `enable` field is set to `true`. If there is a pre-caching failure on a cluster, the upgrade fails for that cluster. The upgrade process continues for all other clusters that have a successful pre-cache.
 
 The pre-caching process can be in the following statuses:
 
-`PrecacheNotStarted`:: This is the initial state all clusters are automatically assigned to on the first reconciliation pass of the `ClusterGroupUpgrade` CR. 
+* `NotStarted`
 +
-In this state, {cgu-operator} deletes any pre-caching namespace and hub view resources of spoke clusters that remain from previous incomplete updates. {cgu-operator} then creates a new `ManagedClusterView` resource for the spoke pre-caching namespace to verify its deletion in the `PrecachePreparing` state.
-`PrecachePreparing`:: Cleaning up any remaining resources from previous incomplete updates is in progress.
-`PrecacheStarting`:: Pre-caching job prerequisites and the job are created.
-`PrecacheActive`:: The job is in "Active" state.
-`PrecacheSucceeded`:: The pre-cache job has succeeded.
-`PrecacheTimeout`:: The artifact pre-caching has been partially done.
-`PrecacheUnrecoverableError`:: The job ends with a non-zero exit code.
+This is the initial state all clusters are automatically assigned to on the first reconciliation pass of the `ClusterGroupUpgrade` CR. In this state, {cgu-operator} deletes any pre-caching namespace and hub view resources of spoke clusters that remain from previous incomplete updates. {cgu-operator} then creates a new `ManagedClusterView` resource for the spoke pre-caching namespace to verify its deletion in the `PrecachePreparing` state.
+* `PreparingToStart`
++
+Cleaning up any remaining resources from previous incomplete updates is in progress.
+* `Starting`
++
+Pre-caching job prerequisites and the job are created.
+* `Active`
++
+The job is in "Active" state.
+*  `Succeeded`
++
+The pre-cache job succeeded.
+* `PrecacheTimeout`
++
+The artifact pre-caching is partially done.
+* `UnrecoverableError`
++
+The job ends with a non-zero exit code.

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-feature.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-feature.adoc
@@ -39,7 +39,7 @@ spec:
 ----
 <1> The `preCaching` field is set to `true`, which enables {cgu-operator} to pull the container images before starting the update.
 
-. When you want to start the update, apply the `ClusterGroupUpgrade` CR by running the following command:
+. When you want to start pre-caching, apply the `ClusterGroupUpgrade` CR by running the following command:
 +
 [source,terminal]
 ----
@@ -59,8 +59,8 @@ $ oc get cgu -A
 +
 [source,terminal]
 ----
-NAMESPACE          NAME              AGE
-ztp-group-du-sno   du-upgrade-4918   10s <1>
+NAMESPACE          NAME              AGE   STATE        DETAILS
+ztp-group-du-sno   du-upgrade-4918   10s   InProgress   Precaching is required and not done <1>
 ----
 <1> The CR is created.
 
@@ -79,17 +79,10 @@ $ oc get cgu -n ztp-group-du-sno du-upgrade-4918 -o jsonpath='{.status}'
   "conditions": [
     {
       "lastTransitionTime": "2022-01-27T19:07:24Z",
-      "message": "Precaching is not completed (required)", <1>
-      "reason": "PrecachingRequired",
-      "status": "False",
-      "type": "Ready"
-    },
-    {
-      "lastTransitionTime": "2022-01-27T19:07:24Z",
       "message": "Precaching is required and not done",
-      "reason": "PrecachingNotDone",
+      "reason": "InProgress",
       "status": "False",
-      "type": "PrecachingDone"
+      "type": "PrecachingSucceeded"
     },
     {
       "lastTransitionTime": "2022-01-27T19:07:34Z",
@@ -101,17 +94,18 @@ $ oc get cgu -n ztp-group-du-sno du-upgrade-4918 -o jsonpath='{.status}'
   ],
   "precaching": {
     "clusters": [
-      "cnfdb1" <2>
+      "cnfdb1" <1>
+      "cnfdb2"
     ],
     "spec": {
       "platformImage": "image.example.io"},
     "status": {
-      "cnfdb1": "Active"}
+      "cnfdb1": "Active"
+      "cnfdb2": "Succeeded"}
     }
 }
 ----
-<1> Displays that the update is in progress.
-<2> Displays the list of identified clusters.
+<1> Displays the list of identified clusters.
 
 . Check the status of the pre-caching job by running the following command on the spoke cluster:
 +
@@ -155,7 +149,7 @@ $ oc get cgu -n ztp-group-du-sno du-upgrade-4918 -o jsonpath='{.status}'
       "message": "Precaching is completed",
       "reason": "PrecachingCompleted",
       "status": "True",
-      "type": "PrecachingDone" <1>
+      "type": "PrecachingSucceeded" <1>
     }
 ----
 <1> The pre-cache tasks are done.

--- a/modules/cnf-topology-aware-lifecycle-manager-troubleshooting.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-troubleshooting.adoc
@@ -220,9 +220,9 @@ spoke3          true           https://api.spoke3.testlab.com:6443     True     
 <1> The value of the `AVAILABLE` field is `True` for the managed clusters.
 
 [discrete]
-=== Checking clusterSelector
+=== Checking clusterLabelSelector
 
-Issue:: You want to check if the `clusterSelector` field is specified in the `ClusterGroupUpgrade` CR in at least one of the managed clusters.
+Issue:: You want to check if the `clusterLabelSelector` field specified in the `ClusterGroupUpgrade` CR matches at least one of the managed clusters.
 
 Resolution:: Run the following command:
 +
@@ -250,16 +250,14 @@ Issue:: You want to check if the canary clusters are present in the list of clus
 [source,yaml]
 ----
 spec:
-    clusters:
-    - spoke1
-    - spoke3
-    clusterSelector:
-    - upgrade2=true
     remediationStrategy:
         canaries:
         - spoke3
         maxConcurrency: 2
         timeout: 240
+    clusterLabelSelectors:
+      - matchLabels:
+          upgrade: true
 ----
 
 Resolution:: Run the following commands:
@@ -276,7 +274,7 @@ $ oc get cgu lab-upgrade -ojsonpath='{.spec.clusters}'
 ["spoke1", "spoke3"]
 ----
 
-. Check if the canary clusters are present in the list of clusters that match `clusterSelector` labels by running the following command:
+. Check if the canary clusters are present in the list of clusters that match `clusterLabelSelector` labels by running the following command:
 +
 [source,terminal]
 ----
@@ -294,7 +292,7 @@ spoke3          true           https://api.spoke3.testlab.com:6443   True     Tr
 
 [NOTE]
 ====
-A cluster can be present in `spec.clusters` and also be matched by the `spec.clusterSelecter` label.
+A cluster can be present in `spec.clusters` and also be matched by the `spec.clusterLabelSelector` label.
 ====
 
 [discrete]
@@ -367,7 +365,7 @@ $ oc get cgu lab-upgrade -ojsonpath='{.status.conditions}'
 +
 [source,json]
 ----
-{"lastTransitionTime":"2022-02-17T22:25:28Z", "message":"The ClusterGroupUpgrade CR has managed policies that are missing:[policyThatDoesntExist]", "reason":"UpgradeCannotStart", "status":"False", "type":"Ready"}
+{"lastTransitionTime":"2022-02-17T22:25:28Z", "message":"Missing managed policies:[policyList]", "reason":"NotAllManagedPoliciesExist", "status":"False", "type":"Validated"}
 ----
 
 [discrete]
@@ -435,3 +433,13 @@ ERROR	controller-runtime.manager.controller.clustergroupupgrade	Reconciler error
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
 ----
 <1> Displays the error.
+
+[discrete]
+=== Clusters are not compliant to some policies after a `ClusterGroupUpgrade` CR has completed
+
+Issue:: The policy compliance status that {cgu-operator} uses to decide if remediation is needed has not yet fully updated for all clusters.
+This may be because:
+* The CGU was run too soon after a policy was created or updated. 
+* The remediation of a policy affects the compliance of subsequent policies in the `ClusterGroupUpgrade` CR.
+
+Resolution:: Create a new and apply `ClusterGroupUpdate` CR with the same specification .

--- a/scalability_and_performance/cnf-talm-for-cluster-upgrades.adoc
+++ b/scalability_and_performance/cnf-talm-for-cluster-upgrades.adoc
@@ -9,7 +9,6 @@ toc::[]
 You can use the {cgu-operator-first} to manage the software lifecycle of multiple {sno} clusters. {cgu-operator} uses {rh-rhacm-first} policies to perform changes on the target clusters.
 
 :FeatureName: {cgu-operator-full}
-include::snippets/technology-preview.adoc[]
 
 include::modules/cnf-about-topology-aware-lifecycle-manager-config.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
@@ -9,7 +9,6 @@ toc::[]
 You can use the {cgu-operator-first} to manage the software lifecycle of {product-title} managed clusters. {cgu-operator} uses {rh-rhacm-first} policies to perform changes on the target clusters.
 
 :FeatureName: The Topology Aware Lifecycle Manager
-include::snippets/technology-preview.adoc[]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> ---> TELCODOCS 477 - [CNF-3882](https://issues.redhat.com//browse/CNF-3882) - 4.12 ACM Topology Aware Lifecycle Manager

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples: 4.12
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/TELCODOCS-477
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

**Topology Aware Lifecycle Manager for cluster updates**
https://50952--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-talm-for-cluster-upgrades.html

**About the ClusterGroupUpgrade CR**
https://50952--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-talm-for-cluster-upgrades.html#talo-about-cgu-crs_cnf-topology-aware-lifecycle-manager

**Creating a backup of cluster resources before upgrade**
https://50952--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-talm-for-cluster-upgrades.html#talo-backup-feature-concept_cnf-topology-aware-lifecycle-manager

**Using the container image pre-cache feature**
https://50952--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-talm-for-cluster-upgrades.html#talo-precache-feature-concept_cnf-topology-aware-lifecycle-manager

**Updating managed clusters with the Topology Aware Lifecycle Manager**
https://50952--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.html

**Update policies on managed clusters**
https://50952--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-talm-for-cluster-upgrades.html#talo-policies-concept_cnf-topology-aware-lifecycle-manager

**Troubleshooting the Topology Aware Lifecycle Manager**
https://50952--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-talm-for-cluster-upgrades.html#talo-troubleshooting_cnf-topology-aware-lifecycle-manager
- Clusters 
https://50952--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-talm-for-cluster-upgrades.html#talo-troubleshooting-clusters_cnf-topology-aware-lifecycle-manager
- Topology Aware Lifecycle Manager 
https://50952--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-talm-for-cluster-upgrades.html#talo-troubleshooting-remediation-talo_cnf-topology-aware-lifecycle-manager

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
