### PR TITLE
TELCODOCS-644/645: Per-Core Runtime Tuning of power states - CRI-O and PAO/NTO

### DIFF
--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -231,8 +231,6 @@ status:
   runtimeClass: performance-manual
 ----
 
-* The pod must have the `cpu-load-balancing.crio.io: true` annotation.
-
 The Node Tuning Operator is responsible for the creation of the high-performance runtime handler config snippet under relevant nodes and for creation of the high-performance runtime class under the cluster. It will have the same content as default runtime handler except it enables the CPU load balancing configuration functionality.
 
 To disable the CPU load balancing for the pod, the `Pod` specification must include the following fields:
@@ -326,3 +324,120 @@ spec:
 ----
 $ oc apply -f my-performance-profile.yaml
 ----
+
+[id="node-tuning-operator-pod-power-saving-config_{context}"]
+== Optional: Power saving configurations
+
+You can enable power savings for a node that has low priority workloads that are colocated with high priority workloads without impacting the latency or throughput of the high priority workloads. Power saving is possible without modifications to the workloads themselves.
+
+[IMPORTANT]
+====
+The feature is supported on Intel Ice Lake and later generations of Intel CPUs. The capabilities of the processor might impact the latency and throughput of the high priority workloads.
+====
+
+When you configure a node with a power saving configuration, you must configure high priority workloads with performance configuration at the pod level, which means that the configuration applies to all the cores used by the pod.
+
+By disabling P-states and C-states at the pod level, you can configure high priority workloads for best performance and lowest latency.
+
+.Power saving configurations
+[cols="1,2", options="header"]
+|====
+|Annotation
+|Description
+
+a|[source,yaml]
+----
+annotations:
+  cpu-c-states.crio.io: "enable"
+  cpu-freq-governor.crio.io: "<governor>"
+----
+|Provides the best performance for a pod by disabling C-states and specifying the governor type for CPU scaling. The `performance` governor is recommended for high priority workloads.
+|====
+
+
+.Prerequisites
+
+* You enabled C-states and OS-controlled P-states in the BIOS
+
+.Procedure
+
+. Generate a `PerformanceProfile` with `per-pod-power-management` set to `true`:
++
+[source,terminal]
+----
+$ podman run --entrypoint performance-profile-creator -v \
+/must-gather:/must-gather:z registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.11 \
+--mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true \
+--split-reserved-cpus-across-numa=false --topology-manager-policy=single-numa-node \
+--must-gather-dir-path /must-gather -power-consumption-mode=low-latency \ <1>
+--per-pod-power-management=true > my-performance-profile.yaml
+----
+<1> The `power-consumption-mode` must be `default` or `low-latency` when the `per-pod-power-management` is set to `true`.
+
++
+.Example `PerformanceProfile` with `perPodPowerManagement`
+
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+     name: performance
+spec:
+    [.....]
+    workloadHints:
+        realTime: true
+        highPowerConsumption: false
+        perPodPowerManagement: true
+----
+
+. Set the default `cpufreq` governor as an additional kernel argument in the `PerformanceProfile` custom resource (CR):
++
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+     name: performance
+spec:
+    ...
+    additionalKernelArgs:
+    - cpufreq.default_governor=schedutil <1>
+----
+<1> Using the `schedutil` governor is recommended, however, you can use other governors such as the `ondemand` or `powersave` governors.
+
+. Set the maximum CPU frequency in the `TunedPerformancePatch` CR:
++
+[source,yaml]
+----
+spec:
+  profile:
+  - data: |
+      [sysfs]
+      /sys/devices/system/cpu/intel_pstate/max_perf_pct = <x> <1>
+----
+<1> The `max_perf_pct` controls the maximum frequency the `cpufreq` driver is allowed to set as a percentage of the maximum supported cpu frequency. This value applies to all CPUs. You can check the maximum supported frequency in `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq`.
+
+
+. Add the desired annotations to your pods. The annotations override the `default` settings.
++
+.Example power saving annotation
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  ...
+  annotations:
+    ...
+    cpu-c-states.crio.io: "enable"
+    cpu-freq-governor.crio.io: "<governor>"
+    ...
+  ...
+spec:
+  ...
+  runtimeClassName: performance-<profile_name>
+  ...
+----
+
+. Restart the pods.

--- a/modules/cnf-understanding-workload-hints.adoc
+++ b/modules/cnf-understanding-workload-hints.adoc
@@ -49,4 +49,15 @@ realTime: true
     | Far edge clusters, latency critical workloads
     | Optimized for absolute minimal latency and maximum determinism at the cost of increased power consumption.
 
+    | Per-pod power management
+    a|[source,terminal]
+----
+workloadHints:
+realTime: true
+highPowerConsumption: false
+perPodPowerManagement: true
+----
+    | Critical and non-critical workloads
+    | Allows for power management per pod.
+
 |===

--- a/modules/ztp-du-bios-config-reference.adoc
+++ b/modules/ztp-du-bios-config-reference.adoc
@@ -65,8 +65,8 @@ The following table is a general recommendation for vDU cluster host BIOS config
 |Disable Energy Efficient Turbo to prevent the processor from using an energy-efficiency based policy.
 
 |Hardware P-States
-|Disabled
-|Disable `P-states` (performance states) to optimize the operating system and CPU for performance over power consumption.
+|Enabled or Disabled
+|Enable OS-controlled P-States to allow power saving configurations. Disable `P-states` (performance states) to optimize the operating system and CPU for performance over power consumption.
 
 |Package C-State
 |C0/C1 state
@@ -88,4 +88,9 @@ The following table is a general recommendation for vDU cluster host BIOS config
 [NOTE]
 ====
 Enable global SR-IOV and VT-d settings in the BIOS for the host. These settings are relevant to bare-metal environments.
+====
+
+[NOTE]
+====
+Enable both `C-states` and OS-controlled `P-States` to allow per pod power management.
 ====

--- a/scalability_and_performance/cnf-low-latency-tuning.adoc
+++ b/scalability_and_performance/cnf-low-latency-tuning.adoc
@@ -17,6 +17,11 @@ include::modules/cnf-about_hyperthreading_for_low_latency_and_real_time_applicat
 
 include::modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about recommended BIOS configuration, see xref:../scalability_and_performance/ztp-vdu-validating-cluster-tuning.adoc#ztp-du-bios-config-reference_vdu-config-ref[Recommended BIOS configuration for vDU cluster hosts].
+
 include::modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc[leveloffset=+2]
 
 include::modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/TELCODOCS-644 and https://issues.redhat.com/browse/TELCODOCS-645
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://51612--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#node-tuning-operator-disabling-cpu-load-balancing-for-dpdk_cnf-master
https://51612--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#node-tuning-operator-pod-power-saving-config_cnf-master
https://51612--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#cnf-understanding-workload-hints_cnf-master
https://51612--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-vdu-validating-cluster-tuning.html#ztp-du-bios-config-reference_vdu-config-ref
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
