### PR TITLE
[rhacs-docs-3.70] Added a important note about failing central instances

### DIFF
--- a/release_notes/370-release-notes.adoc
+++ b/release_notes/370-release-notes.adoc
@@ -6,11 +6,22 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-- *Release date*: Version 3.70.0: 2 June 2022 +
-- *Release date*: Version 3.70.1: 22 June 2022 +
-- *Release date*: Version 3.70.2: 5 October 2022
+.Release dates
+[options="header"]
+|====
+|{product-title-short} version |Released on
+|`3.70.0` |2 June 2022
+|`3.70.1` |22 June 2022
+|`3.70.2` |5 October 2022
+|====
 
 {product-title} is an enterprise-ready, Kubernetes-native container security solution that protects your vital applications across build, deploy, and runtime. It deploys in your infrastructure and integrates with your DevOps tooling and workflows to deliver better security and compliance and to enable DevOps and InfoSec teams to operationalize security.
+
+[IMPORTANT]
+====
+Because of an unexpected schema change in an upstream vulnerability feed on 20 October 2022, Red Hat published a corrupted CVE data file to https://definitions.stackrox.io, and many Central instances downloaded the corrupted file. As a result, when Central processes the corrupted feed data, it fails and enters a `CrashLoopBackOff` state. Although Red Hat has already taken steps to fix the corrupted CVE data file, already affected Central instances do not automatically get out of the `CrashLoopBackOff` state.
+To get Central back to working condition, follow the instructions at  link:https://access.redhat.com/articles/6981104[Central in CrashLoopBackOff - 2022-10-20 Incident].
+====
 
 [id="about-this-release-370"]
 
@@ -176,7 +187,7 @@ Release date: 5 October 2022
 
 This release contains security updates to address the following common vulnerabilities and exposures (CVEs) in the base images:
 
-- link:https://access.redhat.com/security/cve/cve-2022-2526[CVE-2022-2526]: `systemd-resolved`: `use-after-free` when dealing with `DnsStream` in `resolved-dns-stream.c` 
+- link:https://access.redhat.com/security/cve/cve-2022-2526[CVE-2022-2526]: `systemd-resolved`: `use-after-free` when dealing with `DnsStream` in `resolved-dns-stream.c`
 
 - link:https://access.redhat.com/security/cve/cve-2022-29154[CVE-2022-29154]: `rsync`: remote arbitrary files write inside the directories of connecting peers
 


### PR DESCRIPTION
Based on https://github.com/openshift/openshift-docs/pull/51977 

Merge into `rhacs-docs-3.70`, no cherrypicks.