### PR TITLE
BZ2107507: Added note about checkup permissions

### DIFF
--- a/modules/virt-about-cluster-checkup-framework.adoc
+++ b/modules/virt-about-cluster-checkup-framework.adoc
@@ -10,4 +10,13 @@ A _checkup_ is an automated test workload that allows you to verify if a specifi
 
 By using predefined checkups, cluster administrators can improve cluster maintainability, troubleshoot unexpected behavior, minimize errors, and save time. They can also review the results of the checkup and share them with experts for further analysis. Vendors can write and publish checkups for features or services that they provide and verify that their customer environments are configured correctly.
 
-Running a predefined checkup in the cluster involves setting up the namespace and service account for the framework, creating the `ClusterRole` and `ClusterRoleBinding` objects for the service account, enabling permissions for the checkup, and creating the input config map and the checkup job. You can run a checkup multiple times. 
+Running a predefined checkup in the cluster involves setting up the namespace and service account for the framework, creating the `ClusterRole` and `ClusterRoleBinding` objects for the service account, enabling permissions for the checkup, and creating the input config map and the checkup job. You can run a checkup multiple times.
+
+[IMPORTANT]
+====
+You must always:
+
+* Verify that the checkup image is from a trustworthy source before applying it.
+* Review the checkup permissions before creating the `ClusterRole` and `Role` objects.
+* Verify the name of the `ServiceAccount` in the config map. This is because the framework automatically binds these permissions to the checkup instance.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2107507
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/sjhala/BZ2107507/virt/logging_events_monitoring/virt-running-cluster-checkups.html#virt-about-cluster-checkup-framework_virt-running-cluster-checkups
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
