### PR TITLE
GH#51266 - Fixing OCM attribute for Dedicated

### DIFF
--- a/modules/sdpolicy-am-cluster-self-service.adoc
+++ b/modules/sdpolicy-am-cluster-self-service.adoc
@@ -6,6 +6,6 @@
 [id="cluster-self-service_{context}"]
 = Cluster self-service
 
-Customers can create, scale, and delete their clusters from {cluster-manage-url}, provided that they have pre-purchased the necessary subscriptions.
+Customers can create, scale, and delete their clusters from {cluster-manager-url}, provided that they have already purchased the necessary subscriptions.
 
 Actions available in {cluster-manager-first} must not be directly performed from within the cluster as this might cause adverse affects, including having all actions automatically reverted.


### PR DESCRIPTION
This applies to `main`, `enterprise-4.12` and `enterprise-4.11`.

The PR resolves the attribute issue described in https://github.com/openshift/openshift-docs/issues/51266.

The preview link is https://51278--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#cluster-self-service_osd-service-definition.