### PR TITLE
OCP 4.12 : Cloud Controller Manager Doc updates for P

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -12,7 +12,7 @@
 ====
 This Operator is only fully supported for Microsoft Azure Stack Hub.
 
-It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), IBM Cloud, Microsoft Azure, {rh-openstack-first}, and VMware vSphere.
+It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), IBM Cloud, IBM Cloud Power VS, Microsoft Azure, {rh-openstack-first}, and VMware vSphere.
 ====
 
 The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).


### PR DESCRIPTION
Preview : https://52209--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-cloud-controller-manager-operator_cluster-operators-ref

Reviewers :
Manjunath Kumatagi

Branch : enterprise-4.12 and later