### PR TITLE
OSDOCS-3574: Adding preparing to update to 4.12 docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -527,6 +527,12 @@ Topics:
   File: understanding-upgrade-channels-release
 - Name: Understanding OpenShift update duration
   File: understanding-openshift-update-duration
+- Name: Preparing to update to OpenShift Container Platform 4.12
+  File: updating-cluster-prepare
+  Distros: openshift-enterprise
+- Name: Preparing to update to OKD 4.12
+  File: updating-cluster-prepare
+  Distros: openshift-origin
 - Name: Preparing to perform an EUS-to-EUS update
   File: preparing-eus-eus-upgrade
 - Name: Updating a cluster using the web console

--- a/modules/update-preparing-ack.adoc
+++ b/modules/update-preparing-ack.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-cluster-prepare.adoc
+
+:_content-type: PROCEDURE
+[id="update-preparing-ack_{context}"]
+= Providing the administrator acknowledgment
+
+After you have evaluated your cluster for any removed APIs and have migrated any removed APIs, you can acknowledge that your cluster is ready to upgrade from {product-title} 4.11 to 4.12.
+
+[WARNING]
+====
+Be aware that all responsibility falls on the administrator to ensure that all uses of removed APIs have been resolved and migrated as necessary before providing this administrator acknowledgment. {product-title} can assist with the evaluation, but cannot identify all possible uses of removed APIs, especially idle workloads or external tools.
+====
+
+.Prerequisites
+
+* You must have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+* Run the following command to acknowledge that you have completed the evaluation and your cluster is ready for the Kubernetes API removals in {product-title} 4.12:
++
+[source,terminal]
+----
+$ oc -n openshift-config patch cm admin-acks --patch '{"data":{"ack-4.11-kube-1.25-api-removals-in-4.12":"true"}}' --type=merge
+----

--- a/modules/update-preparing-evaluate-alerts.adoc
+++ b/modules/update-preparing-evaluate-alerts.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-cluster-prepare.adoc
+
+[id="update-preparing-evaluate-alerts_{context}"]
+= Reviewing alerts to identify uses of removed APIs
+
+Two alerts fire when an API is in use that will be removed in the next release:
+
+* `APIRemovedInNextReleaseInUse` - for APIs that will be removed in the next {product-title} release.
+* `APIRemovedInNextEUSReleaseInUse` - for APIs that will be removed in the next {product-title} Extended Update Support (EUS) release.
+
+If either of these alerts are firing in your cluster, review the alerts and take action to clear the alerts by migrating manifests and API clients to use the new API version.
+
+Use the `APIRequestCount` API to get more information about which APIs are in use and which workloads are using removed APIs, because the alerts do not provide this information. Additionally, some APIs might not trigger these alerts but are still captured by `APIRequestCount`. The alerts are tuned to be less sensitive to avoid alerting fatigue in production systems.

--- a/modules/update-preparing-evaluate-apirequestcount-workloads.adoc
+++ b/modules/update-preparing-evaluate-apirequestcount-workloads.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-cluster-prepare.adoc
+
+:_content-type: PROCEDURE
+[id="update-preparing-evaluate-apirequestcount-workloads_{context}"]
+= Using APIRequestCount to identify which workloads are using the removed APIs
+
+You can examine the `APIRequestCount` resource for a given API version to help identify which workloads are using the API.
+
+.Prerequisites
+
+* You must have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+* Run the following command and examine the `username` and `userAgent` fields to help identify the workloads that are using the API:
++
+[source,terminal]
+----
+$ oc get apirequestcounts <resource>.<version>.<group> -o yaml
+----
++
+For example:
++
+[source,terminal]
+----
+$ oc get apirequestcounts poddisruptionbudgets.v1beta1.policy -o yaml
+----
++
+You can also use `-o jsonpath` to extract the `username` and `userAgent` values from an `APIRequestCount` resource:
++
+[source,terminal]
+----
+$ oc get apirequestcounts poddisruptionbudgets.v1beta1.policy \
+  -o jsonpath='{range .status.currentHour..byUser[*]}{..byVerb[*].verb}{","}{.username}{","}{.userAgent}{"\n"}{end}' \
+  | sort -k 2 -t, -u | column -t -s, -NVERBS,USERNAME,USERAGENT
+----
++
+.Example output
+[source,terminal]
+----
+VERBS  USERNAME                                                                       USERAGENT
+watch  system:serviceaccount:openshift-operators:3scale-operator                      manager/v0.0.0
+watch  system:serviceaccount:openshift-operators:datadog-operator-controller-manager  manager/v0.0.0
+----

