### PR TITLE
[OSDOCS-3031] added bullets to responsibility tables and notes about SRE help

### DIFF
--- a/modules/policy-shared-responsibility.adoc
+++ b/modules/policy-shared-responsibility.adoc
@@ -78,9 +78,12 @@ Red Hat is responsible for enabling changes to the cluster infrastructure and se
 * Request and configure any additional service load balancers for specific services.
 
 |Cluster version
-|* Communicate schedule and status of upgrades for minor and maintenance versions.
+|* Enable upgrade scheduling process.
+* Monitor upgrade progress and remedy any issues encountered.
 * Publish changelogs and release notes for minor and maintenance upgrades.
-|* Work with Red Hat to establish maintenance start times for upgrades.
+|* Schedule maintenance version upgrades either immediately, for the future, or have automatic upgrades.
+* Acknowledge and schedule minor version upgrades.
+* Ensure the cluster version stays on a supported minor version.
 * Test customer applications on minor and maintenance versions to ensure compatibility.
 
 |Capacity management

--- a/modules/rosa-policy-shared-responsibility.adoc
+++ b/modules/rosa-policy-shared-responsibility.adoc
@@ -77,9 +77,12 @@ Red Hat is responsible for enabling changes to the cluster infrastructure and se
 - Request and configure any additional service load balancers for specific services.
 
 |Cluster version
-|- Communicate schedule and status of upgrades for minor and maintenance versions.
+|- Enable upgrade scheduling process.
+- Monitor upgrade progress and remedy any issues encountered.
 - Publish change logs and release notes for minor and maintenance upgrades.
-|- Work with Red Hat to establish maintenance start times for upgrades.
+|- Schedule maintenance version upgrades either immediately, for the future, or have automatic upgrades.
+- Acknowledge and schedule minor version upgrades.
+- Ensure the cluster version stays on a supported minor version.
 - Test customer applications on minor and maintenance versions to ensure compatibility.
 
 |Capacity management

--- a/upgrading/osd-upgrades.adoc
+++ b/upgrading/osd-upgrades.adoc
@@ -9,6 +9,8 @@ toc::[]
 [role="_abstract"]
 You can schedule automatic or manual upgrade policies to update the version of your {product-title} clusters. Upgrading {product-title} clusters can be done through {cluster-manager-first} or {cluster-manager} CLI.
 
+Red Hat Site Reliability Engineers (SREs) monitor upgrade progress and remedy any issues encountered.
+
 include::modules/upgrade.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/upgrading/rosa-upgrading-sts.adoc
+++ b/upgrading/rosa-upgrading-sts.adoc
@@ -11,6 +11,8 @@ toc::[]
 
 To plan an upgrade, review the xref:../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[{product-title} update life cycle]. The life cycle page includes release definitions, support and upgrade requirements, installation policy information and life cycle dates.
 
+Upgrades are manually initiated or automatically scheduled. Red Hat Site Reliability Engineers (SREs) monitor upgrade progress and remedy any issues encountered.
+
 [id="rosa-sts-upgrading-a-cluster-with-sts"]
 == Upgrading a ROSA cluster that uses STS
 

--- a/upgrading/rosa-upgrading.adoc
+++ b/upgrading/rosa-upgrading.adoc
@@ -11,6 +11,8 @@ toc::[]
 
 To plan an upgrade, review the xref:../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[{product-title} update life cycle]. The life cycle page includes release definitions, support and upgrade requirements, installation policy information and life cycle dates.
 
+Upgrades are manually initiated or automatically scheduled. Red Hat Site Reliability Engineers (SREs) monitor upgrade progress and remedy any issues encountered.
+
 [id="rosa-sts-upgrading-a-cluster"]
 == Upgrading a ROSA cluster
 There are three methods to upgrade {product-title} (ROSA) clusters:


### PR DESCRIPTION
[OSDOCS-3031] added bullets to responsibility tables and notes about SRE help

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.11+

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
https://issues.redhat.com/browse/OSDOCS-3031

Link to docs preview:
https://51788--docspreview.netlify.app/openshift-dedicated/latest/upgrading/osd-upgrades.html
https://51788--docspreview.netlify.app/openshift-rosa/latest/upgrading/rosa-upgrading-sts.html
https://51788--docspreview.netlify.app/openshift-rosa/latest/upgrading/rosa-upgrading.html

https://51788--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/policy-responsibility-matrix.html#change-management_policy-responsibility-matrix
https://51788--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-change-management_rosa-policy-responsibility-matrix

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
