### PR TITLE
OCPBUGS-2957 - Fix ZTP software versions

### DIFF
--- a/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
+++ b/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
@@ -10,9 +10,11 @@ You can configure your hub cluster with a set of ArgoCD applications that genera
 
 .Prerequisites
 
-* Openshift Cluster 4.11 as the hub cluster
-* {rh-rhacm-first} Operator 2.5 installed on the hub cluster
-* Red Hat OpenShift GitOps Operator 1.5 on the hub cluster
+* {product-title} {product-version} or later installed as the hub cluster
+
+* {rh-rhacm-first} 2.3 or later installed on the hub cluster
+
+* {gitops-title} 1.3 or later on the hub cluster
 
 .Procedure
 


### PR DESCRIPTION
ZTP software versions listed in 4.10 docs are confusing and incorrect. 

Fixes https://issues.redhat.com/browse/OCPBUGS-2957

Preview: https://52253--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-preparing-the-hub-cluster-for-ztp_ztp-deploying-disconnected

Merge to main. CP to enterprise-4.10 only. 4.11+ is handled in https://github.com/openshift/openshift-docs/pull/49805, which will be rebased before merging.