### PR TITLE
OCPBUGS#1872 - replacing backticks with doublequotes

### DIFF
--- a/modules/installation-gcp-user-infra-rhcos.adoc
+++ b/modules/installation-gcp-user-infra-rhcos.adoc
@@ -48,7 +48,7 @@ $ gsutil cp <downloaded_image_file_path>/rhcos-<version>-x86_64-gcp.x86_64.tar.g
 +
 [source,terminal]
 ----
-$ export IMAGE_SOURCE=`gs://<bucket_name>/rhcos-<version>-x86_64-gcp.x86_64.tar.gz`
+$ export IMAGE_SOURCE="gs://<bucket_name>/rhcos-<version>-x86_64-gcp.x86_64.tar.gz"
 ----
 
 . Create the cluster image:


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-1872

Version(s):
4.6+

Link to docs preview:
https://51220--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-gcp-user-infra-rhcos_installing-gcp-user-infra

QE review:
- [x] QE has approved this change.
