### PR TITLE
Replace machine-os-content with new format base image (Layering) RN

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -667,6 +667,15 @@ For more information on platform Operators, see "Managing platform Operators". F
 [id="ocp-4-12-machine-config-operator"]
 === Machine Config Operator
 
+[id="ocp-4-12-machine-config-operator-layering"]
+==== {op-system} image layering
+
+{op-system-first} image layering allows you to add new images on top of the base {op-system} image. This layering does not modify the base {op-system} image. Instead, it creates a _custom layered image_ that includes all {op-system} functionality and adds additional functionality to specific nodes in the cluster.
+
+Currently, {op-system} image layering allows you to work with Customer Experience and Engagement (CEE) to obtain and apply Hotfix packages on top of your {op-system} image, based on the link:https://access.redhat.com/solutions/2996001[Red Hat Hotfix policy]. It is planned for future releases that you can use {op-system} image layering to incorporate third-party software packages such as Libreswan or numactl.
+
+For more information, see xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering[{op-system} image layering]. 
+
 [id="ocp-4-12-nodes"]
 === Nodes
 


### PR DESCRIPTION
Release note for [CoreOS layering](https://issues.redhat.com/browse/OSDOCS-3979).

Previews:
[CoreOS Layering Release Note](https://51575--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-machine-config-operator-layering)
