### PR TITLE
OSDOCS-4369: Adding clarification about Private OpenShift cluster default behavior

### DIFF
--- a/modules/private-clusters-about.adoc
+++ b/modules/private-clusters-about.adoc
@@ -6,7 +6,10 @@
 [id="private-clusters-about_{context}"]
 = About private clusters
 
-By default, {product-title} is provisioned using publicly-accessible DNS and endpoints. You can set the DNS, Ingress Controller, and API server to private after you deploy your cluster.
+
+By default, {product-title} is provisioned using publicly-accessible DNS and endpoints. You can set the DNS, Ingress Controller, and API server to private after you deploy your private cluster. 
+
+include::snippets/snip-private-clusters-public-ingress.adoc[]
 
 [discrete]
 [id="private-clusters-about-dns_{context}"]

--- a/modules/private-clusters-default.adoc
+++ b/modules/private-clusters-default.adoc
@@ -40,8 +40,9 @@ Public zones are not supported in Route 53 in an AWS Top Secret Region. Therefor
 must be private if they are deployed to an AWS Top Secret Region.
 ====
 endif::aws-secret[]
-
 By default, {product-title} is provisioned to use publicly-accessible DNS and endpoints. A private cluster sets the DNS, Ingress Controller, and API server to private when you deploy your cluster. This means that the cluster resources are only accessible from your internal network and are not visible to the internet.
+
+include::snippets/snip-private-clusters-public-ingress.adoc[]
 
 To deploy a private cluster, you must:
 

--- a/post_installation_configuration/configuring-private-cluster.adoc
+++ b/post_installation_configuration/configuring-private-cluster.adoc
@@ -15,3 +15,5 @@ include::modules/private-clusters-setting-dns-private.adoc[leveloffset=+1]
 include::modules/private-clusters-setting-ingress-private.adoc[leveloffset=+1]
 
 include::modules/private-clusters-setting-api-private.adoc[leveloffset=+1]
+
+include::modules/nw-ingresscontroller-change-internal.adoc[leveloffset=+2]

--- a/snippets/snip-private-clusters-public-ingress.adoc
+++ b/snippets/snip-private-clusters-public-ingress.adoc
@@ -1,0 +1,12 @@
+// Text snippet included in the following modules:
+//
+// * modules/private-clusters-default.adoc
+// * modules/private-clusters-about.adoc
+// * modules/private-clusters-about-aws.adoc
+
+:_content-type: SNIPPET
+
+[IMPORTANT]
+====
+If the cluster has any public subnets, load balancer services created by administrators might be publicly accessible. To ensure cluster security, verify that these services are explicitly annotated as private.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.8+
<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-4369
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://52037--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-private-cluster.html
This update touches the default private install topic, which is re-used in multiple cloud platform installation assemblies:

- https://52037--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-private.html
- https://52037--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-private.html#private-clusters-default_installing-azure-private
- https://52037--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-private.html#private-clusters-default_installing-gcp-private

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
