### PR TITLE
OSDOCS-4096: Bumping 1.24 to 1.25 throughout doc set

### DIFF
--- a/_unused_topics/looking-inside-nodes.adoc
+++ b/_unused_topics/looking-inside-nodes.adoc
@@ -14,9 +14,9 @@ $ oc get nodes
 
 NAME                                     STATUS  ROLES  AGE    VERSION
 
-ip-10-0-0-1.us-east-2.compute.internal   Ready   worker 3h19m  v1.24.0
+ip-10-0-0-1.us-east-2.compute.internal   Ready   worker 3h19m  v1.25.0
 
-ip-10-0-0-39.us-east-2.compute.internal  Ready   master 3h37m  v1.24.0
+ip-10-0-0-39.us-east-2.compute.internal  Ready   master 3h37m  v1.25.0
 
 …
 

--- a/_unused_topics/understanding-workers-masters.adoc
+++ b/_unused_topics/understanding-workers-masters.adoc
@@ -13,12 +13,12 @@ To see which workers and masters are running on your cluster, type:
 $ oc get nodes
 
 NAME                                   STATUS ROLES  AGE    VERSION
-ip-10-0-0-1.us-east-2.compute.internal Ready  worker 4h20m  v1.24.0
-ip-10-0-0-2.us-east-2.compute.internal Ready  master 4h39m  v1.24.0
-ip-10-0-0.3.us-east-2.compute.internal Ready  worker 4h20m  v1.24.0
-ip-10-0-0-4.us-east-2.compute.internal Ready  master 4h39m  v1.24.0
-ip-10-0-0-5.us-east-2.compute.internal Ready  master 4h39m  v1.24.0
-ip-10-0-0-6.us-east-2.compute.internal Ready  worker 4h20m  v1.24.0
+ip-10-0-0-1.us-east-2.compute.internal Ready  worker 4h20m  v1.25.0
+ip-10-0-0-2.us-east-2.compute.internal Ready  master 4h39m  v1.25.0
+ip-10-0-0.3.us-east-2.compute.internal Ready  worker 4h20m  v1.25.0
+ip-10-0-0-4.us-east-2.compute.internal Ready  master 4h39m  v1.25.0
+ip-10-0-0-5.us-east-2.compute.internal Ready  master 4h39m  v1.25.0
+ip-10-0-0-6.us-east-2.compute.internal Ready  worker 4h20m  v1.25.0
 ----
 
 To see more information about internal and external IP addresses, the type of operating system ({op-system}), kernel version, and container runtime (CRI-O), add the `-o wide` option.
@@ -27,7 +27,7 @@ To see more information about internal and external IP addresses, the type of op
 $ oc get nodes -o wide
 
 NAME                                       STATUS  ROLES  AGE  VERSION  INTERNAL-IP   EXTERNAL-IP  OS-IMAGE             KERNEL-VERSION             CONTAINER-RUNTIME
-ip-10-0-134-252.us-east-2.compute.internal Ready   worker 17h  v1.24.0  10.0.134.252  <none>       Red Hat CoreOS 4.0   3.10.0-957.5.1.el7.x86_64  cri-o://1.24.0-1.rhaos4.0.git2f0cb0d.el7
+ip-10-0-134-252.us-east-2.compute.internal Ready   worker 17h  v1.25.0  10.0.134.252  <none>       Red Hat CoreOS 4.0   3.10.0-957.5.1.el7.x86_64  cri-o://1.25.0-1.rhaos4.0.git2f0cb0d.el7
 
 ....
 ----

--- a/metering/configuring_metering/metering-common-config-options.adoc
+++ b/metering/configuring_metering/metering-common-config-options.adoc
@@ -156,12 +156,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS   ROLES    AGE   VERSION
-ip-10-0-147-106.us-east-2.compute.internal   Ready    master   14h   v1.24.0
-ip-10-0-150-175.us-east-2.compute.internal   Ready    worker   14h   v1.24.0
-ip-10-0-175-23.us-east-2.compute.internal    Ready    master   14h   v1.24.0
-ip-10-0-189-6.us-east-2.compute.internal     Ready    worker   14h   v1.24.0
-ip-10-0-205-158.us-east-2.compute.internal   Ready    master   14h   v1.24.0
-ip-10-0-210-167.us-east-2.compute.internal   Ready    worker   14h   v1.24.0
+ip-10-0-147-106.us-east-2.compute.internal   Ready    master   14h   v1.25.0
+ip-10-0-150-175.us-east-2.compute.internal   Ready    worker   14h   v1.25.0
+ip-10-0-175-23.us-east-2.compute.internal    Ready    master   14h   v1.25.0
+ip-10-0-189-6.us-east-2.compute.internal     Ready    worker   14h   v1.25.0
+ip-10-0-205-158.us-east-2.compute.internal   Ready    master   14h   v1.25.0
+ip-10-0-210-167.us-east-2.compute.internal   Ready    worker   14h   v1.25.0
 ----
 --
 

--- a/modules/ai-adding-worker-nodes-to-cluster.adoc
+++ b/modules/ai-adding-worker-nodes-to-cluster.adoc
@@ -315,6 +315,6 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES           AGE   VERSION
-control-plane-1.example.com    Ready    master,worker   56m   v1.24.0+beaaed6
-compute-1.example.com          Ready    worker          11m   v1.24.0+beaaed6
+control-plane-1.example.com    Ready    master,worker   56m   v1.25.0
+compute-1.example.com          Ready    worker          11m   v1.25.0
 ----

--- a/modules/capi-machine-set-creating.adoc
+++ b/modules/capi-machine-set-creating.adoc
@@ -115,7 +115,7 @@ NAME           CLUSTER        READY VPC BASTION IP
 <cluster_name> <cluster_name> true
 ----
 
-. Create a YAML file that contains the machine template CR and is named `<machine_template_resource_file>.yaml`. 
+. Create a YAML file that contains the machine template CR and is named `<machine_template_resource_file>.yaml`.
 
 . Create the machine template CR by running the following command:
 +
@@ -142,7 +142,7 @@ NAME            AGE
 <template_name> 77m
 ----
 
-. Create a YAML file that contains the machine set CR and is named `<machine_set_resource_file>.yaml`. 
+. Create a YAML file that contains the machine set CR and is named `<machine_set_resource_file>.yaml`.
 
 . Create the machine set CR by running the following command:
 +
@@ -200,7 +200,7 @@ $ oc get node
 [source,terminal]
 ----
 NAME                                     STATUS ROLES  AGE   VERSION
-<ip_address_1>.<region>.compute.internal Ready  worker 5h14m v1.24.0+284d62a
-<ip_address_2>.<region>.compute.internal Ready  master 5h19m v1.24.0+284d62a
-<ip_address_3>.<region>.compute.internal Ready  worker 7m    v1.24.0+284d62a
+<ip_address_1>.<region>.compute.internal Ready  worker 5h14m v1.25.0
+<ip_address_2>.<region>.compute.internal Ready  master 5h19m v1.25.0
+<ip_address_3>.<region>.compute.internal Ready  worker 7m    v1.25.0
 ----

--- a/modules/cleaning-crio-storage.adoc
+++ b/modules/cleaning-crio-storage.adoc
@@ -109,7 +109,7 @@ $ oc get nodes
 +
 ----
 NAME				    STATUS	                ROLES    AGE    VERSION
-ci-ln-tkbxyft-f76d1-nvwhr-master-1  Ready, SchedulingDisabled   master	 133m   v1.24.0
+ci-ln-tkbxyft-f76d1-nvwhr-master-1  Ready, SchedulingDisabled   master	 133m   v1.25.0
 ----
 +
 . Mark the node schedulable. You will know that the scheduling is enabled when `SchedulingDisabled` is no longer in status:
