### PR TITLE
[SRVCOM-1922] Add Serverless 1.25.0 release notes & update feature tables

### DIFF
--- a/modules/serverless-broker-types.adoc
+++ b/modules/serverless-broker-types.adoc
@@ -8,9 +8,6 @@
 
 Cluster administrators can set the default broker implementation for a cluster. When you create a broker, the default broker implementation is used, unless you provide set configurations in the `Broker` object.
 
-:FeatureName: Kafka broker
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 [id="serverless-broker-types-default_{context}"]
 == Default broker implementation for development purposes
 

--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -13,21 +13,17 @@ For the most recent list of major functionality deprecated and removed within {S
 // OCP + OSD table
 ifdef::openshift-enterprise,openshift-dedicated[]
 .Deprecated and removed features tracker
-[cols="3,1,1,1,1,1",options="header"]
+[cols="3,1,1,1",options="header"]
 |====
-|Feature |1.20|1.21|1.22|1.23|1.24
+|Feature |1.20|1.21|1.22 to 1.25
 
 |`KafkaBinding` API
 |Deprecated
 |Deprecated
 |Removed
-|Removed
-|Removed
 
 |`kn func emit` (`kn func invoke` in 1.21+)
 |Deprecated
-|Removed
-|Removed
 |Removed
 |Removed
 
@@ -37,15 +33,17 @@ endif::[]
 // ROSA table
 ifdef::openshift-rosa[]
 .Deprecated and removed features tracker
-[cols="3,1,1",options="header"]
+[cols="3,1,1,1",options="header"]
 |====
-|Feature |1.23|1.24
+|Feature |1.23|1.24|1.25
 
 |`KafkaBinding` API
 |Removed
 |Removed
+|Removed
 
 |`kn func emit` (`kn func invoke` in 1.21+)
+|Removed
 |Removed
 |Removed
 

--- a/modules/serverless-kafka-broker-configmap.adoc
+++ b/modules/serverless-kafka-broker-configmap.adoc
@@ -8,9 +8,6 @@
 
 You can configure the replication factor, bootstrap servers, and the number of topic partitions for a Kafka broker, by creating a config map and referencing this config map in the Kafka `Broker` object.
 
-:FeatureName: Kafka broker
-include::snippets/technology-preview.adoc[]
-
 .Prerequisites
 
 * You have cluster or dedicated administrator permissions on {product-title}.

--- a/modules/serverless-rn-1-25-0.adoc
+++ b/modules/serverless-rn-1-25-0.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies
+//
+// * serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-25-0_{context}"]
+= Release notes for Red Hat {ServerlessProductName} 1.25.0
+
+{ServerlessProductName} 1.25.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+[id="new-features-1.25.0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.4.
+* {ServerlessProductName} now uses Knative Eventing 1.4.
+* {ServerlessProductName} now uses Kourier 1.4.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.4.
+* {ServerlessProductName} now uses Knative Kafka 1.4.
+* The `kn func` CLI plug-in now uses `func` 1.7.0.
+
+* Integrated development environment (IDE) plug-ins for creating and deploying functions are now available for link:https://github.com/redhat-developer/vscode-knative[Visual Studio Code] and link:https://github.com/redhat-developer/intellij-knative[IntelliJ].
+* Knative Kafka broker is now GA. Knative Kafka broker is a highly performant implementation of the Knative broker API, directly targeting Apache Kafka.
++
+It is recommended to not use the MT-Channel-Broker, but the Knative Kafka broker instead.
+* Knative Kafka sink is now GA. A `KafkaSink` takes a `CloudEvent` and sends it to an Apache Kafka topic. Events can be specified in either structured or binary content modes.
+
+* Enabling TLS for internal traffic is now available as a Technology Preview.
+
+[id="fixed-issues-1.25.0_{context}"]
+== Fixed issues
+
+* Previously, Knative Serving had an issue where the readiness probe failed if the container was restarted after a liveness probe fail. This issue has been fixed.
+
+[id="known-issues-1.25.0_{context}"]
+== Known issues
+
+* The Federal Information Processing Standards (FIPS) mode is disabled for Kafka broker, Kafka source, and Kafka sink.
+* The `SinkBinding` object does not support custom revision names for services.

--- a/modules/serverless-sinkbinding-intro.adoc
+++ b/modules/serverless-sinkbinding-intro.adoc
@@ -12,3 +12,8 @@ The `SinkBinding` object injects environment variables into the `PodTemplateSpec
 
 `K_SINK`:: The URL of the resolved sink.
 `K_CE_OVERRIDES`:: A JSON object that specifies overrides to the outbound event.
+
+[NOTE]
+====
+The `SinkBinding` object currently does not support custom revision names for services.
+====

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -13,44 +13,53 @@ The following table provides information about which {ServerlessProductName} fea
 // OCP + OSD table
 ifdef::openshift-enterprise,openshift-dedicated[]
 .Generally Available and Technology Preview features tracker
-[cols="3,1,1",options="header"]
+[cols="3,1,1,1",options="header"]
 |====
-|Feature |1.23|1.24
+|Feature |1.23|1.24|1.25
 
 |`kn func`
 |TP
-|TP
-
-|`kn func invoke`
 |TP
 |TP
 
 |Service Mesh mTLS
 |GA
 |GA
+|GA
 
 |`emptyDir` volumes
+|GA
 |GA
 |GA
 
 |HTTPS redirection
 |GA
 |GA
+|GA
 
 |Kafka broker
 |TP
 |TP
+|GA
 
 |Kafka sink
 |TP
 |TP
+|GA
 
 |Init containers support for Knative services
 |TP
 |GA
+|GA
 
 |PVC support for Knative services
 |TP
+|TP
+|TP
+
+|TLS for internal traffic
+|-
+|-
 |TP
 
 |====
@@ -59,44 +68,53 @@ endif::[]
 // ROSA table
 ifdef::openshift-rosa[]
 .Generally Available and Technology Preview features tracker
-[cols="3,1,1",options="header"]
+[cols="3,1,1,1",options="header"]
 |====
-|Feature |1.23|1.24
+|Feature |1.23|1.24|1.25
 
 |`kn func`
 |TP
-|TP
-
-|`kn func invoke`
 |TP
 |TP
 
 |Service Mesh mTLS
 |GA
 |GA
+|GA
 
 |`emptyDir` volumes
+|GA
 |GA
 |GA
 
 |HTTPS redirection
 |GA
 |GA
+|GA
 
 |Kafka broker
 |TP
 |TP
+|GA
 
 |Kafka sink
+|TP
 |TP
 |TP
 
 |Init containers support for Knative services
 |TP
 |GA
+|GA
 
 |PVC support for Knative services
 |TP
+|TP
+|TP
+
+|TLS for internal traffic
+|-
+|-
 |TP
 
 |====

--- a/serverless/admin_guide/serverless-kafka-admin.adoc
+++ b/serverless/admin_guide/serverless-kafka-admin.adoc
@@ -27,8 +27,8 @@ The `KnativeKafka` CR provides users with additional options, such as:
 
 * Kafka source
 * Kafka channel
-* Kafka broker (Technology Preview)
-* Kafka sink (Technology Preview)
+* Kafka broker
+* Kafka sink
 
 include::modules/serverless-install-kafka-odc.adoc[leveloffset=+1]
 

--- a/serverless/develop/serverless-kafka-developer.adoc
+++ b/serverless/develop/serverless-kafka-developer.adoc
@@ -22,8 +22,8 @@ Knative Kafka provides additional options, such as:
 
 * Kafka source
 * Kafka channel
-* Kafka broker (Technology Preview)
-* Kafka sink (Technology Preview)
+* Kafka broker
+* Kafka sink
 
 include::modules/serverless-kafka-event-delivery.adoc[leveloffset=+1]
 
@@ -45,9 +45,6 @@ include::modules/serverless-kafka-source-yaml.adoc[leveloffset=+2]
 [id="serverless-kafka-developer-broker"]
 == Kafka broker
 
-:FeatureName: Kafka broker
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 include::snippets/serverless-about-kafka-broker.adoc[]
 
 For information about using Kafka brokers, see xref:../../serverless/develop/serverless-using-brokers.adoc#serverless-using-brokers[Creating brokers].
@@ -59,9 +56,6 @@ include::modules/serverless-create-kafka-channel-yaml.adoc[leveloffset=+1]
 == Kafka sink
 
 Kafka sinks are a type of xref:../../serverless/develop/serverless-event-sinks.adoc#serverless-event-sinks[event sink] that are available if a cluster administrator has enabled Kafka on your cluster. You can send events directly from an xref:../../serverless/discover/knative-event-sources.adoc#knative-event-sources[event source] to a Kafka topic by using a Kafka sink.
-
-:FeatureName: Kafka sink
-include::snippets/technology-preview.adoc[leveloffset=+2]
 
 // Kafka sink
 include::modules/serverless-kafka-sink.adoc[leveloffset=+2]

--- a/serverless/develop/serverless-using-brokers.adoc
+++ b/serverless/develop/serverless-using-brokers.adoc
@@ -12,9 +12,6 @@ If a cluster administrator has configured your {ServerlessProductName} deploymen
 
 If your {ServerlessProductName} deployment is not configured to use Kafka broker as the default broker type, the channel-based broker is created when you use the default settings in the following procedures.
 
-:FeatureName: Kafka broker
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 include::modules/serverless-create-broker-kn.adoc[leveloffset=+1]
 include::modules/serverless-creating-broker-annotation.adoc[leveloffset=+1]
 include::modules/serverless-creating-broker-labeling.adoc[leveloffset=+1]
@@ -25,9 +22,6 @@ include::modules/serverless-creating-a-broker-odc.adoc[leveloffset=+1]
 == Creating a Kafka broker when it is not configured as the default broker type
 
 If your {ServerlessProductName} deployment is not configured to use Kafka broker as the default broker type, you can use one of the following procedures to create a Kafka-based broker.
-
-:FeatureName: Kafka broker
-include::snippets/technology-preview.adoc[leveloffset=+2]
 
 include::modules/serverless-kafka-broker.adoc[leveloffset=+2]
 include::modules/serverless-kafka-broker-with-kafka-topic.adoc[leveloffset=+2]

--- a/serverless/functions/serverless-functions-getting-started.adoc
+++ b/serverless/functions/serverless-functions-getting-started.adoc
@@ -27,6 +27,8 @@ ifdef::openshift-enterprise[]
 [role="_additional-resources"]
 == Additional resources
 * xref:../../registry/securing-exposing-registry.adoc#securing-exposing-registry[Exposing a default registry manually]
+* link:https://plugins.jetbrains.com/plugin/16476-knative\--serverless-functions-by-red-hat[Marketplace page for the Intellij Knative plug-in]
+* link:https://marketplace.visualstudio.com/items?itemName=redhat.vscode-knative&utm_source=VSCode.pro&utm_campaign=AhmadAwais[Marketplace page for the Visual Studio Code Knative plug-in]
 // This Additional resource applies only to OCP, but not to OSD nor ROSA.
 endif::[]
 

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -23,6 +23,14 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-25-0.adoc[leveloffset=+1]
+// 1.25.0 additional resources, OCP docs
+ifdef::openshift-enterprise[]
+[role="_additional-resources"]
+.Additional resources
+* xref:../serverless/security/serverless-config-tls.adoc#serverless-config-tls[Configuring TLS authentication]
+endif::[]
+
 include::modules/serverless-rn-1-24-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-23-0.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Versions: 4.6 and 4.8+
Jira: https://issues.redhat.com/browse/SRVCOM-1922
Preview:
https://51075--docspreview.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-tech-preview-features_serverless-release-notes
(sections to review:
1. Generally Available and Technology Preview features
2. Deprecated and removed features
3. Release notes for Red Hat OpenShift Serverless 1.25.0)

https://51075--docspreview.netlify.app/openshift-enterprise/latest/serverless/develop/serverless-custom-event-sources.html#serverless-sinkbinding-intro_context
(note to review: "The `SinkBinding` object currently does not support custom revision names for services.")

https://51075--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-getting-started.html#additional-resources_serverless-functions-getting-started
(two Marketplace additional resources to review at the very end of assembly)

https://51075--docspreview.netlify.app/openshift-enterprise/latest/serverless/install/install-serverless-operator.html#serverless-install-web-console_install-serverless-operator

(the second requirement entry)

https://51075--docspreview.netlify.app/openshift-enterprise/latest/serverless/install/install-serverless-operator.html#additional-resources_install-serverless-operator

(the second additional resource entry)

Dev & QE reviews: complete (but last-minute updates might occur)

Special notes: the text contains a FIXME link to a not-yet-published PR