### PR TITLE
Update obsolete links in Additional resources

### DIFF
--- a/virt/virt-additional-security-privileges-controller-and-launcher.adoc
+++ b/virt/virt-additional-security-privileges-controller-and-launcher.adoc
@@ -20,7 +20,7 @@ include::modules/virt-additional-scc-for-kubevirt-controller.adoc[leveloffset=+1
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-
-// these are RHEL 7 links; unsure if there is an equivalent in later versions //
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/virtualization_tuning_and_optimization_guide/sect-virtualization_tuning_optimization_guide-networking-techniques#sect-Virtualization_Tuning_Optimization_Guide-Networking-Multi-queue_virtio-net[Network multi-queue]
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/virtualization_tuning_and_optimization_guide/sect-virtualization_tuning_optimization_guide-memory-tuning#sect-Virtualization_Tuning_Optimization_Guide-Memory-Huge_Pages[Huge pages]
+* xref:../authentication/managing-security-context-constraints.adoc#security-context-constraints-about_configuring-internal-oauth[Managing security context constraints]
+* xref:../authentication/using-rbac.adoc#using-rbac[Using RBAC to define and apply permissions]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/monitoring_and_managing_system_status_and_performance/index#optimizing-virtual-machine-network-performance_optimizing-virtual-machine-performance-in-rhel[Optimizing virtual machine network performance] in the {op-system-base-full} documentation
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/monitoring_and_managing_system_status_and_performance/index#configuring-huge-pages_monitoring-and-managing-system-status-and-performance[Configuring huge pages] in the {op-system-base} documentation


### PR DESCRIPTION
Updating Additional Resources links in Security Policies assembly because Linux 7 links are obsolete and it is not clear that they were ever relevant.

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: No BZ or Jira
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Security policies](https://52184--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-additional-security-privileges-controller-and-launcher.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
