### PR TITLE
GH#50841: typo and stylistic fixes

### DIFF
--- a/modules/storage-persistent-storage-iscsi-enforcing-disk-quota.adoc
+++ b/modules/storage-persistent-storage-iscsi-enforcing-disk-quota.adoc
@@ -9,5 +9,5 @@ is one persistent volume. Kubernetes enforces unique names for persistent
 volumes.
 
 Enforcing quotas in this way allows the end user to request persistent
-storage by a specific amount (e.g, 10Gi) and be matched with a
+storage by a specific amount (for example, `10Gi`) and be matched with a
 corresponding volume of equal or greater capacity.

--- a/modules/storage-persistent-storage-iscsi-multipath.adoc
+++ b/modules/storage-persistent-storage-iscsi-multipath.adoc
@@ -9,7 +9,7 @@ same IQN for more than one target portal IP address. Multipathing ensures
 access to the persistent volume when one or more of the components in a
 path fail.
 
-To specify multi-paths in the pod specification use the `portals` field.
+To specify multi-paths in the pod specification, use the `portals` field.
 For example:
 
 [source,yaml]

--- a/storage/persistent_storage/persistent-storage-iscsi.adoc
+++ b/storage/persistent_storage/persistent-storage-iscsi.adoc
@@ -31,8 +31,8 @@ By default, they are ports `860` and `3260`.
 
 [IMPORTANT]
 ====
-OpenShift assumes that all nodes in the cluster have already configured iSCSI
-initator, i.e. have installed `iscsi-initiator-utils` package and configured
+OpenShift assumes that all nodes in the cluster have already configured the iSCSI
+initiator, that is, users have installed the `iscsi-initiator-utils` package and configured
 their initiator name in `/etc/iscsi/initiatorname.iscsi`. See Storage
 Administration Guide linked above.
 ====


### PR DESCRIPTION
Versions: 4.6+

#50841

This change fixes a typo (initator > initiator) and makes a few other stylistic updates for better alignment with the style guide.

Preview: https://51070--docspreview.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-iscsi.html 