### PR TITLE
WIP - Adding Vale rule set for Modular docs/Jupiter readiness guidelines

### DIFF
--- a/modules/.vale.ini
+++ b/modules/.vale.ini
@@ -1,4 +1,4 @@
-StylesPath = .vale/styles
+StylesPath = ../.vale/styles
 
 MinAlertLevel = suggestion
 
@@ -7,7 +7,7 @@ https://github.com/rohennes/ocp-rules/releases/latest/download/OpenShiftAsciiDoc
 
 #ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
 [[!.]*.adoc]
-BasedOnStyles = RedHat
+BasedOnStyles = RedHat, OpenShiftAsciiDocValidation
 
 #optional: pass doc attributes to asciidoctor before linting
 #[asciidoctor]


### PR DESCRIPTION
Description: 
Adding Vale rules to check raw AsciiDoc to ensure we follow the [Modular docs guidelines](https://redhat-documentation.github.io/modular-docs/), or [Jupiter readiness guidelines](https://docs.engineering.redhat.com/pages/viewpage.action?spaceKey=JUP&title=Jupiter+Source+files+readiness+Checklist). 

Version(s):
TBD

Source for rule set:
https://github.com/rohennes/ocp-rules

List of potential rules (brainstorming doc):
https://docs.google.com/document/d/1xawRkloLUDj0cz3hlbMxTYIFBK31jMbF6X54U3MPGGY/edit#heading=h.wle8qlzbafpu