### PR TITLE
BZ2076179 - ForbiddenSysctls is not a in KubletConfig

### DIFF
--- a/modules/nodes-containers-sysctls-unsafe.adoc
+++ b/modules/nodes-containers-sysctls-unsafe.adoc
@@ -12,9 +12,8 @@ situations such as high performance or real-time application tuning.
 If you want to use unsafe sysctls, a cluster administrator must enable them
 individually for a specific type of node. The sysctls must be namespaced.
 
-You can further control which sysctls can be set in pods by specifying lists of sysctls or sysctl patterns in the `forbiddenSysctls` and `allowedUnsafeSysctls` fields of the Security Context Constraints.
+You can further control which sysctls are set in pods by specifying lists of sysctls or sysctl patterns in the `allowedUnsafeSysctls` field of the Security Context Constraints.
 
-- The `forbiddenSysctls` option excludes specific sysctls.
 - The `allowedUnsafeSysctls` option controls specific needs such as high performance or real-time application tuning.
 
 [WARNING]


### PR DESCRIPTION
For Versions: 4.8+
[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2076179)

Docs preview: [Working with containers -> Using sysctls in containers -> Enabling unsafe sysctls](https://51454--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-sysctls.html#nodes-containers-sysctls-unsafe_nodes-containers-using)

Ready for QA: @sunilcio Thank you! 