### PR TITLE
[SRVKE-1276]: Add trigger event delivery order docs

### DIFF
--- a/modules/trigger-event-delivery-config.adoc
+++ b/modules/trigger-event-delivery-config.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * /serverless/develop/serverless-triggers.adoc
+
+:_content-type: PROCEDURE
+[id="trigger-event-delivery-config_{context}"]
+= Configuring event delivery ordering for triggers
+
+If you are using a Kafka broker, you can configure the delivery order of events from triggers to event sinks.
+
+.Prerequisites
+
+* The {ServerlessOperatorName}, Knative Eventing, and Knative Kafka are installed on your {product-title} cluster.
+* Kafka broker is enabled for use on your cluster, and you have created a Kafka broker.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* You have installed the OpenShift (`oc`) CLI.
+
+.Procedure
+
+. Create or modify a `Trigger` object and set the `kafka.eventing.knative.dev/delivery.order` annotation:
++
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: <trigger_name>
+  annotations:
+     kafka.eventing.knative.dev/delivery.order: ordered
+...
+----
++
+The supported consumer delivery guarantees are:
++
+`unordered`:: An unordered consumer is a non-blocking consumer that delivers messages unordered, while preserving proper offset management.
++
+`ordered`:: An ordered consumer is a per-partition blocking consumer that waits for a successful response from the CloudEvent subscriber before it delivers the next message of the partition.
++
+The default ordering guarantee is `unordered`.
+
+. Apply the `Trigger` object:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----

--- a/serverless/develop/serverless-event-delivery.adoc
+++ b/serverless/develop/serverless-event-delivery.adoc
@@ -16,3 +16,6 @@ include::modules/serverless-event-delivery-parameters.adoc[leveloffset=+1]
 
 // configuring parameters examples
 include::modules/serverless-configuring-event-delivery-examples.adoc[leveloffset=+1]
+
+// event delivery ordering
+include::modules/trigger-event-delivery-config.adoc[leveloffset=+1]

--- a/serverless/develop/serverless-triggers.adoc
+++ b/serverless/develop/serverless-triggers.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 include::snippets/serverless-brokers-intro.adoc[]
 
+If you are using a Kafka broker, you can configure the delivery order of events from triggers to event sinks. See xref:../../serverless/develop/serverless-triggers.adoc#trigger-event-delivery-config_serverless-triggers[Configuring event delivery ordering for triggers].
+
 // ODC
 include::modules/serverless-create-trigger-odc.adoc[leveloffset=+1]
 // kn trigger
@@ -17,6 +19,8 @@ include::modules/kn-trigger-describe.adoc[leveloffset=+1]
 include::modules/kn-trigger-filtering.adoc[leveloffset=+1]
 include::modules/kn-trigger-update.adoc[leveloffset=+1]
 include::modules/delete-kn-trigger.adoc[leveloffset=+1]
+// event delivery config
+include::modules/trigger-event-delivery-config.adoc[leveloffset=+1]
 
 [id="next-steps_serverless-triggers"]
 == Next steps


### PR DESCRIPTION
Version(s):
OCP 4.6+

Issue:
https://issues.redhat.com/browse/SRVKE-1276

Link to docs preview:
- https://51031--docspreview.netlify.app/openshift-enterprise/latest/serverless/develop/serverless-event-delivery.html#trigger-event-delivery-config_serverless-event-delivery
- https://51031--docspreview.netlify.app/openshift-enterprise/latest/serverless/develop/serverless-triggers.html#trigger-event-delivery-config_serverless-triggers
- https://51031--docspreview.netlify.app/openshift-enterprise/latest/serverless/develop/serverless-triggers.html

QE review:
- [x] QE has approved this change.