### PR TITLE
Adding .vale to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dev_guide/builds/images/chained-build.png.cache
 bin
 commercial_package
 .vscode
+.vale


### PR DESCRIPTION
This is needed otherwise git shows modified files for the .vale folder.