### PR TITLE
OSSMDOC-589: Distributed tracing 2.6 Release Notes.

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -106,13 +106,13 @@ endif::[]
 //distributed tracing
 :DTProductName: Red Hat OpenShift distributed tracing
 :DTShortName: distributed tracing
-:DTProductVersion: 2.4
+:DTProductVersion: 2.6
 :JaegerName: Red Hat OpenShift distributed tracing platform
 :JaegerShortName: distributed tracing platform
-:JaegerVersion: 1.34.1
+:JaegerVersion: 1.38
 :OTELName: Red Hat OpenShift distributed tracing data collection
 :OTELShortName: distributed tracing data collection
-:OTELVersion: 0.49
+:OTELVersion: 0.60
 //logging
 :logging-title: logging subsystem for Red Hat OpenShift
 :logging-title-uc: Logging subsystem for Red Hat OpenShift

--- a/modules/distr-tracing-product-overview.adoc
+++ b/modules/distr-tracing-product-overview.adoc
@@ -1,6 +1,7 @@
 ////
 This module included in the following assemblies:
 -service_mesh/v2x/ossm-architecture.adoc
+- distributed-tracing-release-notes.adoc
 -distr_tracing_arch/distr-tracing-architecture.adoc
 -serverless/serverless-tracing.adoc
 ////

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -13,6 +13,24 @@ Result – If changed, describe the current user experience.
 
 This release adds improvements related to the following components and concepts.
 
+== New features and enhancements {DTProductName} 2.6
+
+This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
+
+=== Component versions supported in {DTProductName} version 2.6
+
+[options="header"]
+|===
+|Operator |Component |Version
+|{JaegerName}
+|Jaeger
+|1.38
+
+|{OTELName}
+|OpenTelemetry
+|0.60
+|===
+
 == New features and enhancements {DTProductName} 2.5
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
@@ -89,7 +107,7 @@ This release of {DTProductName} addresses Common Vulnerabilities and Exposures (
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
-With this release, the {JaegerName} Operator is now installed to the `openshift-distributed-tracing` namespace by default. Previously the default installation had been in the `openshift-operators` namespace.
+With this release, the {JaegerName} Operator is now installed to the `openshift-distributed-tracing` namespace by default. Before this update, the default installation had been in the `openshift-operators` namespace.
 
 === Component versions supported in {DTProductName} version 2.3.0
 


### PR DESCRIPTION
Version(s): 4.9 - 4.12

Issue: [OSSMDOC-589](https://issues.redhat.com/browse/OSSMDOC-589)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.bos.redhat.com/jstickle/OSSMDOC-589/distr_tracing/distributed-tracing-release-notes.html#new-features-and-enhancements-red-hat-openshift-distributed-tracing-2-6

QE review: jkandasa
Peer Review: