### PR TITLE
OCPBUGS-2169 Updated Compliance Operator CLI install instructions for 4.12+

### DIFF
--- a/modules/compliance-operator-cli-installation.adoc
+++ b/modules/compliance-operator-cli-installation.adoc
@@ -22,8 +22,11 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged <1>
   name: openshift-compliance
 ----
+<1> In {product-title} {product-version} with Compliance Operator version 0.1.53 or later, the pod security label must be set to `privileged` at the namespace level.
+
 . Create the `Namespace` object:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-2169](https://issues.redhat.com/browse/OCPBUGS-2169)

Link to docs preview:
**NOTE:** I have used the variable {product-version} which states "Branch Build" in the preview. It will state "4.12" in the 4.12 branch, and so on.

[Installing the Compliance Operator using the CLI](http://file.rdu.redhat.com/antaylor/ocpbugs-2169/security/compliance_operator/compliance-operator-installation.html#installing-compliance-operator-cli_compliance-operator-installation)

QE review:
- [x] QE has approved this change.