### PR TITLE
CMP-1619 File Integrity Operator updates

### DIFF
--- a/modules/file-integrity-important-attributes.adoc
+++ b/modules/file-integrity-important-attributes.adoc
@@ -32,11 +32,15 @@ a default toleration is applied, which allows tolerations to run on control plan
 checks on a node can be resource intensive, so it can be useful to specify a
 longer interval. Defaults to `900`, or 15 minutes.
 
-|`spec.config.name`, `spec.config.namespace`, `spec.config.key`
-|These three attributes allow you to set a custom AIDE configuration. When the name
-or namespace are unset, the File Integrity Operator generates a configuration
-suitable for {op-system} systems. The name and namespace attributes point to the
-config map; the key points to a key inside that config map. Use the key
-attribute to specify a custom key that contains the actual config and defaults
-to `aide.conf`.
+|`maxBackups`
+|The maximum number of AIDE database and log backups leftover from the `re-init` process to keep on a node. Older backups beyond this number are automatically pruned by the daemon.
+
+|`spec.config.name`
+| Name of a configMap that contains custom AIDE configuration. If omitted, a default configuration is created.
+
+|`spec.config.namespace`
+|Namespace of a configMap that contains custom AIDE configuration. If unset, the FIO generates a default configuration suitable for {op-system} systems.
+
+|`spec.config.key`
+|Key that contains actual AIDE configuration in a config map specified by `name` and `namespace`. The default value is `aide.conf`.
 |===

--- a/modules/file-integrity-operator-exploring-daemon-sets.adoc
+++ b/modules/file-integrity-operator-exploring-daemon-sets.adoc
@@ -12,27 +12,31 @@ To find the daemon set that represents a `FileIntegrity` object, run:
 
 [source,terminal]
 ----
-$ oc get ds/aide-ds-$file-integrity-object-name
+$ oc -n openshift-file-integrity get ds/aide-worker-fileintegrity
 ----
 
 To list the pods in that daemon set, run:
 
 [source,terminal]
 ----
-$ oc get pods -lapp=$ds-name
+$ oc -n openshift-file-integrity get pods -lapp=aide-worker-fileintegrity
 ----
 
 To view logs of a single AIDE pod, call `oc logs` on one of the pods.
 
+[source,terminal]
+----
+$ oc -n openshift-file-integrity logs pod/aide-worker-fileintegrity-mr8x6
+----
+
 .Example output
 [source,terminal]
 ----
-debug: aide files locked by aideLoop
+Starting the AIDE runner daemon
+initializing AIDE db
+initialization finished
 running aide check
-aide check returned status 0
-debug: aide files unlocked by aideLoop
-debug: Getting FileIntegrity openshift-file-integrity/worker-fileintegrity
-Created OK configMap 'aide-ds-worker-fileintegrity-ip-10-0-128-73.eu-north-1.compute.internal'
+...
 ----
 
 The config maps created by the AIDE daemon are not retained and are deleted

--- a/modules/file-integrity-understanding-file-integrity-cr.adoc
+++ b/modules/file-integrity-understanding-file-integrity-cr.adoc
@@ -2,16 +2,18 @@
 //
 // * security/file_integrity_operator/file-integrity-operator-understanding.adoc
 
-:_content-type: CONCEPT
+:_content-type: PROCEDURE
 [id="understanding-file-integrity-custom-resource_{context}"]
-=  Understanding the FileIntegrity custom resource
+=  Creating the FileIntegrity custom resource
 
 An instance of a `FileIntegrity` custom resource (CR) represents a set of continuous file integrity scans for one or more nodes.
 
 Each `FileIntegrity` CR is backed by a daemon set running AIDE on the nodes matching the `FileIntegrity` CR specification.
 
-The following example `FileIntegrity` CR enables scans on only the worker nodes, but otherwise uses the defaults.
+.Procedure
 
