### PR TITLE
[SRVOCF-437] Return the buildpacks Tekton task step to on-cluster function builds

### DIFF
--- a/modules/serverless-functions-creating-on-cluster-builds.adoc
+++ b/modules/serverless-functions-creating-on-cluster-builds.adoc
@@ -36,6 +36,18 @@ $ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func
 ----
 $ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.25.0/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
 ----
++
+[NOTE]
+====
+You can also use a community buildpack. For community buildpack support status, see link:https://access.redhat.com/solutions/5893251[Cooperative Community Support].
+
+To use a community buildpack, create the functions buildpacks Tekton task to be able to build the function image:
+
+[source,terminal]
+----
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.25.0/pipelines/resources/tekton/task/func-buildpacks/0.1/func-buildpacks.yaml
+----
+====
 
 . Create a function:
 +


### PR DESCRIPTION
Versions: 4.8+
Jira: https://issues.redhat.com/browse/SRVOCF-437
Preview: https://52288--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-on-cluster-builds.html#serverless-functions-creating-on-cluster-builds_serverless-functions-on-cluster-builds