### PR TITLE
Run preview build before checking vale rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,6 @@ jobs:
 
 stages:
   - build
+  - netlify
   - check-with-vale
   #- automerge
-  - netlify


### PR DESCRIPTION
Changes the Travis build order to kickoff preview build before checking with Vale.

Merge into `main` and cherry-pick into `enterprise-4.11` and `enterprise-4.12`