### PR TITLE
OCPBUGS-1843 fixing typo realtime should be realTime

### DIFF
--- a/modules/cnf-configuring-workload-hints.adoc
+++ b/modules/cnf-configuring-workload-hints.adoc
@@ -10,7 +10,7 @@
 
 . Create a `PerformanceProfile` appropriate for the environment's hardware and topology as described in the table in "Understanding workload hints". Adjust the profile to match the expected workload. In this example, we tune for the lowest possible latency.
 
-. Add the `highPowerConsumption` and `realtime` workload hints. Both are set to `true` here.
+. Add the `highPowerConsumption` and `realTime` workload hints. Both are set to `true` here.
 +
 [source,yaml]
 ----
@@ -22,7 +22,7 @@
       ...
       workloadHints:
         highPowerConsumption: true <1>
-        realtime: true <2>
+        realTime: true <2>
 ----
 <1> If `highPowerConsumption` is `true`, the node is tuned for very low latency at the cost of increased power consumption.
 <2> Disables some debugging and monitoring features that can affect system latency.

--- a/modules/cnf-understanding-low-latency.adoc
+++ b/modules/cnf-understanding-low-latency.adoc
@@ -21,7 +21,7 @@ Administrators must be able to manage their many Edge sites and local services i
 
 {product-title} uses the Node Tuning Operator to implement automatic tuning to achieve low latency performance for {product-title} applications. The cluster administrator uses this performance profile configuration that makes it easier to make these changes in a more reliable way. The administrator can specify whether to update the kernel to kernel-rt, reserve CPUs for cluster and operating system housekeeping duties, including pod infra containers, and isolate CPUs for application containers to run the workloads.
 
-{product-title} also supports workload hints for the Node Tuning Operator that can tune the `PerformanceProfile` to meet the demands of different industry environments. Workload hints are available for `highPowerConsumption` (very low latency at the cost of increased power consumption) and `realtime` (priority given to optimum latency). A combination of `true/false` settings for these hints can be used to deal with application-specific workload profiles and requirements.
+{product-title} also supports workload hints for the Node Tuning Operator that can tune the `PerformanceProfile` to meet the demands of different industry environments. Workload hints are available for `highPowerConsumption` (very low latency at the cost of increased power consumption) and `realTime` (priority given to optimum latency). A combination of `true/false` settings for these hints can be used to deal with application-specific workload profiles and requirements.
 
 Workload hints simplify the fine-tuning of performance to industry sector settings. Instead of a “one size fits all” approach, workload hints can cater to usage patterns such as placing priority on:
 

--- a/modules/cnf-understanding-workload-hints.adoc
+++ b/modules/cnf-understanding-workload-hints.adoc
@@ -21,7 +21,7 @@ The following workload hints can be configured manually. You can also work with 
 ----
 workloadHints:
 highPowerConsumption: false
-realtime: false
+realTime: false
 ----
     | High throughput cluster without latency requirements
     | Performance achieved through CPU partitioning only.
@@ -33,7 +33,7 @@ realtime: false
 ----
 workloadHints:
 highPowerConsumption: false
-realtime: true
+realTime: true
 ----
     | Regional datacenters
     | Both energy savings and low-latency are desirable: compromise between power management, latency and throughput.
@@ -44,7 +44,7 @@ realtime: true
 ----
 workloadHints:
 highPowerConsumption: true
-realtime: true
+realTime: true
 ----
     | Far edge clusters, latency critical workloads
     | Optimized for absolute minimal latency and maximum determinism at the cost of increased power consumption.


### PR DESCRIPTION
OCPBUGS-1843: Typo in "16.3.6. Configuring workload hints manually": workloadHints: real**t**ime
Version(s):

  * PR applies to all versions after a specific version: 4.11 and greater, 4.12 and main

Issue: https://issues.redhat.com/browse/OCPBUGS-1843

Doc preview: 

1. http://file.emea.redhat.com/kquinn/OCPBUGS-1843/scalability_and_performance/cnf-low-latency-tuning.html#cnf-understanding-workload-hints_cnf-master
2. http://file.emea.redhat.com/kquinn/OCPBUGS-1843/scalability_and_performance/cnf-low-latency-tuning.html#configuring-workload-hints_cnf-master
3. http://file.emea.redhat.com/kquinn/OCPBUGS-1843/scalability_and_performance/cnf-low-latency-tuning.html#configuring-workload-hints_cnf-master


NOTE: Originator of doc bug replied LGTM. This is a simple typo update, so should not require LGTM from QE AFAIK. 



