### PR TITLE
RHDEVDOCS-4483 odo dev versus odo deploy

### DIFF
--- a/cli_reference/developer_cli_odo/understanding-odo.adoc
+++ b/cli_reference/developer_cli_odo/understanding-odo.adoc
@@ -14,5 +14,6 @@ Red Hat OpenShift Developer CLI (`odo`) is a tool for creating applications on {
 
 include::modules/odo-key-features.adoc[leveloffset=+1]
 include::modules/odo-core-concepts.adoc[leveloffset=+1]
+include::modules/odo-dev-deploy.adoc[leveloffset=+1]
 include::modules/odo-listing-components.adoc[leveloffset=+1]
 include::modules/odo-telemetry.adoc[leveloffset=+1]

--- a/modules/odo-dev-deploy.adoc
+++ b/modules/odo-dev-deploy.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/developer_cli_odo/understanding-odo.adoc
+
+:_content-type: CONCEPT
+[id="odo-dev-deploy_{context}"]
+= Develop and deploy
+
+The two most important commands in `odo` are `odo dev` and `odo deploy`. Learn when to use which command.
+
+== odo dev
+
+Use the `odo dev` command in the initial development phase of your application. For example, use `odo dev` when you are working with a local development environment and you are:
+
+- Making changes regularly 
+- Previewing changes
+- Testing initial Kubernetes support for your application
+- Debugging and running tests
+- Deploying privately on a local development environment
+
+
+== odo deploy
+
+Use the `odo deploy` command in the deployment stage of development when you are ready for a "production ready" environment. For example, use `odo deploy` when you are working with a production environment and:
+
+- You are ready to expose you application to other users.
+- You need to build and push the container.
+- You require custom Kubernetes YAML for your production environment.


### PR DESCRIPTION
Version(s):
4.8+


Issue:
https://issues.redhat.com/browse/RHDEVDOCS-4483

Link to docs preview:
https://51340--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/developer_cli_odo/understanding-odo.html#odo-dev-deploy_understanding-odo

QE review:
- [ ] QE has approved this change.
