### PR TITLE
RHDEVDOCS-4647- fix incorrect content in 4.11 config map ref

### DIFF
--- a/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -88,8 +88,6 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
-|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
-
 |volumeClaimTemplate|*monv1.EmbeddedPersistentVolumeClaim|Defines persistent storage for Alertmanager. Use this setting to configure the persistent volume claim, including storage class, volume size, and name.
 
 |===
@@ -252,8 +250,6 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 |retentionSize|string|Defines the maximum amount of disk space used by data blocks plus the write-ahead log (WAL). Supported values are `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`, `EB`, and `EiB`. By default, no limit is defined.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
-
-|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines the pod's topology spread constraints.
 
 |volumeClaimTemplate|*monv1.EmbeddedPersistentVolumeClaim|Defines persistent storage for Prometheus. Use this setting to configure the persistent volume claim, including storage class, volume size and name.
 
@@ -435,8 +431,6 @@ Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
 |retention|string|Defines the duration for which Prometheus retains data. This definition must be specified using the following regular expression pattern: `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (ms = milliseconds, s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years). The default value is `15d`.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
-
-|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines topology spread constraints for the pods.
 
 |volumeClaimTemplate|*monv1.EmbeddedPersistentVolumeClaim|Defines persistent storage for Thanos Ruler. Use this setting to configure the storage class and size of a volume.
 


### PR DESCRIPTION
Summary: This PR removes topology spread constraints config info that was inadvertently included in the 4.11 CMO config map reference. This content is auto-generated from the source code.

- Aligned team: DevTools
- For branches: 4.11 ONLY
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4647
- Direct link to doc preview: 
- - https://52248--docspreview.netlify.app/openshift-enterprise/latest/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html#alertmanagermainconfig
- - https://52248--docspreview.netlify.app/openshift-enterprise/latest/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html#prometheusk8sconfig
- - https://52248--docspreview.netlify.app/openshift-enterprise/latest/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html#thanosrulerconfig
- SME review: @ tbd
- QE review: @juzhao 
- Peer review: @rolfedh 