### PR TITLE
[OSDOCS-4162]: Allow setting cluster autoscaler verbosity

### DIFF
--- a/modules/cluster-autoscaler-cr.adoc
+++ b/modules/cluster-autoscaler-cr.adoc
@@ -33,13 +33,14 @@ spec:
       - type: amd.com/gpu
         min: 0
         max: 4
-  scaleDown: <10>
-    enabled: true <11>
-    delayAfterAdd: 10m <12>
-    delayAfterDelete: 5m <13>
-    delayAfterFailure: 30s <14>
-    unneededTime: 5m <15>
-    utilizationThreshold: "0.4" <16>
+  logVerbosity: 4 <10>
+  scaleDown: <11>
+    enabled: true <12>
+    delayAfterAdd: 10m <13>
+    delayAfterDelete: 5m <14>
+    delayAfterFailure: 30s <15>
+    unneededTime: 5m <16>
+    utilizationThreshold: "0.4" <17>
 ----
 <1> Specify the priority that a pod must exceed to cause the cluster autoscaler to deploy additional nodes. Enter a 32-bit integer value. The `podPriorityThreshold` value is compared to the value of the `PriorityClass` that you assign to each pod.
 <2> Specify the maximum number of nodes to deploy. This value is the total number of machines that are deployed in your cluster, not just the ones that the autoscaler controls. Ensure that this value is large enough to account for all of your control plane and compute machines and the total number of replicas that you specify in your `MachineAutoscaler` resources.
@@ -50,13 +51,21 @@ spec:
 <7> Optional: Specify the type of GPU node to deploy. Only `nvidia.com/gpu` and `amd.com/gpu` are valid types.
 <8> Specify the minimum number of GPUs to deploy in the cluster.
 <9> Specify the maximum number of GPUs to deploy in the cluster.
-<10> In this section, you can specify the period to wait for each action by using any valid link:https://golang.org/pkg/time/#ParseDuration[ParseDuration] interval, including `ns`, `us`, `ms`, `s`, `m`, and `h`.
-<11> Specify whether the cluster autoscaler can remove unnecessary nodes.
-<12> Optional: Specify the period to wait before deleting a node after a node has recently been _added_. If you do not specify a value, the default value of `10m` is used.
-<13> Optional: Specify the period to wait before deleting a node after a node has recently been _deleted_. If you do not specify a value, the default value of `0s` is used.
-<14> Optional: Specify the period to wait before deleting a node after a scale down failure occurred. If you do not specify a value, the default value of `3m` is used.
-<15> Optional: Specify the period before an unnecessary node is eligible for deletion. If you do not specify a value, the default value of `10m` is used.
-<16> Optional: Specify the _node utilization level_ below which an unnecessary node is eligible for deletion. The node utilization level is the sum of the requested resources divided by the allocated resources for the node, and must be a value greater than `"0"` but less than `"1"`. If you do not specify a value, the cluster autoscaler uses a default value of `"0.5"`, which corresponds to 50% utilization. This value must be expressed as a string.
+<10> Specify the logging verbosity level between `0` and `10`. The following log level thresholds are provided for guidance: 
++
+--
+* `1`: (Default) Basic information about changes. 
+* `4`: Debug-level verbosity for troubleshooting typical issues.
+* `9`: Extensive, protocol-level debugging information.
+--
++
+If you do not specify a value, the default value of `1` is used.
+<11> In this section, you can specify the period to wait for each action by using any valid link:https://golang.org/pkg/time/#ParseDuration[ParseDuration] interval, including `ns`, `us`, `ms`, `s`, `m`, and `h`.
+<12> Specify whether the cluster autoscaler can remove unnecessary nodes.
+<13> Optional: Specify the period to wait before deleting a node after a node has recently been _added_. If you do not specify a value, the default value of `10m` is used.
+<14> Optional: Specify the period to wait before deleting a node after a node has recently been _deleted_. If you do not specify a value, the default value of `0s` is used.
+<15> Optional: Specify the period to wait before deleting a node after a scale down failure occurred. If you do not specify a value, the default value of `3m` is used.
+<16> Optional: Specify the period before an unnecessary node is eligible for deletion. If you do not specify a value, the default value of `10m` is used.<17> Optional: Specify the _node utilization level_ below which an unnecessary node is eligible for deletion. The node utilization level is the sum of the requested resources divided by the allocated resources for the node, and must be a value greater than `"0"` but less than `"1"`. If you do not specify a value, the cluster autoscaler uses a default value of `"0.5"`, which corresponds to 50% utilization. This value must be expressed as a string.
 // Might be able to add a formula to show this visually, but need to look into asciidoc math formatting and what our tooling supports.
 
 [NOTE]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-4162](https://issues.redhat.com//browse/OSDOCS-4162)

Link to docs preview:
[ClusterAutoscaler resource definition](https://52385--docspreview.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#cluster-autoscaler-cr_applying-autoscaling)

QE review:
- [x] QE has approved this change.

Additional information:
