### PR TITLE
TELCODOCS-972 - update ptpClockThreshold description

### DIFF
--- a/modules/cnf-configuring-the-ptp-fast-event-publisher.adoc
+++ b/modules/cnf-configuring-the-ptp-fast-event-publisher.adoc
@@ -56,14 +56,11 @@ spec:
     phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16" <2>
     ptp4lConf: "" <3>
   ptpClockThreshold: <4>
-    holdOverTimeout: 5 <5>
-    maxOffsetThreshold: 100 <6>
-    minOffsetThreshold: -100 <7>
+    holdOverTimeout: 5
+    maxOffsetThreshold: 100
+    minOffsetThreshold: -100
 ----
 <1> Append `--summary_interval -4` to use PTP fast events.
 <2> Required `phc2sysOpts` values. `-m` prints messages to `stdout`. The `linuxptp-daemon` `DaemonSet` parses the logs and generates Prometheus metrics.
 <3> Specify a string that contains the configuration to replace the default /etc/ptp4l.conf file. To use the default configuration, leave the field empty.
-<4> Optional. If `ptpClockThreshold` stanza is not present, default values are used for `ptpClockThreshold` fields. Stanza shows default `ptpClockThreshold` values.
-<5> Number of seconds to stay in the clock holdover state. Holdover state is the period between local and master clock synchronizations.
-<6> Maximum offset value in nanoseconds. Offset is the time difference between the local and master clock.
-<7> Minimum offset value in nanoseconds.
+<4> Optional. If the `ptpClockThreshold` stanza is not present, default values are used for the `ptpClockThreshold` fields. The stanza shows default `ptpClockThreshold` values. The `ptpClockThreshold` values configure how long after the PTP master clock is disconnected before PTP events are triggered. `holdOverTimeout` is the time value in seconds before the PTP clock event state changes to `FREERUN` when the PTP master clock is disconnected. The `maxOffsetThreshold` and `minOffsetThreshold` settings configure offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`). When the `ptp4l` or `phc2sys` offset value is outside this range, the PTP clock state is set to `FREERUN`. When the offset value is within this range, the PTP clock state is set to `LOCKED`.

--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -10,7 +10,7 @@ You can configure the `linuxptp` services (`ptp4l`, `phc2sys`) as boundary clock
 
 [NOTE]
 ====
-Use the following example `PtpConfig` CR as the basis to `linuxptp` services as boundary clock for your particular hardware and environment. This example CR also configures PTP fast events by setting appropriate values for `ptp4lOpts`, `ptp4lConf` and `ptpClockThreshold`. `ptpClockThreshold` is used only when events are enabled.
+Use the following example `PtpConfig` CR as the basis to configure `linuxptp` services as the boundary clock for your particular hardware and environment. This example CR also configures PTP fast events by setting appropriate values for `ptp4lOpts`, `ptp4lConf`, and `ptpClockThreshold`. `ptpClockThreshold` is used only when events are enabled.
 ====
 
 .Prerequisites
@@ -167,7 +167,7 @@ spec:
 <10> Specify system config options for the `phc2sys` service. If this field is empty the PTP Operator does not start the `phc2sys` service.
 <11> Scheduling policy for ptp4l and phc2sys processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
 <12> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes when `ptpSchedulingPolicy` is set to `SCHED_FIFO`. The `ptpSchedulingPriority` field is not used when `ptpSchedulingPolicy` is set to `SCHED_OTHER`.
-<13> Optional. If `ptpClockThreshold` stanza is not present, default values are used for `ptpClockThreshold` fields. Stanza shows default `ptpClockThreshold` values.
+<13> Optional. If `ptpClockThreshold` stanza is not present, default values are used for `ptpClockThreshold` fields. Stanza shows default `ptpClockThreshold` values. `ptpClockThreshold` values configure how long after the PTP master clock is disconnected before PTP events are triggered. `holdOverTimeout` is the time value in seconds before the PTP clock event state changes to `FREERUN` when the PTP master clock is disconnected. The `maxOffsetThreshold` and `minOffsetThreshold` settings configure offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`). When the `ptp4l` or `phc2sys` offset value is outside this range, the PTP clock state is set to `FREERUN`. When the offset value is within this range, the PTP clock state is set to `LOCKED`.
 <14> Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
 <15> Specify the `profile` object name defined in the `profile` section.
 <16> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -10,7 +10,7 @@ You can configure `linuxptp` services (`ptp4l`, `phc2sys`) as ordinary clock by 
 
 [NOTE]
 ====
