### PR TITLE
OSDOCS-3918: Adds release note for making status.HostIP for pods visible in console

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -65,6 +65,7 @@ For more information, see xref:../installing/installing-troubleshooting.adoc#ins
 * With this update, you can export your application in the ZIP file format to another project or cluster using the *Export application* option on the *+Add* page. 
 * With this update, you can create a Kafka event sink to receive events from a particular source and send them to a Kafka topic.
 * With this update, you can set the default resource preference in the *User Preferences* -> *Applications* page. In addition, you can select another resource type to be the default.
+* With this update, you can make the `status.HostIP` node IP address for pods visible in the *Details* tab of the *Pods* page.
 
 [id="ocp-4-12-helm-page-improvements"]
 ==== Helm page improvements


### PR DESCRIPTION
This PR adds a release note for making status.HostIP for pods visible in console. 

Version(s):
4.12 only

Issue:
[OSDOCS-3918](https://issues.redhat.com/browse/OSDOCS-3918)

Link to docs preview:
https://51185--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-developer-perspective

QE review:
- [x] QE has approved this change.


<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
