### PR TITLE
CCXDEV-6528 Insights Operator configuration

### DIFF
--- a/modules/disabling-insights-operator-alerts.adoc
+++ b/modules/disabling-insights-operator-alerts.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-operator.adoc
+
+
+:_content-type: CONCEPT
+[id="disabling-insights-operator-alerts_{context}"]
+= Disabling Insights Operator alerts
+
+You can stop Insights Operator from firing alerts to the cluster Prometheus instance.
+
+. Navigate to *Workloads* -> *Secrets*.
+. On the *Secrets* page, select *All Projects* from the *Project* list, and then set *Show default projects* to on.
+. Select the *openshift-config* project from the *Projects* list.
+. Search for the *support* secret using the *Search by name* field. If the secret does not exist, click *Create* -> *Key/value secret* to create it.
+. Click the *Options* menu {kebab}, and then click *Edit Secret*.
+. Click *Add Key/Value*.
+. Enter `disableInsightsAlerts` as the key with the value `True`, and click *Save*.
+
+After you save the changes, Insights Operator will no longer send alerts to the cluster Prometheus instance. 

--- a/modules/disabling-insights-operator-gather.adoc
+++ b/modules/disabling-insights-operator-gather.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-operator.adoc
+
+
+:_content-type: PROCEDURE
+[id="disabling-insights-operator-gather_{context}"]
+= Disabling the Insights Operator gather operations
+
+You can disable the Insights Operator gather operations. Disabling the gather operations gives you the ability to increase privacy for your organization as Insights Operator will no longer gather and send Insights cluster reports to Red Hat. This will disable Insights analysis and recommendations for your cluster without affecting other core functions that require communication with Red Hat such as cluster transfers. You can view a list of attempted gather operations for your cluster from the `/insights-operator/gathers.json` file in your Insights Operator archive. Be aware that some gather operations only occur when certain conditions are met and might not appear in your most recent archive. 
+
+:FeatureName: The `InsightsDataGather` custom resource 
+include::snippets/technology-preview.adoc[] 
+
+.Prerequisites
+
+* You are logged in to the {product-title} web console as a user with `cluster-admin` role.
+
+.Procedure
+
+. Navigate to *Administration* -> *CustomResourceDefinitions*.
+. On the *CustomResourceDefinitions* page, use the *Search by name* field to find the *InsightsDataGather* resource definition and click it.
+. On the *CustomResourceDefinition details* page, click the *Instances* tab.
+. Click *cluster*, and then click the *YAML* tab.
+. To disable all the gather operations, edit the `InsightsDataGather` configuration file:
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1alpha1
+kind: InsightsDataGather
+metadata:
+....
+
+spec: <1>
+  gatherConfig: 
+    disabledGatherers: 
+      - all <2>
+----
++
+--
+<1> The `spec` parameter specifies gather configurations. 
+<2> The `all` value disables all gather operations.
+--
+To disable individual gather operations, enter their values under the `disabledGatherers` key:
++
+[source,yaml]
+----
+spec:
+  gatherConfig:
+    disabledGatherers:
+      - clusterconfig/container_images <1>
+      - clusterconfig/host_subnets
+      - workloads/workload_info
+----
++
+--
+<1> Example individual gather operation
+--
++
+. Click *Save*.
++
+After you save the changes, the Insights Operator gather configurations are updated and the operations will no longer occur. 
+
+[NOTE]
+====
+Disabling gather operations degrades Insights Advisor's ability to offer effective recommendations for your cluster.
+====

