### PR TITLE
GH50050 - Remove prerelease tag in mirrors url

### DIFF
--- a/modules/ztp-acm-adding-images-to-mirror-registry.adoc
+++ b/modules/ztp-acm-adding-images-to-mirror-registry.adoc
@@ -46,12 +46,12 @@ $ export OCP_VERSION=<ocp_version> <3>
 +
 [source,terminal]
 ----
-$ sudo wget https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/${OCP_VERSION}/${ISO_IMAGE_NAME} -O /var/www/html/${ISO_IMAGE_NAME}
+$ sudo wget https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/${OCP_VERSION}/${ISO_IMAGE_NAME} -O /var/www/html/${ISO_IMAGE_NAME}
 ----
 +
 [source,terminal]
 ----
-$ sudo wget https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/${OCP_VERSION}/${ROOTFS_IMAGE_NAME} -O /var/www/html/${ROOTFS_IMAGE_NAME}
+$ sudo wget https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/${OCP_VERSION}/${ROOTFS_IMAGE_NAME} -O /var/www/html/${ROOTFS_IMAGE_NAME}
 ----
 
 .Verification steps


### PR DESCRIPTION
For versions 4.10+
Updates issue #50050

Description: Needed to fix another section of the doc

Preview: [Scalability and Performance -> Deploying distributed units at scale in a disconnected environment -> Adding RHCOS and RootFS images to the disconnected mirror host](https://50961--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-acm-adding-images-to-mirror-registry_ztp-deploying-disconnected)