### PR TITLE
OSDOCS-4223 - Update the ROSA CLI procedures

### DIFF
--- a/modules/rosa-getting-started-install-configure-cli-tools.adoc
+++ b/modules/rosa-getting-started-install-configure-cli-tools.adoc
@@ -43,7 +43,7 @@ $ aws sts get-caller-identity
 ----
 
 . Install and configure the latest ROSA CLI (`rosa`).
-.. Download the latest version of the `rosa` CLI for your operating system from the link:https://console.redhat.com/openshift/downloads[*Downloads*] page on the {cluster-manager-url}.
+.. Download the latest version of the `rosa` CLI for your operating system from the link:https://console.redhat.com/openshift/downloads[*Downloads*] page on {cluster-manager}.
 .. Extract the `rosa` binary file from the downloaded archive. The following example extracts the binary from a Linux tar archive:
 +
 [source,terminal]
@@ -69,18 +69,22 @@ $ rosa version
 1.1.7
 ----
 +
-.. Optional: Generate the command completion scripts for the `rosa` CLI. The following example generates the Bash completion scripts for a Linux machine:
+.. Optional: Enable tab completion for the `rosa` CLI. With tab completion enabled, you can press the `Tab` key twice to automatically complete subcommands and receive command suggestions.
++
+`rosa` tab completion is available for different shell types. The following example enables persistent tab completion for Bash on a Linux host. The command generates a `rosa` tab completion configuration file for Bash and saves it to the `/etc/bash_completion.d/` directory:
 +
 [source,terminal]
 ----
-$ rosa completion bash | sudo tee /etc/bash_completion.d/rosa
+# rosa completion bash > /etc/bash_completion.d/rosa
 ----
-.. Optional: Enable `rosa` command completion from your existing terminal. The following example enables Bash completion for `rosa` in an existing terminal on a Linux machine:
 +
-[source,terminal]
-----
-$ source /etc/bash_completion.d/rosa
-----
+You must open a new terminal to activate the configuration.
++
+[NOTE]
+====
+For steps to configure `rosa` tab completion for different shell types, see the help menu by running `rosa completion --help`.
+====
+
 .. Log in to your Red Hat account by using the `rosa` CLI:
 +
 [source,terminal]

--- a/modules/rosa-setting-up-cli.adoc
+++ b/modules/rosa-setting-up-cli.adoc
@@ -8,20 +8,97 @@
 [id="rosa-setting-up-cli_{context}"]
 = Setting up the rosa CLI
 
-
-To set up the `rosa` CLI, download the latest release, then configure and initialize `rosa`:
+Use the following steps to install and configure the {product-title} (ROSA) CLI (`rosa`) on your installation host.
 
 .Procedure
 
-. Download the latest release of the `rosa` CLI for your operating system from the *Download* page of link:https://console.redhat.com/openshift/downloads?quickstart=getting-started#tool-rosa[{product-title}]. 
-+
-. It is recommended that after you download the release, you rename the executable file that you downloaded to `rosa`, and then add `rosa` to your path.
-+
-. Optional: After downloading `rosa`, enable Bash completion for `rosa`. Bash completion helps to automatically complete commands and suggest options when you press `Tab`. The command generates a Bash completion file for `rosa` and sources it to your current shell session.
-+
-To configure your Bash shell to load `rosa` completions for each session, add the following command to your `Bashrc` file (`~/.Bashrc` or `~/.profile`).
+. Download the latest version of the `rosa` CLI for your operating system from the link:https://console.redhat.com/openshift/downloads[*Downloads*] page on {cluster-manager}.
+
+. Extract the `rosa` binary file from the downloaded archive. The following example extracts the binary from a Linux tar archive:
 +
 [source,terminal]
 ----
-$ . <(rosa completion)
+$ tar xvf rosa-linux.tar.gz
 ----
+
+. Add `rosa` to your path. In the following example, the `/usr/local/bin` directory is included in the path of the user:
++
+[source,terminal]
+----
+$ sudo mv rosa /usr/local/bin/rosa
+----
+
+. Verify if the `rosa` CLI tool is installed correctly by querying the `rosa` version:
++
+[source,terminal]
+----
+$ rosa version
+----
++
+.Example output
+[source,terminal]
+----
+1.2.6
+----
+
+. Optional: Enable tab completion for the `rosa` CLI. With tab completion enabled, you can press the `Tab` key twice to automatically complete subcommands and receive command suggestions:
++
+--
+** To enable persistent tab completion for Bash on a Linux host:
+.. Generate a `rosa` tab completion configuration file for Bash and save it to your `/etc/bash_completion.d/` directory:
++
+[source,terminal]
+----
+# rosa completion bash > /etc/bash_completion.d/rosa
+----
++
+.. Open a new terminal to activate the configuration.
+** To enable persistent tab completion for Bash on a macOS host:
+.. Generate a `rosa` tab completion configuration file for Bash and save it to your `/usr/local/etc/bash_completion.d/` directory:
++
+[source,terminal]
+----
+$ rosa completion bash > /usr/local/etc/bash_completion.d/rosa
+----
++
+.. Open a new terminal to activate the configuration.
+** To enable persistent tab completion for Zsh:
+.. If tab completion is not enabled for your Zsh environment, enable it by running the following command:
++
+[source,terminal]
+----
+$ echo "autoload -U compinit; compinit" >> ~/.zshrc
+----
++
+.. Generate a `rosa` tab completion configuration file for Zsh and save it to the first directory in your functions path:
++
+[source,terminal]
+----
+$ rosa completion zsh > "${fpath[1]}/_rosa"
+----
++
+.. Open a new terminal to activate the configuration.
+** To enable persistent tab completion for fish:
+.. Generate a `rosa` tab completion configuration file for fish and save it to your `~/.config/fish/completions/` directory:
++
+[source,terminal]
+----
+$ rosa completion fish > ~/.config/fish/completions/rosa.fish
+----
++
+.. Open a new terminal to activate the configuration.
+** To enable persistent tab completion for PowerShell:
+.. Generate a `rosa` tab completion configuration file for PowerShell and save it to a file named `rosa.ps1`:
++
+[source,terminal]
+----
+PS> rosa completion powershell | Out-String | Invoke-Expression
+----
++
+.. Source the `rosa.ps1` file from your PowerShell profile.
+--
++
+[NOTE]
+====
+For more information about configuring `rosa` tab completion, see the help menu by running `rosa completion --help`.
+====


### PR DESCRIPTION
This applies to `main`, `enterprise-4.12` and `enterprise-4.11`.

The PR relates to https://issues.redhat.com/browse/OSDOCS-4223. The PR enhances the content in the ROSA CLI installation procedures.

The previews are as follows:

- https://50977--docspreview.netlify.app/openshift-rosa/latest/rosa_cli/rosa-get-started-cli.html#rosa-setting-up-cli_rosa-getting-started-cli
- https://50977--docspreview.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-getting-started.html#rosa-getting-started-install-configure-cli-tools_rosa-getting-started