### PR TITLE
OSDOCS-4296: Adding information on user-defined alerting

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -138,6 +138,8 @@ Topics:
       File: osd-accessing-monitoring-for-user-defined-projects
     - Name: Configuring the monitoring stack
       File: osd-configuring-the-monitoring-stack
+    - Name: Enabling alert routing for user-defined projects
+      File: osd-enabling-alert-routing-for-user-defined-projects
     - Name: Managing metrics
       File: osd-managing-metrics
     - Name: Managing alerts

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -230,6 +230,8 @@ Topics:
     File: rosa-accessing-monitoring-for-user-defined-projects
   - Name: Configuring the monitoring stack
     File: rosa-configuring-the-monitoring-stack
+  - Name: Enabling alert routing for user-defined projects
+    File: rosa-enabling-alert-routing-for-user-defined-projects
   - Name: Managing metrics
     File: rosa-managing-metrics
   - Name: Managing alerts

--- a/modules/monitoring-applying-a-custom-configuration-to-alertmanager-for-user-defined-alert-routing.adoc
+++ b/modules/monitoring-applying-a-custom-configuration-to-alertmanager-for-user-defined-alert-routing.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * monitoring/managing-alerts.adoc
+// * monitoring/osd-managing-alerts.adoc
+// * osd_cluster_admin/osd_monitoring/osd-managing-alerts.adoc
+// * rosa_cluster_admin/rosa_monitoring/rosa-managing-alerts.adoc
 
 :_content-type: PROCEDURE
 [id="applying-a-custom-configuration-to-alertmanager-for-user-defined-alert-routing_{context}"]
@@ -10,7 +13,12 @@ If you have enabled a separate instance of Alertmanager dedicated to user-define
 
 .Prerequisites
 
+ifdef::openshift-rosa,openshift-dedicated[]
+* You have access to the cluster as a user with the `cluster-admin` or `dedicated-admin` role.
+endif::[]
+ifndef::openshift-rosa,openshift-dedicated[]
 * You have access to the cluster as a user with the `cluster-admin` role.
+endif::[]
 
 .Procedure
 

--- a/modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc
+++ b/modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc
@@ -1,17 +1,30 @@
 // Module included in the following assemblies:
 //
 // * monitoring/enabling-alert-routing-for-user-defined-projects.adoc
+// * monitoring/osd-enabling-alert-routing-for-user-defined-projects.adoc
+// * osd_cluster_admin/osd_monitoring/osd-enabling-alert-routing-for-user-defined-projects.adoc
+// * rosa_cluster_admin/rosa_monitoring/rosa-enabling-alert-routing-for-user-defined-projects.adoc
 
 :_content-type: PROCEDURE
 [id="enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing_{context}"]
 = Enabling a separate Alertmanager instance for user-defined alert routing
 
+ifndef::openshift-rosa,openshift-dedicated[]
 In some clusters, you might want to deploy a dedicated Alertmanager instance for user-defined projects, which can help reduce the load on the default platform Alertmanager instance and can better separate user-defined alerts from default platform alerts.
-In these cases, you can optionally enable a separate instance of Alertmanager to send alerts only for user-defined projects.
+endif::[]
+ifdef::openshift-rosa,openshift-dedicated[]
+In {product-title}, you may want to deploy a dedicated Alertmanager instance for user-defined projects, which provides user-defined alerts separate from default platform alerts.
+endif::[]
+In these cases, you can optionally enable a separate instance of Alertmanager to send alerts for user-defined projects only.
 
 .Prerequisites
 
+ifdef::openshift-rosa,openshift-dedicated[]
+* You have access to the cluster as a user with the `cluster-admin` or `dedicated-admin` role.
+endif::[]
+ifndef::openshift-rosa,openshift-dedicated[]
 * You have access to the cluster as a user with the `cluster-admin` role.
+endif::[]
 * You have enabled monitoring for user-defined projects in the `cluster-monitoring-config` config map for the `openshift-monitoring` namespace.
 * You have installed the OpenShift CLI (`oc`).
 

