### PR TITLE
RHDEVDOCS-4479: update install guides for odo 30

### DIFF
--- a/cli_reference/developer_cli_odo/installing-odo.adoc
+++ b/cli_reference/developer_cli_odo/installing-odo.adoc
@@ -6,9 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-// The following section describes how to install `{odo-title}` on different platforms using the CLI or the Visual Studio Code (VS Code) IDE.
-
-You can install the `{odo-title}` CLI on Linux, Windows, or macOS by downloading a binary. You can also install the OpenShift VS Code extension, which uses both the `{odo-title}` and the `oc` binaries to interact with your OpenShift Container Platform cluster. For {op-system-base-full}, you can install the `{odo-title}` CLI as an RPM.
+You can install the `{odo-title}` CLI on Linux, Windows, or macOS by downloading a binary. 
 
 [NOTE]
 ====
@@ -22,7 +20,3 @@ include::modules/developer-cli-odo-installing-odo-on-linux.adoc[leveloffset=+1]
 include::modules/developer-cli-odo-installing-odo-on-windows.adoc[leveloffset=+1]
 
 include::modules/developer-cli-odo-installing-odo-on-macos.adoc[leveloffset=+1]
-
-include::modules/developer-cli-odo-installing-odo-on-vs-code.adoc[leveloffset=+1]
-
-include::modules/developer-cli-odo-installing-odo-on-linux-rpm.adoc[leveloffset=+1]

--- a/modules/developer-cli-odo-installing-odo-on-linux.adoc
+++ b/modules/developer-cli-odo-installing-odo-on-linux.adoc
@@ -7,27 +7,28 @@
 
 = Installing {odo-title} on Linux
 
-The `{odo-title}` CLI is available to download as a binary and as a tarball for multiple operating systems and architectures including: 
+The `{odo-title}` CLI is available to download as a binary and as a tar file, for multiple operating systems and architectures including: 
 
-[cols="2,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
-|Operating System|Binary|Tarball
-|Linux|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64[odo-linux-amd64] |link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64.tar.gz[odo-linux-amd64.tar.gz]
-|Linux on IBM Power|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-ppc64le[odo-linux-ppc64le] |link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-ppc64le.tar.gz[odo-linux-ppc64le.tar.gz]
-|Linux on IBM Z and LinuxONE|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-s390x[odo-linux-s390x] |link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-s390x.tar.gz[odo-linux-s390x.tar.gz]
+|Operating system|Binary|Tar file
+|Linux on AMD|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64[`odo-linux-amd64`] |link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64.tar.gz[`odo-linux-amd64.tar.gz`]
+|Linux on ARM|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-arm64[`odo-linux-arm64`] |link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-arm64.tar.gz[`odo-linux-arm64.tar.gz`]
+|Linux on IBM Power|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-ppc64le[`odo-linux-ppc64le`] |link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-ppc64le.tar.gz[`odo-linux-ppc64le.tar.gz`]
+|Linux on IBM Z and LinuxONE|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-s390x[`odo-linux-s390x`] |link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-s390x.tar.gz[`odo-linux-s390x.tar.gz`]
 |===
 
 
 .Procedure
 
-. Navigate to the link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/[content gateway] and download the appropriate file for your operating system and architecture.
+. Go to the link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/[content gateway] and download the appropriate file for your operating system and architecture.
 ** If you download the binary, rename it to `odo`:
 +
 [source,terminal]
 ----
 $ curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64 -o odo
 ----
-** If you download the tarball, extract the binary:
+** If you download the tar file, extract the binary:
 +
 [source,terminal]
 ----
@@ -42,7 +43,7 @@ $ chmod +x <filename>
 ----
 . Place the `{odo-title}` binary in a directory that is on your `PATH`.
 +
-To check your `PATH`, execute the following command:
+To view your `PATH`, run the following command:
 +
 [source,terminal]
 ----

--- a/modules/developer-cli-odo-installing-odo-on-macos.adoc
+++ b/modules/developer-cli-odo-installing-odo-on-macos.adoc
@@ -7,24 +7,25 @@
 
 = Installing {odo-title} on macOS
 
-The `{odo-title}` CLI for macOS is available to download as a binary and as a tarball.
+The `{odo-title}` CLI for macOS is available to download as a binary and as a tar file.
 
-[cols="2,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
-|Operating System|Binary|Tarball
-|macOS|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64[odo-darwin-amd64]|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64.tar.gz[odo-darwin-amd64.tar.gz]
+|Operating system|Binary|Tar file
+|macOS on AMD|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64[odo-darwin-amd64]|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64.tar.gz[odo-darwin-amd64.tar.gz]
+|macOS on ARM|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-arm64[odo-darwin-arm64]|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-arm64.tar.gz[odo-darwin-arm64.tar.gz]
 |===
 
 .Procedure
 
-. Navigate to the link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/[content gateway] and download the appropriate file:
+. Go to the link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/[content gateway] and download the appropriate file:
 ** If you download the binary, rename it to `odo`:
 +
 [source,terminal]
 ----
 $ curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64 -o odo
 ----
-** If you download the tarball, extract the binary:
+** If you download the tar file, extract the binary:
 +
 [source,terminal]
 ----
@@ -35,11 +36,11 @@ $ tar xvzf odo.tar.gz
 +
 [source,terminal]
 ----
-# chmod +x odo
+$ chmod +x odo
 ----
 . Place the `{odo-title}` binary in a directory that is on your `PATH`.
 +
-To check your `PATH`, execute the following command:
+To view your `PATH`, run the following command:
 +
 [source,terminal]
 ----

--- a/modules/developer-cli-odo-installing-odo-on-windows.adoc
+++ b/modules/developer-cli-odo-installing-odo-on-windows.adoc
@@ -9,9 +9,9 @@
 
 The `{odo-title}` CLI for Windows is available to download as a binary and as an archive.
 
-[cols="2,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
-|Operating System|Binary|Tarball
+|Operating system|Binary|Archive
 |Windows|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-windows-amd64.exe[odo-windows-amd64.exe]|link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-windows-amd64.exe.zip[odo-windows-amd64.exe.zip]
 |===
 
@@ -19,10 +19,10 @@ The `{odo-title}` CLI for Windows is available to download as a binary and as an
 
 . Navigate to the link:https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/[content gateway] and download the appropriate file:
 ** If you download the binary, rename it to `odo.exe`.
-** If you download the archive, unzip the binary with a ZIP program and then rename it to `odo.exe`.
+** If you download the archive, extract the binary with a ZIP program and rename it to `odo.exe`.
 . Move the `odo.exe` binary to a directory that is on your `PATH`.
 +
-To check your `PATH`, open the command prompt and execute the following command:
+To view your `PATH`, open the shell prompt and run the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-4479

Link to docs preview:
https://51827--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/developer_cli_odo/installing-odo.html

QE review:
- [ ] QE has approved this change.
