### PR TITLE
[RHACS] Release notes for 3.71.2 patch

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -44,7 +44,7 @@ endif::[]
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 3.71.1
+:rhacs-version: 3.71.2
 :ocp-supported-version: 4.5
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 3.71

--- a/release_notes/371-release-notes.adoc
+++ b/release_notes/371-release-notes.adoc
@@ -18,7 +18,7 @@ toc::[]
 
 * A new top-level Dashboard to increase your efficiency
 * Two new default policies to help improve your security posture
-* Ability to set eBPF as the default collection method to boost performance 
+* Ability to set eBPF as the default collection method to boost performance
 * Additional feature enhancements and bug fixes
 
 [id="new-features-371"]
@@ -38,13 +38,13 @@ The *Status Bar* provides at-a-glance numerical counters for key resources. The 
 
 [options="header"]
 |====================================================================================================================
-| Counter     | Destination                                                           
-| Clusters    | Platform Configuration → Clusters                                      
-| Nodes       | Configuration Management → Application & Infrastructure → Nodes        
-| Violations  | Violations main menu                                                   
-| Deployments | Configuration Management → Application & Infrastructure → Deployments  
-| Images      | Vulnerability Management → Dashboard → Images                         
-| Secrets     | Configuration Management → Application & Infrastructure → Secrets      
+| Counter     | Destination
+| Clusters    | Platform Configuration → Clusters
+| Nodes       | Configuration Management → Application & Infrastructure → Nodes
+| Violations  | Violations main menu
+| Deployments | Configuration Management → Application & Infrastructure → Deployments
+| Images      | Vulnerability Management → Dashboard → Images
+| Secrets     | Configuration Management → Application & Infrastructure → Secrets
 |====================================================================================================================
 
 [id="dashboard-filter"]
@@ -55,13 +55,13 @@ The Dashboard now includes a top-level filter that applies simultaneously to all
 [id="widget-options"]
 ==== Widget options
 
-Some widgets are now customizable to help you focus on what matters the most to you. Widgets offer different controls that change how the data is sorted, allow you to filter the data, and help you to customize the widget’s output. 
+Some widgets are now customizable to help you focus on what matters the most to you. Widgets offer different controls that change how the data is sorted, allow you to filter the data, and help you to customize the widget’s output.
 
 Widgets offer two ways to customize different aspects:
 
-* An *Options* menu, when present,  provides specific options applicable to that widget. 
+* An *Options* menu, when present,  provides specific options applicable to that widget.
 * A *dynamic axis legend*, when present, allows you to filter data by hiding one or more of the axis categories. For example, in the *Policy violations by category* widget, you can click on a severity to include or exclude respective violations from the data.
- 
+
 [NOTE]
 ====
 Individual widget customization settings are short lived and are reset to the system default upon leaving the Dashboard.
@@ -74,20 +74,20 @@ The Dashboard provides the following actionable widgets:
 
 * *Policy violations by severity*: This widget shows the distribution of violations across severity levels for the Dashboard-filtered scope. Clicking a *severity level* in the chart takes you to the *Violations* page, filtered for that severity and scope. It also lists the three most recent violations of a *Critical* level policy within the scope you defined in the Dashboard filter. Clicking a specific violation takes you directly to the *Violations* detail page for that violation.
 
-* *Images at most risk*: This widget lists the top six vulnerable images within the Dashboard-filtered scope, sorted by their computed risk priority, along with the number of critical and important common vulnerabilities and exposures (CVEs) they contain. Click an image name to go directly to the *Image Findings* page under *Vulnerability Management*. Use the *Options* menu to focus on fixable CVEs, or further focus on active images. 
+* *Images at most risk*: This widget lists the top six vulnerable images within the Dashboard-filtered scope, sorted by their computed risk priority, along with the number of critical and important common vulnerabilities and exposures (CVEs) they contain. Click an image name to go directly to the *Image Findings* page under *Vulnerability Management*. Use the *Options* menu to focus on fixable CVEs, or further focus on active images.
 +
 [NOTE]
 ====
-When clusters or namespaces have been selected in the Dashboard filter, the data displayed is already filtered to active images, or images that are being used by deployments within the filtered scope. 
+When clusters or namespaces have been selected in the Dashboard filter, the data displayed is already filtered to active images, or images that are being used by deployments within the filtered scope.
 ====
 
