### PR TITLE
[OCPBUGS-2846]: etcd members can be scaled up and down in a cluster

### DIFF
--- a/modules/vertical-scaling-etcd-members.adoc
+++ b/modules/vertical-scaling-etcd-members.adoc
@@ -6,7 +6,7 @@
 [id="vertical-scaling-etcd-members_{context}"]
 = Vertical scaling etcd cluster members
 
-The Controller machine API manages vertical scaling in the etcd cluster, maintaining quorum stability, and preventing data loss and cluster unavailability.
+The Controller machine API manages vertical scaling in the etcd cluster. The Controller protects the cluster quorum by ensuring learners are in the ‘Ready but not running’ state for scaling up and scaling down by removing members that are pending deletion.
 
 Scale up an etcd cluster by adding a member, which becomes a non-voting member called a _learner_. The _learner_ is promoted to a voting member only when it receives a complete snapshot from the leader.
 

--- a/modules/vertical-scaling-etcd-members.adoc
+++ b/modules/vertical-scaling-etcd-members.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/recommended-host-practices.adoc
+
+:_content-type: CONCEPT
+[id="vertical-scaling-etcd-members_{context}"]
+= Vertical scaling etcd cluster members
+
+Vertical scaling adds and removes etcd members in a cluster. This process maintains the quorum stability and prevents data loss and cluster unavailability.
+
+Scale up an etcd cluster by adding a member, which becomes a non-voting member called a _learner_. The _learner_ is promoted to a voting member only when it receives a complete snapshot from the leader.
+
+Scale down an etcd cluster by removing an active member, which is scheduled for removal. The member is only removed when a replacement member is available. This action protects the etcd quorum and the cluster operation is maintained.

--- a/modules/vertical-scaling-etcd-members.adoc
+++ b/modules/vertical-scaling-etcd-members.adoc
@@ -6,7 +6,7 @@
 [id="vertical-scaling-etcd-members_{context}"]
 = Vertical scaling etcd cluster members
 
-Vertical scaling adds and removes etcd members in a cluster. This process maintains the quorum stability and prevents data loss and cluster unavailability.
+The Controller machine API manages vertical scaling in the etcd cluster, maintaining quorum stability, and preventing data loss and cluster unavailability.
 
 Scale up an etcd cluster by adding a member, which becomes a non-voting member called a _learner_. The _learner_ is promoted to a voting member only when it receives a complete snapshot from the leader.
 

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -21,6 +21,12 @@ include::modules/modify-unavailable-workers.adoc[leveloffset=+1]
 
 include::modules/master-node-sizing.adoc[leveloffset=+1]
 
+include::modules/vertical-scaling-etcd-members.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-unhealthy-member[Replacing an unhealthy etcd member]
+
 include::modules/increasing-aws-flavor-size.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -31,7 +37,7 @@ include::modules/recommended-etcd-practices.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/solutions/4885641[How to use `fio` to check etcd disk performance in {product-title}] 
+* link:https://access.redhat.com/solutions/4885641[How to use `fio` to check etcd disk performance in {product-title}]
 
 include::modules/etcd-defrag.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OCPBUGS-2846](https://issues.redhat.com/browse/OCPBUGS-2846)

Version(s): 4.11+

Link to docs preview: http://file.rdu.redhat.com/tlove/etcd-updated-3805-vertical-scale/scalability_and_performance/recommended-host-practices.html#vertical-scaling-etcd-members_recommended-host-practices  (Updated 11/14)

- [x ] QE review: @geliu2016 
- [ ]  SME/submitter review: @oarribas 

Additional information:
This task was originally in [OSDOCS-3805](https://issues.redhat.com/browse/OSDOCS-3805), and that JIRA was closed. 