@@ -124,5 +124,5 @@ $ oc adm uncordon <nodename>
 +
 ----
 NAME				     STATUS	      ROLES    AGE    VERSION
-ci-ln-tkbxyft-f76d1-nvwhr-master-1   Ready            master   133m   v1.24.0
+ci-ln-tkbxyft-f76d1-nvwhr-master-1   Ready            master   133m   v1.25.0
 ----

--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -128,16 +128,16 @@ Use this command to verify that the real-time kernel is installed:
 $ oc get node -o wide
 ----
 
-Note the worker with the role `worker-rt` that contains the string `4.18.0-305.30.1.rt7.102.el8_4.x86_64   cri-o://1.24.0-99.rhaos4.10.gitc3131de.el8`:
+Note the worker with the role `worker-rt` that contains the string `4.18.0-305.30.1.rt7.102.el8_4.x86_64   cri-o://1.25.0-99.rhaos4.10.gitc3131de.el8`:
 
 [source,terminal]
 ----
 NAME                               	STATUS   ROLES           	AGE 	VERSION                  	INTERNAL-IP
 EXTERNAL-IP   OS-IMAGE                                       	KERNEL-VERSION
 CONTAINER-RUNTIME
-rt-worker-0.example.com	          Ready	 worker,worker-rt   5d17h   v1.24.0
+rt-worker-0.example.com	          Ready	 worker,worker-rt   5d17h   v1.25.0
 128.66.135.107   <none>    	        Red Hat Enterprise Linux CoreOS 46.82.202008252340-0 (Ootpa)
-4.18.0-305.30.1.rt7.102.el8_4.x86_64   cri-o://1.24.0-99.rhaos4.10.gitc3131de.el8
+4.18.0-305.30.1.rt7.102.el8_4.x86_64   cri-o://1.25.0-99.rhaos4.10.gitc3131de.el8
 [...]
 ----
 

--- a/modules/compliance-apply-remediation-for-customized-mcp.adoc
+++ b/modules/compliance-apply-remediation-for-customized-mcp.adoc
@@ -23,11 +23,11 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                       STATUS  ROLES  AGE    VERSION
-ip-10-0-128-92.us-east-2.compute.internal  Ready   master 5h21m  v1.24.0
-ip-10-0-158-32.us-east-2.compute.internal  Ready   worker 5h17m  v1.24.0
-ip-10-0-166-81.us-east-2.compute.internal  Ready   worker 5h17m  v1.24.0
-ip-10-0-171-170.us-east-2.compute.internal Ready   master 5h21m  v1.24.0
-ip-10-0-197-35.us-east-2.compute.internal  Ready   master 5h22m  v1.24.0
+ip-10-0-128-92.us-east-2.compute.internal  Ready   master 5h21m  v1.25.0
+ip-10-0-158-32.us-east-2.compute.internal  Ready   worker 5h17m  v1.25.0
+ip-10-0-166-81.us-east-2.compute.internal  Ready   worker 5h17m  v1.25.0
+ip-10-0-171-170.us-east-2.compute.internal Ready   master 5h21m  v1.25.0
+ip-10-0-197-35.us-east-2.compute.internal  Ready   master 5h22m  v1.25.0
 ----
 
 . Add a label to nodes.

--- a/modules/connected-to-disconnected-verify.adoc
+++ b/modules/connected-to-disconnected-verify.adoc
@@ -44,10 +44,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-47ltxtb-f76d1-mrffg-master-0         Ready    master   42m   v1.24.0
-ci-ln-47ltxtb-f76d1-mrffg-master-1         Ready    master   42m   v1.24.0
-ci-ln-47ltxtb-f76d1-mrffg-master-2         Ready    master   42m   v1.24.0
-ci-ln-47ltxtb-f76d1-mrffg-worker-a-gsxbz   Ready    worker   35m   v1.24.0
-ci-ln-47ltxtb-f76d1-mrffg-worker-b-5qqdx   Ready    worker   35m   v1.24.0
-ci-ln-47ltxtb-f76d1-mrffg-worker-c-rjkpq   Ready    worker   34m   v1.24.0
+ci-ln-47ltxtb-f76d1-mrffg-master-0         Ready    master   42m   v1.25.0
+ci-ln-47ltxtb-f76d1-mrffg-master-1         Ready    master   42m   v1.25.0
+ci-ln-47ltxtb-f76d1-mrffg-master-2         Ready    master   42m   v1.25.0
+ci-ln-47ltxtb-f76d1-mrffg-worker-a-gsxbz   Ready    worker   35m   v1.25.0
+ci-ln-47ltxtb-f76d1-mrffg-worker-b-5qqdx   Ready    worker   35m   v1.25.0
+ci-ln-47ltxtb-f76d1-mrffg-worker-c-rjkpq   Ready    worker   34m   v1.25.0
 ----

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -158,14 +158,14 @@ $ oc get nodes -w
 [source,terminal]
 ----
 NAME                STATUS  ROLES          AGE     VERSION
-host-172-25-75-28   Ready   master         3d20h   v1.24.0
-host-172-25-75-38   Ready   infra,worker   3d20h   v1.24.0
-host-172-25-75-40   Ready   master         3d20h   v1.24.0
-host-172-25-75-65   Ready   master         3d20h   v1.24.0
-host-172-25-75-74   Ready   infra,worker   3d20h   v1.24.0
-host-172-25-75-79   Ready   worker         3d20h   v1.24.0
-host-172-25-75-86   Ready   worker         3d20h   v1.24.0
-host-172-25-75-98   Ready   infra,worker   3d20h   v1.24.0
+host-172-25-75-28   Ready   master         3d20h   v1.25.0
+host-172-25-75-38   Ready   infra,worker   3d20h   v1.25.0
+host-172-25-75-40   Ready   master         3d20h   v1.25.0
+host-172-25-75-65   Ready   master         3d20h   v1.25.0
+host-172-25-75-74   Ready   infra,worker   3d20h   v1.25.0
+host-172-25-75-79   Ready   worker         3d20h   v1.25.0
+host-172-25-75-86   Ready   worker         3d20h   v1.25.0
+host-172-25-75-98   Ready   infra,worker   3d20h   v1.25.0
 ----
 +
 It can take several minutes for all nodes to report their state.

--- a/modules/graceful-restart.adoc
+++ b/modules/graceful-restart.adoc
@@ -35,9 +35,9 @@ The control plane nodes are ready if the status is `Ready`, as shown in the foll
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   75m   v1.24.0
-ip-10-0-170-223.ec2.internal   Ready    master   75m   v1.24.0
-ip-10-0-211-16.ec2.internal    Ready    master   75m   v1.24.0
+ip-10-0-168-251.ec2.internal   Ready    master   75m   v1.25.0
+ip-10-0-170-223.ec2.internal   Ready    master   75m   v1.25.0
+ip-10-0-211-16.ec2.internal    Ready    master   75m   v1.25.0
 ----
 
 . If the control plane nodes are _not_ ready, then check whether there are any pending certificate signing requests (CSRs) that must be approved.
@@ -76,9 +76,9 @@ The worker nodes are ready if the status is `Ready`, as shown in the following o
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-179-95.ec2.internal    Ready    worker   64m   v1.24.0
-ip-10-0-182-134.ec2.internal   Ready    worker   64m   v1.24.0
-ip-10-0-250-100.ec2.internal   Ready    worker   64m   v1.24.0
+ip-10-0-179-95.ec2.internal    Ready    worker   64m   v1.25.0
+ip-10-0-182-134.ec2.internal   Ready    worker   64m   v1.25.0
+ip-10-0-250-100.ec2.internal   Ready    worker   64m   v1.25.0
 ----
 
 . If the worker nodes are _not_ ready, then check whether there are any pending certificate signing requests (CSRs) that must be approved.
@@ -142,12 +142,12 @@ Check that the status for all nodes is `Ready`.
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.24.0
-ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.24.0
-ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.24.0
-ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.24.0
-ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.24.0
-ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.24.0
+ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.25.0
+ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.25.0
+ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.25.0
+ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.25.0
+ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.25.0
+ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.25.0
 ----
 
 If the cluster did not start properly, you might need to restore your cluster using an etcd backup.

--- a/modules/images-configuration-file.adoc
+++ b/modules/images-configuration-file.adoc
@@ -76,10 +76,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                       STATUS                     ROLES    AGE   VERSION
-ci-ln-j5cd0qt-f76d1-vfj5x-master-0         Ready                         master   98m   v1.24.0
-ci-ln-j5cd0qt-f76d1-vfj5x-master-1         Ready,SchedulingDisabled      master   99m   v1.24.0
-ci-ln-j5cd0qt-f76d1-vfj5x-master-2         Ready                         master   98m   v1.24.0
-ci-ln-j5cd0qt-f76d1-vfj5x-worker-b-nsnd4   Ready                         worker   90m   v1.24.0
-ci-ln-j5cd0qt-f76d1-vfj5x-worker-c-5z2gz   NotReady,SchedulingDisabled   worker   90m   v1.24.0
-ci-ln-j5cd0qt-f76d1-vfj5x-worker-d-stsjv   Ready                         worker   90m   v1.24.0
+ci-ln-j5cd0qt-f76d1-vfj5x-master-0         Ready                         master   98m   v1.25.0
+ci-ln-j5cd0qt-f76d1-vfj5x-master-1         Ready,SchedulingDisabled      master   99m   v1.25.0
+ci-ln-j5cd0qt-f76d1-vfj5x-master-2         Ready                         master   98m   v1.25.0
+ci-ln-j5cd0qt-f76d1-vfj5x-worker-b-nsnd4   Ready                         worker   90m   v1.25.0
+ci-ln-j5cd0qt-f76d1-vfj5x-worker-c-5z2gz   NotReady,SchedulingDisabled   worker   90m   v1.25.0
+ci-ln-j5cd0qt-f76d1-vfj5x-worker-d-stsjv   Ready                         worker   90m   v1.25.0
 ----

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -126,12 +126,12 @@ $ oc get node
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE  VERSION
-ip-10-0-137-44.ec2.internal    Ready                      worker   7m   v1.24.0
-ip-10-0-138-148.ec2.internal   Ready                      master   11m  v1.24.0
-ip-10-0-139-122.ec2.internal   Ready                      master   11m  v1.24.0
-ip-10-0-147-35.ec2.internal    Ready                      worker   7m   v1.24.0
-ip-10-0-153-12.ec2.internal    Ready                      worker   7m   v1.24.0
-ip-10-0-154-10.ec2.internal    Ready                      master   11m  v1.24.0
+ip-10-0-137-44.ec2.internal    Ready                      worker   7m   v1.25.0
+ip-10-0-138-148.ec2.internal   Ready                      master   11m  v1.25.0
+ip-10-0-139-122.ec2.internal   Ready                      master   11m  v1.25.0
+ip-10-0-147-35.ec2.internal    Ready                      worker   7m   v1.25.0
+ip-10-0-153-12.ec2.internal    Ready                      worker   7m   v1.25.0
+ip-10-0-154-10.ec2.internal    Ready                      master   11m  v1.25.0
 ----
 +
 The `Imagecontentsourcepolicy` resource does not restart the nodes.

--- a/modules/infrastructure-moving-logging.adoc
+++ b/modules/infrastructure-moving-logging.adoc
@@ -98,13 +98,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS   ROLES          AGE   VERSION
-ip-10-0-133-216.us-east-2.compute.internal   Ready    master         60m   v1.24.0
-ip-10-0-139-146.us-east-2.compute.internal   Ready    master         60m   v1.24.0
-ip-10-0-139-192.us-east-2.compute.internal   Ready    worker         51m   v1.24.0
-ip-10-0-139-241.us-east-2.compute.internal   Ready    worker         51m   v1.24.0
-ip-10-0-147-79.us-east-2.compute.internal    Ready    worker         51m   v1.24.0
-ip-10-0-152-241.us-east-2.compute.internal   Ready    master         60m   v1.24.0
-ip-10-0-139-48.us-east-2.compute.internal    Ready    infra          51m   v1.24.0
+ip-10-0-133-216.us-east-2.compute.internal   Ready    master         60m   v1.25.0
+ip-10-0-139-146.us-east-2.compute.internal   Ready    master         60m   v1.25.0
+ip-10-0-139-192.us-east-2.compute.internal   Ready    worker         51m   v1.25.0
+ip-10-0-139-241.us-east-2.compute.internal   Ready    worker         51m   v1.25.0
+ip-10-0-147-79.us-east-2.compute.internal    Ready    worker         51m   v1.25.0
+ip-10-0-152-241.us-east-2.compute.internal   Ready    master         60m   v1.25.0
+ip-10-0-139-48.us-east-2.compute.internal    Ready    infra          51m   v1.25.0
 ----
 +
 Note that the node has a `node-role.kubernetes.io/infra: ''` label:

--- a/modules/infrastructure-moving-router.adoc
+++ b/modules/infrastructure-moving-router.adoc
@@ -98,7 +98,7 @@ $ oc get node <node_name> <1>
 [source,terminal]
 ----
 NAME                          STATUS  ROLES         AGE   VERSION
-ip-10-0-217-226.ec2.internal  Ready   infra,worker  17h   v1.24.0
+ip-10-0-217-226.ec2.internal  Ready   infra,worker  17h   v1.25.0
 ----
 +
 Because the role list includes `infra`, the pod is running on the correct node.

--- a/modules/install-sno-monitoring-the-installation-manually.adoc
+++ b/modules/install-sno-monitoring-the-installation-manually.adoc
@@ -41,5 +41,5 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                         STATUS   ROLES           AGE     VERSION
-control-plane.example.com    Ready    master,worker   10m     v1.24.0+beaaed6
+control-plane.example.com    Ready    master,worker   10m     v1.25.0
 ----

--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -57,9 +57,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME      STATUS    ROLES   AGE  VERSION
-master-0  Ready     master  63m  v1.24.0
-master-1  Ready     master  63m  v1.24.0
-master-2  Ready     master  64m  v1.24.0
+master-0  Ready     master  63m  v1.25.0
+master-1  Ready     master  63m  v1.25.0
+master-2  Ready     master  64m  v1.25.0
 ----
 +
 The output lists all of the machines that you created.
@@ -179,11 +179,11 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME      STATUS    ROLES   AGE  VERSION
-master-0  Ready     master  73m  v1.24.0
-master-1  Ready     master  73m  v1.24.0
-master-2  Ready     master  74m  v1.24.0
-worker-0  Ready     worker  11m  v1.24.0
-worker-1  Ready     worker  11m  v1.24.0
+master-0  Ready     master  73m  v1.25.0
+master-1  Ready     master  73m  v1.25.0
+master-2  Ready     master  74m  v1.25.0
+worker-0  Ready     worker  11m  v1.25.0
+worker-1  Ready     worker  11m  v1.25.0
 ----
 +
 [NOTE]

--- a/modules/installation-aws-user-infra-bootstrap.adoc
+++ b/modules/installation-aws-user-infra-bootstrap.adoc
@@ -40,7 +40,7 @@ stored the installation files in.
 [source,terminal]
 ----
 INFO Waiting up to 20m0s for the Kubernetes API at https://api.mycluster.example.com:6443...
-INFO API v1.24.0 up
+INFO API v1.25.0 up
 INFO Waiting up to 30m0s for bootstrapping to complete...
 INFO It is now safe to remove the bootstrap resources
 INFO Time elapsed: 1s

