### PR TITLE
File Integrity Operator pod container permissions

### DIFF
--- a/modules/compliance-operator-cli-installation.adoc
+++ b/modules/compliance-operator-cli-installation.adoc
@@ -25,7 +25,7 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged <1>
   name: openshift-compliance
 ----
-<1> In {product-title} {product-version} with Compliance Operator version 0.1.53 or later, the pod security label must be set to `privileged` at the namespace level.
+<1> In {product-title} {product-version}, the pod security label must be set to `privileged` at the namespace level.
 
 . Create the `Namespace` object:
 +

--- a/modules/file-integrity-operator-installing-cli.adoc
+++ b/modules/file-integrity-operator-installing-cli.adoc
@@ -27,8 +27,10 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged <1>
   name: openshift-file-integrity
 ----
+<1> In {product-title} {product-version}, the pod security label must be set to `privileged` at the namespace level.
 
 . Create the `OperatorGroup` object YAML file:
 +


### PR DESCRIPTION
Version(s):
4.12+

Issue:
This is a part of [CMP-1619](https://issues.redhat.com/browse/CMP-1619), however these changes apply only to 4.12+ branches so it is a separate PR.

This change also mirrors https://github.com/openshift/openshift-docs/pull/51481/files

Link to docs preview:
[Installing the File Integrity Operator using the CLI](http://file.rdu.redhat.com/antaylor/FIO-pod-security/security/file_integrity_operator/file-integrity-operator-installation.html#installing-file-integrity-operator-using-cli_file-integrity-operator-installation)