### PR TITLE
OSDOCS-3520: Adding steps to deploy with a GCP Marketplace image

### DIFF
--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -36,11 +36,13 @@ include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 * xref:../../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-enabling-customer-managed-encryption_creating-machineset-gcp[Enabling customer-managed encryption keys for a machine set]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/installation-gcp-marketplace.adoc[leveloffset=+1]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
@@ -48,12 +50,14 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
 .Additional resources
 
 * See xref:../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
 .Additional resources
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service

--- a/modules/installation-creating-gcp-worker.adoc
+++ b/modules/installation-creating-gcp-worker.adoc
@@ -111,7 +111,7 @@ EOF
 <2> `infra_id` is the `INFRA_ID` infrastructure name from the extraction step.
 <3> `zone` is the zone to deploy the worker machine into, for example `us-central1-a`.
 <4> `compute_subnet` is the `selfLink` URL to the compute subnet.
-<5> `image` is the `selfLink` URL to the {op-system} image.
+<5> `image` is the `selfLink` URL to the {op-system} image. To deploy using a GCP Marketplace image, specify `image: \https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145`.
 <6> `machine_type` is the machine type of the instance, for example `n1-standard-4`.
 <7> `service_account_email` is the email address for the worker service account that you created.
 <8> `ignition` is the contents of the `worker.ign` file.

--- a/modules/installation-gcp-marketplace.adoc
+++ b/modules/installation-gcp-marketplace.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+
+:_content-type: PROCEDURE
+[id="installation-gcp-marketplace_{context}"]
+= Using a GCP Marketplace image
+If you want to deploy an {product-title} cluster using a GCP Marketplace image, you must create the manifests and edit the compute machine set definitions to specify the GCP Marketplace image.
+
+.Prerequisites
+
+* You have the {product-title} installation program and the pull secret for your cluster.
+
+.Procedure
+
+. Generate the installation manifests by running the following command:
++
+[source,terminal]
+----
+$ openshift-install create manifests --dir <installation_dir>
+----
+
+. Locate the following files:
+
+** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-0.yaml`
+** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-1.yaml`
+** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-2.yaml`
+
+. In each file, edit the `.spec.template.spec.providerSpec.value.disks[0].image` property to `projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145`.
+
+.Example compute machine set with the GCP Marketplace image
+[source,yaml]
+----
+deletionProtection: false
+disks:
+- autoDelete: true
+  boot: true
+  image: projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145
+  labels: null
+  sizeGb: 128
+  type: pd-ssd
+kind: GCPMachineProviderSpec
+machineType: n2-standard-4
+----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
This PR addresses [osdocs-3520](https://issues.redhat.com/browse/OSDOCS-3520).

Link to docs preview:

- Installing a cluster on GCP with customizations > [Using a GCP Marketplace image](https://51678--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-gcp-marketplace_installing-gcp-customizations)
- Installing a cluster on user-provisioned infrastructure in GCP by using Deployment Manager templates > [Creating additional worker machines in GCP](https://51678--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-creating-gcp-worker_installing-gcp-user-infra)

QE review:
- [x ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Worth noting that I am merging this to main and 4.12 only for the time being to facilitate the closure of 4.12 docs issues. Once the respective machine set doc is merged for 4.12, I will coordinate with @jeana-redhat to ensure that this content is backported to 4.8+.