### PR TITLE
TELCODOCS-799: Defining server hardware that supports IRQ affinity

### DIFF
--- a/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
+++ b/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
@@ -5,7 +5,13 @@
 [id="configuring_for_irq_dynamic_load_balancing_{context}"]
 = Configuring a node for IRQ dynamic load balancing
 
-To configure a cluster node to handle IRQ dynamic load balancing, do the following:
+Configure a cluster node for IRQ dynamic load balancing to control which cores can receive device interrupt requests (IRQ).
+
+.Prerequisites
+
+* For core isolation, all server hardware components must support IRQ affinity. For more information, see the _Additional resources_ section. 
+
+.Procedure
 
 . Log in to the {product-title} cluster as a user with cluster-admin privileges.
 . Set the performance profile `apiVersion` to use `performance.openshift.io/v2`.
@@ -177,3 +183,8 @@ Some IRQ controllers do not support IRQ re-balancing and will always expose all 
 ----
 $ cat /proc/irq/<irq-num>/effective_affinity
 ----
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#ref_hardware-compatibility-with-irq-affinity_cnf-master[Hardware compatibility with IRQ affinity]

--- a/modules/ref_hardware-compatibility-with-irq-affinity.adoc
+++ b/modules/ref_hardware-compatibility-with-irq-affinity.adoc
@@ -1,0 +1,121 @@
+// Module included in the following assemblies:
+//
+// scalability_and_performance/cnf-low-latency-tuning.adoc
+
+:_content-type: REFERENCE
+[id="ref_hardware-compatibility-with-irq-affinity_{context}"]
+= Hardware compatibility with IRQ affinity
+
+For core isolation, all server hardware components must support IRQ affinity. To check if the hardware components of your server support IRQ affinity, view the server's hardware specifications or contact your hardware provider. 
+
+{product-title} supports the following hardware devices for dynamic load balancing:
+
+.Supported network interface controllers
+[cols="1,2,1,1"]
+|===
+|Manufacturer |Model |Vendor ID | Device ID
+
+|Broadcom
+|BCM57414
+|14e4
+|16d7
+
+|Broadcom
+|BCM57508
+|14e4
+|1750
+
+|Intel
+|X710
+|8086
+|1572
+
+|Intel
+|XL710
+|8086
+|1583
+
+|Intel
+|XXV710
+|8086
+|158b
+
+|Intel
+|E810-CQDA2
+|8086
+|1592
+
+|Intel
+|E810-2CQDA2
+|8086
+|1592
+
+|Intel
+|E810-XXVDA2
+|8086
+|159b
+
+|Intel
+|E810-XXVDA4
+|8086
+|1593
+
+|Mellanox
+|MT27700 Family [ConnectX&#8209;4]
+|15b3
+|1013
+
+|Mellanox
+|MT27710 Family [ConnectX&#8209;4{nbsp}Lx]
+|15b3
+|1015
+
+|Mellanox
+|MT27800 Family [ConnectX&#8209;5]
+|15b3
+|1017
+
+|Mellanox
+|MT28880 Family [ConnectX&#8209;5{nbsp}Ex]
+|15b3
+|1019
+
+|Mellanox
+|MT28908 Family [ConnectX&#8209;6]
+|15b3
+|101b
+
+|Mellanox
+|MT28908 Family [ConnectX&#8209;6{nbsp}Lx]
+|15b3
+|101f
+
+|Mellanox
+|MT2892 Family [ConnectX&#8209;6{nbsp}Dx]
+|15b3
+|101d
+
+|Mellanox
+|MT42822 BlueField&#8209;2 in ConnectX&#8209;6 NIC mode
+|15b3
+|a2d6
+
+|Pensando
+|DSC-25 dual-port 25G distributed services card for ionic driver
+|0x1dd8
+|0x1002
+
+|Pensando
+|DSC-100 dual-port 100G distributed services card for ionic driver
+|0x1dd8
+|0x1003
+
+|Silicom
+|STS Family
+|8086
+|1591
+|===
+
+
+
+

--- a/scalability_and_performance/cnf-low-latency-tuning.adoc
+++ b/scalability_and_performance/cnf-low-latency-tuning.adoc
@@ -39,6 +39,8 @@ include::modules/cnf-allocating-multiple-huge-page-sizes.adoc[leveloffset=+2]
 
 include::modules/cnf-configure_for_irq_dynamic_load_balancing.adoc[leveloffset=+2]
 
+include::modules/ref_hardware-compatibility-with-irq-affinity.adoc[leveloffset=+3]
+
 include::modules/configuring_hyperthreading_for_a_cluster.adoc[leveloffset=+2]
 
 include::modules/cnf-understanding-workload-hints.adoc[leveloffset=+2]


### PR DESCRIPTION
[TELCODOCS-799](https://issues.redhat.com//browse/TELCODOCS-799): For core isolation, drivers for all HW components that form a server must adhere to IRQ affinity. That includes NICs, HW raid controllers, and any other devices. No list exists at present. For 4.12, we are starting the list by adding a table of compatible NICs.

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/TELCODOCS-799

Link to docs preview:

- http://file.emea.redhat.com/rohennes/TELCODOCS-799-hardware-affinity/scalability_and_performance/cnf-low-latency-tuning.html#configuring_for_irq_dynamic_load_balancing_cnf-master
- http://file.emea.redhat.com/rohennes/TELCODOCS-799-hardware-affinity/scalability_and_performance/cnf-low-latency-tuning.html#ref_hardware-compatibility-with-irq-affinity_cnf-master

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
