### PR TITLE
GH#49580: Adds known issue to the 4.8 release notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2514,6 +2514,45 @@ $ oc annotate -n <NAMESPACE> route/<ROUTE-NAME> "haproxy.router.openshift.io/bal
 
 * If the images for {op-system} and the Machine Config Operator (MCO) do not change during an upgrade from an {product-title} 4.8.z release to a later 4.8.z release, the upgrade is marked as complete before the control plane nodes have finished upgrading. Following this, the upgrade might fail if you perform operations on your cluster before the upgrade is actually complete. As a workaround, verify that updates are completed on the control plane nodes before performing additional operations on the cluster. You can use the `oc get mcp/master` command to review the status of the MCO-managed nodes that are available on your cluster for each pool. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2025396[*BZ#2025396*])
 
+* After upgrading from a 4.7 {product-title} cluster to 4.8, the routing path from the internal network to the external network pod through secondary network interface controllers (NICs) on {product-title} nodes is disabled by default. This is due to the shared gateway being the default gateway mode in the Open Virtual Network (OVN) design starting from 4.8. If that routing path is required, as a workaround before or after the upgrade, create a `gateway-mode-config` config map in the `openshift-network-operator` namespace to force OVN Gateway mode to local.
++
+
+Enter the following command to create a `gateway-mode-config` in the `openshift-network-operator` namespace:
+
++
+[source,terminal]
+----
+$ cat localGW.yml 
+----
++
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: gateway-mode-config
+    namespace: openshift-network-operator
+data:
+    mode: "local"
+immutable: true
+----
++
+
+[source,terminal]
+----
+$ oc apply -f localGW.yml 
+----
++
+
+[source,terminal]
+----
+configmap/gateway-mode-config created
+----
++
+
+For additional guidance, see (link:https://access.redhat.com/solutions/6962127[*KCS*]) and (link:https://bugzilla.redhat.com/show_bug.cgi?id=2089389[*BZ#2089389*]). This setting will be addressed further in a future release.
+
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Adresses #49580

4.8 only

Link to docs preview (VPN req)
http://file.rdu.redhat.com/opayne/GI49580/release_notes/ocp-4-8-release-notes.html#ocp-4-8-known-issues 
(The last KI right before the Async errata section)

QE review:
- [x] QE has approved this change.





<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