--- a/modules/installation-installing-bare-metal.adoc
+++ b/modules/installation-installing-bare-metal.adoc
@@ -59,7 +59,7 @@ $ ./openshift-install --dir <installation_directory> wait-for bootstrap-complete
 [source,terminal]
 ----
 INFO Waiting up to 30m0s for the Kubernetes API at https://api.test.example.com:6443...
-INFO API v1.24.0 up
+INFO API v1.25.0 up
 INFO Waiting up to 30m0s for bootstrapping to complete...
 INFO It is now safe to remove the bootstrap resources
 ----

--- a/modules/installation-osp-creating-control-plane.adoc
+++ b/modules/installation-osp-creating-control-plane.adoc
@@ -40,7 +40,7 @@ You will see messages that confirm that the control plane machines are running a
 +
 [source,terminal]
 ----
-INFO API v1.24.0 up
+INFO API v1.25.0 up
 INFO Waiting up to 30m0s for bootstrapping to complete...
 ...
 INFO It is now safe to remove the bootstrap resources

--- a/modules/installation-rhv-creating-control-plane-nodes.adoc
+++ b/modules/installation-rhv-creating-control-plane-nodes.adoc
@@ -28,7 +28,7 @@ $ openshift-install wait-for bootstrap-complete --dir $ASSETS_DIR
 .Example output
 [source,terminal]
 ----
-INFO API v1.24.0 up
+INFO API v1.25.0 up
 INFO Waiting up to 40m0s for bootstrapping to complete...
 ----
 

--- a/modules/installation-special-config-rtkernel.adoc
+++ b/modules/installation-special-config-rtkernel.adoc
@@ -92,12 +92,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-139-200.us-east-2.compute.internal  Ready   master   111m  v1.24.0
-ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.24.0
-ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.24.0
-ip-10-0-156-255.us-east-2.compute.internal  Ready   master   111m  v1.24.0
-ip-10-0-164-74.us-east-2.compute.internal   Ready   master   111m  v1.24.0
-ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.24.0
+ip-10-0-139-200.us-east-2.compute.internal  Ready   master   111m  v1.25.0
+ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.25.0
+ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.25.0
+ip-10-0-156-255.us-east-2.compute.internal  Ready   master   111m  v1.25.0
+ip-10-0-164-74.us-east-2.compute.internal   Ready   master   111m  v1.25.0
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.25.0
 ----
 +
 [source,terminal]

--- a/modules/ipi-install-provisioning-the-bare-metal-node.adoc
+++ b/modules/ipi-install-provisioning-the-bare-metal-node.adoc
@@ -35,11 +35,11 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                                STATUS   ROLES           AGE     VERSION
-openshift-master-1.openshift.example.com            Ready    master          30h     v1.24.0
-openshift-master-2.openshift.example.com            Ready    master          30h     v1.24.0
-openshift-master-3.openshift.example.com            Ready    master          30h     v1.24.0
-openshift-worker-0.openshift.example.com            Ready    worker          30h     v1.24.0
-openshift-worker-1.openshift.example.com            Ready    worker          30h     v1.24.0
+openshift-master-1.openshift.example.com            Ready    master          30h     v1.25.0
+openshift-master-2.openshift.example.com            Ready    master          30h     v1.25.0
+openshift-master-3.openshift.example.com            Ready    master          30h     v1.25.0
+openshift-worker-0.openshift.example.com            Ready    worker          30h     v1.25.0
+openshift-worker-1.openshift.example.com            Ready    worker          30h     v1.25.0
 ----
 
 . Get the machine set.
@@ -99,12 +99,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                          STATUS   ROLES   AGE     VERSION
-openshift-master-1.openshift.example.com      Ready    master  30h     v1.24.0
-openshift-master-2.openshift.example.com      Ready    master  30h     v1.24.0
-openshift-master-3.openshift.example.com      Ready    master  30h     v1.24.0
-openshift-worker-0.openshift.example.com      Ready    worker  30h     v1.24.0
-openshift-worker-1.openshift.example.com      Ready    worker  30h     v1.24.0
-openshift-worker-<num>.openshift.example.com  Ready    worker  3m27s   v1.24.0
+openshift-master-1.openshift.example.com      Ready    master  30h     v1.25.0
+openshift-master-2.openshift.example.com      Ready    master  30h     v1.25.0
+openshift-master-3.openshift.example.com      Ready    master  30h     v1.25.0
+openshift-worker-0.openshift.example.com      Ready    worker  30h     v1.25.0
+openshift-worker-1.openshift.example.com      Ready    worker  30h     v1.25.0
+openshift-worker-<num>.openshift.example.com  Ready    worker  3m27s   v1.25.0
 ----
 +
 You can also check the kubelet.

--- a/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
+++ b/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
@@ -20,10 +20,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                         STATUS   ROLES    AGE   VERSION
-master-0.cloud.example.com   Ready    master   145m   v1.24.0
-master-1.cloud.example.com   Ready    master   135m   v1.24.0
-master-2.cloud.example.com   Ready    master   145m   v1.24.0
-worker-2.cloud.example.com   Ready    worker   100m   v1.24.0
+master-0.cloud.example.com   Ready    master   145m   v1.25.0
+master-1.cloud.example.com   Ready    master   135m   v1.25.0
+master-2.cloud.example.com   Ready    master   145m   v1.25.0
+worker-2.cloud.example.com   Ready    worker   100m   v1.25.0
 ----
 
 . Check for inconsistent timing delays due to clock drift. For example:

--- a/modules/ipi-install-troubleshooting-reviewing-the-installation.adoc
+++ b/modules/ipi-install-troubleshooting-reviewing-the-installation.adoc
@@ -20,9 +20,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                   STATUS   ROLES           AGE  VERSION
-master-0.example.com   Ready    master,worker   4h   v1.24.0
-master-1.example.com   Ready    master,worker   4h   v1.24.0
-master-2.example.com   Ready    master,worker   4h   v1.24.0
+master-0.example.com   Ready    master,worker   4h   v1.25.0
+master-1.example.com   Ready    master,worker   4h   v1.25.0
+master-2.example.com   Ready    master,worker   4h   v1.25.0
 ----
 
 . Confirm the installer deployed all pods successfully. The following command

--- a/modules/machine-node-custom-partition.adoc
+++ b/modules/machine-node-custom-partition.adoc
@@ -8,11 +8,11 @@
 [id="machine-node-custom-partition_{context}"]
 = Adding a new {op-system} worker node with a custom `/var` partition in AWS
 
-{product-title} supports partitioning devices during installation by using machine configs that are processed during the bootstrap. However, if you use `/var` partitioning, the device name must be determined at installation and cannot be changed. You cannot add different instance types as nodes if they have a different device naming schema. For example, if you configured the `/var` partition with the default AWS device name for `m4.large` instances, `dev/xvdb`, you cannot directly add an AWS `m5.large` instance, as `m5.large` instances use a `/dev/nvme1n1` device by default. The device might fail to partition due to the different naming schema.   
+{product-title} supports partitioning devices during installation by using machine configs that are processed during the bootstrap. However, if you use `/var` partitioning, the device name must be determined at installation and cannot be changed. You cannot add different instance types as nodes if they have a different device naming schema. For example, if you configured the `/var` partition with the default AWS device name for `m4.large` instances, `dev/xvdb`, you cannot directly add an AWS `m5.large` instance, as `m5.large` instances use a `/dev/nvme1n1` device by default. The device might fail to partition due to the different naming schema.
 
 The procedure in this section shows how to add a new {op-system-first} compute node with an instance that uses a different device name from what was configured at installation. You create a custom user data secret and configure a new machine set. These steps are specific to an AWS cluster. The principles apply to other cloud deployments also. However, the device naming schema is different for other deployments and should be determined on a per-case basis.
 
