### PR TITLE
OSDOCS-3794: Restructured STS Prerequisites

### DIFF
--- a/modules/rosa-sts-aws-requirements-ocm.adoc
+++ b/modules/rosa-sts-aws-requirements-ocm.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc
+
+:_content-type: CONCEPT
+[id="rosa-ocm-requirements_{context}"]
+= Requirements for using {cluster-manager}
+
+The following sections describe requirements for {cluster-manager-url}. If you use the CLI tools exclusively, then you can disregard the requirements.
+
+To use {cluster-manager}, you must link your AWS accounts. This linking concept is also known as account association.

--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -32,9 +32,6 @@ include::modules/rosa-sts-aws-requirements-account.adoc[leveloffset=+2]
 * xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
 * xref:../rosa_support/rosa-troubleshooting-deployments.adoc#rosa-troubleshooting-general-deployment-elb[Creating the service role for the elastic load balancer (ELB)]
 
-include::modules/rosa-sts-aws-requirements-association-concept.adoc[leveloffset=+2]
-include::modules/rosa-sts-aws-requirements-creating-association.adoc[leveloffset=+2]
-include::modules/rosa-sts-aws-requirements-creating-multi-association.adoc[leveloffset=+2]
 include::modules/rosa-sts-aws-requirements-access-req.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -49,6 +46,11 @@ include::modules/rosa-sts-aws-requirements-security-req.adoc[leveloffset=+2]
 [id="additional-resources_aws-security-requirements_{context}"]
 .Additional resources
 * xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS firewall prerequisites]
+
+include::modules/rosa-sts-aws-requirements-ocm.adoc[leveloffset=+2]
+include::modules/rosa-sts-aws-requirements-association-concept.adoc[leveloffset=+3]
+include::modules/rosa-sts-aws-requirements-creating-association.adoc[leveloffset=+3]
+include::modules/rosa-sts-aws-requirements-creating-multi-association.adoc[leveloffset=+3]
 
 
 include::modules/rosa-requirements-deploying-in-opt-in-regions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-3794](https://issues.redhat.com/browse/OSDOCS-3794)

Link to docs preview:
[Requirements for OCM](https://51465--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#rosa-ocm-requirements_rosa-sts-aws-prereqs)

QE review:
- [ ] QE has approved this change.

Additional information:
Changed the order of the prereq sections to separate the CLI and the UI.