### PR TITLE
Adds known issue to 4.11 regarding image indexes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2459,6 +2459,9 @@ openshift.io/scc: hostmount-anyuid
 * There is currently a known issue when creating and editing `egressqos` with incorrect syntax or values success. The incorrect values in `egressqos` should not create successfully. There is currently no workaround for this issue.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097579[*BZ#2097579*])
 
+* Due to the inclusion of old images in some image indexes, running `oc adm catalog mirror` and `oc image mirror` might result in the following error: `error: unable to retrieve source image`. As a temporary workaround, you can use the `--skip-missing` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed]. 
+
+
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Adds known issue to 4.11 regarding image indexes and oc adm catalognd oc image mirror commands

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-3907

Link to docs preview: 
https://51309--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-known-issues

QE review:
Acks received at https://github.com/openshift/openshift-docs/pull/51305

Additional information:
Part of https://github.com/openshift/openshift-docs/pull/51305