### PR TITLE
OCPBUGS#458 -  Fixing file type of OS image example

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1691,7 +1691,7 @@ Additional Nutanix configuration parameters are described in the following table
 
 |`platform.nutanix.clusterOSImage`
 |Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server and pointing the installation program to the image.
-|An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, \http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.ova
+|An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, \http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2
 |====
 [.small]
 --

--- a/modules/installation-nutanix-config-yaml.adoc
+++ b/modules/installation-nutanix-config-yaml.adoc
@@ -74,10 +74,10 @@ platform:
     subnetUUIDs:
     - c7938dc6-7659-453e-a688-e26020c68e43
 ifndef::openshift-origin[]
-    clusterOSImage: http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.ova <5>
+    clusterOSImage: http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2 <5>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-    clusterOSImage: http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.ova <5>
+    clusterOSImage: http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2 <5>
 endif::openshift-origin[]
 credentialsMode: Manual
 publish: External


### PR DESCRIPTION
Versions 4.11+

[OCPBUGS-458](https://issues.redhat.com/browse/OCPBUGS-458)

Per the description of the linked ticket, this PR changes the file type of the clusterOSImage parameter where mentioned throughout the page.

Previews
Table 4: https://52190--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#installation-configuration-parameters-additional-vsphere_installing-nutanix-installer-provisioned

Example yaml: https://52190--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#installation-nutanix-config-yaml_installing-nutanix-installer-provisioned