### PR TITLE
OSDOCS-4396: remove restricted channel group option

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -77,9 +77,6 @@ $ rosa create cluster --cluster=<cluster_name> | <cluster_id> [arguments]
 |--cluster
 |Required: The name or ID (string) of the cluster. When used with the `create cluster` command, this argument is used to generate a sub-domain for your cluster on `openshiftapps.com`.
 
-|--channel-group
-|The channel group (string) is the name of the group where this image belongs, for example `stable` or `fast`. Default: `stable`
-
 |--compute-machine-type
 |The instance type (string) for the compute nodes. Determines the amount of memory and vCPU that are allocated to each compute node.
 

--- a/modules/rosa-list-objects.adoc
+++ b/modules/rosa-list-objects.adoc
@@ -405,15 +405,6 @@ List all of the OpenShift versions that are available for creating a cluster.
 $ rosa list versions [arguments]
 ----
 
-.Arguments
-[cols="30,70"]
-|===
-|Option |Definition
-
-|--channel-group
-|Lists only versions from the specified channel group (string). Default: `stable`
-|===
-
 .Optional arguments inherited from parent commands
 [cols="30,70"]
 |===


### PR DESCRIPTION
Version(s):
4.11, 4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4396

Link to docs preview:
**Create objects**: https://52152--docspreview.netlify.app/openshift-rosa/latest/rosa_cli/rosa-manage-objects-cli.html#rosa-create-objects_rosa-managing-objects-cli
**List and describe objects**: https://52152--docspreview.netlify.app/openshift-rosa/latest/rosa_cli/rosa-manage-objects-cli.html#rosa-list-objects_rosa-managing-objects-cli

No QE review required. 