### PR TITLE
GH#50899: fixing ipi bare metal link

### DIFF
--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -125,4 +125,4 @@ $ sudo virsh pool-autostart default
 $ vim pull-secret.txt
 ----
 +
-In a web browser, navigate to link:https://console.redhat.com/openshift/install/metal/user-provisioned[Install on Bare Metal with user-provisioned infrastructure]. Click **Copy pull secret**. Paste the contents into the `pull-secret.txt` file and save the contents in the `kni` user's home directory.
+In a web browser, navigate to link:https://console.redhat.com/openshift/install/metal/installer-provisioned[Install OpenShift on Bare Metal with installer-provisioned infrastructure]. Click **Copy pull secret**. Paste the contents into the `pull-secret.txt` file and save the contents in the `kni` user's home directory.


### PR DESCRIPTION
Fixes #50899

Version(s):
4.6+

Link to docs preview:
https://51228--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#preparing-the-provisioner-node-for-openshift-install_ipi-install-installation-workflow