### PR TITLE
[SDN-3027]: (Relnotes)  Egress IP Support on RHOSP

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -247,6 +247,12 @@ You can now configure the time-to-live (TTL) duration of both successful and uns
 
 For more information, see xref:../networking/dns-operator.adoc#nw-dns-cache-tuning_dns-operator[Tuning the CoreDNS cache].
 
+[id=ocp-4-12-egress-ip-support]
+==== Egress IP support on {rh-openstack-first}
+
+{rh-openstack}, paired with {product-title}, now supports automatic attachment and detachment of Egress IP addresses. The traffic from one or more pods in any number of namespaces has a consistent source IP address for services outside of the cluster. This support applies to OpenShift SDN and OVN-Kubernetes as default network providers.
+
+
 [id="ocp-4-12-storage"]
 === Storage
 


### PR DESCRIPTION
** This PR was previously peer reviewed, but had updates from SME/QE that require another review. Thank you.

Epic: [SDN-3027](https://issues.redhat.com/browse/SDN-3027)
Version(s): 4.12
Issue: [OSDOCS-4425](https://issues.redhat.com/browse/OSDOCS-4425)
QE review: [x ] QE has approved this change.
SME review: [x ] SME has approved this change.

Link to docs [preview](http://file.rdu.redhat.com/tlove/sdn-3027-relnotes-tlove/release_notes/ocp-4-12-release-notes.html#ocp-4-12-egress-ip-support) Updated: 11/2



