### PR TITLE
OCPBUGS#1823: Default pids-limit and log-max-size updated

### DIFF
--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -15,11 +15,16 @@ To revert the changes implemented by using a `ContainerRuntimeConfig` CR, you mu
 
 You can modify the following settings by using a `ContainerRuntimeConfig` CR:
 
-* **PIDs limit**: The `pidsLimit` parameter sets the CRI-O `pids_limit` parameter, which is maximum number of processes allowed in a container. The default is 1024 (`pids_limit = 1024`).
+* **PIDs limit**: Setting the PIDs limit in the `ContainerRuntimeConfig` is expected to be deprecated. If PIDs limits are required, it is recommended to use the `podPidsLimit` field in the `KubeletConfig` CR instead. The default value of the `podPidsLimit` field is `4096`.
++
+[NOTE]
+====
+The CRI-O flag is applied on the cgroup of the container, while the Kubelet flag is set on the cgroup of the pod. Please adjust the PIDs limit accordingly.
+====
+
 * **Log level**: The `logLevel` parameter sets the CRI-O `log_level` parameter, which is the level of verbosity for log messages. The default is `info` (`log_level = info`). Other options include `fatal`, `panic`, `error`, `warn`, `debug`, and `trace`.
 * **Overlay size**: The `overlaySize` parameter sets the CRI-O Overlay storage driver `size` parameter, which is the maximum size of a container image.
-* **Maximum log size**: The `logSizeMax` parameter sets the CRI-O `log_size_max` parameter, which is the maximum size allowed for the container log file. The default is unlimited (`log_size_max = -1`). If set to a positive number, it must be at least 8192 to not be smaller than  the ConMon read buffer. ConMon is a program that
-monitors communications between a container manager, such as Podman or CRI-O, and the OCI runtime, such as runC or crun, for a single container.
+* **Maximum log size**: Setting the maximum log size in the `ContainerRuntimeConfig` is expected to be deprecated. If a maximum log size is required, it is recommended to use the `ContainerLogMaxSize` field in the `KubeletConfig` CR instead.
 * **Container runtime**: The `defaultRuntime` parameter sets the container runtime to either `runc` or `crun`. The default is `runc`.
 
 :FeatureName: Support for the crun container runtime


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.11, 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/OCPBUGS-1823
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://52356--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#create-a-containerruntimeconfig_post-install-machine-configuration-tasks
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