+. Create the following example `FileIntegrity` CR named `worker-fileintegrity.yaml` to enable scans on worker nodes:
++
 .Example FileIntegrity CR
 [source,yaml]
 ----
@@ -24,4 +26,28 @@ spec:
   nodeSelector:
       node-role.kubernetes.io/worker: ""
   config: {}
+----
+
+. Apply the YAML file to the `openshift-file-integrity` namespace:
++
+[source,terminal]
+----
+$ oc apply -f worker-fileintegrity.yaml -n openshift-file-integrity
+----
+
+.Verification
+
+* Confirm the `FileIntegrity` object was created successfully by running the following command:
++
+[source,terminal]
+----
+$ oc get fileintegrities -n openshift-file-integrity
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                   AGE
+worker-fileintegrity   14s
 ----

--- a/modules/file-integrity-understanding-file-integrity-node-statuses-object.adoc
+++ b/modules/file-integrity-understanding-file-integrity-node-statuses-object.adoc
@@ -24,7 +24,7 @@ worker-fileintegrity-ip-10-0-165-160.ec2.internal   102s
 
 [NOTE]
 ====
-The `FileIntegrityNodeStatus` object might not be created until the second run of the scanner is finished. The period is configurable.
+It might take some time for the `FileIntegrityNodeStatus` object results to be available.
 ====
 
 There is one result object per node. The `nodeName` attribute of each `FileIntegrityNodeStatus` object corresponds to the node being scanned. The

--- a/security/file_integrity_operator/file-integrity-operator-troubleshooting.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-troubleshooting.adoc
@@ -54,14 +54,14 @@ Run:
 +
 [source,terminal]
 ----
-$ oc get pods -lapp=aide-ds-$(<FIO_NAME>)
+$ oc -n openshift-file-integrity get pods -lapp=aide-worker-fileintegrity
 ----
 +
---
-* `FIO_NAME` is the name of the `FileIntegrity` object to get a list of the pods.
-* Adding `-owide` adds the IP address of the node the pod is running on.
---
+[NOTE]
+====
+Adding `-owide` includes the IP address of the node that the pod is running on.
+====
 +
-To check the logs of the daemon pods, run `oc logs`
+To check the logs of the daemon pods, run `oc logs`.
 +
 Check the return value of the AIDE command to see if the check passed or failed.


### PR DESCRIPTION
Version(s):
4.6+

Issue:
[CMP-1619](https://issues.redhat.com/browse/CMP-1619)

Link to docs preview:
[Installing the File Integrity Operator using the CLI](http://file.rdu.redhat.com/antaylor/CMP-1619/security/file_integrity_operator/file-integrity-operator-installation.html#installing-file-integrity-operator-using-cli_file-integrity-operator-installation)
[Creating the FileIntegrity custom resource](http://file.rdu.redhat.com/antaylor/CMP-1619/security/file_integrity_operator/file-integrity-operator-understanding.html#understanding-file-integrity-custom-resource_file-integrity-operator)
[Understanding the FileIntegrityNodeStatuses object](http://file.rdu.redhat.com/antaylor/CMP-1619/security/file_integrity_operator/file-integrity-operator-understanding.html#understanding-file-integrity-node-statuses-object_file-integrity-operator)
[Important attributes](http://file.rdu.redhat.com/antaylor/CMP-1619/security/file_integrity_operator/file-integrity-operator-configuring.html#important-file-integrity-object-attributes_file-integrity-operator)
[Exploring the daemon sets](http://file.rdu.redhat.com/antaylor/CMP-1619/security/file_integrity_operator/file-integrity-operator-advanced-usage.html#file-integrity-operator-exploring-daemon-sets_file-integrity-operator)
[Determining that the daemon set’s pods are running on the expected nodes](http://file.rdu.redhat.com/antaylor/CMP-1619/security/file_integrity_operator/file-integrity-operator-troubleshooting.html#determining-that-the-daemon-sets-pods-are-running-on-the-expected-nodes)

QE review:
- [x] QE has approved this change.