### PR TITLE
Adding redirect for ROSA quickstart guide

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -215,7 +215,7 @@ AddType text/vtt                            vtt
     RewriteRule rosa/rosa_getting_started/rosa-sts-about-iam-resources.html rosa/rosa_architecture/rosa-sts-about-iam-resources.html [NE,R=301]
     RewriteRule rosa/rosa_getting_started/rosa-sts-required-aws-service-quotas.html rosa/rosa_planning/rosa-sts-required-aws-service-quotas.html [NE,R=301]
     RewriteRule rosa/rosa_getting_started/rosa-sts-setting-up-environment.html rosa/rosa_planning/rosa-sts-setting-up-environment.html [NE,R=301]
-    RewriteRule rosa/rosa_getting_started/(rosa-getting-started|rosa-sts-getting-started-workflow).html - [L]
+    RewriteRule rosa/rosa_getting_started/(rosa-quickstart-guide-ui|rosa-getting-started|rosa-sts-getting-started-workflow).html - [L]
     RewriteRule rosa/rosa_getting_started/?(.*)$ rosa/rosa_install_access_delete_clusters/$1 [NE,R=301]
 
     RewriteRule rosa/logging/?(.*)$ rosa/rosa_cluster_admin/rosa_logging/$1 [NE,R=301]


### PR DESCRIPTION
This applies to `main` only.

The PR adds a redirect for the ROSA quickstart guide, so that the URL is not redirected in the catchall redirect rule that follows the updated line.