### PR TITLE
OSDOCS-4086: Updating CLI docs for 4.12

### DIFF
--- a/modules/oc-by-example-content.adoc
+++ b/modules/oc-by-example-content.adoc
@@ -59,7 +59,7 @@ Print the supported API resources on the server
   oc api-resources --namespaced=false
   
   # Print the supported API resources with a specific APIGroup
-  oc api-resources --api-group=extensions
+  oc api-resources --api-group=rbac.authorization.k8s.io
 ----
 
 
@@ -290,7 +290,7 @@ Dump relevant information for debugging and diagnosis
 
 
 == oc completion
-Output shell completion code for the specified shell (bash, zsh or fish)
+Output shell completion code for the specified shell (bash, zsh, fish, or powershell)
 
 .Example usage
 [source,bash,options="nowrap"]
@@ -675,7 +675,7 @@ Create a cluster role
   oc create clusterrole pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
   
   # Create a cluster role named "foo" with API Group specified
-  oc create clusterrole foo --verb=get,list,watch --resource=rs.extensions
+  oc create clusterrole foo --verb=get,list,watch --resource=rs.apps
   
   # Create a cluster role named "foo" with SubResource specified
   oc create clusterrole foo --verb=get,list,watch --resource=pods,pods/status
@@ -947,7 +947,7 @@ Create a role with single rule
   oc create role pod-reader --verb=get --resource=pods --resource-name=readablepod --resource-name=anotherpod
   
   # Create a role named "foo" with API Group specified
-  oc create role foo --verb=get,list,watch --resource=rs.extensions
+  oc create role foo --verb=get,list,watch --resource=rs.apps
   
   # Create a role named "foo" with SubResource specified
   oc create role foo --verb=get,list,watch --resource=pods,pods/status
@@ -1230,7 +1230,7 @@ Delete resources by file names, stdin, resources and names, or by resources and 
   oc delete -k dir
   
   # Delete resources from all files that end with '.json' - i.e. expand wildcard characters in file names
-  oc apply -f '*.json'
+  oc delete -f '*.json'
   
   # Delete a pod based on the type and name in the JSON passed into stdin
   cat pod.json | oc delete -f -


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.12

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
https://issues.redhat.com/browse/OSDOCS-4086

Link to docs preview:
https://51505--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/developer-cli-commands.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
**IMPORTANT:** Updates here are autogenerated and wording can't be manually adjusted.

