### PR TITLE
GH#51826 Updated array with - key for pods nodes 

### DIFF
--- a/modules/nw-metallb-operator-limit-speaker-to-nodes.adoc
+++ b/modules/nw-metallb-operator-limit-speaker-to-nodes.adoc
@@ -26,7 +26,7 @@ spec:
   nodeSelector:  <.>
     node-role.kubernetes.io/worker: ""
   speakerTolerations:   <.>
-    key: "Example"
+  - key: "Example"
     operator: "Exists"
     effect: "NoExecute"
 ----


### PR DESCRIPTION
Added "-" to correct an array for "Example configuration to limit speaker pods to worker nodes"

Version(s):
4.10+ (section appears starting in 4.10)

Issue:
(https://github.com/openshift/openshift-docs/issues/51826)

Link to docs preview:
https://51909--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-operator-install.html#nw-metallb-operator-limit-speaker-to-nodes_metallb-operator-install

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

