### PR TITLE
OCPBUGS#391 - Fixing node_name description in procedure

### DIFF
--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -154,7 +154,7 @@ $ oc debug node/<node_name> -- chroot /host cat "<profile_path>" > config.nmconn
 --
 where:
 
-`<node_name>`:: Specifies the hardware MTU for the primary network interface.
+`<node_name>`:: Specifies the name of a node in your cluster.
 `<profile_path>`:: Specifies the file system path of the NetworkManager connection from the previous step.
 --
 +


### PR DESCRIPTION
Versions: 4.10+

[OCPBUGS-391](https://issues.redhat.com/browse/OCPBUGS-391)

fixes a "node_name" placeholder description to align it with other instances of the same placeholder description throughout the page

Preview: Changing the cluster MTU procedure, step 2, substep iv: https://52040--docspreview.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu.html#nw-cluster-mtu-change_changing-cluster-network-mtu