### PR TITLE
Replace machine-os-content with new format base image (Layering)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -530,6 +530,12 @@ Topics:
   File: cluster-capabilities
 - Name: Configuring additional devices in an IBM Z or LinuxONE environment
   File: ibmz-post-install
+- Name: Red Hat Enterprise Linux CoreOS image layering
+  File: coreos-layering
+  Distros: openshift-enterprise
+- Name: Fedora CoreOS (FCOS) image layering
+  File: coreos-layering
+  Distros: openshift-origin
 ---
 Name: Updating clusters
 Dir: updating

--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -1,0 +1,203 @@
+// Module included in the following assemblies:
+//
+// * post-installation_configuration/coreos-layering.adoc
+
+:_content-type: PROCEDURE
+[id="coreos-layering-configuring_{context}"]
+= Applying a {op-system} custom layered image
+
+You can easily configure {op-system-first} image layering on the nodes in specific machine config pools. The Machine Config Operator (MCO) reboots those nodes with the new custom layered image, overriding the base {op-system-first} image.
+
+To apply a custom layered image to your cluster, you must have the custom layered image in a repository that your cluster can access. Then, create a `MachineConfig` object that points to the custom layered image. You need a separate `MachineConfig` object for each machine config pool that you want to configure.
+
+[IMPORTANT]
+====
+When you configure a custom layered image, {product-title} no longer automatically updates any node that uses the custom layered image. You become responsible for manually updating your nodes as appropriate. If you roll back the custom layer, {product-title} will again automatically update the node. See the Additional resources section that follows for important information about updating nodes that use a custom layered image.
+====
+
+.Prerequisites
+
+* You must create a custom layered image that is based on an {product-title} image digest, not a tag.
++
+[NOTE]
+====
+You should use the same base {op-system} image that is installed on the rest of your cluster. Use the `oc adm release info --image-for rhel-coreos-8` command to obtain the base image being used in your cluster.
+====
++
+For example, the following Containerfile creates a custom layered image from an {product-title} 4.12 image and a Hotfix package:
++
+.Example Containerfile for a custom layer image
+[source,yaml]
+----
+# Using a 4.12.0 image
+FROM quay.io/openshift-release/ocp-release@sha256:6499bc69a0707fcad481c3cb73225b867d <1>
+#Install hotfix rpm
+RUN rpm-ostree override replace https://example.com/hotfixes/haproxy-1.0.16-5.el8.src.rpm && \ <2>
+    rpm-ostree cleanup -m && \
+    ostree container commit
+----
+<1> Specifies an {product-title} release image.
+<2> Specifies the path to the Hotfix package.
++
+[NOTE]
+====
+Instructions on how to create a Containerfile are beyond the scope of this documentation.
+====
+
+* You must push the custom layered image to a repository that your cluster can access.
+
+.Procedure
+
+. Create a machine config file.
+
+.. Create a YAML file similar to the following:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker <1>
+  name: os-layer-hotfix
+spec:
+  osImageURL: quay.io/my-registry/custom-image@sha256:306b606615dcf8f0e5e7d87fee3 <2>
+----
+<1> Specifies the machine config pool to apply the custom layered image.
+<2> Specifies the path to the custom layered image in the repository.
+
+.. Create the `MachineConfig` object:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
++
+[IMPORTANT]
+====
+It is strongly recommended that you test your images outside of your production environment before rolling out to your cluster.
+====
+
+.Verification
+
+You can verify that the custom layered image is applied by performing any of the following checks:
+
+. Check that the worker machine config pool has rolled out with the new machine config:
+
+.. Check that the new machine config is created:
++
+[source,terminal]
+----
+$ oc get mc
+----
++
+.Sample output
+[source,terminal]
+----
+NAME                                               GENERATEDBYCONTROLLER                      IGNITIONVERSION   AGE
+00-master                                          5bdb57489b720096ef912f738b46330a8f577803   3.2.0             95m
+00-worker                                          5bdb57489b720096ef912f738b46330a8f577803   3.2.0             95m
+01-master-container-runtime                        5bdb57489b720096ef912f738b46330a8f577803   3.2.0             95m
+01-master-kubelet                                  5bdb57489b720096ef912f738b46330a8f577803   3.2.0             95m
+01-worker-container-runtime                        5bdb57489b720096ef912f738b46330a8f577803   3.2.0             95m
+01-worker-kubelet                                  5bdb57489b720096ef912f738b46330a8f577803   3.2.0             95m
+99-master-generated-registries                     5bdb57489b720096ef912f738b46330a8f577803   3.2.0             95m
+99-master-ssh                                                                                 3.2.0             98m
+99-worker-generated-registries                     5bdb57489b720096ef912f738b46330a8f577803   3.2.0             95m
+99-worker-ssh                                                                                 3.2.0             98m
+os-layer-hotfix                                                                                                 10s <1>
+rendered-master-15961f1da260f7be141006404d17d39b   5bdb57489b720096ef912f738b46330a8f577803   3.2.0             95m
+rendered-worker-5aff604cb1381a4fe07feaf1595a797e   5bdb57489b720096ef912f738b46330a8f577803   3.2.0             95m
+rendered-worker-5de4837625b1cbc237de6b22bc0bc873   5bdb57489b720096ef912f738b46330a8f577803   3.2.0             4s  <2>
+----
+<1> New machine config
+<2> New rendered machine config
+
+.. Check that the `osImageURL` value in the new machine config points to the expected image:
++
+[source,terminal]
+----
+$ oc describe mc rendered-master-4e8be63aef68b843b546827b6ebe0913
+----
++
+.Example output
+[source,terminal]
+----
+Name:         rendered-master-4e8be63aef68b843b546827b6ebe0913
+Namespace:
+Labels:       <none>
+Annotations:  machineconfiguration.openshift.io/generated-by-controller-version: 8276d9c1f574481043d3661a1ace1f36cd8c3b62
+              machineconfiguration.openshift.io/release-image-version: 4.12.0-ec.3
+API Version:  machineconfiguration.openshift.io/v1
+Kind:         MachineConfig
+...
+  Os Image URL: quay.io/my-registry/custom-image@sha256:306b606615dcf8f0e5e7d87fee3
+----
+
+.. Check that the associated machine config pool is updating with the new machine config:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+.Sample output
+[source,terminal]
+----
+NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+master   rendered-master-6faecdfa1b25c114a58cf178fbaa45e2   True      False      False      3              3                   3                     0                      39m
+worker   rendered-worker-6b000dbc31aaee63c6a2d56d04cd4c1b   False     True       False      3              0                   0                     0                      39m <1>
+----
+<1> When the `UPDATING` field is `True`, the machine config pool is updating with the new machine config. When the field becomes `False`, the worker machine config pool has rolled out to the new machine config.
+
+.. Check the nodes to see that scheduling on the nodes is disabled. This indicates that the change is being applied:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         STATUS                     ROLES                  AGE   VERSION
+ip-10-0-148-79.us-west-1.compute.internal    Ready                      worker                 32m   v1.25.0+3ef6ef3
+ip-10-0-155-125.us-west-1.compute.internal   Ready,SchedulingDisabled   worker                 35m   v1.25.0+3ef6ef3
+ip-10-0-170-47.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.25.0+3ef6ef3
+ip-10-0-174-77.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.25.0+3ef6ef3
+ip-10-0-211-49.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.25.0+3ef6ef3
+ip-10-0-218-151.us-west-1.compute.internal   Ready                      worker                 31m   v1.25.0+3ef6ef3
+----
+
+. When the node is back in the `Ready` state, check that the node is using the custom layered image:
+
+.. Open an `oc debug` session to the node. For example:
++
+[source,terminal]
+----
+$ oc debug node/ip-10-0-155-125.us-west-1.compute.internal
+----
+
+.. Set `/host` as the root directory within the debug shell:
++
+[source,terminal]
+----
+sh-4.4# chroot /host
+----
+
+.. Run the `rpm-ostree status` command to view that the custom layered image is in use:
++
+[source,terminal]
+----
+sh-4.4# sudo rpm-ostree status
+----
++
+.Example output
++
+----
+State: idle
+Deployments:
+* ostree-unverified-registry:quay.io/my-registry/custom-image@sha256:306b606615dcf8f0e5e7d87fee3
+                   Digest: sha256:306b606615dcf8f0e5e7d87fee3
+----
+

