### PR TITLE
Enterprise-4.9: RHDEVDOCS-4544-SBO-RN: Added a deprecation notice for OLM descriptors

### DIFF
--- a/applications/connecting_applications_to_services/sbo-release-notes.adoc
+++ b/applications/connecting_applications_to_services/sbo-release-notes.adoc
@@ -17,6 +17,38 @@ With {servicebinding-title}, you can:
 * Provide service operators a low-touch administrative experience to provision and manage access to services.
 * Enrich development lifecycle with a consistent and declarative service binding method that eliminates discrepancies in cluster environments.
 
+The custom resource definition (CRD) of the {servicebinding-title} supports the following APIs:
+
+* *Service Binding* with the `binding.operators.coreos.com` API group.
+* *Service Binding (Spec API)* with the `servicebinding.io` API group.
+
+[id="support-matrix"]
+== Support matrix
+
+Some features in the following table are in link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]. These experimental features are not intended for production use.
+
+In the table, features are marked with the following statuses:
+
+- *TP*: _Technology Preview_
+
+- *GA*: _General Availability_
+
+Note the following scope of support on the Red Hat Customer Portal for these features:
+
+.Support matrix
+[options="header"]
+|===
+|*{servicebinding-title}* 2+|*API Group and Support Status*|*OpenShift Versions*
+
+|*Version*|*`binding.operators.coreos.com`* |*`servicebinding.io`* |
+|1.3      |GA                               |GA                    |4.9-4.11
+|1.2      |GA                               |GA                    |4.7-4.11
+|1.1.1    |GA                               |TP                    |4.7-4.10
+|1.1      |GA                               |TP                    |4.7-4.10
+|1.0.1    |GA                               |TP                    |4.7-4.9
+|1.0      |GA                               |TP                    |4.7-4.9
+
+|===
 
 [id="servicebinding-inclusive-language"]
 == Making open source more inclusive
@@ -24,9 +56,12 @@ With {servicebinding-title}, you can:
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
 
 // Modules included, most to least recent
+include::modules/sbo-release-notes-1-3.adoc[leveloffset=+1]
+include::modules/sbo-release-notes-1-2.adoc[leveloffset=+1]
+include::modules/sbo-release-notes-1-1-1.adoc[leveloffset=+1]
+include::modules/sbo-release-notes-1-1.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-0-1.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-0.adoc[leveloffset=+1]
-
 
 == Additional resources
 * xref:../../applications/connecting_applications_to_services/understanding-service-binding-operator.adoc#understanding-service-binding-operator[Understanding Service Binding Operator].

--- a/modules/sbo-release-notes-1-1-1.adoc
+++ b/modules/sbo-release-notes-1-1-1.adoc
@@ -1,0 +1,58 @@
+[id="sbo-release-notes-1-1-1_{context}"]
+// Module included in the following assembly:
+//
+// * applications/connecting_applications_to_services/sbo-release-notes.adoc
+:_content-type: REFERENCE
+= Release notes for {servicebinding-title} 1.1.1
+
+{servicebinding-title} 1.1.1 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-1-1_{context}"]
+== Fixed issues
+* Before this update, a security vulnerability `CVE-2021-38561` was noted for {servicebinding-title} Helm chart. This update fixes the `CVE-2021-38561` error and updates the `golang.org/x/text` package from v0.3.6 to v0.3.7. link:https://issues.redhat.com/browse/APPSVC-1124[APPSVC-1124]
+
+* Before this update, users of the Developer Sandbox did not have sufficient permissions to read `ClusterWorkloadResourceMapping` resources. As a result, {servicebinding-title} prevented all service bindings from being successful. With this update, the {servicebinding-title} now includes the appropriate role-based access control (RBAC) rules for any authenticated subject including the Developer Sandbox users. These RBAC rules allow the {servicebinding-title} to `get`, `list`, and `watch` the `ClusterWorkloadResourceMapping` resources for the Developer Sandbox users and to process service bindings successfully. link:https://issues.redhat.com/browse/APPSVC-1135[APPSVC-1135]
+
+[id="known-issues-1-1-1_{context}"]
+== Known issues
+* There is currently a known issue with installing {servicebinding-title} in a single namespace installation mode. The absence of an appropriate namespace-scoped role-based access control (RBAC) rule prevents the successful binding of an application to a few known Operator-backed services that the {servicebinding-title} can automatically detect and bind to. When this happens, it generates an error message similar to the following example:
++
+.Example error message
+[source,text]
+----
+`postgresclusters.postgres-operator.crunchydata.com "hippo" is forbidden:
+        User "system:serviceaccount:my-petclinic:service-binding-operator" cannot
+        get resource "postgresclusters" in API group "postgres-operator.crunchydata.com"
+        in the namespace "my-petclinic"`
+----
++
+Workaround 1: Install the {servicebinding-title} in the `all namespaces` installation mode. As a result, the appropriate cluster-scoped RBAC rule now exists and the binding succeeds.
++
+Workaround 2: If you cannot install the {servicebinding-title} in the `all namespaces` installation mode, install the following role binding into the namespace where the {servicebinding-title} is installed: 
++
+.Example: Role binding for Crunchy Postgres Operator
+[source,yaml]
+----
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: service-binding-crunchy-postgres-viewer
+subjects:
+  - kind: ServiceAccount
+    name: service-binding-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: service-binding-crunchy-postgres-viewer-role
+----
+link:https://issues.redhat.com/browse/APPSVC-1062[APPSVC-1062]
+
+* Currently, when you modify the `ClusterWorkloadResourceMapping` resources, the {servicebinding-title} does not implement correct behavior. As a workaround, perform the following steps:
++
+--
+. Delete any `ServiceBinding` resources that use the corresponding `ClusterWorkloadResourceMapping` resource.
+. Modify the `ClusterWorkloadResourceMapping` resource.
+. Re-apply the `ServiceBinding` resources that you previously removed in step 1.
+--
++
+link:https://issues.redhat.com/browse/APPSVC-1102[APPSVC-1102]

