### PR TITLE
[OSDOCS-4413]: AWS STS uses regional endpoints (4.12 RN)

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -282,6 +282,12 @@ For more information, see xref:../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-j
 
 // Note: use [discrete] for these sub-headings.
 
+[discrete]
+[id="ocp-4-12-auth-aws-sts-endpoints"]
+=== AWS Security Token Service regional endpoints
+
+The Cloud Credential Operator utility (`ccoctl`) now creates secrets that use regional endpoints for the xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc[AWS Security Token Service (AWS STS)]. This approach aligns with AWS recommended best practices. 
+
 [id="ocp-4-12-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-4413](https://issues.redhat.com//browse/OSDOCS-4413)
[OSDOCS-4463](https://issues.redhat.com//browse/OSDOCS-4463) (rel note tracker entry)

Link to docs preview:
[AWS Security Token Service regional endpoints](https://52349--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-auth-aws-sts-endpoints)

QE review:
- [x] QE has approved this change.

Additional information:
Feature PR: #52348