### PR TITLE
add term boot image

### DIFF
--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -101,6 +101,13 @@ action. It consists of _identity_ and _action_.
 == B
 
 ''''
+=== boot image
+
+Usage: boot image(s)
+
+* A boot image is a disk image that contains a bootable operating system (OS) and all the configuration settings for the OS, such as drivers.
+
+''''
 === build
 
 Usage: build(s), or when speaking generally about `Build` objects.


### PR DESCRIPTION
I could not find any definitive source for the correct spelling of "boot image" and I think it's needed since "bootimage" is commonly seen or used in discussions with engineering. So this PR adds the term to the glossary.