### PR TITLE
TELCODOCS-935 - PTP adding Intel Fortville NIC boundary_clock_jbod note for BC config

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -163,7 +163,7 @@ spec:
 <6> The interface that receives the synchronization clock.
 <7> The interface that sends the synchronization clock.
 <8> For Intel Columbiaville 800 Series NICs, set `tx_timestamp_timeout` to `50`.
-<9> For Intel Columbiaville 800 Series NICs, ensure `boundary_clock_jbod` is set to `0`.
+<9> For Intel Columbiaville 800 Series NICs, ensure `boundary_clock_jbod` is set to `0`. For Intel Fortville X710 Series NICs, ensure `boundary_clock_jbod` is set to `1`.
 <10> Specify system config options for the `phc2sys` service. If this field is empty the PTP Operator does not start the `phc2sys` service.
 <11> Scheduling policy for ptp4l and phc2sys processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
 <12> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes. Required if `SCHED_FIFO` is set for `ptpSchedulingPolicy`.


### PR DESCRIPTION
Documentation should be updated to indicate that the boundary_clock_jbod parameter should be set to 0 by default if the intent is to only deploy the service on E810 NICs or add a note that indicates that boundary_clock_jbod should only be set if the service is being deployed on a Fortville (X710) NIC. In other words, the boundary_clock_jbod parameter should be set to "0" for the Intel E810 NIC.

https://issues.redhat.com/browse/TELCODOCS-935

Version(s):
enterprise-4.9+

Preview: https://51518--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#configuring-linuxptp-services-as-boundary-clock_using-ptp