-.Procedure 
+.Procedure
 
 . On a command line, change to the `openshift-machine-api` namespace:
 +
@@ -21,9 +21,9 @@ The procedure in this section shows how to add a new {op-system-first} compute n
 $ oc project openshift-machine-api
 ----
 
-. Create a new secret from the `worker-user-data` secret: 
+. Create a new secret from the `worker-user-data` secret:
 
-.. Export the `userData` section of the secret to a text file: 
+.. Export the `userData` section of the secret to a text file:
 +
 [source,terminal]
 ----
@@ -34,7 +34,7 @@ $ oc get secret worker-user-data --template='{{index .data.userData | base64deco
 +
 [NOTE]
 ====
-Do not change the values in the `ignition` stanza. 
+Do not change the values in the `ignition` stanza.
 ====
 +
 [source,terminal]
@@ -114,7 +114,7 @@ $ oc get secret worker-user-data --template='{{index .data.disableTemplating | b
 $ oc create secret generic worker-user-data-x5 --from-file=userData=userData.txt --from-file=disableTemplating=disableTemplating.txt
 ----
 
-. Create a new machine set for the new node: 
+. Create a new machine set for the new node:
 
 .. Create a new machine set YAML file, similar to the following, which is configured for AWS. Add the required partitions and the newly-created user data secret:
 +
@@ -192,7 +192,7 @@ spec:
 ----
 <1> Specifies a name for the new node.
 <2> Specifies an absolute path to the AWS block device, here an encrypted EBS volume.
-<3> Optional. Specifies an additional EBS volume. 
+<3> Optional. Specifies an additional EBS volume.
 <4> Specifies the user data secret file.
 
 .. Create the machine set:
@@ -202,7 +202,7 @@ spec:
 $ oc create -f <file-name>.yaml
 ----
 +
-The machines might take a few moments to become available. 
+The machines might take a few moments to become available.
 
 . Verify that the new partition and nodes are created:
 
@@ -236,13 +236,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE     VERSION
-ip-10-0-128-78.ec2.internal    Ready    worker   117m    v1.24.0+60f5a1c
-ip-10-0-146-113.ec2.internal   Ready    master   127m    v1.24.0+60f5a1c
-ip-10-0-153-35.ec2.internal    Ready    worker   118m    v1.24.0+60f5a1c
-ip-10-0-176-58.ec2.internal    Ready    master   126m    v1.24.0+60f5a1c
-ip-10-0-217-135.ec2.internal   Ready    worker   2m57s   v1.24.0+60f5a1c <1>
-ip-10-0-225-248.ec2.internal   Ready    master   127m    v1.24.0+60f5a1c
-ip-10-0-245-59.ec2.internal    Ready    worker   116m    v1.24.0+60f5a1c
+ip-10-0-128-78.ec2.internal    Ready    worker   117m    v1.25.0
+ip-10-0-146-113.ec2.internal   Ready    master   127m    v1.25.0
+ip-10-0-153-35.ec2.internal    Ready    worker   118m    v1.25.0
+ip-10-0-176-58.ec2.internal    Ready    master   126m    v1.25.0
+ip-10-0-217-135.ec2.internal   Ready    worker   2m57s   v1.25.0 <1>
+ip-10-0-225-248.ec2.internal   Ready    master   127m    v1.25.0
+ip-10-0-245-59.ec2.internal    Ready    worker   116m    v1.25.0
 ----
 <1> This is new new node.
 
@@ -265,14 +265,12 @@ $ oc debug node/ip-10-0-217-135.ec2.internal -- chroot /host lsblk
 [source,terminal]
 ----
 NAME        MAJ:MIN  RM  SIZE RO TYPE MOUNTPOINT
-nvme0n1     202:0    0   120G  0 disk 
-|-nvme0n1p1 202:1    0     1M  0 part 
-|-nvme0n1p2 202:2    0   127M  0 part 
+nvme0n1     202:0    0   120G  0 disk
+|-nvme0n1p1 202:1    0     1M  0 part
+|-nvme0n1p2 202:2    0   127M  0 part
 |-nvme0n1p3 202:3    0   384M  0 part /boot
 `-nvme0n1p4 202:4    0 119.5G  0 part /sysroot
-nvme1n1     202:16   0    50G  0 disk 
+nvme1n1     202:16   0    50G  0 disk
 `-nvme1n1p1 202:17   0  48.8G  0 part /var <1>
 ----
 <1> The `nvme1n1` device is mounted to the `/var` partition.
-
-

--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -151,12 +151,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                       STATUS                     ROLES    AGE   VERSION
-ci-ln-fm1qnwt-72292-99kt6-master-0         Ready                      master   58m   v1.24.0
-ci-ln-fm1qnwt-72292-99kt6-master-1         Ready                      master   58m   v1.24.0
-ci-ln-fm1qnwt-72292-99kt6-master-2         Ready                      master   58m   v1.24.0
-ci-ln-fm1qnwt-72292-99kt6-worker-a-h5gt4   Ready,SchedulingDisabled   worker   48m   v1.24.0
-ci-ln-fm1qnwt-72292-99kt6-worker-b-7vtmd   Ready                      worker   48m   v1.24.0
-ci-ln-fm1qnwt-72292-99kt6-worker-c-rhzkv   Ready                      worker   48m   v1.24.0
+ci-ln-fm1qnwt-72292-99kt6-master-0         Ready                      master   58m   v1.25.0
+ci-ln-fm1qnwt-72292-99kt6-master-1         Ready                      master   58m   v1.25.0
+ci-ln-fm1qnwt-72292-99kt6-master-2         Ready                      master   58m   v1.25.0
+ci-ln-fm1qnwt-72292-99kt6-worker-a-h5gt4   Ready,SchedulingDisabled   worker   48m   v1.25.0
+ci-ln-fm1qnwt-72292-99kt6-worker-b-7vtmd   Ready                      worker   48m   v1.25.0
+ci-ln-fm1qnwt-72292-99kt6-worker-c-rhzkv   Ready                      worker   48m   v1.25.0
 ----
 
 . After a node returns to the `Ready` state, start a debug session for that node:

--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -128,12 +128,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE   VERSION
-ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.24.0
-ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.24.0
-ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.24.0
-ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.24.0
-ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.24.0
-ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.24.0
+ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.25.0
+ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.25.0
+ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.25.0
+ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.25.0
+ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.25.0
+ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.25.0
 ----
 +
 You can see that scheduling on each worker node is disabled as the change is being applied.

--- a/modules/nodes-nodes-rtkernel-arguments.adoc
+++ b/modules/nodes-nodes-rtkernel-arguments.adoc
@@ -58,9 +58,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.24.0
-ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.24.0
-ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.24.0
+ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.25.0
+ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.25.0
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.25.0
 ----
 +
 [source,terminal]

--- a/modules/nodes-nodes-viewing-listing.adoc
+++ b/modules/nodes-nodes-viewing-listing.adoc
@@ -26,9 +26,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                   STATUS    ROLES     AGE       VERSION
-master.example.com     Ready     master    7h        v1.24.0
-node1.example.com      Ready     worker    7h        v1.24.0
-node2.example.com      Ready     worker    7h        v1.24.0
+master.example.com     Ready     master    7h        v1.25.0
+node1.example.com      Ready     worker    7h        v1.25.0
+node2.example.com      Ready     worker    7h        v1.25.0
 ----
 +
 The following example is a cluster with one unhealthy node:
@@ -42,9 +42,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                   STATUS                      ROLES     AGE       VERSION
-master.example.com     Ready                       master    7h        v1.24.0
-node1.example.com      NotReady,SchedulingDisabled worker    7h        v1.24.0
-node2.example.com      Ready                       worker    7h        v1.24.0
+master.example.com     Ready                       master    7h        v1.25.0
+node1.example.com      NotReady,SchedulingDisabled worker    7h        v1.25.0
+node2.example.com      Ready                       worker    7h        v1.25.0
 ----
 +
 The conditions that trigger a `NotReady` status are shown later in this section.
