### PR TITLE
NE-1018: Add the information about allowedsourceranges

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1226,6 +1226,9 @@ Topics:
   - Name: Configuring ingress cluster traffic using a NodePort
     File: configuring-ingress-cluster-traffic-nodeport
     Distros: openshift-enterprise,openshift-origin
+  - Name: Configuring ingress cluster traffic using load balancer allowed source ranges
+    File: configuring-ingress-cluster-traffic-load-balancer-allowed-source-ranges
+    Distros: openshift-enterprise,openshift-origin
   # Kubernetes NMState (TECHNOLOGY PREVIEW)
 - Name: Kubernetes NMState
   Dir: k8s_nmstate

--- a/modules/nw-configuring-lb-allowed-source-ranges-migration.adoc
+++ b/modules/nw-configuring-lb-allowed-source-ranges-migration.adoc
@@ -1,0 +1,66 @@
+// Modules included in the following assemblies:
+//
+// * networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer-allowed-source-ranges.adoc
+
+:_content-type: PROCEDURE
+[id="nw-configuring-lb-allowed-source-ranges-migration_{context}"]
+= Migrating to load balancer allowed source ranges
+
+If you have already set the annotation `service.beta.kubernetes.io/load-balancer-source-ranges`, you can migrate to load balancer allowed source ranges. When you set the `AllowedSourceRanges`, the Ingress Controller sets the `spec.loadBalancerSourceRanges` field based on the `AllowedSourceRanges` value and unsets the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation.
+
+[NOTE]
+====
+If you have already set the `spec.loadBalancerSourceRanges` field or the load balancer service anotation `service.beta.kubernetes.io/load-balancer-source-ranges` in a previous version of {product-title}, the Ingress Controller starts reporting `Progressing=True` after an upgrade. To fix this, set `AllowedSourceRanges` that overwrites the `spec.loadBalancerSourceRanges` field and clears the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation. The Ingress Controller starts reporting `Progressing=False` again.
+====
+
+.Prerequisites
+
+* You have set the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation.
+
+.Procedure
+
+. Ensure that the `service.beta.kubernetes.io/load-balancer-source-ranges` is set:
++
+[source,terminal]
+----
+$ oc get svc router-default -n openshift-ingress -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/load-balancer-source-ranges: 192.168.0.1/32
+----
+
+. Ensure that the `spec.loadBalancerSourceRanges` field is unset:
++
+[source,terminal]
+----
+$ oc get svc router-default -n openshift-ingress -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+...
+spec:
+  loadBalancerSourceRanges:
+  - 0.0.0.0/0
+...
+----
+
+. Update your cluster to {product-title} 4.12.
+
+. Set the allowed source ranges API for the `ingresscontroller` by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontroller/default \
+    --type=merge --patch='{"spec":{"endpointPublishingStrategy": \
+    {"loadBalancer":{"allowedSourceRanges":["0.0.0.0/0"]}}}}' <1>
+----
+<1> The example value `0.0.0.0/0` specifies the allowed source range.

--- a/modules/nw-configuring-lb-allowed-source-ranges.adoc
+++ b/modules/nw-configuring-lb-allowed-source-ranges.adoc
@@ -1,0 +1,30 @@
+// Modules included in the following assemblies:
+//
+// * networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer-allowed-source-ranges.adoc
+
+:_content-type: PROCEDURE
+[id="nw-configuring-lb-allowed-source-ranges_{context}"]
+= Configuring load balancer allowed source ranges
+
+You can enable and configure the `spec.endpointPublishingStrategy.loadBalancer.allowedSourceRanges` field. By configuring load balancer allowed source ranges, you can limit the access to the load balancer for the Ingress Controller to a specified list of IP address ranges. The Ingress Operator reconciles the load balancer Service and sets the `spec.loadBalancerSourceRanges` field based on `AllowedSourceRanges`.
+
+[NOTE]
+====
+If you have already set the `spec.loadBalancerSourceRanges` field or the load balancer service anotation `service.beta.kubernetes.io/load-balancer-source-ranges` in a previous version of {product-title}, Ingress Controller starts reporting `Progressing=True` after an upgrade. To fix this, set `AllowedSourceRanges` that overwrites the `spec.loadBalancerSourceRanges` field and clears the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation. Ingress Controller starts reporting `Progressing=False` again.
+====
+
+.Prerequisites
+
+* You have a deployed Ingress Controller on a running cluster.
+
+.Procedure
+
+* Set the allowed source ranges API for the Ingress Controller by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontroller/default \
+    --type=merge --patch='{"spec":{"endpointPublishingStrategy": \
+    {"loadBalancer":{"allowedSourceRanges":["0.0.0.0/0"]}}}}' <1>
+----
+<1> The example value `0.0.0.0/0` specifies the allowed source range.

