### PR TITLE
[OSDOCS-4241]: Add a note for cluster updates with various etcd member sizes

### DIFF
--- a/modules/recommended-etcd-practices.adoc
+++ b/modules/recommended-etcd-practices.adoc
@@ -23,7 +23,7 @@ The following hard disk features provide optimal etcd performance:
 * Solid state drives as a minimum selection, however NVMe drives are preferred.
 * Server-grade hardware from various manufacturers for increased reliability.
 * RAID 0 technology for increased performance.
-* Dedicated etcd drives. Do not place log files or other heavy workloads on etcd drives. 
+* Dedicated etcd drives. Do not place log files or other heavy workloads on etcd drives.
 
 Avoid NAS or SAN setups and spinning drives. Always benchmark by using utilities such as fio. Continuously monitor the cluster performance as it increases.
 
@@ -31,6 +31,10 @@ IMPORTANT: Avoid using the Network File System (NFS) protocol or other network b
 
 Some key metrics to monitor on a deployed {product-title} cluster are p99 of etcd disk write ahead log duration and the number of etcd leader changes. Use Prometheus to track these metrics.
 
+[NOTE]
+====
+The etcd member database sizes can vary in a cluster during normal operations. This difference does not affect cluster upgrades, even if the leader size is different from the other members.
+====
 
 To validate the hardware for etcd before or after you create the {product-title} cluster, you can use fio.
 


### PR DESCRIPTION
[OSDOCS-4241](https://issues.redhat.com/browse/OSDOCS-4241)

Version(s): 4.11+

Issue: [OCPBUGS-1756](https://issues.redhat.com/browse/OCPBUGS-1756)

Link to docs [preview](http://file.rdu.redhat.com/tlove/tlove-etcd-osdocs-4241/scalability_and_performance/recommended-host-practices.html#recommended-etcd-practices_recommended-host-practices). (Updated 10/24 at 9:16PM)


Additional information:
This card is a result of Slack discussion where a customer was concerned about doing a cluster upgrade with the etcd leader size different from the other members. It was found to be not-a-bug, however, the reporter wanted a note just to assure the reader that this is not a concern.