--- a/modules/sbo-release-notes-1-1.adoc
+++ b/modules/sbo-release-notes-1-1.adoc
@@ -1,0 +1,66 @@
+[id="sbo-release-notes-1-1_{context}"]
+// Module included in the following assembly:
+//
+// * applications/connecting_applications_to_services/sbo-release-notes.adoc
+:_content-type: REFERENCE
+= Release notes for {servicebinding-title} 1.1
+
+{servicebinding-title} is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
+
+[id="new-features-1-1_{context}"]
+== New features
+This section highlights what is new in {servicebinding-title} 1.1:
+
+* Service Binding Options
+** Workload resource mapping: Define exactly where binding data needs to be projected for the secondary workloads.
+** Bind new workloads using a label selector.
+
+
+[id="fixed-issues-1-1_{context}"]
+== Fixed issues
+* Before this update, service bindings that used label selectors to pick up workloads did not project service binding data into the new workloads that matched the given label selectors. As a result, the Service Binding Operator could not periodically bind such new workloads. With this update, service bindings now project service binding data into the new workloads that match the given label selector. The Service Binding Operator now periodically attempts to find and bind such new workloads. link:https://issues.redhat.com/browse/APPSVC-1083[APPSVC-1083]
+
+
+[id="known-issues-1-1_{context}"]
+== Known issues
+* There is currently a known issue with installing {servicebinding-title} in a single namespace installation mode. The absence of an appropriate namespace-scoped role-based access control (RBAC) rule prevents the successful binding of an application to a few known Operator-backed services that the {servicebinding-title} can automatically detect and bind to. When this happens, it generates an error message similar to the following example:
++
+.Example error message
+[source,text]
+----
+`postgresclusters.postgres-operator.crunchydata.com "hippo" is forbidden:
+        User "system:serviceaccount:my-petclinic:service-binding-operator" cannot
+        get resource "postgresclusters" in API group "postgres-operator.crunchydata.com"
+        in the namespace "my-petclinic"`
+----
++
+Workaround 1: Install the {servicebinding-title} in the `all namespaces` installation mode. As a result, the appropriate cluster-scoped RBAC rule now exists and the binding succeeds.
++
+Workaround 2: If you cannot install the {servicebinding-title} in the `all namespaces` installation mode, install the following role binding into the namespace where the {servicebinding-title} is installed: 
++
+.Example: Role binding for Crunchy Postgres Operator
+[source,yaml]
+----
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: service-binding-crunchy-postgres-viewer
+subjects:
+  - kind: ServiceAccount
+    name: service-binding-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: service-binding-crunchy-postgres-viewer-role
+----
+link:https://issues.redhat.com/browse/APPSVC-1062[APPSVC-1062]
+
+* Currently, when you modify the `ClusterWorkloadResourceMapping` resources, the {servicebinding-title} does not implement correct behavior. As a workaround, perform the following steps:
++
+--
+. Delete any `ServiceBinding` resources that use the corresponding `ClusterWorkloadResourceMapping` resource.
+. Modify the `ClusterWorkloadResourceMapping` resource.
+. Re-apply the `ServiceBinding` resources that you previously removed in step 1.
+--
++
+link:https://issues.redhat.com/browse/APPSVC-1102[APPSVC-1102]

