### PR TITLE
BZ#2117136 Minimum RAM spec update

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -283,8 +283,8 @@ ifdef::osp[]
 ... Select *openstack* as the platform to target.
 ... Specify the {rh-openstack-first} external network name to use for installing the cluster.
 ... Specify the floating IP address to use for external access to the OpenShift API.
-... Specify a {rh-openstack} flavor with at least 16 GB RAM to use for control plane
-and compute nodes.
+... Specify a {rh-openstack} flavor with at least 16 GB RAM to use for control plane nodes
+and 8 GB RAM for compute nodes.
 ... Select the base domain to deploy the cluster to. All DNS records will be
 sub-domains of this base and will also include the cluster name.
 endif::osp[]


### PR DESCRIPTION
Versions 4.6+

BZ [2117136](https://bugzilla.redhat.com/show_bug.cgi?id=2117136)

Updating a configuration specification to change the minimum RAM needed for compute nodes.

Preview: https://51440--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#installation-initializing_installing-openstack-installer-custom