--- a/modules/nw-create-load-balancer-service.adoc
+++ b/modules/nw-create-load-balancer-service.adoc
@@ -54,8 +54,7 @@ spec:
 +
 [NOTE]
 ====
-To restrict traffic through the load balancer to specific IP addresses, it is recommended to use the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation rather than setting the `loadBalancerSourceRanges` field.
-With the annotation, you can more easily migrate to the OpenShift API, which will be implemented in a future release.
+To restrict the traffic through the load balancer to specific IP addresses, it is recommended to use the Ingress Controller field `spec.endpointPublishingStrategy.loadBalancer.allowedSourceRanges`. Do not set the `loadBalancerSourceRanges` field.
 ====
 . Save and exit the file.
 

--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -31,6 +31,11 @@ If empty, the default value is `ingress.config.openshift.io/cluster` `.spec.doma
 |`endpointPublishingStrategy`
 |`endpointPublishingStrategy` is used to publish the Ingress Controller endpoints to other networks, enable load balancer integrations, and provide access to other systems.
 
+On GCP, AWS, and Azure you can configure the following `endpointPublishingStrategy` fields:
+
+* `loadBalancer.scope`
+* `loadBalancer.allowedSourceRanges`
+
 If not set, the default value is based on `infrastructure.config.openshift.io/cluster` `.status.platform`:
 
 * Amazon Web Services (AWS): `LoadBalancerService` (with External scope)
@@ -225,7 +230,7 @@ supports up to `64` threads. If this field is empty, the Ingress Controller uses
 
 * `tunnelTimeout` specifies how long a tunnel connection, including websockets, remains open while the tunnel is idle. The default timeout is `1h`.
 
-* `maxConnections` specifies the maximum number of simultaneous connections that can be established per HAProxy process. Increasing this value allows each ingress controller pod to handle more connections at the cost of additional system resources. Permitted values are `0`, `-1`, any value within the range `2000` and `2000000`, or the field can be left empty. 
+* `maxConnections` specifies the maximum number of simultaneous connections that can be established per HAProxy process. Increasing this value allows each ingress controller pod to handle more connections at the cost of additional system resources. Permitted values are `0`, `-1`, any value within the range `2000` and `2000000`, or the field can be left empty.
 
 ** If this field is left empty or has the value `0`, the Ingress Controller will use the default value of `50000`. This value is subject to change in future releases.
 

--- a/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer-allowed-source-ranges.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer-allowed-source-ranges.adoc
@@ -1,0 +1,16 @@
+:_content-type: ASSEMBLY
+[id="configuring-ingress-cluster-traffic-lb-allowed-source-ranges"]
+= Configuring ingress cluster traffic using load balancer allowed source ranges
+include::_attributes/common-attributes.adoc[]
+:context: configuring-ingress-cluster-traffic-lb-allowed-source-ranges
+
+toc::[]
+
+You can specify a list of IP address ranges for the `IngressController`. This restricts access to the load balancer service when the `endpointPublishingStrategy` is `LoadBalancerService`.
+
+include::modules/nw-configuring-lb-allowed-source-ranges.adoc[leveloffset=+1]
+include::modules/nw-configuring-lb-allowed-source-ranges-migration.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+* xref:../../updating/index.adoc#index[Updating your cluster]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/OSDOCS-3890
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

http://file.rdu.redhat.com/sdudhgao/NE-986/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer-allowed-source-ranges.html


<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
