### PR TITLE
OCPBUGS#2283: Added new `allow-from-kube-apiserver-operator` policy

### DIFF
--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -93,6 +93,31 @@ spec:
 EOF
 ----
 
+.. A policy named `allow-from-kube-apiserver-operator`:
++
+[source,terminal]
+----
+$ cat << EOF| oc create -f -
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-kube-apiserver-operator
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-kube-apiserver-operator
+      podSelector:
+        matchLabels:
+          app: kube-apiserver-operator
+  policyTypes:
+  - Ingress
+EOF
+----
++
+For more details, see link:https://access.redhat.com/solutions/6964520[New `kube-apiserver-operator` webhook controller validating health of webhook].
+
 . Optional: To confirm that the network policies exist in your current project, enter the following command:
 +
 [source,terminal]

--- a/modules/nw-networkpolicy-project-defaults.adoc
+++ b/modules/nw-networkpolicy-project-defaults.adoc
@@ -59,6 +59,21 @@ objects:
     podSelector: {}
     policyTypes:
     - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-kube-apiserver-operator
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: openshift-kube-apiserver-operator
+        podSelector:
+          matchLabels:
+            app: kube-apiserver-operator
+    policyTypes:
+    - Ingress
 ...
 ----
 


### PR DESCRIPTION
Version(s): 4.10+

Issue: https://issues.redhat.com/browse/OCPBUGS-2283

Link to docs preview:
https://52256--docspreview.netlify.app/openshift-enterprise/latest/networking/network_policy/multitenant-network-policy.html#nw-networkpolicy-multitenant-isolation_multitenant-network-policy
https://52256--docspreview.netlify.app/openshift-enterprise/latest/networking/network_policy/default-network-policy.html#nw-networkpolicy-project-defaults_default-network-policy

QE review:
- [x] QE has approved this change.