### PR TITLE
OSDOCS-4231:Set default HAProxy maxconn value to 50000

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -225,11 +225,11 @@ supports up to `64` threads. If this field is empty, the Ingress Controller uses
 
 * `tunnelTimeout` specifies how long a tunnel connection, including websockets, remains open while the tunnel is idle. The default timeout is `1h`.
 
-* `maxConnections` specifies the maximum number of simultaneous connections that can be established per HAProxy process. Increasing this value allows each ingress controller pod handle more connections at the cost of additional system resources. Permitted values are `0`, `-1`, any value within the range `2000` and `2000000`, or the field can be left empty. 
+* `maxConnections` specifies the maximum number of simultaneous connections that can be established per HAProxy process. Increasing this value allows each ingress controller pod to handle more connections at the cost of additional system resources. Permitted values are `0`, `-1`, any value within the range `2000` and `2000000`, or the field can be left empty. 
 
-** If this field is left empty or has the value `0`, the ingress controller will use the default value of `20000`. This value is subject to change in future releases.
+** If this field is left empty or has the value `0`, the Ingress Controller will use the default value of `50000`. This value is subject to change in future releases.
 
-** If the field has the value of `-1`, then HAProxy will dynamically compute a maximum value based on the available `ulimits` in the running container. This process results in a large computed value that will incur significant memory usage compared to the current default value of `20000`.
+** If the field has the value of `-1`, then HAProxy will dynamically compute a maximum value based on the available `ulimits` in the running container. This process results in a large computed value that will incur significant memory usage compared to the current default value of `50000`.
 
 ** If the field has a value that is greater than the current operating system limit, the HAProxy process will not start.
 


### PR DESCRIPTION
4.12+
Issue:
https://issues.redhat.com/browse/NE-1072

Link to docs preview:
https://51058--docspreview.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress


Can you please give a QE review @ShudiLi :
- [ ] QE has approved this change.