### PR TITLE
OADP-717: OADP 1.0.x & OCP 4.11 compatibility issue

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -30,6 +30,8 @@ To back up PVs with snapshots, you must have a cloud provider that supports eith
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc#installing-oadp-gcp[Google Cloud Platform]
 * CSI snapshot-enabled cloud provider, such as xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc#installing-oadp-ocs[OpenShift Data Foundation]
 
+include::snippets/oadp-ocp-compat.adoc[]
+
 If your cloud provider does not support snapshots or if your storage is NFS, you can back up applications with xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#oadp-backing-up-applications-restic_backing-up-applications[Restic backups] on object storage.
 
 You create a default `Secret` and then you install the Data Protection Application.

--- a/backup_and_restore/index.adoc
+++ b/backup_and_restore/index.adoc
@@ -50,6 +50,8 @@ OADP has the following requirements:
 ** Multicloud Object Gateway
 ** S3-compatible object storage, such as Noobaa or Minio
 
+include::snippets/oadp-ocp-compat.adoc[]
+
 :FeatureName: The `CloudStorage` API for S3 storage
 include::snippets/technology-preview.adoc[]
 

--- a/snippets/oadp-ocp-compat.adoc
+++ b/snippets/oadp-ocp-compat.adoc
@@ -1,0 +1,13 @@
+
+//This snippet appears in the following assemblies:
+//
+// * .../backup_and_restore/backing_up_and_restoring/installing/about-installing-oadp.adoc
+// * .../backup_and_restore/index.adoc
+
+:_content-type: SNIPPET
+[NOTE]
+====
+If you want to use CSI backup on OCP 4.11 and later, install OADP 1.1._x_.
+
+OADP 1.0._x_ does not support CSI backup on OCP 4.11 and later. OADP 1.0._x_ includes Velero 1.7._x_ and expects the API group `snapshot.storage.k8s.io/v1beta1`, which is not present on OCP 4.11 and later.
+====


### PR DESCRIPTION
OADP 1.1.1 and OADP 1.0.x; OCP 4.11+

Dev and QE review complete. OCP peer review complete and Avital's suggestion implemented. 

Resolves https://issues.redhat.com/browse/OADP-717 by adding a note to the sections shown in the previews.

Previews: 
1. See note in https://51355--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/index.html#oadp-requirements

2. See 2nd note in https://51355--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html