### PR TITLE
RHDEVDOCS-4602 `tkn-pac` CLI installation instructions need to use only productized artifacts

### DIFF
--- a/modules/op-installing-pipelines-as-code-cli.adoc
+++ b/modules/op-installing-pipelines-as-code-cli.adoc
@@ -22,40 +22,40 @@ You can also install the `tkn-pac` `tkn-pac` version `0.23.1` binaries for the s
 The binaries are compatible with `tkn` version `0.23.1`.
 ====
 
-In addition, you can install `tkn-pac` using the following methods:
+// In addition, you can install `tkn-pac` using the following methods:
 
-[CAUTION]
-====
-The `tkn-pac` CLI tool available using these methods is _not updated regularly_. 
-====
+// [CAUTION]
+// ====
+// The `tkn-pac` CLI tool available using these methods is _not updated regularly_. 
+// ====
 
-* Install on Linux or Mac OS using the `brew` package manager:
-+
-[source,terminal]
-----
-$ brew install openshift-pipelines/pipelines-as-code/tektoncd-pac
-----
-+
-You can upgrade the package by running the following command:
-+
-[source,terminal]
-----
-$ brew upgrade openshift-pipelines/pipelines-as-code/tektoncd-pac
-----
+// * Install on Linux or Mac OS using the `brew` package manager:
+// +
+// [source,terminal]
+// ----
+// $ brew install openshift-pipelines/pipelines-as-code/tektoncd-pac
+// ----
+// +
+// You can upgrade the package by running the following command:
+// +
+// [source,terminal]
+// ----
+// $ brew upgrade openshift-pipelines/pipelines-as-code/tektoncd-pac
+// ----
 
-* Install as a container using `podman`:
-+
-[source,terminal]
-----
-$ podman run -e KUBECONFIG=/tmp/kube/config -v ${HOME}/.kube:/tmp/kube \
-     -it quay.io/openshift-pipeline/pipelines-as-code tkn-pac help
-----
-+
-You can also use `docker` as a substitute for `podman`.
+// * Install as a container using `podman`:
+// +
+// [source,terminal]
+// ----
+// $ podman run -e KUBECONFIG=/tmp/kube/config -v ${HOME}/.kube:/tmp/kube \
+//      -it quay.io/openshift-pipeline/pipelines-as-code tkn-pac help
+// ----
+// +
+// You can also use `docker` as a substitute for `podman`.
 
-* Install from the GitHub repository using `go`:
-+
-[source,terminal]
-----
-$ go install github.com/openshift-pipelines/pipelines-as-code/cmd/tkn-pac
-----
+// * Install from the GitHub repository using `go`:
+// +
+// [source,terminal]
+// ----
+// $ go install github.com/openshift-pipelines/pipelines-as-code/cmd/tkn-pac
+// ----


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`, `enterprise-4.12`
- **JIRA issues**: [RHDEVDOCS-4602 tkn-pac CLI installation instructions need to use only productized artifacts](https://issues.redhat.com/browse/RHDEVDOCS-4602)
- **Preview pages**: [Installing Pipelines as Code CLI](http://file.pnq.redhat.com/sosarkar/4602-tkn-pac-productized/cicd/pipelines/using-pipelines-as-code.html#installing-pipelines-as-code-cli_using-pipelines-as-code)
- **SME review**: @vdemeester  
- **QE review**: Not needed as no new information added.