### PR TITLE
BZ-2093477: Updated IBM Cloud to IBM Cloud VPC

### DIFF
--- a/modules/supported-platforms-for-openshift-clusters.adoc
+++ b/modules/supported-platforms-for-openshift-clusters.adoc
@@ -13,9 +13,9 @@ In {product-title} {product-version}, you can install a cluster that uses instal
 * Google Cloud Platform (GCP)
 * Microsoft Azure
 * Microsoft Azure Stack Hub
-* {rh-openstack-first} versions 16.1 and 16.2 
+* {rh-openstack-first} versions 16.1 and 16.2
 ** The latest {product-title} release supports both the latest {rh-openstack} long-life release and intermediate release. For complete {rh-openstack} release compatibility, see the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
-* IBM Cloud
+* IBM Cloud VPC
 * {rh-virtualization-first}
 * VMware vSphere
 * VMware Cloud (VMC) on AWS


### PR DESCRIPTION
Version(s):
4.10

Issue:
This issue addresses [bz-2093477](https://bugzilla.redhat.com/show_bug.cgi?id=2093477)

Link to docs preview:
[Supported platforms for OpenShift Container Platform clusters](http://file.rdu.redhat.com/mpytlak/bz-2093477/installing/index.html#supported-platforms-for-openshift-clusters_ocp-installation-overview)

QE review:
Not required.

Additional information:

- This work is a continuation of https://github.com/openshift/openshift-docs/pull/46545, which is the primary PR for this update in 4.10 and 4.11 
- The incorrect reference to IBM Cloud was missed in the latter PR for this specific module; and was subsequently fixed in 4.11+ as part of https://github.com/openshift/openshift-docs/pull/44537
- This PR corrects the reference in this module in 4.10.