### PR TITLE
RHDEVDOCS-4111 - Added deployment history details

### DIFF
--- a/modules/go-health-monitoring.adoc
+++ b/modules/go-health-monitoring.adoc
@@ -17,9 +17,9 @@ The {gitops-title} Operator will install the GitOps backend service in the `open
 
 . Click on the application name from the list to view the details of a specific application.
 
-. If the application is `out of sync` or `degraded` applications the respecting icons are displayed under the *Resources*. Hover over the icons to see the health status and the sync status. The icons are:
+. If the application is out of sync or degraded, icons are displayed under *Resources* section. Hover over the icons to see health status and sync status. The icons are:
 
-.. For `degraded`, the broken heart icon is displayed.
-.. For `out of sync`, the yellow yield icon is displayed.
+.. For degraded status, the broken heart icon is displayed.
+.. For out of sync status, the yellow yield icon is displayed.
 
-. Click on the *Deployment History* tab to view the application deployment history. The page includes details such as, *Last deployment*, *Description* (commit message), *Environment*, *Outcome* (Succeeded/Failed), *Author* and *Revision*.
+. To view the deployment history of an application, click the *Deployment History* tab. The page includes details such as, *Last deployment*, *Description* (commit message), *Environment*, *Outcome (Succeeded/Failed)*, *Author* and *Revision*.

--- a/modules/go-health-monitoring.adoc
+++ b/modules/go-health-monitoring.adoc
@@ -15,11 +15,10 @@ The {gitops-title} Operator will install the GitOps backend service in the `open
 
 . Hover over the icons under the *Environment status* column to see the synchronization status of all the environments.
 
-. Click on the application name from the list to view the details of a specific application.
+. Click the application name from the list to view the details of a specific application.
 
-. If the application is out of sync or degraded, icons are displayed under *Resources* section. Hover over the icons to see health status and sync status. The icons are:
+. If the *Resources* section displays icons, hover over the icons to get status details. 
+** A broken heart indicates that resource issues have degraded the application's performance.
+** A yellow yield sign indicates that resource issues have delayed data about the application's health.
 
-.. For degraded status, the broken heart icon is displayed.
-.. For out of sync status, the yellow yield icon is displayed.
-
-. To view the deployment history of an application, click the *Deployment History* tab. The page includes details such as, *Last deployment*, *Description* (commit message), *Environment*, *Outcome (Succeeded/Failed)*, *Author* and *Revision*.
+. To view the deployment history of an application, click the *Deployment History* tab. The page includes details such as the *Last deployment*, *Description* (commit message), *Environment*, *Author*, and *Revision*.

--- a/modules/go-health-monitoring.adoc
+++ b/modules/go-health-monitoring.adoc
@@ -17,9 +17,9 @@ The {gitops-title} Operator will install the GitOps backend service in the `open
 
 . Click on the application name from the list to view the details of a specific application.
 
-. Click on the *Deployment History* to view the application deployment history. The page includes details such as, *Last deployment*, *Description* (commit message), *Environment*, *Outcome* (Succeeded/Failed), *Author* and *Revision*. 
-
 . If the application is `out of sync` or `degraded` applications the respecting icons are displayed under the *Resources*. Hover over the icons to see the health status and the sync status. The icons are:
 
 .. For `degraded`, the broken heart icon is displayed.
 .. For `out of sync`, the yellow yield icon is displayed.
+
+. Click on the *Deployment History* tab to view the application deployment history. The page includes details such as, *Last deployment*, *Description* (commit message), *Environment*, *Outcome* (Succeeded/Failed), *Author* and *Revision*.

--- a/modules/go-health-monitoring.adoc
+++ b/modules/go-health-monitoring.adoc
@@ -17,6 +17,8 @@ The {gitops-title} Operator will install the GitOps backend service in the `open
 
 . Click on the application name from the list to view the details of a specific application.
 
+. Click on the *Deployment History* to view the application deployment history. The page includes details such as, *Last deployment*, *Description* (commit message), *Environment*, *Outcome* (Succeeded/Failed), *Author* and *Revision*. 
+
 . If the application is `out of sync` or `degraded` applications the respecting icons are displayed under the *Resources*. Hover over the icons to see the health status and the sync status. The icons are:
 
 .. For `degraded`, the broken heart icon is displayed.


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise- 4.11-4.12

JIRA issue:
https://issues.redhat.com/browse/RHDEVDOCS-4111

Preview pages: https://52212--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/health-information-for-resources-deployment.html

SME+QE review: @iam-veeramalla @bluengo
Peer-review: @gabriel-rh @sounix000 @bburt-rh 