### PR TITLE
OCPBUGS-2524 correcting version numbers and adding variable substitution

### DIFF
--- a/modules/cnf-checking-numa-aware-scheduler-logs.adoc
+++ b/modules/cnf-checking-numa-aware-scheduler-logs.adoc
@@ -51,14 +51,14 @@ numaresourcesscheduler.nodetopology.openshift.io "numaresourcesscheduler" delete
 
 . Save the following YAML in the file `nro-scheduler-debug.yaml`. This example changes the log level to `Debug`:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: nodetopology.openshift.io/v1alpha1
 kind: NUMAResourcesScheduler
 metadata:
   name: numaresourcesscheduler
 spec:
-  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-container-rhel8:v4.10"
+  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-container-rhel8:v{product-version}"
   logLevel: Debug
 ----
 

--- a/modules/cnf-deploying-the-numa-aware-scheduler.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler.adoc
@@ -69,14 +69,14 @@ $ oc create -f nro-kubeletconfig.yaml
 
 .. Save the following YAML in the `nro-scheduler.yaml` file:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: nodetopology.openshift.io/v1alpha1
 kind: NUMAResourcesScheduler
 metadata:
   name: numaresourcesscheduler
 spec:
-  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-container-rhel8:v4.10"
+  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-container-rhel8:v{product-version}"
 ----
 
 .. Create the `NUMAResourcesScheduler` CR by running the following command:

--- a/modules/cnf-installing-numa-resources-operator-cli.adoc
+++ b/modules/cnf-installing-numa-resources-operator-cli.adoc
@@ -62,7 +62,7 @@ $ oc create -f nro-operatorgroup.yaml
 
 .. Save the following YAML in the `nro-sub.yaml` file:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -94,8 +94,8 @@ $ oc get csv -n openshift-numaresources
 +
 .Example output
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-NAME                            DISPLAY                      VERSION   REPLACES   PHASE
-numaresources-operator.v4.10.0  NUMA Resources Operator      4.10.0               Succeeded
+NAME                             DISPLAY                  VERSION   REPLACES   PHASE
+numaresources-operator.v{product-version}.2   numaresources-operator   {product-version}.2               Succeeded
 ----

--- a/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
+++ b/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
@@ -65,10 +65,10 @@ spec:
 +
 You can use the `ROLE_WORKER_CNF` variable to override the worker pool name:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e
-ROLE_WORKER_CNF=custom-worker-pool registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh
+ROLE_WORKER_CNF=custom-worker-pool registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 ----
 +
 [NOTE]
@@ -81,9 +81,9 @@ Currently, not all tests run selectively on the nodes belonging to the pool.
 
 Use this command to run in dry-run mode. This is useful for checking what is in the test suite and provides output for all of the tests the image would run.
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh -ginkgo.dryRun -ginkgo.v
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh -ginkgo.dryRun -ginkgo.v
 ----
 
 [id="cnf-performing-end-to-end-tests-disconnected-mode_{context}"]
