### PR TITLE
GH#43284: Typo fix

### DIFF
--- a/modules/rosa-policy-shared-responsibility.adoc
+++ b/modules/rosa-policy-shared-responsibility.adoc
@@ -110,7 +110,7 @@ The Identity and Access Management matrix includes responsibilities for managing
 |Application networking
 |Provide native OpenShift RBAC and `dedicated-admin` capabilities.
 |- Configure OpenShift `dedicated-admin` and RBAC to control access to route configuration as required.
-- Manage organization administrators for Red Hat to grant access to {cluster-manager}. The cluster maanger is used to configure router options and provide service load balancer quota.
+- Manage organization administrators for Red Hat to grant access to {cluster-manager}. The cluster manager is used to configure router options and provide service load balancer quota.
 
 |Cluster networking
 |- Provide customer access controls through {cluster-manager}.


### PR DESCRIPTION
Fixes small typo as reported in https://github.com/openshift/openshift-docs/issues/43284

Preview: https://51359--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-identity-access-management_rosa-policy-responsibility-matrix