--- a/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * monitoring/enabling-alert-routing-for-user-defined-projects.adoc
+// * monitoring/osd-enabling-alert-routing-for-user-defined-projects.adoc
+// * osd_cluster_admin/osd_monitoring/osd-enabling-alert-routing-for-user-defined-projects.adoc
+// * rosa_cluster_admin/rosa_monitoring/rosa-enabling-alert-routing-for-user-defined-projects.adoc
 
 :_content-type: PROCEDURE
 [id="granting-users-permission-to-configure-alert-routing-for-user-defined-projects_{context}"]
@@ -11,7 +14,12 @@ You can grant users permission to configure alert routing for user-defined proje
 
 .Prerequisites
 
+ifdef::openshift-rosa,openshift-dedicated[]
+* You have access to the cluster as a user with the `cluster-admin` or `dedicated-admin` role.
+endif::[]
+ifndef::openshift-rosa,openshift-dedicated[]
 * You have access to the cluster as a user with the `cluster-admin` role.
+endif::[]
 * The user account that you are assigning the role to already exists.
 * You have installed the OpenShift CLI (`oc`).
 * You have enabled monitoring for user-defined projects.

--- a/modules/monitoring-listing-alerting-rules-for-all-projects-in-a-single-view.adoc
+++ b/modules/monitoring-listing-alerting-rules-for-all-projects-in-a-single-view.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * monitoring/managing-alerts.adoc
+// * monitoring/osd-managing-alerts.adoc
+// * osd_cluster_admin/osd_monitoring/osd-managing-alerts.adoc
+// * rosa_cluster_admin/rosa_monitoring/rosa-managing-alerts.adoc
 
 :_content-type: PROCEDURE
 [id="listing-alerting-rules-for-all-projects-in-a-single-view_{context}"]
@@ -10,7 +13,12 @@ As a cluster administrator, you can list alerting rules for core {product-title}
 
 .Prerequisites
 
+ifdef::openshift-rosa,openshift-dedicated[]
+* You have access to the cluster as a user with the `cluster-admin` or `dedicated-admin` role.
+endif::[]
+ifndef::openshift-rosa,openshift-dedicated[]
 * You have access to the cluster as a user with the `cluster-admin` role.
+endif::[]
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure

--- a/modules/monitoring-managing-alerting-rules-for-user-defined-projects.adoc
+++ b/modules/monitoring-managing-alerting-rules-for-user-defined-projects.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * monitoring/managing-alerts.adoc
+//
 
 :_content-type: CONCEPT
 [id="managing-alerting-rules-for-user-defined-projects_{context}"]
@@ -9,6 +10,13 @@
 {product-title} monitoring ships with a set of default alerting rules. As a cluster administrator, you can view the default alerting rules.
 
 In {product-title} {product-version}, you can create, view, edit, and remove alerting rules in user-defined projects.
+
+ifdef::openshift-rosa,openshift-dedicated[]
+[IMPORTANT]
+====
+Managing alerting rules for user-defined projects is only available in {product-title} version 4.11 and up. 
+====
+endif::[]
 
 .Alerting rule considerations
 

--- a/modules/osd-monitoring-understanding-alert-routing-for-user-defined-projects.adoc
+++ b/modules/osd-monitoring-understanding-alert-routing-for-user-defined-projects.adoc
@@ -1,23 +1,21 @@
 // Module included in the following assemblies:
 //
-// * monitoring/enabling-alert-routing-for-user-defined-projects.adoc
+// * monitoring/osd-enabling-alert-routing-for-user-defined-projects.adoc
+// * osd_cluster_admin/osd_monitoring/osd-enabling-alert-routing-for-user-defined-projects.adoc
+// * rosa_cluster_admin/rosa_monitoring/rosa-enabling-alert-routing-for-user-defined-projects.adoc
 
 :_content-type: CONCEPT
-[id="understanding-alert-routing-for-user-defined-projects_{context}"]
+[id="osd-understanding-alert-routing-for-user-defined-projects_{context}"]
 = Understanding alert routing for user-defined projects
 
 [role="_abstract"]
 As a cluster administrator, you can enable alert routing for user-defined projects. 
 With this feature, you can allow users with the **alert-routing-edit** role to configure alert notification routing and receivers for user-defined projects.
