### PR TITLE
OCPBUGS#2454 - Changing egress IP assignment description

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -179,7 +179,7 @@ When creating an `EgressIP` object, the following conditions apply to nodes that
 
 When a pod matches the selector for multiple `EgressIP` objects, there is no guarantee which of the egress IP addresses that are specified in the `EgressIP` objects is assigned as the egress IP address for the pod.
 
-Additionally, if an `EgressIP` object specifies multiple egress IP addresses, there is no guarantee which of the egress IP addresses might be assigned to a pod. For example, if a pod matches a selector for an `EgressIP` object with two egress IP addresses, `10.10.20.1` and `10.10.20.2`, either might be assigned to the pod.
+Additionally, if an `EgressIP` object specifies multiple egress IP addresses, there is no guarantee which of the egress IP addresses might be used. For example, if a pod matches a selector for an `EgressIP` object with two egress IP addresses, `10.10.20.1` and `10.10.20.2`, either might be used for each TCP connection or UDP conversation.
 
 [id="nw-egress-ips-node-architecture_{context}"]
 == Architectural diagram of an egress IP address configuration


### PR DESCRIPTION
Versions 4.6+

[OCPBUGS-2454](https://issues.redhat.com/browse/OCPBUGS-2454)

Per the description in the linked Jira ticket, the paragraph I modified seemed to be misleading about how egress ip addresses are used/assigned. This PR changes the description to what the reporter suggested in the ticket.

Preview: https://52168--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-node-assignment_configuring-egress-ips-ovn