### PR TITLE
RHDEVDOCS-4473: rel notes odo 3.0

### DIFF
--- a/cli_reference/developer_cli_odo/odo-release-notes.adoc
+++ b/cli_reference/developer_cli_odo/odo-release-notes.adoc
@@ -1,74 +1,90 @@
 :_content-type: ASSEMBLY
 [id='odo-release-notes']
-= `{odo-title}` release notes
+= odo 3.0 release notes
 include::_attributes/common-attributes.adoc[]
 :context: odo-release-notes
 
 toc::[]
 
 [id="odo-notable-improvements_{context}"]
-== Notable changes and improvements in `{odo-title}` version 2.5.0
+== Notable changes and improvements in odo version 3.0
 
-// #5238
-* Creates unique routes for each component, using `adler32` hashing
-// #5252
-* Supports additional fields in the devfile for assigning resources:
-** cpuRequest
-** cpuLimit
-** memoryRequest
-** memoryLimit
-// #5276
-* Adds the `--deploy` flag to the `odo delete` command, to remove components deployed using the `odo deploy` command:
-+
-[source,terminal]
-----
-$ odo delete --deploy
-----
-// #5237
-* Adds mapping support to the `odo link` command
-// #5279
-* Supports ephemeral volumes using the `ephemeral` field in `volume` components
-// #5270
-* Sets the default answer to `yes` when asking for telemetry opt-in
-// #5260
-* Improves metrics by sending additional telemetry data to the devfile registry
-// #5287
-* Updates the bootstrap image to `registry.access.redhat.com/ocp-tools-4/odo-init-container-rhel8:1.1.11`
-// #5308
-* The upstream repository is available at link:https://github.com/redhat-developer/odo[]
+`odo` 3.0 includes new commands to improve the developer experience. These commands provide the same functionality as before, but in a faster and more efficient manner.
 
-
+For more information, see the section "Major highlights of odo 3.0" in xref:./understanding-odo.adoc#understanding-odo[Understanding odo].
 
 [id="odo-fixed-issues_{context}"]
-== Bug fixes
-// #5294
-* Previously, `odo deploy` would fail if the `.odo/env` file did not exist. The command now creates the `.odo/env` file if required.
-// #5286
-* Previously, interactive component creation using the `odo create` command would fail if disconnect from the cluster. This issue is fixed in the latest release.
+== Bug fixes in odo version 3.0
+
+* Before this update, `odo` did not honor directory entries in the `.gitignore` file, for example, `/target`. With this update, `odo` honors all `.gitignore` entries. 
+link:https://github.com/redhat-developer/odo/issues/4389[(odo-4389)]
+
+* Before this update, port names did not match endpoint names. With this update, `odo` ensures that the names match.
+link:https://github.com/redhat-developer/odo/issues/4737[(odo-4737)]
+
+* Before this update, when running the `odo deploy` command, variables defined in a devfile would not be substituted in URI-referenced deployment manifest YAML files. With this update, `odo` performs the variable substitution correctly.
+link:https://github.com/redhat-developer/odo/issues/5451[(odo-5451)]
+
+* Before this update, running the command `odo init --name <name> --devfile-path <path>` caused a panic to occur with a non-existent path. This update fixes the issue.
+link:https://github.com/redhat-developer/odo/issues/5540[(odo-5540)]
+
+* Before this update, `odo` commands ignored namespace settings in the `.odo/env/env.yaml` file. With this update, `odo` applies the namespace setting.
+link:https://github.com/redhat-developer/odo/issues/5544[(odo-5544)]
+
+* Before this update, running the `odo dev` command could fail after you deployed a component with the `odo deploy` command. This update fixes the issue.
+link:https://github.com/redhat-developer/odo/issues/5546[(odo-5546)]
+
+* Before this update, the `odo dev` command did not use the `.gitignore` file when synchronizing files to a container. With this update, `odo` uses the `.gitignore` file.
+link:https://github.com/redhat-developer/odo/issues/5581[(odo-5581)]
+
+* Before this update, the `odo deploy` and `odo build-images` commands did not work on Windows operating systems. With this update, `odo` can now build images on Windows.
+link:https://github.com/redhat-developer/odo/issues/5588[(odo-5588)]
+
+* Before this update, the `odo delete` command failed for Kubernetes components. This update fixes the issue.
+link:https://github.com/redhat-developer/odo/issues/5637[(odo-5637)]
+
+* With this update, `odo` now supports the `command` field in container components.
+link:https://github.com/redhat-developer/odo/issues/5648[(odo-5648)]
+
+* Before this update, when you stopped the `odo dev` process, resources created using `odo deploy` were removed. With this update, `odo` only deletes resources that were deployed using `odo dev`.
+link:https://github.com/redhat-developer/odo/issues/5700[(odo-5700)]
+
+* Before this update, `odo` would display volumes defined in the devfile as containers. This update fixes the issue.
+link:https://github.com/redhat-developer/odo/issues/5779[(odo-5779)]
+
+* Before this update, `odo` would save the component name in the `env.yaml` file. With this update, the component name is only specified in the devfile.
+link:https://github.com/redhat-developer/odo/issues/5780[(odo-5780)]
 
 
-[id="odo-getting-support_{context}"]
-== Getting support
+* Before this update, after terminating the `odo dev` command, `odo` would delete the `ServiceBinding` resource but the logs would have an entry stating `Failed to delete the ServiceBinding resource`. This update fixes the issue.
+link:https://github.com/redhat-developer/odo/issues/5797[(odo-5797)]
 
