### PR TITLE
RHDEVDOCS-4485 migration guide - odo v2 to v3

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -689,6 +689,8 @@ Topics:
     File: installing-odo
   - Name: Configuring the odo CLI
     File: configuring-the-odo-cli
+  - Name: Migrating from v2 to v3
+    File: odo-migration-guide    
   - Name: odo CLI reference
     File: odo-cli-reference
 - Name: Knative CLI (kn) for use with OpenShift Serverless

--- a/cli_reference/developer_cli_odo/odo-migration-guide.adoc
+++ b/cli_reference/developer_cli_odo/odo-migration-guide.adoc
@@ -1,0 +1,27 @@
+:_content-type: ASSEMBLY
+[id='odo-migration-guide']
+= Migrating from odo v2 to v3
+include::_attributes/common-attributes.adoc[]
+:context: odo-migration-guide
+
+toc::[]
+
+`odo` 3.0 includes many new commands to improve the developer experience, providing the same functionality as before, but in a faster and more efficient manner.
+
+include::modules/odo-migrate-existing-component.adoc[leveloffset=+1]
+
+include::modules/odo-push-watch-to-odo-dev.adoc[leveloffset=+1]
+
+include::modules/odo-ingress-route-port-forwarding.adoc[leveloffset=+1]
+
+include::modules/odo-debugging-changes.adoc[leveloffset=+1]
+
+include::modules/odo-default-config-changes.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../storage/understanding-ephemeral-storage.adoc#storage-ephemeral-storage-overview_understanding-ephemeral-storage[Understanding ephemeral storage].
+
+include::modules/odo-command-changes.adoc[leveloffset=+1]
+

--- a/modules/odo-command-changes.adoc
+++ b/modules/odo-command-changes.adoc
@@ -1,0 +1,90 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/developer_cli_odo/odo-migration-guide.adoc
+
+:_content-type: REFERENCE
+[id="odo-command-changes_{context}"]
+
+= Commands added, modified or removed in v3
+
+The following table contains a list of `odo` commands that have been added, modified, or removed in v3. An *X* indicates that the command is not present in that version.
+
+[cols="2,2,3",options="header"]
+|===
+
+| v2 | v3 | Notes
+
+| `app delete`| *X*|
+| `app describe`| *X*| 
+| `app list`| *X*|
+| `catalog describe service`| *X*| 
+| `catalog describe component`| `registry --details`|
+| `catalog list service`| |In a future release, this command will be replaced with `odo list services`
+| `catalog list component`| `registry`|
+| `catalog search service`| *X*|
+| `catalog search component`| `registry --filter`|
+| `config set`| *X*|
+| `config unset`| *X*|
+| `config view`| *X*|
+| `debug info`| *X*| Debug mode is started with the `odo dev --debug` command, which blocks the terminal. The application can be running in inner-loop mode only if `odo dev` is running in the terminal.
+| `debug port-forward`| *X*| Port forwarding is automatically configured when you run `odo dev --debug`, if the endpoint is defined in the devfile.
+| `env set`| *X*|
+| `env uset`| *X*|
+| `env view`| *X*|
+| `preference set`| `preference set`|
+| `preference unset`| `preference unset`|
+| `preference view`| `preference view`|
+| `project create`| `create namespace` + 
+`create project`|
+| `project delete`| `delete namespace` + 
+`delete project`|
+| `project get`| *X*|
+| `project list`| `list namespace` + 
+`list project`|
+| `project set`| `set namespace` + 
+`set project`|
+| `registry add`| `preference add registry`|
+| `registry delete`| `preference remove registry`|
+| `registry list`| `preference view`|
+| `registry update`| *X* | Use `preference remove registry` and `preference add registry` instead.
+| `service create` + 
+`service delete` + 
+`service describe` + 
+`service list` | *X*|
+| `storage create` + 
+`storage delete` + 
+`storage list` | *X*|
+| `test`| |This command will be restored in a future release
+| `url create` + 
+`url delete` + 
+`url list`| *X*| `odo dev` automatically sets port forwarding between the container and localhost. If you require `Ingress` or `Route` resources for inner-loop development, you explicitly define them in the Devfile as Kubernetes components.
+| `build-images`| `build-images`|
+| `deploy`| `deploy`|
+| `login`| `login`|
+| `logout`| `logout`|
+| `create` +  
+`component create`| `init`|
+| `delete` + 
+`component delete`| `delete component`|
+| `describe` + 
+`component describe`| `describe component`|
+| `exec` + 
+`component exec`| *X*|
+| `link` + 
+`component link`| `add binding list` + 
+`component list` |
+| `list`| `log` + 
+`component log`|
+| `logs`| `push` + 
+`component push` |In v3, the `odo dev` command behaves more like `watch` in v2. There is an option to disable automatic reloads when a file changes (`--no-watch`). In future, there will be an option to trigger _sync_ explicitly when the `--no-watch` option is used.
+| `status` + 
+`component status`| *X*|
+| `unlink` + 
+`component unlink`| `remove binding`|
+| `watch` + 
+`component watch`| `dev`|
+| *X*| `describe binding`|
+| *X*| `list binding`|
+| *X*| `analyze`|
+
+|===

