### PR TITLE
Added example for specifying address and port number

### DIFF
--- a/modules/acs-quick-install-secured-cluster-using-helm.adoc
+++ b/modules/acs-quick-install-secured-cluster-using-helm.adoc
@@ -28,7 +28,7 @@ $ helm install -n stackrox --create-namespace \
     --set centralEndpoint=<endpoint_of_central_service> <2>
 ----
 <1> Use the `-f` option to specify the path for the init bundle.
-<2> Specify the address and port number for Central.
+<2> Specify the address and port number for Central. For example, `acs.domain.com:443`.
 
 * Run the following command on {ocp} clusters:
 +
@@ -42,4 +42,4 @@ $ helm install -n stackrox --create-namespace \
     --set scanner.disable=false
 ----
 <1> Use the `-f` option to specify the path for the init bundle.
-<2> Specify the address and port number for Central.
+<2> Specify the address and port number for Central. For example, `acs.domain.com:443`.


### PR DESCRIPTION
Based on the info at https://srox.slack.com/archives/C0313JYKH8W/p1665526429037699

- Adds an example value for specifying Central's address and port number.

Merge in `rhacs-docs` and cherry-pick in:
- `rhacs-docs-3.72`
- `rhacs-docs-3.71`
- `rhacs-docs-3.70`

Preview: https://openshift-docs-git-slack-helm-install-ex-gnelson.vercel.app/openshift-acs/master/installing/installing_helm/install-helm-quick.html#installing-secured-cluster-services-quickly_acs-install-helm-quick