### PR TITLE
Adds important admonition and note to disconnected installations when…

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -174,6 +174,11 @@ $ oc image mirror -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mir
 ----
 +
 <1> For `REMOVABLE_MEDIA_PATH`, you must use the same path that you specified when you mirrored the images.
++
+[IMPORTANT]
+====
+Running `oc image mirror` might result in the following error: `error: unable to retrieve source image`. This error occurs when image indexes include references to images that no longer exist on the image registry. Image indexes might retain older references to allow users running those images an upgrade path to newer points on the upgrade graph. As a temporary workaround, you can use the `--skip-missing` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed]. 
+====
 
 ** If the local container registry is connected to the mirror host, take the following actions:
 ... Directly push the release images to the local registry by using following command:

--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/disconnected_install/installing-mirroring-installation-images.adoc
 
+:_content-type: CONCEPT
 [id="olm-mirror-catalog_{context}"]
 = Mirroring Operator catalogs for use with disconnected clusters
 
@@ -9,7 +10,8 @@ You can mirror the Operator contents of a Red Hat-provided catalog, or a custom 
 
 [IMPORTANT]
 ====
-The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+* The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+* Running `oc adm catalog mirror` might result in the following error: `error: unable to retrieve source image`. This error occurs when image indexes include references to images that no longer exist on the image registry. Image indexes might retain older references to allow users running those images an upgrade path to newer points on the upgrade graph. As a temporary workaround, you can use the `--skip-missing` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed]. 
 ====
 
 The `oc adm catalog mirror` command also automatically mirrors the index image that is specified during the mirroring process, whether it be a Red Hat-provided index image or your own custom-built index image, to the target registry. You can then use the mirrored index image to create a catalog source that allows Operator Lifecycle Manager (OLM) to load the mirrored catalog onto your {product-title} cluster.


### PR DESCRIPTION
Adds important admonition and note to disconnected installations when using oc adm catalog and oc image mirror commands

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-3907

Link to docs preview:

- https://51305--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-installation-images.html#olm-mirror-catalog_installing-mirroring-installation-images
- https://51305--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-installation-images.html#installation-mirror-repository_installing-mirroring-installation-images

Change management acks: 
QE: Ying Zhou
DPM: Kathryn Alexander 
PM: Daniel Messer
SME: Filip Brychta
PE: Eric Rich

Associated pull requests for Release Note changes and admonitions: 

4.12: https://github.com/openshift/openshift-docs/pull/51308
4.11: https://github.com/openshift/openshift-docs/pull/51309
4.10: https://github.com/openshift/openshift-docs/pull/51311


