### PR TITLE
[OSDOCS-4405]: ccoctl gcp delete specify dir param (4.12 RN)

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -303,6 +303,12 @@ For more information, see xref:../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-j
 
 The Cloud Credential Operator utility (`ccoctl`) now creates secrets that use regional endpoints for the xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc[AWS Security Token Service (AWS STS)]. This approach aligns with AWS recommended best practices. 
 
+[discrete]
+[id="ocp-4-12-auth-ccoctl-gcp-del-dir"]
+=== Credentials requests directory parameter for deleting GCP resources with the Cloud Credential Operator utility
+
+With this release, when you xref:../installing/installing_gcp/uninstalling-cluster-gcp.adoc#cco-ccoctl-deleting-sts-resources_uninstalling-cluster-gcp[delete GCP resources with the Cloud Credential Operator utility], you must specify the directory containing the files for the component `CredentialsRequest` objects.
+
 [id="ocp-4-12-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-4405](https://issues.redhat.com//browse/OSDOCS-4405)

Link to docs preview:
[Credentials requests directory parameter for deleting GCP resources with the Cloud Credential Operator utility](https://52381--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-auth-ccoctl-gcp-del-dir)

QE review:
- [x] QE has approved this change.

Additional information:
Feature PR: #52380 