### PR TITLE
CNV-16413: Remove TP note from critical alerts

### DIFF
--- a/virt/logging_events_monitoring/virt-virtualization-alerts.adoc
+++ b/virt/logging_events_monitoring/virt-virtualization-alerts.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {VirtProductName} critical alerts
-include::snippets/technology-preview.adoc[]
-
 {VirtProductName} has alerts that inform you when a problem occurs. Critical alerts require immediate attention.
 
 Each alert has a corresponding description of the problem, a reason for why the alert is occurring, a troubleshooting process to diagnose the source of the problem, and steps for resolving the alert.


### PR DESCRIPTION
Version(s): 4.11+

Issue: [CNV-16413](https://issues.redhat.com//browse/CNV-16413)

Link to docs preview: http://file.rdu.redhat.com/sjess/CNV16413/virt/logging_events_monitoring/virt-virtualization-alerts.html

QE review:
- [x] QE has approved this change.