### PR TITLE
TELCODOCS-432: Adding support for iPXE to ZTP

### DIFF
--- a/modules/ztp-deploying-a-site.adoc
+++ b/modules/ztp-deploying-a-site.adoc
@@ -116,7 +116,7 @@ spec:
     nodes:
       - hostName: "example-node1.example.com" <6>
         role: "master"
-        bmcAddress: "idrac-virtualmedia+https://[1111:2222:3333:4444::bbbb:1]/redfish/v1/Systems/System.Embedded.1" <7>
+        bmcAddress: idrac-virtualmedia://<out_of_band_ip>/<system_id>/ <7>
         bmcCredentialsName:
           name: "example-node1-bmh-secret" <8>
         bootMACAddress: "AA:BB:CC:DD:EE:11"
@@ -160,7 +160,7 @@ spec:
 <4> Applies to three-node and standard clusters. The value defines the cluster network sections.
 <5> Applies to three-node and standard clusters. The value defines the cluster network sections.
 <6> Applies to all cluster types. For single node deployments, define one host. For three-node deployments, define three hosts. For standard deployments, define three hosts with `role: master` and two or more hosts defined with `role: worker`.
-<7> Applies to all cluster types. Specifies the BMC address.
+<7> Applies to all cluster types. Specifies the BMC address. ZTP supports iPXE and virtual media booting by using Redfish or IPMI protocols. For more information about BMC addressing, see the _Additional resources_ section.
 <8> Applies to all cluster types. Specifies the BMC credentials.
 <9> Applies to all cluster types. Specifies the network settings for the node.
 

--- a/modules/ztp-manually-install-a-single-managed-cluster.adoc
+++ b/modules/ztp-manually-install-a-single-managed-cluster.adoc
@@ -271,7 +271,7 @@ spec:
   automatedCleaningMode: disabled
   online: true
 ----
-<1> The baseboard management console address of the installation ISO on the target bare-metal host.
+<1> The baseboard management console (BMC) address on the target bare-metal host. ZTP supports iPXE and virtual media booting by using Redfish or IPMI protocols. For more information about BMC addressing, see the _Additional resources_ section.
 <2> The MAC address of the target bare-metal host.
 +
 Optionally, you can add `bmac.agent-install.openshift.io/hostname: <host-name>` as an annotation to set the managed cluster’s hostname. If you don't add the annotation, the hostname will default to either a hostname from the DHCP server or local host.

--- a/modules/ztp-ztp-custom-resources.adoc
+++ b/modules/ztp-ztp-custom-resources.adoc
@@ -29,7 +29,7 @@ Both methods create the CRs shown in the following table. On the cluster site, a
 
 |`BareMetalHost`
 |Contains the connection information for the Baseboard Management Controller (BMC) of the target bare-metal host.
-|Provides access to the BMC in order to load and boot the Discovery image ISO on the target server by using the Redfish protocol.
+|Provides access to the BMC to load and boot the discovery image on the target server by using the Redfish protocol. ZTP supports iPXE and virtual media network booting.
 
 |`InfraEnv`
 |Contains information for pulling {product-title} onto the target bare-metal host.
@@ -49,7 +49,7 @@ Both methods create the CRs shown in the following table. On the cluster site, a
 
 |`Agent`
 |Contains hardware information about the target bare-metal host.
-|Created automatically on the hub when the target machine's Discovery image ISO boots.
+|Created automatically on the hub when the target machine's discovery image boots.
 
 |`ManagedCluster`
 |When a cluster is managed by the hub, it must be imported and known. This Kubernetes object provides that interface.

--- a/scalability_and_performance/ztp-deploying-disconnected.adoc
+++ b/scalability_and_performance/ztp-deploying-disconnected.adoc
@@ -123,6 +123,11 @@ include::modules/ztp-customizing-the-install-extra-manifests.adoc[leveloffset=+1
 
 include::modules/ztp-deploying-a-site.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
+
 include::modules/ztp-talo-integration.adoc[leveloffset=+1]
 
 // End of 340
@@ -195,6 +200,11 @@ include::modules/ztp-roll-out-the-configuration-changes.adoc[leveloffset=+2]
 // Manual installation moved here
 
 include::modules/ztp-manually-install-a-single-managed-cluster.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
 
 include::modules/ztp-du-host-bios-requirements.adoc[leveloffset=+2]
 


### PR DESCRIPTION
[TELCODOCS-432](https://issues.redhat.com//browse/TELCODOCS-432): Zero touch provisioning currently only features virtual installation media for booting remote images on nodes. With this update, ZTP leverages Metal3 functionality to also support PXE booting. 

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/TELCODOCS-432

Link to docs preview:
* http://file.emea.redhat.com/rohennes/TELCODOCS-432-support-PXE-with-ZTP/scalability_and_performance/ztp-deploying-disconnected.html#ztp-deploying-a-site_ztp-deploying-disconnected
* http://file.emea.redhat.com/rohennes/TELCODOCS-432-support-PXE-with-ZTP/scalability_and_performance/ztp-deploying-disconnected.html#ztp-manually-install-a-single-managed-cluster_ztp-deploying-disconnected

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
