### PR TITLE
OSDOCS-4379: Add ROSA quickstart guide

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -8,8 +8,10 @@
 :op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
 :cluster-manager-first: Red Hat OpenShift Cluster Manager
 :cluster-manager: OpenShift Cluster Manager
-:cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager]
+:cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager Hybrid Cloud Console]
 :cluster-manager-url-pull: link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager]
+:hybrid-console: Red Hat Hybrid Cloud Console
+:hybrid-console-second: Hybrid Cloud Console
 :AWS: Amazon Web Services (AWS)
 :GCP: Google Cloud Platform (GCP)
 :kebab: image:kebab.png[title="Options menu"]

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -37,10 +37,11 @@ endif::openshift-origin[]
 :ai-version: 2.3
 :cluster-manager-first: Red Hat OpenShift Cluster Manager
 :cluster-manager: OpenShift Cluster Manager
-:cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager]
+:cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager Hybrid Cloud Console]
 :cluster-manager-url-pull: link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager]
 :insights-advisor-url: link:https://console.redhat.com/openshift/insights/advisor/[Insights Advisor]
 :hybrid-console: Red Hat Hybrid Cloud Console
+:hybrid-console-second: Hybrid Cloud Console
 :rh-storage-first: Red Hat OpenShift Data Foundation
 :rh-storage: OpenShift Data Foundation
 :rh-rhacm-first: Red Hat Advanced Cluster Management (RHACM)

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -78,10 +78,12 @@ Name: Getting started
 Dir: rosa_getting_started
 Distros: openshift-rosa
 Topics:
+- Name: ROSA quickstart guide
+  File: rosa-quickstart
+- Name: Comprehensive guide to getting started with ROSA
+  File: rosa-getting-started
 - Name: Understanding the ROSA with STS deployment workflow
   File: rosa-sts-getting-started-workflow
-- Name: Getting started with ROSA
-  File: rosa-getting-started
 ---
 Name: Prepare your environment
 Dir: rosa_planning

--- a/modules/deploy-app.adoc
+++ b/modules/deploy-app.adoc
@@ -2,23 +2,33 @@
 //
 // * rosa_getting_started/rosa-getting-started.adoc
 // * osd_getting_started/osd-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="deploy-app_{context}"]
 = Deploying an application from the Developer Catalog
 
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
+
 From the {product-title} web console, you can deploy a test application from the Developer Catalog and expose it with a route.
 
+ifndef::quickstart[]
 .Prerequisites
 
 * You logged in to {cluster-manager-url}.
 * You created an {product-title} cluster.
 * You configured an identity provider for your cluster.
 * You added your user account to the configured identity provider.
+endif::[]
 
 .Procedure
 
-. From {cluster-manager}, click *Open console*.
+. From the {cluster-manager} {hybrid-console-second}, click *Open console*.
 
 . In the *Administrator* perspective, select *Home* -> *Projects* -> *Create Project*.
 
@@ -64,3 +74,10 @@ Welcome to your Node.js application on OpenShift
 . Optional: Delete the application and clean up the resources that you created:
 .. In the *Administrator* perspective, navigate to *Home* -> *Projects*.
 .. Click the action menu for your project and select *Delete Project*.
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-getting-started-access-cluster-web-console.adoc
+++ b/modules/rosa-getting-started-access-cluster-web-console.adoc
@@ -1,13 +1,22 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-getting-started-access-cluster-web-console_{context}"]
 = Accessing a cluster through the web console
 
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
+
 After you have created a cluster administrator user or added a user to your configured identity provider, you can log into your {product-title} (ROSA) cluster through the web console.
 
+ifdef::getting-started[]
 .Prerequisites
 
 * You have an AWS account.
@@ -15,6 +24,7 @@ After you have created a cluster administrator user or added a user to your conf
 * You logged in to your Red Hat account by using the `rosa` CLI.
 * You created a ROSA cluster.
 * You have created a cluster administrator user or added your user account to the configured identity provider.
+endif::[]
 
 .Procedure
 
@@ -36,3 +46,10 @@ Console URL:                https://console-openshift-console.apps.example-clust
 +
 * If you created a `cluster-admin` user, log in by using the provided credentials.
 * If you configured an identity provider for your cluster, select the identity provider name in the *Log in with...* dialog and complete any authorization requests that are presented by your provider.
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-getting-started-configure-an-idp-and-grant-access.adoc
+++ b/modules/rosa-getting-started-configure-an-idp-and-grant-access.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 [id="rosa-getting-started-configure-an-idp-and-grant-access_{context}"]
 = Configuring an identity provider and granting cluster access

--- a/modules/rosa-getting-started-configure-an-idp.adoc
+++ b/modules/rosa-getting-started-configure-an-idp.adoc
@@ -1,10 +1,18 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-getting-started-configure-an-idp_{context}"]
 = Configuring an identity provider
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
 
 You can configure different identity provider types for your {product-title} (ROSA) cluster. Supported types include GitHub, GitHub Enterprise, GitLab, Google, LDAP, OpenID Connect and HTPasswd identity providers.
 
@@ -15,6 +23,7 @@ The HTPasswd identity provider option is included only to enable the creation of
 
 The following procedure configures a GitHub identity provider as an example.
 
+ifdef::getting-started[]
 .Prerequisites
 
 * You have an AWS account.
@@ -22,6 +31,7 @@ The following procedure configures a GitHub identity provider as an example.
 * You logged in to your Red Hat account by using the `rosa` CLI.
 * You created a ROSA cluster.
 * You have a GitHub user account.
+endif::[]
 
 .Procedure
 