-* *Deployments at most risk*: This widget provides the information that was previously available in the *Top risky deployments* widget, but displays additional information such as the resource location (cluster and namespace) and the risk priority score. Additionally, you can click on a deployment to view risk information about the deployment; for example, its policy violations and vulnerabilities. 
+* *Deployments at most risk*: This widget provides the information that was previously available in the *Top risky deployments* widget, but displays additional information such as the resource location (cluster and namespace) and the risk priority score. Additionally, you can click on a deployment to view risk information about the deployment; for example, its policy violations and vulnerabilities.
 
 * *Aging images*: Older images present a higher security risk as they can contain vulnerabilities that have already been addressed. If older images are active, they can expose deployments to exploits. This widget allows you to quickly assess your security posture and identify offending images. You can use the default ranges or customize the age intervals with your own values. You can view both inactive and active images or use the Dashboard filter to focus on a particular area for active images. You can then click on an age group in this widget to view only those images in the *Vulnerability Management* -> *Images* page.
-  
+
 * *Policy violations by category*: This widget can help you gain insights about the challenges your organization is facing in complying with security policies, by analyzing which types of policies are violated more than others. The widget shows the five policy categories of highest interest. Explore the *Options* menu for different ways to slice the data. You can filter the data to focus exclusively on deploy or runtime violations. You can also change the sorting mode. By default, the data is sorted by the number of violations within the highest severity first. Therefore, all categories with critical policies will appear before categories without critical policies. The other sorting mode considers the total number of violations regardless of severity. As some categories contain no critical policies (for example, “Docker CIS”), the two sorting modes can provide significantly different views, offering additional insight. Click on a severity level at the bottom of the graph to include or exclude that level from the data, potentially resulting in a different top five selection, as well as a different ranking order. Data is filtered to the scope selected by the Dashboard filter.
 
-* *Compliance by standard*: The *Compliance* widget is an improvement over a similar widget included in the past. It uses the Dashboard filter, allowing you to focus on areas that matter to you the most. The widget lists the top or bottom six compliance benchmarks, depending on sort order. Select *Options* to sort by the respective coverage percentage. Click on one of the benchmark labels or graphs to go directly to the *Compliance Controls* page, filtered by the Dashboard scope and the selected benchmark. 
+* *Compliance by standard*: The *Compliance* widget is an improvement over a similar widget included in the past. It uses the Dashboard filter, allowing you to focus on areas that matter to you the most. The widget lists the top or bottom six compliance benchmarks, depending on sort order. Select *Options* to sort by the respective coverage percentage. Click on one of the benchmark labels or graphs to go directly to the *Compliance Controls* page, filtered by the Dashboard scope and the selected benchmark.
 
 [id="removed-widgets"]
 ==== Removed widgets
@@ -112,9 +112,9 @@ Role-based Access Control (RBAC) in {product-title-short} has been enhanced to a
 
 
 [id="network-policies-list"]
-=== List of network policies in Deployment tab for violations 
+=== List of network policies in Deployment tab for violations
 
-A new information section has been added to help resolve a "missing Kubernetes network policy" violation. When viewing a violation, select the *Deployment* tab and scroll to the new *Network policy* section. It lists all the Kubernetes network policies applicable to the namespace of the offending deployment. You can use this list to verify which network policies exist in the namespace to help you determine why a deployment was flagged as missing a network policy. 
+A new information section has been added to help resolve a "missing Kubernetes network policy" violation. When viewing a violation, select the *Deployment* tab and scroll to the new *Network policy* section. It lists all the Kubernetes network policies applicable to the namespace of the offending deployment. You can use this list to verify which network policies exist in the namespace to help you determine why a deployment was flagged as missing a network policy.
 
 
 [id="alpine-316"]
@@ -124,14 +124,14 @@ Scanner now supports Alpine 3.16.
 == Enhancements
 
 [id="roxctl-image-scan"]
-=== Change to roxctl image scan behavior 
+=== Change to roxctl image scan behavior
 
 The default value for the `--include-snoozed` option of the `roxctl image scan` command is set to `false`. If the `--include-snoozed` option is set to `false`, the scan does not include snoozed CVEs.
 
 [id="diagnostic-bundle-update"]
 === Update to diagnostic bundles
 
