### PR TITLE
BZ2077157: Adding HighNodeUtilization profile

### DIFF
--- a/modules/nodes-descheduler-profiles.adoc
+++ b/modules/nodes-descheduler-profiles.adoc
@@ -43,9 +43,11 @@ Pods where the sum of restarts over all containers (including Init Containers) i
 
 * `LowNodeUtilization`: finds nodes that are underutilized and evicts pods, if possible, from overutilized nodes in the hope that recreation of evicted pods will be scheduled on these underutilized nodes.
 +
-A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
+`HighNodeUtilization`: finds nodes that are underutilized and evicts pods from the nodes in the hope that these pods will be scheduled compactly into fewer nodes.
 +
-A node is considered overutilized if its usage is above 50% for any of the thresholds (CPU, memory, and number of pods).
+- A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
++
+- A node is considered overutilized if its usage is above 50% for any of the thresholds (CPU, memory, and number of pods).
 
 * `PodLifeTime`: evicts pods that are too old.
 +


### PR DESCRIPTION
For versions 4.8+
[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2077157)

Preview: [Evicting pods using the descheduler -> Descheduler profiles ](https://51538--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-descheduler.html#nodes-descheduler-profiles_nodes-descheduler)

- [ ] QE review