--- a/modules/coreos-layering-removing.adoc
+++ b/modules/coreos-layering-removing.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// * post-installation_configuration/coreos-layering.adoc
+
+:_content-type: PROCEDURE
+[id="coreos-layering-removing_{context}"]
+= Removing a {op-system} custom layered image
+
+You can easily revert {op-system-first} image layering from the nodes in specific machine config pools. The Machine Config Operator (MCO) reboots those nodes with the cluster base {op-system-first} image, overriding the custom layered image.
+
+To remove a {op-system-first} custom layered image from your cluster, you need to delete the machine config that applied the image.
+
+.Procedure
+
+. Delete the machine config that applied the custom layered image.
++
+[source,terminal]
+----
+$ oc delete mc os-layer-hotfix
+----
++
+After deleting the machine config, the nodes reboot.
+
+.Verification
+
+You can verify that the custom layered image is removed by performing any of the following checks:
+
+. Check that the worker machine config pool is updating with the previous machine config:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+.Sample output
+[source,terminal]
+----
+NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+master   rendered-master-6faecdfa1b25c114a58cf178fbaa45e2   True      False      False      3              3                   3                     0                      39m
+worker   rendered-worker-6b000dbc31aaee63c6a2d56d04cd4c1b   False     True       False      3              0                   0                     0                      39m <1>
+----
+<1> When the `UPDATING` field is `True`, the machine config pool is updating with the previous machine config. When the field becomes `False`, the worker machine config pool has rolled out to the previous machine config.
+
+. Check the nodes to see that scheduling on the nodes is disabled. This indicates that the change is being applied:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         STATUS                     ROLES                  AGE   VERSION
+ip-10-0-148-79.us-west-1.compute.internal    Ready                      worker                 32m   v1.25.0+3ef6ef3
+ip-10-0-155-125.us-west-1.compute.internal   Ready,SchedulingDisabled   worker                 35m   v1.25.0+3ef6ef3
+ip-10-0-170-47.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.25.0+3ef6ef3
+ip-10-0-174-77.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.25.0+3ef6ef3
+ip-10-0-211-49.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.25.0+3ef6ef3
+ip-10-0-218-151.us-west-1.compute.internal   Ready                      worker                 31m   v1.25.0+3ef6ef3
+----
+
+. When the node is back in the `Ready` state, check that the node is using the base image:
+
+.. Open an `oc debug` session to the node. For example:
++
+[source,terminal]
+----
+$ oc debug node/ip-10-0-155-125.us-west-1.compute.internal
+----
+
+.. Set `/host` as the root directory within the debug shell:
++
+[source,terminal]
+----
+sh-4.4# chroot /host
+----
+
+.. Run the `rpm-ostree status` command to view that the custom layered image is in use:
++
+[source,terminal]
+----
+sh-4.4# sudo rpm-ostree status
+----
++
+.Example output
++
+----
+State: idle
+Deployments:
+* ostree-unverified-registry:podman pull quay.io/openshift-release-dev/ocp-release@sha256:e2044c3cfebe0ff3a99fc207ac5efe6e07878ad59fd4ad5e41f88cb016dacd73
+                   Digest: sha256:e2044c3cfebe0ff3a99fc207ac5efe6e07878ad59fd4ad5e41f88cb016dacd73
+----

