### PR TITLE
Adds import mode to images new features in the 4.12 release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -68,6 +68,21 @@ For more information, see xref:../installing/installing-troubleshooting.adoc#ins
 [id="ocp-4-12-ibm-power"]
 === IBM Power
 
+[id="ocp-4-12-images"]
+=== Images
+
+A new import value, `importMode`, has been added to the `importPolicy` parameter of image streams. The following fields are available for this value: 
+
+* `Legacy`: `Legacy` is the default value for `importMode`. When active, the manifest list is discarded, and a single sub-manifest is imported. The platform is chosen in the following order of priority: 
++
+. Tag annotations
+. Control plane architecture
+. Linux/AMD64
+. The first manifest in the list 
+
+* `PreserveOriginal`: When active, the original manifest is preserved. For manifest lists, the manifest list and all of its sub-manifests are imported. 
+
+
 [id="ocp-4-12-security"]
 === Security and compliance
 


### PR DESCRIPTION
Adds import mode to images new features in the 4.12 release notes

Version(s): 4.12 

Issue: https://issues.redhat.com/browse/OSDOCS-4279

Link to docs preview: https://51191--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-images

QE review:

Pending QE