### PR TITLE
OSDOCS-4095: Adding timezone option to cron job config

### DIFF
--- a/modules/nodes-nodes-jobs-creating-cron.adoc
+++ b/modules/nodes-nodes-jobs-creating-cron.adoc
@@ -21,43 +21,45 @@ kind: CronJob
 metadata:
   name: pi
 spec:
-  schedule: "*/1 * * * *"  <1>
-  concurrencyPolicy: "Replace" <2>
-  startingDeadlineSeconds: 200 <3>
-  suspend: true            <4>
-  successfulJobsHistoryLimit: 3 <5>
-  failedJobsHistoryLimit: 1     <6>
-  jobTemplate:             <7>
+  schedule: "*/1 * * * *"          <1>
+  timeZone: Etc/UTC                <2>
+  concurrencyPolicy: "Replace"     <3>
+  startingDeadlineSeconds: 200     <4>
+  suspend: true                    <5>
+  successfulJobsHistoryLimit: 3    <6>
+  failedJobsHistoryLimit: 1        <7>
+  jobTemplate:                     <8>
     spec:
       template:
         metadata:
-          labels:          <8>
+          labels:                  <9>
             parent: "cronjobpi"
         spec:
           containers:
           - name: pi
             image: perl
             command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
-          restartPolicy: OnFailure <9>
+          restartPolicy: OnFailure <10>
 ----
 +
 <1> Schedule for the job specified in link:https://en.wikipedia.org/wiki/Cron[cron format]. In this example, the job will run every minute.
-<2> An optional concurrency policy, specifying how to treat concurrent jobs within a cron job. Only one of the following concurrent policies may be specified. If not specified, this defaults to allowing concurrent executions.
+<2> An optional time zone for the schedule. See link:https://en.wikipedia.org/wiki/List_of_tz_database_time_zones[List of tz database time zones] for valid options. If not specified, the Kubernetes controller manager interprets the schedule relative to its local time zone. This setting is offered as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview].
+<3> An optional concurrency policy, specifying how to treat concurrent jobs within a cron job. Only one of the following concurrent policies may be specified. If not specified, this defaults to allowing concurrent executions.
 * `Allow` allows cron jobs to run concurrently.
 * `Forbid` forbids concurrent runs, skipping the next run if the previous has not
 finished yet.
 * `Replace` cancels the currently running job and replaces
 it with a new one.
-<3> An optional deadline (in seconds) for starting the job if it misses its
+<4> An optional deadline (in seconds) for starting the job if it misses its
 scheduled time for any reason. Missed jobs executions will be counted as failed
 ones. If not specified, there is no deadline.
-<4> An optional flag allowing the suspension of a cron job. If set to `true`,
+<5> An optional flag allowing the suspension of a cron job. If set to `true`,
 all subsequent executions will be suspended.
-<5> The number of successful finished jobs to retain (defaults to 3).
-<6> The number of failed finished jobs to retain (defaults to 1).
-<7> Job template. This is similar to the job example.
-<8> Sets a label for jobs spawned by this cron job.
-<9> The restart policy of the pod. This does not apply to the job controller.
+<6> The number of successful finished jobs to retain (defaults to 3).
+<7> The number of failed finished jobs to retain (defaults to 1).
+<8> Job template. This is similar to the job example.
+<9> Sets a label for jobs spawned by this cron job.
+<10> The restart policy of the pod. This does not apply to the job controller.
 +
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.12

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
https://issues.redhat.com/browse/OSDOCS-4095

Link to docs preview:
https://51863--docspreview.netlify.app/openshift-enterprise/latest/nodes/jobs/nodes-nodes-jobs.html#nodes-nodes-jobs-creating-cron_nodes-nodes-jobs

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
