### PR TITLE
RHDEVDOCS-4349-fix-incorrect-info-about-alertmanger-instances

### DIFF
--- a/modules/monitoring-configuring-persistent-storage.adoc
+++ b/modules/monitoring-configuring-persistent-storage.adoc
@@ -13,7 +13,7 @@ Running cluster monitoring with persistent storage means that your metrics are s
 
 * Dedicate sufficient local persistent storage to ensure that the disk does not become full. How much storage you need depends on the number of pods.
 
-* Make sure you have a persistent volume (PV) ready to be claimed by the persistent volume claim (PVC), one PV for each replica. Because Prometheus has two replicas and Alertmanager has three replicas, you need five PVs to support the entire monitoring stack. The PVs should be available from the Local Storage Operator. This does not apply if you enable dynamically provisioned storage.
+* Verify that you have a persistent volume (PV) ready to be claimed by the persistent volume claim (PVC), one PV for each replica. Because Prometheus and Alertmanager both have two replicas, you need four PVs to support the entire monitoring stack. The PVs are available from the Local Storage Operator, but not if you have enabled dynamically provisioned storage.
 
 * Use the block type of storage.
 


### PR DESCRIPTION
Summary: This PR fixes an issue where we incorrectly list the number of Alertmanager replicas in OCP 4.10+.

- Aligned team: DevTools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4349
- Direct link to doc preview (requires RH VPN access): http://file.rdu.redhat.com/bburt/RHDEVDOCS-4349-fix-incorrect-info-about-alertmanger-instances/monitoring/configuring-the-monitoring-stack.html#persistent-storage-prerequisites
- SME review: n/a
- QE review: @juzhao 
- Peer review: @ tbd