### PR TITLE
Fill in 'Purpose' section for CVO in op-ref

### DIFF
--- a/modules/baremetal-event-relay.adoc
+++ b/modules/baremetal-event-relay.adoc
@@ -9,7 +9,7 @@
 The OpenShift {redfish-operator} manages the life-cycle of the Bare Metal Event Relay. The Bare Metal Event Relay enables you to configure the types of cluster event that are monitored using Redfish hardware events.
 
 [discrete]
-== Configuration Objects
+== Configuration objects
 You can use this command to edit the configuration after installation: for example, the webhook port.
 You can edit configuration objects with:
 
@@ -46,7 +46,3 @@ The proxy enables applications running on bare-metal clusters to respond quickly
 * Scope: Namespaced
 * CR: HardwareEvent
 * Validation: Yes
-
-[discrete]
-== Additional Resources
-You can learn more in the topic xref:../monitoring/using-rfhe.adoc[Monitoring Redfish hardware events].

--- a/modules/cluster-version-operator.adoc
+++ b/modules/cluster-version-operator.adoc
@@ -8,6 +8,10 @@
 [discrete]
 == Purpose
 
+Cluster Operators manage specific areas of cluster functionality. The Cluster Version Operator (CVO) manages the lifecycle of cluster Operators, many of which are installed in {product-title} by default.
+
+The CVO also checks with the OpenShift Update Service to see the valid updates and update paths based on current component versions and information in the graph.
+
 [discrete]
 == Project
 

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -16,10 +16,21 @@ Cluster Operators are not managed by Operator Lifecycle Manager (OLM) and Operat
 ====
 
 include::modules/baremetal-event-relay.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[discrete]
+[id="additional-resources_cluster-op-ref-baremetal"]
+=== Additional resources
+
+* xref:../monitoring/using-rfhe.adoc#using-rfhe[Monitoring Redfish hardware events]
+
 include::modules/cloud-credential-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[discrete]
+[id="additional-resources_cluster-op-ref-cco"]
+=== Additional resources
+
 * xref:../rest_api/security_apis/credentialsrequest-cloudcredential-openshift-io-v1.adoc#credentialsrequest-cloudcredential-openshift-io-v1[CredentialsRequest custom resource]
 * xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator]
 
@@ -36,6 +47,14 @@ include::modules/cluster-network-operator.adoc[leveloffset=+1]
 include::modules/cluster-samples-operator.adoc[leveloffset=+1]
 include::modules/cluster-storage-operator.adoc[leveloffset=+1]
 include::modules/cluster-version-operator.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[discrete]
+[id="additional-resources_cluster-op-ref-cvo"]
+=== Additional resources
+
+* xref:../architecture/control-plane.adoc#operators-overview_control-plane[Operators in {product-title}]
+
 include::modules/console-operator.adoc[leveloffset=+1]
 include::modules/cluster-dns-operator.adoc[leveloffset=+1]
 include::modules/etcd-operator.adoc[leveloffset=+1]
@@ -43,9 +62,11 @@ include::modules/ingress-operator.adoc[leveloffset=+1]
 include::modules/insights-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[discrete]
+[id="additional-resources_cluster-op-ref-insights"]
+=== Additional resources
 
-* See xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc[About remote health monitoring] for details about Insights Operator and Telemetry.
+* xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for details about Insights Operator and Telemetry
 
 include::modules/kube-apiserver-operator.adoc[leveloffset=+1]
 include::modules/kube-controller-manager-operator.adoc[leveloffset=+1]
@@ -81,15 +102,17 @@ include::modules/olm-arch-catalog-registry.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [discrete]
-[id="cluster-operators-ref-olm-addtl-resources"]
+[id="additional-resources_cluster-op-ref-olm"]
 === Additional resources
 
-* For more information, see the sections on xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[understanding Operator Lifecycle Manager (OLM)].
+* xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Understanding Operator Lifecycle Manager (OLM)]
 
 include::modules/openshift-service-ca-operator.adoc[leveloffset=+1]
 include::modules/vsphere-problem-detector-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[discrete]
+[id="additional-resources_cluster-op-ref-vpd"]
+=== Additional resources
 
-* For more details, see xref:../installing/installing_vsphere/using-vsphere-problem-detector-operator.adoc#using-vsphere-problem-detector-operator[Using the vSphere Problem Detector Operator].
+* xref:../installing/installing_vsphere/using-vsphere-problem-detector-operator.adoc#using-vsphere-problem-detector-operator[Using the vSphere Problem Detector Operator]


### PR DESCRIPTION
No JIRA/BZ.

Filling in a blank section in the Operators reference guide.

Also bringing the "Additional resources" sections throughout the assembly uniformly up to latest guideline standards.

Preview: https://51407--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-version-operator_cluster-operators-ref 

Applies to 4.6+. No QE req'd.