### PR TITLE
TELCODOCS-328 - RN for IPv6 support for VIPs

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -659,6 +659,11 @@ For more information, see xref:../networking/network_observability/network-obser
 
 If you configured and deployed your hosting service cluster, you can now deploy the SR-IOV Operator for a hosted cluster. For more information, see xref:../networking/hardware_networks/configuring-sriov-operator.adoc#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for hosted control planes].
 
+[id="ocp-4-12-nw-api-ingress-ipv6-support"]
+==== Support for IPv6 virtual IP (VIP) addresses for the Ingress VIP and API VIP services 
+
+With this update, in installer-provisioned infrastructure clusters, the `ingressVIP` and `apiVIP` configuration settings in the `install-config.yaml` file are deprecated. Instead, use the `ingressVIPs` and `apiVIPs` configuration settings. These settings support dual-stack networking for applications that require IPv4 and IPv6 access to the cluster by using the Ingress VIP and API VIP services. The `ingressVIPs` and `apiVIPs` configuration settings use a list format to specify an IPv4 address, an IPv6 address, or both IP address formats. The order of the list indicates the primary and secondary VIP address for each service. The primary IP address must be from the IPv4 network when using dual stack networking. 
+
 [id="ocp-4-12-storage"]
 === Storage
 
@@ -1092,6 +1097,11 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |Deprecated
 
+|`ingressVIP` and `apiVIP` settings in the `install-config.yaml` file for installer-provisioned infrastructure clusters
+|General Availability
+|General Availability
+|Deprecated
+
 |====
 
 [discrete]
@@ -1313,7 +1323,7 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-4-12-bare-metal-hardware-bug-fixes"]
 ==== Bare Metal Hardware Provisioning
 
-* In recent versions of server firmware the time between server operations has increased. This causes timeouts during installer-provisioned infrastructure (IPI) installations when the {product-title} installation program waits for a response from the Baseboard Management Controller (BMC). The new `python3-sushy` release increases the number of server side attempts to contact the BMC. This update accounts for the extended waiting time and avoids timeouts during installation. (link:https://issues.redhat.com/browse/OCPBUGS-4097[*OCPBUGS-4097*])
+* In recent versions of server firmware the time between server operations has increased. This causes timeouts during installer-provisioned infrastructure installations when the {product-title} installation program waits for a response from the Baseboard Management Controller (BMC). The new `python3-sushy` release increases the number of server side attempts to contact the BMC. This update accounts for the extended waiting time and avoids timeouts during installation. (link:https://issues.redhat.com/browse/OCPBUGS-4097[*OCPBUGS-4097*])
 
 * Before this update, the Ironic provisioning service did not support Baseboard Management Controllers (BMC) that use weak eTags combined with strict eTag validation. By design, if the BMC provides a weak eTag, Ironic returns two eTags: the original eTag and the original eTag converted to the strong format for compatibility with BMC that do not support weak eTags. Although Ironic can send two eTags, BMC using strict eTag validation rejects such requests due to the presence of the second eTag. As a result, on some older server hardware, bare-metal provisioning failed with the following error: `HTTP 412 Precondition Failed`. In {product-title} 4.12 and later, this behavior changes and Ironic no longer attempts to send two eTags in cases where a weak eTag is provided. Instead, if a Redfish request dependent on an eTag fails with an eTag validation error, Ironic retries the request with known workarounds. This minimizes the risk of bare-metal provisioning failures on machines with strict eTag validation. (link:https://issues.redhat.com/browse/OCPBUGS-3479[*OCPBUGS-3479*])
 


### PR DESCRIPTION
[TELCODOCS-328](https://issues.redhat.com//browse/TELCODOCS-328) : Adding support for IPv6 virtual IP addresses in Ingress VIP and API VIP services in IPI clusters. To do this, `ingressVIP` and `apiVIP` installation configuration settings are deprecated and replaced with `ingressVIPs` and `apiVIPs`. The new settings use a list format where you can add both address formats if required. IPv4 must be primary address in dual-stack networks. 

Related updates to content in #51135.

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/TELCODOCS-328

Link to docs preview:
- http://file.emea.redhat.com/rohennes/TELCODOCS-328-rn/release_notes/ocp-4-12-release-notes.html#ocp-4-12-nw-api-ingress-ipv6-support
- (see installation dep table) http://file.emea.redhat.com/rohennes/TELCODOCS-328-rn/release_notes/ocp-4-12-release-notes.html#ocp-4-12-deprecated-removed-features


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
