### PR TITLE
CNV-17511: Adding UI SSH Command content

### DIFF
--- a/modules/virt-copying-the-ssh-command.adoc
+++ b/modules/virt-copying-the-ssh-command.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virt-accessing-vm-consoles.adoc
+
+:_content-type: PROCEDURE
+[id="virt-copying-the-ssh-command_{context}"]
+= Copying the SSH command from the web console
+
+Copy the command to access a running virtual machine (VM) via SSH from the *Actions* list in the web console.
+
+.Procedure
+
+. In the {product-title} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
+. Select a virtual machine to open the *Virtual Machine Overview* page.
+. From the *Actions* list, select *Copy SSH Command*. You can now paste this command onto the OpenShift CLI (`oc`).

--- a/virt/virtual_machines/virt-accessing-vm-consoles.adoc
+++ b/virt/virtual_machines/virt-accessing-vm-consoles.adoc
@@ -23,6 +23,8 @@ include::modules/virt-connecting-vnc-console.adoc[leveloffset=+2]
 
 include::modules/virt-vm-rdp-console-web.adoc[leveloffset=+2]
 
+include::modules/virt-copying-the-ssh-command.adoc[leveloffset=+2]
+
 [id="virt-accessing-vm-consoles-cli"]
 == Accessing virtual machine consoles by using CLI commands
 


### PR DESCRIPTION
Version(s): 4.6 - 4.9

Issue: https://issues.redhat.com/browse/CNV-17511

Link to docs preview:
http://file.rdu.redhat.com/sjess/CNV17511A/virt/virtual_machines/virt-accessing-vm-consoles.html#virt-copying-the-ssh-command_virt-accessing-vm-consoles

http://file.rdu.redhat.com/sjess/CNV17511A/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html#virt-copying-the-ssh-command_virt-using-the-default-pod-network-with-virt

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->