### PR TITLE
OCPBUGS#2788: Adding DHCP:flase to static IP snippet

### DIFF
--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -25,6 +25,7 @@ The following snippet statically configures an IP address on the Ethernet interf
       type: ethernet
       state: up
       ipv4:
+        dhcp: false
         address:
         - ip: 192.168.122.250 <1>
           prefix-length: 24
@@ -132,6 +133,7 @@ The following snippet configures a static route and a static IP on interface `et
       type: ethernet
       state: up
       ipv4:
+        dhcp: false
         address:
         - ip: 192.0.2.251 <1>
           prefix-length: 24


### PR DESCRIPTION
OCPBUGS-2788: Adding missing DHCP parameter for static IP snippet. 

Version(s):
4.8+ 

Issue:
https://issues.redhat.com/browse/OCPBUGS-2788

Link to docs preview:
https://52185--docspreview.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-nmstate-IP-management-static_k8s_nmstate-updating-node-network-config 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
