### PR TITLE
GH#51954 - Adding affinity rules to pod limitation documentation

### DIFF
--- a/modules/nw-metallb-operator-limit-speaker-to-nodes.adoc
+++ b/modules/nw-metallb-operator-limit-speaker-to-nodes.adoc
@@ -26,7 +26,7 @@ spec:
   nodeSelector:  <.>
     node-role.kubernetes.io/worker: ""
   speakerTolerations:   <.>
-    key: "Example"
+  - key: "Example"
     operator: "Exists"
     effect: "NoExecute"
 ----
@@ -36,4 +36,4 @@ spec:
 After you apply a manifest with the `spec.nodeSelector` field, you can check the number of pods that the Operator deployed with the `oc get daemonset -n metallb-system speaker` command.
 Similarly, you can display the nodes that match your labels with a command like `oc get nodes -l node-role.kubernetes.io/worker=`.
 
-You can optionally allow the node to control which speaker pods should, or should not, be scheduled on them by applying a list of tolerations. For more information about taints and tolerations, see the additional resources.
+You can optionally allow the node to control which speaker pods should, or should not, be scheduled on them by using affinity rules. You can also limit these pods by applying a list of tolerations. For more information about affinity rules, taints, and tolerations, see the additional resources.


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://github.com/openshift/openshift-docs/issues/51954

Link to docs preview:
https://51957--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-operator-install.html#nw-metallb-operator-limit-speaker-to-nodes_metallb-operator-install

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->