### PR TITLE
OSDOCS-4315 added architectures to Compliance Operator Supported Profiles table

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -8,86 +8,106 @@
 The Compliance Operator provides the following compliance profiles:
 
 .Supported compliance profiles
-[cols="10%,40%,10%,40%", options="header"]
+[cols="10%,40%,10%,40%,10%", options="header"]
 
 |===
 |Profile
 |Profile title
-|Compliance Operator version 
+|Compliance Operator version
 |Industry compliance benchmark
+|Supported architectures
 
 |ocp4-cis
 |CIS Red Hat OpenShift Container Platform 4 Benchmark
 |0.1.39+
 |link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] footnote:cisbenchmark[To locate the CIS RedHat OpenShift Container Platform v4 Benchmark, go to  link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks] and type `Kubernetes` in the search box. Click on *Kubernetes* and then *Download Latest CIS Benchmark*, where you can then register to download the benchmark.]
+|`x86_64`
+ `ppc64le`
+ `s390x`
 
 |ocp4-cis-node
 |CIS Red Hat OpenShift Container Platform 4 Benchmark
 |0.1.39+
 |link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] footnote:cisbenchmark[]
+|`x86_64`
+ `ppc64le`
+ `s390x`
 
 |ocp4-e8
 |Australian Cyber Security Centre (ACSC) Essential Eight
 |0.1.39+
 |link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[ACSC Hardening Linux Workstations and Servers]
+|`x86_64`
 
 |ocp4-moderate
 |NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Platform level
 |0.1.39+
 |link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
-
-|ocp4-moderate-node
-|NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Node level
-|0.1.44+
-|link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
-
-|ocp4-nerc-cip
-|North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Platform level
-|0.1.44+
-|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
-
-|ocp4-nerc-cip-node
-|North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Node level
-|0.1.44+
-|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
-
-|ocp4-pci-dss
-|PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
-|0.1.47+
-|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
-
-|ocp4-pci-dss-node
-|PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
-|0.1.47+
-|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
+|`x86_64`
 
 |rhcos4-e8
 |Australian Cyber Security Centre (ACSC) Essential Eight
 |0.1.39+
 |link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[ACSC Hardening Linux Workstations and Servers]
+|`x86_64`
 
 |rhcos4-moderate
 |NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS
 |0.1.39+
 |link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
+|`x86_64`
+
+|ocp4-moderate-node
+|NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Node level
+|0.1.44+
+|link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
+|`x86_64`
+
+|ocp4-nerc-cip
+|North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Platform level
+|0.1.44+
+|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
+|`x86_64`
+
+|ocp4-nerc-cip-node
+|North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Node level
+|0.1.44+
+|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
+|`x86_64`
 
 |rhcos4-nerc-cip
 |North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for Red Hat Enterprise Linux CoreOS
 |0.1.44+
 |link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
+|`x86_64`
+
+|ocp4-pci-dss
+|PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
+|0.1.47+
+|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
+|`x86_64`
+
+|ocp4-pci-dss-node
+|PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
+|0.1.47+
+|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
+|`x86_64`
 
 |ocp4-high
 |NIST 800-53 High-Impact Baseline for Red Hat OpenShift - Platform level
 |0.1.52+
 |link:https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/800-53[NIST SP-800-53 Release Search]
+|`x86_64`
 
 |ocp4-high-node
 |NIST 800-53 High-Impact Baseline for Red Hat OpenShift - Node level
 |0.1.52+
 |link:https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/800-53[NIST SP-800-53 Release Search]
+|`x86_64`
 
 |rhcos4-high
 |NIST 800-53 High-Impact Baseline for Red Hat Enterprise Linux CoreOS
 |0.1.52+
 |link:https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/800-53[NIST SP-800-53 Release Search]
+|`x86_64`
 |===


### PR DESCRIPTION
Version(s):
4.6+

Issue:
[OSDOCS-4315](https://issues.redhat.com//browse/OSDOCS-4315)

Link to docs preview:
[Compliance Operator Supported Profiles table](http://file.rdu.redhat.com/antaylor/osdocs-4315/security/compliance_operator/compliance-operator-supported-profiles.html#compliance-supported-profiles_compliance-operator-supported-profiles)