### PR TITLE
Adds guide for adding a hint file to the node ip configuration

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -75,7 +75,16 @@ include::modules/ipi-install-configuring-the-raid.adoc[leveloffset=+2]
 
 * xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
 
+include::modules/overriding-default-node-ip-selection-logic.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-ip-selection"]
+.Additional resources
+
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#overriding-default-node-ip-selection-logic_ipi-install-installation-workflow[Optional: Overriding the default node IP selection logic].
+
 include::modules/ipi-install-creating-a-disconnected-registry.adoc[leveloffset=+1]
+
 
 [discrete]
 [id="prerequisites_ipi-disconnected-registry"]

--- a/modules/nw-how-nw-iface-selected.adoc
+++ b/modules/nw-how-nw-iface-selected.adoc
@@ -20,8 +20,9 @@ As a result, the kubelet service uses the selected IP address as the node IP add
 If hardware or networking is reconfigured after installation, it is possible that the `nodeip-configuration.service` service can select a different NIC after a reboot.
 In some cases, you might be able to detect that a different NIC is selected by reviewing the `INTERNAL-IP` column in the output from the `oc get nodes -o wide` command.
 
-If network communication is disrupted or misconfigured because a different NIC is selected, one strategy for overriding the selection process is to set the correct IP address explicitly.
-The following list identifies the high-level steps and considerations:
+If network communication is disrupted or misconfigured because a different NIC is selected, you can create a hint file that includes the `NODEIP_HINT` variable to override the default IP selection logic. To create a hint file, see Optional: Overriding the default node IP selection logic. 
+
+In some situations, creating a hint file might be insufficient for overriding the selection process. The following list identifies the high-level steps and considerations to manually override the IP address: 
 
 * Create a shell script that determines the IP address to use for {product-title} communication. Have the script create a custom unit file such as `/etc/systemd/system/kubelet.service.d/98-nodenet-override.conf`. Use the custom unit file, `98-nodenet-override.conf`, to set the `KUBELET_NODE_IP` environment variable to the IP address.
 

--- a/modules/overriding-default-node-ip-selection-logic.adoc
+++ b/modules/overriding-default-node-ip-selection-logic.adoc
@@ -1,0 +1,77 @@
+// This is included in the following assemblies:
+//
+// * installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+
+:_content-type: PROCEDURE
+[id="overriding-default-node-ip-selection-logic_{context}"]
+= Optional: Overriding the default node IP selection logic 
+
+You can create a hint file that includes the `NODEIP_HINT` variable to override the default IP selection logic. This allows users to select a specific node IP address from the subnet `NODEIP_HINT` variable and specify which IP address is used. For example, a node that has two interfaces, `eth0` with the subnet range `10.0.0.10/24`, and `eth1` with the subnet range `192.0.2.5/25`, will by default route traffic to `eth0` and use the `10.0.0.10` address. `NODEIP_HINT` can be configured to point at `192.0.2.1` so that the correct subnet, `192.0.2.5`, is used. 
+
+Use the following procedure to override the default node IP selection logic. 
+
+.Procedure
+
+. Add a hint file to your your `/etc/default/nodeip-configuration` file. The contents of your hint file must match the following example: 
++
+[source,text]
+----
+NODEIP_HINT=<node_ip_address>
+----
++
+[IMPORTANT]
+====
+* Do not use the exact IP address of a node as a hint, because `runtimecfg` treats it as a VIP and ignores it when looking for a node IP address. This causes the node using the hint IP address to fail to configure correctly. For example, if the ideal node IP address is `192.0.2.5`, use `192.0.2.1`. 
+* The IP address in the hint file is only used to determine the correct subnet. It will not receive traffic as a result of appearing in the hint file. 
+====
+
+. Activate the hint by creating a machine config manifest for both `master` and `worker` roles before deploying the cluster: 
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+ labels:
+   machineconfiguration.openshift.io/role: master
+   name: 99-nodeip-hint-master
+spec:
+ config:
+   ignition:
+     version: 3.2.0
+   storage:
+     files:
+     - contents:
+         source: data:text/plain;charset=utf-8;base64, <encoded_content> <1>
+       mode: 0644
+       overwrite: true
+       path: /etc/default/nodeip-configuration
+----
++
+<1> Replace `<encoded_contents>` with the  base64-encoded content of the `/etc/default/nodeip-configuration` file. 
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+ labels:
+   machineconfiguration.openshift.io/role: worker
+   name: 99-nodeip-hint-worker
+spec:
+ config:
+   ignition:
+     version: 3.2.0
+   storage:
+     files:
+     - contents:
+         source: data:text/plain;charset=utf-8;base64, <encoded_content> <1> 
+       mode: 0644
+       overwrite: true
+       path: /etc/default/nodeip-configuration
+----
+<1> Replace `<encoded_contents>` with the  base64-encoded content of the `/etc/default/nodeip-configuration` file. 
+
+. Save the manifest to the directory where you store your cluster configuration, for example, `~/clusterconfigs`. 
+
+. Deploy the cluster. 

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -96,6 +96,14 @@ In {product-title} 4.12, the following improvements have been made in the *Helm*
 Beginning with {product-title} {product-version}, you can configure the networking settings such as DNS servers or search domains, VLANs, bridges, and interface bonding using the Kubernetes NMState Operator on your VMware vSphere instance.
 
 For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc[About the Kubernetes NMState Operator].
+[id="overriding-default-node-ip-selection-logic"]
+==== Node IP selection improvements 
+
+Previously, the `nodeip-configuration` service on a cluster host selected the IP address from the interface that the default route used. If multiple routes were present, the service would select the route with the lowest metric value. As a result, network traffic could be distributed from the incorrect interface. 
+
+With {product-title} 4.12, a new interface has been added to the `nodeip-configuration` service, which allows users to create a hint file. The hint file contains a variable, `NODEIP_HINT`, that overrides the default IP selection logic and selects a specific node IP address from the subnet `NODEIP_HINT` variable. Using the `NODEIP_HINT` variable allows users to specify which IP address is used, ensuring that network traffic is distributed from the correct interface. 
+
+For more information, see xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#overriding-default-node-ip-selection-logic_ipi-install-installation-workflow[Optional: Overriding the default node IP selection logic]. 
 
 [id="ocp-4-12-nw-external-dns-operator"]
 ==== External DNS Operator


### PR DESCRIPTION
Adds guide for adding a hint file to the node ip configuration

4.12

Issue:
https://issues.redhat.com/browse/OPNET-150 / https://issues.redhat.com/browse/OSDOCS-4376

Link to docs preview:

Release note: https://51816--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-networking

New section: https://51816--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#proc-overriding-default-node-ip-selection-logic_ipi-install-installation-workflow

Troubleshooting: https://51816--docspreview.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-network-issues.html#nw-how-nw-iface-selected_troubleshooting-network-issues

QE review:
Pending QE/SME