-These notifications are routed by the default Alertmanager instance or, if enabled, an optional Alertmanager instance dedicated to user-defined monitoring.
+These notifications are routed by an Alertmanager instance dedicated to user-defined monitoring.
 
 Users can then create and configure user-defined alert routing by creating or editing the `AlertmanagerConfig` objects for their user-defined projects without the help of an administrator.
 
-After a user has defined alert routing for a user-defined project, user-defined alert notifications are routed as follows:
-
-* To the `alertmanager-main` pods in the `openshift-monitoring` namespace if using the default platform Alertmanager instance.
-
-* To the `alertmanager-user-workload` pods in the `openshift-user-workload-monitoring` namespace if you have enabled a separate instance of Alertmanager for user-defined projects. 
+After a user has defined alert routing for a user-defined project, user-defined alert notifications are routed to the `alertmanager-user-workload` pods in the `openshift-user-workload-monitoring` namespace.
 
 [NOTE]
 ====

--- a/monitoring/osd-enabling-alert-routing-for-user-defined-projects.adoc
+++ b/monitoring/osd-enabling-alert-routing-for-user-defined-projects.adoc
@@ -1,0 +1,30 @@
+:_content-type: ASSEMBLY
+[id="osd-enabling-alert-routing-for-user-defined-projects"]
+= Enabling alert routing for user-defined projects
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: osd-enabling-alert-routing-for-user-defined-projects
+
+toc::[]
+
+[role="_abstract"]
+In {product-title}, a cluster administrator can enable alert routing for user-defined projects. This process consists of two general steps:
+
+* Enable alert routing for user-defined projects to use a separate Alertmanager instance.
+* Grant additional users permission to configure alert routing for user-defined projects.
+
+After you complete these steps, developers and other users can configure custom alerts and alert routing for their user-defined projects.
+
+//Overview of setting up alert routing for user-defined projects
+include::modules/osd-monitoring-understanding-alert-routing-for-user-defined-projects.adoc[leveloffset=+1]
+
+// Enabling a dedicated Alertmanager instance for use in user-defined projects
+include::modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc[leveloffset=+1]
+
+// Granting users permission to configure alert routing for user-defined projects
+include::modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc[Accessing monitoring for user-defined projects]
+* xref:../monitoring/osd-managing-alerts.adoc#creating-alert-routing-for-user-defined-projects_managing-alerts.adoc#creating-alerting-rules-for-user-defined-projects_osd-managing-alerts[Creating alert routing for user-defined projects]

