### PR TITLE
[OSDOCS-4464]: ccoctl gcp delete specify dir param

### DIFF
--- a/modules/cco-ccoctl-deleting-sts-resources.adoc
+++ b/modules/cco-ccoctl-deleting-sts-resources.adoc
@@ -41,27 +41,13 @@ ifdef::aws-sts[]
 +
 [source,terminal]
 ----
-$ ccoctl aws delete --name=<name> --region=<aws_region>
+$ ccoctl aws delete \
+  --name=<name> \ <1>
+  --region=<aws_region> <2>
 ----
 +
-where:
-+
-** `<name>` matches the name used to originally create and tag the cloud resources.
-** `<aws_region>` is the AWS region in which cloud resources will be deleted.
-endif::aws-sts[]
-ifdef::google-cloud-platform[]
-* Delete the GCP resources that `ccoctl` created:
-+
-[source,terminal]
-----
-$ ccoctl gcp delete --name=<name> --project=<gcp_project_id>
-----
-+
-where:
-+
-** `<name>` matches the name used to originally create and tag the cloud resources.
-** `<gcp_project_id>` is the GCP project ID in which cloud resources will be deleted.
-endif::google-cloud-platform[]
+<1> `<name>` matches the name that was originally used to create and tag the cloud resources.
+<2> `<aws_region>` is the AWS region in which to delete cloud resources.
 +
 .Example output:
 +
@@ -83,6 +69,40 @@ endif::google-cloud-platform[]
 2021/04/08 17:51:39 Identity Provider with ARN arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com deleted
 ----
 //Would love a GCP version of the above output.
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+. Obtain the {product-title} release image by running the following command:
++
+[source,terminal]
+----
+$ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
+----
+
+. Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image by running the following command:
++
+[source,terminal]
+----
+$ oc adm release extract --credentials-requests \
+  --cloud=gcp \
+  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
+  $RELEASE_IMAGE
+----
++
+<1> `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
+
+. Delete the GCP resources that `ccoctl` created:
++
+[source,terminal]
+----
+$ ccoctl gcp delete \
+  --name=<name> \ <1>
+  --project=<gcp_project_id> \ <2>
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
+----
++
+<1> `<name>` matches the name that was originally used to create and tag the cloud resources.
+<2> `<gcp_project_id>` is the GCP project ID in which to delete cloud resources.
+endif::google-cloud-platform[]
 
 .Verification
 


### PR DESCRIPTION
Version(s):
4.10+ (see _Additional information_ below)

Issue:
[OSDOCS-4464](https://issues.redhat.com//browse/OSDOCS-4464)

Link to docs preview:
[Deleting GCP resources with the Cloud Credential Operator utility](https://52380--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/uninstalling-cluster-gcp.html#cco-ccoctl-deleting-sts-resources_uninstalling-cluster-gcp)

QE review:
- [x] QE has approved this change.

Additional information:
Cherrypicks into 4.11 and 4.10 will need to accompany the code backports and be done in tandem with the .z rel notes.
4.12 RN PR: #52381
4.11 RN PR: #53494
4.10 RN PR: #52348

Text for .z rel notes:
```
[id="ocp-4-YY-ZZ-notable-technical-changes"]
==== Notable technical changes

* With this release, when you xref:../installing/installing_gcp/uninstalling-cluster-gcp.adoc#cco-ccoctl-deleting-sts-resources_uninstalling-cluster-gcp[delete GCP resources with the Cloud Credential Operator utility], you must specify the directory containing the files for the component `CredentialsRequest` objects.
```