### PR TITLE
CNV-17511: Adding SSH command info to 4.8

### DIFF
--- a/modules/virt-copying-the-ssh-command.adoc
+++ b/modules/virt-copying-the-ssh-command.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virt-accessing-vm-consoles.adoc
+
+:_content-type: PROCEDURE
+[id="virt-copying-the-ssh-command_{context}"]
+= Copying the SSH command from the web console
+
+Copy the command to access a running virtual machine (VM) via SSH from the *Actions* list in the web console.
+
+.Procedure
+
+. In the {product-title} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Virtual Machines* tab.
+. Select a virtual machine to open the *Virtual Machine Overview* page.
+. From the *Actions* list, select *Copy SSH Command*. You can now paste this command onto the OpenShift CLI (`oc`).

--- a/virt/virtual_machines/virt-accessing-vm-consoles.adoc
+++ b/virt/virtual_machines/virt-accessing-vm-consoles.adoc
@@ -23,6 +23,8 @@ include::modules/virt-connecting-vnc-console.adoc[leveloffset=+2]
 
 include::modules/virt-vm-rdp-console-web.adoc[leveloffset=+2]
 
+include::modules/virt-copying-the-ssh-command.adoc[leveloffset=+2]
+
 [id="virt-accessing-vm-consoles-cli"]
 == Accessing virtual machine consoles by using CLI commands
 


### PR DESCRIPTION
Version(s): 4.6

Issue: https://issues.redhat.com/browse/CNV-17511

Link to docs preview: http://file.rdu.redhat.com/sjess/CNV17511C/virt/virtual_machines/virt-accessing-vm-consoles.html#virt-copying-the-ssh-command_virt-accessing-vm-consoles

QE review:
- [x] QE has approved this change. See: https://github.com/openshift/openshift-docs/pull/51750
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

