### PR TITLE
RHDEVDOCS-4544-SBO-RN: Added a deprecation notice for OLM descriptors

### DIFF
--- a/applications/connecting_applications_to_services/sbo-release-notes.adoc
+++ b/applications/connecting_applications_to_services/sbo-release-notes.adoc
@@ -41,6 +41,7 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 |*{servicebinding-title}* 2+|*API Group and Support Status*|*OpenShift Versions*
 
 |*Version*|*`binding.operators.coreos.com`* |*`servicebinding.io`* |
+|1.3      |GA                               |GA                    |4.9-4.11
 |1.2      |GA                               |GA                    |4.7-4.11
 |1.1.1    |GA                               |TP                    |4.7-4.10
 |1.1      |GA                               |TP                    |4.7-4.10
@@ -55,6 +56,7 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
 
 // Modules included, most to least recent
+include::modules/sbo-release-notes-1-3.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-2.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-1-1.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-1.adoc[leveloffset=+1]

--- a/modules/sbo-release-notes-1-3.adoc
+++ b/modules/sbo-release-notes-1-3.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assembly:
+//
+// * applications/connecting_applications_to_services/sbo-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="sbo-release-notes-1-3_{context}"]
+= Release notes for {servicebinding-title} 1.3
+
+{servicebinding-title} 1.3 is now available on {product-title} 4.9, 4.10, and 4.11.
+
+[id="removal-notice-1-3_{context}"]
+== Removed functionality
+* In {servicebinding-title} 1.3, the Operator Lifecycle Manager (OLM) descriptor feature has been removed to improve resource utilization. As an alternative to OLM descriptors, you can use CRD annotations to declare binding data.


### PR DESCRIPTION
**Purpose**: To resolve [RHDEVDOCS-4544](https://issues.redhat.com/browse/RHDEVDOCS-4544): Release Notes, New Features and Known Issues for SBO 1.3

**Aligned team**: Dev Tools

**OCP version for cherry-picking**: enterprise-4.11 and later

**Preview pages**: https://51554--docspreview.netlify.app/openshift-enterprise/latest/applications/connecting_applications_to_services/sbo-release-notes.html#sbo-release-notes-1-3_servicebinding-release-notes

**SME Review completed**: @dperaza4dustbit 
**QE review completed**: @pmacik 
**Peer-review needed**: @jc-berger 