### PR TITLE
BZ2110339: Default inheritable capabilities for linux container should not be empty

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1947,6 +1947,8 @@ This update fixes the problem by introducing client-go 1.22.
 
 * Previously, pod namespaces managed by CRI-O, for example network, IPC, and UTS, were not unmounted when the pod was removed. This resulted in leakage, driving the Open vSwitch CPU to 100%, which caused pod latency and other performance impacts. This has been resolved and pod namespaces are unmounted when removed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2003193[*BZ#2003193*])
 
+* Containers are started with non-empty inheritable Linux process capabilities. The workaround is to modify the entry point of a container using a utility such as `capsh(1)` to drop inheritable capabilities prior to when the primary process starts. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2076265[*BZ#2076265*])
+
 [discrete]
 [id="ocp-4-10-openshift-cli-bug-fixes"]
 ==== OpenShift CLI (oc)


### PR DESCRIPTION
Version(s):
  * PR applies only to a specific single version (e.g. 4.10): 4.10

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2110339

Link to docs preview:
Link to docs preview: http://file.emea.redhat.com/tmulquee/BZ2110339/release_notes/ocp-4-10-release-notes.html#ocp-4-10-bug-fixes - at end of Nodes section, search for 2076265.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
The original PR this content was developed with was https://github.com/openshift/openshift-docs/pull/49995


<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - 
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