--- a/monitoring/osd-managing-alerts.adoc
+++ b/monitoring/osd-managing-alerts.adoc
@@ -6,7 +6,71 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-Alerts for monitoring workloads in user-defined projects are not currently supported in this {product-title}.
+In {product-title}, the Alerting UI enables you to manage alerts, silences, and alerting rules.
+
+* *Alerting rules*. Alerting rules contain a set of conditions that outline a particular state within a cluster. Alerts are triggered when those conditions are true. An alerting rule can be assigned a severity that defines how the alerts are routed.
+* *Alerts*. An alert is fired when the conditions defined in an alerting rule are true. Alerts provide a notification that a set of circumstances are apparent within an {product-title} cluster.
+* *Silences*. A silence can be applied to an alert to prevent notifications from being sent when the conditions for an alert are true. You can mute an alert after the initial notification, while you work on resolving the underlying issue.
+
+[NOTE]
+====
+The alerts, silences, and alerting rules that are available in the Alerting UI relate to the projects that you have access to. For example, if you are logged in with `cluster-admin` or `dedicated-admin` privileges, all alerts, silences, and alerting rules are accessible.
+====
+
+// Accessing the Alerting UI in the Administrator and Developer perspectives
+include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=+1]
+
+// Searching and filtering alerts, silences, and alerting rules
+include::modules/monitoring-searching-alerts-silences-and-alerting-rules.adoc[leveloffset=+1]
+
+// Getting information about alerts, silences and alerting rules
+include::modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc[leveloffset=+1]
+
+// Managing silences
+include::modules/monitoring-managing-silences.adoc[leveloffset=+1]
+include::modules/monitoring-silencing-alerts.adoc[leveloffset=+2]
+include::modules/monitoring-editing-silences.adoc[leveloffset=+2]
+include::modules/monitoring-expiring-silences.adoc[leveloffset=+2]
+
+// Managing alerting rules for user-defined projects
+include::modules/monitoring-managing-alerting-rules-for-user-defined-projects.adoc[leveloffset=+1]
+include::modules/monitoring-optimizing-alerting-for-user-defined-projects.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* See the link:https://prometheus.io/docs/practices/alerting/[Prometheus alerting documentation] for further guidelines on optimizing alerts
+* See xref:../monitoring/osd-understanding-the-monitoring-stack.adoc#osd-understanding-the-monitoring-stack[Monitoring overview] for details about {product-title} {product-version} monitoring architecture
+
+include::modules/monitoring-creating-alerting-rules-for-user-defined-projects.adoc[leveloffset=+2]
+include::modules/monitoring-reducing-latency-for-alerting-rules-that-do-not-query-platform-metrics.adoc[leveloffset=+2]
+
+* See xref:../monitoring/osd-understanding-the-monitoring-stack.adoc#osd-understanding-the-monitoring-stack[Monitoring overview] for details about {product-title} {product-version} monitoring architecture.
+
+include::modules/monitoring-accessing-alerting-rules-for-your-project.adoc[leveloffset=+2]
+include::modules/monitoring-listing-alerting-rules-for-all-projects-in-a-single-view.adoc[leveloffset=+2]
+include::modules/monitoring-removing-alerting-rules-for-user-defined-projects.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See the link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager documentation]
+
+[role="_additional-resources"]
+.Additional resources
+* See xref:../monitoring/osd-understanding-the-monitoring-stack.adoc#osd-understanding-the-monitoring-stack[Monitoring overview] for details about {product-title} monitoring architecture.
+* See the link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager documentation] for information about alerting rules.
+* See the link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[Prometheus relabeling documentation] for information about how relabeling works.
+* See the link:https://prometheus.io/docs/practices/alerting/[Prometheus alerting documentation] for further guidelines on optimizing alerts.
+
+// Applying a custom configuration to Alertmanager for user-defined alert routing
+include::modules/monitoring-applying-a-custom-configuration-to-alertmanager-for-user-defined-alert-routing.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See link:https://www.pagerduty.com/[the PagerDuty official site] for more information on PagerDuty.
+* See link:https://www.pagerduty.com/docs/guides/prometheus-integration-guide/[the PagerDuty Prometheus Integration Guide] to learn how to retrieve the `service_key`.
+* See link:https://prometheus.io/docs/alerting/configuration/[Alertmanager configuration] for configuring alerting through different alert receivers.
 
 [id="alerts-next-steps"]
 == Next steps

--- a/osd_cluster_admin/osd_monitoring/osd-enabling-alert-routing-for-user-defined-projects.adoc
+++ b/osd_cluster_admin/osd_monitoring/osd-enabling-alert-routing-for-user-defined-projects.adoc
@@ -1,0 +1,37 @@
+:_content-type: ASSEMBLY
+[id="osd-enabling-alert-routing-for-user-defined-projects"]
+= Enabling alert routing for user-defined projects
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: osd-enabling-alert-routing-for-user-defined-projects
+
+toc::[]
+
+[role="_abstract"]
+In {product-title}, a cluster administrator can enable alert routing for user-defined projects. 
+
+[IMPORTANT]
+====
+Managing alerting rules for user-defined projects is only available in {product-title} version 4.11 and up. 
+====
+
+This process consists of two general steps:
+
+* Enable alert routing for user-defined projects to use a separate Alertmanager instance.
+* Grant additional users permission to configure alert routing for user-defined projects.
+
+After you complete these steps, developers and other users can configure custom alerts and alert routing for their user-defined projects.
+
+//Overview of setting up alert routing for user-defined projects
+include::modules/osd-monitoring-understanding-alert-routing-for-user-defined-projects.adoc[leveloffset=+1]
+
+// Enabling a dedicated Alertmanager instance for use in user-defined projects
+include::modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc[leveloffset=+1]
+
+// Granting users permission to configure alert routing for user-defined projects
+include::modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../osd_cluster_admin/osd_monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc#osd-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]
+* xref:../../osd_cluster_admin/osd_monitoring/osd-managing-alerts.adoc#creating-alerting-rules-for-user-defined-projects_osd-managing-alerts[Creating alert routing for user-defined projects]

