### PR TITLE
Adds the procedure to import manifest list

### DIFF
--- a/modules/importing-manifest-list-through-imagestreamimport.adoc
+++ b/modules/importing-manifest-list-through-imagestreamimport.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+// * openshift_images/image-streams-manage.adoc
+
+:_content-type: PROCEDURE
+[id="importing-manifest-list-through-imagestreamimport_{context}"]
+= Importing a manifest list through ImageStreamImport
+
+
+You can use the `ImageStreamImport` resource to find and import image manifests from other container image registries into the cluster. Individual images or an entire image repository can be imported. 
+
+Use the following procedure to import a manifest list through the `ImageStreamImport` object with the `importMode` value.  
+
+.Procedure
+
+. Create an `ImageStreamImport` YAML file and set the `importMode` parameter to `PreserveOriginal` on the tags that you will import as a manifest list:
++
+[source,yaml]
+----
+apiVersion: image.openshift.io/v1
+kind: ImageStreamImport
+metadata:
+  name: app
+  namespace: myapp
+spec:
+  import: true
+  images:
+  - from:
+      kind: DockerImage
+      name: <registry>/<user_name>/<image_name>
+    to:
+      name: latest
+    referencePolicy:
+      type: Source
+    importPolicy:
+      importMode: "PreserveOriginal"
+----
+
+. Create the `ImageStreamImport` by running the following command: 
++
+[source,terminal]
+----
+$ oc create -f <your_imagestreamimport.yaml>
+----
+

--- a/modules/importmode-configuration-fields.adoc
+++ b/modules/importmode-configuration-fields.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+// * assembly/openshift_images/managing-image-streams.adoc
+
+:_content-type: CONCEPT
+[id="importmode-configuration-fields_{context}"]
+= importMode configuration fields
+
+The following table describes the configuration fields available for the `importMode` value:
+
+[cols="3a,8a",options="header"]
+|===
+|Parameter |Description
+
+| *Legacy* | The default value for `importMode`. When active, the manifest list is discarded, and a single sub-manifest is imported. The platform is chosen in the following order of priority:
+
+. Tag annotations
+. Control plane architecture
+. Linux/AMD64
+. The first manifest in the list
+
+| *PreserveOriginal* | When active, the original manifest is preserved. For manifest lists, the manifest list and all of its sub-manifests are imported.
+
+|===

--- a/openshift_images/image-streams-manage.adoc
+++ b/openshift_images/image-streams-manage.adoc
@@ -31,3 +31,6 @@ include::modules/images-imagestream-import.adoc[leveloffset=+2]
 
 include::modules/images-imagestream-import-images-private-registry.adoc[leveloffset=+1]
 include::modules/images-allow-pods-to-reference-images-from-secure-registries.adoc[leveloffset=+2]
+
+include::modules/importing-manifest-list-through-imagestreamimport.adoc[leveloffset=+1]
+include::modules/importmode-configuration-fields.adoc[leveloffset=+2]


### PR DESCRIPTION
Adds the procedure to import manifest list

Versions: 4.12+

Issue: https://issues.redhat.com/browse/OSDOCS-4279

Pending QE/SME

Preview: https://52173--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/image-streams-manage.html#importing-manifest-list-through-imagestreamimport_image-streams-managing