### PR TITLE
GH#52123 Initial Planning Configuration to resources rosa-sts-aws-prereqs

### DIFF
--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -19,7 +19,7 @@ Instance types can vary for control plane and infrastructure nodes, depending on
 - Two `r5.xlarge` infrastructure nodes
 - Two `m5.xlarge` customizable worker nodes
 
-For further guidance on worker node counts, see the link to "Initial Planning Considerations" in the "Additional resources" section of this page.
+For further guidance on worker node counts, see the information about initial planning considerations in the "Instance types" topic listed in the "Additional resources" section of this page.
 
 [id="rosa-ebs-storage_{context}"]
 == AWS Elastic Block Store (EBS) storage

--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -4,7 +4,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 [id="rosa-sts-aws-prereqs"]
 = AWS prerequisites for ROSA with STS
 
-
 toc::[]
 
 {product-title} (ROSA) provides a model that allows Red Hat to deploy clusters into a customer’s existing Amazon Web Service (AWS) account.
@@ -83,3 +82,4 @@ include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+1]
 == Additional resources
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-sre-access_rosa-policy-process-security[SRE access to all Red Hat OpenShift Service on AWS clusters]
 * xref:../applications/deployments/osd-config-custom-domains-applications.adoc#osd-applications-config-custom-domains[Configuring custom domains for applications]
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-instance-types_rosa-service-definition[Instance types]


### PR DESCRIPTION
Added worker node count resource (titled "Initial Planning Considerations") to Additional Resources on AWS prerequisites for ROSA with STS.

Version(s):
4.11+

Issue:
https://github.com/openshift/openshift-docs/issues/52123

Link to docs preview:
https://52234--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#rosa-ec2-instances_rosa-sts-aws-prereqs

QE review:
- [x] QE has approved this change.