-You can create diagnostic bundles to assist Red Hat in supporting you with {product-title-short}. This diagnostic bundle has been enhanced to include notifiers, auth providers and auth provider groups, access control roles with attached permission set and access scope, and system configuration information. Users with the `DebugLogs` permission can read listed entities from a generated diagnostic bundle regardless of their respective permissions. 
+You can create diagnostic bundles to assist Red Hat in supporting you with {product-title-short}. This diagnostic bundle has been enhanced to include notifiers, auth providers and auth provider groups, access control roles with attached permission set and access scope, and system configuration information. Users with the `DebugLogs` permission can read listed entities from a generated diagnostic bundle regardless of their respective permissions.
 
 [id="ocp4-cis-benchmarks"]
 === Align OCP4-CIS scanning benchmarks control numbers
@@ -230,7 +230,7 @@ In the table, features are marked with the following statuses:
 | GA
 | DEP
 
-|  `vulns` fields of `storage.Node` object in response payload of `v1/nodes` 
+|  `vulns` fields of `storage.Node` object in response payload of `v1/nodes`
 | GA
 | GA
 | DEP
@@ -240,7 +240,7 @@ In the table, features are marked with the following statuses:
 | GA
 | DEP
 
-|`ids` field in the `/v1/cves/suppress` and `/v1/cves/unsuppress` API payload 
+|`ids` field in the `/v1/cves/suppress` and `/v1/cves/unsuppress` API payload
 | GA
 | GA
 | DEP
@@ -267,7 +267,7 @@ In the table, features are marked with the following statuses:
 ** Use `/v1/imagecves/suppress` and `/v1/imagecves/unsuppress` to snooze and unsnooze image vulnerabilities.
 ** Use `/v1/nodecves/suppress` and `/v1/nodecves/unsuppress` to snooze and unsnooze node and host vulnerabilities.
 ** Use `/v1/clustercves/suppress` and `/v1/clustercves/unsuppress` to snooze and unsnooze platform (Kubernetes, Istio, and {ocp}) vulnerabilities.
-* *Updated 30 August 2022:* 
+* *Updated 30 August 2022:*
 ** The `ids` field in the `/v1/cves/suppress` and `/v1/cves/unsuppress` API payload will be renamed to `cves` in the {product-title-short} 3.73 release.
 ** The `cves.ids` field of the `storage.VulnerabilityRequest` object in the response of `VulnerabilityRequestService` endpoints will be renamed to `cves.cves` in the {product-title-short} 3.73 release.
 
@@ -283,6 +283,14 @@ In the table, features are marked with the following statuses:
 [id="bug-fixes-371"]
 == Bug fixes
 
+[id="bug-fixes-371-2"]
+=== Resolved in version 3.71.2
+
+Release date: 17 October 2022
+
+* Because of a bug in {product-title-short} 3.72.0, the Collector pods previously stopped responding and reach a segmentation fault after allocating a memory block for the protocol buffer heap under certain load conditions.
+The patch release 3.71.2 fixes this issue.
+
 [id="bug-fixes-371-1"]
 === Resolved in version 3.71.1
 
@@ -290,9 +298,9 @@ Release date: 5 October 2022
 
 This release contains security updates to address the following CVEs in the base images:
 
-- link:https://access.redhat.com/security/cve/cve-2022-2526[CVE-2022-2526]: `systemd-resolved`: `use-after-free` when dealing with `DnsStream` in `resolved-dns-stream.c` 
+- link:https://access.redhat.com/security/cve/cve-2022-2526[CVE-2022-2526]: `systemd-resolved`: `use-after-free` when dealing with `DnsStream` in `resolved-dns-stream.c`
 
-- link:https://access.redhat.com/security/cve/cve-2022-29154[CVE-2022-29154]: `rsync`: remote arbitrary files write inside the directories of connecting peers 
+- link:https://access.redhat.com/security/cve/cve-2022-29154[CVE-2022-29154]: `rsync`: remote arbitrary files write inside the directories of connecting peers
 
 [id="bug-fixes-371-0"]
 === Resolved in version 3.71.0


### PR DESCRIPTION
- Added release notes for 3.71.2 patch.
- Updated the version number in common-attributes file.

Merge into `rhacs-docs-3.71` branch. No cherrypicks required.

Preview: https://openshift-docs-git-rhacs-docs-371-gnelson.vercel.app/openshift-acs/master/release_notes/371-release-notes.html#bug-fixes-371-2

Please note that the changes are only in lines 286 -293