### PR TITLE
GH#49479: updated ACM doc link for 4.10

### DIFF
--- a/scalability_and_performance/ztp-deploying-disconnected.adoc
+++ b/scalability_and_performance/ztp-deploying-disconnected.adoc
@@ -61,7 +61,7 @@ include::modules/ztp-pgt-config-best-practices.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For details about best practice for scaling clusters with {rh-rhacm-first}, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.4/html/install/installing#performance-and-scalability[ACM performance and scalability considerations].
+* For details about best practice for scaling clusters with {rh-rhacm-first}, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/install/installing#performance-and-scalability[ACM performance and scalability considerations].
 
 [NOTE]
 ====


### PR DESCRIPTION
Addresses https://github.com/openshift/openshift-docs/issues/49479 for 4.10. 

Version(s):
4.10 only

Link to docs preview:
http://file.rdu.redhat.com/~ahardin/August-2022/4-10-Issue-49479/scalability_and_performance/ztp-deploying-disconnected.html#ztp-the-policygentemplate_ztp-deploying-disconnected