### PR TITLE
OCPBUGS#2226: ptpSchedulingPriority value updated to 10

### DIFF
--- a/modules/cnf-configuring-fifo-priority-scheduling-for-ptp.adoc
+++ b/modules/cnf-configuring-fifo-priority-scheduling-for-ptp.adoc
@@ -39,7 +39,7 @@ spec:
   - name: "profile1"
 ...
     ptpSchedulingPolicy: SCHED_FIFO <1>
-    ptpSchedulingPriority: 65 <2>
+    ptpSchedulingPriority: 10 <2>
 ----
 <1> Scheduling policy for `ptp4l` and `phc2sys` processes. Use `SCHED_FIFO` on systems that support FIFO scheduling.
 <2> Required. Sets the integer value 1-65 used to configure FIFO priority for `ptp4l` and `phc2sys` processes.

--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -143,7 +143,7 @@ spec:
       timeSource                        0xA0
     phc2sysOpts:                        "-a -r -n 24" <10>
     ptpSchedulingPolicy:                SCHED_OTHER   <11>
-    ptpSchedulingPriority:              65            <12>
+    ptpSchedulingPriority:              10            <12>
   ptpClockThreshold:                                  <13>
     holdOverTimeout:                    5
     maxOffsetThreshold:                 100
@@ -166,7 +166,7 @@ spec:
 <9> For Intel Columbiaville 800 Series NICs, ensure `boundary_clock_jbod` is set to `0`. For Intel Fortville X710 Series NICs, ensure `boundary_clock_jbod` is set to `1`.
 <10> Specify system config options for the `phc2sys` service. If this field is empty the PTP Operator does not start the `phc2sys` service.
 <11> Scheduling policy for ptp4l and phc2sys processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
-<12> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes. Required if `SCHED_FIFO` is set for `ptpSchedulingPolicy`.
+<12> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes when `ptpSchedulingPolicy` is set to `SCHED_FIFO`. The `ptpSchedulingPriority` field is not used when `ptpSchedulingPolicy` is set to `SCHED_OTHER`.
 <13> Optional. If `ptpClockThreshold` stanza is not present, default values are used for `ptpClockThreshold` fields. Stanza shows default `ptpClockThreshold` values.
 <14> Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
 <15> Specify the `profile` object name defined in the `profile` section.

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -138,7 +138,7 @@ spec:
       userDescription                    ;
       timeSource                         0xA0
     ptpSchedulingPolicy:                 SCHED_OTHER    <10>
-    ptpSchedulingPriority:               65             <11>
+    ptpSchedulingPriority:               10             <11>
   ptpClockThreshold:                                    <12>
     holdOverTimeout:                     5
     maxOffsetThreshold:                  100
@@ -160,7 +160,7 @@ spec:
 <8> For Intel Columbiaville 800 Series NICs, set `tx_timestamp_timeout` to `50`.
 <9> For Intel Columbiaville 800 Series NICs, set `boundary_clock_jbod` to `0`.
 <10> Scheduling policy for `ptp4l` and `phc2sys` processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
-<11> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes. Required if `SCHED_FIFO` is set for `ptpSchedulingPolicy`.
+<11> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes when `ptpSchedulingPolicy` is set to `SCHED_FIFO`. The `ptpSchedulingPriority` field is not used when `ptpSchedulingPolicy` is set to `SCHED_OTHER`.
 <12> Optional. If `ptpClockThreshold` stanza is not present, default values are used for `ptpClockThreshold` fields. Stanza shows default `ptpClockThreshold` values.
 <13> Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
 <14> Specify the `profile` object name defined in the `profile` section.

--- a/networking/using-ptp.adoc
+++ b/networking/using-ptp.adoc
@@ -47,7 +47,17 @@ include::modules/nw-ptp-device-discovery.adoc[leveloffset=+2]
 
 include::modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about FIFO priority scheduling on PTP hardware, see xref:../networking/using-ptp.adoc#cnf-configuring-fifo-priority-scheduling-for-ptp_using-ptp[Configuring FIFO priority scheduling for PTP hardware].
+
 include::modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about FIFO priority scheduling on PTP hardware, see xref:../networking/using-ptp.adoc#cnf-configuring-fifo-priority-scheduling-for-ptp_using-ptp[Configuring FIFO priority scheduling for PTP hardware].
 
 include::modules/ptp-configuring-linuxptp-services-as-boundary-clock-dual-nic.adoc[leveloffset=+2]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.9, 4.10, 4.11, 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/OCPBUGS-2226
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://51637--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#configuring-linuxptp-services-as-boundary-clock_using-ptp
https://51637--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#configuring-linuxptp-services-as-ordinary-clock_using-ptp
https://51637--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#cnf-configuring-fifo-priority-scheduling-for-ptp_using-ptp

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
