### PR TITLE
[SRVOCF-442] Move on-cluster function building to separate assembly; add the section on specifying which function to build

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3629,6 +3629,8 @@ Topics:
     File: serverless-functions-setup
   - Name: Getting started with functions
     File: serverless-functions-getting-started
+  - Name: On-cluster function building and deploying
+    File: serverless-functions-on-cluster-builds
   - Name: Developing Node.js functions
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions

--- a/modules/serverless-functions-creating-on-cluster-builds.adoc
+++ b/modules/serverless-functions-creating-on-cluster-builds.adoc
@@ -69,7 +69,7 @@ git:
 +
 [source,terminal]
 ----
-$ kn func deploy
+$ kn func deploy --remote
 ----
 +
 If you are not logged into the container registry referenced in your function configuration, you are prompted to provide credentials for the remote container registry that hosts the function image:
@@ -85,4 +85,4 @@ Please provide credentials for image registry used by Pipeline.
    Function deployed at URL: http://test-function.default.svc.cluster.local
 ----
 
-. To update your function, commit and push new changes by using Git, then run the `kn func deploy` command again.
+. To update your function, commit and push new changes by using Git, then run the `kn func deploy --remote` command again.

--- a/modules/serverless-functions-specifying-function-revision.adoc
+++ b/modules/serverless-functions-specifying-function-revision.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-on-cluster-builds.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-functions-specifying-function-revision_{context}"]
+= Specifying function revision
+
+When building and deploying a function on the cluster, you must specify the location of the function code by specifying the Git repository, branch, and subdirectory within the repository. You do not need to specify the branch if you use the `main` branch. Similarly, you do not need to specify the subdirectory if your function is at the root of the repository. You can specify these parameters in the `func.yaml` configuration file, or by using flags with the `kn func deploy` command.
+
+.Prerequisites
+
+* {pipelines-title} must be installed on your cluster.
+
+* You have installed the OpenShift (`oc`) CLI.
+
+* You have installed the Knative (`kn`) CLI.
+
+.Procedure
+
+* Deploy your function:
++
+[source,terminal]
+----
+$ kn func deploy --remote \ <1>
+                 --git-url <repo-url> \ <2>
+                 [--git-branch <branch>] \ <3>
+                 [--git-dir <function-dir>] <4>
+----
++
+--
+<1> With the `--remote` flag, the build runs remotely.
+<2> Substitute `<repo-url>` with the URL of the Git repository.
+<3> Substitute `<branch>` with the Git branch, tag, or commit. If using the latest commit on the `main` branch, you can skip this flag.
+<4> Substitute `<function-dir>` with the directory containing the function if it is different than the repository root directory.
+--
++
+For example:
++
+[source,terminal]
+----
+$ kn func deploy --remote \
+                 --git-url https://example.com/alice/myfunc.git \
+                 --git-branch my-feature \
+                 --git-dir functions/example-func/
+----

--- a/serverless/functions/serverless-functions-getting-started.adoc
+++ b/serverless/functions/serverless-functions-getting-started.adoc
@@ -19,7 +19,6 @@ Before you can complete the following procedures, you must ensure that you have 
 include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-kn-func-run.adoc[leveloffset=+1]
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
-include::modules/serverless-functions-on-cluster-builds.adoc[leveloffset=+1]
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-kn-func-invoke.adoc[leveloffset=+1]
 

--- a/serverless/functions/serverless-functions-on-cluster-builds.adoc
+++ b/serverless/functions/serverless-functions-on-cluster-builds.adoc
@@ -1,0 +1,12 @@
+:_content-type: ASSEMBLY
+[id="serverless-functions-on-cluster-builds"]
+= On-cluster function building and deploying
+:context: serverless-functions-on-cluster-builds
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+Instead of building a function locally, you can build a function directly on the cluster. When using this workflow on a local development machine, you only need to work with the function source code. This is useful, for example, when you cannot install on-cluster function building tools, such as docker or podman.
+
+include::modules/serverless-functions-creating-on-cluster-builds.adoc[leveloffset=+1]
+include::modules/serverless-functions-specifying-function-revision.adoc[leveloffset=+1]


### PR DESCRIPTION
[SRVOCF-442](https://issues.redhat.com//browse/SRVOCF-442)

Versions: 4.6 and 4.8+

Preview: https://51183--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-on-cluster-builds.html

Dev & QE reviews: complete