### PR TITLE
docs: removed Duplicate oc-edit in YAML code block

### DIFF
--- a/modules/cluster-logging-collector-limits.adoc
+++ b/modules/cluster-logging-collector-limits.adoc
@@ -19,7 +19,6 @@ $ oc -n openshift-logging edit ClusterLogging instance
 +
 [source,yaml]
 ----
-$ oc edit ClusterLogging instance
 
 apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogging"


### PR DESCRIPTION
Modified .adoc file to remove extra  `$ oc edit ClusterLogging instance` in 'enterprise-4.12' branch

Resolves: #51946 

Signed-off-by: Yashasvi Chaurasia <yashasvi12977@gmail.com>

