### PR TITLE
BZ2105682 Updated Image prune conditions list

### DIFF
--- a/modules/pruning-images-manual.adoc
+++ b/modules/pruning-images-manual.adoc
@@ -188,6 +188,9 @@ You can apply conditions to your manually pruned images.
 *** Replica sets
 *** Build configurations
 *** Builds
+*** Jobs
+*** Cronjobs
+*** Statefulsets
 *** `--keep-tag-revisions` most recent items in `stream.status.tags[].items`
 ** That are exceeding the smallest limit defined in the same project and are not currently referenced by any:
 *** Running pods
@@ -198,6 +201,9 @@ You can apply conditions to your manually pruned images.
 *** Replica sets
 *** Build configurations
 *** Builds
+*** Jobs
+*** Cronjobs
+*** Statefulsets
 * There is no support for pruning from external registries.
 * When an image is pruned, all references to the image are removed from all
 image streams that have a reference to the image in `status.tags`.


### PR DESCRIPTION
**BZ2105682**
Updated Image prune conditions list

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

**Version(s):**
PR applies to 4.8+ 

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

**Issue:**
https://bugzilla.redhat.com/show_bug.cgi?id=2105682

**Link to docs preview:**
https://51285--docspreview.netlify.app/openshift-enterprise/latest/applications/pruning-objects.html#pruning-images-conditions_pruning-objects

QE @jitendar-singh  review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

**Additional information:**
N/A

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
