### PR TITLE
[SRVCOM-2121] Add the marketplace prerequisite for the Serverless operator

### DIFF
--- a/modules/serverless-install-web-console.adoc
+++ b/modules/serverless-install-web-console.adoc
@@ -12,6 +12,7 @@ You can install the {ServerlessOperatorName} from the OperatorHub by using the {
 
 ifdef::openshift-enterprise[]
 * You have access to an {product-title} account with cluster administrator access.
+* Your cluster has the Marketplace capability enabled or the Red Hat Operator catalog source configured manually.
 endif::[]
 
 ifdef::openshift-dedicated,openshift-rosa[]

--- a/serverless/install/install-serverless-operator.adoc
+++ b/serverless/install/install-serverless-operator.adoc
@@ -48,6 +48,8 @@ If you want to xref:../../serverless/serverless-tracing.adoc#serverless-tracing[
 == Additional resources
 ifdef::openshift-enterprise[]
 * xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+* xref:../../operators/understanding/olm-understanding-operatorhub.adoc#olm-operatorhub-overview[Understanding OperatorHub]
+* xref:../../post_installation_configuration/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
 endif::[]
 * xref:../../serverless/admin_guide/serverless-ha.adoc#serverless-ha[Configuring high availability replicas on {ServerlessProductName}]
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/SRVCOM-2121

Link to docs preview:
https://51572--docspreview.netlify.app/openshift-enterprise/latest/serverless/install/install-serverless-operator.html#serverless-install-web-console_install-serverless-operator

(the second requirement entry)

https://51572--docspreview.netlify.app/openshift-enterprise/latest/serverless/install/install-serverless-operator.html#additional-resources_install-serverless-operator

(the second additional resource entry)

QE-approved (in https://github.com/openshift/openshift-docs/pull/51075#pullrequestreview-1138967587 )