### PR TITLE
BZ:2099233 - Updating docs. Expanding clusters no longer requires DHCP

### DIFF
--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -6,7 +6,8 @@
 [id='preparing-the-bare-metal-node_{context}']
 = Preparing the bare metal node
 
-Expanding the cluster requires a DHCP server. Each node must have a DHCP reservation.
+To expand your cluster, you must provide the node with the relevant IP address. This can be done with a static configuration, or with a DHCP (Dynamic Host Configuration protocol) server. When expanding the cluster using a DHCP server, each node must have a DHCP reservation.
+
 
 [IMPORTANT]
 .Reserving IP addresses so they become static IP addresses
@@ -44,12 +45,13 @@ $ echo -ne "root" | base64
 $ echo -ne "password" | base64
 ----
 
-. Create a configuration file for the bare metal node using the following example `bmh.yaml` file, replacing values in the YAML to match your environment:
+. Create a configuration file for the bare metal node. Depending on whether you are using a static configuration or a DHCP server, use one of the following example `bmh.yaml` files, replacing values in the YAML to match your environment:
 +
 [source,terminal]
 ----
 $ vim bmh.yaml
 ----
+* *Static configuration* `bmh.yaml`:
 +
 [source,yaml]
 ----
@@ -61,24 +63,37 @@ metadata:
 type: Opaque
 stringData:
  nmstate: |
-  routes:
-   config:
-   - destination: 0.0.0.0/0
-     next-hop-address: <next_hop_address>
-     next-hop-interface: <next_hop_interface>
-  dns-resolver:
-   config:
-    server:
-    - <dns_server_ip_address>
-  interfaces:
-  - name: <nic_interface>
-    state: up
-    ipv4:
-     address:
-     - ip: <ip_address>
-       prefix-length: <cidr>
-     enabled: true
-     dhcp: false
+  hosts:
+  - name: openshift-master-0
+    role: master
+    bmc:
+      address: redfish+http://<out_of_band_ip>/redfish/v1/Systems/
+      username: <user>
+      password: <password>
+      disableCertificateVerification: null
+    bootMACAddress: <NIC1_mac_address>
+    bootMode: UEFI
+    rootDeviceHints:
+      deviceName: "/dev/sda"
+    networkConfig: <3>
+      interfaces:
+      - name: <nic1_name> <4>
+        type: ethernet
+        state: up
+        ipv4:
+          address:
+          - ip: <ip_address> <4>
+            prefix-length: 24
+          enabled: true
+      dns-resolver:
+        config:
+          server:
+          - <dns_ip_address> <4>
+      routes:
+        config:
+        - destination: 0.0.0.0/0
+          next-hop-address: <next_hop_ip_address> <4>
+          next-hop-interface: <next_hop_nic1_name> <4>
 ---
 apiVersion: v1
 kind: Secret
@@ -87,8 +102,8 @@ metadata:
   namespace: openshift-machine-api
 type: Opaque
 data:
-  username: <base64_of_uid> <3>
-  password: <base64_of_pwd> <4>
+  username: <base64_of_uid> <5>
+  password: <base64_of_pwd> <5>
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -97,39 +112,90 @@ metadata:
   namespace: openshift-machine-api
 spec:
   online: True
-  bootMACAddress: <nic1_mac_address> <5>
+  bootMACAddress: <nic1_mac_address> <6>
   bmc:
-    address: <protocol>://<bmc_url> <6>
+    address: <protocol>://<bmc_url> <7>
     credentialsName: openshift-worker-<num>-bmc-secret <2>
-    disableCertificateVerification: True <7>
-    username: <bmc_username> <8>
+    disableCertificateVerification: True <8>
+    username: <bmc_username> <9>
     password: <bmc_password> <9>
   rootDeviceHints:
     deviceName: <root_device_hint> <10>
   preprovisioningNetworkDataName: openshift-worker-<num>-network-config-secret <11>
 ----
 +
-<1> Optional: To configure the network interface for a newly created node, specify the name of the secret that contains the network configuration. Follow the `nmstate` syntax to define the network configuration for your node. See "Optional: Configuring host network interfaces in the install-config.yaml file" for details on configuring NMState syntax.
+<1> To configure the network interface for a newly created node, specify the name of the secret that contains the network configuration. Follow the `nmstate` syntax to define the network configuration for your node. See "Optional: Configuring host network interfaces in the install-config.yaml file" for details on configuring NMState syntax.
 +
 <2> Replace `<num>` for the worker number of the bare metal node in the `name` fields, the `credentialsName` field, and the `preprovisioningNetworkDataName` field.
 +
