### PR TITLE
[SRVOCF-437] Functions docs - update links, add substep

### DIFF
--- a/modules/serverless-functions-creating-on-cluster-builds.adoc
+++ b/modules/serverless-functions-creating-on-cluster-builds.adoc
@@ -23,18 +23,18 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 . In each namespace where you want to run {pipelines-shortname} and deploy a function, you must create the following resources:
 
-.. Create the functions buildpacks Tekton task to be able to build the function image:
+.. Create the `s2i` Tekton task to be able to use Source-to-Image in the pipeline:
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.22.0/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.25.0/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
 ----
 
 .. Create the `kn func` deploy Tekton task to be able to deploy the function in the pipeline:
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.22.0/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.25.0/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
 ----
 
 . Create a function:
@@ -51,17 +51,15 @@ $ kn func create <function_name> -l <runtime>
 [source,yaml]
 ----
 ...
-build: git <1>
 git:
-  url: <git_repository_url> <2>
-  revision: main <3>
-  contextDir: <directory_path> <4>
+  url: <git_repository_url> <1>
+  revision: main <2>
+  contextDir: <directory_path> <3>
 ...
 ----
-<1> Required. Specify `git` build type.
-<2> Required. Specify the Git repository that contains your function's source code.
-<3> Optional. Specify the Git repository revision to be used. This can be a branch, tag or commit.
-<4> Optional. Specify the function's directory path if the function is not located in the Git repository root folder.
+<1> Required. Specify the Git repository that contains your function's source code.
+<2> Optional. Specify the Git repository revision to be used. This can be a branch, tag, or commit.
+<3> Optional. Specify the function's directory path if the function is not located in the Git repository root folder.
 
 . Implement the business logic of your function. Then, use Git to commit and push the changes.
 


### PR DESCRIPTION
Version(s): 4.6 and 4.8+

Issue: https://issues.redhat.com/browse/SRVOCF-437

Link to docs preview: https://51030--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-on-cluster-builds.html#serverless-functions-creating-on-cluster-builds_serverless-functions-on-cluster-builds

Dev & QE reviews: complete