### PR TITLE
OSDOCS-4199: Added support statement about multiple vCenter deployments

### DIFF
--- a/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
@@ -10,6 +10,8 @@ In {product-title} version {product-version}, you can install a cluster on VMwar
 
 Once you configure your VMC environment for {product-title} deployment, you use the {product-title} installation program from the bastion management host, co-located in the VMC environment. The installation program and control plane automates the process of deploying and managing the resources needed for the {product-title} cluster.
 
+include::snippets/vcenter-support.adoc[]
+
 include::modules/setting-up-vmc-for-vsphere.adoc[leveloffset=+1]
 include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 

--- a/installing/installing_vmc/installing-restricted-networks-vmc.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc.adoc
@@ -10,6 +10,8 @@ In {product-title} version {product-version}, you can install a cluster on VMwar
 
 Once you configure your VMC environment for {product-title} deployment, you use the {product-title} installation program from the bastion management host, co-located in the VMC environment. The installation program and control plane automates the process of deploying and managing the resources needed for the {product-title} cluster.
 
+include::snippets/vcenter-support.adoc[]
+
 include::modules/setting-up-vmc-for-vsphere.adoc[leveloffset=+1]
 include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 

--- a/installing/installing_vmc/installing-vmc-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-customizations.adoc
@@ -12,6 +12,8 @@ Once you configure your VMC environment for {product-title} deployment, you use 
 
 To customize the {product-title} installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
+include::snippets/vcenter-support.adoc[]
+
 include::modules/setting-up-vmc-for-vsphere.adoc[leveloffset=+1]
 include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 

--- a/installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
+++ b/installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
@@ -12,6 +12,8 @@ Once you configure your VMC environment for {product-title} deployment, you use 
 
 By customizing your network configuration, your cluster can coexist with existing IP address allocations in your environment and integrate with existing VXLAN configurations. You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
 
+include::snippets/vcenter-support.adoc[]
+
 include::modules/setting-up-vmc-for-vsphere.adoc[leveloffset=+1]
 include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 

--- a/installing/installing_vmc/installing-vmc-network-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-network-customizations.adoc
@@ -12,6 +12,8 @@ Once you configure your VMC environment for {product-title} deployment, you use 
 
 By customizing your {product-title} network configuration, your cluster can coexist with existing IP address allocations in your environment and integrate with existing VXLAN configurations. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster. You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
 
+include::snippets/vcenter-support.adoc[]
+
 include::modules/setting-up-vmc-for-vsphere.adoc[leveloffset=+1]
 include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 

--- a/installing/installing_vmc/installing-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-vmc-user-infra.adoc
@@ -10,6 +10,8 @@ In {product-title} version {product-version}, you can install a cluster on VMwar
 
 Once you configure your VMC environment for {product-title} deployment, you use the {product-title} installation program from the bastion management host, co-located in the VMC environment. The installation program and control plane automates the process of deploying and managing the resources needed for the {product-title} cluster.
 
+include::snippets/vcenter-support.adoc[]
+
 include::modules/setting-up-vmc-for-vsphere.adoc[leveloffset=+1]
 include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 

--- a/installing/installing_vmc/installing-vmc.adoc
+++ b/installing/installing_vmc/installing-vmc.adoc
@@ -10,6 +10,8 @@ In {product-title} version {product-version}, you can install a cluster on VMwar
 
 Once you have configured your VMC environment for {product-title} deployment, you use the {product-title} installation program from the bastion management host, co-located in the VMC environment. The installation program and control plane automates the process of deploying and managing the resources needed for the {product-title} cluster.
 
+include::snippets/vcenter-support.adoc[]
+
 include::modules/setting-up-vmc-for-vsphere.adoc[leveloffset=+1]
 include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 

--- a/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 In {product-title} {product-version}, you can install a cluster on VMware vSphere infrastructure in a restricted network by creating an internal mirror of the installation release content.
 
+include::snippets/vcenter-support.adoc[]
+
 [id="prerequisites_installing-restricted-networks-installer-provisioned-vsphere"]
 == Prerequisites
 

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -9,6 +9,8 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on
 VMware vSphere infrastructure that you provision in a restricted network.
 
+include::snippets/vcenter-support.adoc[]
+
 [IMPORTANT]
 ====
 The steps for performing a user-provisioned infrastructure installation are provided as an example only. Installing a cluster with infrastructure you provide requires knowledge of the vSphere platform and the installation process of {product-title}. Use the user-provisioned infrastructure installation instructions as a guide; you are free to create the required resources through other methods.

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -9,6 +9,8 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on your
 VMware vSphere instance by using installer-provisioned infrastructure. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
+include::snippets/vcenter-support.adoc[]
+
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -11,6 +11,8 @@ VMware vSphere instance by using installer-provisioned infrastructure with custo
 
 You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
 
+include::snippets/vcenter-support.adoc[]
+
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
@@ -9,6 +9,8 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on your
 VMware vSphere instance by using installer-provisioned infrastructure.
 
+include::snippets/vcenter-support.adoc[]
+
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -16,6 +16,8 @@ You must set most of the network configuration parameters during installation,
 and you can modify only `kubeProxy` configuration parameters in a running
 cluster.
 
+include::snippets/vcenter-support.adoc[]
+
 [IMPORTANT]
 ====
 The steps for performing a user-provisioned infrastructure installation are provided as an example only. Installing a cluster with infrastructure you provide requires knowledge of the vSphere platform and the installation process of {product-title}. Use the user-provisioned infrastructure installation instructions as a guide; you are free to create the required resources through other methods.

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -9,6 +9,8 @@ toc::[]
 In {product-title} version {product-version}, you can install a cluster on
 VMware vSphere infrastructure that you provision.
 
+include::snippets/vcenter-support.adoc[]
+
 [IMPORTANT]
 ====
 The steps for performing a user-provisioned infrastructure installation are provided as an example only. Installing a cluster with infrastructure you provide requires knowledge of the vSphere platform and the installation process of {product-title}. Use the user-provisioned infrastructure installation instructions as a guide; you are free to create the required resources through other methods.

--- a/snippets/vcenter-support.adoc
+++ b/snippets/vcenter-support.adoc
@@ -1,0 +1,23 @@
+// Text snippet included in the following modules:
+//
+// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere.adoc
+// * installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
+// * installing/installing_vmc/installing-restricted-networks-vmc.adoc
+// * installing/installing_vmc/installing-vmc-customizations.adoc
+// * installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
+// * installing/installing_vmc/installing-vmc-network-customizations.adoc
+// * installing/installing_vmc/installing-vmc-user-infra.adoc
+// * installing/installing_vmc/installing-vmc.adoc
+
+:_content-type: SNIPPET
+
+[NOTE]
+====
+{product-title} supports deploying a cluster to a single VMware vCenter only. Deploying a cluster with machines/machine sets on multiple vCenters is not supported.
+====


### PR DESCRIPTION
Version(s):
4.6+

Issue:
This PR addresses [OSDOCS-4199](https://issues.redhat.com//browse/OSDOCS-4199), which was opened per this Slack [thread](https://coreos.slack.com/archives/CBQHQFU0N/p1661771325587699).

Link to docs preview:

- [Installing a cluster on vSphere](https://51063--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned.html)
- [Installing a cluster on VMC](https://51063--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc.html)

Worth mentioning that the support note available in the preview has been added to all of the vSphere and VMC installation topics.

QE review:
Pending.