### PR TITLE
CNV-13681: image node limits

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3455,6 +3455,8 @@ Topics:
     File: virt-managing-node-labeling-obsolete-cpu-models
   - Name: Preventing node reconciliation
     File: virt-preventing-node-reconciliation
+  - Name: Node image limits
+    File: virt-node-image-limits
 # Removed the Node Networking content from the topic map because this section is now part of the OCP docs
 # Logging, events, and monitoring
 - Name: Logging, events, and monitoring

--- a/modules/virt-disabling-node-image-limits.adoc
+++ b/modules/virt-disabling-node-image-limits.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assembly:
+//
+// * virt/node_maintenance/virt-node-image-limits.adoc
+//
+
+:_content-type: PROCEDURE
+[id="virt-disabling-node-image-limits_{context}"]
+= Disabling node image limits
+
+If your pod has more than 50 images, you can disable the image limit by editing the `KubeletConfig` object.
+
+.Prerequisites
+* Create a `kubeletconfig` custom resource (CR)
+
+.Procedure
+
+* In the `kubeletConfig` CR, set the value of of `nodeStatusMaxImages` to `-1`.

--- a/modules/virt-disabling-node-image-limits.adoc
+++ b/modules/virt-disabling-node-image-limits.adoc
@@ -7,7 +7,7 @@
 [id="virt-disabling-node-image-limits_{context}"]
 = Disabling node image limits
 
-If your pod has more than 50 images, you can disable the image limit by editing the `KubeletConfig` object.
+If your node has more than 50 images, you can disable the image limit by editing the `KubeletConfig` object.
 
 .Prerequisites
 * Create a `kubeletconfig` custom resource (CR)

--- a/virt/node_maintenance/virt-node-image-limits.adoc
+++ b/virt/node_maintenance/virt-node-image-limits.adoc
@@ -1,0 +1,17 @@
+:_content-type: ASSEMBLY
+[id="virt-using-skip-node"]
+= Node image limits
+include::_attributes/common-attributes.adoc[]
+:context: virt-disabling-node-image-limits
+
+toc::[]
+
+If a single node contains more than 50 images, pod scheduling might be imbalanced across nodes. This is because the list of images on a node is shortened to 50 by default.
+
+include::modules/virt-disabling-node-image-limits.adoc[leveloffset=+1]
+
+[id="additional-resources_{context}"]
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing-about_nodes-nodes-jobs[Managing nodes] 

--- a/virt/node_maintenance/virt-node-image-limits.adoc
+++ b/virt/node_maintenance/virt-node-image-limits.adoc
@@ -1,5 +1,5 @@
 :_content-type: ASSEMBLY
-[id="virt-using-skip-node"]
+[id="virt-node-image-limits"]
 = Node image limits
 include::_attributes/common-attributes.adoc[]
 :context: virt-disabling-node-image-limits
@@ -14,4 +14,4 @@ include::modules/virt-disabling-node-image-limits.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing-about_nodes-nodes-jobs[Managing nodes] 
+* xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing-about_nodes-nodes-jobs[Managing nodes]


### PR DESCRIPTION
Version(s): 4.10+

Issue: [CNV-13681](https://issues.redhat.com//browse/CNV-13681)

Link to docs preview: http://file.rdu.redhat.com/sjess/2CNV13681/virt/node_maintenance/virt-node-image-limits.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
