### PR TITLE
OSDOCS-4226: Adds notes for 4.10.35 release

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3456,3 +3456,27 @@ $ oc adm release info 4.10.34 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-35"]
+=== RHBA-2022:6728 - {product-title} 4.10.35 bug fix update
+
+Issued: 2022-10-04
+
+{product-title} release 4.10.35, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:6728[RHBA-2022:6728] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:6727[RHBA-2022:6727] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.35 --pullspecs
+----
+
+[id="ocp-4-10-35-bug-fixes"]
+==== Bug fixes
+
+* Previously, the logic in the Ingress Operator did not validate whether a kubernetes service object in the `openshift-ingress` namespace was created by the Ingress Controller it was attempting to reconcile with. Consequently, the Operator would modify or remove kubernetes services with the same name and namespace regardless of ownership. With this update, the Ingress Operator now checks for the ownership of existing kubernetes services it attempts to create or remove. If the ownership does not match, the Ingress Operator provides an error. (link:https://issues.redhat.com/browse/OCPBUGS-1623[*OCPBUGS-1623*])
+
+[id="ocp-4-10-35-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.10.35 release

4.10 only

Issue:
[OSDOCS-4226](https://issues.redhat.com/browse/OSDOCS-4226)

Link to docs preview (VPN req)
http://file.rdu.redhat.com/opayne/RN-4.10.35/release_notes/ocp-4-10-release-notes.html#ocp-4-10-35

QE review:
- [ ] QE has approved this change.
--QE review not needed for this change.

Additional information:
Links to RHBA will not work yet (Bug link and docs links will).

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
