### PR TITLE
OSDOCS-3560: Updated Support coverage

### DIFF
--- a/modules/rosa-policy-shared-responsibility.adoc
+++ b/modules/rosa-policy-shared-responsibility.adoc
@@ -85,8 +85,9 @@ Red Hat is responsible for enabling changes to the cluster infrastructure and se
 |Capacity management
 |- Monitor the use of the control plane. Control planes include control plane nodes and infrastructure nodes.
 - Scale and resize control plane nodes to maintain quality of service.
-- Monitor the use of customer resources including network, storage and compute capacity. Where autoscaling features are not enabled alert customer for any changes required to cluster resources, such as new compute nodes to scale and additional storage.
-|- Use the provided {cluster-manager} controls to add or remove additional worker nodes as required.
+| - Monitors worker node utilization and, if appropriate, enables the auto-scaling feature.
+- Determines the scaling strategy of the cluster. See the additional resources for more information on machine pools.
+- Use the provided {cluster-manager} controls to add or remove additional worker nodes as required.
 - Respond to Red Hat notifications regarding cluster resource requirements.
 
 |===

--- a/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc
@@ -10,4 +10,10 @@ This documentation outlines Red Hat, cloud provider, and customer responsibiliti
 
 include::modules/rosa-policy-responsibilities.adoc[leveloffset=+1]
 include::modules/rosa-policy-shared-responsibility.adoc[leveloffset=+1]
+
+[id="additional-resources-rosa-policy-responsibility-matrix"]
+[role="_additional-resources"]
+=== Additional resources
+* xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc#rosa-nodes-machinepools-about[About machine pools]
+
 include::modules/rosa-policy-customer-responsibility.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-3560](https://issues.redhat.com/browse/OSDOCS-3560)

Link to docs preview:
[Responsibility assignment matrix in ROSA](https://51072--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-change-management_rosa-policy-responsibility-matrix)

QE review:
NEEDED

Additional information:
Removed an incorrect responsibility from SRE and added a new responsibility for the customer. I also added a link to "About machine pools" in a new additional resources section.