### PR TITLE
TELCODOCS:976 - Z-stream update to release notes for sandboxed contai…

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -48,8 +48,8 @@ endif::openshift-origin[]
 :sandboxed-containers-first: OpenShift sandboxed containers
 :sandboxed-containers-operator: OpenShift sandboxed containers Operator
 :sandboxed-containers-version: 1.3
-:sandboxed-containers-version-z: 1.3.0
-:sandboxed-containers-legacy-version: 1.2.2
+:sandboxed-containers-version-z: 1.3.1
+:sandboxed-containers-legacy-version: 1.3.0
 :cert-manager-operator: cert-manager Operator for Red Hat OpenShift
 :secondary-scheduler-operator-full: Secondary Scheduler Operator for Red Hat OpenShift
 :secondary-scheduler-operator: Secondary Scheduler Operator

--- a/sandboxed_containers/sandboxed-containers-4.11-release-notes.adoc
+++ b/sandboxed_containers/sandboxed-containers-4.11-release-notes.adoc
@@ -146,3 +146,12 @@ Issued: 2022-08-17
 {sandboxed-containers-first} release {sandboxed-containers-version}.0 is now available. This advisory contains an update for {sandboxed-containers-first} with enhancements and bug fixes.
 
 The list of bug fixes included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2022:6072[RHSA-2022:6072] advisory.
+
+[id="sandboxed-containers-1-3-1"]
+=== RHSA-2022:7058 - {sandboxed-containers-first} {sandboxed-containers-version}.1 security fix and bug fix advisory.
+
+Issued: 2022-10-19
+
+{sandboxed-containers-first} release {sandboxed-containers-version}.1 is now available. This advisory contains an update for {sandboxed-containers-first} with security fixes and a bug fix.
+
+The list of bug fixes included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:7058[RHSA-2022:7058] advisory.


### PR DESCRIPTION
Version(s): Only 4.11

Issue:
[TELCODOCS-976](https://issues.redhat.com/browse/TELCODOCS-976)

[Link to docs preview](https://51829--docspreview.netlify.app/openshift-enterprise/latest/sandboxed_containers/sandboxed-containers-4.11-release-notes.html#sandboxed-containers-1-3-1)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

