### PR TITLE
RHDEVDOCS-4540 - Clarify custom Prometheus guidance for user-defined monitoring

### DIFF
--- a/modules/monitoring-support-considerations.adoc
+++ b/modules/monitoring-support-considerations.adoc
@@ -21,7 +21,7 @@ This procedure is a supported exception to the preceding statement.
 +
 * *Modifying resources of the stack.* The {product-title} monitoring stack ensures its resources are always in the state it expects them to be. If they are modified, the stack will reset them.
 * *Deploying user-defined workloads to `openshift-&#42;`, and `kube-&#42;` projects.* These projects are reserved for Red Hat provided components and they should not be used for user-defined workloads.
-* *Installing custom Prometheus instances on {product-title}.*
+* *Installing custom Prometheus instances on {product-title}.* A custom instance is a Prometheus custom resource (CR) managed by the Prometheus Operator.
 * *Enabling symptom based monitoring by using the `Probe` custom resource definition (CRD) in Prometheus Operator.*
 
 [NOTE]

--- a/monitoring/enabling-monitoring-for-user-defined-projects.adoc
+++ b/monitoring/enabling-monitoring-for-user-defined-projects.adoc
@@ -8,10 +8,7 @@ toc::[]
 
 In {product-title} {product-version}, you can enable monitoring for user-defined projects in addition to the default platform monitoring. You can monitor your own projects in {product-title} without the need for an additional monitoring solution. Using this feature centralizes monitoring for core platform components and user-defined projects.
 
-[NOTE]
-====
-Custom Prometheus instances and the Prometheus Operator installed through Operator Lifecycle Manager (OLM) can cause issues with user-defined workload monitoring if it is enabled. Custom Prometheus instances are not supported in {product-title}.
-====
+include::snippets/monitoring-custom-prometheus-note.adoc[]
 
 // Enabling monitoring for user-defined projects
 include::modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc[leveloffset=+1]

--- a/snippets/monitoring-custom-prometheus-note.adoc
+++ b/snippets/monitoring-custom-prometheus-note.adoc
@@ -1,0 +1,10 @@
+// Text snippet included in the following modules:
+//
+// * modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
+
+:_content-type: SNIPPET
+
+[NOTE]
+====
+Versions of Prometheus Operator installed using Operator Lifecycle Manager (OLM) are not compatible with user-defined monitoring. Therefore, custom Prometheus instances installed as a Prometheus custom resource (CR) managed by the OLM Prometheus Operator are not supported in {product-title}.
+====


### PR DESCRIPTION
Summary: This PR updates the wording in the user-defined monitoring topic to clarify what a custom Prometheus instance is and that these custom instances are not supported.

- Aligned team: DevTools
- For branches: 4.6+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4540
- Direct link to doc preview:
- - https://51804--docspreview.netlify.app/openshift-enterprise/latest/monitoring/enabling-monitoring-for-user-defined-projects.html
- - https://51804--docspreview.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#support-considerations_configuring-the-monitoring-stack
- SME review: @simonpasquier 
- QE review: @juzhao 
- Peer review: @gabriel-rh 