### PR TITLE
[RHACS] Update RHACS version number for patch

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -44,7 +44,7 @@ endif::[]
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 3.70.1
+:rhacs-version: 3.70.2
 :ocp-supported-version: 4.5
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 3.70


### PR DESCRIPTION
Version(s):
`rhacs-docs-3.70` only

Issue: none

Link to docs preview: [example of version number](https://openshift-docs-9zsf6ubol-kcarmichael08.vercel.app/openshift-acs/master/configuration/enable-offline-mode.html#download-images-directly_enable-offline-mode)

QE review:
- [ ] QE has approved this change. (**N/A**)

