### PR TITLE
OSDOCS-3329: ARM support on Azure installations

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -18,11 +18,12 @@ Before you install an {product-title} cluster, you need to select the best insta
 If you want to install and manage {product-title} yourself, you can install it on the following platforms:
 
 * Alibaba Cloud
-* Amazon Web Services (AWS) on x86_64 instances
+* Amazon Web Services (AWS) on `x86_64` instances
 ifndef::openshift-origin[]
-* Amazon Web Services (AWS) on arm64 instances
+* Amazon Web Services (AWS) on `arm64` instances
 endif::openshift-origin[]
-* Microsoft Azure
+* Microsoft Azure on `x86_64` instances
+* Microsoft Azure on `arm64` instances
 * Microsoft Azure Stack Hub
 * Google Cloud Platform (GCP)
 * {rh-openstack-first}
@@ -127,12 +128,13 @@ Not all installation options are supported for all platforms, as shown in the fo
 //This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
 |===
-||Alibaba |AWS (x86_64) |AWS (arm64) |Azure |Azure Stack Hub |GCP |Nutanix |{rh-openstack} |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Power
+||Alibaba |AWS (x86_64) |AWS (arm64) |Azure (x86_64) |Azure (arm64)|Azure Stack Hub |GCP |Nutanix |{rh-openstack} |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Power
 
 |Default
 |xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[&#10003;]
 |xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[&#10003;]
 |xref:../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[&#10003;]
+|xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[&#10003;]
 |xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[&#10003;]
 |xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc#installing-azure-stack-hub-default[&#10003;]
 |xref:../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[&#10003;]
@@ -151,6 +153,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_alibaba/installing-alibaba-customizations.adoc#installing-alibaba-customizations[&#10003;]
 |xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[&#10003;]
 |xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[&#10003;]
+|xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[&#10003;]
 |xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[&#10003;]
 |xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc#installing-azure-stack-hub-default[&#10003;]
 |xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[&#10003;]
@@ -171,6 +174,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[&#10003;]
 |xref:../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[&#10003;]
 |xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[&#10003;]
+|xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[&#10003;]
 |xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc#installing-azure-stack-hub-network-customizations[&#10003;]
 |xref:../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[&#10003;]
 |
@@ -190,6 +194,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[&#10003;]
 |
 |
+|
 |xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[&#10003;]
 |
 |xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[&#10003;]
@@ -206,6 +211,7 @@ ifndef::openshift-origin[]
 |
 |xref:../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[&#10003;]
 |xref:../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[&#10003;]
+|xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[&#10003;]
 |xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[&#10003;]
 |
 |xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[&#10003;]
@@ -225,6 +231,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[&#10003;]
 |xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[&#10003;]
 |xref:../installing/installing_azure/installing-azure-vnet.adoc#installing-azure-vnet[&#10003;]
+|xref:../installing/installing_azure/installing-azure-vnet.adoc#installing-azure-vnet[&#10003;]
 |
 |xref:../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[&#10003;]
 |
@@ -242,6 +249,7 @@ ifndef::openshift-origin[]
 |
 |xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[&#10003;]
 |
+|xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[&#10003;]
 |xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[&#10003;]
 |
 |
@@ -273,10 +281,12 @@ ifndef::openshift-origin[]
 |
 |
 |
+|
 
 |China regions
 |
 |xref:../installing/installing_aws/installing-aws-china.adoc#installing-aws-china-region[&#10003;]
+|
 |
 |
 |

--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -36,6 +36,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-azure-arm-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-government-region.adoc
+++ b/installing/installing_azure/installing-azure-government-region.adoc
@@ -44,6 +44,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-azure-arm-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/installing-azure-network-customizations.adoc
@@ -39,6 +39,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-azure-arm-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-private.adoc
+++ b/installing/installing_azure/installing-azure-private.adoc
@@ -39,6 +39,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-azure-arm-tested-machine-types.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-vnet.adoc
+++ b/installing/installing_azure/installing-azure-vnet.adoc
@@ -33,6 +33,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-azure-arm-tested-machine-types.adoc[leveloffset=+2] 
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/modules/installation-azure-arm-tested-machine-types.adoc
+++ b/modules/installation-azure-arm-tested-machine-types.adoc
@@ -1,0 +1,20 @@
+
+// Module included in the following assemblies:
+//
+// installing/installing_azure/installing-azure-customizations.adoc
+// installing/installing_azure/installing-azure-government-region.adoc
+// installing/installing_azure/installing-azure-network-customizations.adoc
+// installing/installing_azure/installing-azure-private.adoc
+// installing/installing_azure/installing-azure-user-infra.adoc
+// installing/installing_azure/installing-azure-vnet.adoc
+
+[id="installation-azure-arm-tested-machine-types_{context}"]
+= Tested instance types for Azure ARM
+
+The following Microsoft Azure instance types have been tested with {product-title}.
+
+.Machine types
+[%collapsible]
+====
+include::https://raw.githubusercontent.com/openshift/installer/master/docs/user/azure/tested_instance_types_aarch64.md[] 
+====

--- a/modules/installation-azure-marketplace-subscribe.adoc
+++ b/modules/installation-azure-marketplace-subscribe.adoc
@@ -30,6 +30,11 @@ endif::mapi[]
 * While the images are the same, the Azure Marketplace publisher is different depending on your region. If you are located in North America, specify `redhat` as the publisher. If you are located in EMEA, specify `redhat-limited` as the publisher.
 * The offer includes a `rh-ocp-worker` SKU and a `rh-ocp-worker-gen1` SKU. The `rh-ocp-worker` SKU represents a Hyper-V generation version 2 VM image. The default instance types used in {product-title} are version 2 compatible. If you are going to use an instance type that is only version 1 compatible, use the image associated with the `rh-ocp-worker-gen1` SKU. The `rh-ocp-worker-gen1` SKU represents a Hyper-V version 1 VM image.
 
+[IMPORTANT]
+====
+Installing images with the Azure marketplace is not supported on clusters with `arm64` instances. 
+====
+
 .Prerequisites
 
 * You have installed the Azure CLI client `(az)`.

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -489,23 +489,17 @@ endif::rhv[]
 
 ifndef::openshift-origin[]
 
-ifndef::aws,bare,ibm-power,ibm-z[]
+ifndef::aws,bare,ibm-power,ibm-z,azure[]
 |`compute.architecture`
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
 |String
-endif::aws,bare,ibm-power,ibm-z[]
+endif::aws,bare,ibm-power,ibm-z,azure[]
 
-ifdef::aws[]
+ifdef::aws,bare,azure[]
 |`compute.architecture`
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
 |String
-endif::aws[]
-
-ifdef::bare[]
-|`compute.architecture`
-|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
-|String
-endif::bare[]
+endif::aws,bare,azure[]
 
 ifdef::ibm-z[]
 |`compute.architecture`
@@ -562,23 +556,17 @@ For details, see the "Additional RHV parameters for machine pools" table.
 endif::rhv[]
 
 ifndef::openshift-origin[]
-ifndef::aws,bare,ibm-z,ibm-power[]
+ifndef::aws,bare,ibm-z,ibm-power,azure[]
 |`controlPlane.architecture`
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
 |String
-endif::aws,bare,ibm-z,ibm-power[]
+endif::aws,bare,ibm-z,ibm-power,azure[]
 
-ifdef::aws[]
+ifdef::aws,bare,azure[]
 |`controlPlane.architecture`
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
 |String
-endif::aws[]
-
-ifdef::bare[]
-|`controlPlane.architecture`
-|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
-|String
-endif::bare[]
+endif::aws,bare,azure[]
 
 ifdef::ibm-z[]
 |`controlPlane.architecture`


### PR DESCRIPTION
For versions 4.12+
[OSDOCS-3329](https://issues.redhat.com//browse/OSDOCS-3329)

Previews: 

- `installing/installing-preparing.adoc`
   [Supported installation methods for different platforms ](https://52327--docspreview.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#supported-installation-methods-for-different-platforms)
- `modules/installation-azure-arm-tested-machine-types.adoc`
   [Tested instance types for Azure ARM](https://52327--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations.html#installation-azure-arm-tested-machine-types_installing-azure-customizations) [This change is in every Azure install section]
- `modules/installation-configuration-parameters.adoc`
  [Installation configuration parameters](https://52327--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations.html#installation-configuration-parameters_installing-azure-customizations)
- `modules/installation-azure-marketplace-subscribe.adoc` 
  [Selecting an Azure marketplace image](https://52327--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations.html#installation-azure-marketplace-subscribe_installing-azure-customizations)


QE review: 

- [x] QE has approved this change