### PR TITLE
OCPBUGS#1989 - removing authfile flag

### DIFF
--- a/modules/mirror-registry-localhost.adoc
+++ b/modules/mirror-registry-localhost.adoc
@@ -30,8 +30,7 @@ $ sudo ./mirror-registry install \
 +
 [source,terminal]
 ----
-$ podman login --authfile pull-secret.txt \
-  -u init \
+$ podman login -u init \
   -p <password> \
   <host_example_com>:8443> \
   --tls-verify=false <1>

--- a/modules/mirror-registry-remote.adoc
+++ b/modules/mirror-registry-remote.adoc
@@ -33,8 +33,7 @@ $ sudo ./mirror-registry install -v \
 +
 [source,terminal]
 ----
-$ podman login --authfile pull-secret.txt \
-  -u init \
+$ podman login -u init \
   -p <password> \
   <host_example_com>:8443> \
   --tls-verify=false <1>


### PR DESCRIPTION
Versions 4.10+

[OCPBUGS-1989](https://issues.redhat.com/browse/OCPBUGS-1989)

Per the description of the Jira ticket, this PR removes an --authfile flag from login commands due to it being unnecessary (when the -u and -p flags are already included)

Preview (2 instances below linked heading): https://52236--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-localhost_installing-mirroring-creating-registry
