### PR TITLE
GH#51081 - Updating boot_device to include aarch64

### DIFF
--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -54,21 +54,22 @@ metadata:
   labels:
     machineconfiguration.openshift.io/role: worker
 boot_device:
-  layout: x86_64
+  layout: x86_64 <1>
   luks:
-    tpm2: true <1>
-    tang: <2>
+    tpm2: true <2>
+    tang: <3>
       - url: http://tang1.example.com:7500
         thumbprint: jwGN5tRFK-kF6pIX89ssF3khxxX
       - url: http://tang2.example.com:7500
         thumbprint: VCJsvZFjBSIHSldw78rOrq7h2ZF
-    threshold: 2 <3>
+    threshold: 2 <4>
 openshift:
   fips: true
 ----
-<1> Include this field if you want to use a Trusted Platform Module (TPM) to encrypt the root file system.
-<2> Include this section if you want to use one or more Tang servers.
-<3> Specify the minimum number of TPM v2 and Tang encryption conditions that must be met for decryption to occur.
+<1> Set this field to the instruction set architecture of the cluster nodes. Some examples include, `x86_64`, `aarch64`, or `ppc64le`. 
+<2> Include this field if you want to use a Trusted Platform Module (TPM) to encrypt the root file system.
+<3> Include this section if you want to use one or more Tang servers.
+<4> Specify the minimum number of TPM v2 and Tang encryption conditions that must be met for decryption to occur.
 
 [IMPORTANT]
 ====
@@ -196,7 +197,7 @@ openshift:
 ----
 +
 <1> For control plane configurations, replace `worker` with `master` in both of these locations.
-<2> On ppc64le nodes, set this field to `ppc64le`.  On all other nodes, this field can be omitted.
+<2> Set this field to the instruction set architecture of the cluster nodes. Some examples include, `x86_64`, `aarch64`, or `ppc64le`. 
 <3> Include this section if you want to encrypt the root file system. For more details, see the _About disk encryption_ section.
 <4> Include this field if you want to use a Trusted Platform Module (TPM) to encrypt the root file system.
 <5> Include this section if you want to use one or more Tang servers.


### PR DESCRIPTION
For versions 4.11+
Fixed issue: #51081

Preview: 
[Installation configuration -> Customizing nodes -> About disk encryption](https://51146--docspreview.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-encrypt-disk_installing-customizing)
[Installation configuration -> Customizing nodes -> Configuring disk encryption and mirroring ](https://51146--docspreview.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-storage-procedure_installing-customizing)