### PR TITLE
Slack: Replace Windows 2019 support for bare metal

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -18,18 +18,18 @@ The following table lists the link:https://docs.microsoft.com/en-us/windows/rele
 |Supported Windows Server version
 
 |Amazon Web Services (AWS)
-|Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)
+|Windows Server 2019, version 1809
 
 |Microsoft Azure
-a|* Windows Server 2022 Long-Term Servicing Channel (LTSC). OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later.
-* Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)
+a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+* Windows Server 2019, version 1809
 
 |VMware vSphere
-|Windows Server 2022 Long-Term Servicing Channel (LTSC). OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later.
+|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
 
 |Bare metal or provider agnostic
-a|* Windows Server 2022 Long-Term Servicing Channel (LTSC). OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later.
-* Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)
+a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+* Windows Server 2019, version 1809
 |===
 
 == Supported networking
@@ -63,10 +63,10 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Supported Windows Server version
 
 |Default VXLAN port
-a|* Windows Server 2022 Long-Term Servicing Channel (LTSC)
-* Windows Server 2019, version 1809 Long-Term Servicing Channel (LTSC)
+a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+* Windows Server 2019, version 1809
 
 |Custom VXLAN port
-|Windows Server 2022 Long-Term Servicing Channel (LTSC). OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later.
+|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
 
 |===


### PR DESCRIPTION
Per [Slack conversation](https://coreos.slack.com/archives/CM4ERHBJS/p1666209985400479), Windows 2019 is supported for bare metal installs. Was [removed in error](https://github.com/openshift/openshift-docs/pull/48535/files#diff-73ce6ce818bbc0c475ea75b2bc38368999148193b12f31299bb9daac55347377L30). Replacing in the docs.

Previews
[WMCO 6.0.0 supported platforms and Windows Server versions](https://51880--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-6-x.html#wmco-prerequisites-supported-6.0.0_windows-containers-release-notes)
[Supported networking](https://51880--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-6-x.html#wmco-prerequisites-supported-6.0.0_windows-containers-release-notes)