@@ -60,9 +60,9 @@ $ oc get nodes -o wide
 [source,terminal]
 ----
 NAME                STATUS   ROLES    AGE    VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                                                       KERNEL-VERSION                 CONTAINER-RUNTIME
-master.example.com  Ready    master   171m   v1.24.0   10.0.129.108   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.24.0-30.rhaos4.10.gitf2f339d.el8-dev
-node1.example.com   Ready    worker   72m    v1.24.0   10.0.129.222   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.24.0-30.rhaos4.10.gitf2f339d.el8-dev
-node2.example.com   Ready    worker   164m   v1.24.0   10.0.142.150   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.24.0-30.rhaos4.10.gitf2f339d.el8-dev
+master.example.com  Ready    master   171m   v1.25.0   10.0.129.108   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.25.0-30.rhaos4.10.gitf2f339d.el8-dev
+node1.example.com   Ready    worker   72m    v1.25.0   10.0.129.222   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.25.0-30.rhaos4.10.gitf2f339d.el8-dev
+node2.example.com   Ready    worker   164m   v1.25.0   10.0.142.150   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.25.0-30.rhaos4.10.gitf2f339d.el8-dev
 ----
 
 * The following command lists information about a single node:
@@ -83,7 +83,7 @@ $ oc get node node1.example.com
 [source,terminal]
 ----
 NAME                   STATUS    ROLES     AGE       VERSION
-node1.example.com      Ready     worker    7h        v1.24.0
+node1.example.com      Ready     worker    7h        v1.25.0
 ----
 
 * The following command provides more detailed information about a specific node, including the reason for
@@ -155,9 +155,9 @@ System Info:    <9>
  OS Image:                                Red Hat Enterprise Linux CoreOS 410.8.20190520.0 (Ootpa)
  Operating System:                        linux
  Architecture:                            amd64
- Container Runtime Version:               cri-o://1.24.0-0.6.dev.rhaos4.3.git9ad059b.el8-rc2
- Kubelet Version:                         v1.24.0
- Kube-Proxy Version:                      v1.24.0
+ Container Runtime Version:               cri-o://1.25.0-0.6.dev.rhaos4.3.git9ad059b.el8-rc2
+ Kubelet Version:                         v1.25.0
+ Kube-Proxy Version:                      v1.25.0
 PodCIDR:                                  10.128.4.0/24
 ProviderID:                               aws:///us-east-2a/i-04e87b31dc6b3e171
 Non-terminated Pods:                      (12 in total)  <10>

--- a/modules/nodes-nodes-working-evacuating.adoc
+++ b/modules/nodes-nodes-working-evacuating.adoc
@@ -44,7 +44,7 @@ $ oc get node <node1>
 [source,terminal]
 ----
 NAME        STATUS                     ROLES     AGE       VERSION
-<node1>     Ready,SchedulingDisabled   worker    1d        v1.24.0
+<node1>     Ready,SchedulingDisabled   worker    1d        v1.25.0
 ----
 
 . Evacuate the pods using one of the following methods:

--- a/modules/nodes-scheduler-node-selectors-cluster.adoc
+++ b/modules/nodes-scheduler-node-selectors-cluster.adoc
@@ -168,7 +168,7 @@ $ oc get nodes -l type=user-node
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.24.0
+ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.25.0
 ----
 
 * Add labels directly to a node:
@@ -221,5 +221,5 @@ $ oc get nodes -l type=user-node,region=east
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.24.0
+ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.25.0
 ----

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -168,7 +168,7 @@ $ oc get nodes -l type=user-node,region=east
 [source,terminal]
 ----
 NAME                          STATUS   ROLES    AGE   VERSION
-ip-10-0-142-25.ec2.internal   Ready    worker   17m   v1.24.0
+ip-10-0-142-25.ec2.internal   Ready    worker   17m   v1.25.0
 ----
 
 . Add the matching node selector to a pod:

--- a/modules/nodes-scheduler-node-selectors-project.adoc
+++ b/modules/nodes-scheduler-node-selectors-project.adoc
@@ -161,7 +161,7 @@ $ oc get nodes -l type=user-node
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.24.0
+ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.25.0
 ----
 
 * Add labels directly to a node:
@@ -214,5 +214,5 @@ $ oc get nodes -l type=user-node,region=east
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.24.0
+ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.25.0
 ----

--- a/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
+++ b/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
@@ -62,13 +62,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME       STATUS   ROLES                   AGE   VERSION
-master-0   Ready    master                  2d    v1.24.0
-master-1   Ready    master                  2d    v1.24.0
-master-2   Ready    master                  2d    v1.24.0
-worker-0   Ready    worker                  2d    v1.24.0
-worker-1   Ready    worker                  2d    v1.24.0
-worker-2   Ready    mcp-offloading,worker   47h   v1.24.0
-worker-3   Ready    mcp-offloading,worker   47h   v1.24.0
+master-0   Ready    master                  2d    v1.25.0
+master-1   Ready    master                  2d    v1.25.0
+master-2   Ready    master                  2d    v1.25.0
+worker-0   Ready    worker                  2d    v1.25.0
+worker-1   Ready    worker                  2d    v1.25.0
+worker-2   Ready    mcp-offloading,worker   47h   v1.25.0
+worker-3   Ready    mcp-offloading,worker   47h   v1.25.0
 ----
 --
 

--- a/modules/olm-catalogsource-image-template.adoc
+++ b/modules/olm-catalogsource-image-template.adoc
@@ -12,20 +12,20 @@ endif::[]
 [id="olm-catalogsource-image-template_{context}"]
 = Image template for custom catalog sources
 
-Operator compatibility with the underlying cluster can be expressed by a catalog source in various ways. One way, which is used for the default Red Hat-provided catalog sources, is to identify image tags for index images that are specifically created for a particular platform release, for example {product-title} 4.11.
+Operator compatibility with the underlying cluster can be expressed by a catalog source in various ways. One way, which is used for the default Red Hat-provided catalog sources, is to identify image tags for index images that are specifically created for a particular platform release, for example {product-title} 4.12.
 
-During a cluster upgrade, the index image tag for the default Red Hat-provided catalog sources are updated automatically by the Cluster Version Operator (CVO) so that Operator Lifecycle Manager (OLM) pulls the updated version of the catalog. For example during an upgrade from {product-title} 4.10 to 4.11, the `spec.image` field in the `CatalogSource` object for the `redhat-operators` catalog is updated from:
+During a cluster upgrade, the index image tag for the default Red Hat-provided catalog sources are updated automatically by the Cluster Version Operator (CVO) so that Operator Lifecycle Manager (OLM) pulls the updated version of the catalog. For example during an upgrade from {product-title} 4.11 to 4.12, the `spec.image` field in the `CatalogSource` object for the `redhat-operators` catalog is updated from:
 
 [source,terminal]
 ----
-registry.redhat.io/redhat/redhat-operator-index:v4.10
+registry.redhat.io/redhat/redhat-operator-index:v4.11
 ----
 
 to:
 
 [source,terminal]
 ----
-registry.redhat.io/redhat/redhat-operator-index:v4.11
+registry.redhat.io/redhat/redhat-operator-index:v4.12
 ----
 
 However, the CVO does not automatically update image tags for custom catalogs. To ensure users are left with a compatible and supported Operator installation after a cluster upgrade, custom catalogs should also be kept updated to reference an updated index image.
@@ -64,7 +64,7 @@ metadata:
       "quay.io/example-org/example-catalog:v{kube_major_version}.{kube_minor_version}"
 spec:
   displayName: Example Catalog
