### PR TITLE
OADP 693: Document restore of deploymentconfigs using restic and worka…

### DIFF
--- a/modules/oadp-creating-restore-cr.adoc
+++ b/modules/oadp-creating-restore-cr.adoc
@@ -55,3 +55,71 @@ $ oc get restore -n openshift-adp <restore> -o jsonpath='{.status.phase}'
 $ oc get all -n <namespace> <1>
 ----
 <1> Namespace that you backed up.
+
+. If you use Restic to restore `DeploymentConfig` objects or if you use post-restore hooks, run the `dc-restic-post-restore.sh` cleanup script by entering the following command:
++
+[source,terminal]
+----
+$ bash dc-restic-post-restore.sh <restore-name>
+----
++
+[NOTE]
+====
+In the course of the restore process, the OADP Velero plug-ins scale down the `DeploymentConfig` objects and restore the pods as standalone pods to prevent the cluster from deleting the restored `DeploymentConfig` pods immediately on restore and to allow Restic and post-restore hooks to complete their actions on the restored pods. The cleanup script removes these disconnected pods and scale any `DeploymentConfig` objects back up to the appropriate number of replicas.
+====
++
+.`dc-restic-post-restore.sh` cleanup script
+[%collapsible]
+====
+[source,bash]
+----
+#!/bin/bash
+set -e
+
+# if sha256sum exists, use it to check the integrity of the file
+if command -v sha256sum >/dev/null 2>&1; then
+  CHECKSUM_CMD="sha256sum"
+else
+  CHECKSUM_CMD="shasum -a 256"
+fi
+
+label_name () {
+    if [ "${#1}" -le "63" ]; then
+	echo $1
+	return
+    fi
+    sha=$(echo -n $1|$CHECKSUM_CMD)
+    echo "${1:0:57}${sha:0:6}"
+}
+
+OADP_NAMESPACE=${OADP_NAMESPACE:=openshift-adp}
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: ${BASH_SOURCE} restore-name"
+    exit 1
+fi
+
+echo using OADP Namespace $OADP_NAMESPACE
+echo restore: $1
+
+label=$(label_name $1)
+echo label: $label
+
+echo Deleting disconnected restore pods
+oc delete pods -l oadp.openshift.io/disconnected-from-dc=$label
+
+for dc in $(oc get dc --all-namespaces -l oadp.openshift.io/replicas-modified=$label -o jsonpath='{range .items[*]}{.metadata.namespace}{","}{.metadata.name}{","}{.metadata.annotations.oadp\.openshift\.io/original-replicas}{","}{.metadata.annotations.oadp\.openshift\.io/original-paused}{"\n"}')
+do
+    IFS=',' read -ra dc_arr <<< "$dc"
+    if [ ${#dc_arr[0]} -gt 0 ]; then
+	echo Found deployment ${dc_arr[0]}/${dc_arr[1]}, setting replicas: ${dc_arr[2]}, paused: ${dc_arr[3]}
+	cat <<EOF | oc patch dc  -n ${dc_arr[0]} ${dc_arr[1]} --patch-file /dev/stdin
+spec:
+  replicas: ${dc_arr[2]}
+  paused: ${dc_arr[3]}
+EOF
+    fi
+done
+----
+
+====

--- a/modules/oadp-restic-issues.adoc
+++ b/modules/oadp-restic-issues.adoc
@@ -38,64 +38,6 @@ spec:
 
 . Wait for the `Restic` pods to restart so that the changes are applied.
 
-[id="restic-restore-deploymentconfig-issue_{context}"]
-== Restore CR of Restic backup is "PartiallyFailed", "Failed", or remains "InProgress"
-
-The `Restore` CR of a Restic backup completes with a `PartiallyFailed` or `Failed` status or it remains `InProgress` and does not complete.
-
-If the status is `PartiallyFailed` or `Failed`, the `Velero` pod log displays the error message, `level=error msg="unable to successfully complete restic restores of pod's volumes"`.
-
-If the status is `InProgress`, the `Restore` CR logs are unavailable and no errors appear in the `Restic` pod logs.
-
-.Cause
-
-The `DeploymentConfig` object redeploys the `Restore` pod, causing the `Restore` CR to fail.
-
-.Solution
-
-. Create a `Restore` CR that excludes the `ReplicationController`, `DeploymentConfig`, and `TemplateInstances` resources:
-+
-[source,terminal]
-----
-$ velero restore create --from-backup=<backup> -n openshift-adp \ <1>
-  --include-namespaces <namespace> \ <2>
-  --exclude-resources replicationcontroller,deploymentconfig,templateinstances.template.openshift.io \
-  --restore-volumes=true
-----
-<1> Specify the name of the `Backup` CR.
-<2> Specify the `include-namespaces` in the `Backup` CR.
-
-. Verify that the status of the `Restore` CR is `Completed`:
-+
-[source,terminal]
-----
-$ oc get restore -n openshift-adp <restore> -o jsonpath='{.status.phase}'
-----
-
-. Create a `Restore` CR that includes the `ReplicationController` and `DeploymentConfig` resources:
-+
-[source,terminal]
-----
-$ velero restore create --from-backup=<backup> -n openshift-adp \
-  --include-namespaces <namespace> \
-  --include-resources replicationcontroller,deploymentconfig \
-  --restore-volumes=true
-----
-
-. Verify that the status of the `Restore` CR is `Completed`:
-+
-[source,terminal]
-----
-$ oc get restore -n openshift-adp <restore> -o jsonpath='{.status.phase}'
-----
-
-. Verify that the backup resources have been restored:
-+
-[source,terminal]
-----
-$ oc get all -n <namespace>
-----
-
 [id="restic-backup-cannot-be-recreated-after-s3-bucket-emptied_{context}"]
 == Restic Backup CR cannot be recreated after bucket is emptied
 


### PR DESCRIPTION
merge to 4.9+

OADP 693: Document restore of deploymentconfigs using restic and workaround with script
Resolves: https://issues.redhat.com/browse/OADP-693
OADP 1.1.1
Preview:
https://51834--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.html#oadp-creating-restore-cr_restoring-applications