### PR TITLE
[rhacs-docs-3.71] Added a important note about failing central instances

### DIFF
--- a/release_notes/371-release-notes.adoc
+++ b/release_notes/371-release-notes.adoc
@@ -8,6 +8,12 @@ toc::[]
 
 {product-title} ({product-title-short}) is an enterprise-ready, Kubernetes-native container security solution that protects your vital applications across build, deploy, and runtime. It deploys in your infrastructure and integrates with your DevOps tooling and workflows to deliver better security and compliance and to enable DevOps and InfoSec teams to operationalize security.
 
+[IMPORTANT]
+====
+Because of an unexpected schema change in an upstream vulnerability feed on 20 October 2022, Red Hat published a corrupted CVE data file to https://definitions.stackrox.io, and many Central instances downloaded the corrupted file. As a result, when Central processes the corrupted feed data, it fails and enters a `CrashLoopBackOff` state. Although Red Hat has already taken steps to fix the corrupted CVE data file, already affected Central instances do not automatically get out of the `CrashLoopBackOff` state.
+To get Central back to working condition, follow the instructions at  link:https://access.redhat.com/articles/6981104[Central in CrashLoopBackOff - 2022-10-20 Incident].
+====
+
 [id="about-this-release-371"]
 
 {product-title-short} 3.71 includes:
@@ -22,9 +28,9 @@ toc::[]
 [options="header"]
 |====
 |{product-title-short} version |Released on
-|`3.70.0` |25 July 2022
-|`3.70.1` |5 October 2022
-|`3.70.2` |17 October 2022
+|`3.71.0` |25 July 2022
+|`3.71.1` |5 October 2022
+|`3.71.2` |17 October 2022
 |====
 
 [id="new-features-371"]


### PR DESCRIPTION
Based on https://github.com/openshift/openshift-docs/pull/51977 

Merge into `rhacs-docs-3.71`, no cherrypicks.