### PR TITLE
GH #51114: Corrected template path for 4.10

### DIFF
--- a/modules/deployment-plug-in-cluster.adoc
+++ b/modules/deployment-plug-in-cluster.adoc
@@ -10,7 +10,7 @@ After pushing an image with your changes to a registry, you can deploy the plug-
 
 .Procedure
 
-. To deploy your plug-in to a cluster, instantiate the link:https://github.com/spadgett/console-plugin-template/blob/main/template.yaml[template] by running the following command:
+. To deploy your plug-in to a cluster, instantiate the link:https://github.com/spadgett/console-plugin-template/blob/release-4.10/template.yaml[template] by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Resolves https://github.com/openshift/openshift-docs/issues/51114

Version(s):
4.10 only

Link to docs preview:
http://file.rdu.redhat.com/~ahardin/August-2022/4-10-issue-51114/web_console/dynamic-plug-ins.html#deploy-on-cluster_dynamic-plugins