### PR TITLE
OSDOCS-4411: Added instructions for troubleshooting a stuck cluster deletion

### DIFF
--- a/modules/rosa-deleting-sts-iam-resources-account-wide.adoc
+++ b/modules/rosa-deleting-sts-iam-resources-account-wide.adoc
@@ -14,5 +14,5 @@ If you no longer need to install a ROSA with STS cluster by using {cluster-manag
 ====
 The account-wide IAM roles and policies might be used by other ROSA clusters in the same AWS account. You must only remove the resources if they are not required by other clusters.
 
-The {cluster-manager} and user IAM roles are required if you want to install and manage other ROSA clusters in the same AWS account by using {cluster-manager}. You must only remove the roles if you no longer need to install ROSA clusters in your account by using {cluster-manager}.
+The {cluster-manager} and user IAM roles are required if you want to install, manage, and delete other ROSA clusters in the same AWS account by using {cluster-manager}. You must only remove the roles if you no longer need to install ROSA clusters in your account by using {cluster-manager}. See the "Additional resources" section for information on repairing your cluster if these roles are removed prior to deletion.
 ====

--- a/modules/rosa-troubleshooting-cluster-deletion.adoc
+++ b/modules/rosa-troubleshooting-cluster-deletion.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * rosa_support/rosa-troubleshooting-deployments.adoc
+:_content-type: PROCEDURE
+[id="rosa-troubleshooting-cluster-deletion_{context}"]
+= Repairing a cluster that cannot be deleted
+
+In specific cases, the following error appears in {cluster-manager-url} if you attempt to delete your cluster.
+
+[source,terminal]
+----
+Error deleting cluster
+CLUSTERS-MGMT-400: Failed to delete cluster <hash>: sts_user_role is not linked to your account. sts_ocm_role is linked to your organization <org number> which requires sts_user_role to be linked to your Red Hat account <account ID>.Please create a user role and link it to the account: User Account <account ID> is not authorized to perform STS cluster operations
+
+Operation ID: b0572d6e-fe54-499b-8c97-46bf6890011c
+----
+
+If you try to delete your cluster from the CLI, the following error appears.
+
+[source,terminal]
+----
+E: Failed to delete cluster <hash>: sts_user_role is not linked to your account. sts_ocm_role is linked to your organization <org_number> which requires sts_user_role to be linked to your Red Hat account <account_id>.Please create a user role and link it to the account: User Account <account ID> is not authorized to perform STS cluster operations
+----
+
+This error occurs when the `user-role` is unlinked or deleted.
+
+.Procedure
+
+. Run the following command to create the `user-role` IAM resource:
++
+[source,terminal]
+----
+$ rosa create user-role
+----
++
+. After you see that the role has been created, you can delete the cluster. The following confirms that the role was created and linked:
++
+[source,terminal]
+----
+I: Successfully linked role ARN <user role ARN> with account <account ID>
+----

--- a/rosa_install_access_delete_clusters/rosa-sts-deleting-cluster.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-deleting-cluster.adoc
@@ -35,3 +35,4 @@ include::modules/rosa-unlinking-and-deleting-ocm-and-user-iam-roles.adoc[levelof
 == Additional resources
 
 * For information about the AWS IAM resources for ROSA clusters that use STS, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for ROSA clusters that use STS].
+* For information on cluster errors that are due to missing IAM roles, see xref:../rosa_support/rosa-troubleshooting-deployments.adoc#rosa-troubleshooting-cluster-deletion_rosa-troubleshooting-cluster-deployments[Repairing a cluster that cannot be deleted].

--- a/rosa_planning/rosa-sts-ocm-role.adoc
+++ b/rosa_planning/rosa-sts-ocm-role.adoc
@@ -51,6 +51,12 @@ include::modules/rosa-sts-about-ocm-role.adoc[leveloffset=+1]
 include::modules/rosa-sts-ocm-role-creation.adoc[leveloffset=+2]
 include::modules/rosa-sts-about-user-role.adoc[leveloffset=+1]
 include::modules/rosa-sts-user-role-creation.adoc[leveloffset=+2]
+
+[IMPORTANT]
+====
+If you unlink or delete your `user-role` IAM role prior to deleting your cluster, an error prevents you from deleting your cluster. You must create or relink this role to proceed with the deletion process. See xref:../rosa_support/rosa-troubleshooting-deployments.adoc#rosa-troubleshooting-cluster-deletion_rosa-troubleshooting-cluster-deployments[Repairing a cluster that cannot be deleted] for more information.
+====
+
 include::modules/rosa-sts-aws-requirements-association-concept.adoc[leveloffset=+1]
 include::modules/rosa-sts-aws-requirements-creating-association.adoc[leveloffset=+2]
 include::modules/rosa-sts-aws-requirements-creating-multi-association.adoc[leveloffset=+2]

--- a/rosa_support/rosa-troubleshooting-deployments.adoc
+++ b/rosa_support/rosa-troubleshooting-deployments.adoc
@@ -11,3 +11,4 @@ This document describes how to troubleshoot cluster deployment errors.
 include::modules/rosa-troubleshooting-general-deployment.adoc[leveloffset=+1]
 include::modules/rosa-troubleshooting-osdccsadmin-deployment.adoc[leveloffset=+1]
 include::modules/rosa-troubleshooting-elb-service-role.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-cluster-deletion.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-4411](https://issues.redhat.com/browse/OSDOCS-4411)

Link to docs preview:

- [Repairing your cluster section](https://52174--docspreview.netlify.app/openshift-rosa/latest/rosa_support/rosa-troubleshooting-deployments.html#rosa-troubleshooting-cluster-deletion_rosa-troubleshooting-cluster-deployments)
- [Important Note](https://52174--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-deleting-cluster.html#rosa-deleting-sts-resources-account-wide_rosa-sts-deleting-cluster) referencing this new section
- [Additional resources](https://52174--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-deleting-cluster.html#additional-resources_rosa-sts-deleting-cluster) linking to this section
- Section containing [second important note](https://52174--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-ocm-role.html#rosa-sts-user-role-iam-basic-role_rosa-sts-ocm-role)

QE review:
- [x] QE has approved this change.

Additional information:
Added instructions for how to solve a stuck cluster deletion due to a lost user-role.