### PR TITLE
GH#5117 Updated cluster-logging-loki.adoc

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -579,6 +579,9 @@ AddType text/vtt                            vtt
     RewriteRule ^dedicated/support/summarizing-cluster-specifications.html /dedicated/osd_support/osd-summarizing-cluster-specifications.html [NE,R=301]
     RewriteRule ^dedicated/support/?(.*)$ /dedicated/osd_support/$1 [NE,R=301]
 
+    # Redirects for PTP changes delivered in https://github.com/openshift/openshift-docs/pull/35889
+    RewriteRule ^container-platform/(4\.9|4\.10|4\.11)/networking/configuring-ptp.html /container-platform/$1/networking/using-ptp.html [NE,R=302]
+
     # OCP specific redirects
     RewriteRule ^(container-platform|enterprise)/(3\.2|3\.3|3\.4|3\.5|3\.6|3\.7)/architecture/additional_concepts/throttling\.html(.*)$ /$1/$2/admin_guide/overcommit.html$3 [NE,L,R=301]
     RewriteRule ^(container-platform|enterprise)/(.[^/])/admin_guide/install/(advanced_install|deploy_router|docker_registry|first_steps|overview|prerequisites|quick_install|upgrades)\.html(.*)$ /$1/$2/install/$3.html$4 [NE,R=301]

--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -503,7 +503,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[&#10003;]
 |
 |
-|
+|xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[&#10003;]
 |xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[&#10003;]
 |
 |xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[&#10003;]

--- a/modules/cluster-logging-loki-deploy.adoc
+++ b/modules/cluster-logging-loki-deploy.adoc
@@ -101,12 +101,16 @@ oc apply -f logging-loki.yaml
   apiVersion: logging.openshift.io/v1
   kind: ClusterLogging
   metadata:
-    name: cr-lokistack
+    name: instance
     namespace: openshift-logging
   spec:
-     logStore:
+    managementState: Managed
+    logStore:
+       type: lokistack
        lokistack:
          name: logging-loki
+       collection: 
+         type: "vector"
 ----
 +
 .. Apply the configuration:

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -54,7 +54,7 @@ spec:
       freq_est_interval                  1
       dscp_event                         0
       dscp_general                       0
-      dataset_comparison                 ieee1588
+      dataset_comparison                 G.8275.x
       G.8275.defaultDS.localPriority     128
       #
       # Port Data Set


### PR DESCRIPTION
Updated the following:

 apiVersion: logging.openshift.io/v1
  kind: ClusterLogging
  metadata:
    name: cr-lokistack
    namespace: openshift-logging
  spec:
     logStore:
       lokistack:
         name: logging-loki

TO:

 apiVersion: logging.openshift.io/v1
kind: ClusterLogging
metadata:
  name: instance
  namespace: openshift-logging
spec:
  managementState: Managed
  logStore:
     type: lokistack
     lokistack:
       name: logging-loki

Also updated:
oc apply -f cr-lokistack.yaml

To:
oc apply -f instance.yaml


Version(s):
4.10+

Issue:
https://github.com/openshift/openshift-docs/issues/51817

Link to docs preview:
https://52041--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-loki.html#logging-loki-deploy_cluster-logging-loki

QE review:
- [x] QE has approved this change.
