### PR TITLE
OSDOCS-4365: Added RN for enabling a feature set at install

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -76,6 +76,12 @@ All {product-title} 4.11 clusters require this administrator acknowledgment befo
 
 For more information, see xref:../updating/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.12].
 
+[id="ocp-4-12-feature-set"]
+==== Enabling a feature set when installing a cluster
+Beginning with {product-title} {product-version}, you can enable a feature set as part of the installation process. A feature set is a collection of {product-title} features that are not enabled by default.
+
+For more information about enabling a feature set during installation, see xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling {product-title} features using feature gates].
+
 [id="ocp-4-12-post-installation"]
 === Post-installation configuration
 
@@ -119,16 +125,16 @@ In {product-title} 4.12, you can do the following from the *Helm* page:
 [id="ocp-4-12-images"]
 === Images
 
-A new import value, `importMode`, has been added to the `importPolicy` parameter of image streams. The following fields are available for this value: 
+A new import value, `importMode`, has been added to the `importPolicy` parameter of image streams. The following fields are available for this value:
 
-* `Legacy`: `Legacy` is the default value for `importMode`. When active, the manifest list is discarded, and a single sub-manifest is imported. The platform is chosen in the following order of priority: 
+* `Legacy`: `Legacy` is the default value for `importMode`. When active, the manifest list is discarded, and a single sub-manifest is imported. The platform is chosen in the following order of priority:
 +
 . Tag annotations
 . Control plane architecture
 . Linux/AMD64
-. The first manifest in the list 
+. The first manifest in the list
 
-* `PreserveOriginal`: When active, the original manifest is preserved. For manifest lists, the manifest list and all of its sub-manifests are imported. 
+* `PreserveOriginal`: When active, the original manifest is preserved. For manifest lists, the manifest list and all of its sub-manifests are imported.
 
 
 [id="ocp-4-12-security"]
@@ -308,7 +314,7 @@ For more information, see xref:../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-j
 [id="ocp-4-12-auth-aws-sts-endpoints"]
 === AWS Security Token Service regional endpoints
 
-The Cloud Credential Operator utility (`ccoctl`) now creates secrets that use regional endpoints for the xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc[AWS Security Token Service (AWS STS)]. This approach aligns with AWS recommended best practices. 
+The Cloud Credential Operator utility (`ccoctl`) now creates secrets that use regional endpoints for the xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc[AWS Security Token Service (AWS STS)]. This approach aligns with AWS recommended best practices.
 
 [discrete]
 [id="ocp-4-12-auth-ccoctl-gcp-del-dir"]


### PR DESCRIPTION
Version(s):
4.12

Issue:
This PR address the release note for [osdocs-4365](https://issues.redhat.com/browse/OSDOCS-4365).

Link to docs preview:
[Enabling a feature set when installing a cluster](https://52319--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-feature-set)

QE review:
- [yes] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Update for the installation doc is being tracked in https://github.com/openshift/openshift-docs/pull/52178

