### PR TITLE
OCPBUGS-1849: Move section about disabling Transparent Huge Pages

### DIFF
--- a/modules/disabling-transparent-huge-pages.adoc
+++ b/modules/disabling-transparent-huge-pages.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc
+
+:_content-type: PROCEDURE
+[id="disable-thp_{context}"]
+= Disabling Transparent Huge Pages
+
+Transparent Huge Pages (THP) attempt to automate most aspects of creating, managing, and using huge pages. Since THP automatically manages the huge pages, this is not always handled optimally for all types of workloads. THP can lead to performance regressions, since many applications handle huge pages on their own. Therefore, consider disabling THP. The following steps describe how to disable THP using the Node Tuning Operator (NTO).
+
+.Procedure
+
+. Create a file with the following content and name it `thp-disable-tuned.yaml`:
++
+[source,yaml]
+----
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: thp-workers-profile
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Custom tuned profile for OpenShift to turn off THP on worker nodes
+      include=openshift-node
+
+      [vm]
+      transparent_hugepages=never
+    name: openshift-thp-never-worker
+
+  recommend:
+  - match:
+    - label: node-role.kubernetes.io/worker
+    priority: 25
+    profile: openshift-thp-never-worker
+----
+
+. Create the Tuned object:
++
+[source,terminal]
+----
+$ oc create -f thp-disable-tuned.yaml
+----
+
+. Check the list of active profiles:
++
+[source,terminal]
+----
+$ oc get profile -n openshift-cluster-node-tuning-operator
+----
+
+.Verification
+
+* Log in to one of the nodes and do a regular THP check to verify if the nodes applied the profile successfully:
++
+[source,terminal]
+----
+$ cat /sys/kernel/mm/transparent_hugepage/enabled
+----
++
+.Example output
+[source,terminal]
+----
+always madvise [never]
+----

--- a/modules/how-huge-pages-are-consumed-by-apps.adoc
+++ b/modules/how-huge-pages-are-consumed-by-apps.adoc
@@ -71,8 +71,3 @@ than the pod request.
 
 * Applications that consume huge pages via `shmget()` with `SHM_HUGETLB` must run
 with a supplemental group that matches *_proc/sys/vm/hugetlb_shm_group_*.
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-configuring_transparent_huge_pages[Configuring Transparent Huge Pages]

--- a/modules/ibm-z-disable-thp.adoc
+++ b/modules/ibm-z-disable-thp.adoc
@@ -2,73 +2,8 @@
 //
 // * scalability_and_performance/ibm-z-recommended-host-practices.adoc
 
-:_content-type: PROCEDURE
+:_content-type: CONCEPT
 [id="ibm-z-disable-thp_{context}"]
-= How to disable Transparent Huge Pages
+= Disable Transparent Huge Pages
 
-Transparent Huge Pages (THP) attempt to automate most aspects of creating, managing, and using huge pages. Since THP automatically manages the huge pages, this is not always handled optimally for all types of workloads. THP can lead to performance regressions, since many applications handle huge pages on their own. Therefore, consider disabling THP. The following steps describe how to disable THP using a Node Tuning Operator (NTO) profile.
-
-[id="disable-thp-with-a-nto-profile_{context}"]
-== Disable THP with a Node Tuning Operator (NTO) profile
-
-.Procedure
-
-. Copy the following NTO sample profile into a YAML file. For example, `thp-s390-tuned.yaml`:
-+
-[source,yaml]
-----
-apiVersion: tuned.openshift.io/v1
-kind: Tuned
-metadata:
-  name: thp-workers-profile
-  namespace: openshift-cluster-node-tuning-operator
-spec:
-  profile:
-  - data: |
-      [main]
-      summary=Custom tuned profile for OpenShift on IBM Z to turn off THP on worker nodes
-      include=openshift-node
-
-      [vm]
-      transparent_hugepages=never
-    name: openshift-thp-never-worker
-
-  recommend:
-  - match:
-    - label: node-role.kubernetes.io/worker
-    priority: 35
-    profile: openshift-thp-never-worker
-----
-
-. Create the NTO profile:
-+
-[source,terminal]
-----
-$ oc create -f thp-s390-tuned.yaml
-----
-
-. Check the list of active profiles:
-+
-[source,terminal]
-----
-$ oc get tuned -n openshift-cluster-node-tuning-operator
-----
-
-. Remove the profile:
-+
-[source,terminal]
-----
-$ oc delete -f thp-s390-tuned.yaml
-----
-
-.Verification
-
-* Log in to one of the nodes and do a regular THP check to verify if the nodes applied the profile successfully:
-+
-[source,terminal]
-----
-$ cat /sys/kernel/mm/transparent_hugepage/enabled
-always madvise [never]
-----
-
-
+Transparent Huge Pages (THP) attempt to automate most aspects of creating, managing, and using huge pages. Since THP automatically manages the huge pages, this is not always handled optimally for all types of workloads. THP can lead to performance regressions, since many applications handle huge pages on their own. Therefore, consider disabling THP.

--- a/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc
+++ b/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc
@@ -18,3 +18,5 @@ include::modules/consuming-huge-pages-resource-using-the-downward-api.adoc[level
 * xref:../nodes/containers/nodes-containers-downward-api.adoc#nodes-containers-downward-api[Allowing containers to consume Downward API objects]
 
 include::modules/configuring-huge-pages.adoc[leveloffset=+1]
+
+include::modules/disabling-transparent-huge-pages.adoc[leveloffset=+1]


### PR DESCRIPTION
Moving the section about disabling THP into scalability_and_performance and adjusting the IBM Z instructions.

Other changes:
 - lower the priority to 25 to make the configuration work on SNO clusters nodes.
 - dropping z-systems specific info.
 - removing the deletion of the config which was confusing and would roll-back the changes.

Version(s):
4.8+

Links to docs preview:
 - https://51068--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.html
 -  https://51068--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ibm-z-recommended-host-practices.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
