### PR TITLE
vSphere Windows Server 2022 support for WMCO 3.x

### DIFF
--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -19,7 +19,7 @@ You must use link:https://docs.microsoft.com/en-us/powershell/scripting/install/
 
 .Procedure
 
-. Create a new VM in the vSphere client using the Windows Server Semi-Annual Channel (SAC): Windows Server 20H2 ISO image that includes the link:https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351[Microsoft patch KB4565351]. This patch is required to set the VXLAN UDP port, which is required for clusters installed on vSphere. See the link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.hostclient.doc/GUID-77AB6625-F968-4983-A230-A020C0A70326.html[VMware documentation] for more information.
+. Create a new VM in the vSphere client using Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later.
 +
 [IMPORTANT]
 ====

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -85,16 +85,21 @@ The following table lists the supported link:https://docs.microsoft.com/en-us/wi
 |Supported Windows Server version
 
 |Amazon Web Services (AWS)
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+|Windows Server 2019, version 1809
 
 |Microsoft Azure
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+|Windows Server 2019, version 1809
 
 |VMware vSphere
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2022 (OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later)
+a|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+
+[NOTE]
+====
+Windows Server 2019 is unsupported, because the [KB4565351](https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351) patch is not included. 
+====
 
 |bare metal
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+|Windows Server 2019, version 1809
 |===
 
 == Supported networking
@@ -128,8 +133,8 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Supported Windows Server version
 
 |Default VXLAN port
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+|Windows Server 2019, version 1809
 
 |Custom VXLAN port
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2022 (OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later)
+|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
 |===


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-4351

Merge after WMCO 3.1.2 relesaes, planned Nov. 8 2022

Removed _Long-Term Servicing Channel (LTSC)_ to match similar change in 6.0.0.
Added Windows 2019 not supported note for vShpere
Added back Windows Server 20H2

[Supported Windows Server versions](http://file.rdu.redhat.com/mburke/winc-windows-2022-3x/windows_containers/understanding-windows-container-workloads.html#supported-windows-server-versions)
[Supported networking](http://file.rdu.redhat.com/mburke/winc-windows-2022-3x/windows_containers/understanding-windows-container-workloads.html#supported-networking)
