### PR TITLE
RHDEVDOCS-4310 - clarify confusing statements about custom Prometheus support

### DIFF
--- a/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
+++ b/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
@@ -11,11 +11,12 @@ You can use the `prometheus-adapter` resource to expose custom application metri
 
 .Prerequisites
 
-* You have a custom Prometheus instance installed. In this example, it is presumed that Prometheus was installed in a user-defined `custom-prometheus` project.
+* You have a custom Prometheus instance installed as a Prometheus pod managed by a deployment or `StatefulSet` object but not by a Prometheus custom resource (CR).  
+* You have installed the custom Prometheus instance in a user-defined `custom-prometheus` project.
 +
-[NOTE]
+[IMPORTANT]
 ====
-Custom Prometheus instances and the Prometheus Operator installed through Operator Lifecycle Manager (OLM) can cause issues with user-defined workload monitoring if it is enabled. Custom Prometheus instances are not supported in {product-title}.
+Custom Prometheus instances and the Prometheus Operator installed through Operator Lifecycle Manager (OLM) are not compatible with user-defined monitoring if it is enabled. Therefore, custom Prometheus instances that are installed as a Prometheus custom resource (CR) managed by the OLM Prometheus Operator are not supported in {product-title}.
 ====
 +
 * You have deployed an application and a service in a user-defined project. In this example, it is presumed that the application and its service monitor were installed in a user-defined `custom-prometheus` project.

--- a/modules/monitoring-support-considerations.adoc
+++ b/modules/monitoring-support-considerations.adoc
@@ -6,7 +6,7 @@
 = Support considerations for monitoring
 
 The following modifications are explicitly not supported:
-
+ 
 * *Creating additional `ServiceMonitor`, `PodMonitor`, and `PrometheusRule` objects in the `openshift-&#42;` and `kube-&#42;` projects.*
 * *Modifying any resources or objects deployed in the `openshift-monitoring` or `openshift-user-workload-monitoring` projects.* The resources created by the {product-title} monitoring stack are not meant to be used by any other resources, as there are no guarantees about their backward compatibility.
 +
@@ -18,7 +18,7 @@ The Alertmanager configuration is deployed as a secret resource in the `openshif
 * *Modifying resources of the stack.* The {product-title} monitoring stack ensures its resources are always in the state it expects them to be. If they are modified, the stack will reset them.
 * *Deploying user-defined workloads to `openshift-&#42;`, and `kube-&#42;` projects.* These projects are reserved for Red Hat provided components and they should not be used for user-defined workloads.
 * *Modifying the monitoring stack Grafana instance.*
-* *Installing custom Prometheus instances on {product-title}.*
+* *Installing custom Prometheus instances on {product-title}.* A custom instance is a Prometheus custom resource (CR) managed by the Prometheus Operator.
 * *Enabling symptom based monitoring by using the `Probe` custom resource definition (CRD) in Prometheus Operator.*
 * *Modifying Alertmanager configurations by using the `AlertmanagerConfig` CRD in Prometheus Operator.*
 


### PR DESCRIPTION
Summary:

- Aligned team: DevTools
- For branches: 4.6, 4.7 ONLY
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4310
- Direct link to doc preview (RH VPN access required):
- - http://file.rdu.redhat.com/bburt/RHDEVDOCS-4310-clarify-contradictory-guidance-in-autoscaling-topic/monitoring/configuring-the-monitoring-stack.html#support-considerations_configuring-the-monitoring-stack
- - http://file.rdu.redhat.com/bburt/RHDEVDOCS-4310-clarify-contradictory-guidance-in-autoscaling-topic/monitoring/exposing-custom-application-metrics-for-autoscaling.html#exposing-custom-application-metrics-for-horizontal-pod-autoscaling_exposing-custom-application-metrics-for-autoscaling
- SME review: @simonpasquier 
- QE review: @juzhao  
- Peer review: @gabriel-rh 