### PR TITLE
Osdocs 3859

### DIFF
--- a/modules/rosa-sdpolicy-am-aws-compute-types.adoc
+++ b/modules/rosa-sdpolicy-am-aws-compute-types.adoc
@@ -3,14 +3,15 @@
 //
 // * assemblies/rosa-service-definition.adoc
 :_content-type: CONCEPT
-[id="rosa-sdpolicy-aws-compute-types_{context}"]
-= AWS compute types
+[id="rosa-sdpolicy-aws-instance-types_{context}"]
+= AWS instance types
 
-{product-title} offers the following worker node types and sizes:
+{product-title} offers the following worker node instance types and sizes:
 
-.General purpose compute types
+.General purpose
 [%collapsible]
 ====
+- m5.metal (96&#8224; vCPU, 384 GiB) 
 - m5.xlarge (4 vCPU, 16 GiB)
 - m5.2xlarge (8 vCPU, 32 GiB)
 - m5.4xlarge (16 vCPU, 64 GiB)
@@ -18,6 +19,21 @@
 - m5.12xlarge (48 vCPU, 192 GiB)
 - m5.16xlarge (64 vCPU, 256 GiB)
 - m5.24xlarge (96 vCPU, 384 GiB)
+- m5a.xlarge (4 vCPU, 16 GiB)
+- m5a.2xlarge (8 vCPU, 32 GiB)
+- m5a.4xlarge (16 vCPU, 64 GiB)
+- m5a.8xlarge (32 vCPU, 128 GiB)
+- m5a.12xlarge (48 vCPU, 192 GiB)
+- m5a.16xlarge (64 vCPU, 256 GiB)
+- m5a.24xlarge (96 vCPU, 384 GiB)
+- m5ad.xlarge (4 vCPU, 16 GiB)
+- m5ad.2xlarge (8 vCPU, 32 GiB)
+- m5ad.4xlarge (16 vCPU, 64 GiB)
+- m5ad.8xlarge (32 vCPU, 128 GiB)
+- m5ad.12xlarge (48 vCPU, 192 GiB)
+- m5ad.16xlarge (64 vCPU, 256 GiB)
+- m5ad.24xlarge (96 vCPU, 384 GiB)
+- m5d.metal (96&#8224; vCPU, 384 GiB)
 - m5d.xlarge (4 vCPU, 16 GiB)
 - m5d.2xlarge (8 vCPU, 32 GiB)
 - m5d.4xlarge (16 vCPU, 64 GiB)
@@ -25,6 +41,7 @@
 - m5d.12xlarge (48 vCPU, 192 GiB)
 - m5d.16xlarge (64 vCPU, 256 GiB)
 - m5d.24xlarge (96 vCPU, 384 GiB)
+- m5n.metal (96 vCPU, 384 GiB)
 - m5n.xlarge (4 vCPU, 16 GiB)
 - m5n.2xlarge (8 vCPU, 32 GiB)
 - m5n.4xlarge (16 vCPU, 64 GiB)
@@ -32,6 +49,7 @@
 - m5n.12xlarge (48 vCPU, 192 GiB)
 - m5n.16xlarge (64 vCPU, 256 GiB)
 - m5n.24xlarge (96 vCPU, 384 GiB)
+- m5dn.metal (96 vCPU, 384 GiB)
 - m5dn.xlarge (4 vCPU, 16 GiB)
 - m5dn.2xlarge (8 vCPU, 32 GiB)
 - m5dn.4xlarge (16 vCPU, 64 GiB)
@@ -39,11 +57,13 @@
 - m5dn.12xlarge (48 vCPU, 192 GiB)
 - m5dn.16xlarge (64 vCPU, 256 GiB)
 - m5dn.24xlarge (96 vCPU, 384 GiB)
+- m5zn.metal (48 vCPU, 192 GiB)
 - m5zn.xlarge (4 vCPU, 16 GiB)
 - m5zn.2xlarge (8 vCPU, 32 GiB)
 - m5zn.3xlarge (12 vCPU, 48 GiB)
 - m5zn.6xlarge (24 vCPU, 96 GiB)
 - m5zn.12xlarge (48 vCPU, 192 GiB)
+- m6i.metal (128 vCPU, 512 GiB)
 - m6i.xlarge (4 vCPU, 16 GiB)
 - m6i.2xlarge (8 vCPU, 32 GiB)
 - m6i.4xlarge (16 vCPU, 64 GiB)
@@ -52,9 +72,11 @@
 - m6i.16xlarge (64 vCPU, 256 GiB)
 - m6i.24xlarge (96 vCPU, 384 GiB)
 - m6i.32xlarge (128 vCPU, 512 GiB)
+
+&#8224; These instance types provide 96 logical processors on 48 physical cores. They run on single servers with two physical Intel sockets. 
 ====
 
-.Burstable general purpose compute types
+.Burstable general purpose
 [%collapsible]
 ====
 - t3.xlarge (4 vCPU, 16 GiB)
@@ -63,7 +85,7 @@
 - t3a.2xlarge (8 vCPU, 32 GiB)
 ====
 
-.Memory-optimized compute types
+.Memory-optimized
 [%collapsible]
 ====
 - r4.xlarge (4 vCPU, 30.5 GiB)
@@ -71,6 +93,7 @@
 - r4.4xlarge (16 vCPU, 122 GiB)
 - r4.8xlarge (32 vCPU, 244 GiB)
 - r4.16xlarge (64 vCPU, 488 GiB)
+- r5.metal (96&#8224;  vCPU, 768 GiB)
 - r5.xlarge (4 vCPU, 32 GiB)
 - r5.2xlarge (8 vCPU, 64 GiB)
 - r5.4xlarge (16 vCPU, 128 GiB)
@@ -92,6 +115,7 @@
 - r5ad.12xlarge (48 vCPU, 384 GiB)
 - r5ad.16xlarge (64 vCPU, 512 GiB)
 - r5ad.24xlarge (96 vCPU, 768 GiB)
+- r5d.metal (96&#8224;  vCPU, 768 GiB)
 - r5d.xlarge (4 vCPU, 32 GiB)
 - r5d.2xlarge (8 vCPU, 64 GiB)
 - r5d.4xlarge (16 vCPU, 128 GiB)
@@ -99,6 +123,7 @@
 - r5d.12xlarge (48 vCPU, 384 GiB)
 - r5d.16xlarge (64 vCPU, 512 GiB)
 - r5d.24xlarge (96 vCPU, 768 GiB)
+- r5n.metal (96 vCPU, 768 GiB)
 - r5n.xlarge (4 vCPU, 32 GiB)
 - r5n.2xlarge (8 vCPU, 64 GiB)
 - r5n.4xlarge (16 vCPU, 128 GiB)
@@ -106,6 +131,7 @@
 - r5n.12xlarge (48 vCPU, 384 GiB)
 - r5n.16xlarge (64 vCPU, 512 GiB)
 - r5n.24xlarge (96 vCPU, 768 GiB)
+- r5dn.metal (96 vCPU, 768 GiB)
 - r5dn.xlarge (4 vCPU, 32 GiB)
 - r5dn.2xlarge (8 vCPU, 64 GiB)
 - r5dn.4xlarge (16 vCPU, 128 GiB)
@@ -113,6 +139,7 @@
 - r5dn.12xlarge (48 vCPU, 384 GiB)
 - r5dn.16xlarge (64 vCPU, 512 GiB)
 - r5dn.24xlarge (96 vCPU, 768 GiB)
+- r6i.metal (128 vCPU, 1,024 GiB)
 - r6i.xlarge (4 vCPU, 32 GiB)
 - r6i.2xlarge (8 vCPU, 64 GiB)
 - r6i.4xlarge (16 vCPU, 128 GiB)
@@ -121,16 +148,23 @@
 - r6i.16xlarge (64 vCPU, 512 GiB)
 - r6i.24xlarge (96 vCPU, 768 GiB)
 - r6i.32xlarge (128 vCPU, 1,024 GiB)
+- x2iezn.metal (48 vCPU, 1,536 GiB)
+- z1d.metal (48&#135; vCPU, 384 GiB)
 - z1d.xlarge (4 vCPU, 32 GiB)
 - z1d.2xlarge (8 vCPU, 64 GiB)
 - z1d.3xlarge (12 vCPU, 96 GiB)
 - z1d.6xlarge (24 vCPU, 192 GiB)
 - z1d.12xlarge (48 vCPU, 384 GiB)
+
+&#8224; These instance types provide 96 logical processors on 48 physical cores. They run on single servers with two physical Intel sockets.
+
+&#135; This instance type provides 48 logical processors on 24 physical cores.
 ====
 
-.Compute-optimized compute types
+.Compute-optimized
 [%collapsible]
 ====
+- c5.metal (96 vCPU, 192 GiB)
 - c5.xlarge (4 vCPU, 8 GiB)
 - c5.2xlarge (8 vCPU, 16 GiB)
 - c5.4xlarge (16 vCPU, 32 GiB)
@@ -138,6 +172,7 @@
 - c5.12xlarge (48 vCPU, 96 GiB)
 - c5.18xlarge (72 vCPU, 144 GiB)
 - c5.24xlarge (96 vCPU, 192 GiB)
+- c5d.metal (96 vCPU, 192 GiB)
 - c5d.xlarge (4 vCPU, 8 GiB)
 - c5d.2xlarge (8 vCPU, 16 GiB)
 - c5d.4xlarge (16 vCPU, 32 GiB)
@@ -159,11 +194,13 @@
 - c5ad.12xlarge (48 vCPU, 96 GiB)
 - c5ad.16xlarge (64 vCPU, 128 GiB)
 - c5ad.24xlarge (96 vCPU, 192 GiB)
+- c5n.metal (72 vCPU, 192 GiB)
 - c5n.xlarge (4 vCPU, 10.5 GiB)
 - c5n.2xlarge (8 vCPU, 21 GiB)
 - c5n.4xlarge (16 vCPU, 42 GiB)
 - c5n.9xlarge (36 vCPU, 96 GiB)
 - c5n.18xlarge (72 vCPU, 192 GiB)
+- c6i.metal (128 vCPU, 256 GiB)
 - c6i.xlarge (4 vCPU, 8 GiB)
 - c6i.2xlarge (8 vCPU, 16 GiB)
 - c6i.4xlarge (16 vCPU, 32 GiB)
@@ -174,18 +211,26 @@
 - c6i.32xlarge (128 vCPU, 256 GiB)
 ====
 
-.Storage-optimized compute types
+.Storage-optimized
 [%collapsible]
 ====
+- i3.metal (72&#8224; vCPU, 512 GiB)
 - i3.xlarge	(4 vCPU, 30.5 GiB)
 - i3.2xlarge (8 vCPU, 61 GiB)
 - i3.4xlarge (16 vCPU, 122 GiB)
 - i3.8xlarge (32 vCPU, 244 GiB)
 - i3.16xlarge (64 vCPU, 488 GiB)
+- i3en.metal (96 vCPU, 768 GiB)
 - i3en.xlarge (4 vCPU, 32 GiB)
 - i3en.2xlarge (8 vCPU, 64 GiB)
 - i3en.3xlarge (12 vCPU, 96 GiB)
 - i3en.6xlarge (24 vCPU, 192 GiB)
 - i3en.12xlarge (48 vCPU, 384 GiB)
 - i3en.24xlarge (96 vCPU, 768 GiB)
+
+&#8224; This instance type provides 72 logical processors on 36 physical cores.
+====
+[NOTE]
+====
+Virtual instance types initialize faster than ".metal" instance types.
 ====

--- a/modules/rosa-sdpolicy-am-compute.adoc
+++ b/modules/rosa-sdpolicy-am-compute.adoc
@@ -3,8 +3,8 @@
 //
 // * assemblies/rosa-service-definition.adoc
 :_content-type: CONCEPT
-[id="rosa-sdpolicy-compute_{context}"]
-= Compute
+[id="rosa-sdpolicy-instance-types_{context}"]
+= Instance types
 
 Single availability zone clusters require a minimum of 3 control planes, 2 infrastructure nodes, and 2 worker nodes deployed to a single availability zone.
 

--- a/modules/rosa-sdpolicy-networking.adoc
+++ b/modules/rosa-sdpolicy-networking.adoc
@@ -22,7 +22,7 @@ To use a custom hostname for a route, you must update your DNS provider by creat
 {product-title} supports the use of custom certificate authorities to be trusted by builds when pulling images from an image registry.
 
 [id="rosa-sdpolicy-load-balancers_{context}"]
-== Load Balancers
+== Load balancers
 {product-title} uses up to five different load balancers:
 
 - An internal control plane load balancer that is internal to the cluster and used to balance traffic for internal cluster communications.

--- a/modules/sdpolicy-am-aws-compute-types-ccs.adoc
+++ b/modules/sdpolicy-am-aws-compute-types-ccs.adoc
@@ -3,14 +3,15 @@
 //
 // * assemblies/osd-service-definition.adoc
 :_content-type: CONCEPT
-[id="aws-compute-types-ccs_{context}"]
-= AWS compute types for Customer Cloud Subscription clusters
+[id="aws-instance-types-ccs_{context}"]
+= AWS instance types for Customer Cloud Subscription clusters
 
-{product-title} offers the following worker node types and sizes on AWS:
+{product-title} offers the following worker node instance types and sizes on AWS:
 
 .General purpose
 [%collapsible]
 ====
+- m5.metal (96&#8224;  vCPU, 384 GiB)
 - m5.xlarge (4 vCPU, 16 GiB)
 - m5.2xlarge (8 vCPU, 32 GiB)
 - m5.4xlarge (16 vCPU, 64 GiB)
@@ -18,6 +19,21 @@
 - m5.12xlarge (48 vCPU, 192 GiB)
 - m5.16xlarge (64 vCPU, 256 GiB)
 - m5.24xlarge (96 vCPU, 384 GiB)
+- m5a.xlarge (4 vCPU, 16 GiB)
+- m5a.2xlarge (8 vCPU, 32 GiB)
+- m5a.4xlarge (16 vCPU, 64 GiB)
+- m5a.8xlarge (32 vCPU, 128 GiB)
+- m5a.12xlarge (48 vCPU, 192 GiB)
+- m5a.16xlarge (64 vCPU, 256 GiB)
+- m5a.24xlarge (96 vCPU, 384 GiB)
+- m5ad.xlarge (4 vCPU, 16 GiB)
+- m5ad.2xlarge (8 vCPU, 32 GiB)
+- m5ad.4xlarge (16 vCPU, 64 GiB)
+- m5ad.8xlarge (32 vCPU, 128 GiB)
+- m5ad.12xlarge (48 vCPU, 192 GiB)
+- m5ad.16xlarge (64 vCPU, 256 GiB)
+- m5ad.24xlarge (96 vCPU, 384 GiB)
+- m5d.metal (96&#8224;  vCPU, 384 GiB)
 - m5d.xlarge (4 vCPU, 16 GiB)
 - m5d.2xlarge (8 vCPU, 32 GiB)
 - m5d.4xlarge (16 vCPU, 64 GiB)
@@ -25,6 +41,7 @@
 - m5d.12xlarge (48 vCPU, 192 GiB)
 - m5d.16xlarge (64 vCPU, 256 GiB)
 - m5d.24xlarge (96 vCPU, 384 GiB)
+- m5n.metal (96 vCPU, 384 GiB)
 - m5n.xlarge (4 vCPU, 16 GiB)
 - m5n.2xlarge (8 vCPU, 32 GiB)
 - m5n.4xlarge (16 vCPU, 64 GiB)
@@ -32,6 +49,7 @@
 - m5n.12xlarge (48 vCPU, 192 GiB)
 - m5n.16xlarge (64 vCPU, 256 GiB)
 - m5n.24xlarge (96 vCPU, 384 GiB)
+- m5dn.metal (96 vCPU, 384 GiB)
 - m5dn.xlarge (4 vCPU, 16 GiB)
 - m5dn.2xlarge (8 vCPU, 32 GiB)
 - m5dn.4xlarge (16 vCPU, 64 GiB)
@@ -39,11 +57,13 @@
 - m5dn.12xlarge (48 vCPU, 192 GiB)
 - m5dn.16xlarge (64 vCPU, 256 GiB)
 - m5dn.24xlarge (96 vCPU, 384 GiB)
+- m5zn.metal (48 vCPU, 192 GiB)
 - m5zn.xlarge (4 vCPU, 16 GiB)
 - m5zn.2xlarge (8 vCPU, 32 GiB)
 - m5zn.3xlarge (12 vCPU, 48 GiB)
 - m5zn.6xlarge (24 vCPU, 96 GiB)
 - m5zn.12xlarge (48 vCPU, 192 GiB)
+- m6i.metal (128 vCPU, 512 GiB)
 - m6i.xlarge (4 vCPU, 16 GiB)
 - m6i.2xlarge (8 vCPU, 32 GiB)
 - m6i.4xlarge (16 vCPU, 64 GiB)
@@ -52,9 +72,11 @@
 - m6i.16xlarge (64 vCPU, 256 GiB)
 - m6i.24xlarge (96 vCPU, 384 GiB)
 - m6i.32xlarge (128 vCPU, 512 GiB)
+
+&#8224; These instance types provide 96 logical processors on 48 physical cores. They run on single servers with two physical Intel sockets. 
 ====
 
-.Burstable general purpose compute types
+.Burstable general purpose
 [%collapsible]
 ====
 - t3.xlarge (4 vCPU, 16 GiB)
@@ -71,6 +93,7 @@
 - r4.4xlarge (16 vCPU, 122 GiB)
 - r4.8xlarge (32 vCPU, 244 GiB)
 - r4.16xlarge (64 vCPU, 488 GiB)
+- r5.metal (96&#8224; vCPU, 768 GiB)
 - r5.xlarge (4 vCPU, 32 GiB)
 - r5.2xlarge (8 vCPU, 64 GiB)
 - r5.4xlarge (16 vCPU, 128 GiB)
@@ -92,6 +115,7 @@
 - r5ad.12xlarge (48 vCPU, 384 GiB)
 - r5ad.16xlarge (64 vCPU, 512 GiB)
 - r5ad.24xlarge (96 vCPU, 768 GiB)
+- r5d.metal (96&#8224; vCPU, 768 GiB)
 - r5d.xlarge (4 vCPU, 32 GiB)
 - r5d.2xlarge (8 vCPU, 64 GiB)
 - r5d.4xlarge (16 vCPU, 128 GiB)
@@ -99,6 +123,7 @@
 - r5d.12xlarge (48 vCPU, 384 GiB)
 - r5d.16xlarge (64 vCPU, 512 GiB)
 - r5d.24xlarge (96 vCPU, 768 GiB)
+- r5n.metal (96 vCPU, 768 GiB)
 - r5n.xlarge (4 vCPU, 32 GiB)
 - r5n.2xlarge (8 vCPU, 64 GiB)
 - r5n.4xlarge (16 vCPU, 128 GiB)
@@ -106,6 +131,7 @@
 - r5n.12xlarge (48 vCPU, 384 GiB)
 - r5n.16xlarge (64 vCPU, 512 GiB)
 - r5n.24xlarge (96 vCPU, 768 GiB)
+- r5dn.metal (96 vCPU, 768 GiB)
 - r5dn.xlarge (4 vCPU, 32 GiB)
 - r5dn.2xlarge (8 vCPU, 64 GiB)
 - r5dn.4xlarge (16 vCPU, 128 GiB)
@@ -113,6 +139,7 @@
 - r5dn.12xlarge (48 vCPU, 384 GiB)
 - r5dn.16xlarge (64 vCPU, 512 GiB)
 - r5dn.24xlarge (96 vCPU, 768 GiB)
+- r6i.metal (128 vCPU, 1,024 GiB)
 - r6i.xlarge (4 vCPU, 32 GiB)
 - r6i.2xlarge (8 vCPU, 64 GiB)
 - r6i.4xlarge (16 vCPU, 128 GiB)
@@ -121,16 +148,23 @@
 - r6i.16xlarge (64 vCPU, 512 GiB)
 - r6i.24xlarge (96 vCPU, 768 GiB)
 - r6i.32xlarge (128 vCPU, 1,024 GiB)
+- x2iezn.metal (48 vCPU, 1,536 GiB)
+- z1d.metal (48&#135; vCPU, 384 GiB)
 - z1d.xlarge (4 vCPU, 32 GiB)
 - z1d.2xlarge (8 vCPU, 64 GiB)
 - z1d.3xlarge (12 vCPU, 96 GiB)
 - z1d.6xlarge (24 vCPU, 192 GiB)
 - z1d.12xlarge (48 vCPU, 384 GiB)
+
+&#8224; These instance types provide 96 logical processors on 48 physical cores. They run on single servers with two physical Intel sockets.
+
+&#135; This instance type provides 48 logical processors on 24 physical cores.
 ====
 
 .Compute-optimized
 [%collapsible]
 ====
+- c5.metal (96 vCPU, 192 GiB)
 - c5.xlarge (4 vCPU, 8 GiB)
 - c5.2xlarge (8 vCPU, 16 GiB)
 - c5.4xlarge (16 vCPU, 32 GiB)
@@ -138,6 +172,7 @@
 - c5.12xlarge (48 vCPU, 96 GiB)
 - c5.18xlarge (72 vCPU, 144 GiB)
 - c5.24xlarge (96 vCPU, 192 GiB)
+- c5d.metal (96 vCPU, 192 GiB)
 - c5d.xlarge (4 vCPU, 8 GiB)
 - c5d.2xlarge (8 vCPU, 16 GiB)
 - c5d.4xlarge (16 vCPU, 32 GiB)
@@ -159,11 +194,13 @@
 - c5ad.12xlarge (48 vCPU, 96 GiB)
 - c5ad.16xlarge (64 vCPU, 128 GiB)
 - c5ad.24xlarge (96 vCPU, 192 GiB)
+- c5n.metal (72 vCPU, 192 GiB)
 - c5n.xlarge (4 vCPU, 10.5 GiB)
 - c5n.2xlarge (8 vCPU, 21 GiB)
 - c5n.4xlarge (16 vCPU, 42 GiB)
 - c5n.9xlarge (36 vCPU, 96 GiB)
 - c5n.18xlarge (72 vCPU, 192 GiB)
+- c6i.metal (128 vCPU, 256 GiB)
 - c6i.xlarge (4 vCPU, 8 GiB)
 - c6i.2xlarge (8 vCPU, 16 GiB)
 - c6i.4xlarge (16 vCPU, 32 GiB)
@@ -174,18 +211,27 @@
 - c6i.32xlarge (128 vCPU, 256 GiB)
 ====
 
-.Storage-optimized compute types
+.Storage-optimized
 [%collapsible]
 ====
+- i3.metal (72&#8224; vCPU, 512 GiB)
 - i3.xlarge	(4 vCPU, 30.5 GiB)
 - i3.2xlarge (8 vCPU, 61 GiB)
 - i3.4xlarge (16 vCPU, 122 GiB)
 - i3.8xlarge (32 vCPU, 244 GiB)
 - i3.16xlarge (64 vCPU, 488 GiB)
+- i3en.metal (96 vCPU, 768 GiB)
 - i3en.xlarge (4 vCPU, 32 GiB)
 - i3en.2xlarge (8 vCPU, 64 GiB)
 - i3en.3xlarge (12 vCPU, 96 GiB)
 - i3en.6xlarge (24 vCPU, 192 GiB)
 - i3en.12xlarge (48 vCPU, 384 GiB)
 - i3en.24xlarge (96 vCPU, 768 GiB)
+
+&#8224; This instance type provides 72 logical processors on 36 physical cores.
+====
+
+[NOTE]
+====
+Virtual instance types initialize faster than ".metal" instance types.
 ====

--- a/modules/sdpolicy-am-aws-compute-types-non-ccs.adoc
+++ b/modules/sdpolicy-am-aws-compute-types-non-ccs.adoc
@@ -3,8 +3,8 @@
 //
 // * assemblies/osd-service-definition.adoc
 :_content-type: CONCEPT
-[id="aws-compute-types-non-ccs_{context}"]
-= AWS compute types for standard clusters
+[id="aws-instance-types-non-ccs_{context}"]
+= AWS instance types for standard clusters
 
 {product-title} offers the following worker node types and sizes on AWS:
 

--- a/modules/sdpolicy-am-compute.adoc
+++ b/modules/sdpolicy-am-compute.adoc
@@ -3,8 +3,8 @@
 //
 // * assemblies/osd-service-definition.adoc
 :_content-type: CONCEPT
-[id="compute_{context}"]
-= Compute
+[id="instance-types_{context}"]
+= Instance types
 
 Single availability zone clusters require a minimum of 2 worker nodes for Customer Cloud Subscription (CCS) clusters deployed to a single availability zone. A minimum of 4 worker nodes is required for standard clusters. These 4 worker nodes are included in the base subscription.
 

--- a/osd_architecture/osd_policy/osd-service-definition.adoc
+++ b/osd_architecture/osd_policy/osd-service-definition.adoc
@@ -17,6 +17,11 @@ include::snippets/pid-limits.adoc[]
 * xref:../../osd_architecture/osd_policy/osd-service-definition.adoc#sdpolicy-red-hat-operator_osd-service-definition[Red Hat Operator Support]
 
 include::modules/sdpolicy-am-aws-compute-types-ccs.adoc[leveloffset=+2]
+[role="_additional-resources-instance-types"]
+.Additional Resources
+
+* link:https://aws.amazon.com/ec2/instance-types[AWS Instance Types]
+
 include::modules/sdpolicy-am-aws-compute-types-non-ccs.adoc[leveloffset=+2]
 include::modules/sdpolicy-am-gcp-compute-types.adoc[leveloffset=+2]
 include::modules/sdpolicy-am-regions-availability-zones.adoc[leveloffset=+2]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
@@ -21,6 +21,11 @@ include::snippets/pid-limits.adoc[]
 * xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-red-hat-operator_rosa-service-definition[Red Hat Operator Support]
 
 include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+2]
+[role="_additional-resources-instance-types"]
+.Additional Resources
+
+* link:https://aws.amazon.com/ec2/instance-types[AWS Instance Types]
+
 include::modules/rosa-sdpolicy-am-regions-az.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-sla.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-limited-support.adoc[leveloffset=+2]


### PR DESCRIPTION
Added .metal and other AWS instance types to ROSA and OSD-CCS. Changed "compute types" to "instance types" to match AWS. Also added footnotes for special instance types, and added links to AWS under additional resources.

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-3859
https://issues.redhat.com/browse/OSDOCS-3902


Link to docs preview:
<b>ROSA:</b>
1. Changed "Compute types" to "instance types": https://51260--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-instance-types_rosa-service-definition
2. Added instance types, footnotes, and link to additional information: https://51260--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-aws-instance-types_rosa-service-definition

<b>OSD:</b>
1. Changed "Compute types" to "instance types": https://51260--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#instance-types_osd-service-definition
2. Added instance types, footnotes, and link to additional information: https://51260--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#aws-instance-types-ccs_osd-service-definition

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
