### PR TITLE
Removing pipedream from the Vale script 

### DIFF
--- a/scripts/check-with-vale.sh
+++ b/scripts/check-with-vale.sh
@@ -15,30 +15,9 @@ if [ -n "${FILES}" ] ;
         if [ "$TRAVIS" = true ] ; then
             #clean out conditional markup in Travis CI
             sed -i -e 's/ifdef::.*\|ifndef::.*\|ifeval::.*\|endif::.*/ /' ${FILES}
-            echo ""
-            vale ${FILES} --glob='*.adoc' --no-exit
-            echo ""
-            set -x
-            #run vale again, and this time send to pipedream
-            PR_DATA=''
-            if [ "$1" == false ] ; then
-                PR_DATA='{"PR": [{"Number": "None", "SHA": "None"}],'
-            else
-                PR_DATA='{"PR": [{"Number": "'"$1"'", "SHA": "'"$2"'"}]',
-            fi
-            echo "${PR_DATA}" > vale_errors.json
-            ERROR_DATA=$(vale ${FILES} --minAlertLevel=error --glob='*.adoc' --output=JSON --no-exit)
-            echo "${ERROR_DATA:1}" >> vale_errors.json
-            LAST_LINE=$(tail -n1 vale_errors.json)
-            if echo "$LAST_LINE" | grep -q ',.$'; then
-                echo "No Vale errors."
-            else
-                curl -H "Content-Type: text/json" --data "@vale_errors.json" https://eox4isrzuh8pnai.m.pipedream.net
-            fi
+            vale ${FILES} --glob='*.adoc' --minAlertLevel=error --no-exit
         else
-            echo ""
-            vale ${FILES} --glob='*.adoc'
-            echo ""
+            vale ${FILES} --glob='*.adoc' --minAlertLevel=suggestion
         fi
     else
         echo "No asciidoc files added or modified."


### PR DESCRIPTION
Removing pipedream from build and setting vale level to errors in the build log.

example run: https://app.travis-ci.com/github/openshift/openshift-docs/jobs/586305867