### PR TITLE
OSDOCS-3574: Adding RNs for removed APIs and admin ack

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -49,7 +49,7 @@ This release adds improvements related to the following components and concepts.
 
 [id="ocp-4-12-aws-load-balancer-customization"]
 ==== Specify the load balancer type in AWS during installation
-Beginning with {product-title} {product-version}, you can specify either Network Load Balancer (NLB) or Classic as a persistent load balancer type in AWS during installation. Afterwards, if an Ingress Controller is deleted, the load balancer type persists with the lbType configured during installation. 
+Beginning with {product-title} {product-version}, you can specify either Network Load Balancer (NLB) or Classic as a persistent load balancer type in AWS during installation. Afterwards, if an Ingress Controller is deleted, the load balancer type persists with the lbType configured during installation.
 
 For more information, see xref:../installing/installing_aws/installing-aws-network-customizations.adoc[Installing a cluster on AWS with network customizations].
 
@@ -58,6 +58,17 @@ For more information, see xref:../installing/installing_aws/installing-aws-netwo
 The installer now gathers serial console logs from the bootstrap and control plane hosts on GCP and Azure. This log data is added to the standard bootstrap log bundle.
 
 For more information, see xref:../installing/installing-troubleshooting.adoc#installation-bootstrap-gather_installing-troubleshooting[Troubleshooting installation issues].
+
+[id="ocp-4-12-admin-ack-upgrading"]
+==== Required administrator acknowledgment when upgrading from {product-title} 4.11 to 4.12
+
+{product-title} 4.12 uses Kubernetes 1.25, which removed xref:../release_notes/ocp-4-12-release-notes.adoc#ocp-4-12-removed-kube-1-25-apis[several deprecated APIs].
+
+A cluster administrator must provide a manual acknowledgment before the cluster can be upgraded from {product-title} 4.11 to 4.12. This is to help prevent issues after upgrading to {product-title} 4.12, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this is done, the administrator can provide the administrator acknowledgment.
+
+All {product-title} 4.11 clusters require this administrator acknowledgment before they can be upgraded to {product-title} 4.12.
+
+For more information, see xref:../updating/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.12].
 
 [id="ocp-4-12-post-installation"]
 === Post-installation configuration
@@ -214,7 +225,7 @@ For more information, see xref:../networking/hardware_networks/about-sriov.adoc#
 === Nodes
 
 [id="ocp-4-12-node-cgroups-v2"]
-==== Linux Control Group version 2 promoted to Techology Preview
+==== Linux Control Group version 2 promoted to Technology Preview
 
 {product-title} support for link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux Control Group version 2] (cgroup v2) has been promoted to Technology Preview. cgroup v2 is the next version of the kernel link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/resource_management_guide/ch01[control groups]. cgroups v2 offers multiple improvements, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation. For more information, see xref:../nodes/clusters/nodes-cluster-cgroups-2.adoc#nodes-cluster-cgroups-2[Enabling Linux Control Group version 2 (cgroup v2)].
 
@@ -367,6 +378,55 @@ Red Hat Virtualization (RHV) will be deprecated in an upcoming release of {produ
 
 [id="ocp-4-12-removed-features"]
 === Removed features
+
+[id="ocp-4-12-removed-kube-1-25-apis"]
+==== Beta APIs removed from Kubernetes 1.25
+
+Kubernetes 1.25 removed the following deprecated APIs, so you must migrate manifests and API clients to use the appropriate API version. For more information about migrating removed APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25[Kubernetes documentation].
+
+.APIs removed from Kubernetes 1.25
+[cols="2,2,2,1",options="header",]
+|===
+|Resource |Removed API |Migrate to |Notable changes
+
+|`CronJob`
+|`batch/v1beta1`
+|`batch/v1`
+|No
+
+|`EndpointSlice`
+|`discovery.k8s.io/v1beta1`
+|`discovery.k8s.io/v1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#endpointslice-v125[Yes]
+
+|`Event`
+|`events.k8s.io/v1beta1`
+|`events.k8s.io/v1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#event-v125[Yes]
+
+|`HorizontalPodAutoscaler`
+|`autoscaling/v2beta1`
+|`autoscaling/v2`
+|No
+
+|`PodDisruptionBudget`
+|`policy/v1beta1`
+|`policy/v1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125[Yes]
+
+|`PodSecurityPolicy`
+|`policy/v1beta1`
+|link:https://kubernetes.io/docs/concepts/security/pod-security-admission/[Pod Security Admission] ^[1]^
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#psp-v125[Yes]
+
+|`RuntimeClass`
+|`node.k8s.io/v1beta1`
+|`node.k8s.io/v1`
+|No
+
+|===
+[.small]
+1. For more information about pod security admission in {product-title}, see xref:../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission].
 
 [id="ocp-4-12-future-removals"]
 === Future Kubernetes API removals


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-3573

Link to docs preview:
* http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3574-rn/release_notes/ocp-4-12-release-notes.html#ocp-4-9-admin-ack-upgrading
* http://file.rdu.redhat.com/~ahoffer/2022/OSDOCS-3574-rn/release_notes/ocp-4-12-release-notes.html#ocp-4-12-removed-kube-1-25-apis

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
**The Travis check failure is expected. It will pass once PR #51163 merges.**
