### PR TITLE
OSDOCS-4341 GCP: Authenticate using Service Account on a GCP VM

### DIFF
--- a/installing/installing_gcp/installing-gcp-account.adoc
+++ b/installing/installing_gcp/installing-gcp-account.adoc
@@ -19,6 +19,11 @@ include::modules/installation-gcp-limits.adoc[leveloffset=+1]
 
 include::modules/installation-gcp-service-account.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* See xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-create-iam_manually-creating-iam-gcp[Manually creating IAM] for more details about using manual credentials mode.
+
 include::modules/installation-gcp-permissions.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-regions.adoc[leveloffset=+1]

--- a/modules/installation-gcp-limits.adoc
+++ b/modules/installation-gcp-limits.adoc
@@ -37,7 +37,7 @@ the bootstrap process and are removed after the cluster deploys.
 |Resources removed after bootstrap
 
 ifeval::["{context}" == "installing-gcp-account"]
-|Service account |IAM	|Global	|5 |0
+|Service account |IAM	|Global	|6 |1
 |Firewall rules	|Compute	|Global	|11 |1
 |Forwarding rules	|Compute	|Global	|2	|0
 |In-use global IP addresses	|Compute	|Global	|4	|1
@@ -54,7 +54,7 @@ ifeval::["{context}" == "installing-gcp-account"]
 endif::[]
 
 ifdef::template[]
-|Service account |IAM	|Global	|5 |0
+|Service account |IAM	|Global	|6 |1
 |Firewall rules	|Networking	|Global	|11 |1
 |Forwarding rules	|Compute	|Global	|2	|0
 // |In-use IP addresses global	|Networking	|Global	|4	|1

--- a/modules/installation-gcp-service-account.adoc
+++ b/modules/installation-gcp-service-account.adoc
@@ -30,8 +30,12 @@ See link:https://cloud.google.com/iam/docs/granting-roles-to-service-accounts#gr
 While making the service account an owner of the project is the easiest way to gain the required permissions, it means that service account has complete control over the project. You must determine if the risk that comes from offering that power is acceptable.
 ====
 
-. Create the service account key in JSON format.
-See link:https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys[Creating service account keys]
-in the GCP documentation.
+. You can create the service account key in JSON format, or attach the service account to a GCP virtual machine.
+See link:https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys[Creating service account keys] and link:https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances[Creating and enabling service accounts for instances] in the GCP documentation.
 +
-The service account key is required to create a cluster.
+You must have a service account key or a virtual machine with an attached service account to create the cluster.
++
+[NOTE]
+====
+If you use a virtual machine with an attached service account to create your cluster, you must set `credentialsMode: Manual` in the `install-config.yaml` file before installation.
+====

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -348,7 +348,7 @@ endif::azure,ash[]
 ifdef::gcp[]
 .. Select *gcp* as the platform to target.
 .. If you have not configured the service account key for your GCP account on
-your computer, you must obtain it from GCP and paste the contents of the file
+your host, you must obtain it from GCP and paste the contents of the file
 or enter the absolute path to the file.
 .. Select the project ID to provision the cluster in. The default value is
 specified by the service account that you configured.

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -77,7 +77,7 @@ the mirror host.
 endif::restricted[]
 ifndef::restricted[]
 ifdef::ibm-z,ibm-z-kvm[ your provisioning machine.]
-ifndef::ibm-z,ibm-z-kvm,private[ a local computer.]
+ifndef::ibm-z,ibm-z-kvm,private[ the host you are using for installation.]
 ifdef::private[]
 a bastion host on your cloud network or a machine that has access to the to the network through a VPN.
 

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -229,21 +229,6 @@ $ ssh-add <path>/<file_name> <1>
 Identity added: /home/<you>/<path>/<file_name> (<computer_name>)
 ----
 
-ifdef::gcp[]
-. Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the full path to your service account private key file.
-+
-[source,terminal]
-----
-$ export GOOGLE_APPLICATION_CREDENTIALS="<your_service_account_file>"
-----
-. Verify that the credentials were applied.
-+
-[source,terminal]
-----
-$ gcloud auth list
-----
-endif::gcp[]
-
 .Next steps
 
 * When you install {product-title}, provide the SSH public key to the installation program.


### PR DESCRIPTION
[OSDOCS-4341](https://issues.redhat.com/browse/OSDOCS-4341) / [CORS-2260](https://issues.redhat.com/browse/CORS-2260)

Applies to main and 4.12

Docs preview:
[Configuring a GCP project](https://52170--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-service-account_installing-gcp-account)
[Generating SSH key pair (removed unnecessary steps)](https://52170--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-default.html#ssh-agent-using_installing-gcp-default)
[Obtaining the installation program](https://52170--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-default.html#installation-obtaining-installer_installing-gcp-default)
[GCP account limits](https://52170--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-limits_installing-gcp-account)

QE review:
- [X] QE has approved this change.
