### PR TITLE
OSDOCS-4109: OLM Known issue with PSAs for SQLite catalogs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -740,6 +740,17 @@ The default Red Hat-provided Operator catalogs for {product-title} 4.11 releases
 
 For more information, see xref:../operators/understanding/olm-packaging-format.html#olm-file-based-catalogs_olm-packaging-format[File-based catalogs].
 
+[id="ocp-4-11-olm-opm-known-issue"]
+==== Known issue with SQLite database format catalogs and restricted pod security enforcement.
+
+There is a known issue in `opm` that prevents SQLite-based catalog source pods from reaching a ready state under restricted pod security enforcement. (link:https://issues.redhat.com/browse/OCPBUGS-122[*OCPBUGS-122*])
+
+Pod security admission was introduced in Kubernetes 1.24 to ensure pod security standards. In {product-title} 4.11, namespaces do not have restricted pod security enforcement by default. Default restricted enforcement for namespaces is planned for a future release of {product-title}. When restricted enforcement occurs, the security context of the pod specification for catalog source pods must match the restricted pod security standard. If your catalog source image requires a different pod security standard, the pod security admissions label for the namespace must be explicitly set.
+
+A workaround is available for cluster administrators. Catalog authors can prevent the known issue by updating `opm` or migrating their catalog to the file-based catalog format. For more information about the issue and how to explicitly set the pod security level for namespaces, see link:https://access.redhat.com/articles/6977554[SQLite-based CatalogSource pod does not become ready due to "Error: open ./db-<number>: permission denied"] (Red Hat Knowledgebase). 
+
+For more information about pod security admissions, see xref:../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission].
+
 [id="ocp-4-11-osdk"]
 === Operator development
 


### PR DESCRIPTION
Version(s): 4.11 release notes

Issue: [OSDOCS-4109](https://issues.redhat.com//browse/OSDOCS-4109)

Link to docs preview: 

QE review:
- [ ] QE has approved this change.

Additional information:
In OpenShift 4.12, restricted enforcement of pod security admissions will be active in all namespaces. SQLite database format catalog sources created with a version of opm released prior to OpenShift 4.11 do not work on restricted namespaces. This release note notifies cluster administrators and catalog authors of the issue. Workarounds are available for both cluster admins and catalog maintainers. Details are published in a [KCS article](https://access.redhat.com/articles/6977554).