### PR TITLE
CNV-13681: node image max note - additional versions

### DIFF
--- a/modules/nodes-nodes-managing-about.adoc
+++ b/modules/nodes-nodes-managing-about.adoc
@@ -92,3 +92,8 @@ Most https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/[Kub
 * ClusterDomain
 * RuntimeRequestTimeout
 * StaticPodPath
+
+[NOTE]
+====
+If a single node contains more than 50 images, pod scheduling might be imbalanced across nodes. This is because the list of images on a node is shortened to 50 by default. You can disable the image limit by editing the `KubeletConfig` object and setting the value of `nodeStatusMaxImages` to `-1`.
+====


### PR DESCRIPTION
Version(s): 4.8-4.10

Issue: [CNV-13681](https://issues.redhat.com//browse/CNV-13681)

Link to docs preview: http://file.rdu.redhat.com/sjess/CNV13681-X/nodes/nodes/nodes-nodes-managing.html

QE review:
- [x] QE has approved this change. see: https://github.com/openshift/openshift-docs/pull/51060 - reconfigured topic location and for 4.11. This is for previous versions per the Jira story
