### PR TITLE
BZ1957067: Explain the route domain configuration

### DIFF
--- a/modules/nw-creating-a-route.adoc
+++ b/modules/nw-creating-a-route.adoc
@@ -73,8 +73,8 @@ spec:
     kind: Service
     name: hello-openshift
 ----
-<1> `<Ingress_Domain>` is the default ingress domain name.
-<2> `targetPort` is the target port on pods that is selected by the service that this route points to.  
+<1> `<Ingress_Domain>` is the default ingress domain name. The `ingresses.config/cluster` object is created during the installation and cannot be changed. If you want to specify a different domain, you can specify an alternative cluster domain using the `appsDomain` option.
+<2> `targetPort` is the target port on pods that is selected by the service that this route points to.
 
 +
 [NOTE]

--- a/modules/nw-ingress-configuring-application-domain.adoc
+++ b/modules/nw-ingress-configuring-application-domain.adoc
@@ -43,7 +43,7 @@ spec:
   domain: apps.example.com            <1>
   appsDomain: <test.example.com>      <2>
 ----
-<1> Default domain
+<1> Specifies the default domain. You cannot modify the default domain after installation.
 <2> Optional: Domain for {product-title} infrastructure to use for application routes. Instead of the default prefix, `apps`, you can use an alternative prefix like `test`.
 +
 . Verify that an existing route contains the domain name specified in the `appsDomain` field by exposing the route and verifying the route domain change:

--- a/networking/routes/route-configuration.adoc
+++ b/networking/routes/route-configuration.adoc
@@ -42,7 +42,7 @@ include::modules/nw-throughput-troubleshoot.adoc[leveloffset=+1]
 * xref:../../nodes/edge/nodes-edge-remote-workers.adoc#nodes-edge-remote-workers-latency[Latency spikes or temporary reduction in throughput to remote workers]
 
 
-* xref:../../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration 
+* xref:../../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration
 parameters]
 endif::[]
 
@@ -66,3 +66,8 @@ include::modules/nw-ingress-edge-route-default-certificate.adoc[leveloffset=+1]
 include::modules/nw-ingress-reencrypt-route-custom-cert.adoc[leveloffset=+1]
 
 include::modules/nw-router-configuring-dual-stack.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/ingress-operator.adoc#configuring-ingress[Specifying an alternative cluster domain using the appsDomain option]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.8+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=1957067
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://52393--docspreview.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-creating-a-route_route-configuration

https://52393--docspreview.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-configuring-application-domain_configuring-ingress

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
