### PR TITLE
[enterprise-4.10] Fixing Azure Marketplace manifest directory

### DIFF
--- a/modules/installation-azure-marketplace-manifests.adoc
+++ b/modules/installation-azure-marketplace-manifests.adoc
@@ -21,9 +21,9 @@ $ openshift-install create manifests --dir <installation_dir>
 ----
 +
 . Edit the `.spec.template.spec.providerSpec.value.image` property of the compute machine set definitions, replacing the `offer`, `publisher`, `sku`, and `version` values with the details gathered in the section titled "Selecting an Azure Marketplace image". These are the three files that must be updated:
-** `<installation_dir>/man/openshift/99_openshift-cluster-api_worker-machineset-0.yaml`
-** `<installation_dir>/man/openshift/99_openshift-cluster-api_worker-machineset-1.yaml`
-** `<installation_dir>/man/openshift/99_openshift-cluster-api_worker-machineset-2.yaml`
+** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-0.yaml`
+** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-1.yaml`
+** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-2.yaml`
 
 . In each file, replace the value of the `.spec.template.spec.providerSpec.value.image.resourceID` property with an empty value (`""`).
 


### PR DESCRIPTION
Fixing an incorrect URL in the Azure Marketplace installation procedure on editing manifests.

Merge to 4.10 and CP to 4.8 and 4.9.

Doc preview: https://bscott-rh.github.io/openshift-docs/azure-manifest-fix/installing/installing_azure/installing-azure-customizations.html#installation-azure-marketplace-manifests_installing-azure-customizations