### PR TITLE
BZ1978291: Updating QoS language to pod-centric vs container-centric.

### DIFF
--- a/modules/nodes-cluster-overcommit-qos-about.adoc
+++ b/modules/nodes-cluster-overcommit-qos-about.adoc
@@ -17,8 +17,7 @@ time. When this occurs, the node must give priority to one pod over another. The
 facility used to make this decision is referred to as a Quality of Service (QoS)
 Class.
 
-For each compute resource, a container is divided into one of three QoS classes
-with decreasing order of priority:
+A pod is designated as one of three QoS classes with decreasing order of priority:
 
 .Quality of Service Classes
 [options="header",cols="1,1,5"]
@@ -28,16 +27,16 @@ with decreasing order of priority:
 |1 (highest)
 |*Guaranteed*
 |If limits and optionally requests are set (not equal to 0) for all resources
-and they are equal, then the container is classified as *Guaranteed*.
+and they are equal, then the pod is classified as *Guaranteed*.
 
 |2
 |*Burstable*
 |If requests and optionally limits are set (not equal to 0) for all resources,
-and they are not equal, then the container is classified as *Burstable*.
+and they are not equal, then the pod is classified as *Burstable*.
 
 |3 (lowest)
 |*BestEffort*
-|If requests and limits are not set for any of the resources, then the container
+|If requests and limits are not set for any of the resources, then the pod
 is classified as *BestEffort*.
 |===
 
@@ -62,12 +61,12 @@ from lower OoS classes from using resources requested by pods in higher QoS clas
 
 {product-title} uses the `qos-reserved` parameter as follows:
 
-- A value of `qos-reserved=memory=100%` will prevent the `Burstable` and `BestEffort` QOS classes from consuming memory
+- A value of `qos-reserved=memory=100%` will prevent the `Burstable` and `BestEffort` QoS classes from consuming memory
 that was requested by a higher QoS class. This increases the risk of inducing OOM
 on `BestEffort` and `Burstable` workloads in favor of increasing memory resource guarantees
 for `Guaranteed` and `Burstable` workloads.
 
-- A value of `qos-reserved=memory=50%` will allow the `Burstable` and `BestEffort` QOS classes
+- A value of `qos-reserved=memory=50%` will allow the `Burstable` and `BestEffort` QoS classes
 to consume half of the memory requested by a higher QoS class.
 
 - A value of `qos-reserved=memory=0%`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.8+
<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://bugzilla.redhat.com/show_bug.cgi?id=1978291

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://51716--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-overcommit-qos-about_nodes-cluster-overcommit
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