--- a/modules/odo-debugging-changes.adoc
+++ b/modules/odo-debugging-changes.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/developer_cli_odo/odo-migration-guide.adoc
+
+:_content-type: CONCEPT
+[id="odo-debugging-changes_{context}"]
+
+= Changes to component debugging
+
+With `odo` v2, you use the `odo push --debug` command to run a component in debug mode. To set up port forwarding to the component's debug port, you have to run `odo debug port-forward`.
+
+In `odo` v3, you specify the debug port in the `devfile.yaml` as an endpoint, and run the `odo dev --debug` command to start the component in debug mode. The following example shows a `container` component in the Devfile, where port `3000` is the application port and `5858` is the debug port:
+
+.Sample Devfile
+[source,yaml]
+----
+- name: runtime
+  container:
+    image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+    memoryLimit: 1024Mi
+    endpoints:
+    - name: "3000-tcp"
+      targetPort: 3000
+    - name: debug
+      exposure: none
+      targetPort: 5858
+----

--- a/modules/odo-default-config-changes.adoc
+++ b/modules/odo-default-config-changes.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/developer_cli_odo/odo-migration-guide.adoc
+
+:_content-type: CONCEPT
+[id="odo-default-config-changes_{context}"]
+
+= Changes to default configurations
+
+== Ephemeral storage
+
+By default, `odo` v2 uses _ephemeral storage_ for the components it creates. `odo` v3 now uses the underlying `PersistentVolume` storage that is configured for users. If you want to continue using ephemeral storage for `odo` components, change the default configuration with the `odo preference` command:
+
+[source,terminal]
+----
+$ odo preference set Ephemeral true
+----

--- a/modules/odo-ingress-route-port-forwarding.adoc
+++ b/modules/odo-ingress-route-port-forwarding.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/developer_cli_odo/odo-migration-guide.adoc
+
+:_content-type: CONCEPT
+[id="odo-ingress-route-port-forwarding_{context}"]
+
+= Ingress and Route replaced by port forwarding
+
+With `odo` v2, you use `Route` resources on OpenShift, or `Ingress` resources on Kubernetes, to access applications that you push to the cluster with `odo push`. `odo` v3 uses port-forwarding.
+
+When running `odo dev`, `odo` forwards a port on the development system to the port on the container cluster, allowing you remote access to your deployed application. It also displays the information when the application starts on the cluster:
+
+[source,terminal]
+----
+$ odo dev
+...
+...
+-  Forwarding from 127.0.0.1:40001 -> 8080
+----
+
+The output indicates that `odo` is forwarding port `40001` on the development system to port `8080` of the application represented by the current `odo` component.
+
+[NOTE]
+====
+`odo` v3 no longer creates `Ingress` or `Route` resources by default, and the `odo url` set of commands are not present in v3.
+====

--- a/modules/odo-migrate-existing-component.adoc
+++ b/modules/odo-migrate-existing-component.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/developer_cli_odo/odo-migration-guide.adoc
+
+:_content-type: PROCEDURE
+[id="odo-migrate-existing-component_{context}"]
+
+= Migrating an existing odo component from v2 to v3
+
+If you have created an `odo` component with `odo` v2, use the following steps to migrate it to `odo` v3.
+
+.Procedure
+
+. Use the `cd` command to move to the component directory, and delete the component from the Kubernetes cluster:
++
+[source,terminal]
+----
+$ odo delete
+----
+
+. Download and install `odo` v3.
+
+. Run `odo dev` to start developing your application with `odo` v3.
+
+. Run `odo list` to see a list of components that are running on the cluster and what version of `odo` they are running.

--- a/modules/odo-push-watch-to-odo-dev.adoc
+++ b/modules/odo-push-watch-to-odo-dev.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/developer_cli_odo/odo-migration-guide.adoc
+
+:_content-type: CONCEPT
+[id="odo-push-watch-to-odo-dev_{context}"]
+
+= odo push and odo watch replaced by odo dev
+
+`odo` v3 replaces the commands `odo push` and `odo watch` from v2 with a single command `odo dev`. 
+
+With `odo` v2, if you wanted to automatically synchronize the code running on the developer system with the application running on a Kubernetes cluster, you had to perform two steps:
+
+. `odo push` to start the application on the cluster
+. `odo watch` to automatically synchronize the code
+
+To delete the inner loop resources of the component from the cluster, you had to use `odo delete` or`odo component delete`.
+
+With `odo` v3, `odo dev` starts the application on the cluster and automatically synchronizes the code.
+`odo dev` is a long-running process that blocks the terminal. When you enter `Ctrl+C`, `odo` v3 stops the process and automatically cleans up the component resources from the cluster.


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-4485

Link to docs preview:
https://51479--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/developer_cli_odo/odo-migration-guide.html

QE review:
- [ ] QE has approved this change.

