### PR TITLE
OSDOCS-3714: Specified wildcards

### DIFF
--- a/modules/osd-applications-config-custom-domains.adoc
+++ b/modules/osd-applications-config-custom-domains.adoc
@@ -16,8 +16,8 @@ Custom API domains are not supported because Red Hat controls the API domain. Ho
 .Prerequisites
 
 * A user account with `dedicated-admin` privileges
-* A unique wildcard domain, such as `*.apps.<company_name>.io`
-* A wildcard custom certificate, such as `CN=*.apps.<company_name>.io`
+* A unique domain or wildcard domain, such as `*.apps.<company_name>.io`
+* A custom certificate or wildcard custom certificate, such as `CN=*.apps.<company_name>.io`
 * Access to a cluster with the latest version of the `oc` CLI installed
 
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-3714](https://issues.redhat.com/browse/OSDOCS-3714)

Link to docs preview:

- [OSD](https://52244--docspreview.netlify.app/openshift-dedicated/latest/applications/deployments/osd-config-custom-domains-applications.html#osd-applications-config-custom-domains_osd-config-custom-domains-applications)
- [ROSA](https://52244--docspreview.netlify.app/openshift-rosa/latest/applications/deployments/osd-config-custom-domains-applications.html)

Additional information:
Revised the prerequisites to include custom domains as well as wildcard domains.