### PR TITLE
OSDOCS-4365: Added ability to enable a feature set during install

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -538,6 +538,10 @@ accounts for the dramatically decreased machine performance.
 |The number of compute machines, which are also known as worker machines, to provision.
 |A positive integer greater than or equal to `2`. The default value is `3`.
 
+|`featureSet`
+|Enables the cluster for a feature set. A feature set is a collection of {product-title} features that are not enabled by default. For more information about enabling a feature set during installation, see "Enabling features using feature gates".
+|String. The name of the feature set to enable, such as `TechPreviewNoUpgrade`.
+
 |`controlPlane`
 |The configuration for the machines that comprise the control plane.
 |Array of `MachinePool` objects.

--- a/modules/nodes-cluster-enabling-features-install.adoc
+++ b/modules/nodes-cluster-enabling-features-install.adoc
@@ -1,0 +1,89 @@
+// Module included in the following assemblies:
+//
+// * nodes/cluster/nodes-cluster-enabling-features.adoc
+
+:_content-type: PROCEDURE
+[id="nodes-cluster-enabling-features-install_{context}"]
+= Enabling feature sets at installation
+
+You can enable feature sets for all nodes in the cluster by editing the `install-config.yaml` file before you deploy the cluster.
+
+.Prerequisites
+
+* You have an `install-config.yaml` file.
+
+.Procedure
+
+. Use the `featureSet` parameter to specify the name of the feature set you want to enable, such as `TechPreviewNoUpgrade`:
++
+.Sample `install-config.yaml` file with an enabled feature set
+
+[source,yaml]
+----
+compute:
+- hyperthreading: Enabled
+  name: worker
+  platform:
+    aws:
+      rootVolume:
+        iops: 2000
+        size: 500
+        type: io1
+      metadataService:
+        authentication: Optional
+      type: c5.4xlarge
+      zones:
+      - us-west-2c
+  replicas: 3
+featureSet: TechPreviewNoUpgrade
+----
+
+. Save the file and reference it when using the installation program to deploy the cluster.
+
+[NOTE]
+====
+Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
+====
+
+.Verification
+
+You can verify that the feature gates are enabled by looking at the `kubelet.conf` file on a node after the cluster is installed.
+
+. Start a debug session for a node:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+. Change your root directory to the host:
++
+[source,terminal]
+----
+sh-4.2# chroot /host
+----
+
+. View the `kubelet.conf` file:
++
+[source,terminal]
+----
+sh-4.2# cat /etc/kubernetes/kubelet.conf
+----
++
+.Sample output
++
+[source,terminal]
+----
+ ...
+featureGates:
+  TechPreviewNoUpgrade: true,
+  LegacyNodeRoleBehavior: false
+ ...
+----
++
+The features that are listed as `true` are enabled on your cluster.
++
+[NOTE]
+====
+The features listed vary depending upon the {product-title} version.
+====

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -18,6 +18,8 @@ include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+1]
 ** xref:../../cicd/builds/build-strategies.adoc#builds-using-build-volumes_build-strategies-s2i[Source-to-image (S2I) build volumes] and xref:../../cicd/builds/build-strategies.adoc#builds-using-build-volumes_build-strategies-docker[Docker build volumes]
 ** xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-swap-memory_nodes-nodes-working[Swap memory on nodes]
 
+include::modules/nodes-cluster-enabling-features-install.adoc[leveloffset=+1]
+
 include::modules/nodes-cluster-enabling-features-console.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-enabling-features-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
This PR addresses [osdocs-4365](https://issues.redhat.com/browse/OSDOCS-4365). I (1) updated the optional installation configuration parameters, which are shared by all installation topics, to reference `featureSet`; and (2) updated "Enabling features using feature gates" to include the procedure for how to enable a feature set by updating the `install-config.yaml` file before deploying the cluster.

Link to docs preview:

- Installation configuration parameters > [Optional configuration parameters](https://52178--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-configuration-parameters-optional_installing-aws-customizations)
- [Enabling features using feature gates](https://52178--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html)
