### PR TITLE
OSDOCS-4339: Added gcp to platform parameter

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -256,7 +256,7 @@ The string must be 14 characters or fewer long.
 endif::osp[]
 
 |`platform`
-|The configuration for the specific platform upon which to perform the installation: `alibabacloud`, `aws`, `baremetal`, `azure`, `ibmcloud`, `nutanix`, `openstack`, `ovirt`, `vsphere`, or `{}`. For additional information about `platform.<platform>` parameters, consult the table for your specific platform that follows.
+|The configuration for the specific platform upon which to perform the installation: `alibabacloud`, `aws`, `baremetal`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `ovirt`, `vsphere`, or `{}`. For additional information about `platform.<platform>` parameters, consult the table for your specific platform that follows.
 |Object
 
 ifndef::openshift-origin[]
@@ -1088,7 +1088,7 @@ Additional GCP configuration parameters are described in the following table:
 |String.
 
 |`platform.gcp.projectID`
-|The name of the GCP project where the installation program installs the cluster. 
+|The name of the GCP project where the installation program installs the cluster.
 |String.
 
 |`platform.gcp.region`
@@ -1130,7 +1130,7 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 
 |`platform.gcp.defaultMachinePlatform.type`
 |The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for control plane and compute machines.
-|The GCP machine type, for example `n1-standard-4`. 
+|The GCP machine type, for example `n1-standard-4`.
 
 |`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey.name`
 |The name of the customer managed encryption key to be used for machine disk encryption.
@@ -1185,7 +1185,7 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |One or more strings, for example `control-plane-tag1`.
 
 |`controlPlane.platform.gcp.type`
-|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for control plane machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter. 
+|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for control plane machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter.
 |The GCP machine type, for example `n1-standard-4`.
 
 |`controlPlane.platform.gcp.zones`
@@ -1226,7 +1226,7 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |One or more strings, for example `compute-network-tag1`.
 
 |`compute.platform.gcp.type`
-|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for compute machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter. 
+|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for compute machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter.
 |The GCP machine type, for example `n1-standard-4`.
 
 |`compute.platform.gcp.zones`


### PR DESCRIPTION
Version(s):
4.8+

Issue:
This PR addresses [osdocs-4339.](https://issues.redhat.com/browse/OSDOCS-4339) I added `gcp` as a supported value of the `platform` parameter.

Link to docs preview:
Installation configuration parameters > [Required configuration parameters](https://51756--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-configuration-parameters-required_installing-gcp-customizations)
