### PR TITLE
Update link to point at latest SLA document

### DIFF
--- a/modules/rosa-sdpolicy-am-sla.adoc
+++ b/modules/rosa-sdpolicy-am-sla.adoc
@@ -5,4 +5,4 @@
 :_content-type: CONCEPT
 [id="rosa-sdpolicy-sla_{context}"]
 = Service Level Agreement (SLA)
-Any SLAs for the service itself are defined in Appendix 4 of the link:https://www.redhat.com/licenses/Appendix_4_Red_Hat_Online_Services_20210503.pdf[Red Hat Enterprise Agreement Appendix 4 (Online Subscription Services)].
+Any SLAs for the service itself are defined in Appendix 4 of the link:https://www.redhat.com/licenses/Appendix_4_Red_Hat_Online_Services_20220720.pdf[Red Hat Enterprise Agreement Appendix 4 (Online Subscription Services)].


### PR DESCRIPTION
There have been more recent license agreements released https://www.redhat.com/en/about/agreements (inside the `Product Appendices` tab). Specifically, Appendix 4 has been updated [June 2022](https://www.redhat.com/licenses/Appendix_4_Red_Hat_Online_Services_20220720.pdf), however the documentation is referencing the license agreement from [May 2021](https://www.redhat.com/licenses/Appendix_4_Red_Hat_Online_Services_20210503.pdf)

Version(s):
  * PR applies to this block in the ROSA documentation in general (not version specific) - https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-sla_rosa-service-definition

Link to docs preview:
https://52307--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-sla_rosa-service-definition

QE review:
- [ ] QE has approved this change.