### PR TITLE
Adds known issue to 4.12 regarding image indexes and oc adm catalog a…

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -715,6 +715,9 @@ This script removes unauthenticated subjects from the following cluster role bin
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 
+* Due to the inclusion of old images in some image indexes, running `oc adm catalog mirror` and `oc image mirror` might result in the following error: `error: unable to retrieve source image`. As a temporary workaround, you can use the `--skip-missing` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed]. 
+
+
 [id="ocp-4-12-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Adds known issue to 4.12 regarding image indexes and oc adm catalognd oc image mirror commands

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-3907

Link to docs preview:
https://51308--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-known-issues

QE review:
Acks received at https://github.com/openshift/openshift-docs/pull/51305


Additional information:
Part of https://github.com/openshift/openshift-docs/pull/51305/