-  image: quay.io/example-org/example-catalog:v1.24
+  image: quay.io/example-org/example-catalog:v1.25
   priority: -400
   publisher: Example Org
 ----
@@ -77,11 +77,11 @@ If the `spec.image` field and the `olm.catalogImageTemplate` annotation are both
 If the `spec.image` field is not set and the annotation does not resolve to a usable pull spec, OLM stops reconciliation of the catalog source and sets it into a human-readable error condition.
 ====
 
-For an {product-title} 4.11 cluster, which uses Kubernetes 1.24, the `olm.catalogImageTemplate` annotation in the preceding example resolves to the following image reference:
+For an {product-title} 4.12 cluster, which uses Kubernetes 1.25, the `olm.catalogImageTemplate` annotation in the preceding example resolves to the following image reference:
 
 [source,terminal]
 ----
-quay.io/example-org/example-catalog:v1.24
+quay.io/example-org/example-catalog:v1.25
 ----
 
 For future releases of {product-title}, you can create updated index images for your custom catalogs that target the later Kubernetes version that is used by the later {product-title} version. With the `olm.catalogImageTemplate` annotation set before the upgrade, upgrading the cluster to the later {product-title} version would then automatically update the catalog's index image as well.

--- a/modules/querying-the-status-of-cluster-nodes-using-the-cli.adoc
+++ b/modules/querying-the-status-of-cluster-nodes-using-the-cli.adoc
@@ -26,12 +26,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                          STATUS   ROLES    AGE   VERSION
-compute-1.example.com         Ready    worker   33m   v1.24.0
-control-plane-1.example.com   Ready    master   41m   v1.24.0
-control-plane-2.example.com   Ready    master   45m   v1.24.0
-compute-2.example.com         Ready    worker   38m   v1.24.0
-compute-3.example.com         Ready    worker   33m   v1.24.0
-control-plane-3.example.com   Ready    master   41m   v1.24.0
+compute-1.example.com         Ready    worker   33m   v1.25.0
+control-plane-1.example.com   Ready    master   41m   v1.25.0
+control-plane-2.example.com   Ready    master   45m   v1.25.0
+compute-2.example.com         Ready    worker   38m   v1.25.0
+compute-3.example.com         Ready    worker   33m   v1.25.0
+control-plane-3.example.com   Ready    master   41m   v1.25.0
 ----
 
 . Review CPU and memory resource availability for each cluster node:

--- a/modules/restore-determine-state-etcd-member.adoc
+++ b/modules/restore-determine-state-etcd-member.adoc
@@ -71,7 +71,7 @@ $ oc get nodes -l node-role.kubernetes.io/master | grep "NotReady"
 .Example output
 [source,terminal]
 ----
-ip-10-0-131-183.ec2.internal   NotReady   master   122m   v1.24.0 <1>
+ip-10-0-131-183.ec2.internal   NotReady   master   122m   v1.25.0 <1>
 ----
 <1> If the node is listed as `NotReady`, then the *node is not ready*.
 
@@ -95,9 +95,9 @@ $ oc get nodes -l node-role.kubernetes.io/master
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE     VERSION
-ip-10-0-131-183.ec2.internal   Ready    master   6h13m   v1.24.0
-ip-10-0-164-97.ec2.internal    Ready    master   6h13m   v1.24.0
-ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.24.0
+ip-10-0-131-183.ec2.internal   Ready    master   6h13m   v1.25.0
+ip-10-0-164-97.ec2.internal    Ready    master   6h13m   v1.25.0
+ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.25.0
 ----
 
 .. Check whether the status of an etcd pod is either `Error` or `CrashloopBackoff`:

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -8,7 +8,7 @@
 
 This procedure details the steps to replace a bare metal etcd member that is unhealthy either because the machine is not running or because the node is not ready.
 
-If you are running installer-provisioned infrastructure or you used the Machine API to create your machines, follow these steps. Otherwise you must create the new control plane node using the same method that was used to originally create it. 
+If you are running installer-provisioned infrastructure or you used the Machine API to create your machines, follow these steps. Otherwise you must create the new control plane node using the same method that was used to originally create it.
 
 .Prerequisites
 
@@ -115,7 +115,7 @@ You can now exit the node shell.
 After you remove the member, the cluster might be unreachable for a short time while the remaining etcd instances reboot.
 ====
 
-. Remove the old secrets for the unhealthy etcd member that was removed by running the following commands. 
+. Remove the old secrets for the unhealthy etcd member that was removed by running the following commands.
 
 .. List the secrets for the unhealthy etcd member that was removed.
 +
@@ -314,7 +314,7 @@ baremetal   4.11.3    True        False         False      3d15h
 $ oc delete machine -n openshift-machine-api examplecluster-control-plane-2
 ----
 +
-If deletion of the machine is delayed for any reason or the command is obstructed and delayed, you can force deletion by removing the machine object finalizer field. 
+If deletion of the machine is delayed for any reason or the command is obstructed and delayed, you can force deletion by removing the machine object finalizer field.
 +
 [IMPORTANT]
 ====
@@ -373,7 +373,7 @@ baremetalhost.metal3.io "openshift-control-plane-2" deleted
 +
 After you remove the `BareMetalHost` and `Machine` objects, then the `Machine` controller automatically deletes the `Node` object.
 +
-If, after deletion of the `BareMetalHost` object, the machine node requires excessive time for deletion, the machine node can be deleted using: 
+If, after deletion of the `BareMetalHost` object, the machine node requires excessive time for deletion, the machine node can be deleted using:
 +
 [source,terminal]
 ----
@@ -389,10 +389,10 @@ Verify the node has been deleted:
 $ oc get nodes
 
 NAME                     STATUS ROLES   AGE   VERSION
-openshift-control-plane-0 Ready master 3h24m v1.24.0+9546431
-openshift-control-plane-1 Ready master 3h24m v1.24.0+9546431
-openshift-compute-0       Ready worker 176m v1.24.0+9546431
-openshift-compute-1       Ready worker 176m v1.24.0+9546431
+openshift-control-plane-0 Ready master 3h24m v1.25.0
+openshift-control-plane-1 Ready master 3h24m v1.25.0
+openshift-compute-0       Ready worker 176m v1.25.0
+openshift-compute-1       Ready worker 176m v1.25.0
 ----
 
 . Create the new `BareMetalHost` object and the secret to store the BMC credentials:
@@ -434,7 +434,7 @@ spec:
 EOF
 ----
 +
-[Note] 
+[Note]
 ====
 The username and password can be found from the other bare metal host's secrets. The protocol to use in `bmc:address` can be taken from other bmh objects.
 ====
@@ -486,7 +486,7 @@ examplecluster-control-plane-0         Running                          3h11m   
 examplecluster-control-plane-1         Running                          3h11m   openshift-control-plane-1   baremetalhost:///openshift-machine-api/openshift-control-plane-1/d9f9acbc-329c-475e-8d81-03b20280a3e1   externally provisioned
 examplecluster-control-plane-2         Running                          3h11m   openshift-control-plane-2   baremetalhost:///openshift-machine-api/openshift-control-plane-2/3354bdac-61d8-410f-be5b-6a395b056135   externally provisioned
 examplecluster-compute-0               Running                          165m    openshift-compute-0         baremetalhost:///openshift-machine-api/openshift-compute-0/3d685b81-7410-4bb3-80ec-13a31858241f         provisioned
-examplecluster-compute-1               Running                          165m    openshift-compute-1         baremetalhost:///openshift-machine-api/openshift-compute-1/0fdae6eb-2066-4241-91dc-e7ea72ab13b9         provisioned 
+examplecluster-compute-1               Running                          165m    openshift-compute-1         baremetalhost:///openshift-machine-api/openshift-compute-1/0fdae6eb-2066-4241-91dc-e7ea72ab13b9         provisioned
 ----
 <1> The new machine, `clustername-8qw5l-master-3` is being created and is ready after the phase changes from `Provisioning` to `Running`.
 +
