### PR TITLE
 kubelet is not able to convert  TLS Security profile 1.0 to 1.1 for old, 1.3 to 1.2 for intermediate.

### DIFF
--- a/modules/tls-profiles-kubelet-configuring.adoc
+++ b/modules/tls-profiles-kubelet-configuring.adoc
@@ -33,13 +33,6 @@ spec:
 
 You can see the ciphers and the minimum TLS version of the configured TLS security profile in the `kubelet.conf` file on a configured node.
 
-[IMPORTANT]
-====
-The kubelet does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3`, it is not supported. The kubelet converts the `Modern` profile to `Intermediate`.
-
-The kubelet also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`, and TLS `1.3` of a `Custom` profile to `1.2`.
-====
-
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-1241