### PR TITLE
CNV-17511: ssh command new content

### DIFF
--- a/modules/virt-copying-the-ssh-command.adoc
+++ b/modules/virt-copying-the-ssh-command.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virt-accessing-vm-consoles.adoc
+
+:_content-type: PROCEDURE
+[id="virt-copying-the-ssh-command_{context}"]
+= Copying the SSH command from the web console
+
+Copy the command to access a running virtual machine (VM) via SSH.
+
+.Procedure
+
+. In the {product-title} console, click *Virtualization* -> *VirtualMachines* from the side menu.
+. Use the search and filters to find your VM in the list.
+. Click the *Options* menu {kebab} for your virtual machine and select *Copy SSH command*. You can now paste this command onto the OpenShift CLI (oc).

--- a/virt/virtual_machines/virt-accessing-vm-consoles.adoc
+++ b/virt/virtual_machines/virt-accessing-vm-consoles.adoc
@@ -30,6 +30,8 @@ include::modules/virt-switching-displays.adoc[leveloffset=+2]
 
 * xref:../../virt/virtual_machines/advanced_vm_management/virt-configuring-mediated-devices.adoc#virt-configuring-mediated-devices[Configuring mediated devices]
 
+include::modules/virt-copying-the-ssh-command.adoc[leveloffset=+2]
+
 [id="virt-accessing-vm-consoles-cli"]
 == Accessing virtual machine consoles by using CLI commands
 


### PR DESCRIPTION
Version(s): 4.12+

Issue: [CNV-17511](https://issues.redhat.com//browse/CNV-17511)

Link to docs preview:
http://file.rdu.redhat.com/sjess/CNV17511B/virt/virtual_machines/virt-accessing-vm-consoles.html#virt-copying-the-ssh-command_virt-accessing-vm-consoles

http://file.rdu.redhat.com/sjess/CNV17511B/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html#virt-copying-the-ssh-command_virt-using-the-default-pod-network-with-virt

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
