### PR TITLE
OSDOCS-4071-2: Updates to dynamic plug-in deployment procedure part 2

### DIFF
--- a/modules/deployment-plug-in-cluster.adoc
+++ b/modules/deployment-plug-in-cluster.adoc
@@ -10,7 +10,7 @@ After pushing an image with your changes to a registry, you can deploy the plug-
 
 .Procedure
 
-. To deploy your plug-in to a cluster, instantiate the link:https://github.com/spadgett/console-plugin-template/blob/main/template.yaml[template] by running the following command:
+. To deploy your plug-in to a cluster, instantiate the link:https://github.com/openshift/console-plugin-template/tree/release-4.10[template]your plug-in by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/dynamic-plug-ins-get-started.adoc
+++ b/modules/dynamic-plug-ins-get-started.adoc
@@ -14,9 +14,9 @@ To get started using the dynamic plug-in, you must set up your environment to wr
 
 .Procedure
 
-. Visit this link:https://github.com/spadgett/console-plugin-template[repository] containing a template for creating plug-ins.
+. Visit this link:https://github.com/openshift/console-plugin-template/tree/release-4.10[repository] containing a template for creating plug-ins.
 
-. Select `Use this Template` from the *<> Code* tab to create a GitHub repository.
+. Select `Use this Template` to create a new repository from `console-plugin-template`.
 
 . Re-name the template with the name of your plug-in.
 


### PR DESCRIPTION
[OSDOCS-4071](https://issues.redhat.com//browse/OSDOCS-4071): This Pr provides updates to the procedure for deploying a plug-in on a cluster. This Pr is pt.2 that includes specifics for the 4.10 version. 

See part 1 in #49996

4.10 only

Issue:
[OSDOCS-4071](https://issues.redhat.com//browse/OSDOCS-4071)

Link to docs preview (VPN req)
http://file.rdu.redhat.com/opayne/OSDOCS-4071-2/web_console/dynamic-plug-ins.html#deploy-on-cluster_dynamic-plugins

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
