### PR TITLE
OSDOCS-4254: Add node label context

### DIFF
--- a/modules/rosa-osd-node-label-about.adoc
+++ b/modules/rosa-osd-node-label-about.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
+// * osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.adoc
+
+
+:_content-type: CONCEPT
+[id="rosa-osd-node-label-about_{context}"]
+= Node labels
+
+A label is a key-value pair applied to a `Node` object. You can use labels to organize sets of objects and control the scheduling of pods.
+
+You can add labels during cluster creation or after. Labels can be modified or updated at any time.
+

--- a/osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.adoc
+++ b/osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.adoc
@@ -13,7 +13,15 @@ You can edit machine pool configuration options such as scaling, adding node lab
 
 include::modules/creating-a-machine-pool-ocm.adoc[leveloffset=+1]
 include::modules/rosa-scaling-worker-nodes.adoc[leveloffset=+1]
-include::modules/rosa-adding-node-labels.adoc[leveloffset=+1]
+
+include::modules/rosa-osd-node-label-about.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about labels, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/[Kubernetes Labels and Selectors overview].
+
+include::modules/rosa-adding-node-labels.adoc[leveloffset=+2]
 include::modules/rosa-adding-taints.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
@@ -21,7 +21,14 @@ include::modules/creating-a-machine-pool-cli.adoc[leveloffset=+2]
 * For a detailed list of the arguments that are available for the `rosa create machinepool` subcommand, see xref:../../rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-machinepool_rosa-managing-objects-cli[Managing objects with the rosa CLI].
 
 include::modules/rosa-scaling-worker-nodes.adoc[leveloffset=+1]
-include::modules/rosa-adding-node-labels.adoc[leveloffset=+1]
+include::modules/rosa-osd-node-label-about.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about labels, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/[Kubernetes Labels and Selectors overview].
+
+include::modules/rosa-adding-node-labels.adoc[leveloffset=+2]
 include::modules/rosa-adding-taints.adoc[leveloffset=+1]
 
 == Additional resources


### PR DESCRIPTION
Version(s):
4.11, 4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4254

Link to docs preview:
ROSA: https://51640--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#rosa-osd-node-label-about_rosa-managing-worker-nodes
Dedicated: https://51640--docspreview.netlify.app/openshift-dedicated/latest/osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.html#rosa-osd-node-label-about_osd-managing-worker-nodes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

