### PR TITLE
OSDOCS-3520: RN for GCP Marketplace support

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -53,6 +53,12 @@ Beginning with {product-title} {product-version}, you can specify either Network
 
 For more information, see xref:../installing/installing_aws/installing-aws-network-customizations.adoc[Installing a cluster on AWS with network customizations].
 
+[id="ocp-4-12-installation-and-upgrade-gcp-marketplace"]
+==== Google Cloud Platform Marketplace offering
+{product-title} is now available on the GCP Marketplace. Installing an {product-title} with a GCP Marketplace image lets you create self-managed cluster deployments that are billed on pay-per-use basis (hourly, per core) through GCP, while still being supported directly by Red Hat.
+
+For more information about installing using installer-provisioned infrastructure, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-marketplace_installing-gcp-customizations[Using a GCP Marketplace image]. For more information about installing a using user-provisioned infrastructure, see xref:../installing/installing_gcp/installing-gcp-user-infra.adoc#installation-creating-gcp-worker_installing-gcp-user-infra[Creating additional worker machines in GCP].
+
 [id="ocp-4-12-gcp-azure-serial-console-logs"]
 ==== Troubleshooting bootstrap failures during installation on GCP and Azure
 The installer now gathers serial console logs from the bootstrap and control plane hosts on GCP and Azure. This log data is added to the standard bootstrap log bundle.
@@ -112,16 +118,16 @@ In {product-title} 4.12, the following improvements have been made in the *Helm*
 [id="ocp-4-12-images"]
 === Images
 
-A new import value, `importMode`, has been added to the `importPolicy` parameter of image streams. The following fields are available for this value: 
+A new import value, `importMode`, has been added to the `importPolicy` parameter of image streams. The following fields are available for this value:
 
-* `Legacy`: `Legacy` is the default value for `importMode`. When active, the manifest list is discarded, and a single sub-manifest is imported. The platform is chosen in the following order of priority: 
+* `Legacy`: `Legacy` is the default value for `importMode`. When active, the manifest list is discarded, and a single sub-manifest is imported. The platform is chosen in the following order of priority:
 +
 . Tag annotations
 . Control plane architecture
 . Linux/AMD64
-. The first manifest in the list 
+. The first manifest in the list
 
-* `PreserveOriginal`: When active, the original manifest is preserved. For manifest lists, the manifest list and all of its sub-manifests are imported. 
+* `PreserveOriginal`: When active, the original manifest is preserved. For manifest lists, the manifest list and all of its sub-manifests are imported.
 
 
 [id="ocp-4-12-security"]


### PR DESCRIPTION
Version(s):
4.12

Issue:
This PR is the release note for [osdocs-3520](https://issues.redhat.com/browse/OSDOCS-3520).

Link to docs preview:
[Google Marketplace offering](https://51706--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-installation-and-upgrade-gcp-marketplace)

QE review:
- [yes ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->