### PR TITLE
Updated the list of TechPreviewNoUpgrades features

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -17,10 +17,8 @@ The following Technology Preview features are enabled by this feature set:
 ** Microsoft Azure File CSI Driver Operator. Enables the provisioning of persistent volumes (PVs) by using the Container Storage Interface (CSI) driver for Microsoft Azure File Storage.
 ** CSI automatic migration. Enables automatic migration for supported in-tree volume plug-ins to their equivalent Container Storage Interface (CSI) drivers. Supported for:
 *** Amazon Web Services (AWS) Elastic Block Storage (EBS)
-*** OpenStack Cinder
-*** Azure Disk
+*** Google Compute Engine Persistent Disk
 *** Azure File
-*** Google Cloud Platform Persistent Disk (CSI)
 *** VMware vSphere
 ** Cluster Cloud Controller Manager Operator. Enables the Cluster Cloud Controller Manager Operator rather than the in-tree cloud controller. Available as a Technology Preview for:
 *** Alibaba Cloud

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -12,8 +12,7 @@ include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+1]
 
 .Additional resources
 
-* For more information on the features activated by the `TechPreviewNoUpgrade` feature gate, see the following topics:
-** xref:../../storage/container_storage_interface/persistent-storage-csi-azure-file.adoc#persistent-storage-csi-azure-file[Azure File CSI Driver Operator]
+* For more information about the features activated by the `TechPreviewNoUpgrade` feature gate, see the following topics:
 ** xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration]
 ** xref:../../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_cluster-operators-ref[Cluster Cloud Controller Manager Operator]
 ** xref:../../cicd/builds/build-strategies.adoc#builds-using-build-volumes_build-strategies-s2i[Source-to-image (S2I) build volumes] and xref:../../cicd/builds/build-strategies.adoc#builds-using-build-volumes_build-strategies-docker[Docker build volumes]


### PR DESCRIPTION
Updating the list of features enabled by the TechPreviewNoUpgrades feature set. 

Preview: [Enabling feature sets using the web console](https://51071--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)

Dev review complete
No QE needed