### PR TITLE
ospbugs#1858: Removed vSphere-specific note from module

### DIFF
--- a/modules/installation-machine-requirements.adoc
+++ b/modules/installation-machine-requirements.adoc
@@ -36,15 +36,6 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
 :ibm-z:
 endif::[]
-ifeval::["{context}" == "installing-vsphere"]
-:vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:vsphere:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:vsphere:
-endif::[]
 ifeval::["{context}" == "installing-ibm-power"]
 :ibm-power:
 endif::[]
@@ -107,13 +98,6 @@ Note that {op-system} is based on {op-system-base-full} 8 and inherits all of it
 endif::[]
 See link:https://access.redhat.com/articles/rhel-limits[Red Hat Enterprise Linux technology capabilities and limits].
 
-ifdef::vsphere[]
-[IMPORTANT]
-====
-All virtual machines must reside in the same datastore and in the same folder as the installer. Ensure that all virtual machine names across a vSphere installation are unique.
-====
-endif::vsphere[]
-
 ifeval::["{context}" == "installing-bare-metal"]
 :!bare-metal:
 endif::[]
@@ -128,15 +112,6 @@ ifeval::["{context}" == "installing-ibm-z"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
 :!ibm-z:
-endif::[]
-ifeval::["{context}" == "installing-vsphere"]
-:!vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:!vsphere:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:!vsphere:
 endif::[]
 ifeval::["{context}" == "installing-ibm-power"]
 :!ibm-power:


### PR DESCRIPTION
Version(s):
4.10+

Issue:
This PR addresses [ocpbugs1858](https://issues.redhat.com/browse/OCPBUGS-1858).

Link to docs preview:
[Required machines for cluster installation](https://51092--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-machine-requirements_installing-vsphere)

