### PR TITLE
OSDOCS-4391 Adding shared VPC parameters to install config parameters

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -616,7 +616,8 @@ accounts for the dramatically decreased machine performance.
 |The only supported value is `3`, which is the default value.
 
 |`credentialsMode`
-|The Cloud Credential Operator (CCO) mode. If no mode is specified, the CCO dynamically tries to determine the capabilities of the provided credentials, with a preference for mint mode on the platforms where multiple modes are supported.
+|The Cloud Credential Operator (CCO) mode. If no mode is specified, the CCO dynamically tries to determine the capabilities of the provided credentials, with a preference for mint mode on the platforms where multiple modes are supported. 
+ifdef::gcp[If you are installing on GCP into a shared virtual private cloud (VPC), `credentialsMode` must be set to `Passthrough`.]
 [NOTE]
 ====
 Not all CCO modes are supported for all cloud providers. For more information about CCO modes, see the _Cloud Credential Operator_ entry in the _Cluster Operators reference_ content.
@@ -1112,7 +1113,11 @@ Additional GCP configuration parameters are described in the following table:
 |Parameter|Description|Values
 
 |`platform.gcp.network`
-|The name of the existing VPC that you want to deploy your cluster to.
+|The name of the existing Virtual Private Cloud (VPC) where you want to deploy your cluster. If you want to deploy your cluster into a shared VPC, you must set `platform.gcp.networkProjectID` with the name of the GCP project that contains the shared VPC.
+|String.
+
+|`platform.gcp.networkProjectID`
+|Optional. The name of the GCP project that contains the shared VPC where you want to deploy your cluster.
 |String.
 
 |`platform.gcp.projectID`
@@ -1124,12 +1129,32 @@ Additional GCP configuration parameters are described in the following table:
 |Any valid region name, such as `us-central1`.
 
 |`platform.gcp.controlPlaneSubnet`
-|The name of the existing subnet in your VPC that you want to deploy your control plane machines to.
+|The name of the existing subnet where you want to deploy your control plane machines.
 |The subnet name.
 
 |`platform.gcp.computeSubnet`
-|The name of the existing subnet in your VPC that you want to deploy your compute machines to.
+|The name of the existing subnet where you want to deploy your compute machines.
 |The subnet name.
+
+|`platform.gcp.createFirewallRules`
+|Optional. Set this value to `Disabled` if you want to create and manage your firewall rules using network tags. By default, the cluster will automatically create and manage the firewall rules that are required for cluster communication. Your service account must have `roles/compute.networkAdmin` and `roles/compute.securityAdmin` privileges in the host project to perform these tasks automatically. If your service account does not have the `roles/dns.admin` privilege in the host project, it must have the `dns.networks.bindPrivateDNSZone` permission.
+|`Enabled` or `Disabled`. The default value is `Enabled`.
+
+|`platform.gcp.publicDNSZone.project`
+|Optional. The name of the project that contains the public DNS zone. If you set this value, your service account must have the `roles/dns.admin` privilege in the specified project. If you do not set this value, it defaults to `gcp.projectId`.
+|The name of the project that contains the public DNS zone.
+
+|`platform.gcp.publicDNSZone.id`
+|Optional. The ID or name of an existing public DNS zone.  The public DNS zone domain must match the `baseDomain` parameter. If you do not set this value, the installation program will use a public DNS zone in the service project.
+|The public DNS zone name.
+
+|`platform.gcp.privateDNSZone.project`
+|Optional. The name of the project that contains the private DNS zone. If you set this value, your service account must have the `roles/dns.admin` privilege in the host project. If you do not set this value, it defaults to `gcp.projectId`.
+|The name of the project that contains the private DNS zone.
+
+|`platform.gcp.privateDNSZone.id`
+|Optional. The ID or name of an existing private DNS zone.  If you do not set this value, the installation program will create a private DNS zone in the service project.
+|The private DNS zone name.
 
 |`platform.gcp.licenses`
 |A list of license URLs that must be applied to the compute images.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-4391

Applies to 4.12.

Issue:
https://issues.redhat.com/browse/OSDOCS-4391

Link to docs preview:
https://51964--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-configuration-parameters-additional-gcp_installing-gcp-customizations

QE review:
- [X] QE has approved this change.