--- a/modules/sbo-release-notes-1-2.adoc
+++ b/modules/sbo-release-notes-1-2.adoc
@@ -1,0 +1,64 @@
+[id="sbo-release-notes-1-2_{context}"]
+// Module included in the following assembly:
+//
+// * applications/connecting_applications_to_services/sbo-release-notes.adoc
+:_content-type: REFERENCE
+= Release notes for {servicebinding-title} 1.2
+
+{servicebinding-title} 1.2 is now available on {product-title} 4.7, 4.8, 4.9, 4.10, and 4.11.
+
+[id="new-features-1-2_{context}"]
+== New features
+This section highlights what is new in {servicebinding-title} 1.2:
+
+* Enable {servicebinding-title} to consider optional fields in the annotations by setting the `optional` flag value to `true`.
+* Support for `servicebinding.io/v1beta1` resources.
+* Improvements to the discoverability of bindable services by exposing the relevant binding secret without requiring a workload to be present.
+
+[id="known-issues-1-2_{context}"]
+== Known issues
+* Currently, when you install {servicebinding-title} on {product-title} 4.11, the memory footprint of {servicebinding-title} increases beyond expected limits. With low usage, however, the memory footprint stays within the expected ranges of your environment or scenarios. In comparison with {product-title} 4.10, under stress, both the average and maximum memory footprint increase considerably. This issue is evident in the previous versions of {servicebinding-title} as well. There is currently no workaround for this issue. link:https://issues.redhat.com/browse/APPSVC-1200[APPSVC-1200]
+
+* By default, the projected files get their permissions set to 0644. {servicebinding-title} cannot set specific permissions due to a bug in Kubernetes that causes issues if the service expects specific permissions such as, `0600`. As a workaround, you can modify the code of the program or the application that is running inside a workload resource to copy the file to the `/tmp` directory and set the appropriate permissions. link:https://issues.redhat.com/browse/APPSVC-1127[APPSVC-1127]
+
+* There is currently a known issue with installing {servicebinding-title} in a single namespace installation mode. The absence of an appropriate namespace-scoped role-based access control (RBAC) rule prevents the successful binding of an application to a few known Operator-backed services that the {servicebinding-title} can automatically detect and bind to. When this happens, it generates an error message similar to the following example:
++
+.Example error message
+[source,text]
+----
+`postgresclusters.postgres-operator.crunchydata.com "hippo" is forbidden:
+        User "system:serviceaccount:my-petclinic:service-binding-operator" cannot
+        get resource "postgresclusters" in API group "postgres-operator.crunchydata.com"
+        in the namespace "my-petclinic"`
+----
++
+Workaround 1: Install the {servicebinding-title} in the `all namespaces` installation mode. As a result, the appropriate cluster-scoped RBAC rule now exists and the binding succeeds.
++
+Workaround 2: If you cannot install the {servicebinding-title} in the `all namespaces` installation mode, install the following role binding into the namespace where the {servicebinding-title} is installed: 
++
+.Example: Role binding for Crunchy Postgres Operator
+[source,yaml]
+----
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: service-binding-crunchy-postgres-viewer
+subjects:
+  - kind: ServiceAccount
+    name: service-binding-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: service-binding-crunchy-postgres-viewer-role
+----
+link:https://issues.redhat.com/browse/APPSVC-1062[APPSVC-1062]
+
+* According to the specification, when you change the `ClusterWorkloadResourceMapping` resources, {servicebinding-title} must use the previous version of the `ClusterWorkloadResourceMapping` resource to remove the binding data that was being projected until now. Currently, when you change the `ClusterWorkloadResourceMapping` resources, the {servicebinding-title} uses the latest version of the `ClusterWorkloadResourceMapping` resource to remove the binding data. As a result, {the servicebinding-title} might remove the binding data incorrectly. As a workaround, perform the following steps:
++
+--
+. Delete any `ServiceBinding` resources that use the corresponding `ClusterWorkloadResourceMapping` resource.
+. Modify the `ClusterWorkloadResourceMapping` resource.
+. Re-apply the `ServiceBinding` resources that you previously removed in step 1.
+--
++
+link:https://issues.redhat.com/browse/APPSVC-1102[APPSVC-1102]

--- a/modules/sbo-release-notes-1-3.adoc
+++ b/modules/sbo-release-notes-1-3.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assembly:
+//
+// * applications/connecting_applications_to_services/sbo-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="sbo-release-notes-1-3_{context}"]
+= Release notes for {servicebinding-title} 1.3
+
+{servicebinding-title} 1.3 is now available on {product-title} 4.9, 4.10, and 4.11.
+
+[id="removal-notice-1-3_{context}"]
+== Removed functionality
+* In {servicebinding-title} 1.3, the Operator Lifecycle Manager (OLM) descriptor feature has been removed to improve resource utilization. As an alternative to OLM descriptors, you can use CRD annotations to declare binding data.


### PR DESCRIPTION
Purpose: Manual CP from https://github.com/openshift/openshift-docs/pull/51554 to enterprise-4.9

Aligned team: Dev Tools

OCP version this PR applies to: enterprise-4.9 only

Preview pages: [Download to see the preview](https://drive.google.com/file/d/1PTy5NUl2fKmSQe5UUdkUFaWZ_NiTzBHY/view?usp=sharing)