### PR TITLE
OCPBUGS#1111 - Typo Fix

### DIFF
--- a/modules/nodes-pods-autoscaling-creating-cpu.adoc
+++ b/modules/nodes-pods-autoscaling-creating-cpu.adoc
@@ -59,7 +59,7 @@ Events:                <none>
 
 To create a horizontal pod autoscaler for CPU utilization:
 
-. Perform one of the following one of the following:
+. Perform one of the following:
 
 ** To scale based on the percent of CPU utilization, create a `HorizontalPodAutoscaler` object for an existing object:
 +


### PR DESCRIPTION
Versions: 4.6+

https://issues.redhat.com/browse/OCPBUGS-1111

Removes a typo where text is repeated in a single sentence.

Preview: https://51170--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling.html