### PR TITLE
OSDOCS-4072: adds ingress firewall node operator

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1024,6 +1024,9 @@ Topics:
 - Name: Understanding the Ingress Operator
   File: ingress-operator
   Distros: openshift-enterprise,openshift-origin
+- Name: Understanding the Ingress Node Firewall Operator
+  File: ingress-node-firewall-operator
+  Distros: openshift-enterprise,openshift-origin
 - Name: Configuring the Ingress Controller for manual DNS management
   File: ingress-controller-dnsmgt
   Distros: openshift-enterprise,openshift-origin

--- a/modules/nw-infw-operator-config-object.adoc
+++ b/modules/nw-infw-operator-config-object.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-node-firewall-operator.adoc
+
+:_content-type: CONCEPT
+[id="nw-infw-operator-config-object_{context}"]
+== Ingress Node Firewall configuration object
+
+The fields for the Ingress Node Firewall configuration object are described in the following table:
+
+.Ingress Node Firewall Configuration object
+[cols=".^2,.^2,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`metadata.name`
+|`string`
+|The name of the CR object. The name of the firewall rules object must be `ingressnodefirewallconfig`.
+
+|`metadata.namespace`
+|`string`
+|Namespace for the Ingress Firewall Operator CR object. The `IngressNodeFirewallConfig` CR must be created inside the `openshift-ingress-node-firewall` namespace.
+
+|`spec.nodeSelector`
+|`string`
+|
+A node selection constraint used to target nodes through specified node labels. For example:
+
+[source,yaml]
+----
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+----
+
+[NOTE]
+====
+One label used in `nodeSelector` must match a label on the nodes in order for the daemon set to start. For example, if the node labels `node-role.kubernetes.io/worker` and `node-type.kubernetes.io/vm` are applied to a node, then at least one label must be set using `nodeSelector` for the daemon set to start.
+====
+
+|====
+
+[NOTE]
+====
+The Operator consumes the CR and creates an ingress node firewall daemon set on all the nodes that match the `nodeSelector`.
+====
+
+[discrete]
+[id="nw-ingress-node-firewall-example-cr-2_{context}"]
+== Ingress Node Firewall Operator example configuration
+
+A complete Ingress Node Firewall Configuration is specified in the following example:
+
+.Example Ingress Node Firewall Configuration object
+[source,yaml]
+----
+apiVersion: ingressnodefirewall.openshift.io/v1alpha1
+kind: IngressNodeFirewallConfig
+metadata:
+  name: ingressnodefirewallconfig
+  namespace: openshift-ingress-node-firewall
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+----
+
+[NOTE]
+====
+The Operator consumes the CR and creates an ingress node firewall daemon set on all the nodes that match the `nodeSelector`.
+====

--- a/modules/nw-infw-operator-cr.adoc
+++ b/modules/nw-infw-operator-cr.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-node-firewall-operator.adoc
+
+:_content-type: CONCEPT
+[id="nw-infw-operator-cr_{context}"]
+= Ingress Node Firewall Operator
+
+The Ingress Node Firewall Operator provides ingress firewall rules at a node level by deploying the daemon set to nodes you specify and manage in the firewall configurations. To deploy the daemon set, you create an `IngressNodeFirewallConfig` custom resource (CR). The Operator applies the `IngressNodeFirewallConfig` CR to create ingress node firewall daemon set `daemon`, which run on all nodes that match the `nodeSelector`.
+
+You configure `rules` of the `IngressNodeFirewall` CR and apply them to clusters using the `nodeSelector` and setting values to "true".
+
+[IMPORTANT]
+====
+The Ingress Node Firewall Operator supports only stateless firewall rules.
+
+The maximum transmission units (MTU) parameter is 4Kb (kilobytes) in {product-title} {product-version}.
+
+Network interface controllers (NICs) that do not support native XDP drivers will run at a lower performance.
+====

--- a/modules/nw-infw-operator-deploying.adoc
+++ b/modules/nw-infw-operator-deploying.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-node-firewall-operator.adoc
+
+:_content-type: PROCEDURE
+[id="nw-infw-operator-deploying_{context}"]
+= Deploying Ingress Node Firewall Operator
+
+.Prerequisite
+* The Ingress Node Firewall Operator is installed.
+
+.Procedure
+
+To delploy the Ingress Node Firewall Operator, create a `IngressNodeFirewallConfig` custom resource that will deploy the Operator's daemon set. You can deploy one or multiple `IngressNodeFirewall` CRDs to nodes by applying firewall rules.
+
+. Create the `IngressNodeFirewallConfig` inside the `openshift-ingress-node-firewall` namespace named `ingressnodefirewallconfig`.
+
+. Run the following command to deploy Ingress Node Firewall Operator rules:
++
+[source,terminal]
+----
+$ oc apply -f rule.yaml
+----

--- a/modules/nw-infw-operator-installing.adoc
+++ b/modules/nw-infw-operator-installing.adoc
@@ -1,0 +1,151 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-node-firewall-operator.adoc
+
+:_content-type: PROCEDURE
+[id="installing-infw-operator_{context}"]
+= Installing the Ingress Node Firewall Operator
+
+As a cluster administrator, you can install the Ingress Node Firewall Operator by using the {product-title} CLI or the web console.
+
+[id="install-operator-cli_{context}"]
+== Installing the Ingress Node Firewall Operator using the CLI
+
+As a cluster administrator, you can install the Operator using the CLI.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You have an account with administrator privileges.
+
+.Procedure
+
+. To create the `openshift-ingress-node-firewall` namespace, enter the following command:
++
+[source,terminal]
+----
+$ cat << EOF| oc create -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: v1.24
+  name: openshift-ingress-node-firewall
+EOF
+----
+
+. To create an `OperatorGroup` CR, enter the following command:
++
+[source,terminal]
+----
+$ cat << EOF| oc create -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ingress-node-firewall-operators
+  namespace: openshift-ingress-node-firewall
+EOF
+----
+
+. Subscribe to the Ingress Node Firewall Operator.
+
+.. To create a `Subscription` CR for the Ingress Node Firewall Operator, enter the following command:
++
+[source,terminal]
+----
+$ cat << EOF| oc create -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ingress-node-firewall-sub
+  namespace: openshift-ingress-node-firewall
+spec:
+  name: ingress-node-firewall
+  channel: stable
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+----
+
+. To verify that the Operator is installed, enter the following command:
++
+[source,terminal]
+----
+$ oc get ip -n openshift-ingress-node-firewall
+----
++
+.Example output
+[source,terminal]
+----
+NAME            CSV                                         APPROVAL    APPROVED
+install-5cvnz   ingress-node-firewall.4.12.0-202211122336   Automatic   true
+----
+
+. To verify the version of the Operator, enter the following command:
+
++
+[source,terminal]
+----
+$ oc get csv -n openshift-ingress-node-firewall
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                        DISPLAY                          VERSION               REPLACES                                    PHASE
+ingress-node-firewall.4.12.0-202211122336   Ingress Node Firewall Operator   4.12.0-202211122336   ingress-node-firewall.4.12.0-202211102047   Succeeded
+----
+
+[id="install-operator-web-console_{context}"]
+== Installing the Ingress Node Firewall Operator using the web console
+
+As a cluster administrator, you can install the Operator using the web console.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You have an account with administrator privileges.
+
+.Procedure
+
+
+. Install the Ingress Node Firewall Operator:
+
+.. In the {product-title} web console, click *Operators* -> *OperatorHub*.
+
+.. Select *Ingress Node Firewall Operator* from the list of available Operators, and then click *Install*.
+
+.. On the *Install Operator* page, under *Installed Namespace*, select *Operator recommended Namespace*.
+
+.. Click *Install*.
+
+. Verify that the Ingress Node Firewall Operator is installed successfully:
+
+.. Navigate to the *Operators* -> *Installed Operators* page.
+
+.. Ensure that *Ingress Node Firewall Operator* is listed in the *openshift-ingress-node-firewall* project with a *Status* of *InstallSucceeded*.
++
+[NOTE]
+====
+During installation an Operator might display a *Failed* status.
+If the installation later succeeds with an *InstallSucceeded* message, you can ignore the *Failed* message.
+====
+
++
+If the Operator does not have a *Status* of *InstallSucceeded*, troubleshoot using the following steps:
+
++
+* Inspect the *Operator Subscriptions* and *Install Plans* tabs for any failures or errors under *Status*.
+* Navigate to the *Workloads* -> *Pods* page and check the logs for pods in the `openshift-ingress-node-firewall` project.
+* Check the namespace of the YAML file. If the annotation is missing, you can add the annotation `workload.openshift.io/allowed=management` to the Operator namespace with the following command:
++
+[source,terminal]
+----
+$ oc annotate ns/openshift-ingress-node-firewall workload.openshift.io/allowed=management
+----
++
+[NOTE]
+====
+For {sno} clusters, the `openshift-ingress-node-firewall` namespace requires the `workload.openshift.io/allowed=management` annotation.
+====

--- a/modules/nw-infw-operator-rules-object.adoc
+++ b/modules/nw-infw-operator-rules-object.adoc
@@ -1,0 +1,155 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-node-firewall-operator.adoc
+
+:_content-type: CONCEPT
+[id="nw-ingress-node-firewall-operator-rules-object_{context}"]
+= Ingress Node Firewall rules object
+
+The fields for the Ingress Node Firewall rules object are described in the following table:
+
+.Ingress Node Firewall rules object
+[cols=".^2,.^2,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`metadata.name`
+|`string`
+|The name of the CR object.
+
+|`interfaces`
+|`array`
+|The fields for this object specify the interfaces to apply the firewall rules to. For example, `- en0` and
+`- en1`.
+
+|`nodeSelector`
+|`array`
+|You can use `nodeSelector` to select the nodes to apply the firewall rules to. Set the value of your named `nodeselector` labels to `true` to apply the rule.
+
+|`ingress`
+|`object`
+|`ingress` allows you to configure the rules that allow outside access to the services on your cluster.
+|====
+
+[discrete]
+[id="nw-infw-ingress-rules-object_{context}"]
+=== Ingress object configuration
+
+The values for the `ingress` object are defined in the following table:
+
+.`ingress` object
+[cols=".^3,.^2,.^5a",options="header"]
+|====
+|Field|Type|Description
+
+|`sourceCIDRs`
+|`array`
+|Allows you to set the CIDR block. You can configure multiple CIDRs from different address families.
+
+[NOTE]
+====
+Different CIDRs allow you to use the same order rule. In the case that there are multiple `IngressNodeFirewall` objects for the same nodes and interfaces with overlapping CIDRs, the `order` field will specify which rule is applied first. Rules are applied in ascending order.
+====
+
+|`rules`
+|`array`
+|Ingress firewall `rules.order` objects are ordered starting at `1` for each `source.CIDR` with up to 100 rules per CIDR. Lower order rules are executed first.
+
+`rules.protocolConfig.protocol` supports the following protocols: TCP, UDP, SCTP, ICMP and ICMPv6. ICMP and ICMPv6 rules can match against ICMP and ICMPv6 types or codes. TCP, UDP, and SCTP rules can match against a single destination port or a range of ports using `<start : end-1>` format.
+
+Set `rules.action` to `allow` to apply the rule or `deny` to disallow the rule.
+
+[NOTE]
+====
+Ingress firewall rules are verified using a verification webhook that blocks any invalid configuration. The verification webhook prevents you from blocking any critical cluster services such as the API server or SSH.
+====
+|====
+
+[discrete]
+[id="nw-ingress-node-firewall-example-cr_{context}"]
+== Ingress Node Firewall rules object example
+
+A complete Ingress Node Firewall configuration is specified in the following example:
+
+.Example Ingress Node Firewall configuration
+[source,yaml]
+----
+apiVersion: ingressnodefirewall.openshift.io/v1alpha1
+kind: IngressNodeFirewall
+metadata:
+  name: ingressnodefirewall
+spec:
+  interfaces:
+  - eth0
+  nodeSelector:
+    matchLabels:
+      <do_node_ingress_firewall>: 'true'
+  ingress:
+  - sourceCIDRs:
+       - 172.16.0.0/12
+    rules:
+    - order: 10
+      protocolConfig:
+        protocol: ICMP
+        icmp:
+          icmpType: 8 #ICMP Echo request
+      action: Deny
+    - order: 20
+      protocolConfig:
+        protocol: TCP
+        tcp:
+          ports: "8000-9000"
+      action: Deny
+  - sourceCIDRs:
+       - fc00:f853:ccd:e793::0/64
+    rules:
+    - order: 10
+      protocolConfig:
+        protocol: ICMPv6
+        icmpv6:
+          icmpType: 128 #ICMPV6 Echo request
+      action: Deny
+----
+
+[discrete]
+[id="nw-ingress-node-firewall-zero-trust-example-cr_{context}"]
+== Zero trust Ingress Node Firewall rules object example
+
+Zero trust Ingress Node Firewall rules can provide additional security to multi-interface clusters. For example, you can use zero trust Ingress Node Firewall rules to drop all traffic on a specific interface except for SSH.
+
+A complete configuration of a zero trust Ingress Node Firewall rule set is specified in the following example:
+
+[IMPORTANT]
+====
+Users need to add all ports their application will use to their allowlist in the following case to ensure proper functionality.
+====
+
+.Example zero trust Ingress Node Firewall rules
+[source,yaml]
+----
+apiVersion: ingressnodefirewall.openshift.io/v1alpha1
+kind: IngressNodeFirewall
+metadata:
+ name: ingressnodefirewall-zero-trust
+spec:
+ interfaces:
+ - eth1 <1>
+ nodeSelector:
+   matchLabels:
+     <do_node_ingress_firewall>: 'true'
+ ingress:
+ - sourceCIDRs:
+      - 0.0.0.0/0 <2>
+   rules:
+   - order: 10
+     protocolConfig:
+       protocol: TCP
+       tcp:
+         ports: 22
+     action: Allow
+   - order: 20
+     action: Deny <3>
+----
+<1> Multi-interface cluster
+<2> `0.0.0.0/0` set to match any CIDR
+<3> `action` set to `deny`

--- a/modules/nw-infw-operator-troubleshooting.adoc
+++ b/modules/nw-infw-operator-troubleshooting.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-node-firewall-operator.adoc
+
+:_content-type: PROCEDURE
+[id="nw-infw-operator-troubleshooting_{context}"]
+= Troubleshooting the Ingress Node Firewall Operator
+
+* Run the following command to list installed Ingress Node Firewall custom resource definitions (CRD):
++
+[source,terminal]
+----
+$ oc get crds | grep ingressnodefirewall
+----
++
+.Example output
+[source,terminal]
+----
+NAME               READY   UP-TO-DATE   AVAILABLE   AGE
+ingressnodefirewallconfigs.ingressnodefirewall.openshift.io       2022-08-25T10:03:01Z
+ingressnodefirewallnodestates.ingressnodefirewall.openshift.io    2022-08-25T10:03:00Z
+ingressnodefirewalls.ingressnodefirewall.openshift.io             2022-08-25T10:03:00Z
+----
+
+* Run the following command to view the state of the Ingress Node Firewall Operator:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ingress-node-firewall
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                       READY  STATUS         RESTARTS  AGE
+ingress-node-firewall-controller-manager   2/2    Running        0         5d21h
+ingress-node-firewall-daemon-pqx56         3/3    Running        0         5d21h
+----
++
+The following fields provide information about the status of the Operator:
+`READY`, `STATUS`, `AGE`, and `RESTARTS`. The `STATUS` field is `Running` when the Ingress Node Firewall Operator is deploying a daemon set to the assigned nodes.
+
+* Run the following command to collect all ingress firewall node pods' logs:
++
+[source,terminal]
+----
+$ oc adm must-gather – gather_ingress_node_firewall
+----
++
+The logs are available in the sos node's report containing eBPF `bpftool` outputs at `/sos_commands/ebpf`. These reports include lookup tables used or updated as the ingress firewall XDP handles packet processing, updates statistics, and emits events.

--- a/modules/nw-infw-operator-viewing.adoc
+++ b/modules/nw-infw-operator-viewing.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-node-firewall-operator.adoc
+
+:_content-type: PROCEDURE
+[id="nw-infw-operator-viewing_{context}"]
+= Viewing Ingress Node Firewall Operator rules
+
+.Procedure
+
+. Run the following command to view all current rules :
++
+[source,terminal]
+----
+$ oc get ingressnodefirewall
+----
+
+. Choose one of the returned `<resource>` names and run the following command to view the rules or configs:
++
+[source,terminal]
+----
+$ oc get <resource> <name> -o yaml
+----

--- a/networking/ingress-node-firewall-operator.adoc
+++ b/networking/ingress-node-firewall-operator.adoc
@@ -1,0 +1,23 @@
+:_content-type: ASSEMBLY
+[id="ingress-node-firewall-operator"]
+= Ingress Node Firewall Operator in {product-title}
+include::_attributes/common-attributes.adoc[]
+:context: ingress-node-firewall-operator
+
+toc::[]
+
+The Ingress Node Firewall Operator allows administrators to manage firewall configurations at the node level.
+
+include::modules/nw-infw-operator-installing.adoc[leveloffset=+1]
+
+include::modules/nw-infw-operator-cr.adoc[leveloffset=+1]
+
+include::modules/nw-infw-operator-deploying.adoc[leveloffset=+1]
+
+include::modules/nw-infw-operator-config-object.adoc[leveloffset=+1]
+
+include::modules/nw-infw-operator-rules-object.adoc[leveloffset=+2]
+
+include::modules/nw-infw-operator-viewing.adoc[leveloffset=+1]
+
+include::modules/nw-infw-operator-troubleshooting.adoc[leveloffset=+1]

--- a/networking/networking-operators-overview.adoc
+++ b/networking/networking-operators-overview.adoc
@@ -23,3 +23,7 @@ When you create your {product-title} cluster, pods and services running on the c
 [id="networking-operators-overview-external-dns-operator"]
 == External DNS Operator
 The External DNS Operator deploys and manages ExternalDNS to provide the name resolution for services and routes from the external DNS provider to {product-title}. For more information, see xref:../networking/external_dns_operator/understanding-external-dns-operator.adoc#external-dns-operator[Understanding the External DNS Operator].
+
+[id="ingress-node-firewall-operator-1"]
+== Ingress Node Firewall Operator
+The Ingress Node Firewall Operator uses an extended Berkley Packet Filter (eBPF) and eXpress Data Path (XDP) plugin to process node firewall rules, update statistics and generate events for dropped traffic. The operator manages ingress node firewall resources, verifies firewall configuration, does not allow incorrectly configured rules that can prevent cluster access, and loads ingress node firewall XDP programs to the selected interfaces in the rule's object(s). For more information, see xref:../networking/ingress-node-firewall-operator.adoc#ingress-node-firewall-operator[Understanding the Ingress Node Firewall Operator]


### PR DESCRIPTION
[OSDOCS-4072](https://issues.redhat.com//browse/OSDOCS-4072): adds stateless ingress node firewall  operator
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
[Jira](https://issues.redhat.com/browse/OSDOCS-4006)

<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
Operator [Overview](https://52114--docspreview.netlify.app/openshift-enterprise/latest/networking/networking-operators-overview.html)
InFW [Operator](https://52114--docspreview.netlify.app/openshift-enterprise/latest/networking/ingress-node-firewall-operator.html#ingress-node-firewall-operator)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
@anuragthehatter @asood-rh  PTAL
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
