### PR TITLE
[SRVKE-1278 + SRVKE-1327] : Add kafka sink security config docs

### DIFF
--- a/modules/serverless-kafka-broker-sasl-default-config.adoc
+++ b/modules/serverless-kafka-broker-sasl-default-config.adoc
@@ -6,7 +6,7 @@
 [id="serverless-kafka-broker-sasl-default-config_{context}"]
 = Configuring SASL authentication for Kafka brokers
 
-_Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for authentication. If you use SASL authentication on your cluster, users must provide credentials to Knative for communicating with the Kafka cluster, otherwise events cannot be produced or consumed.
+_Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for authentication. If you use SASL authentication on your cluster, users must provide credentials to Knative for communicating with the Kafka cluster; otherwise events cannot be produced or consumed.
 
 .Prerequisites
 

--- a/modules/serverless-kafka-sasl-channels.adoc
+++ b/modules/serverless-kafka-sasl-channels.adoc
@@ -6,7 +6,7 @@
 [id="serverless-kafka-sasl-channels_{context}"]
 = Configuring SASL authentication for Kafka channels
 
-_Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for authentication. If you use SASL authentication on your cluster, users must provide credentials to Knative for communicating with the Kafka cluster, otherwise events cannot be produced or consumed.
+_Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for authentication. If you use SASL authentication on your cluster, users must provide credentials to Knative for communicating with the Kafka cluster; otherwise events cannot be produced or consumed.
 
 .Prerequisites
 

--- a/modules/serverless-kafka-sasl-source.adoc
+++ b/modules/serverless-kafka-sasl-source.adoc
@@ -6,7 +6,7 @@
 [id="serverless-kafka-sasl-source_{context}"]
 = Configuring SASL authentication for Kafka sources
 
-_Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for authentication. If you use SASL authentication on your cluster, users must provide credentials to Knative for communicating with the Kafka cluster, otherwise events cannot be produced or consumed.
+_Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for authentication. If you use SASL authentication on your cluster, users must provide credentials to Knative for communicating with the Kafka cluster; otherwise events cannot be produced or consumed.
 
 .Prerequisites
 
@@ -53,7 +53,7 @@ spec:
         secretKeyRef:
           name: <kafka_auth_secret>
           key: password
-      saslType:
+      type:
         secretKeyRef:
           name: <kafka_auth_secret>
           key: saslType

--- a/modules/serverless-kafka-sink-security-config.adoc
+++ b/modules/serverless-kafka-sink-security-config.adoc
@@ -1,0 +1,91 @@
+// Module is included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-kafka-admin.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-kafka-sink-security-config_{context}"]
+= Configuring security for Kafka sinks
+
+_Transport Layer Security_ (TLS) is used by Apache Kafka clients and servers to encrypt traffic between Knative and Kafka, as well as for authentication. TLS is the only supported method of traffic encryption for Knative Kafka.
+
+_Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for authentication. If you use SASL authentication on your cluster, users must provide credentials to Knative for communicating with the Kafka cluster; otherwise events cannot be produced or consumed.
+
+.Prerequisites
+
+* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resources (CRs) are installed on your {product-title} cluster.
+* Kafka sink is enabled in the `KnativeKafka` CR.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* You have a Kafka cluster CA certificate stored as a `.pem` file.
+* You have a Kafka cluster client certificate and a key stored as `.pem` files.
+* You have installed the OpenShift (`oc`) CLI.
+* You have chosen the SASL mechanism to use, for example, `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
+
+.Procedure
+
+. Create the certificate files as a secret in the same namespace as your `KafkaSink` object:
++
+[IMPORTANT]
+====
+Certificates and keys must be in PEM format.
+====
+
+** For authentication using SASL without encryption:
++
+[source,terminal]
+----
+$ oc create secret -n <namespace> generic <secret_name> \
+  --from-literal=protocol=SASL_PLAINTEXT \
+  --from-literal=sasl.mechanism=<sasl_mechanism> \
+  --from-literal=user=<username> \
+  --from-literal=password=<password>
+----
+
+** For authentication using SASL and encryption using TLS:
++
+[source,terminal]
+----
+$ oc create secret -n <namespace> generic <secret_name> \
+  --from-literal=protocol=SASL_SSL \
+  --from-literal=sasl.mechanism=<sasl_mechanism> \
+  --from-file=ca.crt=<my_caroot.pem_file_path> \ <1>
+  --from-literal=user=<username> \
+  --from-literal=password=<password>
+----
+<1> The `ca.crt` can be omitted to use the system's root CA set if you are using a public cloud managed Kafka service, such as Red Hat OpenShift Streams for Apache Kafka.
+
+** For authentication and encryption using TLS:
++
+[source,terminal]
+----
+$ oc create secret -n <namespace> generic <secret_name> \
+  --from-literal=protocol=SSL \
+  --from-file=ca.crt=<my_caroot.pem_file_path> \ <1>
+  --from-file=user.crt=<my_cert.pem_file_path> \
+  --from-file=user.key=<my_key.pem_file_path>
+----
+<1> The `ca.crt` can be omitted to use the system's root CA set if you are using a public cloud managed Kafka service, such as Red Hat OpenShift Streams for Apache Kafka.
+
+. Create or modify a `KafkaSink` object and add a reference to your secret in the `auth` spec:
++
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1alpha1
+kind: KafkaSink
+metadata:
+   name: <sink_name>
+   namespace: <namespace>
+spec:
+...
+   auth:
+     secret:
+       ref:
+         name: <secret_name>
+...
+----
+
+. Apply the `KafkaSink` object:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----

--- a/serverless/admin_guide/serverless-kafka-admin.adoc
+++ b/serverless/admin_guide/serverless-kafka-admin.adoc
@@ -42,12 +42,19 @@ Kafka clusters are generally secured by using the TLS or SASL authentication met
 Red Hat recommends that you enable both SASL and TLS together.
 ====
 
+// kafka broker security config
 include::modules/serverless-kafka-broker-tls-default-config.adoc[leveloffset=+2]
 include::modules/serverless-kafka-broker-sasl-default-config.adoc[leveloffset=+2]
+
+// kafka channel security config
 include::modules/serverless-kafka-tls-channels.adoc[leveloffset=+2]
 include::modules/serverless-kafka-sasl-channels.adoc[leveloffset=+2]
 include::modules/serverless-kafka-sasl-source.adoc[leveloffset=+2]
 
+// kafka sink security config
+include::modules/serverless-kafka-sink-security-config.adoc[leveloffset=+2]
+
+// kafka broker general configmap
 include::modules/serverless-kafka-broker-configmap.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
OCP 4.6+ except 4.7

Issue:
https://issues.redhat.com/browse/SRVKE-1278
https://issues.redhat.com/browse/SRVKE-1327

Link to docs preview:
https://50970--docspreview.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-kafka-admin.html#serverless-kafka-sink-security-config_serverless-kafka-admin

QE review:
- [x] QE has approved this change.