--- a/modules/coreos-layering-updating.adoc
+++ b/modules/coreos-layering-updating.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * post-installation_configuration/coreos-layering.adoc
+
+:_content-type: REFERENCE
+[id="coreos-layering-updating_{context}"]
+= Updating with a {op-system} custom layered image
+
+When you configure {op-system-first} image layering, {product-title} no longer automatically updates the node pool that uses the custom layered image. You become responsible to manually update your nodes as appropriate.
+
+To update a node that uses a custom layered image, follow these general steps:
+
+. The cluster automatically upgrades to version x.y.z+1, except for the nodes that use the custom layered image.
+
+. You could then create a new Containerfile that references the updated {product-title} image and the RPM that you had previously applied.
+
+. Create a new machine config that points to the updated custom layered image.
+
+Updating a node with a custom layered image is not required. However, if that node gets too far behind the current {product-title} version, you could experience unexpected results.
+

--- a/post_installation_configuration/coreos-layering.adoc
+++ b/post_installation_configuration/coreos-layering.adoc
@@ -1,0 +1,118 @@
+:_content-type: ASSEMBLY
+[id="coreos-layering"]
+= {op-system} image layering
+include::_attributes/common-attributes.adoc[]
+:context: coreos-layering
+
+toc::[]
+
+
+{op-system-first} image layering allows you to easily extend the functionality of your base {op-system} image by _layering_ additional images onto the base image. This layering does not modify the base {op-system} image. Instead, it creates a _custom layered image_ that includes all {op-system} functionality and adds additional functionality to specific nodes in the cluster.
+
+You create a custom layered image by using a Containerfile and applying it to nodes by using a `MachineConfig` object. The Machine Config Operator overrides the base {op-system} image, as specified by the `osImageURL` value in the associated machine config, and boots the new image. You can remove the custom layered image by deleting the machine config, The MCO reboots the nodes back to the base {op-system} image.
+
+With {op-system} image layering, you can install RPMs into your base image, and your custom content will be booted alongside {op-system}. The Machine Config Operator (MCO) can roll out these custom layered images and monitor these custom containers in the same way it does for the default {op-system} image. {op-system} image layering gives you greater flexibility in how you manage your {op-system} nodes.
+
+// NOTE from https://issues.redhat.com/browse/OCPBUGS-2214?focusedCommentId=21430101&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-21430101
+
+[IMPORTANT]
+====
+RPMs installed through a custom layered image can conflict with RPMs installed by using a machine config. It is recommended to use either machine config or a custom layered image to add extensions, but not both, unless you are certain there will be no conflicts. If there is a conflict, the MCO enters a `degraded` state when it tries to install the machine config RPM. You need to remove the conflicting extension from your machine config before proceeding.
+====
+
+As soon as you apply the custom layered image to your cluster, you effectively _take ownership_ of your custom layered images and those nodes. While Red Hat remains responsible for maintaining and updating the base {op-system} image on standard nodes, you are responsible for maintaining and updating images on nodes that use a custom layered image. You assume the responsibility for the package you applied with the custom layered image and any issues that might arise with the package.
+
+:FeatureName: Image layering
+include::snippets/technology-preview.adoc[]
+
+Currently, {op-system} image layering allows you to work with Customer Experience and Engagement (CEE) to obtain and apply link:https://access.redhat.com/solutions/2996001[Hotfix packages] on top of your {op-system} image. In some instances, you might want a bug fix or enhancement before it is included in an official {product-title} release. {op-system} image layering allows you to easily add the Hotfix before it is officially released and remove the Hotfix when the underlying {op-system} image incorporates the fix.
+
+[IMPORTANT]
+====
+Some Hotfixes require a Red Hat Support Exception and are outside of the normal scope of {product-title} support coverage or life cycle policies.
+====
+
+In the event you want a Hotfix, it will be provided to you based on link:https://access.redhat.com/solutions/2996001[Red Hat Hotfix policy]. Apply it on top of the base image and test that new custom layered image in a non-production environment. When you are satisfied that the custom layered image is safe to use in production, you can roll it out on your own schedule to specific node pools. For any reason, you can easily roll back the custom layered image and return to using the default {op-system}.
+
+[NOTE]
+====
+It is planned for future releases that you can use {op-system} image layering to incorporate third-party software packages such as libreswan or numactl.
+====
+
+////
+Future features
+By using layering, you can extend your {op-system} in a number of ways, including:
+
+* {op-system} Hotfixes
+* Third-party RHEL packages.
+* Bleeding edge drivers and kernel enhancements to improve performance or add capabilities.
+* Foresic client tools to investigate possible and actual break-ins.
+* Inventory agents that provide a coherent view of the entire fleet.
+* Critical and important CVEs as soon as errata are available in RHEL to keep your systems secure.
+* SSH Key management packages.
+////
+
+To apply a custom layered image, you create a Containerfile that references an {product-title} image and the Hotfix that you want to apply. For example:
+
+// For example, the following Containerfile installs a Hotfix:
+
+.Example Containerfile to apply a Hotfix
+[source,yaml]
+----
+# Using a 4.12.0 image
+FROM quay.io/openshift-release-dev/ocp-release@sha256:6499bc69a0707fcad481c3cb73225b867d
+#Install hotfix rpm
+RUN rpm-ostree override replace https://example.com/myrepo/haproxy-1.0.16-5.el8.src.rpm && \
+    rpm-ostree cleanup -m && \
+    ostree container commit
+----
+
+////
+For example, the following Containerfile installs the libreswan package from quay.io:
+[source,terminal]
+----
+# Using aa 4.12.0 image
+FROM quay.io/openshift-release-dev/ocp-release@sha256:6499bc69a0707fcad481c3cb73225b867dc31b345c6e6204e28
+RUN rpm-ostree install libreswan && \
+    rpm-ostree cleanup -m && \
+    ostree container commit
+----
+////
+
+[NOTE]
+====
+Use the same base {op-system} image installed on the rest of your cluster. Use the `oc adm release info --image-for rhel-coreos-8` command to obtain the base image used in your cluster.
+====
+
+Push the resulting custom layered image to an image registry. In a non-production {product-title} cluster, create a `MachineConfig` object for the targeted node pool that points to the new image.
+
+The Machine Config Operator (MCO) updates the operating system with content provided in the machine config. This creates a custom layered image that overrides the base {op-system} image on those nodes.
+
+After you create the machine config, the MCO:
+
+. Renders a new machine config for the specified pool or pools.
+. Performs cordon and drain operations on the nodes in the pool or pools.
+. Writes the rest of the machine config parameters onto the nodes.
+. Applies the custom layered image to the node.
+. Reboots the node using the new image.
+
+[IMPORTANT]
+====
+It is strongly recommended that you test your images outside of your production environment before rolling out to your cluster.
+====
+
+include::modules/coreos-layering-configuring.adoc[leveloffset=+1]
+
+.Additional resources
+xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering-updating_coreos-layering[Updating with a {op-system} custom layered image]
+
+include::modules/coreos-layering-removing.adoc[leveloffset=+1]
+include::modules/coreos-layering-updating.adoc[leveloffset=+1]
+
+////
+Sources:
+https://docs.google.com/document/d/1Eow2IReNWqnIh5HvCfcKV2MWgHUmFKSnBkt2rH6_V_M/edit
+https://hackmd.io/OKc5ZnN7SQm3myHaGqksBg
+https://github.com/openshift/enhancements/blob/master/enhancements/ocp-coreos-layering/ocp-coreos-layering.md
+https://docs.google.com/document/d/1RbfCJuL_NBaWvUmd9nmiG8-7MwzsvWHjrIS2LglCYM0/edit
+////


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3979

Release note added via https://github.com/openshift/openshift-docs/pull/51575

Preview: [RHCOS image layering](https://51073--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html)