### PR TITLE
[OSDOCS-4283] changed step from 3 to 5 business days

### DIFF
--- a/modules/policy-incident.adoc
+++ b/modules/policy-incident.adoc
@@ -25,7 +25,7 @@ The general workflow of how a new incident is managed by Red Hat:
 . After the initial investigation, the incident is assigned an incident lead, who coordinates the recovery efforts.
 . The incident lead manages all communication and coordination around recovery, including any relevant notifications or support case updates.
 . The incident is recovered.
-. The incident is documented and a root cause analysis is performed within 3 business days of the incident.
+. The incident is documented and a root cause analysis is performed within 5 business days of the incident.
 . A root cause analysis (RCA) draft document is shared with the customer within 7 business days of the incident.
 
 [id="notifications_{context}"]

--- a/modules/rosa-policy-incident.adoc
+++ b/modules/rosa-policy-incident.adoc
@@ -25,7 +25,7 @@ When managing a new incident, Red Hat uses the following general workflow:
 . After the initial investigation, the incident is assigned an incident lead, who coordinates the recovery efforts.
 . An incident lead manages all communication and coordination around recovery, including any relevant notifications and support case updates.
 . The incident is recovered.
-. The incident is documented and a root cause analysis (RCA) is performed within 3 business days of the incident.
+. The incident is documented and a root cause analysis (RCA) is performed within 5 business days of the incident.
 . An RCA draft document will be shared with the customer within 7 business days of the incident.
 
 [id="rosa-policy-notifications_{context}"]


### PR DESCRIPTION
[OSDOCS-4283] changed step from 3 to 5 business days

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.11+

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
https://issues.redhat.com/browse/OSDOCS-4283

Link to docs preview:
https://51235--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/policy-process-security.html#incident-management_policy-process-security

https://51235--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.html#rosa-policy-incident-management_rosa-policy-process-security

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
