### PR TITLE
OSDOCS-4117: Release note for IBM Cloud VPC GA

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -59,6 +59,12 @@ The installer now gathers serial console logs from the bootstrap and control pla
 
 For more information, see xref:../installing/installing-troubleshooting.adoc#installation-bootstrap-gather_installing-troubleshooting[Troubleshooting installation issues].
 
+[id="ocp-4-12-ibm-cloud-vpc"]
+==== IBM Cloud VPC general availability
+IBM Cloud VPC is now generally available in {product-title} {product-version}.
+
+For more information about installing a cluster, see xref:../installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc#preparing-to-install-on-ibm-cloud[Preparing to install on IBM Cloud VPC].
+
 [id="ocp-4-12-admin-ack-upgrading"]
 ==== Required administrator acknowledgment when upgrading from {product-title} 4.11 to 4.12
 
@@ -684,6 +690,11 @@ In the table below, features are marked with the following statuses:
 |TP
 |TP
 |TP
+
+|IBM Cloud VPC clusters
+|TP
+|TP
+|GA
 
 |Serverless functions
 |TP


### PR DESCRIPTION
Version(s):
4.12

Issue:
This PR address the release note to announce the general availability of IBM Cloud VPC. Related feature work includes:

- [osodcs-4117](https://issues.redhat.com/browse/OSDOCS-4117)
- [osdocs-4152](https://issues.redhat.com/browse/OSDOCS-4152)

Link to docs preview:

- [IBM Cloud VPC general availability](https://52189--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-ibm-cloud-vpc)
- [Technology Preview features](https://52189--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-technology-preview)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->