### PR TITLE
CFE-652: Installing ALBO on STS cluster

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1070,6 +1070,8 @@ Topics:
     File: understanding-aws-load-balancer-operator
   - Name: Installing the AWS Load Balancer Operator
     File: install-aws-load-balancer-operator
+  - Name: Installing the AWS Load Balancer Operator on Secure Token Service cluster
+    File: installing-albo-sts-cluster  
   - Name: Creating an instance of the AWS Load Balancer Controller
     File: create-instance-aws-load-balancer-controller
   - Name: Serving Multiple Ingresses through a single AWS Load Balancer

--- a/modules/bootstrap-aws-load-balancer-operator.adoc
+++ b/modules/bootstrap-aws-load-balancer-operator.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+// * networking/installing-albo-sts-cluster.adoc
+
+:_content-type: PROCEDURE
+[id="nw-bootstra-albo-on-sts-cluster_{context}"]
+= Bootstrapping AWS Load Balancer Operator on Secure Token Service cluster
+
+.Prerequisites
+
+* You must extract and prepare the `coctl` binary.
+
+.Procedure
+
+. Download the `CredentialsRequest` custom resource (CR) of the AWS Load Balancer Operator, and create a directory to store it by running the following command:
++
+[source,terminal]
+----
+$ curl --create-dirs -o <path-to-credrequests-dir>/cr.yaml https://raw.githubusercontent.com/openshift/aws-load-balancer-operator/main/hack/operator-credentials-request.yaml
+----
+
+. Use the `ccoctl` tool to process `CredentialsRequest` objects of the AWS Load Balancer Operator, by running the following command:
++
+[source,terminal]
+----
+$ ccoctl aws create-iam-roles \
+    --name <name> --region=<aws_region> \
+    --credentials-requests-dir=<path-to-credrequests-dir> \
+    --identity-provider-arn <oidc-arn>
+----
+
+. Apply the secrets generated in the manifests directory of your cluster by running the following command:
++
+[source,terminal]
+----
+$ ls manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
+----
+
+. Verify that the credentials secret of the AWS Load Balancer Operator is created by running the following command:
++
+[source,terminal]
+----
+$ oc -n aws-load-balancer-operator get secret aws-load-balancer-operator --template='{{index .data "credentials"}}' | base64 -d
+----
++
+.Example output
+[source,terminal]
+----
+[default]
+sts_regional_endpoints = regional
+role_arn = arn:aws:iam::999999999999:role/aws-load-balancer-operator-aws-load-balancer-operator
+web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+----

--- a/modules/configuring-albo-on-sts-cluster.adoc
+++ b/modules/configuring-albo-on-sts-cluster.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+// * networking/installing-albo-sts-cluster.adoc
+
+:_content-type: PROCEDURE
+[id="nw-installing-albo-on-sts-cluster_{context}"]
+= Configuring AWS Load Balancer Operator on Secure Token Service cluster
+
+.Prerequisites
+
+* You must extract and prepare the `coctl` binary.
+
+.Procedure
+
+. The AWS Load Balancer Operator creates the `CredentialsRequest` object in the `openshift-cloud-credential-operator` namespace for each `AWSLoadBalancerController` custom resource (CR). You can extract and save the created `CredentialsRequest` object in a directory by running the following command:
++
+[source,terminal]
+----
+$ oc get credentialsrequest -n openshift-cloud-credential-operator  \
+    aws-load-balancer-controller-<cr-name> -o yaml > <path-to-credrequests-dir>/cr.yaml <1>
+----
+<1> The `aws-load-balancer-controller-<cr-name>` parameter specifies the credential request name created by the AWS Load Balancer Operator. The `cr-name` specifies the name of the AWS Load Balancer Controller instance.
+
+. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory by running the following command:
++
+[source,terminal]
+----
+$ ccoctl aws create-iam-roles \
+    --name <name> --region=<aws_region> \
+    --credentials-requests-dir=<path-to-credrequests-dir> \
+    --identity-provider-arn <oidc-arn>
+----
+
+. Apply the secrets generated in manifests directory to your cluster, by running the following command:
++
+[source,terminal]
+----
+$ ls manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
+----
+
+. Verify that the `aws-load-balancer-controller` pod is created:
++
+[source,terminal]
+----
+$ oc -n aws-load-balancer-operator get pods
+NAME                                                            READY   STATUS    RESTARTS   AGE
+aws-load-balancer-controller-cluster-9b766d6-gg82c              1/1     Running   0          137m
+aws-load-balancer-operator-controller-manager-b55ff68cc-85jzg   2/2     Running   0          3h26m
+----

--- a/networking/aws_load_balancer_operator/installing-albo-sts-cluster.adoc
+++ b/networking/aws_load_balancer_operator/installing-albo-sts-cluster.adoc
@@ -1,0 +1,19 @@
+:_content-type: ASSEMBLY
+[id="albo-sts-cluster"]
+= Installing AWS Load Balancer Operator on Secure Token Service cluster
+include::_attributes/common-attributes.adoc[]
+:context: albo-sts-cluster
+
+toc::[]
+
+You can install the AWS Load Balancer Operator on the Secure Token Service (STS) cluster.
+
+The AWS Load Balancer Operator relies on `CredentialsRequest` to bootstrap the Operator and for each `AWSLoadBalancerController` instance. The AWS Load Balancer Operator waits until the required secrets are created and available. The Cloud Credential Operator does not provision the secrets automatically in the STS cluster. You must set the credentials secrets manually by using the `ccoctl` binary. 
+
+include::modules/bootstrap-aws-load-balancer-operator.adoc[leveloffset=+1]
+
+include::modules/configuring-albo-on-sts-cluster.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+* xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-configuring_cco-mode-sts[Configuring the Cloud Credential Operator utility]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/CFE-652
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://52392--docspreview.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/installing-albo-sts-cluster.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
