### PR TITLE
RHDEVDOCS-4449 Buildah works only with pipeline SA

### DIFF
--- a/modules/op-about-pipelines.adoc
+++ b/modules/op-about-pipelines.adoc
@@ -97,3 +97,8 @@ spec: <4>
 <8> Task `build-image`, which uses the `buildah` ClusterTask to build application images from a given Git repository.
 <9> Task `apply-manifests`, which uses a user-defined Task with the same name.
 <10> Specifies the sequence in which Tasks are run in a Pipeline. In this example, the `apply-manifests` Task is run only after the `build-image` Task is completed.
+
+[NOTE]
+====
+The {pipelines-title} Operator installs the Buildah cluster task and creates the `pipeline` service account with sufficient permission to build and push an image. The Buildah cluster task can fail when associated with a different service account with insufficient permissions.
+====


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.8`, `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`, `enterprise-4.12`
- **JIRA issues**: [RHDEVDOCS-4449 Document that Buildah cluster task works only with pipeline SA](https://issues.redhat.com/browse/RHDEVDOCS-4449)
- **Bugzilla bug**: [#1973633](https://bugzilla.redhat.com/show_bug.cgi?id=1973633).
- **Preview pages**: See the note at the bottom of the section [Understanding OpenShift Pipelines --> Pipelines](http://file.pnq.redhat.com/sosarkar/4449-buildah-pipeline-sa/cicd/pipelines/understanding-openshift-pipelines.html#about-pipelines_understanding-openshift-pipelines)
- **SME review**: @vdemeester           
- **QE review**: Not required as it's only a minor missing information.
- **Peer-review**: jc-berger

**Note for merge**: Please let me know if there is merge conflict after cherry-picking for older branches, such as 4.8 and 4.9. 