-.For Product
+* Before this update, if you ran the `odo dev` command on a white background terminal, the colours could look wrong or the content could be hard to read. With this update, the content is displayed correctly.
+link:https://github.com/redhat-developer/odo/issues/5843[(odo-5843)]
 
-If you find an error, encounter a bug, or have suggestions for improving the functionality of `{odo-title}`, file an issue in link:http://bugzilla.redhat.com[Bugzilla]. Choose *OpenShift Developer Tools and Services* as a product type and *odo* as a component.
+* Before this update, the `odo logs` command could be slow to respond in certain environments. With this update, the command responds as expected.
+link:https://github.com/redhat-developer/odo/issues/5872[(odo-5872)]
 
-Provide as many details in the issue description as possible.
+* Before this update, the `odo dev port forward` command might timeout if the application is not ready. This update fixes the issue.
+link:https://github.com/redhat-developer/odo/issues/5877[(odo-5877)]
 
-.For Documentation
+* Before this update, the `odo dev` command would output the message `Executing the application`, after cleaning up the resources. With this update, the message is no longer output.
+link:https://github.com/redhat-developer/odo/issues/5881[(odo-5881)]
 
-If you find an error or have suggestions for improving the documentation, file an issue in link:http://bugzilla.redhat.com[Bugzilla]. Choose the *{product-title}* product type and the *Documentation* component type.
+* Before this update, `odo` would not deploy `ServiceBinding` resources when you ran the `odo deploy` command. With this update, `ServiceBinding` resources are deployed correctly.
+link:https://github.com/redhat-developer/odo/issues/5883[(odo-5883)]
 
+* Before this update, if the `Ephemeral` preference was set to `false`, the persistent volume claim (PVC) would not be owned by the `Deployment` resource. This update fixes the issue.
+link:https://github.com/redhat-developer/odo/issues/5886[(odo-5886)]
 
+* Before this update, `odo` would send telemetry data even if the `ODO_DEBUG_TELEMETRY_FILE` environment variable was set. With this update, `odo` saves all telemetry data to a file when the variable is set.
+link:https://github.com/redhat-developer/odo/issues/5937[(odo-5937)]
 
+* Before this update, the output from some `odo` commands was inconsistent. This update fixes the issue.
+link:https://github.com/redhat-developer/odo/issues/5999[(odo-5999)]
 
+* Before this update, when running the `odo list` command, non-`odo` components would not be reported. With this update, `odo` reports all components for `odo list`.
+link:https://github.com/redhat-developer/odo/issues/6007[(odo-6007)]
 
-////
-[id="odo-known-issues_{context}"]
-== Known issues
-
-////
-
-//[id="odo-technology-preview_{context}"]
-//== Technology Preview features `{odo-title}`
+* Before this update, `odo` failed to execute the `run` command in the `java-quarkus` devfile. This update fixes the issue. 
+link:https://github.com/redhat-developer/odo/issues/6022[(odo-6022)]


### PR DESCRIPTION
Version(s):
4.8+


Issue:
https://issues.redhat.com/browse/RHDEVDOCS-4473

Link to docs preview:
https://51902--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/developer_cli_odo/odo-release-notes.html

QE review:
- [ ] QE has approved this change.