@@ -524,11 +524,11 @@ $ oc get nodes
 ----
 $ oc get nodes
 NAME                     STATUS ROLES   AGE   VERSION
-openshift-control-plane-0 Ready master 4h26m v1.24.0+9546431
-openshift-control-plane-1 Ready master 4h26m v1.24.0+9546431
-openshift-control-plane-2 Ready master 12m   v1.24.0+9546431
-openshift-compute-0       Ready worker 3h58m v1.24.0+9546431
-openshift-compute-1       Ready worker 3h58m v1.24.0+9546431
+openshift-control-plane-0 Ready master 4h26m v1.25.0
+openshift-control-plane-1 Ready master 4h26m v1.25.0
+openshift-control-plane-2 Ready master 12m   v1.25.0
+openshift-compute-0       Ready worker 3h58m v1.25.0
+openshift-compute-1       Ready worker 3h58m v1.25.0
 ----
 
 .Verification
@@ -547,7 +547,7 @@ $ oc get pods -n openshift-etcd -o wide | grep etcd | grep -v guard
 ----
 etcd-openshift-control-plane-0      5/5     Running     0     105m
 etcd-openshift-control-plane-1      5/5     Running     0     107m
-etcd-openshift-control-plane-2      5/5     Running     0     103m 
+etcd-openshift-control-plane-2      5/5     Running     0     103m
 ----
 +
 If the output from the previous command only lists two pods, you can manually force an etcd redeployment. In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
@@ -617,4 +617,3 @@ $ oc get etcd -o=jsonpath='{range.items[0].status.conditions[?(@.type=="NodeInst
 ----
 AllNodesAtLatestRevision
 ----
-

--- a/modules/rhcos-add-extensions.adoc
+++ b/modules/rhcos-add-extensions.adoc
@@ -94,7 +94,7 @@ $ oc get node | grep worker
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.24.0
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.25.0
 ----
 +
 [source,terminal]

--- a/modules/rhcos-enabling-multipath-day-2.adoc
+++ b/modules/rhcos-enabling-multipath-day-2.adoc
@@ -104,12 +104,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE   VERSION
-ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.24.0
-ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.24.0
-ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.24.0
-ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.24.0
-ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.24.0
-ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.24.0
+ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.25.0
+ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.25.0
+ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.25.0
+ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.25.0
+ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.25.0
+ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.25.0
 ----
 +
 You can see that scheduling on each worker node is disabled as the change is being applied.

--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -125,13 +125,13 @@ The `upgrade` playbook only upgrades the {product-title} packages. It does not u
 [source,terminal]
 ----
 NAME                        STATUS                        ROLES    AGE    VERSION
-mycluster-control-plane-0   Ready                         master   145m   v1.24.0
-mycluster-control-plane-1   Ready                         master   145m   v1.24.0
-mycluster-control-plane-2   Ready                         master   145m   v1.24.0
-mycluster-rhel8-0           Ready                         worker   98m    v1.24.0
-mycluster-rhel8-1           Ready                         worker   98m    v1.24.0
-mycluster-rhel8-2           Ready                         worker   98m    v1.24.0
-mycluster-rhel8-3           Ready                         worker   98m    v1.24.0
+mycluster-control-plane-0   Ready                         master   145m   v1.25.0
+mycluster-control-plane-1   Ready                         master   145m   v1.25.0
+mycluster-control-plane-2   Ready                         master   145m   v1.25.0
+mycluster-rhel8-0           Ready                         worker   98m    v1.25.0
+mycluster-rhel8-1           Ready                         worker   98m    v1.25.0
+mycluster-rhel8-2           Ready                         worker   98m    v1.25.0
+mycluster-rhel8-3           Ready                         worker   98m    v1.25.0
 ----
 
 . Optional: Update the operating system packages that were not updated by the `upgrade` playbook. To update packages that are not on {product-version}, use the following command:

--- a/modules/sandboxed-containers-check-node-eligiblilty.adoc
+++ b/modules/sandboxed-containers-check-node-eligiblilty.adoc
@@ -110,6 +110,6 @@ $ oc get nodes --selector='feature.node.kubernetes.io/runtime.kata=true'
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE     VERSION
-compute-3.example.com          Ready                      worker   4h38m   v1.24.0
-compute-2.example.com          Ready                      worker   4h35m   v1.24.0
+compute-3.example.com          Ready                      worker   4h38m   v1.25.0
+compute-2.example.com          Ready                      worker   4h35m   v1.25.0
 ----

--- a/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
+++ b/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
@@ -105,6 +105,6 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES           AGE   VERSION
-control-plane-1.example.com    Ready    master,worker   56m   v1.24.0+beaaed6
-compute-1.example.com          Ready    worker          11m   v1.24.0+beaaed6
+control-plane-1.example.com    Ready    master,worker   56m   v1.25.0
+compute-1.example.com          Ready    worker          11m   v1.25.0
 ----

--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -198,10 +198,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.24.0
-ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.24.0
-ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.24.0
-ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.24.0
-ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.24.0
-ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.24.0
+ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.25.0
+ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.25.0
+ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.25.0
+ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.25.0
+ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.25.0
+ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.25.0
 ----

--- a/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
@@ -31,9 +31,9 @@ $ oc get nodes -l node-role.kubernetes.io/worker
 [source,terminal]
 ----
 NAME              STATUS   ROLES    AGE   VERSION
-compute-node-0    Ready    worker   30m   v1.24.0
-compute-node-1    Ready    worker   30m   v1.24.0
-compute-node-2    Ready    worker   30m   v1.24.0
+compute-node-0    Ready    worker   30m   v1.25.0
+compute-node-1    Ready    worker   30m   v1.25.0
+compute-node-2    Ready    worker   30m   v1.25.0
 ----
 +
 Note the names of your compute nodes.

--- a/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
@@ -26,9 +26,9 @@ $ oc get nodes -l node-role.kubernetes.io/master
 [source,terminal]
 ----
 NAME                    STATUS   ROLES    AGE   VERSION
-control-plane-node-0    Ready    master   75m   v1.24.0
-control-plane-node-1    Ready    master   75m   v1.24.0
-control-plane-node-2    Ready    master   75m   v1.24.0
+control-plane-node-0    Ready    master   75m   v1.25.0
+control-plane-node-1    Ready    master   75m   v1.25.0
+control-plane-node-2    Ready    master   75m   v1.25.0
 ----
 +
 Note the names of your control plane nodes.

--- a/modules/virt-accessing-vm-yaml-ssh.adoc
+++ b/modules/virt-accessing-vm-yaml-ssh.adoc
@@ -159,7 +159,7 @@ $ oc get node __<node_name>__ -o wide
 [source,terminal]
 ----
 NAME    STATUS   ROLES   AGE    VERSION  INTERNAL-IP      EXTERNAL-IP
-node01  Ready    worker  6d22h  v1.24.0  192.168.55.101   <none>
+node01  Ready    worker  6d22h  v1.25.0  192.168.55.101   <none>
 ----
 
 . Log in to the VM via SSH by specifying the IP address of the node where the VM is running and the port number. Use the port number displayed by the `oc get svc` command and the IP address of the node displayed by the `oc get node` command. The following example shows the `ssh` command with the username, node's IP address, and the port number:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.12

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
https://issues.redhat.com/browse/OSDOCS-4096

Link to docs preview:
https://51372--docspreview.netlify.app/openshift-enterprise/latest/welcome/index.html
But the changes are throughout; I'm not putting a link to every single section :smile_cat: 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Please ignore the file with the "TODO" in it for now, during peer review