--- a/osd_cluster_admin/osd_monitoring/osd-managing-alerts.adoc
+++ b/osd_cluster_admin/osd_monitoring/osd-managing-alerts.adoc
@@ -6,7 +6,71 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-Alerts for monitoring workloads in user-defined projects are not currently supported in this {product-title}.
+In {product-title}, the Alerting UI enables you to manage alerts, silences, and alerting rules.
+
+* *Alerting rules*. Alerting rules contain a set of conditions that outline a particular state within a cluster. Alerts are triggered when those conditions are true. An alerting rule can be assigned a severity that defines how the alerts are routed.
+* *Alerts*. An alert is fired when the conditions defined in an alerting rule are true. Alerts provide a notification that a set of circumstances are apparent within an {product-title} cluster.
+* *Silences*. A silence can be applied to an alert to prevent notifications from being sent when the conditions for an alert are true. You can mute an alert after the initial notification, while you work on resolving the underlying issue.
+
+[NOTE]
+====
+The alerts, silences, and alerting rules that are available in the Alerting UI relate to the projects that you have access to. For example, if you are logged in with `cluster-admin` or `dedicated-admin` privileges, all alerts, silences, and alerting rules are accessible.
+====
+
+// Accessing the Alerting UI in the Administrator and Developer perspectives
+include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=+1]
+
+// Searching and filtering alerts, silences, and alerting rules
+include::modules/monitoring-searching-alerts-silences-and-alerting-rules.adoc[leveloffset=+1]
+
+// Getting information about alerts, silences and alerting rules
+include::modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc[leveloffset=+1]
+
+// Managing silences
+include::modules/monitoring-managing-silences.adoc[leveloffset=+1]
+include::modules/monitoring-silencing-alerts.adoc[leveloffset=+2]
+include::modules/monitoring-editing-silences.adoc[leveloffset=+2]
+include::modules/monitoring-expiring-silences.adoc[leveloffset=+2]
+
+// Managing alerting rules for user-defined projects
+include::modules/monitoring-managing-alerting-rules-for-user-defined-projects.adoc[leveloffset=+1]
+include::modules/monitoring-optimizing-alerting-for-user-defined-projects.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* See the link:https://prometheus.io/docs/practices/alerting/[Prometheus alerting documentation] for further guidelines on optimizing alerts
+* See xref:../../osd_cluster_admin/osd_monitoring/osd-understanding-the-monitoring-stack.adoc#osd-understanding-the-monitoring-stack[Monitoring overview] for details about {product-title} {product-version} monitoring architecture
+
+include::modules/monitoring-creating-alerting-rules-for-user-defined-projects.adoc[leveloffset=+2]
+include::modules/monitoring-reducing-latency-for-alerting-rules-that-do-not-query-platform-metrics.adoc[leveloffset=+2]
+
+* See xref:../../osd_cluster_admin/osd_monitoring/osd-understanding-the-monitoring-stack.adoc#osd-understanding-the-monitoring-stack[Monitoring overview] for details about {product-title} {product-version} monitoring architecture.
+
+include::modules/monitoring-accessing-alerting-rules-for-your-project.adoc[leveloffset=+2]
+include::modules/monitoring-listing-alerting-rules-for-all-projects-in-a-single-view.adoc[leveloffset=+2]
+include::modules/monitoring-removing-alerting-rules-for-user-defined-projects.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See the link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager documentation]
+
+[role="_additional-resources"]
+.Additional resources
+* See xref:../../osd_cluster_admin/osd_monitoring/osd-understanding-the-monitoring-stack.adoc#osd-understanding-the-monitoring-stack[Monitoring overview] for details about {product-title} monitoring architecture.
+* See the link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager documentation] for information about alerting rules.
+* See the link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[Prometheus relabeling documentation] for information about how relabeling works.
+* See the link:https://prometheus.io/docs/practices/alerting/[Prometheus alerting documentation] for further guidelines on optimizing alerts.
+
+// Applying a custom configuration to Alertmanager for user-defined alert routing
+include::modules/monitoring-applying-a-custom-configuration-to-alertmanager-for-user-defined-alert-routing.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See link:https://www.pagerduty.com/[the PagerDuty official site] for more information on PagerDuty.
+* See link:https://www.pagerduty.com/docs/guides/prometheus-integration-guide/[the PagerDuty Prometheus Integration Guide] to learn how to retrieve the `service_key`.
+* See link:https://prometheus.io/docs/alerting/configuration/[Alertmanager configuration] for configuring alerting through different alert receivers.
 
 [id="alerts-next-steps"]
 == Next steps