-<3> Replace `<base64_of_uid>` with the base64 string of the user name.
+<3> Add the NMState YAML syntax to configure the host interfaces.
 +
-<4> Replace `<base64_of_pwd>` with the base64 string of the password.
+<4> Replace `<nic1_name>`, `<ip_address>`, `<dns_ip_address>`, `<next_hop_ip_address>` and `<next_hop_nic1_name>` with appropriate values.
 +
-<5> Replace `<nic1_mac_address>` with the MAC address of the bare metal node's first NIC. See the "BMC addressing" section for additional BMC configuration options.
+<5> Replace `<base64_of_uid>` and  `<base64_of_pwd>` with the base64 string of the user name and password.
 +
-<6> Replace `<protocol>` with the BMC protocol, such as IPMI, RedFish, or others. Replace `<bmc_url>` with the URL of the bare metal node's baseboard management controller.
+<6> Replace `<nic1_mac_address>` with the MAC address of the bare metal node's first NIC. See the "BMC addressing" section for additional BMC configuration options.
 +
-<7> To skip certificate validation, set `disableCertificateVerification` to true.
+<7> Replace `<protocol>` with the BMC protocol, such as IPMI, RedFish, or others. Replace `<bmc_url>` with the URL of the bare metal node's baseboard management controller.
 +
-<8> Replace `<bmc_username>` with the string of the BMC user name.
+<8> To skip certificate validation, set `disableCertificateVerification` to true.
 +
-<9> Replace `<bmc_password>` with the string of the BMC password.
+<9> Replace `<bmc_username>` and `<bmc_password>` with the string of the BMC user name and password.
 +
 <10> Optional: Replace `<root_device_hint>` with a device path if you specify a root device hint.
 +
 <11> Optional: If you have configured the network interface for the newly created node, provide the network configuration secret name in the `preprovisioningNetworkDataName` of the BareMetalHost CR.
+
+* *DHCP configuration* `bmh.yaml`:
++
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshift-worker-<num>-bmc-secret <1>
+  namespace: openshift-machine-api
+type: Opaque
+data:
+  username: <base64_of_uid> <2>
+  password: <base64_of_pwd> <2>
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: openshift-worker-<num> <1>
+  namespace: openshift-machine-api
+spec:
+  online: True
+  bootMACAddress: <nic1_mac_address> <3>
+  bmc:
+    address: <protocol>://<bmc_url> <4>
+    credentialsName: openshift-worker-<num>-bmc-secret <1>
+    disableCertificateVerification: True <5>
+    username: <bmc_username> <6>
+    password: <bmc_password> <6>
+  rootDeviceHints:
+    deviceName: <root_device_hint> <7>
+  preprovisioningNetworkDataName: openshift-worker-<num>-network-config-secret <8>
+----
++
+<1> Replace `<num>` for the worker number of the bare metal node in the `name` fields, the `credentialsName` field, and the `preprovisioningNetworkDataName` field.
++
+<2> Replace `<base64_of_uid>` and `<base64_of_pwd>` with the base64 string of the user name and password.
++
+<3> Replace `<nic1_mac_address>` with the MAC address of the bare metal node's first NIC. See the "BMC addressing" section for additional BMC configuration options.
++
+<4> Replace `<protocol>` with the BMC protocol, such as IPMI, RedFish, or others. Replace `<bmc_url>` with the URL of the bare metal node's baseboard management controller.
++
+<5> To skip certificate validation, set `disableCertificateVerification` to true.
++
+<6> Replace `<bmc_username>` and `<bmc_password>` with the string of the BMC user name and password.
++
+<7> Optional: Replace `<root_device_hint>` with a device path if you specify a root device hint.
++
+<8> Optional: If you have configured the network interface for the newly created node, provide the network configuration secret name in the `preprovisioningNetworkDataName` of the BareMetalHost CR.
+
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
Main, 4.10, 4.11, 4.12

Issue:
[BZ-2099233](https://bugzilla.redhat.com/show_bug.cgi)

[Link to docs preview](https://50954--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
