### PR TITLE
GITOPS-2269 - updated 4.8 release notes

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -43,6 +43,22 @@ include::modules/gitops-release-notes-1-5-0.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-4-12.adoc[leveloffset=+1]
 
+include::modules/gitops-release-notes-1-4-5.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-4-3.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-4-2.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-4-1.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-4-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-3-7.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-3-6.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-3-2.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-3-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-0.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-3-2.adoc
+++ b/modules/gitops-release-notes-1-3-2.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-3-2_{context}"]
+= Release notes for {gitops-title} 1.3.2
+
+{gitops-title} 1.3.2 is now available on {product-title} 4.6, 4.7, 4.8, and 4.9.
+
+[id="new-features-1-3-2_{context}"]
+== New features
+
+In addition to the fixes and stability improvements, the following sections highlight what is new in {gitops-title} 1.3.2:
+
+* Upgraded Argo CD to version *2.1.8*
+
+* Upgraded Dex to version *2.30.0*
+
+[id="fixed-issues-1-3-2_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, in the OperatorHub UI under the *Infrastructure Features* section, when you filtered by `Disconnected`, the {gitops-title} Operator did not show in the search results, as the Operator did not have the related annotation set in its CSV file. With this update, the `Disconnected Cluster` annotation has been added to the {gitops-title} Operator as an infrastructure feature. link:https://issues.redhat.com/browse/GITOPS-1539[GITOPS-1539]
+
+* When using a `Namespace-scoped` Argo CD instance, for example, an Argo CD instance that is not scoped to *All Namepsaces* in a cluster, {gitops-title} dynamically maintains a list of managed namespaces. These namespaces include the `argocd.argoproj.io/managed-by` label. This list of namespaces is stored in a cache in *Argo CD -> Settings -> Clusters -> "in-cluster" -> NAMESPACES*. Before this update, if you deleted one of these namespaces, the Operator ignored that operation, and the namespace remained in the list. This behavior broke the *CONNECTION STATE* in that cluster configuration, and all sync attempts resulted in errors. For example:
++
+[source,text]
+----
+Argo service account does not have <random_verb> on <random_resource_type> in namespace <the_namespace_you_deleted>. 
+----
++
+This bug is fixed. link:https://issues.redhat.com/browse/GITOPS-1521[GITOPS-1521]
+
+* With this update, the {gitops-title} Operator has been annotated with the *Deep Insights* capability level. link:https://issues.redhat.com/browse/GITOPS-1519[GITOPS-1519]
+
+* Previously, the Argo CD Operator managed the `resource.exclusion` field by itself but ignored the `resource.inclusion` field. This prevented the `resource.inclusion` field configured in the `Argo CD` CR from being generated in the `argocd-cm` configuration map. This issue is fixed in this release. link:https://issues.redhat.com/browse/GITOPS-1518[GITOPS-1518]

--- a/modules/gitops-release-notes-1-3-6.adoc
+++ b/modules/gitops-release-notes-1-3-6.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-3-6_{context}"]
+= Release notes for {gitops-title} 1.3.6
+
+{gitops-title} 1.3.6 is now available on {product-title} 4.7 and above.
+
+[id="fixed-issues-1-3-6_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* In {gitops-title}, improper access control allows admin privilege escalation link:https://access.redhat.com/security/cve/CVE-2022-1025[(CVE-2022-1025)]. This update fixes the issue.
+
+* A path traversal flaw allows leaking of out-of-bound files link:https://access.redhat.com/security/cve/CVE-2022-24731[(CVE-2022-24731)]. This update fixes the issue.
+
+* A path traversal flaw and improper access control allows leaking of out-of-bound files link:https://access.redhat.com/security/cve/CVE-2022-24730[(CVE-2022-24730)]. This update fixes the issue.

--- a/modules/gitops-release-notes-1-3-7.adoc
+++ b/modules/gitops-release-notes-1-3-7.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-3-7_{context}"]
+= Release notes for {gitops-title} 1.3.7
+
+{gitops-title} 1.3.7 is now available on {product-title} 4.7 and above.
+
+[id="fixed-issues-1-3-7_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* Before this update, a flaw was found in OpenSSL. This update fixes the issue by updating the base images for OpenSSL to the latest version to avoid the flaw. link:https://access.redhat.com/security/cve/CVE-2022-0778[(CVE-2022-0778)].
+
+[NOTE]
+====
+To install the current release of {gitops-title} 1.3 and receive further updates during its product life cycle, switch to the **GitOps-1.3** channel.
+====

--- a/modules/gitops-release-notes-1-4-0.adoc
+++ b/modules/gitops-release-notes-1-4-0.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-4-0_{context}"]
+= Release notes for {gitops-title} 1.4.0
+
+{gitops-title} 1.4.0 is now available on {product-title} 4.7, 4.8, and 4.9.
+
+[id="new-features-1-4-0_{context}"]
+== New features
+
+The current release adds the following improvements:
+
+* This enhancement upgrades {gitops-title} Application Manager (kam) to version *0.0.41*. link:https://issues.redhat.com/browse/GITOPS-1669[GITOPS-1669]
+
+* This enhancement upgrades Argo CD to version *2.2.2*. link:https://issues.redhat.com/browse/GITOPS-1532[GITOPS-1532]
+
+* This enhancement upgrades Helm to version *3.7.1*. link:https://issues.redhat.com/browse/GITOPS-1530[GITOPS-1530]
+
+* This enhancement adds the health status of the `DeploymentConfig`, `Route`, and `OLM Operator` items to the Argo CD Dashboard and {product-title} web console. This information helps you monitor the overall health status of your application. link:https://issues.redhat.com/browse/GITOPS-655[GITOPS-655], link:https://issues.redhat.com/browse/GITOPS-915[GITOPS-915], link:https://issues.redhat.com/browse/GITOPS-916[GITOPS-916], link:https://issues.redhat.com/browse/GITOPS-1110[GITOPS-1110]
+
+* With this update, you can specify the number of desired replicas for the `argocd-server` and `argocd-repo-server` components by setting the `.spec.server.replicas` and `.spec.repo.replicas` attributes in the Argo CD custom resource, respectively. If you configure the horizontal pod autoscaler (HPA) for the `argocd-server` components, it takes precedence over the Argo CD custom resource attributes. link:https://issues.redhat.com/browse/GITOPS-1245[GITOPS-1245]
+
+* As an administrative user, when you give Argo CD access to a namespace by using the `argocd.argoproj.io/managed-by` label, it assumes namespace-admin privileges. These privileges are an issue for administrators who provide namespaces to non-administrators, such as development teams, because the privileges enable non-administrators to modify objects such as network policies.
++
+With this update, administrators can configure a common cluster role for all the managed namespaces. In role bindings for the Argo CD application controller, the Operator refers to the `CONTROLLER_CLUSTER_ROLE` environment variable. In role bindings for the Argo CD server, the Operator refers to the `SERVER_CLUSTER_ROLE` environment variable. If these environment variables contain custom roles, the Operator doesn't create the default admin role. Instead, it uses the existing custom role for all managed namespaces. link:https://issues.redhat.com/browse/GITOPS-1290[GITOPS-1290]
+
+* With this update, the Environment page in the {product-title} Developer Console displays a broken heart icon to indicate degraded resources, excluding ones whose status is Progressing, Missing, and Unknown. The console displays a yellow yield sign icon to indicate out-of-sync resources. link:https://issues.redhat.com/browse/GITOPS-1307[GITOPS-1307]
+
+[id="fixed-issues-1-4-0_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, when the Route to the {gitops-title} Application Manager (kam) was accessed without specifying a path in the URL, a default page without any helpful information was displayed to the user. This update fixes the issue so that the default page displays download links for kam. link:https://issues.redhat.com/browse/GITOPS-923[GITOPS-923]
+
+* Before this update, setting a resource quota in the namespace of the Argo CD custom resource might cause the setup of the Red Hat SSO (RH SSO) instance to fail. This update fixes this issue by setting a minimum resource request for the RH SSO deployment pods. link:https://issues.redhat.com/browse/GITOPS-1297[GITOPS-1297]
+
+* Before this update, if you changed the log level for the `argocd-repo-server` workload, the Operator didn't reconcile this setting. The workaround was to delete the deployment resource so that the Operator recreated it with the new log level. With this update, the log level is correctly reconciled for existing `argocd-repo-server` workloads. link:https://issues.redhat.com/browse/GITOPS-1387[GITOPS-1387]
+
+* Before this update, if the Operator managed an Argo CD instance that lacked the `.data` field in the `argocd-secret` `Secret`, the Operator on that instance crashed. This update fixes the issue so that the Operator doesn't crash when the `.data` field is missing. Instead, the secret regenerates and the `gitops-operator-controller-manager` resource is redeployed. link:https://issues.redhat.com/browse/GITOPS-1402[GITOPS-1402]
+
+* Before this update, the `gitopsservice` service was annotated as an internal object. This update removes the annotation so you can update or delete the default Argo CD instance and run GitOps workloads on infrastructure nodes by using the UI. link:https://issues.redhat.com/browse/GITOPS-1429[GITOPS-1429]
+
+[id="known-issues-1-4-0_{context}"]
+== Known issues
+
+These are the known issues in the current release:
+
+* If you migrate from the Dex authentication provider to the Keycloak provider, you might experience login issues with Keycloak.
++
+To prevent this issue, when migrating, uninstall Dex by removing the `.spec.dex` section from the Argo CD custom resource. Allow a few minutes for Dex to uninstall completely. Then, install Keycloak by adding `.spec.sso.provider: keycloak` to the Argo CD custom resource.
++
+As a workaround, uninstall Keycloak by removing `.spec.sso.provider: keycloak`. Then, re-install it. link:https://issues.redhat.com/browse/GITOPS-1450[GITOPS-1450], link:https://issues.redhat.com/browse/GITOPS-1331[GITOPS-1331]

--- a/modules/gitops-release-notes-1-4-12.adoc
+++ b/modules/gitops-release-notes-1-4-12.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-4-12_{context}"]
 = Release notes for {gitops-title} 1.4.12
 
-{gitops-title} 1.4.12 is now available on {product-title} 4.8, 4.9, and 4.10.
+{gitops-title} 1.4.12 is now available on {product-title} 4.7 and above.
 
 [id="fixed-issues-1-4-12_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-4-3.adoc
+++ b/modules/gitops-release-notes-1-4-3.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-4-3_{context}"]
+= Release notes for {gitops-title} 1.4.3
+
+[role="_abstract"]
+{gitops-title} 1.4.3 is now available on {product-title} 4.7, 4.8, and 4.9.
+
+[id="fixed-issues-1-4-3_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* Before this update, the TLS certificate in the `argocd-tls-certs-cm` configuration map was deleted by the {gitops-title} unless the certificate was configured in the ArgoCD CR specification `tls.initialCerts` field. This update fixes this issue. link:https://issues.redhat.com/browse/GITOPS-1725[GITOPS-1725]

--- a/modules/gitops-release-notes-1-4-5.adoc
+++ b/modules/gitops-release-notes-1-4-5.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-4-5_{context}"]
+= Release notes for {gitops-title} 1.4.5
+
+[role="_abstract"]
+{gitops-title} 1.4.5 is now available on {product-title} 4.7, and above.
+
+[id="fixed-issues-1-4-5_{context}"]
+== Fixed issues
+
+[WARNING]
+====
+You should directly upgrade to {gitops-title} v1.4.5 from {gitops-title} v1.4.3. Do not use {gitops-title} v1.4.4 in a production environment. Major issues that affected {gitops-title} v1.4.4 are fixed in {gitops-title} 1.4.5. 
+====
+
+The following issue has been resolved in the current release:
+
+* Before this update, Argo CD pods were stuck in the `ErrImagePullBackOff` state. The following error message was shown:
+[source,yaml]
+----
+reason: ErrImagePull
+          message: >-
+            rpc error: code = Unknown desc = reading manifest
+            sha256:ff4ad30752cf0d321cd6c2c6fd4490b716607ea2960558347440f2f370a586a8
+            in registry.redhat.io/openshift-gitops-1/argocd-rhel8: StatusCode:
+            404, <HTML><HEAD><TITLE>Error</TITLE></HEAD><BODY> 
+----
+This issue is now fixed. link:https://issues.redhat.com/browse/GITOPS-1848[GITOPS-1848]

--- a/modules/gitops-release-notes-1-5-0.adoc
+++ b/modules/gitops-release-notes-1-5-0.adoc
@@ -6,7 +6,7 @@
 = Release notes for {gitops-title} 1.5.0
 
 [role="_abstract"]
-{gitops-title} 1.5.0 is now available on {product-title} 4.8, 4.9, and 4.10.
+{gitops-title} 1.5.0 is now available on {product-title} 4.8 and above.
 
 [id="new-features-1-5-0_{context}"]
 == New features

--- a/modules/gitops-release-notes-1-5-1.adoc
+++ b/modules/gitops-release-notes-1-5-1.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-1_{context}"]
 = Release notes for {gitops-title} 1.5.1
 
-{gitops-title} 1.5.1 is now available on {product-title} 4.8, 4.9, and 4.10.
+{gitops-title} 1.5.1 is now available on {product-title} 4.8 and above.
 
 [id="fixed-issues-1-5-1_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-5-2.adoc
+++ b/modules/gitops-release-notes-1-5-2.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-2_{context}"]
 = Release notes for {gitops-title} 1.5.2
 
-{gitops-title} 1.5.2 is now available on {product-title} 4.8, 4.9, and 4.10.
+{gitops-title} 1.5.2 is now available on {product-title} 4.8 and  above.
 
 [id="fixed-issues-1-5-2_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-5-3.adoc
+++ b/modules/gitops-release-notes-1-5-3.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-3_{context}"]
 = Release notes for {gitops-title} 1.5.3
 
-{gitops-title} 1.5.3 is now available on {product-title} 4.8, 4.9, and 4.10.
+{gitops-title} 1.5.3 is now available on {product-title} 4.8 and above.
 
 [id="fixed-issues-1-5-3_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-5-4.adoc
+++ b/modules/gitops-release-notes-1-5-4.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-4_{context}"]
 = Release notes for {gitops-title} 1.5.4
 
-{gitops-title} 1.5.4 is now available on {product-title} 4.8, 4.9, and 4.10.
+{gitops-title} 1.5.4 is now available on {product-title} 4.8 and above.
 
 [id="fixed-issues-1-5-4_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-5-5.adoc
+++ b/modules/gitops-release-notes-1-5-5.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-5_{context}"]
 = Release notes for {gitops-title} 1.5.5
 
-{gitops-title} 1.5.5 is now available on {product-title} 4.8, 4.9, and 4.10.
+{gitops-title} 1.5.5 is now available on {product-title} 4.8 and above.
 
 [id="new-features-1-5-5_{context}"]
 == New features

--- a/modules/gitops-release-notes-1-5-6.adoc
+++ b/modules/gitops-release-notes-1-5-6.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-6_{context}"]
 = Release notes for {gitops-title} 1.5.6
 
-{gitops-title} 1.5.6 is now available on {product-title} 4.8, 4.9, and 4.10.
+{gitops-title} 1.5.6 is now available on {product-title} 4.8 and above.
 
 [id="fixed-issues-1-5-6_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-6-0.adoc
+++ b/modules/gitops-release-notes-1-6-0.adoc
@@ -6,7 +6,7 @@
 [id="gitops-release-notes-1-6-0_{context}"]
 = Release notes for {gitops-title} 1.6.0
 
-{gitops-title} 1.6.0 is now available on {product-title} 4.8, 4.9, and 4.10.
+{gitops-title} 1.6.0 is now available on {product-title} 4.8 and above.
 
 [id="new-features-1-6-0_{context}"]
 == New features

--- a/modules/gitops-release-notes-1-6-1.adoc
+++ b/modules/gitops-release-notes-1-6-1.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-6-1_{context}"]
 = Release notes for {gitops-title} 1.6.1
 
-{gitops-title} 1.6.1 is now available on {product-title} 4.8, 4.9, and 4.10.
+{gitops-title} 1.6.1 is now available on {product-title} 4.8 and above.
 
 [id="fixed-issues-1-6-1_{context}"]
 == Fixed issues

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -15,10 +15,10 @@ In the table, features are marked with the following statuses:
 |*OpenShift GitOps* 6+|*Component Versions*|*OpenShift Versions*|*Support status*
 
 |*Version*|*kam*|*Helm*|*Kustomize*|*Argo CD*|*ApplicationSet*|*Dex*||
-|1.6.0 |0.0.46 TP |3.8.1 GA |4.4.1 GA |2.4.5 GA |2.4.5 GA |2.30.3 GA |4.8-4.10 |GA
-|1.5.0 |0.0.42 TP |3.8.0 GA |4.4.1 GA |2.3.3 GA |0.4.1 TP |2.30.3 GA |4.6-4.9 |GA
-|1.4.0 |0.0.41 TP |3.7.1 GA |4.2.0 GA |2.2.2 GA |0.2.0 TP |2.30.0 GA |4.7-4.9 |GA
-|1.3.0|0.0.40|3.6.0|4.2.0|2.1.2|0.2.0|2.28.0|4.6-4.9|GA
+|1.6.0 |0.0.46 TP |3.8.1 GA |4.4.1 GA |2.4.5 GA |2.4.5 GA |2.30.3 GA |4.8-4.11 |GA
+|1.5.0 |0.0.42 TP |3.8.0 GA |4.4.1 GA |2.3.3 GA |0.4.1 TP |2.30.3 GA |4.8-4.11 |GA
+|1.4.0 |0.0.41 TP |3.7.1 GA |4.2.0 GA |2.2.2 GA |0.2.0 TP |2.30.0 GA |4.7-4.11 |GA
+|1.3.0|0.0.40|3.6.0|4.2.0|2.1.2|0.2.0|2.28.0|4.7-4.9|GA
 |1.2.0|0.0.38|3.5.0|3.9.4|2.0.5|0.1.0|N/A|4.8|GA
 |1.1.0|0.0.32|3.5.0|3.9.4|2.0.0|N/A|N/A|4.7|GA
 |===


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise- 4.8

JIRA issue:
https://issues.redhat.com/browse/GITOPS-2269

Preview pages: 

SME+QE review: @wtam2018 
Peer-review: @gabriel-rh 