### PR TITLE
GH#51581 - Fixing a release note link and heading

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -3598,11 +3598,11 @@ $ oc adm release info 4.8.49 --pullspecs
 To update an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-8-50"]
-=== RHSA-2022:6511 - {product-title} 4.8.50 bug fix update
+=== RHBA-2022:6511 - {product-title} 4.8.50 bug fix update
 
 Issued: 2022-09-21
 
-{product-title} release 4.8.50 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:6511[RHSA-2022:6511] advisory. There are no RPM packages with this update.
+{product-title} release 4.8.50 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:6511[RHBA-2022:6511] advisory. There are no RPM packages with this update.
 
 You can view the container images in this release by running the following command:
 


### PR DESCRIPTION
#51581

Version 4.8

Fixes the heading and hyperlink of a release note entry.

Preview: https://bscott-rh.github.io/openshift-docs/GH%2351581/release_notes/ocp-4-8-release-notes.html#ocp-4-8-50 