### PR TITLE
[RHACS] Fix invalid style issue in table

### DIFF
--- a/release_notes/372-release-notes.adoc
+++ b/release_notes/372-release-notes.adoc
@@ -98,7 +98,6 @@ In the table, features are marked with the following statuses:
 
 .Deprecated and removed features tracker
 [cols="1,2,1,1,1",options="header"]
-[source, adoc]
 |====
 |Category | Feature | {product-title-short} 3.70 |{product-title-short} 3.71 | {product-title-short} 3.72
 


### PR DESCRIPTION
Fixes the asciidoctor warning `asciidoctor: WARNING: 372-release-notes.adoc: line 101: invalid style for table block: source`

Merge into `rhacs-docs` and cherry-pick into `rhacs-docs-3.72`