### PR TITLE
OCPBUGS#1902: OpenStack: Note that app creds are not supported

### DIFF
--- a/modules/installation-osp-describing-cloud-parameters.adoc
+++ b/modules/installation-osp-describing-cloud-parameters.adoc
@@ -19,7 +19,7 @@ The {product-title} installation program relies on a file that is called `clouds
 +
 [IMPORTANT]
 ====
-Remember to add a password to the `auth` field. You can also keep secrets in link:https://docs.openstack.org/os-client-config/latest/user/configuration.html#splitting-secrets[a separate file] from `clouds.yaml`.
+Remember to add a password to the `auth` field. You can also keep secrets in link:https://docs.openstack.org/os-client-config/latest/user/configuration.html#splitting-secrets[a separate file] from `clouds.yaml`. {product-title} does not support application credentials.
 ====
 
 ** If your {rh-openstack} distribution does not include the Horizon web UI, or you do not want to use Horizon, create the file yourself. For detailed information about `clouds.yaml`, see https://docs.openstack.org/openstacksdk/latest/user/config/configuration.html#config-files[Config files] in the {rh-openstack} documentation.


### PR DESCRIPTION
Application credentials won't work with legacy in-tree cloud-provider which is still part of 4.11. This commit adds a note that we don't support that way of providing OpenStack cloud credentials.

Version(s):
PR applies to 4.11 and all previous versions.

Issue:
https://issues.redhat.com/browse/OCPBUGS-1902

Link to docs preview:

QE review:
- [ ] QE has approved this change.

Additional information: