### PR TITLE
[RHACS] fix error in xref

### DIFF
--- a/installing/installing_helm/install-helm-customization.adoc
+++ b/installing/installing_helm/install-helm-customization.adoc
@@ -19,7 +19,7 @@ High-level installation flow:
 Before you install:
 
 * Understand xref:../../architecture/acs-architecture.adoc[{product-title} architecture].
-* Review the xref:../prerequisites.adoc#acs-general-requirements_acs-prerequisites[prerequisites for installing {product-title}].
+* Review the xref:../../installing/prerequisites.adoc#acs-general-requirements_acs-prerequisites[prerequisites for installing {product-title}].
 
 include::modules/adding-helm-repository.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Fixing an error that is preventing portal build.

Merge to:
- `rhacs-docs`

Cherry pick to:

- `rhacs-docs-3.72`
- `rhacs-docs-3.71`
- `rhacs-docs-3.70`

Issue:
none

[Link to docs preview](https://openshift-docs-oomeadfjq-kcarmichael08.vercel.app/openshift-acs/master/installing/installing_helm/install-helm-customization.html)

QE review:
- [ ] QE has approved this change. (N/A)

