### PR TITLE
update to release.openshift.io/feature-set to match OCP 4.12

### DIFF
--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -419,7 +419,7 @@ stringData:
 
 [IMPORTANT]
 ====
-The release image includes `CredentialsRequest` objects for Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set. You can identify these objects by their use of the `release.openshift.io/feature-gate: TechPreviewNoUpgrade` annotation.
+The release image includes `CredentialsRequest` objects for Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set. You can identify these objects by their use of the `release.openshift.io/feature-set: TechPreviewNoUpgrade` annotation.
 
 * If you are not using any of these features, do not create secrets for these objects. Creating secrets for Technology Preview features that you are not using can cause the installation to fail.
 
@@ -430,13 +430,13 @@ The release image includes `CredentialsRequest` objects for Technology Preview f
 +
 [source,terminal]
 ----
-$ grep "release.openshift.io/feature-gate" *
+$ grep "release.openshift.io/feature-set" *
 ----
 +
 .Example output
 [source,terminal]
 ----
-0000_30_capi-operator_00_credentials-request.yaml:  release.openshift.io/feature-gate: TechPreviewNoUpgrade
+0000_30_capi-operator_00_credentials-request.yaml:  release.openshift.io/feature-set: TechPreviewNoUpgrade
 ----
 // Right now, only the CAPI Operator is an issue, but it might make sense to update `0000_30_capi-operator_00_credentials-request.yaml` to `<tech_preview_credentials_request>.yaml` for the future.
 

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -202,7 +202,7 @@ endif::google-cloud-platform[]
 +
 [IMPORTANT]
 ====
-The release image includes `CredentialsRequest` objects for Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set. You can identify these objects by their use of the `release.openshift.io/feature-gate: TechPreviewNoUpgrade` annotation.
+The release image includes `CredentialsRequest` objects for Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set. You can identify these objects by their use of the `release.openshift.io/feature-set: TechPreviewNoUpgrade` annotation.
 
 * If you are not using any of these features, do not create secrets for these objects. Creating secrets for Technology Preview features that you are not using can cause the installation to fail.
 
@@ -213,13 +213,13 @@ The release image includes `CredentialsRequest` objects for Technology Preview f
 +
 [source,terminal]
 ----
-$ grep "release.openshift.io/feature-gate" *
+$ grep "release.openshift.io/feature-set" *
 ----
 +
 .Example output
 [source,terminal]
 ----
-0000_30_capi-operator_00_credentials-request.yaml:  release.openshift.io/feature-gate: TechPreviewNoUpgrade
+0000_30_capi-operator_00_credentials-request.yaml:  release.openshift.io/feature-set: TechPreviewNoUpgrade
 ----
 // Right now, only the CAPI Operator is an issue, but it might make sense to update `0000_30_capi-operator_00_credentials-request.yaml` to `<tech_preview_credentials_request>.yaml` for the future.
 


### PR DESCRIPTION
This was replaced in https://github.com/openshift/cluster-version-operator/pull/821 to allow more featuresets and allow for a future migration to include actual gates. Because usage of this manifest would prevent upgrades, there are not upgrade concerns for this change.

4.12+

Preview: https://51495--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.html#installation-user-infra-generate-k8s-manifest-ignition_installing-azure-stack-hub-user-infra