### PR TITLE
TELCODOCS-625: Release Notes: Updated Assisted Installer row in Technology Preview

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2294,7 +2294,7 @@ In the table below, features are marked with the following statuses:
 |Assisted Installer
 |TP
 |TP
-|TP
+|GA
 
 |AWS Security Token Service (STS)
 |GA


### PR DESCRIPTION
In the 4.10 release notes, the Technology Preview Features section indicated that Assisted Installer was still a technology preview. It was GA from 4.10 forward. This PR is related to https://github.com/openshift/openshift-docs/pull/51679

Signed-off-by: John Wilkins [jowilkin@redhat.com](mailto:jowilkin@redhat.com)

Issue: https://issues.redhat.com/browse/TELCODOCS-625

Version(s): 4.10

Link to docs preview: http://jowilkin.com:8080/TELCODOCS-625-4.10-rn/release_notes/ocp-4-10-release-notes.html#ocp-4-10-technology-preview

QE review:
Additional information: This is a change to release notes, and requires change management.