### PR TITLE
Remove CCM from list of WINC windows services

### DIFF
--- a/modules/windows-node-services.adoc
+++ b/modules/windows-node-services.adoc
@@ -25,9 +25,6 @@ The following Windows-specific services are installed on each Windows node:
 |link:https://github.com/openshift/prometheus-community-windows_exporter[Windows Exporter]
 |Exports Prometheus metrics from Windows nodes 
 
-|link:https://kubernetes.io/docs/concepts/architecture/cloud-controller/[Kubernetes Cloud Controller Manager (CCM)]
-|Interacts with the underlying Azure cloud platform.
-
 |hybrid-overlay
 |Creates the {product-title} link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/container-networking/architecture#container-network-management-with-host-network-service[Host Network Service (HNS)].
 


### PR DESCRIPTION
Per @aravindhp remove CCM from the list of Windows Services added by WMCO. 4.7-4.9 only. [Slack convo](https://coreos.slack.com/archives/CM4ERHBJS/p1665707017697599?thread_ts=1665602295.644929&cid=CM4ERHBJS).