### PR TITLE
TELCODOCS-492: RN to document support for provisioning IPv6 clusters from dual-stack hub clusters

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3186,3 +3186,7 @@ $ oc adm release info 4.12.2 --pullspecs
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 =======
+
+[id="ocp-4-12-nw-ipv6-spoke-cluster-support"]
+==== Support for provisioning IPv6 spoke clusters from dual-stack hub clusters
+With this update, you can provision IPv6 address spoke clusters from dual-stack hub clusters. In a zero touch provisioning (ZTP) environment, the HTTP server on the hub cluster that hosts the boot ISO now listens on both IPv4 and IPv6 networks. The provisioning service also checks the baseboard management controller (BMC) address scheme on the target spoke cluster and provides a matching URL for the installation media. These updates offer the ability to provision single-stack, IPv6 spoke clusters from a dual-stack hub cluster. 


### PR DESCRIPTION
[TELCODOCS-492](https://issues.redhat.com//browse/TELCODOCS-492): RN to document support for provisioning IPv6 spoke clusters from dual-stack hub clusters.

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/TELCODOCS-492

Link to docs preview:
http://file.emea.redhat.com/rohennes/TELCODOCS-492-rn/release_notes/ocp-4-12-release-notes.html#ocp-4-12-nw-ipv6-spoke-cluster-support

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
