### PR TITLE
typo

### DIFF
--- a/modules/windows-containers-release-notes-limitations.adoc
+++ b/modules/windows-containers-release-notes-limitations.adoc
@@ -27,12 +27,11 @@ Note the following limitations when working with Windows nodes managed by the WM
 
 * Windows nodes are not supported in clusters that are in a disconnected environment.
 
-* {productwinc} supports only in-tree storage drivers for all cloud providers. 
+* {productwinc} supports only in-tree storage drivers for all cloud providers.
 
 * Kubernetes has identified the following link:https://kubernetes.io/docs/concepts/windows/intro/#limitations[node feature limitations] :
 ** Huge pages are not supported for Windows containers.
 ** Privileged containers are not supported for Windows containers.
 ** Pod termination grace periods require the containerd container runtime to be installed on the Windows node.
 
-* Kubernetes has identified link:https://kubernetes.io/docs/concepts/windows/intro/#api[several API compatability issues].
-
+* Kubernetes has identified link:https://kubernetes.io/docs/concepts/windows/intro/#api[several API compatibility issues].


### PR DESCRIPTION
- Applies to 4.6 and above versions [typo is there in all] QE not needed.
- [GH issue](https://github.com/openshift/openshift-docs/issues/50522)
- [Preview](https://51119--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-6-x.html#windows-containers-release-notes-limitations_windows-containers-release-notes)