### PR TITLE
TELCODOCS-961 - Configuring PGT CRs with compliance duration settings

### DIFF
--- a/modules/ztp-configuring-pgt-compliance-eval-timeouts.adoc
+++ b/modules/ztp-configuring-pgt-compliance-eval-timeouts.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp-deploying-disconnected.adoc
+
+:_content-type: PROCEDURE
+[id="ztp-configuring-pgt-compliance-eval-timeouts_{context}"]
+= Configuring policy compliance evaluation timeouts for PolicyGenTemplate CRs
+
+Use {rh-rhacm-first} installed on a hub cluster to monitor and report on whether your managed clusters are compliant with applied policies. {rh-rhacm} uses policy templates to apply predefined policy controllers and policies. Policy controllers are Kubernetes custom resource definition (CRD) instances.
+
+You can override the default policy evaluation intervals with `PolicyGenTemplate` custom resources (CRs). You configure duration settings that define how long a `ConfigurationPolicy` CR can be in a state of policy compliance or non-compliance before {rh-rhacm} re-evaluates the applied cluster policies.
+
+The zero touch provisioning (ZTP) policy generator generates `ConfigurationPolicy` CR policies with pre-defined policy evaluation intervals. The default value for the `noncompliant` state is 10 seconds. The default value for the `compliant` state is 10 minutes. To disable the evaluation interval, set the value to `never`.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You have logged in to the hub cluster as a user with `cluster-admin` privileges.
+
+* You have created a Git repository where you manage your custom site configuration data.
+
+.Procedure
+
+. To configure the evaluation interval for all policies in a `PolicyGenTemplate` CR, add `evaluationInterval` to the `spec` field, and then set the appropriate `compliant` and `noncompliant` values. For example:
++
+[source,yaml]
+----
+spec:
+  evaluationInterval:
+    compliant: 30m
+    noncompliant: 20s
+----
+
+. To configure the evaluation interval for the `spec.sourceFiles` object in a `PolicyGenTemplate` CR, add `evaluationInterval` to the `sourceFiles` field, for example:
++
+[source,yaml]
+----
+spec:
+  sourceFiles:
+   - fileName: SriovSubscription.yaml
+     policyName: "sriov-sub-policy"
+     evaluationInterval:
+       compliant: never
+       noncompliant: 10s
+----
+
+. Commit the `PolicyGenTemplate` CRs files in the Git repository and push your changes.
+
+.Verification
+
+Check that the managed spoke cluster policies are monitored at the expected intervals.
+
+. Log in as a user with `cluster-admin` privileges on the managed cluster.
+
+. Get the pods that are running in the `open-cluster-management-agent-addon` namespace. Run the following command:
++
+[source,terminal]
+----
+$ oc get pods -n open-cluster-management-agent-addon
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         READY   STATUS    RESTARTS        AGE
+config-policy-controller-858b894c68-v4xdb    1/1     Running   22 (5d8h ago)   10d
+----
+
+. Check the applied policies are being evaluated at the expected interval in the logs for the `config-policy-controller` pod:
++
+[source,terminal]
+----
+$ oc logs -n open-cluster-management-agent-addon config-policy-controller-858b894c68-v4xdb
+----
++
+.Example output
+[source,terminal]
+----
+2022-05-10T15:10:25.280Z       info   configuration-policy-controller controllers/configurationpolicy_controller.go:166      Skipping the policy evaluation due to the policy not reaching the evaluation interval  {"policy": "compute-1-config-policy-config"}
+2022-05-10T15:10:25.280Z       info   configuration-policy-controller controllers/configurationpolicy_controller.go:166      Skipping the policy evaluation due to the policy not reaching the evaluation interval  {"policy": "compute-1-common-compute-1-catalog-policy-config"}
+----

--- a/scalability_and_performance/ztp-deploying-disconnected.adoc
+++ b/scalability_and_performance/ztp-deploying-disconnected.adoc
@@ -72,6 +72,8 @@ Scaling the hub cluster to managing large numbers of spoke clusters is affected 
 
 include::modules/ztp-creating-the-policygentemplate-cr.adoc[leveloffset=+1]
 
+include::modules/ztp-configuring-pgt-compliance-eval-timeouts.adoc[leveloffset=+1]
+
 include::modules/ztp-creating-ztp-custom-resources-for-multiple-managed-clusters.adoc[leveloffset=+1]
 
 include::modules/ztp-using-pgt-to-update-source-crs.adoc[leveloffset=+2]


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-961

Merge to main, CP to enterprise-4.11+

Preview (temporary TOC location, will be updated in https://github.com/openshift/openshift-docs/pull/49805): http://file.emea.redhat.com/aireilly/td-961/scalability_and_performance/ztp-deploying-disconnected.html#ztp-configuring-pgt-compliance-eval-timeouts_ztp-deploying-disconnected
