### PR TITLE
OSDOCS-4346: Adds notes for 4.9.50 release'

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -3241,3 +3241,31 @@ $ oc adm release info 4.9.49 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-9-50"]
+=== RHSA-2022:6905 - {product-title} 4.9.50 bug fix and security update
+
+Issued: 2022-10-19
+
+{product-title} release 4.9.50, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:6905[RHSA-2022:6905] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:6903[RHBA-2022:6903] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.9.50 --pullspecs
+----
+
+[id="ocp-4-9-50-bug-fixes"]
+==== Bug fixes
+
+* Previously, in {product-title} 4.8, a change to the HAProxy configuration template caused the `accept-proxy` option not to set on all bind lines when the configuration has more than one bind. This resulted in proxy protocol to be enabled IPv6 and not IPv4. With this update, the HAProxy configuration template is set to `accept-proxy` on every bind line when proxy protocol is configured. Now, {product-title} enables proxy protocol for IPv6 and IPv4 on dual-stack clusters with proxy protocol configured. (link:https://issues.redhat.com/browse/OCPBUGS-1338[*OCPBUGS-1338*])
+
+* Previously, the Ingress Operator did not validate if a kubernetes service object in the `openshift-ingress` namespace was created by the Ingress Controller. Consequently, the Ingress Operator would modify or remove kubernetes services with the same name and namespace. With this update, the Ingress Operator displays an error message and does not modify or remove kubernetes services with the same name in the `openshift-ingress` namespace.  (link:https://issues.redhat.com/browse/OCPBUGS-1624[*OCPBUGS-1624*])
+
+* Previously, the `openshift-router` process dismissed the `SIGTERM` shutdown signal at runtime. Consequently, the container would ignore a kubernetes shutdown request resulting in the container taking approximately one hour to shut down. With this update, the `SIGTERM` handler in GO code is propagated to the cache initialization function, and the router now responds to `SIGTERM` signals during initialization. (link:https://issues.redhat.com/browse/OCPBUGS-1620[*OCPBUGS-1620*])
+
+[id="ocp-4-9-50-updating"]
+==== Updating
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4346](https://issues.redhat.com//browse/OSDOCS-4346): Adds notes for 4.9.50 release

Version(s):
4.9 only

Issue:
[OSDOCS-4346](https://issues.redhat.com/browse/OSDOCS-4346)

Link to docs preview (VPN required)
http://file.rdu.redhat.com/opayne/RN-4.9.50/release_notes/ocp-4-9-release-notes.html#ocp-4-9-50

QE review:
- [ ] QE has approved this change.
** This change does not require QE Review

Additional information:
Links to advisories will not work yet!
All suggestions welcome for the bug doc text for this release. Especially the first 2!

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
