### PR TITLE
[RHACS] Added a important note about failing central instances

### DIFF
--- a/release_notes/372-release-notes.adoc
+++ b/release_notes/372-release-notes.adoc
@@ -16,6 +16,13 @@ toc::[]
 |`3.72.1` |20 October 2022
 |====
 
+[IMPORTANT]
+====
+Because of an unexpected schema change in an upstream vulnerability feed on 20 October 2022, Red Hat published a corrupted CVE data file to https://definitions.stackrox.io, and many Central instances downloaded the corrupted file. As a result, when Central processes the corrupted feed data, it fails and enters a `CrashLoopBackOff` state. Although Red Hat has already taken steps to fix the corrupted CVE data file, already affected Central instances do not automatically get out of the `CrashLoopBackOff` state.
+
+To get Central back to working condition, follow the instructions at  link:https://access.redhat.com/articles/6981104[Central in CrashLoopBackOff - 2022-10-20 Incident].
+====
+
 [id="about-this-release-372"]
 == About this release
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-13233

- Added important admonition on top of the release notes.

Merge into `rhacs-docs`, and cherrypick into:
- `rhacs-docs-3.72`

Preview: https://openshift-docs-git-rox-13233-gnelson.vercel.app/openshift-acs/master/release_notes/372-release-notes.html