### PR TITLE
Adds the 1.2.8 OMR release notes

### DIFF
--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -12,6 +12,16 @@ These release notes track the development of the _mirror registry for Red Hat Op
 For an overview of the _mirror registry for Red Hat OpenShift_, see xref:../../installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-flags_installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red Hat OpenShift].
 
 
+[id="mirror-registry-for-openshift-1-2-8"]
+== Mirror registry for Red Hat OpenShift 1.2.8
+
+_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.7.9.
+
+The following advisory is available for the _mirror registry for Red Hat OpenShift_:
+
+* link:https://access.redhat.com/errata/RHBA-2022:7065[RHBA-2022:7065 - mirror registry for Red Hat OpenShift 1.2.8]
+
+
 [id="mirror-registry-for-openshift-1-2-7"]
 == Mirror registry for Red Hat OpenShift 1.2.7
 


### PR DESCRIPTION
Adds the 1.2.8 OMR release notes

For 4.10+

Issue: https://issues.redhat.com/browse/OSDOCS-4390

No QE needed

Preview: https://51907--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-for-openshift-1-2-8