### PR TITLE
OSDOCS-3937: Configure HAProxy reload interval

### DIFF
--- a/modules/configuring-haproxy-interval.adoc
+++ b/modules/configuring-haproxy-interval.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+// * scalability_and_performance/routing-optimization.adoc
+// * post_installation_configuration/network-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="configuring-haproxy-interval_{context}"]
+= Configuring HAProxy reload interval
+
+When you update a route or an endpoint associated with a route, {product-title} router updates the configuration for HAProxy. Then, HAProxy reloads the updated configuration for those changes to take effect. When HAProxy reloads, it generates a new process that handles new connections using the updated configuration.
+
+HAProxy keeps the old process running to handle existing connections until those connections are all closed. When old processes have long-lived connections, these processes can accumulate and consume resources.
+
+The default minimum HAProxy reload interval is five seconds. You can configure an Ingress Controller using its `spec.tuningOptions.reloadInterval` field to set a longer minimum reload interval.
+
+[WARNING]
+====
+Setting a large value for the minimum HAProxy reload interval can cause latency in observing updates to routes and their endpoints. To lessen the risk, avoid setting a value larger than the tolerable latency for updates.
+====
+
+.Procedure
+
+* Change the minimum HAProxy reload interval of the default Ingress Controller to 15 seconds by running the following command:
++
+[source, terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontrollers/default --type=merge --patch='{"spec":{"tuningOptions":{"reloadInterval":"15s"}}}'
+----

--- a/modules/ingress-liveness-readiness-startup-probes.adoc
+++ b/modules/ingress-liveness-readiness-startup-probes.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+// * scalability_and_performance/routing-optimization.adoc
+// * post_installation_configuration/network-configuration.adoc
+
+:_content-type: REFERENCE
+[id="ingress-liveness-readiness-startup-probes_{context}"]
+= Configuring Ingress Controller liveness, readiness, and startup probes
+
+Cluster administrators can configure the timeout values for the kubelet's liveness, readiness, and startup probes for router deployments that are managed by the {product-title} Ingress Controller (router). The liveness and readiness probes of the router use the default timeout value
+of 1 second, which is too short for the kubelet's probes to succeed in some scenarios. Probe timeouts can cause unwanted router restarts that interrupt application connections. The ability to set larger timeout values can reduce the risk of unnecessary and unwanted restarts.
+
+You can update the `timeoutSeconds` value on the `livenessProbe`, `readinessProbe`, and `startupProbe` parameters of the router container.
+
+[cols="3a,8a",options="header"]
+|===
+ |Parameter |Description
+
+ |`livenessProbe`
+ |The `livenessProbe` reports to the kubelet whether a pod is dead and needs to be restarted.
+
+ |`readinessProbe`
+ |The `readinessProbe` reports whether a pod is healthy or unhealthy. When the readiness probe reports an unhealthy pod, then the kubelet marks the pod as not ready to accept traffic. Subsequently, the endpoints for that pod are marked as not ready, and this status propogates to the kube-proxy. On cloud platforms with a configured load balancer, the kube-proxy communicates to the cloud load-balancer not to send traffic to the node with that pod.
+
+ |`startupProbe`
+ |The `startupProbe` gives the router pod up to 2 minutes to initialize before the kubelet begins sending the router liveness and readiness probes.  This initialization time can prevent routers with many routes or endpoints from prematurely restarting.
+|===
+
+
+[IMPORTANT]
+====
+The timeout configuration option is an advanced tuning technique that can be used to work around issues. However, these issues should eventually be diagnosed and possibly a support case or https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&summary=Summary&issuetype=1&priority=10200&versions=12385624[Jira issue] opened for any issues that causes probes to time out.
+====
+
+The following example demonstrates how you can directly patch the default router deployment to set a 5-second timeout for the liveness and readiness probes:
+
+
+[source, terminal]
+----
+$ oc -n openshift-ingress patch deploy/router-default --type=strategic --patch='{"spec":{"template":{"spec":{"containers":[{"name":"router","livenessProbe":{"timeoutSeconds":5},"readinessProbe":{"timeoutSeconds":5}}]}}}}'
+----
+
+.Verification
+[source, terminal]
+----
+$ oc -n openshift-ingress describe deploy/router-default | grep -e Liveness: -e Readiness:
+    Liveness:   http-get http://:1936/healthz delay=0s timeout=5s period=10s #success=1 #failure=3
+    Readiness:  http-get http://:1936/healthz/ready delay=0s timeout=5s period=10s #success=1 #failure=3
+----

--- a/modules/router-performance-optimizations.adoc
+++ b/modules/router-performance-optimizations.adoc
@@ -2,53 +2,10 @@
 // * scalability_and_performance/routing-optimization.adoc
 // * post_installation_configuration/network-configuration.adoc
 
-:_content-type: Procedure
+:_content-type: CONCEPT
 [id="router-performance-optimizations_{context}"]
 = Ingress Controller (router) performance optimizations
 
 {product-title} no longer supports modifying Ingress Controller deployments by setting environment variables such as `ROUTER_THREADS`, `ROUTER_DEFAULT_TUNNEL_TIMEOUT`, `ROUTER_DEFAULT_CLIENT_TIMEOUT`, `ROUTER_DEFAULT_SERVER_TIMEOUT`, and `RELOAD_INTERVAL`.
 
 You can modify the Ingress Controller deployment, but if the Ingress Operator is enabled, the configuration is overwritten.
-
-== Configuring Ingress Controller liveness, readiness, and startup probes
-
-Cluster administrators can configure the timeout values for the kubelet's liveness, readiness, and startup probes for router deployments that are managed by the {product-title} Ingress Controller (router). The liveness and readiness probes of the router use the default timeout value
-of 1 second, which is too short for the kubelet's probes to succeed in some scenarios. Probe timeouts can cause unwanted router restarts that interrupt application connections. The ability to set larger timeout values can reduce the risk of unnecessary and unwanted restarts.
-
-You can update the `timeoutSeconds` value on the `livenessProbe`, `readinessProbe`, and `startupProbe` parameters of the router container.
-
-[cols="3a,8a",options="header"]
-|===
- |Parameter |Description
-
- |`livenessProbe`
- |The `livenessProbe` reports to the kubelet whether a pod is dead and needs to be restarted.
-
- |`readinessProbe`
- |The `readinessProbe` reports whether a pod is healthy or unhealthy. When the readiness probe reports an unhealthy pod, then the kubelet marks the pod as not ready to accept traffic. Subsequently, the endpoints for that pod are marked as not ready, and this status propogates to the kube-proxy. On cloud platforms with a configured load balancer, the kube-proxy communicates to the cloud load-balancer not to send traffic to the node with that pod.
-
- |`startupProbe`
- |The `startupProbe` gives the router pod up to 2 minutes to initialize before the kubelet begins sending the router liveness and readiness probes.  This initialization time can prevent routers with many routes or endpoints from prematurely restarting.
-|===
-
-
-[IMPORTANT]
-====
-The timeout configuration option is an advanced tuning technique that can be used to work around issues. However, these issues should eventually be diagnosed and possibly a support case or https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&summary=Summary&issuetype=1&priority=10200&versions=12385624[Jira issue] opened for any issues that causes probes to time out.
-====
-
-The following example demonstrates how you can directly patch the default router deployment to set a 5-second timeout for the liveness and readiness probes:
-
-
-[source, terminal]
-----
-$ oc -n openshift-ingress patch deploy/router-default --type=strategic --patch='{"spec":{"template":{"spec":{"containers":[{"name":"router","livenessProbe":{"timeoutSeconds":5},"readinessProbe":{"timeoutSeconds":5}}]}}}}'
-----
-
-.Verification
-[source, terminal]
-----
-$ oc -n openshift-ingress describe deploy/router-default | grep -e Liveness: -e Readiness:
-    Liveness:   http-get http://:1936/healthz delay=0s timeout=5s period=10s #success=1 #failure=3
-    Readiness:  http-get http://:1936/healthz/ready delay=0s timeout=5s period=10s #success=1 #failure=3
-----

--- a/post_installation_configuration/network-configuration.adoc
+++ b/post_installation_configuration/network-configuration.adoc
@@ -111,6 +111,8 @@ The {product-title} HAProxy router scales to optimize performance.
 include::modules/baseline-router-performance.adoc[leveloffset=+2]
 
 include::modules/router-performance-optimizations.adoc[leveloffset=+2]
+include::modules/ingress-liveness-readiness-startup-probes.adoc[leveloffset=+3]
+include::modules/configuring-haproxy-interval.adoc[leveloffset=+3]
 
 [id="post-installation-osp-fips"]
 == Post-installation {rh-openstack} network configuration

--- a/scalability_and_performance/routing-optimization.adoc
+++ b/scalability_and_performance/routing-optimization.adoc
@@ -13,3 +13,5 @@ include::modules/baseline-router-performance.adoc[leveloffset=+1]
 For more information on Ingress sharding, see xref:../networking/ingress-operator.adoc#nw-ingress-sharding-route-labels_configuring-ingress[Configuring Ingress Controller sharding by using route labels] and xref:../networking/ingress-operator.adoc#nw-ingress-sharding-namespace-labels_configuring-ingress[Configuring Ingress Controller sharding by using namespace labels].
 
 include::modules/router-performance-optimizations.adoc[leveloffset=+1]
+include::modules/ingress-liveness-readiness-startup-probes.adoc[leveloffset=+2]
+include::modules/configuring-haproxy-interval.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/OSDOCS-3937
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://51892--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/network-configuration.html#configuring-haproxy-interval_post-install-network-configuration

https://51892--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/routing-optimization.html#configuring-haproxy-interval_routing-optimization

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
