### PR TITLE
Adds known issue for oc adm catalog and oc image mirror command

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2621,6 +2621,9 @@ and recreate it without a BFD profile. (link:https://bugzilla.redhat.com/show_bu
 
 * The {op-system} kernel experiences a soft lockup and eventually panics due to a bug in the Netfilter module. A fix is planned to resolve this issue in a future z-stream release of {product-title}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2061445[*BZ#2061445*])
 
+* Due to the inclusion of old images in some image indexes, running `oc adm catalog mirror` and `oc image mirror` might result in the following error: `error: unable to retrieve source image`. As a temporary workaround, you can use the `--skip-missing` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed]. 
+
+
 [id="ocp-4-10-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Adds known issue to 4.10 regarding image indexes and oc adm catalog oc image mirror commands

Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OSDOCS-3907

Link to docs preview:
https://stevsmit.github.io/openshift-docs/ocp-4-10-release-notes.html#ocp-4-10-known-issues

QE review:
Acks received at https://github.com/openshift/openshift-docs/pull/51305

Additional information:
Part of https://github.com/openshift/openshift-docs/pull/51305