### PR TITLE
Osdocs390748

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -178,6 +178,11 @@ $ oc image mirror -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mir
 ----
 +
 <1> For `REMOVABLE_MEDIA_PATH`, you must use the same path that you specified when you mirrored the images.
++
+[IMPORTANT]
+====
+Due to the inclusion of old images in some image indexes, running `oc image mirror` might result in the following error: `error: unable to retrieve source image`. As a temporary workaround, you can use the `--continue-on-error` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed]. 
+====
 
 ** If the local container registry is connected to the mirror host, take the following actions:
 ... Directly push the release images to the local registry by using following command:

--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -21,7 +21,8 @@ You can mirror the Operator content of a Red Hat-provided catalog, or a custom c
 
 [IMPORTANT]
 ====
-The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+* The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+* Due to the inclusion of old images in some image indexes, running `oc adm catalog mirror` might result in the following error: `error: unable to retrieve source image`. As a temporary workaround, you can use the `--continue-on-error` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed].
 ====
 
 The `oc adm catalog mirror` command also automatically mirrors the index image that is specified during the mirroring process, whether it be a Red Hat-provided index image or your own custom-built index image, to the target registry. You can then use the mirrored index image to create a catalog source that allows Operator Lifecycle Manager (OLM) to load the mirrored catalog onto your {product-title} cluster.

--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2514,6 +2514,9 @@ $ oc annotate -n <NAMESPACE> route/<ROUTE-NAME> "haproxy.router.openshift.io/bal
 
 * If the images for {op-system} and the Machine Config Operator (MCO) do not change during an upgrade from an {product-title} 4.8.z release to a later 4.8.z release, the upgrade is marked as complete before the control plane nodes have finished upgrading. Following this, the upgrade might fail if you perform operations on your cluster before the upgrade is actually complete. As a workaround, verify that updates are completed on the control plane nodes before performing additional operations on the cluster. You can use the `oc get mcp/master` command to review the status of the MCO-managed nodes that are available on your cluster for each pool. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2025396[*BZ#2025396*])
 
+* Due to the inclusion of old images in some image indexes, running `oc adm catalog mirror` and `oc image mirror` might result in the following error: `error: unable to retrieve source image`. As a temporary workaround, you can use the `--continue-on-error` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed]. 
+
+
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Adds known issue to 4.8 regarding image indexes and oc adm catalog oc image mirror commands

Version(s):
4.8

Issue:
https://issues.redhat.com/browse/OSDOCS-3907

Link to docs preview:
https://stevsmit.github.io/openshift-docs/ocp-4-8-release-notes.html#ocp-4-8-known-issues
https://stevsmit.github.io/openshift-docs/installing-mirroring-installation-images48.html
https://stevsmit.github.io/openshift-docs/olm-restricted-networks.html#olm-mirror-catalog_olm-restricted-networks

QE review:
Pending QE

Additional information:
Part of https://github.com/openshift/openshift-docs/pull/51305