### PR TITLE
OADP-762: Must-gather image is not updated in downstream docs

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 :oadp-troubleshooting:
 :namespace: openshift-adp
 :local-product: OADP
-:must-gather: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.0
+:must-gather: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.1
 
 toc::[]
 


### PR DESCRIPTION
[OADP-762](https://issues.redhat.com//browse/OADP-762): Must-gather image is not updated in downstream docs

Resolves: https://issues.redhat.com/browse/OADP-762

merge to 4.9+

OADP 1.1.1

OTP 4.6+