### PR TITLE
OCPBUGS-2032: Typo in Telco RAN 4.11.6 RNs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2643,7 +2643,7 @@ For {sno}, you can use the {cgu-operator-first} Operator to create a backup of a
 For more information, see xref:../scalability_and_performance/cnf-talm-for-cluster-upgrades.html#talo-backup-feature-concept_cnf-topology-aware-lifecycle-manager[Creating a backup of cluster resources before upgrade].
 
 [id="ocp-4-11-RAN-disabling-chronyd"]
-=====  Disable chronyd in the `PolicyGenTemplate` custome resource (CR)
+=====  Disable chronyd in the `PolicyGenTemplate` custom resource (CR)
 
 You must disable `chronyd` if you update to {product-title} 4.11 from earlier versions. To disable `chronyd`, add the following line in the `[service]` section under `.spec.profile.data` of the `TunedPerformancePatch.yaml` file. The `TunedPerformancePatch.yaml` file is referenced in the group `PolicyGenTemplate` CR:
 


### PR DESCRIPTION
Fixes a typo in the 4.11.5 Telco RAN release notes


Version(s):
4.11 only

Issue:
[OCPBUGS-2032](https://issues.redhat.com/browse/OCPBUGS-2032)

Link to docs preview:
https://51267--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-RAN-disabling-chronyd

QE review:
- [ ] QE has approved this change.
QE review not needed for typo fix


<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
