### PR TITLE
[enterprise-4.10] TELCODOCS-968 - Fix alignment error in NROP KubeletConfig CR

### DIFF
--- a/modules/cnf-deploying-the-numa-aware-scheduler.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler.adoc
@@ -48,13 +48,14 @@ spec:
       memory: "512Mi"
     reservedMemory:
       - numaNode: 0
-  limits:
-    memory: "1124Mi"
+        limits:
+          memory: "1124Mi"
     systemReserved:
       memory: "512Mi"
     topologyManagerPolicy: "single-numa-node" <1>
+    topologyManagerScope: "pod"
 ----
-<1> `topologyManagerPolicy` must be set to `single-numa-node`.
+<1> Set the `topologyManagerPolicy` field to `single-numa-node`.
 
 .. Create the `KubeletConfig` custom resource (CR) by running the following command:
 +


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-968

manual CP to 4.10 for https://github.com/openshift/openshift-docs/pull/51503

Fixes an alignment error in NROP KubeletConfig CR and removes a note that mandates setting the Topology Manager scope to pod. Setting scope to pod is no longer required.

Preview: https://51503--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-deploying-the-numa-aware-scheduler_numa-aware