### PR TITLE
RHDEVDOCS-4511 Pipelines 1.6.4 Release Notes

### DIFF
--- a/modules/op-release-notes-1-6.adoc
+++ b/modules/op-release-notes-1-6.adoc
@@ -332,3 +332,72 @@ When you upgrade to future releases, the {pipelines-title} Operator will automat
 
 * Before this update, setting the `clusterTasks` and `pipelineTemplates` fields to `false` in the `TektonConfig` CR slowed the removal of cluster tasks and pipeline templates. This update improves the speed of lifecycle management of Tekton resources such as cluster tasks and pipeline templates.
 // https://issues.redhat.com/browse/SRVKP-2043
+
+[id="release-notes-1-6-4_{context}"]
+== Release notes for {pipelines-title} General Availability 1.6.4
+
+[id="known-issues-1-6-4_{context}"]
+=== Known issues
+
+* After upgrading from {pipelines-title} 1.5.2 to 1.6.4, accessing the event listener routes returns a `503` error. 
++
+Workaround: Modify the target port in the YAML file for the event listener's route.
++
+. Extract the route name for the relevant namespace.
++
+[source,terminal]
+----
+$ oc get route -n <namespace>
+----
++
+. Edit the route to modify the value of the `targetPort` field.
++
+[source,terminal]
+----
+$ oc edit route -n <namespace> <el-route_name>
+----
++
+.Example: Existing event listener route
++
+[source,yaml]
+----
+...
+spec:
+  host: el-event-listener-q8c3w5-test-upgrade1.apps.ve49aws.aws.ospqa.com
+  port:
+    targetPort: 8000
+  to:
+    kind: Service
+    name: el-event-listener-q8c3w5
+    weight: 100
+  wildcardPolicy: None
+...
+----
++
+.Example: Modified event listener route
++
+[source,yaml]
+----
+...
+spec:
+  host: el-event-listener-q8c3w5-test-upgrade1.apps.ve49aws.aws.ospqa.com
+  port:
+    targetPort: http-listener
+  to:
+    kind: Service
+    name: el-event-listener-q8c3w5
+    weight: 100
+  wildcardPolicy: None
+...
+----
+
+// https://issues.redhat.com/browse/SRVKP-2502
+
+[id="fixed-issues-1-6-4_{context}"]
+=== Fixed issues
+
+* Before this update, the Operator failed when creating RBAC resources if any namespace was in a `Terminating` state. With this update, the Operator ignores namespaces in a `Terminating` state and creates the RBAC resources.
+// https://issues.redhat.com/browse/SRVKP-2248
+
+* Before this update, the task runs failed or restarted due to absence of annotation specifying the release version of the associated Tekton controller. With this update, the inclusion of the appropriate annotations are automated, and the tasks run without failure or restarts. 
+// https://issues.redhat.com/browse/SRVKP-2445


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`, `enterprise-4.12`
- **JIRA issues**: [RHDEVDOCS-4511 Pipelines 1.6.4 RN](https://issues.redhat.com/browse/RHDEVDOCS-4511)
- **Preview pages**: [Pipelines 1.6.4 Release Notes](http://file.pnq.redhat.com/sosarkar/Pipelines-1-6-4-RN/cicd/pipelines/op-release-notes.html#release-notes-1-6-4_op-release-notes)
- **SME review**: @rupalibehera           
- **Peer-review**: @gabriel-rh   