### PR TITLE
RHDEVDOCS-4601-how-to-resize-prometheus-storage-volumes

### DIFF
--- a/modules/monitoring-resizing-a-persistent-storage-volume.adoc
+++ b/modules/monitoring-resizing-a-persistent-storage-volume.adoc
@@ -1,0 +1,206 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+:_content-type: PROCEDURE
+[id="resizing-a-persistent-storage-volume_{context}"]
+= Resizing a persistent storage volume
+
+{product-title} does not support resizing an existing persistent storage volume used by `StatefulSet` resources, even if the underlying `StorageClass` resource used supports persistent volume sizing.
+Therefore, even if you update the `storage` field for an existing persistent volume claim (PVC) with a larger size, this setting will not be propagated to the associated persistent volume (PV).
+
+However, resizing a PV is still possible by using a manual process. If you want to resize a PV for a monitoring component such as Prometheus, Thanos Ruler, or Alertmanager, you can update the appropriate config map in which the component is configured. Then, patch the PVC, and delete and orphan the pods.
+Orphaning the pods recreates the `StatefulSet` resource immediately and automatically updates the size of the volumes mounted in the pods with the new PVC settings.
+No service disruption occurs during this process. 
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* *If you are configuring core {product-title} monitoring components*:
+** You have access to the cluster as a user with the `cluster-admin` role.
+** You have created the `cluster-monitoring-config` `ConfigMap` object.
+** You have configured at least one PVC for core {product-title} monitoring components.
+* *If you are configuring components that monitor user-defined projects*:
+** You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+** You have configured at least one PVC for components that monitor user-defined projects.
+
+.Procedure
+
+. Edit the `ConfigMap` object:
+** *To resize a PVC for a component that monitors core {product-title} projects*:
+.. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+----
+
+.. Add a new storage size for the PVC configuration for the component under `data/config.yaml`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    <component>: <1>
+      volumeClaimTemplate:
+        spec:
+          storageClassName: <storage_class> <2>
+          resources:
+            requests:
+              storage: <amount_of_storage> <3>
+----
+<1> Specify the core monitoring component.
+<2> Specify the storage class.
+<3> Specify the new size for the storage volume.
++
+The following example configures a PVC that sets the local persistent storage to 100 gigabytes for the Prometheus instance that monitors core {product-title} components:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: local-storage
+          resources:
+            requests:
+              storage: 100Gi
+----
++
+The following example configures a PVC that sets the local persistent storage for Alertmanager to 40 gigabytes:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    alertmanagerMain:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: local-storage
+          resources:
+            requests:
+              storage: 40Gi
+----
+
+** *To resize a PVC for a component that monitors user-defined projects*:
++
+[NOTE]
+====
+You can resize the volumes for the Thanos Ruler and Prometheus instances that monitor user-defined projects.
+====
++
+.. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
+----
+
+.. Update the PVC configuration for the monitoring component under `data/config.yaml`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    <component>: <1>
+      volumeClaimTemplate:
+        spec:
+          storageClassName: <storage_class> <2>
+          resources:
+            requests:
+              storage: <amount_of_storage> <3>
+----
+<1> Specify the core monitoring component.
+<2> Specify the storage class.
+<3> Specify the new size for the storage volume.
++
+The following example configures the PVC size to 100 gigabytes for the Prometheus instance that monitors user-defined projects:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    prometheus:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: local-storage
+          resources:
+            requests:
+              storage: 100Gi
+----
++
+The following example sets the PVC size to 20 gigabytes for Thanos Ruler:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    thanosRuler:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: local-storage
+          resources:
+            requests:
+              storage: 20Gi
+----
++
+[NOTE]
+====
+Storage requirements for the `thanosRuler` component depend on the number of rules that are evaluated and how many samples each rule generates.
+====
+
+. Save the file to apply the changes. The pods affected by the new configuration restart automatically.
++
+[WARNING]
+====
+When you save changes to a monitoring config map, the pods and other resources in the related project might be redeployed. The monitoring processes running in that project might also be restarted.
+====
+
+. Manually patch every PVC with the updated storage request. The following example resizes the storage size for the Prometheus component in the `openshift-monitoring` namespace to 100Gi:
++
+[source,terminal]
+----
+$ for p in $(oc -n openshift-monitoring get pvc -l app.kubernetes.io/name=prometheus -o jsonpath='{range .items[*]}{.metadata.name} {end}'); do \
+  oc -n openshift-monitoring patch pvc/${p} --patch '{"spec": {"resources": {"requests": {"storage":"100Gi"}}}}'; \
+  done
+
+----
+
+. Delete the underlying StatefulSet with the `--cascade=orphan` parameter:
++
+[source,terminal]
+----
+$ oc delete statefulset -l app.kubernetes.io/name=prometheus --cascade=orphan
+----

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -79,6 +79,7 @@ include::modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.ado
 // Configuring persistent storage
 include::modules/monitoring-configuring-persistent-storage.adoc[leveloffset=+1]
 include::modules/monitoring-configuring-a-local-persistent-volume-claim.adoc[leveloffset=+2]
+include::modules/monitoring-resizing-a-persistent-storage-volume.adoc[leveloffset=+2]
 include::modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc[leveloffset=+2]
 include::modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Summary: This PR explains how to resize persistent storage volumes for monitoring components.

- Aligned team: DevTools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4601
- Direct link to doc preview: https://52277--docspreview.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#resizing-a-persistent-storage-volume_configuring-the-monitoring-stack
- SME review: @JoaoBraveCoding 
- QE review: @juzhao 
- Peer review: @gabriel-rh 