--- a/rosa_cluster_admin/rosa_monitoring/rosa-enabling-alert-routing-for-user-defined-projects.adoc
+++ b/rosa_cluster_admin/rosa_monitoring/rosa-enabling-alert-routing-for-user-defined-projects.adoc
@@ -1,0 +1,37 @@
+:_content-type: ASSEMBLY
+[id="rosa-enabling-alert-routing-for-user-defined-projects"]
+= Enabling alert routing for user-defined projects
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-enabling-alert-routing-for-user-defined-projects
+
+toc::[]
+
+[role="_abstract"]
+In {product-title}, a cluster administrator can enable alert routing for user-defined projects. 
+
+[IMPORTANT]
+====
+Managing alerting rules for user-defined projects is only available in {product-title} version 4.11 and up. 
+====
+
+This process consists of two general steps:
+
+* Enable alert routing for user-defined projects to use a separate Alertmanager instance.
+* Grant additional users permission to configure alert routing for user-defined projects.
+
+After you complete these steps, developers and other users can configure custom alerts and alert routing for their user-defined projects.
+
+//Overview of setting up alert routing for user-defined projects
+include::modules/osd-monitoring-understanding-alert-routing-for-user-defined-projects.adoc[leveloffset=+1]
+
+// Enabling a dedicated Alertmanager instance for use in user-defined projects
+include::modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc[leveloffset=+1]
+
+// Granting users permission to configure alert routing for user-defined projects
+include::modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../rosa_cluster_admin/rosa_monitoring/rosa-accessing-monitoring-for-user-defined-projects.adoc#rosa-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]
+* xref:../../rosa_cluster_admin/rosa_monitoring/rosa-managing-alerts.adoc#creating-alerting-rules-for-user-defined-projects_rosa-managing-alerts[Creating alert routing for user-defined projects]

