### PR TITLE
 adds description for targetPort

### DIFF
--- a/modules/nw-creating-a-route.adoc
+++ b/modules/nw-creating-a-route.adoc
@@ -56,7 +56,7 @@ $ oc expose svc hello-openshift
 ----
 $ oc get routes -o yaml <name of resource> <1>
 ----
-<1> In this example, the route is named `hello-openshift`. 
+<1> In this example, the route is named `hello-openshift`.
 
 .Sample YAML definition of the created unsecured route:
 [source,yaml]
@@ -68,12 +68,14 @@ metadata:
 spec:
   host: hello-openshift-hello-openshift.<Ingress_Domain> <1>
   port:
-    targetPort: 8080
+    targetPort: 8080 <2>
   to:
     kind: Service
     name: hello-openshift
 ----
 <1> `<Ingress_Domain>` is the default ingress domain name.
+<2> `targetPort` is the target port on pods that is selected by the service that this route points to.  
+
 +
 [NOTE]
 ====


### PR DESCRIPTION
- Applies to 4.8 and above
- Adds description for targetPort parameter.
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2115269)
- [Preview](https://52285--docspreview.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html)
@lihongan  ptal