### PR TITLE
TELCODOCS-968 - Fix alignment in NROP KubeletConfig CR + setting the topology manager scope to pod is no longer required

### DIFF
--- a/modules/cnf-deploying-the-numa-aware-scheduler.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler.adoc
@@ -48,15 +48,14 @@ spec:
       memory: "512Mi"
     reservedMemory:
       - numaNode: 0
-  limits:
-    memory: "1124Mi"
+        limits:
+          memory: "1124Mi"
     systemReserved:
       memory: "512Mi"
     topologyManagerPolicy: "single-numa-node" <1>
-    topologyManagerScope: "pod" <2>
+    topologyManagerScope: "pod"
 ----
-<1> `topologyManagerPolicy` must be set to `single-numa-node`.
-<2> `topologyManagerScope` must be set to pod.
+<1> Set the `topologyManagerPolicy` field to `single-numa-node`.
 
 .. Create the `KubeletConfig` custom resource (CR) by running the following command:
 +


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-968

CP to 4.10+

Fixes an alignment error in NROP KubeletConfig CR and removes a note that mandates setting the Topology Manager scope to pod. Setting scope to pod is no longer required.

Preview: https://51503--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-deploying-the-numa-aware-scheduler_numa-aware