### PR TITLE
TELCODOCS-625: 4.11 Release Notes: Set Assisted Installer from TP to GA for release 4.10 and 4.11.

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1560,7 +1560,7 @@ sourceStrategy:
 
 * Previously, a rare bug caused inconsistency during AWS cluster installations. The installation program has been updated to avoid this scenario. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2046277[*BZ#2046277*])
 
-* Previously, the number of supported user-defined tags was 8, and reserved {product-title} tags were 2 for AWS resources. With this release, the number of supported user-defined tags is now 25 and reserved {product-title} tags are 25 for AWS resources. You can now add up to 25 user tags during installation. (link:https://issues.redhat.com/browse/CFE-592[*CFE#592*])   
+* Previously, the number of supported user-defined tags was 8, and reserved {product-title} tags were 2 for AWS resources. With this release, the number of supported user-defined tags is now 25 and reserved {product-title} tags are 25 for AWS resources. You can now add up to 25 user tags during installation. (link:https://issues.redhat.com/browse/CFE-592[*CFE#592*])
 
 * Previously, the bootstrap machine used a default size and instance type when installing on Azure using installer-provisioned infrastructure. With this update, the bootstrap machine uses the size and instance type of the control plane machines. You can now control the size and instance type of the bootstrap machine by modifying the control plane settings in your installation configuration. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2026356[*BZ#2026356*])
 
@@ -2090,8 +2090,8 @@ In the table below, features are marked with the following statuses:
 
 |Assisted Installer
 |TP
-|TP
-|TP
+|GA
+|GA
 
 |`kdump` on `x86_64` architecture
 |TP


### PR DESCRIPTION
In the 4.11 release notes, the Technology Preview Features section indicated that Assisted Installer was still a technology preview. It was GA from 4.10 forward. 

This PR is related to https://github.com/openshift/openshift-docs/pull/51680

Signed-off-by: John Wilkins <jowilkin@redhat.com>

Issue: https://issues.redhat.com/browse/TELCODOCS-625

Version(s): 4.11

Link to docs preview: http://jowilkin.com:8080/TELCODOCS-625-rn/release_notes/ocp-4-11-release-notes.html#ocp-4-11-technology-preview

QE review:
Additional information: This is a change to release notes, and requires change management.