### PR TITLE
GH50801: Remove redundant callout labels

### DIFF
--- a/modules/cluster-autoscaler-cr.adoc
+++ b/modules/cluster-autoscaler-cr.adoc
@@ -30,9 +30,9 @@ spec:
       - type: nvidia.com/gpu <7>
         min: 0 <8>
         max: 16 <9>
-      - type: amd.com/gpu <7>
-        min: 0 <8>
-        max: 4 <9>
+      - type: amd.com/gpu
+        min: 0
+        max: 4
   scaleDown: <10>
     enabled: true <11>
     delayAfterAdd: 10m <12>


### PR DESCRIPTION
Versions: 4.6+

#50801

Removes redundant/duplicated callout labels from sample YAML to match the same code block as it appears on https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/machine_management/applying-autoscaling

Note to reviewer: the values for min and max appear blue now that they do not have a callout label next to them. I have attempted to troubleshoot with team members and determined that this is likely caused by some style configuration or highlighting bug that is out of my control. The information is still technically accurate despite being a different color.

Preview: https://51358--docspreview.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html