### PR TITLE
OADP-772: User wants to know what to expect in each `Update channel` of OADP Operator

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -39,6 +39,13 @@ include::modules/oadp-configuring-noobaa-for-dr.adoc[leveloffset=+1]
 
 [discrete]
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 * link:https://{velero-domain}/docs/v{velero-version}/locations/[Overview of backup and snapshot locations in the Velero documentation]
+
+include::modules/about-oadp-update-channels.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../operators/understanding/olm/olm-understanding-olm.adoc#olm-csv_olm-understanding-olm[Cluster service version]

--- a/modules/about-oadp-update-channels.adoc
+++ b/modules/about-oadp-update-channels.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/installing/about-installing-oadp.adoc
+
+
+:_content-type: CONCEPT
+[id="about-oadp-update-channels_{context}"]
+= About OADP update channels
+
+When you install an OADP Operator, you choose an _update channel_. This channel determines which upgrades to the OADP Operator and to Velero you receive. You can switch channels at any time.
+
+There are three update channels:
+
+* The *stable* channel contains the latest minor updates (y-stream updates) and patches (z-stream updates) of OADP ClusterServiceVersion`. As each new release is published, the available `ClusterServiceVersion` of the OADP Operator will be appended with the latest available minor patch.
+
+* The *stable-1.0* channel contains `oadp.v1.0._z_`, the most recent OADP 1.0 `ClusterServiceVersion`.
+
+* The *stable-1.1* channel contains `oadp.v1.1._z_`, the most recent OADP 1.1 `ClusterServiceVersion`.
+
+*Which update channel is right for you?*
+
+* Choose the *stable* update channel to install the latest stable OADP version and to receive both minor updates and patches. If you choose this channel, you will receive all y-stream and all z-stream updates for version _x.y.z_.
+
+* Choose the *stable-1._y_* update channel to install OADP 1._y_ and to continue receiving patches for it. If you choose this channel, you will receive all z-stream patches for version 1._y_._z_.
+
+*When must you switch update channels?*
+
+* If you have OADP 1._y_ installed and you want to receive patches only for that y-stream, you must switch from the *stable* update channel to the *stable-1._y_* update channel. You will then receive all z-stream patches for version 1._y_._z_.
+
+* If you have OADP 1.0 installed, want to upgrade to OADP 1.1, and then receive patches only for OADP 1.1, you must switch from the *stable-1.0* update channel to the *stable-1.1* update channel. You will then receive all z-stream patches for version 1.1._z_.
+
+* If you have OADP 1._y_ installed, with _y_ greater than 0, and want to switch to OADP 1.0, you must _uninstall_ your OADP Operator and then reinstall it using the *stable-1.0* update channel. You will then receive all z-stream patches for version 1.0._z_.
+
+[NOTE]
+====
+You cannot switch from OADP 1._y_ to OADP 1.0 by switching update channels. You must uninstall the Operator and then reinstall it.
+====


### PR DESCRIPTION
OADP 1.1.1; OCP 4.9+ 

Dev and QE have approved. 

Resolves https://issues.redhat.com/browse/OADP-772 by adding a description of update channels to general installation information.

Preview: https://51412--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#about-oadp-update-channels_about-installing-oadp

