### PR TITLE
Adds known issue to 4.9 release notes

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -178,6 +178,11 @@ $ oc image mirror -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mir
 ----
 +
 <1> For `REMOVABLE_MEDIA_PATH`, you must use the same path that you specified when you mirrored the images.
++
+[IMPORTANT]
+====
+Due to the inclusion of old images in some image indexes, running `oc image mirror` might result in the following error: `error: unable to retrieve source image`. As a temporary workaround, you can use the `--continue-on-error` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed]. 
+====
 
 ** If the local container registry is connected to the mirror host, take the following actions:
 ... Directly push the release images to the local registry by using following command:

--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -9,7 +9,8 @@ You can mirror the Operator contents of a Red Hat-provided catalog, or a custom 
 
 [IMPORTANT]
 ====
-The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+* The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+* Due to the inclusion of old images in some image indexes, running `oc adm catalog mirror` might result in the following error: `error: unable to retrieve source image`. As a temporary workaround, you can use the `--continue-on-error` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed].
 ====
 
 The `oc adm catalog mirror` command also automatically mirrors the index image that is specified during the mirroring process, whether it be a Red Hat-provided index image or your own custom-built index image, to the target registry. You can then use the mirrored index image to create a catalog source that allows Operator Lifecycle Manager (OLM) to load the mirrored catalog onto your {product-title} cluster.

--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2144,6 +2144,9 @@ As a workaround, cluster administrators can delete the `catalog-operator` pod in
 
 * The flag that is used to hide or show the *Storage* -> *Overview* page in the {product-title} web console is misconfigured. As a result, the overview page is not visible after deploying a cluster that includes OpenShift Cluster Storage. This is planned to be fixed in a later release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2013132[*BZ#2013132*])
 
+* Due to the inclusion of old images in some image indexes, running `oc adm catalog mirror` and `oc image mirror` might result in the following error: `error: unable to retrieve source image`. As a temporary workaround, you can use the `--continue-on-error` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed]. 
+
+
 [id="ocp-4-9-devdocs-3418"]
 * In {product-title} 4.6 and later, image references for a pull must specify the following Red Hat registries:
 +


### PR DESCRIPTION
Adds known issue to 4.9 regarding image indexes and oc adm catalog oc image mirror commands

Version(s):
4.9

Issue:
https://issues.redhat.com/browse/OSDOCS-3907

Link to docs preview:
https://stevsmit.github.io/openshift-docs/installing-mirroring-installation-images.html
https://stevsmit.github.io/openshift-docs/olm-restricted-networks.html#olm-mirror-catalog_olm-restricted-networks
https://stevsmit.github.io/openshift-docs/ocp-4-9-release-notes.html#ocp-4-9-known-issues


QE review:
Pending QE

Additional information:
Part of https://github.com/openshift/openshift-docs/pull/51305