@@ -102,9 +102,9 @@ A `mirror` executable is shipped in the image to provide the input required by `
 
 Run this command from an intermediate machine that has access both to the cluster and to link:https://catalog.redhat.com/software/containers/explore[registry.redhat.io] over the internet:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/mirror -registry my.local.registry:5000/ |  oc image mirror -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/mirror -registry my.local.registry:5000/ |  oc image mirror -f -
 ----
 
 Then, follow the instructions in the following section about overriding the registry used to fetch the images.
@@ -114,9 +114,9 @@ Then, follow the instructions in the following section about overriding the regi
 
 This is done by setting the `IMAGE_REGISTRY` environment variable:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY="my.local.registry:5000/" -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY="my.local.registry:5000/" -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 ----
 
 [id="cnf-performing-end-to-end-tests-mirroring-to-cluster-internal-registry_{context}"]
@@ -211,9 +211,9 @@ echo "{\"auths\": { \"$REGISTRY\": { \"auth\": $TOKEN } }}" > dockerauth.json
 
 . Do the mirroring:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true -a=$(pwd)/dockerauth.json -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true -a=$(pwd)/dockerauth.json -f -
 ----
 
 . Run the tests:
@@ -230,25 +230,25 @@ $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAG
 
 . The `mirror` command tries to mirror the u/s images by default. This can be overridden by passing a file with the following format to the image:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 [
     {
         "registry": "public.registry.io:5000",
-        "image": "imageforcnftests:4.11"
+        "image": "imageforcnftests:{product-version}"
     },
     {
         "registry": "public.registry.io:5000",
-        "image": "imagefordpdk:4.11"
+        "image": "imagefordpdk:{product-version}"
     }
 ]
 ----
 
 . Pass it to the `mirror` command, for example saving it locally as `images.json`. With the following command, the local path is mounted in `/kubeconfig` inside the container and that can be passed to the mirror command.
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/mirror --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" |  oc image mirror -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/mirror --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" |  oc image mirror -f -
 ----
 
 [id="cnf-performing-end-to-end-tests-running-in-single-node-cluster_{context}"]
@@ -340,9 +340,9 @@ Depending on the requirements, the tests can use different images. There are two
 
 For example, to change the `CNF_TESTS_IMAGE` with a custom registry run the following command:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 ----
 
 [id="cnf-performing-end-to-end-tests-ginkgo-parameters_{context}"]
@@ -352,18 +352,18 @@ The Ginkgo BDD (Behavior-Driven Development) framework serves as the base for th
 
 You can use the `-ginkgo.focus` parameter to filter a set of tests:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh -ginkgo.focus="performance|sctp"
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh -ginkgo.focus="performance|sctp"
 ----
 
 You can run only the latency test using the `-ginkgo.focus` parameter.
 
 To run only the latency test, you must provide the `-ginkgo.focus` parameter and the `PERF_TEST_PROFILE` environment variable that has the name of the `PerformanceProfile` that needs to be tested. For example:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run --rm -v $KUBECONFIG:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 -e PERF_TEST_PROFILE=<performance_profile_name> registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\[config\]|\[performance\]\ Latency\ Test"
+$ docker run --rm -v $KUBECONFIG:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 -e PERF_TEST_PROFILE=<performance_profile_name> registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\[config\]|\[performance\]\ Latency\ Test"
 ----
 
 [NOTE]
@@ -524,7 +524,7 @@ CLEAN_PERFORMANCE_PROFILE="false" registry.redhat.io/openshift-kni/cnf-tests /us
 
 If the `kubeconfig` file is in the current folder, you can run the test suite by using the following command:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e \
 DISCOVERY_MODE=true registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
@@ -1116,9 +1116,9 @@ CNF end-to-end tests produce two outputs: a JUnit test output and a test failure
 
 A JUnit-compliant XML is produced by passing the `--junit` parameter together with the path where the report is dumped:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh --junit /path/to/junit
+$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh --junit /path/to/junit
 ----
 
 [id="cnf-performing-end-to-end-tests-test-failure-report_{context}"]
@@ -1126,9 +1126,9 @@ $ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECO
 
 A report with information about the cluster state and resources for troubleshooting can be produced by passing the `--report` parameter with the path where the report is dumped:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/reportdest:/path/to/report -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh --report /path/to/report
+$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/reportdest:/path/to/report -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh --report /path/to/report
 ----
 
 [id="cnf-performing-end-to-end-tests-podman_{context}"]
@@ -1187,7 +1187,7 @@ When you configure reserved and isolated CPUs, the infra containers in pods use 
 
 To override the performance profile, the manifest must be mounted inside the container and the tests must be instructed by setting the `PERFORMANCE_PROFILE_MANIFEST_OVERRIDE`:
 
-[source,termal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 ----


### PR DESCRIPTION
[OCPBUGS-2524]:  Updating product version in appropriate places

Version(s):
  * PR applies to: 4.11, 4.12 and main
 
Issue:
https://issues.redhat.com/browse/OCPBUGS-2524 and https://issues.redhat.com/browse/OCPBUGS-2483

Link to docs preview:
https://52144--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-creating-nrop-cr_numa-aware

https://52144--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#installing-the-numa-resources-operator_numa-aware

QE review:
- [x] QE has approved this change.

NOTE:
SME and QE approved a simple update of version numbers replacing with variable {product-version}