### PR TITLE
RHDEVDOCS-4560 - add missing Telemeter Client info to CMO config map reference

### DIFF
--- a/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -144,7 +144,7 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 
 |openshiftStateMetrics|*link:#openshiftstatemetricsconfig[OpenShiftStateMetricsConfig]|`OpenShiftMetricsConfig` defines settings for the `openshift-state-metrics` agent.
 
-|telemeterClient|*TelemeterClientConfig|`TelemeterClientConfig` defines settings for the Telemeter Client component.
+|telemeterClient|*link:#telemeterclientconfig[TelemeterClientConfig]|`TelemeterClientConfig` defines settings for the Telemeter Client component.
 
 |thanosQuerier|*link:#thanosquerierconfig[ThanosQuerierConfig]|`ThanosQuerierConfig` defines settings for the Thanos Querier component.
 
@@ -366,6 +366,27 @@ link:#prometheusrestrictedconfig[PrometheusRestrictedConfig]
 |url|string|Defines the URL of the remote write endpoint to which samples will be sent.
 
 |writeRelabelConfigs|[]monv1.RelabelConfig|Defines the list of remote write relabel configurations.
+
+|===
+
+== TelemeterClientConfig
+
+=== Description
+
+The `TelemeterClientConfig` resource defines settings for the `telemeter-client` component.
+
+=== Required
+* `nodeSelector`
+* `tolerations`
+
+Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfiguration]
+
+[options="header"]
+|===
+| Property | Type | Description 
+|nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
+
+|tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
 |===
 


### PR DESCRIPTION
Summary: This PR adds missing Telemeter client config map info to the CMO config map reference for monitoring.

Note that this content is auto-generated from the source code in the Cluster Monitoring Operator repo. Peer reviewers only need to check for proper rendering of content and for correct functioning of hyperlinks. Any changes that need to be made to the text will have to be made in the source code in the CMO repo.

- Aligned team: DevTools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4560
- Direct link to doc preview: https://51761--docspreview.netlify.app/openshift-enterprise/latest/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html#telemeterclientconfig
- SME review: @simonpasquier 
- QE review: @juzhao 
- Peer review: @jc-berger 