### PR TITLE
BZ#2104394: removing unnecessary steps

### DIFF
--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -246,24 +246,6 @@ metadata:
   providerID: aws:///us-east-1a/i-0fdb85790d76d0c3f
 ----
 
-... Remove the `metadata.annotations` and `metadata.generation` fields:
-+
-[source,yaml]
-----
-  annotations:
-    machine.openshift.io/instance-state: running
-  ...
-  generation: 2
-----
-
-... Remove the `metadata.resourceVersion` and `metadata.uid` fields:
-+
-[source,yaml]
-----
-  resourceVersion: "13291"
-  uid: a282eb70-40a2-4e89-8009-d05dd420d31a
-----
-
 .. Delete the machine of the unhealthy member:
 +
 [source,terminal]


### PR DESCRIPTION
Versions 4.8+

BZ [#2104394](https://bugzilla.redhat.com/show_bug.cgi?id=2104394)

Per the description of the BZ ticket, the two steps removed in this PR are not necessary for the procedure.

Preview: https://52268--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member