### PR TITLE
Update worker latency profile docs

### DIFF
--- a/modules/nodes-cluster-worker-latency-profiles-about.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-about.adoc
@@ -24,6 +24,12 @@ All worker latency profiles configure the following parameters:
 Manually modifying the `node-monitor-grace-period` parameter is not supported.
 ====
 
+The following Operators monitor the changes to the worker latency profiles and respond accordingly:
+
+* The Machine Config Operator (MCO) updates the `node-status-frequency` parameter on the worker nodes.
+* The Kubernetes API Server Operator updates the `node-monitor-grace-period` parameter on the control plane nodes.
+* The Kubernetes Controller Manager Operator updates the `default-not-ready-toleration-seconds` and `default-unreachable-toleration-seconds` parameters on the control plance nodes. 
+
 While the default configuration works in most cases, {product-title} offers two other worker latency profiles for situations where the network is experiencing higher latency than usual. The three worker latency profiles are described in the following sections:
 
 Default worker latency profile:: With the `Default` profile, each kubelet reports its node status to the Kubelet Controller Manager Operator (kube controller) every 10 seconds. The Kubelet Controller Manager Operator checks the kubelet for a status every 5 seconds. 

--- a/nodes/clusters/nodes-cluster-worker-latency-profiles.adoc
+++ b/nodes/clusters/nodes-cluster-worker-latency-profiles.adoc
@@ -16,8 +16,6 @@ toc::[]
 
 include::snippets/worker-latency-profile-intro.adoc[]
 
-These worker latency profiles are three sets of parameters that are pre-defined with carefully tuned values that control the reaction of the cluster to latency issues  without needing to determine the best values manually.  
-
 You can configure worker latency profiles when installing a cluster or at any time you notice increased latency in your cluster network.
 
 include::modules/nodes-cluster-worker-latency-profiles-about.adoc[leveloffset=+1]


### PR DESCRIPTION
Updating the worker latency profile docs with information in https://github.com/sairameshv/docs/tree/main/workerLatencyProfiles

Preview: [Understanding worker latency profiles](https://51280--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-worker-latency-profiles.html#nodes-cluster-worker-latency-profiles-about_nodes-cluster-worker-latency-profiles) the list aafter the Important note