@@ -97,3 +107,10 @@ $ rosa list idps --cluster=<cluster_name>
 NAME        TYPE      AUTH URL
 github-1    GitHub    https://oauth-openshift.apps.<cluster_name>.<random_string>.p1.openshiftapps.com/oauth2callback/github-1
 ----
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-getting-started-create-cluster-admin-user.adoc
+++ b/modules/rosa-getting-started-create-cluster-admin-user.adoc
@@ -1,10 +1,18 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-getting-started-create-cluster-admin-user_{context}"]
 = Creating a cluster administrator user for quick cluster access
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
 
 Before configuring an identity provider, you can create a user with `cluster-admin` privileges for immediate access to your {product-title} (ROSA) cluster.
 
@@ -13,12 +21,14 @@ Before configuring an identity provider, you can create a user with `cluster-adm
 The cluster administrator user is useful when you need quick access to a newly deployed cluster. However, consider configuring an identity provider and granting cluster administrator privileges to the identity provider users as required. For more information about setting up an identity provider for your ROSA cluster, see _Configuring an identity provider and granting cluster access_.
 ====
 
+ifdef::getting-started[]
 .Prerequisites
 
 * You have an AWS account.
 * You installed and configured the latest AWS (`aws`), ROSA (`rosa`), and OpenShift (`oc`) CLIs on your workstation.
 * You logged in to your Red Hat account by using the `rosa` CLI.
 * You created a ROSA cluster.
+endif::[]
 
 .Procedure
 
@@ -48,6 +58,7 @@ I: It may take up to a minute for the account to become active.
 It might take approximately one minute for the `cluster-admin` user to become active.
 ====
 
+ifdef::getting-started[]
 . Log in to the cluster through the CLI:
 .. Run the command provided in the output of the preceding step to log in:
 +
@@ -68,3 +79,22 @@ $ oc whoami
 ----
 cluster-admin
 ----
+endif::[]
+
+
+ifdef::quickstart[]
+
+. Log in to the cluster through the {cluster-manager} {hybrid-console-second}:
+.. Navigate to {cluster-manager-url} and select your cluster.
+.. In your cluster, click *Open console*.
+.. Under the _Log in with..._ prompt, click *Cluster-Admin*.
+.. Enter your credentials.
+.. Click *Log in*.
+endif::[]
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-getting-started-deleting-a-cluster.adoc
+++ b/modules/rosa-getting-started-deleting-a-cluster.adoc
@@ -1,10 +1,18 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-getting-started-deleting-a-cluster_{context}"]
 = Deleting a ROSA cluster and the AWS STS resources
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
 
 You can delete a ROSA cluster that uses the AWS Security Token Service (STS) by using the ROSA CLI (`rosa`). You can also use the ROSA CLI to delete the AWS Identity and Access Management (IAM) account-wide roles, the cluster-specific Operator roles, and the OpenID Connect (OIDC) provider. To delete the account-wide inline and Operator policies, you can use the AWS IAM Console.
 
@@ -13,11 +21,13 @@ You can delete a ROSA cluster that uses the AWS Security Token Service (STS) by 
 Account-wide IAM roles and policies might be used by other ROSA clusters in the same AWS account. You must only remove the resources if they are not required by other clusters.
 ====
 
+ifdef::getting-started[]
 .Prerequisites
 
 * You installed and configured the latest AWS (`aws`), ROSA (`rosa`), and OpenShift (`oc`) CLIs on your workstation.
 * You logged in to your Red Hat account by using the `rosa` CLI.
 * You created a ROSA cluster.
+endif::[]
 
 .Procedure
 
@@ -56,16 +66,16 @@ $ rosa delete operator-roles -c <cluster_id> --mode auto <1>
 
 . Delete the account-wide roles:
 +
+[IMPORTANT]
+====
+Account-wide IAM roles and policies might be used by other ROSA clusters in the same AWS account. You must only remove the resources if they are not required by other clusters.
+====
++
 [source,terminal]
 ----
 $ rosa delete account-roles --prefix <prefix> --mode auto <1>
 ----
 <1> You must include the `--<prefix>` argument. Replace `<prefix>` with the prefix of the account-wide roles to delete. If you did not specify a custom prefix when you created the account-wide roles, specify the default prefix, `ManagedOpenShift`.
-+
-[IMPORTANT]
-====
-Account-wide IAM roles and policies might be used by other ROSA clusters in the same AWS account. You must only remove the resources if they are not required by other clusters.
-====
 
 . Delete the account-wide inline and Operator IAM policies that you created for ROSA deployments that use STS:
 .. Log in to the link:https://console.aws.amazon.com/iamv2/home#/home[AWS IAM Console].
@@ -73,3 +83,10 @@ Account-wide IAM roles and policies might be used by other ROSA clusters in the 
 .. With the policy selected, click on *Actions* -> *Delete* to open the delete policy dialog.
 .. Enter the policy name to confirm the deletion and select *Delete* to delete the policy.
 .. Repeat this step to delete each of the account-wide inline and Operator policies for the cluster.
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-getting-started-enable-rosa.adoc
+++ b/modules/rosa-getting-started-enable-rosa.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/rosa-getting-started.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-getting-started-enable-rosa_{context}"]
@@ -21,4 +22,4 @@ Consider using a dedicated AWS account to run production clusters. If you are us
 
 . Sign in to the https://console.aws.amazon.com/rosa/home[AWS Management Console].
 
-. Enable ROSA in your AWS account by navigating to the link:https://console.aws.amazon.com/rosa/home[ROSA service] and selecting *Enable OpenShift*.
+. Activate ROSA in your AWS account by navigating to the link:https://console.aws.amazon.com/rosa/home[ROSA service] and selecting *Enable OpenShift*.

--- a/modules/rosa-getting-started-environment-setup.adoc
+++ b/modules/rosa-getting-started-environment-setup.adoc
@@ -1,16 +1,17 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/rosa-quickstart.adoc
 
 [id="rosa-getting-started-environment-setup_{context}"]
 = Setting up the environment
 
 Before you create a {product-title} (ROSA) cluster, you must set up your environment by completing the following tasks:
 
-* Enable ROSA in your AWS account
-* Install and configure the required CLI tools
-* Verify the configuration of the CLI tools
-* Verify that the AWS Elastic Load Balancing (ELB) service role exists
-* Verify that the required AWS resource quotas are available
+* Enable ROSA in your AWS account.
+* Install and configure the required command line interface (CLI) tools.
+* Verify the configuration of the CLI tools.
+* Verify that the AWS Elastic Load Balancing (ELB) service role exists.
+* Verify that the required AWS resource quotas are available.
 
 You can follow the procedures in this section to complete these setup requirements.

--- a/modules/rosa-getting-started-grant-admin-privileges.adoc
+++ b/modules/rosa-getting-started-grant-admin-privileges.adoc
@@ -1,13 +1,22 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-getting-started-grant-admin-privileges_{context}"]
 = Granting administrator privileges to a user
 
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
+
 After you have added a user to your configured identity provider, you can grant the user `cluster-admin` or `dedicated-admin` privileges for your {product-title} (ROSA) cluster.
 
+ifdef::getting-started[]
 .Prerequisites
 
 * You have an AWS account.
@@ -15,6 +24,7 @@ After you have added a user to your configured identity provider, you can grant 
 * You logged in to your Red Hat account by using the `rosa` CLI.
 * You created a ROSA cluster.
 * You have configured a GitHub identity provider for your cluster and added identity provider users.
+endif::[]
 
 .Procedure
 
@@ -72,3 +82,10 @@ $ rosa list users --cluster=<cluster_name>
 ID                 GROUPS
 <idp_user_name>    dedicated-admins
 ----
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-getting-started-grant-user-access.adoc
+++ b/modules/rosa-getting-started-grant-user-access.adoc
@@ -1,15 +1,24 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-getting-started-grant-user-access_{context}"]
 = Granting user access to a cluster
 
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
+
 You can grant a user access to your {product-title} (ROSA) cluster by adding them to your configured identity provider.
 
 You can configure different types of identity providers for your ROSA cluster. The following example procedure adds a user to a GitHub organization that is configured for identity provision to the cluster.
 
+ifdef::getting-started[]
 .Prerequisites
 
 * You have an AWS account.
@@ -18,9 +27,17 @@ You can configure different types of identity providers for your ROSA cluster. T
 * You created a ROSA cluster.
 * You have a GitHub user account.
 * You have configured a GitHub identity provider for your cluster.
+endif::[]
 
 .Procedure
 
 . Navigate to link:https://github.com[github.com] and log in to your GitHub account.
 
 . Invite users that require access to the ROSA cluster to your GitHub organization. Follow the steps in link:https://docs.github.com/en/organizations/managing-membership-in-your-organization/inviting-users-to-join-your-organization[Inviting users to join your organization] in the GitHub documentation.
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-getting-started-install-configure-cli-tools.adoc
+++ b/modules/rosa-getting-started-install-configure-cli-tools.adoc
@@ -1,13 +1,29 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-getting-started-install-configure-cli-tools_{context}"]
 = Installing and configuring the required CLI tools
 
-Use the following steps to install and configure the AWS, {product-title} (ROSA) and OpenShift CLI tools on your workstation.
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
 
+Use the following steps to install and configure 
+ifdef::quickstart[]
+the AWS and {product-title} (ROSA) CLI tools 
+endif::[]
+ifdef::getting-started[]
+AWS, {product-title} (ROSA), and OpenShift CLI tools 
+endif::[]
+on your workstation.
+
+ifdef::getting-started[]
 .Prerequisites
 
 * You have an AWS account.
@@ -17,6 +33,7 @@ Use the following steps to install and configure the AWS, {product-title} (ROSA)
 ====
 You can create a Red Hat account by navigating to link:https://console.redhat.com[console.redhat.com] and selecting *Register for a Red Hat account*.
 ====
+endif::[]
 
 .Procedure
 
@@ -43,7 +60,7 @@ $ aws sts get-caller-identity
 ----
 
 . Install and configure the latest ROSA CLI (`rosa`).
-.. Download the latest version of the `rosa` CLI for your operating system from the link:https://console.redhat.com/openshift/downloads[*Downloads*] page on {cluster-manager}.
+.. Download the latest version of the `rosa` CLI for your operating system from the link:https://console.redhat.com/openshift/downloads[*Downloads*] page on the {cluster-manager-first} {hybrid-console-second}.
 .. Extract the `rosa` binary file from the downloaded archive. The following example extracts the binary from a Linux tar archive:
 +
 [source,terminal]
@@ -66,8 +83,9 @@ $ rosa version
 .Example output
 [source,terminal]
 ----
-1.1.7
+1.2.8
 ----
+ifdef::getting-started[]
 +
 .. Optional: Enable tab completion for the `rosa` CLI. With tab completion enabled, you can press the `Tab` key twice to automatically complete subcommands and receive command suggestions.
 +
@@ -84,7 +102,7 @@ You must open a new terminal to activate the configuration.
 ====
 For steps to configure `rosa` tab completion for different shell types, see the help menu by running `rosa completion --help`.
 ====
-
+endif::[]
 .. Log in to your Red Hat account by using the `rosa` CLI:
 +
 [source,terminal]
@@ -124,12 +142,13 @@ OCM Account Name:             Your Name
 OCM Account Username:         you@domain.com
 OCM Account Email:            you@domain.com
 OCM Organization ID:          <org_id>
-OCM Organization Name:        Your organisation
+OCM Organization Name:        Your organization
 OCM Organization External ID: <external_org_id>
 ----
 +
 Check that the information in the output is correct before proceeding.
 
+ifdef::getting-started[]
 . Install and configure the latest OpenShift CLI (`oc`).
 .. Use the `rosa` CLI to download the latest version of the `oc` CLI:
 +
@@ -162,3 +181,12 @@ $ rosa verify openshift-client
 I: Verifying whether OpenShift command-line tool is available...
 I: Current OpenShift Client Version: 4.9.12
 ----
+endif::[]
+
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-getting-started-revoke-admin-privileges.adoc
+++ b/modules/rosa-getting-started-revoke-admin-privileges.adoc
@@ -1,13 +1,22 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-getting-started-revoke-admin-privileges_{context}"]
 = Revoking administrator privileges from a user
 
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
+
 Follow the steps in this section to revoke `cluster-admin` or `dedicated-admin` privileges from a user.
 
+ifdef::getting-started[]
 .Prerequisites
 
 * You installed and configured the latest AWS (`aws`), ROSA (`rosa`), and OpenShift (`oc`) CLIs on your workstation.
@@ -15,6 +24,7 @@ Follow the steps in this section to revoke `cluster-admin` or `dedicated-admin` 
 * You created a ROSA cluster.
 * You have configured a GitHub identity provider for your cluster and added an identity provider user.
 * You granted `cluster-admin` or `dedicated-admin` privileges to a user.
+endif::[]
 
 .Procedure
 
@@ -72,3 +82,10 @@ $ rosa list users --cluster=<cluster_name>
 ----
 W: There are no users configured for cluster '<cluster_name>'
 ----
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-getting-started-revoke-user-access.adoc
+++ b/modules/rosa-getting-started-revoke-user-access.adoc
@@ -1,23 +1,40 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-getting-started-revoke-user-access_{context}"]
 = Revoking user access to a cluster
 
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
+
 You can revoke cluster access for an identity provider user by removing them from your configured identity provider.
 
 You can configure different types of identity providers for your ROSA cluster. The following example procedure revokes cluster access for a member of a GitHub organization that is configured for identity provision to the cluster.
 
+ifdef::getting-started[]
 .Prerequisites
 
 * You have a ROSA cluster.
 * You have a GitHub user account.
 * You have configured a GitHub identity provider for your cluster and added an identity provider user.
+endif::[]
 
 .Procedure
 
 . Navigate to link:https://github.com[github.com] and log in to your GitHub account.
 
 . Remove the user from your GitHub organization. Follow the steps in link:https://docs.github.com/en/organizations/managing-membership-in-your-organization/removing-a-member-from-your-organization[Removing a member from your organization] in the GitHub documentation.
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-getting-started-revoking-admin-privileges-and-user-access.adoc
+++ b/modules/rosa-getting-started-revoking-admin-privileges-and-user-access.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 [id="rosa-getting-started-revoking-admin-privileges-and-user-access_{context}"]
 = Revoking administrator privileges and user access

--- a/modules/rosa-getting-started-verify-aws-quota.adoc
+++ b/modules/rosa-getting-started-verify-aws-quota.adoc
@@ -1,18 +1,28 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-getting-started-verify-aws-quota_{context}"]
 = Verifying AWS quota availability
 
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
+
 Verify that the required resource quotas are available for your account in the default AWS region.
 
+ifdef::getting-started[]
 .Prerequisites
 
 * You have an AWS account.
 * You installed and configured the latest AWS (`aws`), ROSA (`rosa`), and OpenShift (`oc`) CLIs on your workstation.
 * You logged in to your Red Hat account by using the `rosa` CLI.
+endif::[]
 
 .Procedure
 
@@ -29,3 +39,10 @@ $ rosa verify quota
 I: Validating AWS quota...
 I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
 ----
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-getting-started-verify-elb-role.adoc
+++ b/modules/rosa-getting-started-verify-elb-role.adoc
@@ -1,10 +1,18 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-getting-started-verify-elb-role_{context}"]
 = Creating the ELB service role
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
 
 Check if the `AWSServiceRoleForElasticLoadBalancing` AWS Elastic Load Balancing (ELB) service role exists and if not, create it.
 
@@ -13,10 +21,12 @@ Check if the `AWSServiceRoleForElasticLoadBalancing` AWS Elastic Load Balancing 
 `Error creating network Load Balancer: AccessDenied:` is produced if you attempt to create a {product-title} (ROSA) cluster without the AWS ELB service role in place.
 ====
 
+ifdef::getting-started[]
 .Prerequisites
 
 * You have an AWS account.
 * You installed and configured the latest AWS CLI (`aws`) on your workstation.
+endif::[]
 
 .Procedure
 
@@ -46,3 +56,10 @@ ROLELASTUSED    2022-01-06T09:27:57+00:00       us-east-1
 ----
 $ aws iam create-service-linked-role --aws-service-name "elasticloadbalancing.amazonaws.com"
 ----
+
+ifeval::["{context}" == "rosa-getting-started"]
+:getting-started:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-sts-associating-your-aws-account.adoc
+++ b/modules/rosa-sts-associating-your-aws-account.adoc
@@ -1,13 +1,22 @@
 // Module included in the following assemblies:
 //
 // * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-sts-associating-your-aws-account_{context}"]
 = Associating your AWS account with your Red Hat organization
 
-Before using {cluster-manager-first} to create {product-title} (ROSA) clusters that use the AWS Security Token Service (STS), create an {cluster-manager} IAM role and link it to your Red Hat organization. Then, create a user IAM role and link it to your Red Hat user account in the same Red Hat organization.
+ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
+:quick-install:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
 
+Before using the {cluster-manager-first} {hybrid-console-second} to create {product-title} (ROSA) clusters that use the AWS Security Token Service (STS), create an {cluster-manager} IAM role and link it to your Red Hat organization. Then, create a user IAM role and link it to your Red Hat user account in the same Red Hat organization.
+
+ifdef::quick-install[]
 .Prerequisites
 
 * You have completed the AWS prerequisites for ROSA with STS.
@@ -21,23 +30,29 @@ To successfully install ROSA clusters, use the latest version of the ROSA CLI.
 ====
 * You have logged in to your Red Hat account by using the `rosa` CLI.
 * You have organization administrator privileges in your Red Hat organization.
+endif::[]
 
 .Procedure
 
 . Create an {cluster-manager} role and link it to your Red Hat organization:
 +
+[NOTE]
+====
+To enable automatic deployment of the cluster-specific Operator roles and the OpenID Connect (OIDC) provider using the {cluster-manager} {hybrid-console-second}, you must apply the administrative privileges to the role by choosing the _Admin OCM role_ command in the *Accounts and roles* step of creating a ROSA cluster. For more information about the basic and administrative privileges for the {cluster-manager} role, see _Understanding AWS account association_.
+====
++
+[NOTE]
+====
+If you choose the _Basic OCM role_ command in the *Accounts and roles* step of creating a ROSA cluster in the {cluster-manager} {hybrid-console-second}, you must deploy a ROSA cluster using manual mode. You will be prompted to configure the cluster-specific Operator roles and the OpenID Connect (OIDC) provider in a later step.
+====
++
 [source,terminal]
 ----
-$ rosa create ocm-role --admin
+$ rosa create ocm-role
 ----
 +
 Select the default values at the prompts to quickly create and link the role.
 +
-[NOTE]
-====
-If you want to enable automatic deployment of the cluster-specific Operator roles and the OpenID Connect (OIDC) provider using {cluster-manager}, you must apply the administrative privileges to the role. For more information about the basic and administrative privileges for the {cluster-manager} role, see _Understanding AWS account association_.
-====
-
 . Create a user role and link it to your {cluster-manager} user account:
 +
 [source,terminal]
@@ -51,3 +66,10 @@ Select the default values at the prompts to quickly create and link the role
 ====
 The Red Hat user account must exist in the Red Hat organization that is linked to your {cluster-manager} role.
 ====
+
+ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
+:quick-install:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-sts-creating-a-cluster-quickly-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-quickly-cli.adoc
@@ -2,13 +2,22 @@
 //
 // * rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-creating-a-cluster-quickly.adoc
 // * rosa_getting_started/rosa-getting-started.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-sts-creating-a-cluster-quickly-cli_{context}"]
 = Creating a cluster quickly using the CLI
 
+ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
+:quick-install:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
+
 When using the {product-title} (ROSA) CLI (`rosa`) to create a cluster that uses the AWS Security Token Service (STS), you can select the default options to create the cluster quickly.
 
+ifndef::quickstart[]
 .Prerequisites
 
 * You have completed the AWS prerequisites for ROSA with STS.
@@ -22,6 +31,7 @@ To successfully install ROSA clusters, use the latest version of the ROSA CLI.
 ====
 * You have logged in to your Red Hat account by using the `rosa` CLI.
 * You have verified that the AWS Elastic Load Balancing (ELB) service role exists in your AWS account.
+endif::[]
 
 .Procedure
 
@@ -77,3 +87,11 @@ If the installation fails or the `State` field does not change to `ready` after 
 $ rosa logs install --cluster <cluster_name|cluster_id> --watch <1>
 ----
 <1> Specify the `--watch` flag to watch for new log messages as the installation progresses. This argument is optional.
+
+
+ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
+:quick-install:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
@@ -1,13 +1,22 @@
 // Module included in the following assemblies:
 //
 // * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-sts-creating-a-cluster-using-defaults-ocm_{context}"]
-= Creating a cluster with the default options using {cluster-manager}
+= Creating a cluster with the default options using {cluster-manager} {hybrid-console-second}
 
-When using {cluster-manager-first} to create a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS), you can select the default options to create the cluster quickly. You can also use the admin {cluster-manager} IAM role to enable automatic deployment of the cluster-specific Operator roles and the OpenID Connect (OIDC) provider.
+ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
+:quick-install:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
 
+When using the {cluster-manager-first} {hybrid-console-second} to create a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS), you can select the default options to create the cluster quickly. You can also use the admin {cluster-manager} IAM role to enable automatic deployment of the cluster-specific Operator roles and the OpenID Connect (OIDC) provider.
+
+ifdef::quick-install[]
 .Prerequisites
 
 * You have completed the AWS prerequisites for ROSA with STS.
@@ -21,7 +30,8 @@ To successfully install ROSA clusters, use the latest version of the ROSA CLI.
 ====
 * You have verified that the AWS Elastic Load Balancing (ELB) service role exists in your AWS account.
 * You have associated your AWS account with your Red Hat organization. When you associated your account, you applied the administrative permissions to the {cluster-manager} role. For detailed steps, see _Associating your AWS account with your Red Hat organization_.
-* You have created the required account-wide STS roles and policies, including the Operator policies. For detailed steps, see _Creating the account-wide STS roles and policies_.
+* You have created the required account-wide STS roles and policies. For detailed steps, see _Creating the account-wide STS roles and policies_.
+endif::[]
 
 .Procedure
 
@@ -31,7 +41,7 @@ To successfully install ROSA clusters, use the latest version of the ROSA CLI.
 
 . Review and complete the *Prerequisites* listed on the *Accounts and roles* page. Select the checkbox to acknowledge that you have read and completed all of the prerequisites.
 
-. Verify that your AWS account ID is listed in the *Associated AWS accounts* drop-down menu and that the installer, support, worker, and control plane account role Amazon Resource Names (ARNs) are listed on the *Accounts and roles* page. 
+. Verify that your AWS account ID is listed in the *Associated AWS accounts* drop-down menu and that the installer, support, worker, and control plane account role Amazon Resource Names (ARNs) are listed on the *Accounts and roles* page.
 +
 [NOTE]
 ====
@@ -54,3 +64,10 @@ If your AWS account ID is not listed, check that you have successfully associate
 ====
 If the installation fails or the cluster *State* does not change to *Ready* after about 40 minutes, check the installation troubleshooting documentation for details. For more information, see _Troubleshooting installations_. For steps to contact Red Hat Support for assistance, see _Getting support for Red Hat OpenShift Service on AWS_.
 ====
+
+ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
+:quick-install:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]

--- a/modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc
@@ -1,13 +1,22 @@
 // Module included in the following assemblies:
 //
 // * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-sts-creating-account-wide-sts-roles-and-policies_{context}"]
 = Creating the account-wide STS roles and policies
 
-Before using {cluster-manager-first} to create {product-title} (ROSA) clusters that use the AWS Security Token Service (STS), create the required account-wide STS roles and policies, including the Operator policies.
+ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
+:quick-install:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
 
+Before using the {cluster-manager-first} {hybrid-console-second} to create {product-title} (ROSA) clusters that use the AWS Security Token Service (STS), create the required account-wide STS roles and policies, including the Operator policies.
+
+ifdef::quick-install[]
 .Prerequisites
 
 * You have completed the AWS prerequisites for ROSA with STS.
@@ -20,10 +29,20 @@ Before using {cluster-manager-first} to create {product-title} (ROSA) clusters t
 To successfully install ROSA clusters, use the latest version of the ROSA CLI.
 ====
 * You have logged in to your Red Hat account by using the `rosa` CLI.
+endif::[]
 
 .Procedure
 
-. If they do not exist in your AWS account, create the required account-wide STS roles and policies, including the Operator policies:
+ifdef::quick-install[]
+. Check your AWS account for existing roles and policies:
++
+[source,terminal]
+----
+$ rosa list account-roles
+----
+endif::[]
+
+. If they do not exist in your AWS account, create the required account-wide STS roles and policies:
 +
 [source,terminal]
 ----

--- a/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
+++ b/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-interactive-mode-reference.adoc
+// * rosa_getting_started/quickstart.adoc
 
 :_content-type: CONCEPT
 [id="rosa-sts-overview-of-the-default-cluster-specifications_{context}"]
@@ -20,7 +21,7 @@ You can quickly create a {product-title} (ROSA) cluster with the AWS Security To
 
 |Cluster settings
 |* Default cluster version: Latest
-* Default AWS region for installations using {cluster-manager}: us-east-1 (US East, North Virginia)
+* Default AWS region for installations using the {cluster-manager-first} {hybrid-console-second}: us-east-1 (US East, North Virginia)
 * Default AWS region for installations using the `rosa` CLI: Defined by your `aws` CLI configuration
 * Availability: Single zone
 * Monitoring for user-defined projects: Enabled
@@ -60,7 +61,7 @@ You can quickly create a {product-title} (ROSA) cluster with the AWS Security To
 +
 [NOTE]
 ====
-For installations using {cluster-manager}, the `auto` mode requires an admin-privileged {cluster-manager} role.
+For installations using the {cluster-manager} {hybrid-console-second}, the `auto` mode requires an admin-privileged {cluster-manager} role.
 ====
 * Default Operator role prefix: `<cluster_name>-<4_digit_random_string>`
 

--- a/modules/rosa-sts-understanding-aws-account-association.adoc
+++ b/modules/rosa-sts-understanding-aws-account-association.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
+// * rosa_getting_started/quickstart.adoc
 
 ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
 :quick-install:
@@ -8,16 +9,19 @@ endif::[]
 ifeval::["{context}" == "rosa-sts-creating-a-cluster-with-customization"]
 :custom-install:
 endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="rosa-sts-understanding-aws-account-association_{context}"]
 = Understanding AWS account association
 
-Before you can use {cluster-manager-first} to create {product-title} (ROSA) clusters that use the AWS Security Token Service (STS), you must associate your AWS account with your Red Hat organization. You can associate your account by creating and linking the following IAM roles.
+Before you can use the {cluster-manager-first} {hybrid-console-second} to create {product-title} (ROSA) clusters that use the AWS Security Token Service (STS), you must associate your AWS account with your Red Hat organization. You can associate your account by creating and linking the following IAM roles.
 
 {cluster-manager} role:: Create an {cluster-manager} IAM role and link it to your Red Hat organization.
 +
-You can apply basic or administrative permissions to the {cluster-manager} role. The basic permissions enable cluster maintenance using {cluster-manager}. The administrative permissions enable automatic deployment of the cluster-specific Operator roles and the OpenID Connect (OIDC) provider using {cluster-manager}.
+You can apply basic or administrative permissions to the {cluster-manager} role. The basic permissions enable cluster maintenance using the {cluster-manager} {hybrid-console-second}. The administrative permissions enable automatic deployment of the cluster-specific Operator roles and the OpenID Connect (OIDC) provider using the {cluster-manager} {hybrid-console-second}.
 ifdef::quick-install[]
 +
 You can use the administrative permissions with the {cluster-manager} role to deploy a cluster quickly.
@@ -25,11 +29,14 @@ endif::quick-install[]
 
 User role:: Create a user IAM role and link it to your Red Hat user account. The Red Hat user account must exist in the Red Hat organization that is linked to your {cluster-manager} role.
 +
-The user role is used by Red Hat to verify your AWS identity when you use {cluster-manager} to install a cluster and the required STS resources.
+The user role is used by Red Hat to verify your AWS identity when you use the {cluster-manager} {hybrid-console-second} to install a cluster and the required STS resources.
 
 ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
 :!quick-install:
 endif::[]
 ifeval::["{context}" == "rosa-sts-creating-a-cluster-with-customization"]
 :!custom-install:
+endif::[]
+ifeval::["{context}" == "rosa-quickstart"]
+:quickstart:
 endif::[]

--- a/rosa_getting_started/rosa-getting-started.adoc
+++ b/rosa_getting_started/rosa-getting-started.adoc
@@ -1,14 +1,19 @@
 :_content-type: ASSEMBLY
 [id="rosa-getting-started"]
-= Getting started with {product-title}
+= Comprehensive guide to getting started with {product-title}
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-getting-started
 
 toc::[]
 
-Follow this getting started document to quickly create a {product-title} (ROSA) cluster, grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.
+[NOTE]
+====
+If you are looking for a quickstart guide for ROSA, see xref:../rosa_getting_started/rosa-quickstart.adoc#rosa-quickstart[{product-title} quickstart guide].
+====
 
-You can create a ROSA cluster either with or without the AWS Security Token Service (STS). The procedures in this document enable you to create a cluster that uses AWS STS. For more information about using AWS STS with ROSA clusters, see xref:../rosa_architecture/rosa-understanding.adoc#rosa-using-sts_rosa-understanding[Using the AWS Security Token Service].
+Follow this getting started document to create a {product-title} (ROSA) cluster, grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.
+
+You can create a ROSA cluster either with or without the AWS Security Token Service (STS). The procedures in this document enable you to create a cluster that uses AWS STS. For more information about using AWS STS with ROSA clusters, see xref:../rosa_architecture/rosa-understanding.adoc#rosa-understanding-aws-sts_rosa-understanding[Using the AWS Security Token Service].
 
 [id="rosa-getting-started-prerequisites_{context}"]
 == Prerequisites

--- a/rosa_getting_started/rosa-quickstart.adoc
+++ b/rosa_getting_started/rosa-quickstart.adoc
@@ -1,0 +1,171 @@
+:_content-type: ASSEMBLY
+[id="rosa-quickstart"]
+= {product-title} quickstart guide
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-quickstart
+
+toc::[]
+
+[NOTE]
+====
+If you are looking for a comprehensive getting started guide for ROSA, see xref:../rosa_getting_started/rosa-getting-started.adoc#rosa-getting-started[Comprehensive guide to getting started with {product-title}].
+====
+
+Follow this guide to quickly create a {product-title} (ROSA) cluster using the {cluster-manager-first} {hybrid-console-second}, grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.
+
+The procedures in this document enable you to create a cluster that uses AWS Security Token Service (STS). For more information about using AWS STS with ROSA clusters, see xref:../rosa_architecture/rosa-understanding.adoc#rosa-understanding-aws-sts_rosa-understanding[Using the AWS Security Token Service].
+
+[id="rosa-getting-started-prerequisites_{context}"]
+== Prerequisites
+
+* You reviewed the xref:../rosa_architecture/rosa-understanding.adoc#rosa-understanding[introduction to {product-title} (ROSA)], and the documentation on ROSA xref:../rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc#rosa-architecture-models[architecture models] and xref:../rosa_architecture/rosa_architecture_sub/rosa-basic-architecture-concepts.adoc#rosa-basic-architecture-concepts[architecture concepts].
+
+* You have read the documentation on xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[limits and scalability] and the xref:../rosa_planning/rosa-planning-environment.adoc#rosa-planning-environment[guidelines for planning your environment].
+
+* You have reviewed the detailed xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
+
+* You have the xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-sts-required-aws-service-quotas[AWS service quotas that are required to run a ROSA cluster].
+
+
+//This content is pulled from rosa-getting-started-environment-setup.adoc
+include::modules/rosa-getting-started-environment-setup.adoc[leveloffset=+1]
+
+
+//This content is pulled from rosa-getting-started-enable-rosa.adoc
+[discrete]
+include::modules/rosa-getting-started-enable-rosa.adoc[leveloffset=+2]
+
+
+//This content is pulled from rosa-getting-started-install-configure-cli-tools
+[discrete]
+include::modules/rosa-getting-started-install-configure-cli-tools.adoc[leveloffset=+2]
+
+
+//This content is pulled from rosa-getting-started-verify-elb-role.adoc
+[discrete]
+include::modules/rosa-getting-started-verify-elb-role.adoc[leveloffset=+2]
+
+
+//This content is pulled from rosa-getting-started-verify-aws-quota.adoc
+[discrete]
+include::modules/rosa-getting-started-verify-aws-quota.adoc[leveloffset=+2]
+
+
+//This content is pulled from rosa-sts-creating-a-cluster-quickly.adoc
+[id="rosa-quickstart-creating-a-cluster"]
+== Creating a ROSA cluster with AWS STS using the default auto mode
+
+The procedures in this document use the `auto` modes in the {cluster-manager} {hybrid-console-second} to immediately create the required Identity and Access Management (IAM) resources using the current AWS account. The required resources include the account-wide IAM roles and policies, cluster-specific Operator roles and policies, and OpenID Connect (OIDC) identity provider.
+
+//This content is pulled from rosa-sts-creating-a-cluster-quickly-ocm.adoc
+When using the {cluster-manager} {hybrid-console-second} to create a {product-title} (ROSA) cluster that uses the STS, you can select the default options to create the cluster quickly.
+
+Before you can use the {cluster-manager} {hybrid-console-second} to deploy ROSA with STS clusters, you must associate your AWS account with your Red Hat organization and create the required account-wide STS roles and policies.
+
+
+//This content is pulled from rosa-sts-overview-of-the-default-cluster-specifications.adoc
+[discrete]
+include::modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc[leveloffset=+2]
+
+
+//This content is pulled from rosa-sts-understanding-aws-account-association.adoc
+[discrete]
+include::modules/rosa-sts-understanding-aws-account-association.adoc[leveloffset=+2]
+
+
+//This content is pulled from rosa-sts-associating-your-aws-account.adoc
+[discrete]
+include::modules/rosa-sts-associating-your-aws-account.adoc[leveloffset=+2]
+
+
+//This content is pulled from rosa-sts-creating-account-wide-sts-roles-and-policies.adoc
+[discrete]
+include::modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+2]
+
+
+//This content is pulled from rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
+[discrete]
+include::modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc[leveloffset=+2]
+
+////
+.Additional resources
+
+* For information about the account-wide IAM roles and policies that are required for ROSA deployments that use STS, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference].
+* For details about using the `auto` and `manual` modes to create the required STS resources, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-understanding-deployment-modes_rosa-sts-creating-a-cluster-with-customizations[Understanding the auto and manual deployment modes].
+* For information about the update life cycle for ROSA, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[{product-title} update life cycle].
+////
+
+
+//This content is pulled from rosa-getting-started-create-cluster-admin-user.adoc
+include::modules/rosa-getting-started-create-cluster-admin-user.adoc[leveloffset=+1]
+
+.Additional resource
+
+* For steps to log in to the ROSA web console, see xref:../rosa_getting_started/rosa-quickstart.adoc#rosa-getting-started-access-cluster-web-console_rosa-quickstart[Accessing a cluster through the web console].
+
+
+//This content is pulled from rosa-getting-started-configure-an-idp-and-grant-access.adoc
+include::modules/rosa-getting-started-configure-an-idp-and-grant-access.adoc[leveloffset=+1]
+
+
+//This content is pulled from rosa-getting-started-configure-an-idp.adoc
+[discrete]
+include::modules/rosa-getting-started-configure-an-idp.adoc[leveloffset=+2]
+
+.Additional resource
+
+* For detailed steps to configure each of the supported identity provider types, see xref:../rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc#rosa-sts-config-identity-providers[Configuring identity providers for STS].
+
+
+//This content is pulled from rosa-getting-started-grant-user-access.adoc
+[discrete]
+include::modules/rosa-getting-started-grant-user-access.adoc[leveloffset=+2]
+
+
+//This content is pulled from rosa-getting-started-grant-admin-privileges.adoc
+[discrete]
+include::modules/rosa-getting-started-grant-admin-privileges.adoc[leveloffset=+2]
+
+
+//This content is pulled from rosa-getting-started-access-cluster-web-console.adoc
+include::modules/rosa-getting-started-access-cluster-web-console.adoc[leveloffset=+1]
+
+
+//This content is pulled from deploy-app.adoc
+include::modules/deploy-app.adoc[leveloffset=+1]
+
+
+//This content is pulled from rosa-getting-started-revoking-admin-privileges-and-user-access.adoc
+include::modules/rosa-getting-started-revoking-admin-privileges-and-user-access.adoc[leveloffset=+1]
+
+
+//This content is pulled from rosa-getting-started-revoke-admin-privileges.adoc
+[discrete]
+include::modules/rosa-getting-started-revoke-admin-privileges.adoc[leveloffset=+2]
+
+
+//This content is pulled from rosa-getting-started-revoke-admin-privileges.adoc
+[discrete]
+include::modules/rosa-getting-started-revoke-user-access.adoc[leveloffset=+2]
+
+
+//This content is pulled from rosa-getting-started-deleting-a-cluster.adoc
+include::modules/rosa-getting-started-deleting-a-cluster.adoc[leveloffset=+1]
+
+[id="next-steps_{context}"]
+== Next steps
+
+* xref:../adding_service_cluster/adding-service.adoc#adding-service[Adding services to a cluster using the {cluster-manager} console]
+* xref:../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#rosa-managing-worker-nodes[Managing compute nodes]
+* xref:../rosa_cluster_admin/rosa_monitoring/rosa-configuring-the-monitoring-stack.adoc#rosa-configuring-the-monitoring-stack[Configuring the monitoring stack]
+* xref:../rosa_cluster_admin/rosa_logging/rosa-install-logging.adoc#rosa-install-logging[Installing logging add-on services]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* For more information about setting up accounts and ROSA clusters using AWS STS, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-overview-of-the-deployment-workflow[Understanding the ROSA with STS deployment workflow].
+
+* For information about setting up accounts and ROSA clusters without using AWS STS, see xref:../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-getting-started-workflow.adoc#rosa-understanding-the-deployment-workflow[Understanding the ROSA deployment workflow].
+
+* For documentation on upgrading your cluster, see xref:../upgrading/rosa-upgrading.adoc#rosa-upgrading[Upgrading ROSA clusters].

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
@@ -6,9 +6,14 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[NOTE]
+====
+If you are looking for a quickstart guide for ROSA, see xref:../rosa_getting_started/rosa-quickstart.adoc#rosa-quickstart[{product-title} quickstart guide].
+====
+
 Create a {product-title} (ROSA) cluster quickly by using the default options and automatic AWS Identity and Access Management (IAM) resource creation. You can deploy your cluster by using {cluster-manager-first} or the ROSA CLI (`rosa`).
 
-The procedures in this document use the `auto` modes in the ROSA CLI (`rosa`) and {cluster-manager} to immediately create the required IAM resources using the current AWS account. The required resources include the account-wide IAM roles and policies, Operator policies, cluster-specific Operator roles, and OpenID Connect (OIDC) identity provider.
+The procedures in this document use the `auto` modes in the ROSA CLI (`rosa`) and {cluster-manager} to immediately create the required IAM resources using the current AWS account. The required resources include the account-wide IAM roles and policies, cluster-specific Operator roles and policies, and OpenID Connect (OIDC) identity provider.
 
 Alternatively, you can use `manual` mode, which outputs the `aws` commands needed to create the IAM resources instead of deploying them automatically. For steps to deploy a ROSA cluster by using `manual` mode or with customizations, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-cluster-using-customizations_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster using customizations].
 
@@ -43,3 +48,4 @@ include::modules/rosa-sts-creating-a-cluster-quickly-cli.adoc[leveloffset=+1]
 * For more information about using OpenID Connect (OIDC) identity providers in AWS IAM, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html[Creating OpenID Connect (OIDC) identity providers] in the AWS documentation.
 * For more information about troubleshooting ROSA cluster installations, see xref:../rosa_support/rosa-troubleshooting-installations.adoc#rosa-troubleshooting-installations[Troubleshooting installations].
 * For steps to contact Red Hat Support for assistance, see xref:../rosa_architecture/rosa-getting-support.adoc#rosa-getting-support[Getting support for Red Hat OpenShift Service on AWS].
+


### PR DESCRIPTION
Version(s):
4.11, 4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4379

Link to docs preview:
https://51818--docspreview.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-quickstart.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
This quickstart guide was made possible by the efforts of the entire OpenShift Service Delivery Docs team. It combines Getting started and install content written primarily by @pneedle-rh and @EricPonvelle, and involves incredible collaboration by @eohartman and @aldiazRH. Thanks, team! 