--- a/modules/update-preparing-evaluate-apirequestcount.adoc
+++ b/modules/update-preparing-evaluate-apirequestcount.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-cluster-prepare.adoc
+
+:_content-type: PROCEDURE
+[id="update-preparing-evaluate-apirequestcount_{context}"]
+= Using APIRequestCount to identify uses of removed APIs
+
+You can use the `APIRequestCount` API to track API requests and review whether any of them are using one of the removed APIs.
+
+.Prerequisites
+
+* You must have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+* Run the following command and examine the `REMOVEDINRELEASE` column of the output to identify the removed APIs that are currently in use:
++
+[source,terminal]
+----
+$ oc get apirequestcounts
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                                      REMOVEDINRELEASE   REQUESTSINCURRENTHOUR   REQUESTSINLAST24H
+...
+poddisruptionbudgets.v1.policy                                                               391                     8114
+poddisruptionbudgets.v1beta1.policy                                       1.25               2                       23
+podmonitors.v1.monitoring.coreos.com                                                         3                       70
+podnetworkconnectivitychecks.v1alpha1.controlplane.operator.openshift.io                     612                     11748
+pods.v1                                                                                      1531                    38634
+podsecuritypolicies.v1beta1.policy                                        1.25               3                       39
+podtemplates.v1                                                                              2                       79
+preprovisioningimages.v1alpha1.metal3.io                                                     2                       39
+priorityclasses.v1.scheduling.k8s.io                                                         12                      248
+prioritylevelconfigurations.v1beta1.flowcontrol.apiserver.k8s.io          1.26               3                       86
+...
+----
++
+[IMPORTANT]
+====
+You can safely ignore the following entries that appear in the results:
+
+* The `system:serviceaccount:kube-system:generic-garbage-collector` and the `system:serviceaccount:kube-system:namespace-controller` users might appear in the results because these services invoke all registered APIs when searching for resources to remove.
+* The `system:kube-controller-manager` and `system:cluster-policy-controller` users might appear in the results because they walk through all resources while enforcing various policies.
+====
++
+You can also use `-o jsonpath` to filter the results:
++
+[source,terminal]
+----
+$ oc get apirequestcounts -o jsonpath='{range .items[?(@.status.removedInRelease!="")]}{.status.removedInRelease}{"\t"}{.metadata.name}{"\n"}{end}'
+----
++
+.Example output
+[source,terminal]
+----
+1.26	flowschemas.v1beta1.flowcontrol.apiserver.k8s.io
+1.26	horizontalpodautoscalers.v2beta2.autoscaling
+1.25	poddisruptionbudgets.v1beta1.policy
+1.25	podsecuritypolicies.v1beta1.policy
+1.26	prioritylevelconfigurations.v1beta1.flowcontrol.apiserver.k8s.io
+----