-Use the following example `PtpConfig` CR as the basis to `linuxptp` services as ordinary clock for your particular hardware and environment. This example CR also configures PTP fast events by setting appropriate values for `ptp4lOpts`, `ptp4lConf` and `ptpClockThreshold`. `ptpClockThreshold` is used only when events are enabled.
+Use the following example `PtpConfig` CR as the basis to configure `linuxptp` services as ordinary clock for your particular hardware and environment. This example CR also configures PTP fast events by setting appropriate values for `ptp4lOpts`, `ptp4lConf` and `ptpClockThreshold`. `ptpClockThreshold` is used only when events are enabled.
 ====
 
 .Prerequisites
@@ -161,7 +161,7 @@ spec:
 <9> For Intel Columbiaville 800 Series NICs, set `boundary_clock_jbod` to `0`.
 <10> Scheduling policy for `ptp4l` and `phc2sys` processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
 <11> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes when `ptpSchedulingPolicy` is set to `SCHED_FIFO`. The `ptpSchedulingPriority` field is not used when `ptpSchedulingPolicy` is set to `SCHED_OTHER`.
-<12> Optional. If `ptpClockThreshold` stanza is not present, default values are used for `ptpClockThreshold` fields. Stanza shows default `ptpClockThreshold` values.
+<12> Optional. If the `ptpClockThreshold` stanza is not present, default values are used for the `ptpClockThreshold` fields. The stanza shows default `ptpClockThreshold` values. The `ptpClockThreshold` values configure how long after the PTP master clock is disconnected before PTP events are triggered. `holdOverTimeout` is the time value in seconds before the PTP clock event state changes to `FREERUN` when the PTP master clock is disconnected. The `maxOffsetThreshold` and `minOffsetThreshold` settings configure offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`). When the `ptp4l` or `phc2sys` offset value is outside this range, the PTP clock state is set to `FREERUN`. When the offset value is within this range, the PTP clock state is set to `LOCKED`.
 <13> Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
 <14> Specify the `profile` object name defined in the `profile` section.
 <15> Set `priority` to `0` for ordinary clock.

--- a/modules/ztp-configuring-ptp-fast-events.adoc
+++ b/modules/ztp-configuring-ptp-fast-events.adoc
@@ -60,7 +60,7 @@ You can configure PTP fast events for vRAN clusters that are deployed using the 
 <2> Device specific interface name.
 <3> You must append the `--summary_interval -4` value to `ptp4lOpts` in `.spec.sourceFiles.spec.profile` to enable PTP fast events.
 <4> Required `phc2sysOpts` values. `-m` prints messages to `stdout`. The `linuxptp-daemon` `DaemonSet` parses the logs and generates Prometheus metrics.
-<5> `ptpClockThreshold` configues how long the clock stays in clock holdover state. Holdover state is the period between local and master clock synchronizations. Offset is the time difference between the local and master clock.
+<5> Optional. If the `ptpClockThreshold` stanza is not present, default values are used for the `ptpClockThreshold` fields. The stanza shows default `ptpClockThreshold` values. The `ptpClockThreshold` values configure how long after the PTP master clock is disconnected before PTP events are triggered. `holdOverTimeout` is the time value in seconds before the PTP clock event state changes to `FREERUN` when the PTP master clock is disconnected. The `maxOffsetThreshold` and `minOffsetThreshold` settings configure offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`). When the `ptp4l` or `phc2sys` offset value is outside this range, the PTP clock state is set to `FREERUN`. When the offset value is within this range, the PTP clock state is set to `LOCKED`.
 
 . Apply the following `PolicyGenTemplate` changes to your specific site YAML files, for example, `example-sno-site.yaml`:
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/TELCODOCS-972 by correcting ptpClockThreshold description in ZTP docs.

Merge to 4.9+

Preview: https://52188--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-configuring-ptp-fast-events_ztp-deploying-disconnected