### PR TITLE
OCPBUGS#1487 - Updating oc mirror flag description

### DIFF
--- a/modules/oc-mirror-command-reference.adoc
+++ b/modules/oc-mirror-command-reference.adoc
@@ -65,7 +65,7 @@ The following tables describe the `oc mirror` subcommands and flags:
 |Ignore past mirrors when downloading images and packing layers. Disables incremental mirroring and might download more data.
 
 |`--manifests-only`
-|Generate manifests for `ImageContentSourcePolicy` and `CatalogSource` objects to configure a cluster to use the mirror registry, but do not actually mirror any images.
+|Generate manifests for `ImageContentSourcePolicy` objects to configure a cluster to use the mirror registry, but do not actually mirror any images.
 
 |`--max-per-registry <int>`
 |Specify the number of concurrent requests allowed per registry. The default is `6`.


### PR DESCRIPTION
Versions 4.11+

[OCPBUGS-1487](https://issues.redhat.com/browse/OCPBUGS-1487)

Removes mention of the Catalog Source object from the description of the --manifests only flag, since the flag does not generate that object (per the description of the Jira ticket)

Preview: https://51965--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected.html#oc-mirror-command-reference_installing-mirroring-disconnected