### PR TITLE
OSDOCS-3898: vSphere Topology Awareness

### DIFF
--- a/modules/persistent-storage-csi-vsphere-top-aware.adoc
+++ b/modules/persistent-storage-csi-vsphere-top-aware.adoc
@@ -1,0 +1,209 @@
+// Module included in the following assemblies:
+//
+// persistent-storage-csi-vsphere.adoc
+//
+
+:content-type: PROCEDURE
+[id="persistent-storage-csi-vsphere-top-aware_{context}"]
+= Configuring vSphere CSI Topology
+
+{product-title} provides the ability to deploy {product-title} for vSphere on different zones and regions, which allows you to deploy over multiple compute clusters, thus helping to avoid a single point of failure. 
+
+[NOTE]
+====
+{product-title} on vSphere does not support multiple Datacenters.
+====
+
+This is accomplished by defining zone and region categories in vCenter, and then assigning these categories to different failure domains, such as a compute cluster, by creating tags for these zone and region categories. After you have created the appropriate categories, and assigned tags to vCenter objects, you can create additional machinesets that create virtual machines (VMs) that are responsible for scheduling pods in those failure domains.
+
+.Procedure
+. In the VMware vCenter vSphere client GUI, define appropriate zone and region catagories and tags.
++
+While vSphere allows you to create categories with any arbitrary name, {product-title} strongly recommends use of `openshift-region` and `openshift-zone` names for defining topology.
++
+The following example defines two failure domains with one region and two zones:
++
+.vSphere topology with one region and two zones
+|===
+|Compute cluster | Failure domain |Description
+
+|Compute cluster: ocp1, 
+Datacenter: Atlanta
+|openshift-region: us-east-1 (tag), openshift-zone: us-east-1a (tag)
+|This defines a failure domain in region us-east-1 with zone us-east-1a.
+
+|Computer cluster: ocp2, 
+Datacenter: Atlanta
+|openshift-region: us-east-1 (tag), openshift-zone: us-east-1b (tag)
+|This defines a different failure domain within the same region called us-east-1b.
+|===
++
+For more information about vSphere categories and tags, see the VMware vSphere documentation.
+
+. To allow the container storage interface (CSI) driver to detect this topology, edit the `clusterCSIDriver` object YAML file `driverConfig` section:
+* Specify the `openshift-zone` and `openshift-region` categories that you created earlier.
+* Set `driverType` to `vSphere`.
++
+[source, terminal]
+----
+~ $ oc edit clustercsidriver csi.vsphere.vmware.com -o yaml
+----
++
+.Example output
++
+[source, terminal]
+----
+apiVersion: operator.openshift.io/v1
+kind: ClusterCSIDriver
+metadata:
+ name: csi.vsphere.vmware.com
+spec:
+ logLevel: Normal
+ managementState: Managed
+ observedConfig: null
+ operatorLogLevel: Normal
+ unsupportedConfigOverrides: null
+ driverConfig: 
+  driverType: vSphere <1>
+    vSphere:
+      topologyCategories: <2>
+      - openshift-zone
+      - openshift-region
+----
+<1> Ensure that `driverType` is set to `vSphere`.
+<2> `openshift-zone` and `openshift-region` categories created earlier in vCenter.
+
+. Verify that `CSINode` object has topology keys by running the following commands:
++
+[source, terminal]
+----
+~ $ oc get csinode
+----
++
+.Example output
++
+[source, terminal]
+----
+NAME                        DRIVERS     AGE
+co8-4s88d-infra-2m5vd       1           27m
+co8-4s88d-master-0          1           70m
+co8-4s88d-master-1          1           70m
+co8-4s88d-master-2          1           70m
+co8-4s88d-worker-j2hmg      1           47m
+co8-4s88d-worker-mbb46      1           47m
+co8-4s88d-worker-zlk7d      1           47m
+----
++
+[source, terminal]
+----
+~ $ oc get csinode co8-4s88d-worker-j2hmg -o yaml
+----
++
+.Example output
++
+[source, terminal]
+----
+...
+spec:
+    drivers:
+    - allocatable:
+        count: 59
+    name: csi-vsphere.vmware.com
+    nodeID: co8-4s88d-worker-j2hmg
+    topologyKeys: <1>
+    - topology.csi.vmware.com/openshift-zone
+    - topology.csi.vmware.com/openshift-region
+----
+<1> Topology keys from vSphere `openshift-zone` and `openshift-region` catagories.
++
+[NOTE]
+=====
+`CSINode` objects might take some time to receive updated topology information. After the driver is updated, `CSINode` objects should have topology keys in them.
+=====
+
+. Create a tag to assign to datastores across failure domains:
++
+When an {product-title} spans more than one failure domain, the datastore might not be shared across those failure domains, which is where topology-aware provisioning of persistent volumes (PVs) is useful. 
++
+.. In vCenter, create a category for tagging the datastores. For example, `openshift-zonal-datastore-cat`. You can use any other category name, provided the category uniquely is used for tagging datastores participating in {product-title} cluster. Also, ensure that `StoragePod`, `Datastore`, and `Folder` are selected as Associable Entities for the created category. 
+.. In vCenter, create a tag that uses the previously created category. This example uses the tag name `openshift-zonal-datastore`.
+.. Assign the previously created tag (in this example `openshift-zonal-datastore`) to each datastore in a failure domain that would be considered for dynamic provisioning.
++
+[NOTE]
+====
+You can use any names you like for categories and tags. The names used in this example are provided as recommendations. Ensure that the tags and categories that you define uniquely identify only datastores that are shared with all hosts in the {product-title} cluster.
+====
+
+. Create a storage policy that targets the tag-based datastores in each failure domain:
+.. In vCenter, from the main menu, click *Policies and Profiles*.
+.. On the *Policies and Profiles* page, in the navigation pane, click *VM Storage Policies*.
+.. Click *CREATE*.
+.. Type a name for the storage policy.
+.. For the rules, choose Tag Placement rules and select the tag and category that targets the desired datastores (in this example, the `openshift-zonal-datastore` tag).
++ 
+The datastores are listed in the storage compatibility table.
+
+. Create a new storage class that uses the new zoned storage policy:
+.. Click *Storage* > *StorageClasses*.
+.. On the *StorageClasses* page, click *Create StorageClass*.
+.. Type a name for the new storage class in *Name*.
+.. Under *Provisioner*, select *csi.vsphere.vmware.com*. 
+.. Under *Additional parameters*, for the StoragePolicyName parameter, set *Value* to the name of the new zoned storage policy that you created earlier.
+.. Click *Create*.
++
+.Example output
++
+[source, yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: zoned-sc <1>
+provisioner: csi.vsphere.vmware.com
+parameters:
+  StoragePolicyName: zoned-storage-policy <2>
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+----
+<1> New topology aware storage class name.
+<2> Specify zoned storage policy.
++
+[NOTE]
+====
+You can also create the storage class by editing the preceding YAML file and running the command `oc create -f $FILE`.
+====
+
+.Results
+Creating persistent volume claims (PVCs) and PVs from the topology aware storage class are truly zonal, and should use the datastore in their respective zone depending on how pods are scheduled:
+
+[source, terminal]
+----
+~ $ oc get pv <pv-name> -o yaml
+----
+
+.Example output
+
+[source, terminal]
+----
+...
+nodeAffinity:
+  required:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: topology.csi.vmware.com/openshift-zone <1>
+        operator: In  
+        values:
+        - <openshift-zone>
+      -key: topology.csi.vmware.com/openshift-region <1>
+        operator: In
+        values:
+        - <openshift-region>
+...
+peristentVolumeclaimPolicy: Delete
+storageClassName: <zoned-storage-class-name> <2>
+volumeMode: Filesystem
+...
+----
+<1> PV has zoned keys.
+<2> PV is using the zoned storage class.

--- a/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
@@ -48,5 +48,10 @@ To remove a third-party CSI driver, see xref:../../storage/container_storage_int
 
 include::modules/persistent-storage-csi-vsphere-install-issues.adoc[leveloffset=+1]
 
+include::modules/persistent-storage-csi-vsphere-top-aware.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vcenter-esxi-management/GUID-16422FF7-235B-4A44-92E2-532F6AED0923.html?hWord=N4IghgNiBcIC5gOYgL5A[VMware vSphere tag documenation]
+
 == Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/OSDOCS-3898
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://52116--docspreview.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

PM review: @gcharot
Engr review: @gnufied 
QE review: @duanwei33 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
