### PR TITLE
docs: asciidoctor link fix.

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -245,7 +245,7 @@ Use only one level 1 heading (`=`) in any file.
 
 If you have a section heading that you do not want to appear in the TOC (like if you think that some section is not worth showing up or if there are already too many nested levels), you can use a discrete (or floating) heading:
 
-http://asciidoctor.org/docs/user-manual/#discrete-or-floating-section-titles
+https://docs.asciidoctor.org/asciidoc/latest/blocks/discrete-headings/
 
 A discrete heading also will not get a section number in the Customer Portal build of the doc. Previously, we would use plain bold mark-up around a heading like this, but discrete headings also allow you to ignore section nesting rules (like jumping from a `==` section level to a `====` level if you wanted for some style reason).
 


### PR DESCRIPTION
Old link was redirecting to the root of the new documentation.
