### PR TITLE
OCPBUGS#2082 - Admonition wording update

### DIFF
--- a/storage/persistent_storage/persistent-storage-iscsi.adoc
+++ b/storage/persistent_storage/persistent-storage-iscsi.adoc
@@ -31,10 +31,13 @@ By default, they are ports `860` and `3260`.
 
 [IMPORTANT]
 ====
-OpenShift assumes that all nodes in the cluster have already configured the iSCSI
-initiator, that is, users have installed the `iscsi-initiator-utils` package and configured
-their initiator name in `/etc/iscsi/initiatorname.iscsi`. See Storage
-Administration Guide linked above.
+Users must ensure that the iSCSI initiator is already configured on all 
+{product-title} nodes by installing the `iscsi-initiator-utils` 
+package and configuring their initiator name in `/etc/iscsi/initiatorname.iscsi`. 
+The `iscsi-initiator-utils` package is already installed on deployments 
+that use {op-system-first}.
+
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/managing_storage_devices/index#configuring-an-iscsi-initiator_managing-storage-devices[Managing Storage Devices].
 ====
 
 include::modules/storage-persistent-storage-iscsi-provisioning.adoc[leveloffset=+1]


### PR DESCRIPTION
Versions 4.6+

[OCPBUGS-2082](https://issues.redhat.com/browse/OCPBUGS-2082)

This PR updates the wording of an admonition to make it less anthropomorphic and more user focused. It also adds information about the iscsi intitiator utils package already being installed on deployments using RHCOS. These changes have been acknowledged by Jan Safranek.

Preview: https://51571--docspreview.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-iscsi.html