### PR TITLE
[RHACS] Fix image versions for patch

### DIFF
--- a/release_notes/370-release-notes.adoc
+++ b/release_notes/370-release-notes.adoc
@@ -211,18 +211,18 @@ Release date: 2 June 2022
 | Main
 | Includes Central, Sensor, Admission Controller, and Compliance.
 Also includes `roxctl` for use in continuous integration (CI) systems.
-| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.70.1`
+| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.70.2`
 
 | Scanner
 | Scans images and nodes.
-| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:3.70.1`
+| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:3.70.2`
 
 | Scanner DB
 | Stores image scan results and vulnerability definitions.
-| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:3.70.1`
+| `registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:3.70.2`
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.
-| `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:3.70`
-  `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.70.1`
+a| - `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:3.70.2` +
+  - `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:3.70.2`
 |===


### PR DESCRIPTION
Version(s):

`rhacs-docs-3.72`

Issue: none

[Link to docs preview](https://openshift-docs-8vzhs19il-kcarmichael08.vercel.app/openshift-acs/master/release_notes/370-release-notes.html#image-versions-370)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change. *N/A*
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Forgot to update the image versions for 3.70.2.