--- a/rosa_cluster_admin/rosa_monitoring/rosa-managing-alerts.adoc
+++ b/rosa_cluster_admin/rosa_monitoring/rosa-managing-alerts.adoc
@@ -6,7 +6,71 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-Alerts for monitoring workloads in user-defined projects are not currently supported in this {product-title}.
+In {product-title}, the Alerting UI enables you to manage alerts, silences, and alerting rules.
+
+* *Alerting rules*. Alerting rules contain a set of conditions that outline a particular state within a cluster. Alerts are triggered when those conditions are true. An alerting rule can be assigned a severity that defines how the alerts are routed.
+* *Alerts*. An alert is fired when the conditions defined in an alerting rule are true. Alerts provide a notification that a set of circumstances are apparent within an {product-title} cluster.
+* *Silences*. A silence can be applied to an alert to prevent notifications from being sent when the conditions for an alert are true. You can mute an alert after the initial notification, while you work on resolving the underlying issue.
+
+[NOTE]
+====
+The alerts, silences, and alerting rules that are available in the Alerting UI relate to the projects that you have access to. For example, if you are logged in with `cluster-admin` or `dedicated-admin` privileges, all alerts, silences, and alerting rules are accessible.
+====
+
+// Accessing the Alerting UI in the Administrator and Developer perspectives
+include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=+1]
+
+// Searching and filtering alerts, silences, and alerting rules
+include::modules/monitoring-searching-alerts-silences-and-alerting-rules.adoc[leveloffset=+1]
+
+// Getting information about alerts, silences and alerting rules
+include::modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc[leveloffset=+1]
+
+// Managing silences
+include::modules/monitoring-managing-silences.adoc[leveloffset=+1]
+include::modules/monitoring-silencing-alerts.adoc[leveloffset=+2]
+include::modules/monitoring-editing-silences.adoc[leveloffset=+2]
+include::modules/monitoring-expiring-silences.adoc[leveloffset=+2]
+
+// Managing alerting rules for user-defined projects
+include::modules/monitoring-managing-alerting-rules-for-user-defined-projects.adoc[leveloffset=+1]
+include::modules/monitoring-optimizing-alerting-for-user-defined-projects.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* See the link:https://prometheus.io/docs/practices/alerting/[Prometheus alerting documentation] for further guidelines on optimizing alerts
+* See xref:../../rosa_cluster_admin/rosa_monitoring/rosa-understanding-the-monitoring-stack.adoc#rosa-understanding-the-monitoring-stack[Monitoring overview] for details about {product-title} {product-version} monitoring architecture
+
+include::modules/monitoring-creating-alerting-rules-for-user-defined-projects.adoc[leveloffset=+2]
+include::modules/monitoring-reducing-latency-for-alerting-rules-that-do-not-query-platform-metrics.adoc[leveloffset=+2]
+
+* See xref:../../rosa_cluster_admin/rosa_monitoring/rosa-understanding-the-monitoring-stack.adoc#rosa-understanding-the-monitoring-stack[Monitoring overview] for details about {product-title} {product-version} monitoring architecture.
+
+include::modules/monitoring-accessing-alerting-rules-for-your-project.adoc[leveloffset=+2]
+include::modules/monitoring-listing-alerting-rules-for-all-projects-in-a-single-view.adoc[leveloffset=+2]
+include::modules/monitoring-removing-alerting-rules-for-user-defined-projects.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See the link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager documentation]
+
+[role="_additional-resources"]
+.Additional resources
+* See xref:../../rosa_cluster_admin/rosa_monitoring/rosa-understanding-the-monitoring-stack.adoc#rosa-understanding-the-monitoring-stack[Monitoring overview] for details about {product-title} monitoring architecture.
+* See the link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager documentation] for information about alerting rules.
+* See the link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[Prometheus relabeling documentation] for information about how relabeling works.
+* See the link:https://prometheus.io/docs/practices/alerting/[Prometheus alerting documentation] for further guidelines on optimizing alerts.
+
+// Applying a custom configuration to Alertmanager for user-defined alert routing
+include::modules/monitoring-applying-a-custom-configuration-to-alertmanager-for-user-defined-alert-routing.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See link:https://www.pagerduty.com/[the PagerDuty official site] for more information on PagerDuty.
+* See link:https://www.pagerduty.com/docs/guides/prometheus-integration-guide/[the PagerDuty Prometheus Integration Guide] to learn how to retrieve the `service_key`.
+* See link:https://prometheus.io/docs/alerting/configuration/[Alertmanager configuration] for configuring alerting through different alert receivers.
 
 [id="alerts-next-steps"]
 == Next steps


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> ---> 
[OSDOCS-4296](https://issues.redhat.com//browse/OSDOCS-4296): Adding information on user-defined alerting now that the feature is enabled.


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): PR applies to `main`, `enterprise-4.11` and `enterprise-4.12`.


<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/OSDOCS-4296
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
[OpenShift Dedicated - Enabling alert routing for user-defined projects](https://51335--docspreview.netlify.app/openshift-dedicated/latest/osd_cluster_admin/osd_monitoring/osd-enabling-alert-routing-for-user-defined-projects.html)
[OpenShift Dedicated - Managing alerts](https://51335--docspreview.netlify.app/openshift-dedicated/latest/osd_cluster_admin/osd_monitoring/osd-managing-alerts.html)
[ROSA - Enabling alert routing for user-defined projects](https://51335--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_monitoring/rosa-enabling-alert-routing-for-user-defined-projects.html)
[ROSA - Managing alerts](https://51335--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_monitoring/rosa-managing-alerts.html)
[OpenShift Enterprise - Enabling alert routing for user-defined projects](https://51335--docspreview.netlify.app/openshift-enterprise/latest/monitoring/enabling-alert-routing-for-user-defined-projects.html#understanding-alert-routing-for-user-defined-projects_enabling-alert-routing-for-user-defined-projects)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
