### PR TITLE
[rhacs-docs-3.69] Added a important note about failing central instances

### DIFF
--- a/release_notes/369-release-notes.adoc
+++ b/release_notes/369-release-notes.adoc
@@ -11,6 +11,12 @@ toc::[]
 - 3.69.1 Release date: April 6, 2022
 - 3.69.2 Release date: June 22, 2022
 
+[IMPORTANT]
+====
+Because of an unexpected schema change in an upstream vulnerability feed on 20 October 2022, Red Hat published a corrupted CVE data file to https://definitions.stackrox.io, and many Central instances downloaded the corrupted file. As a result, when Central processes the corrupted feed data, it fails and enters a `CrashLoopBackOff` state. Although Red Hat has already taken steps to fix the corrupted CVE data file, already affected Central instances do not automatically get out of the `CrashLoopBackOff` state.
+To get Central back to working condition, follow the instructions at  link:https://access.redhat.com/articles/6981104[Central in CrashLoopBackOff - 2022-10-20 Incident].
+====
+
 [id="new-features-369"]
 == New features
 


### PR DESCRIPTION
Based on https://github.com/openshift/openshift-docs/pull/51977 

Merge into `rhacs-docs-3.69`, no cherrypicks.