### PR TITLE
OSDOCS-4120: Updated guidance on vMotion

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -230,14 +230,17 @@ For more information about creating an account with only the required privileges
 [id="installation-vsphere-installer-infra-requirements-vmotion_{context}"]
 == Using {product-title} with vMotion
 
-[IMPORTANT]
-====
-{product-title} generally supports compute-only vMotion. Using Storage vMotion can cause issues and is not supported.
-====
+If you intend on using vMotion in your vSphere environment, consider the following before installing a {product-title} cluster.
 
-If you are using vSphere volumes in your pods, migrating a VM across datastores either manually or through Storage vMotion causes invalid references within {product-title} persistent volume (PV) objects. These references prevent affected pods from starting up and can result in data loss.
+* {product-title} generally supports compute-only vMotion. Using Storage vMotion can cause issues and is not supported.
++
+--
+To help ensure the uptime of your compute and control plane nodes, it is recommended that you follow the VMware best practices for vMotion. It is also recommended to use VMware anti-affinity rules to improve the availability of {product-title} during maintenance or hardware issues.
 
-Similarly, {product-title} does not support selective migration of VMDKs across datastores, using datastore clusters for VM provisioning or for dynamic or static provisioning of PVs, or using a datastore that is part of a datastore cluster for dynamic or static provisioning of PVs.
+For more information about vMotion and anti-affinity rules, see the VMware vSphere documentation for  link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vcenterhost.doc/GUID-3B41119A-1276-404B-8BFB-A32409052449.html[vMotion networking requirements] and link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.resmgmt.doc/GUID-FBE46165-065C-48C2-B775-7ADA87FF9A20.html[VM anti-affinity rules].
+--
+* If you are using vSphere volumes in your pods, migrating a VM across datastores either manually or through Storage vMotion causes, invalid references within {product-title} persistent volume (PV) objects. These references prevent affected pods from starting up and can result in data loss.
+* Similarly, {product-title} does not support selective migration of VMDKs across datastores, using datastore clusters for VM provisioning or for dynamic or static provisioning of PVs, or using a datastore that is part of a datastore cluster for dynamic or static provisioning of PVs.
 
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-resources_{context}"]


### PR DESCRIPTION
Version(s):
4.6+

Issue:
This PR addresses [OSDOCS-4120](https://issues.redhat.com/browse/OSDOCS-4120), which was opened as a result of this Slack [thread](https://coreos.slack.com/archives/CH06KMDRV/p1663065026062779).

Link to docs preview:
[vSphere infrastructure requirements](https://51056--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-vsphere-infrastructure_installing-vsphere-installer-provisioned-customizations) > Using OpenShift Container Platform with vMotion

QE review:
Pending