--- a/modules/insights-operator-configuring.adoc
+++ b/modules/insights-operator-configuring.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-operator.adoc
+
+
+:_content-type: PROCEDURE
+[id="insights-operator-configuring-sca_{context}"]
+= Configuring Insights Operator
+
+You can configure Insights Operator to meet the needs of your organization. The Insights Operator is configured using a combination of the default configurations in the `pod.yaml` file in the Insights Operator `Config` directory and the configurations stored in the `support` secret in the `openshift-config` namespace. The `support` secret does not exist by default and must be created when adding custom configurations for the first time. Configurations in the `support` secret override the defaults set in the `pod.yaml` file.
+
+The table below describes the available configuration attributes:
+
+.Insights Operator configurable attributes
+[options="header"]
+|====
+|Attribute name|Description|Value type|Default value
+|`username`|Specifies username for basic authentication with `console.redhat.com` (overrides the default `pull-secret` token authentication when set)|String|Not set
+|`password`|Specifies password for basic authentication with `console.redhat.com` (overrides the default `pull-secret` token authentication when set)|String|Not set
+|`enableGlobalObfuscation`|Enables the global obfuscation of IP addresses and the cluster domain name|Boolean|`false`
+|`scaInterval`|Specifies the frequency of the simple content access entitlements download|Time interval|`8h`
+|`scaPullDisabled`|Disables the simple content access entitlements download|Boolean|`false`
+|`clusterTransferInterval`|Specifies how often Insights Operator checks OpenShift Cluster Manager for available cluster transfers|Time interval|`24h`
+|`disableInsightsAlerts`|Disables Insights Operator alerts to the cluster Prometheus instance|Boolean|`False`
+|====
+
+This procedure describes how to set custom Insights Operator configurations.
+
+[IMPORTANT]
+====
+Red Hat recommends you consult Red Hat Support before making changes to the default Insights Operator configuration. 
+====
+
+.Prerequisites
+
+* You are logged in to the {product-title} web console as a user with `cluster-admin` role.
+
+.Procedure
+
+. Navigate to *Workloads* -> *Secrets*.
+. On the *Secrets* page, select *All Projects* from the *Project* list, and then set *Show default projects* to on.
+. Select the *openshift-config* project from the *Project* list.
+. Search for the *support* secret using the *Search by name* field. If it does not exist, click *Create* -> *Key/value secret* to create it.
+. Click the *Options* menu {kebab} for the secret, and then click *Edit Secret*.
+. Click *Add Key/Value*.
+. Enter an attribute name with an appropriate value (see table above), and click *Save*.
+. Repeat the above steps for any additional configurations.

--- a/modules/understanding-insights-operator-alerts.adoc
+++ b/modules/understanding-insights-operator-alerts.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-operator.adoc
+
+
+:_content-type: CONCEPT
+[id="understanding-insights-operator-alerts_{context}"]
+= Understanding Insights Operator alerts
+
+Insights Operator declares alerts through the Prometheus monitoring system to Alertmanager. You can view these alerts in the Alerting UI accessible through the *Administrator* perspective and the *Developer* perspective in the {product-title} web console. 
+
+Currently, Insights Operator sends the following alerts when the conditions are met:
+
+.Insights Operator alerts
+[options="header"]
+|====
+|Alert|Description
+|`InsightsDisabled`|Insights Operator is disabled.
+|`SimpleContentAccessNotAvailable`|Simple content access is not enabled in Red Hat Subscription Management.
+|`InsightsRecommendationActive`|Insights has an active recommendation for the cluster.
+|====

--- a/support/remote_health_monitoring/using-insights-operator.adoc
+++ b/support/remote_health_monitoring/using-insights-operator.adoc
@@ -18,5 +18,9 @@ The Insights Operator periodically gathers configuration and component failure s
 
 * For more information on using Insights Advisor to identify issues with your cluster, see xref:../../support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc#using-insights-to-identify-issues-with-your-cluster[Using Insights to identify issues with your cluster].
 
+include::modules/understanding-insights-operator-alerts.adoc[leveloffset=+1]
+include::modules/disabling-insights-operator-alerts.adoc[leveloffset=+1]
 include::modules/insights-operator-downloading-archive.adoc[leveloffset=+1]
 include::modules/insights-operator-gather-duration.adoc[leveloffset=+1]
+include::modules/disabling-insights-operator-gather.adoc[leveloffset=+1]
+include::modules/insights-operator-configuring.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
  * PR applies to 4.12+

Issues:
https://issues.redhat.com/browse/CCXDEV-6528 Insights Operator Configuring 
https://issues.redhat.com/browse/CCXDEV-9117 Gathering Disable (TP)

<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://52395--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

