### PR TITLE
OADP-664: OADP-on-ODF limitations (backupStorageLocation)

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -34,6 +34,9 @@ If your cloud provider does not support snapshots or if your storage is NFS, you
 
 You create a default `Secret` and then you install the Data Protection Application.
 
+
+include::modules/oadp-configuring-noobaa-for-dr.adoc[leveloffset=+1]
+
 [discrete]
 [role="_additional-resources"]
 == Additional resources

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -36,6 +36,7 @@ include::modules/oadp-setting-resource-limits-and-requests.adoc[leveloffset=+2]
 include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 
 include::modules/oadp-installing-dpa.adoc[leveloffset=+1]
+include::modules/oadp-configuring-noobaa-for-dr.adoc[leveloffset=+2]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
 :installing-oadp-ocs!:

--- a/modules/oadp-configuring-noobaa-for-dr.adoc
+++ b/modules/oadp-configuring-noobaa-for-dr.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+
+:_content-type: PROCEDURE
+[id="oadp-configuring-noobaa-for-dr_{context}"]
+= Configuring NooBaa for disaster recovery on {rh-storage}
+
+If you use cluster storage for your NooBaa bucket `backupStorageLocation` on {rh-storage}, configure NooBaa as an external object store.
+
+[WARNING]
+====
+Failure to configure NooBaa as an external object store might lead to backups not being available.
+====
+
+.Procedure
+
+* Configure NooBaa as an external object store as described in link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.11/html/managing_hybrid_and_multicloud_resources/adding-storage-resources-for-hybrid-or-multicloud_rhodf#doc-wrapper[Adding storage resources for hybrid or Multicloud].


### PR DESCRIPTION
OADP 1.1.1; OCP 4.9+

Has passed Dev and QE review.

Resolves https://issues.redhat.com/browse/OADP-664 

Previews:
1. In the general installation section: https://51106--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html

2. As part of Installing OADP on OCF: https://51106--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html#oadp-configuring-noobaa-for-dr_installing-oadp-ocs