--- a/modules/update-preparing-list.adoc
+++ b/modules/update-preparing-list.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-cluster-prepare.adoc
+
+[id="update-preparing-list_{context}"]
+= Removed Kubernetes APIs
+
+{product-title} 4.12 uses Kubernetes 1.25, which removed the following deprecated APIs. You must migrate manifests and API clients to use the appropriate API version. For more information about migrating removed APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25[Kubernetes documentation].
+
+.APIs removed from Kubernetes 1.25
+[cols="2,2,2,1",options="header",]
+|===
+|Resource |Removed API |Migrate to |Notable changes
+
+|`CronJob`
+|`batch/v1beta1`
+|`batch/v1`
+|No
+
+|`EndpointSlice`
+|`discovery.k8s.io/v1beta1`
+|`discovery.k8s.io/v1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#endpointslice-v125[Yes]
+
+|`Event`
+|`events.k8s.io/v1beta1`
+|`events.k8s.io/v1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#event-v125[Yes]
+
+|`HorizontalPodAutoscaler`
+|`autoscaling/v2beta1`
+|`autoscaling/v2`
+|No
+
+|`PodDisruptionBudget`
+|`policy/v1beta1`
+|`policy/v1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125[Yes]
+
+|`PodSecurityPolicy`
+|`policy/v1beta1`
+|link:https://kubernetes.io/docs/concepts/security/pod-security-admission/[Pod Security Admission] ^[1]^
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#psp-v125[Yes]
+
+|`RuntimeClass`
+|`node.k8s.io/v1beta1`
+|`node.k8s.io/v1`
+|No
+
+|===
+[.small]
+1. For more information about pod security admission in {product-title}, see _Understanding and managing pod security admission_.

--- a/modules/update-preparing-migrate.adoc
+++ b/modules/update-preparing-migrate.adoc
@@ -1,0 +1,8 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-cluster-prepare.adoc
+
+[id="update-preparing-migrate_{context}"]
+= Migrating instances of removed APIs
+
+For information about how to migrate removed Kubernetes APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25[Deprecated API Migration Guide] in the Kubernetes documentation.

--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -24,6 +24,7 @@ See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permis
 * If your cluster uses manually maintained credentials, ensure that the Cloud Credential Operator (CCO) is in an upgradeable state. For more information, see xref:../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Upgrading clusters with manually maintained credentials].
 * If your cluster uses manually maintained credentials with the AWS Secure Token Service (STS), obtain a copy of the `ccoctl` utility from the release image being updated to and use it to process any updated credentials. For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-upgrading[Upgrading an OpenShift Container Platform cluster configured for manual mode with STS].
 * Ensure that you address all `Upgradeable=False` conditions so the cluster allows an update to the next minor version. An alert displays at the top of the *Cluster Settings* page when you have one or more cluster Operators that cannot be upgraded. You can still update to the next available patch update for the minor release you are currently on.
+* Review the list of APIs that were removed in Kubernetes 1.25, migrate any affected components to use the new API version, and provide the administrator acknowledgment. For more information, see xref:../updating/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.12].
 
 [IMPORTANT]
 ====

--- a/updating/updating-cluster-prepare.adoc
+++ b/updating/updating-cluster-prepare.adoc
@@ -1,19 +1,24 @@
 :_content-type: ASSEMBLY
 [id="updating-cluster-prepare"]
-= Preparing to update to {product-title} 4.9
+= Preparing to update to {product-title} 4.12
 include::_attributes/common-attributes.adoc[]
 :context: updating-cluster-prepare
 
 toc::[]
 
-{product-title} 4.9 uses Kubernetes 1.22, which removed a significant number of deprecated `v1beta1` APIs.
+{product-title} 4.12 uses Kubernetes 1.25, which removed several deprecated APIs.
 
-{product-title} 4.8.14 introduced a requirement that an administrator must provide a manual acknowledgment before the cluster can be updated from {product-title} 4.8 to 4.9. This is to help prevent issues after upgrading to {product-title} 4.9, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this evaluation and migration is complete, the administrator can provide the acknowledgment.
+A cluster administrator must provide a manual acknowledgment before the cluster can be updated from {product-title} 4.11 to 4.12. This is to help prevent issues after upgrading to {product-title} 4.12, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this evaluation and migration is complete, the administrator can provide the acknowledgment.
 
-Before you can update your {product-title} 4.8 cluster to 4.9, you must provide the administrator acknowledgment.
+Before you can update your {product-title} 4.11 cluster to 4.12, you must provide the administrator acknowledgment.
 
 // Removed Kubernetes APIs
 include::modules/update-preparing-list.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
 
 [id="evaluating-cluster-removed-apis"]
 == Evaluating your cluster for removed APIs

--- a/updating/updating-cluster-within-minor.adoc
+++ b/updating/updating-cluster-within-minor.adoc
@@ -22,9 +22,10 @@ See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permis
 * Ensure all Operators previously installed through Operator Lifecycle Manager (OLM) are updated to their latest version in their latest channel. Updating the Operators ensures they have a valid update path when the default OperatorHub catalogs switch from the current minor version to the next during a cluster update. See xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Upgrading installed Operators] for more information.
 * Ensure that all machine config pools (MCPs) are running and not paused. Nodes associated with a paused MCP are skipped during the update process. You can pause the MCPs if you are performing a canary rollout update strategy.
 //remove this???^ or maybe just add another bullet that you can break up the update?
-* To accommodate the time it takes to update, you are able to do a partial update by updating the worker or custom pool nodes. You can pause and resume within the progress bar of each pool. 
+* To accommodate the time it takes to update, you are able to do a partial update by updating the worker or custom pool nodes. You can pause and resume within the progress bar of each pool.
 * If your cluster uses manually maintained credentials, ensure that the Cloud Credential Operator (CCO) is in an upgradeable state. For more information, see xref:../updating/updating-cluster-cli.adoc#manually-maintained-credentials-upgrade_updating-cluster-cli[Upgrading clusters with manually maintained credentials].
 * If your cluster uses manually maintained credentials with the AWS Secure Token Service (STS), obtain a copy of the `ccoctl` utility from the release image being updated to and use it to process any updated credentials. For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-upgrading[Upgrading an OpenShift Container Platform cluster configured for manual mode with STS].
+* Review the list of APIs that were removed in Kubernetes 1.25, migrate any affected components to use the new API version, and provide the administrator acknowledgment. For more information, see xref:../updating/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.12].
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-3574

Link to docs preview:
* OCP: https://51163--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-cluster-prepare.html
* OKD: http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3574/updating/updating-cluster-prepare.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
Note that the majority of this content was reviewed/added in 4.9. So it's not technically brand new content, but looks like it. The files were removed via https://github.com/openshift/openshift-docs/pull/40658/files because they weren't applicable for 4.10 or 4.11.
