### PR TITLE
GH#50581 - Fixing wording in yaml

### DIFF
--- a/modules/eco-configuring-machine-health-check-with-poison-pill.adoc
+++ b/modules/eco-configuring-machine-health-check-with-poison-pill.adoc
@@ -66,7 +66,7 @@ spec:
   remediationTemplate: <1>
     kind: PoisonPillRemediationTemplate
     apiVersion: poison-pill.medik8s.io/v1alpha1
-    name: <poison-pill-remediation-template-sample>
+    name: poisonpillremediationtemplate-sample
 ----
 <1> Specify the details for the remediation template.
 +


### PR DESCRIPTION
For version 4.10 
Fixes issue: #50581

Preview: [Remediating nodes with the Poison Pill Operator -> Configuring machine health checks to use the Poison Pill Operator](https://kelbrown20.github.io/bug-fix-previews/GH50581-fix-wording-in-nodes/nodes/nodes/eco-poison-pill-operator.html#configuring-machine-health-check-with-poison-pill_poison-pill-operator-remediate-nodes)