### PR TITLE
OCPBUGS-2461 improving SR-IOV cleanup procedure

### DIFF
--- a/modules/nw-sriov-operator-uninstall.adoc
+++ b/modules/nw-sriov-operator-uninstall.adoc
@@ -32,6 +32,13 @@ $ oc delete sriovnetworknodepolicy -n openshift-sriov-network-operator --all
 $ oc delete sriovibnetwork -n openshift-sriov-network-operator --all
 ----
 
+. Change the SR-IOV Network Operator configuration custom resource (CR):
++
+[source,terminal]
+----
+$ oc patch sriovoperatorconfig default --type=merge -n openshift-sriov-network-operator   --patch '{ "spec": { "enableOperatorWebhook": false, "enableInjector": false } }'
+----
+
 . Follow the instructions in the "Deleting Operators from a cluster" section to remove the SR-IOV Network Operator from your cluster.
 
 . Delete the SR-IOV custom resource definitions that remain in the cluster after the SR-IOV Network Operator is uninstalled:
@@ -66,12 +73,6 @@ $ oc delete crd sriovnetworks.sriovnetwork.openshift.io
 $ oc delete crd sriovoperatorconfigs.sriovnetwork.openshift.io
 ----
 
-. Change the SR-IOV Network Operator configuration custom resource (CR):
-+
-[source,terminal]
-----
-$ oc patch sriovoperatorconfig default --type=merge -n openshift-sriov-network-operator   --patch '{ "spec": { "enableOperatorWebhook": false, "enableInjector": false } }'
-----
 
 . Delete the SR-IOV Network Operator namespace:
 +

--- a/modules/nw-sriov-operator-uninstall.adoc
+++ b/modules/nw-sriov-operator-uninstall.adoc
@@ -66,21 +66,11 @@ $ oc delete crd sriovnetworks.sriovnetwork.openshift.io
 $ oc delete crd sriovoperatorconfigs.sriovnetwork.openshift.io
 ----
 
-. Delete the SR-IOV webhooks:
+. Change the SR-IOV Network Operator configuration custom resource (CR):
 +
 [source,terminal]
 ----
-$ oc delete mutatingwebhookconfigurations network-resources-injector-config
-----
-+
-[source,terminal]
-----
-$ oc delete MutatingWebhookConfiguration sriov-operator-webhook-config
-----
-+
-[source,terminal]
-----
-$ oc delete ValidatingWebhookConfiguration sriov-operator-webhook-config
+$ oc patch sriovoperatorconfig default --type=merge -n openshift-sriov-network-operator   --patch '{ "spec": { "enableOperatorWebhook": false, "enableInjector": false } }'
 ----
 
 . Delete the SR-IOV Network Operator namespace:


### PR DESCRIPTION
[OCPBUGS-2461]: Improve the SR-IOV operator cleanup/uninstall

Version(s):
  * PR applies to all versions after a specific version: 4.8 and greater including main

Issue:
https://issues.redhat.com/browse/OCPBUGS-2461

Link to docs preview:
https://52214--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/uninstalling-sriov-operator.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
