### PR TITLE
OCPBUGS#2890 Removing supported instance types from AWS UPI restricted doc

### DIFF
--- a/installing/installing_aws/installing-aws-secret-region.adoc
+++ b/installing/installing_aws/installing-aws-secret-region.adoc
@@ -46,7 +46,7 @@ include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
-include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 

--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -51,8 +51,6 @@ include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/csr-management.adoc[leveloffset=+2]
 
-include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
-
 include::modules/installation-aws-user-infra-requirements.adoc[leveloffset=+1]
 
 include::modules/installation-aws-permissions.adoc[leveloffset=+2]

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -69,8 +69,6 @@ include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/csr-management.adoc[leveloffset=+2]
 
-include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
-
 include::modules/installation-aws-user-infra-requirements.adoc[leveloffset=+1]
 
 include::modules/installation-aws-permissions.adoc[leveloffset=+2]

--- a/modules/installation-aws-tested-machine-types.adoc
+++ b/modules/installation-aws-tested-machine-types.adoc
@@ -5,6 +5,7 @@
 // installing/installing_aws/installing-aws-government-region.adoc
 // installing/installing_aws/installing-aws-network-customizations.adoc
 // installing/installing_aws/installing-aws-private.adoc
+// installing/installing_aws/installing-aws-secret-region.adoc
 // installing/installing_aws/installing-aws-user-infra.adoc
 // installing/installing_aws/installing-aws-vpc.adoc
 // installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -12,6 +13,9 @@
 
 ifeval::["{context}" == "installing-aws-localzone"]
 :localzone:
+endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:secretregion:
 endif::[]
 
 [id="installation-aws-tested-machine-types_{context}"]
@@ -30,13 +34,13 @@ endif::localzone[]
 Use the machine types included in the following charts for your AWS instances. If you use an instance type that is not listed in the chart, ensure that the instance size you use matches the minimum resource requirements that are listed in "Minimum resource requirements for cluster installation".
 ====
 
-ifndef::localzone[]
+ifndef::localzone,secretregion[]
 .Machine types based on 64-bit x86 architecture
 [%collapsible]
 ====
 include::https://raw.githubusercontent.com/openshift/installer/master/docs/user/aws/tested_instance_types_x86_64.md[]
 ====
-endif::localzone[]
+endif::localzone,secretregion[]
 ifdef::localzone[]
 .Machine types based on 64-bit x86 architecture for AWS Local Zones
 [%collapsible]
@@ -49,7 +53,24 @@ ifdef::localzone[]
 * `t3.*`
 ====
 endif::localzone[]
+ifdef::secretregion[]
+.Machine types based on 64-bit x86 architecture for secret regions
+[%collapsible]
+====
+* `c4.*`
+* `c5.*`
+* `i3.*`
+* `m4.*`
+* `m5.*`
+* `r4.*`
+* `r5.*`
+* `t3.*`
+====
+endif::secretregion[]
 
 ifeval::["{context}" == "installing-aws-localzone"]
 :!localzone:
+endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:!secretregion:
 endif::[]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-2890

The "supported instance types" module was replaced by "tested instance types" in https://github.com/openshift/openshift-docs/pull/49799, but was not removed from the UPI, Secret regions, and restricted UPI docs.

Applies to 4.10+ 

Doc preview:
[Secret region](https://52199--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-secret-region.html#installation-aws-tested-machine-types_installing-aws-secret-region)
[Restricted UPI](https://52199--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws.html#installation-aws-tested-machine-types_installing-restricted-networks-aws)
[UPI](https://52199--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-aws-tested-machine-types_installing-aws-user-infra)

QE review:
- [x] QE has approved this change.