### PR TITLE
GH#50305: Removing erroneous dash before image name

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -76,7 +76,7 @@ $ oc adm release extract \
 --credentials-requests \
 --cloud=gcp \
 --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
---quay.io/<path_to>/ocp-release:<version>
+quay.io/<path_to>/ocp-release:<version>
 ----
 endif::google-cloud-platform[]
 ifdef::alibabacloud-default,alibabacloud-customizations[]
@@ -85,7 +85,7 @@ $ oc adm release extract \
 --credentials-requests \
 --cloud=alibabacloud \
 --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
---quay.io/<path_to>/ocp-release:<version>
+quay.io/<path_to>/ocp-release:<version>
 ----
 endif::alibabacloud-default,alibabacloud-customizations[]
 +

--- a/modules/cco-ccoctl-upgrading.adoc
+++ b/modules/cco-ccoctl-upgrading.adoc
@@ -52,7 +52,7 @@ endif::google-cloud-platform[]
 $ oc adm release extract --credentials-requests \
 --cloud=aws \
 --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
---quay.io/<path_to>/ocp-release:<version>
+quay.io/<path_to>/ocp-release:<version>
 ----
 +
 <1> `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.11+


Issue:
https://github.com/openshift/openshift-docs/issues/50305

Link to docs preview:
https://51375--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-upgrading_sts-mode-upgrading

Also fixes image paths here:
https://51375--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.html#cco-ccoctl-creating-at-once_cco-mode-gcp-workload-identity

https://51375--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-default.html#cco-ccoctl-creating-at-once_installing-alibaba-default

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
