### PR TITLE
[OSDOCS-4413]: AWS STS uses regional endpoints

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
@@ -56,6 +56,7 @@ metadata:
 stringData:
   credentials: |-
     [default]
+    sts_regional_endpoints = regional
     role_name: <operator-role-name> <3>
     web_identity_token_file: <path-to-token> <4>
 ----


### PR DESCRIPTION
Version(s):
4.10+ (see _Additional information_ below)

Issue:
[OSDOCS-4413](https://issues.redhat.com//browse/OSDOCS-4413)

Link to docs preview:
[About manual mode with AWS Secure Token Service](https://52348--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#sts-mode-about)

QE review:
- [x] QE has approved this change.

Additional information:
Cherrypicks into 4.11 and 4.10 will need to accompany the code backports and be done in tandem with the .z rel notes.
4.12 RN PR: #52349
4.11 RN PR: #53493
4.10 RN PR: #53567

Text for .z rel notes:
```
[id="ocp-4-YY-ZZ-notable-technical-changes"]
==== Notable technical changes

* The Cloud Credential Operator utility (`ccoctl`) now creates secrets that use regional endpoints for the xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc[AWS Security Token Service (AWS STS)]. This approach aligns with AWS recommended best practices. 

```