### PR TITLE
OCPBUGS-627:fixing Enabling Ipsec encryption command

### DIFF
--- a/modules/nw-ovn-ipsec-enable.adoc
+++ b/modules/nw-ovn-ipsec-enable.adoc
@@ -20,6 +20,6 @@ As a cluster administrator, you can enable IPsec encryption after cluster instal
 +
 [source,terminal]
 ----
-$ oc patch networks.operator.openshift.io/cluster --type=json \
--p='[{"op":"remove", "path":"/spec/defaultNetwork/ovnKubernetesConfig/ipsecConfig"}]'
+$ oc patch networks.operator.openshift.io cluster --type=merge \
+-p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipsecConfig":{ }}}}}'
 ----


### PR DESCRIPTION
Versions:
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-627

Link to docs preview:
https://51153--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.html#nw-ovn-ipsec-enable_configuring-ipsec-ovn

QE review @weliang1 :
- QE has approved this change.


