### PR TITLE
OCPBUGS-1716 - Verify Dell firmware compatibility with IPI clusters using Redfish virtual media

### DIFF
--- a/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
+++ b/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
@@ -80,9 +80,9 @@ platform:
 
 [NOTE]
 ====
-Currently, Redfish is only supported on Dell with iDRAC firmware versions `4.20.20.20` through `04.40.00.00` for installer-provisioned installations on bare metal deployments. There is a known issue with version `04.40.00.00`. With iDRAC 9 firmware version `04.40.00.00`, the Virtual Console plug-in defaults to `eHTML5`, which causes problems with the *InsertVirtualMedia* workflow. Set the plug-in to `HTML5` to avoid this issue. The menu path is: *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
+There is a known issue on Dell iDRAC 9 with firmware version `04.40.00.00` or later for installer-provisioned installations on bare metal deployments. The Virtual Console plug-in defaults to eHTML5, an enhanced version of HTML5, which causes problems with the *InsertVirtualMedia* workflow. Set the plug-in to use HTML5 to avoid this issue. The menu path is *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
 
-Ensure the {product-title} cluster nodes have AutoAttach Enabled through the iDRAC console. The menu path is: *Configuration* -> *Virtual Media* -> *Attach Mode* -> `AutoAttach` .
+Ensure the {product-title} cluster nodes have *AutoAttach* enabled through the iDRAC console. The menu path is: *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach* .
 
 Use `idrac-virtualmedia://` as the protocol for Redfish virtual media. Using `redfish-virtualmedia://` will not work on Dell hardware, because the `idrac-virtualmedia://` protocol corresponds to the `idrac` hardware type and the Redfish protocol in Ironic. Dell's `idrac-virtualmedia://` protocol uses the Redfish standard with Dell's OEM extensions. Ironic also supports the `idrac` type with the WSMAN protocol. Therefore, you must specify `idrac-virtualmedia://` to avoid unexpected behavior when electing to use Redfish with virtual media on Dell hardware.
 ====
@@ -124,9 +124,9 @@ platform:
 
 [NOTE]
 ====
-Currently, Redfish is only supported on Dell hardware with iDRAC firmware versions `4.20.20.20` through `04.40.00.00` for installer-provisioned installations on bare metal deployments. There is a known issue with version `04.40.00.00`. With iDRAC 9 firmware version `04.40.00.00`, the Virtual Console plug-in defaults to `eHTML5`, which causes problems with the *InsertVirtualMedia* workflow. Set the plug-in to `HTML5` to avoid this issue. The menu path is: *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
+There is a known issue on Dell iDRAC 9 with firmware version `04.40.00.00` or later for installer-provisioned installations on bare metal deployments. The Virtual Console plug-in defaults to eHTML5, an enhanced version of HTML5, which causes problems with the *InsertVirtualMedia* workflow. Set the plug-in to use HTML5 to avoid this issue. The menu path is *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
 
-Ensure the {product-title} cluster nodes have AutoAttach Enabled through the iDRAC console. The menu path is: *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach* .
+Ensure the {product-title} cluster nodes have *AutoAttach* enabled through the iDRAC console. The menu path is: *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach* .
 
 The `redfish://` URL protocol corresponds to the `redfish` hardware type in Ironic.
 ====

--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -6,15 +6,29 @@
 [id='ipi-install-firmware-requirements-for-installing-with-virtual-media_{context}']
 = Firmware requirements for installing with virtual media
 
-The installer for installer-provisioned {product-title} clusters validates the hardware and firmware compatibility with Redfish virtual media. The following table lists the minimum firmware versions tested and verified to work for installer-provisioned {product-title} clusters deployed by using Redfish virtual media.
+The installation program for installer-provisioned {product-title} clusters validates the hardware and firmware compatibility with Redfish virtual media. The installation program does not begin installation on a node if the node firmware is not compatible. The following tables list the minimum firmware versions tested and verified to work for installer-provisioned {product-title} clusters deployed by using Redfish virtual media.
 
-.Firmware compatibility for Redfish virtual media
+[NOTE]
+====
+Red Hat does not test every combination of firmware, hardware, or other third-party components. For further information about third-party support, see link:https://access.redhat.com/third-party-software-support[Red Hat third-party support policy]. For information about updating the firmware, see the hardware documentation for the nodes or contact the hardware vendor.
+====
+
+.Firmware compatibility for HP hardware with Redfish virtual media 
+[frame="topbot", options="header"]
+[cols="1,1,1"]
+|====
+| Model | Management | Firmware versions
+| 10th Generation | iLO5 | 2.63 or later
+
+|====
+
+.Firmware compatibility for Dell hardware with Redfish virtual media
 [frame="topbot", options="header"]
 |====
-|Hardware| Model | Management | Firmware versions
-| HP | 10th Generation | iLO5 | 2.63 or later
+| Model | Management | Firmware versions
 
-.2+| Dell | 14th Generation | iDRAC 9 | v4.20.20.20 - v4.40.00.00 only
+| 15th Generation | iDRAC 9 | v5.10.00.00 - v5.10.50.00 only
+| 14th Generation | iDRAC 9 | v5.10.00.00 - v5.10.50.00 only
 
 | 13th Generation .2+| iDRAC 8 | v2.75.75.75 or later
 
@@ -22,16 +36,6 @@ The installer for installer-provisioned {product-title} clusters validates the h
 
 [NOTE]
 ====
-Red Hat does not test every combination of firmware, hardware, or other third-party components. For further information about third-party support, see link:https://access.redhat.com/third-party-software-support[Red Hat third-party support policy].
 
-See the hardware documentation for the nodes or contact the hardware vendor for information about updating the firmware.
-
-For HP servers, Redfish virtual media is not supported on 9th generation systems running iLO4, because Ironic does not support iLO4 with virtual media.
-
-For Dell servers, ensure the {product-title} cluster nodes have AutoAttach Enabled through the iDRAC console. The menu path is: *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach* . With iDRAC 9 firmware version `04.40.00.00`, the Virtual Console plug-in defaults to `eHTML5`, which causes problems with the *InsertVirtualMedia* workflow. Set the plug-in to `HTML5` to avoid this issue. The menu path is: *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
-====
-
-[IMPORTANT]
-====
-The installer will not initiate installation on a node if the node firmware is below the foregoing versions when installing with virtual media.
+For Dell servers, ensure the {product-title} cluster nodes have *AutoAttach* enabled through the iDRAC console. The menu path is *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach* . With iDRAC 9 firmware version `04.40.00.00` or later, the Virtual Console plug-in defaults to eHTML5, an enhanced version of HTML5, which causes problems with the *InsertVirtualMedia* workflow. Set the plug-in to use HTML5 to avoid this issue. The menu path is *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
 ====


### PR DESCRIPTION
OCPBUGS-1716: Updating Dell firmware compatibility with IPI clusters using Redfish virtual media after testing on OCP 4.10+

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-1716

Link to docs preview:

- http://file.emea.redhat.com/rohennes/OCPBUGS-1716-virtual-media-firmware/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites
Removed reference to redfish virtual media FW compatibility from notes:
- http://file.emea.redhat.com/rohennes/OCPBUGS-1716-virtual-media-firmware/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#bmc-addressing-for-dell-idrac_ipi-install-installation-workflow

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
