### PR TITLE
Update doc_guidelines for distro map product versions

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -454,7 +454,7 @@ If you create a release notes assembly for a sub-product within the `openshift/o
 
 When possible, generalize references to the product name and/or version by using
 the `{product-title}` and/or `{product-version}` attributes. These attributes
-are pulled by AsciiBinder from the distro mapping definitions in the
+are pulled by AsciiBinder from the OpenShift distribution, or _distro_, mapping definitions in the
 https://github.com/openshift/openshift-docs/blob/main/_distro_map.yml[_distro_map.yml]
 file.
 
@@ -464,7 +464,7 @@ while the associated `{product-version}` comes from the `name:` fields on any
 
 How these attributes render is dependent on which distro and branch build you
 are viewing. The following table shows the current distros and the
-possible values for `{product-title}` and `{product-version}`.
+possible values for `{product-title}` and `{product-version}`, depending on the branch:
 
 [options="header"]
 |===
@@ -472,19 +472,27 @@ possible values for `{product-title}` and `{product-version}`.
 
 |`openshift-origin`
 |OKD
-|1.2, 1.3, 1.4, 1.5, 3.6, 3.7, 3.9, 3.10, 3.11, Latest
+a|* 3.6, 3.7, 3.9, 3.10, 3.11
+* 4.6, 4.7, 4.8, 4.9, 4.10, 4.11
+* 4 for the `latest/` build from the `main` branch
 
 |`openshift-enterprise`
 |OpenShift Container Platform
-|3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.9, 3.10, 3.11, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 4.10, 4.11, 4.12
+a|* 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.9, 3.10, 3.11
+* 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 4.10, 4.11, 4.12
 
 |`openshift-dedicated`
 |OpenShift Dedicated
-|Latest
+a|* No value set for the latest `dedicated/` build from the `enterprise-4.11` branch
+* 3 for the `dedicated/3` build from the `enterprise-3.11` branch
+
+|`openshift-rosa`
+|Red Hat OpenShift Service on AWS
+|No value set for the `rosa/` build from the `enterprise-4.11` branch
 
 |`openshift-online`
 |OpenShift Online
-|Latest
+|Pro
 |===
 
 For example:


### PR DESCRIPTION
(No JIRA/BZ)

The table in our repo guidelines discussing the default AsciiBinder-generated product name/version attributes had gotten out of date. This updates the table per the latest version of https://github.com/openshift/openshift-docs/blob/main/_distro_map.yml.

No preview build, but rendered version of the in-repo markdown is here:

https://github.com/adellape/openshift-docs/blob/update_product_ver_table/contributing_to_docs/doc_guidelines.adoc#product-name-and-version

No QE req'd.

Doesn't look like we have uniformly been cherry-picking changes to this file into previous branches, so not labeling for other branches.