### PR TITLE
Updates the Web Console release notes to make notes for each perspective clear

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -59,23 +59,30 @@ For more information, see xref:../installing/installing-troubleshooting.adoc#ins
 [id="ocp-4-12-web-console"]
 === Web console
 
+[id="ocp-4-12-Administrator-perspective"]
+==== Administrator Perspective
+
+With this release, there are several updates to the *Administrator* perspective of the web console.
+
 [id="ocp-4-12-developer-perspective"]
 ==== Developer Perspective
 
-* With this update, you can export your application in the ZIP file format to another project or cluster by using the *Export application* option on the *+Add* page.
-* With this update, you can create a Kafka event sink to receive events from a particular source and send them to a Kafka topic.
-* With this update, you can set the default resource preference in the *User Preferences* -> *Applications* page. In addition, you can select another resource type to be the default.
-* With this update, you can make the `status.HostIP` node IP address for pods visible in the *Details* tab of the *Pods* page.
+With this release, there are several updates to the *Developer* perspective of the web console. You can perform the following actions:
+
+* Export your application in the ZIP file format to another project or cluster by using the *Export application* option on the *+Add* page.
+* Create a Kafka event sink to receive events from a particular source and send them to a Kafka topic.
+* Set the default resource preference in the *User Preferences* -> *Applications* page. In addition, you can select another resource type to be the default.
+* Make the `status.HostIP` node IP address for pods visible in the *Details* tab of the *Pods* page.
 
 [id="ocp-4-12-helm-page-improvements"]
-==== Helm page improvements
+===== Helm page improvements
 
-In {product-title} 4.12, the following improvements have been made in the *Helm* page:
+In {product-title} 4.12, you can do the following from the *Helm* page:
 
-* With this update, you can create Helm releases and repositories using the *Create* button.
-* With this update, you can create, update, or delete a cluster-scoped or a namespace-scoped Helm chart repository.
-* With this update, you can view the list of the existing Helm chart repositories with their scope in the *Repositories* page.
-* With this update, you can view the newly created Helm release in the *Helm Releases* page.
+* Create Helm releases and repositories using the *Create* button.
+* Create, update, or delete a cluster-scoped or a namespace-scoped Helm chart repository.
+* View the list of the existing Helm chart repositories with their scope in the *Repositories* page.
+* View the newly created Helm release in the *Helm Releases* page.
 
 [id="ocp-4-12-oc"]
 === OpenShift CLI (oc)


### PR DESCRIPTION
No related issue: Updates the Web Console release notes to make notes for each perspective clear

Version(s):
4.12 only

Link to docs preview:
https://51966--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-web-console

Additional information:
Included some edits to remove some parallelism

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
