### PR TITLE
BZ-2097619-4-11 update vSphere driver version in 4.11

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
@@ -16,7 +16,11 @@ To create CSI-provisioned persistent volumes (PVs) that mount to vSphere storage
 
 * *vSphere CSI Driver Operator*: The Operator provides a storage class, called `thin-csi`, that you can use to create persistent volumes claims (PVCs). The vSphere CSI Driver Operator supports dynamic volume provisioning by allowing storage volumes to be created on-demand, eliminating the need for cluster administrators to pre-provision storage.
 
-* *vSphere CSI driver*: The driver enables you to create and mount vSphere PVs.
+* *vSphere CSI driver*: The driver enables you to create and mount vSphere PVs. In {product-title} 4.11, the driver version is 2.5.1.
+
+//Please update driver version as needed with each major OCP release starting with 4.13.
+
+//Listing the VMWare driver version here because it has a more variable set of features. The Operator version does not change independently (is parallel).
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
This is one of three PRs for this BZ, each documenting a different version of a third-party storage driver specific to each major OpenShift release.

Version(s):
PR applies to: 4.11

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2097619

Link to docs preview:
https://51369--docspreview.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html#overview

Additional information:
https://github.com/openshift/openshift-docs/pull/51384
https://github.com/openshift/openshift-docs/pull/51371

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
