### PR TITLE
[OCPBUGS-2544]: IPsec offering is east/west for intra-cluster traffic

### DIFF
--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -22,7 +22,7 @@ ifeval::["{context}" == "about-ovn-kubernetes"]
 
 |Hybrid networking|Supported|Not supported
 
-|IPsec encryption|Supported|Not supported
+|IPsec encryption for intra-cluster communication|Supported|Not supported
 
 |IPv6|Supported ^[3]^|Not supported
 


### PR DESCRIPTION
[OCPBUGS-2544](https://issues.redhat.com/browse/OCPBUGS-2544)

Version(s): 4.11+

Link to docs [preview](http://file.rdu.redhat.com/tlove/sdn-ocpbugs-2544-tlove/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html#nw-ovn-kubernetes-matrix_about-ovn-kubernetes)  (Updated 10/25)

[x] QE has approved this change.





 
