### PR TITLE
Update RHACS version number for patch 3.71

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -44,7 +44,7 @@ endif::[]
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 3.71.1
+:rhacs-version: 3.71.0
 :ocp-supported-version: 4.5
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 3.71

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -44,7 +44,7 @@ endif::[]
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 3.71.0
+:rhacs-version: 3.71.1
 :ocp-supported-version: 4.5
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 3.71


### PR DESCRIPTION
Version(s):

- `rhacs-docs-3.71` only

Issue: none

Link to docs preview: [example of version number](https://openshift-docs-90wj3ax9d-kcarmichael08.vercel.app/openshift-acs/master/configuration/enable-offline-mode.html#download-images-directly_enable-offline-mode)

QE review:
- [ ] QE has approved this change. (**N/A**)

