### PR TITLE
Fix asciidoc list rendering bug #50556

### DIFF
--- a/modules/nw-sriov-configuring-device.adoc
+++ b/modules/nw-sriov-configuring-device.adoc
@@ -36,9 +36,8 @@ It might take several minutes for a configuration change to apply.
 .Procedure
 
 . Create an `SriovNetworkNodePolicy` object, and then save the YAML in the `<name>-sriov-node-network.yaml` file. Replace `<name>` with the name for this configuration.
-
 ifdef::virt-sriov[]
-// The list breaks because of the [NOTE]
++
 [source,yaml]
 ----
 apiVersion: sriovnetwork.openshift.io/v1
@@ -89,7 +88,6 @@ endif::virt-sriov[]
 
 . Optional: Label the SR-IOV capable cluster nodes with `SriovNetworkNodePolicy.Spec.NodeSelector` if they are not already labeled. For more information about labeling nodes, see "Understanding how to update labels on nodes".
 
-[start=2]
 . Create the `SriovNetworkNodePolicy` object:
 +
 [source,terminal]


### PR DESCRIPTION
Fixes #50556

Previews: 
* https://51301--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.html#nw-sriov-configuring-device_virt-configuring-sriov-device-for-vms
* https://docs.openshift.com/container-platform/4.11/networking/hardware_networks/configuring-sriov-device.html#nw-sriov-configuring-device_configuring-sriov-device

The module has ifdefs and is used in two places

Merge to main, CP to enterprise-4.8+
