### PR TITLE
[enterprise-4.8] CNV-17636: Moved the service section to separate assembly

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2898,6 +2898,12 @@ Topics:
     Topics:
     - Name: Configuring the virtual machine for the default pod network
       File: virt-using-the-default-pod-network-with-virt
+      Distros: openshift-enterprise
+    - Name: Configuring the virtual machine for the default pod network with OKD Virtualization
+      File: virt-using-the-default-pod-network-with-virt
+      Distros: openshift-origin
+    - Name: Creating a service to expose a virtual machine
+      File: virt-creating-service-vm
     - Name: Attaching a virtual machine to a Linux bridge network
       File: virt-attaching-vm-multiple-networks
     - Name: Configuring IP addresses for virtual machines

--- a/modules/virt-about-services.adoc
+++ b/modules/virt-about-services.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-creating-service-vm.adoc
+
+:_content-type: CONCEPT
+[id="virt-about-services_{context}"]
+= About services
+
+A Kubernetes _service_ is an abstract way to expose an application running on a set of pods as a network service. Services allow your applications to receive traffic. Services can be exposed in different ways by specifying a `spec.type` in the `Service` object:
+
+ClusterIP:: Exposes the service on an internal IP address within the cluster. `ClusterIP` is the default service `type`.
+
+NodePort:: Exposes the service on the same port of each selected node in the cluster. `NodePort` makes a service accessible from outside the cluster.
+
+LoadBalancer:: Creates an external load balancer in the current cloud (if supported) and assigns a fixed, external IP address to the service.
+
+
+[id="services-dual-stack-cluster_{context}"]
+== Dual-stack support
+
+If IPv4 and IPv6 dual-stack networking is enabled for your cluster, you can create a service that uses IPv4, IPv6, or both, by defining the `spec.ipFamilyPolicy` and the `spec.ipFamilies` fields in the `Service` object.
+
+The `spec.ipFamilyPolicy` field can be set to one of the following values:
+
+SingleStack:: The control plane assigns a cluster IP address for the service based on the first configured service cluster IP range.
+
+PreferDualStack:: The control plane assigns both IPv4 and IPv6 cluster IP addresses for the service on clusters that have dual-stack configured.
+
+RequireDualStack:: This option fails for clusters that do not have dual-stack networking enabled. For clusters that have dual-stack configured, the behavior is the same as when the value is set to `PreferDualStack`. The control plane allocates cluster IP addresses from both IPv4 and IPv6 address ranges.
+
+You can define which IP family to use for single-stack or define the order of IP families for dual-stack by setting the `spec.ipFamilies` field to one of the following array values:
+
+* `[IPv4]`
+* `[IPv6]`
+* `[IPv4, IPv6]`
+* `[IPv6, IPv4]`

--- a/modules/virt-creating-a-service-from-a-virtual-machine.adoc
+++ b/modules/virt-creating-a-service-from-a-virtual-machine.adoc
@@ -1,48 +1,18 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
+// * virt/virtual_machines/vm_networking/virt-creating-service-vm.adoc
 
 :_content-type: PROCEDURE
 [id="virt-creating-a-service-from-a-virtual-machine_{context}"]
 
-= Creating a service from a virtual machine
+= Exposing a virtual machine as a service
 
-Create a service from a running virtual machine by first creating a `Service` object to expose the virtual machine.
-
-[NOTE]
-====
-If IPv4 and IPv6 dual-stack networking is enabled for your cluster, you can create a service that uses IPv4, IPv6, or both, by defining the `spec.ipFamilyPolicy` and the `spec.ipFamilies` fields in the `Service` object.
-
-The `spec.ipFamilyPolicy` field can be set to one of the following values:
-
-* `SingleStack`: The control plane assigns a cluster IP address for the service based on the first configured service cluster IP range.
-
-* `PreferDualStack`: The control plane assigns both IPv4 and IPv6 cluster IP addresses for the service on clusters that have dual-stack configured.
-
-* `RequireDualStack`: This option fails for clusters that do not have dual-stack networking enabled. For clusters that have dual-stack configured, the behavior is the same as when the value is set to `PreferDualStack`. The control plane allocates cluster IP addresses from both IPv4 and IPv6 address ranges.
-
-You can define which IP family to use for single-stack or define the order of IP families for dual-stack by setting the `spec.ipFamilies` field to one of the following array values:
-
-* `[IPv4]`
-* `[IPv6]`
-* `[IPv4, IPv6]`
-* `[IPv6, IPv4]`
-====
-
-The `ClusterIP` service type exposes the virtual machine internally, within the cluster. The `NodePort` or `LoadBalancer` service types expose the virtual machine externally, outside of the cluster.
-
-This procedure presents an example of how to create, connect to, and expose a `Service` object of `type: ClusterIP` as a virtual machine-backed service.
-
-[NOTE]
-====
-`ClusterIP` is the default service `type`, if the service `type` is not specified.
-====
+Create a `ClusterIP`, `NodePort`, or `LoadBalancer` service to connect to a running virtual machine (VM) from within or outside the cluster.
 
 .Procedure
 
-. Edit the virtual machine YAML as follows:
+. Edit the `VirtualMachine` manifest to add the label for service creation:
 +
-
 [source,yaml]
 ----
 apiVersion: kubevirt.io/v1
@@ -56,51 +26,20 @@ spec:
     metadata:
       labels:
         special: key <1>
-    spec:
-      domain:
-        devices:
-          disks:
-            - name: containerdisk
-              disk:
-                bus: virtio
-            - name: cloudinitdisk
-              disk:
-                bus: virtio
-          interfaces:
-          - masquerade: {}
-            name: default
-        resources:
-          requests:
-            memory: 1024M
-      networks:
-        - name: default
-          pod: {}
-      volumes:
-        - name: containerdisk
-          containerDisk:
-            image: kubevirt/fedora-cloud-container-disk-demo
-        - name: cloudinitdisk
-          cloudInitNoCloud:
-            userData: |
-              #!/bin/bash
-              echo "fedora" | passwd fedora --stdin
+# ...
 ----
 <1> Add the label `special: key` in the `spec.template.metadata.labels` section.
 +
 
 [NOTE]
 ====
-Labels on a virtual machine are passed through to the pod. The labels on
-the `VirtualMachine` configuration, for example `special: key`, must match the labels in
-the `Service` YAML `selector` attribute, which you create later
-in this procedure.
+Labels on a virtual machine are passed through to the pod. The `special: key` label must match the label in the `spec.selector` attribute of the `Service` manifest.
 ====
 
-. Save the virtual machine YAML to apply your changes.
+. Save the `VirtualMachine` manifest file to apply your changes.
 
-. Edit the `Service` YAML to configure the settings necessary to create and expose the `Service` object:
+. Create a `Service` manifest to expose the VM:
 +
-
 [source,yaml]
 ----
 apiVersion: v1
@@ -109,69 +48,53 @@ metadata:
   name: vmservice <1>
   namespace: example-namespace <2>
 spec:
+  externalTrafficPolicy: Cluster <3>
   ports:
-  - port: 27017
+  - nodePort: 30000 <4>
+    port: 27017
     protocol: TCP
-    targetPort: 22 <3>
+    targetPort: 22 <5>
   selector:
-    special: key <4>
-  type: ClusterIP <5>
+    special: key <6>
+  type: NodePort <7>
 ----
-<1> Specify the `name` of the service you are creating and exposing.
-<2> Specify `namespace` in the `metadata` section of the `Service` YAML that corresponds to the `namespace` you specify in the virtual machine YAML.
-<3> Add `targetPort: 22`, exposing the service on SSH port `22`.
-<4> In the `spec` section of the `Service` YAML, add `special: key` to the `selector` attribute, which corresponds to the `labels` you added in the virtual machine YAML configuration file.
-<5> In the `spec` section of the `Service` YAML, add `type: ClusterIP` for a
-ClusterIP service. To create and expose other types of services externally, outside of the cluster, such as `NodePort` and `LoadBalancer`, replace
-`type: ClusterIP` with `type: NodePort` or `type: LoadBalancer`, as appropriate.
-+
+<1> The name of the `Service` object.
+<2> The namespace where the `Service` object resides. This must match the `metadata.namespace` field of the `VirtualMachine` manifest.
+<3> Optional: Specifies how the nodes distribute service traffic that is received on external IP addresses. This only applies to `NodePort` and `LoadBalancer` service types. The default value is `Cluster` which routes traffic evenly to all cluster endpoints.
+<4> Optional: When set, the `nodePort` value must be unique across all services. If not specified, a value in the range above `30000` is dynamically allocated.
+<5> Optional: The VM port to be exposed by the service. It must reference an open port if a port list is defined in the VM manifest. If `targetPort` is not specified, it takes the same value as `port`.
+<6> The reference to the label that you added in the `spec.template.metadata.labels` stanza of the `VirtualMachine` manifest.
+<7> The type of service.  Possible values are `ClusterIP`, `NodePort` and `LoadBalancer`.
 
-. Save the `Service` YAML to store the service configuration.
-. Create the `ClusterIP` service:
+. Save the `Service` manifest file.
+. Create the service by running the following command:
 +
-
 [source,terminal]
 ----
 $ oc create -f <service_name>.yaml
 ----
 
-+
-. Start the virtual machine. If the virtual machine is already running, restart it.
-+
-
-+
-. Query the `Service` object to verify it is available and is configured with type `ClusterIP`.
-+
+. Start the VM. If the VM is already running, restart it.
 
 .Verification
-* Run the `oc get service` command, specifying the `namespace` that you reference in the virtual machine and `Service` YAML files.
+. Query the `Service` object to verify that it is available:
 +
-
 [source, terminal]
 ----
 $ oc get service -n example-namespace
 ----
 +
-
-.Example output
+.Example output for `ClusterIP` service
 [source, terminal]
 ----
 NAME        TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)     AGE
 vmservice   ClusterIP   172.30.3.149   <none>        27017/TCP   2m
 ----
 +
-
-** As shown from the output, `vmservice` is running.
-** The `TYPE` displays as `ClusterIP`, as you specified in the `Service` YAML.
-
-. Establish a connection to the virtual machine that you want to use to back your service. Connect from an object inside the cluster, such as another virtual machine.
-+
-
-.. Edit the virtual machine YAML as follows:
-+
-
-[source,yaml]
+.Example output for `NodePort` service
+[source, terminal]
 ----
+<<<<<<< HEAD
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -208,46 +131,31 @@ spec:
             userData: |
               #!/bin/bash
               echo "fedora" | passwd fedora --stdin
+=======
+NAME        TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)            AGE
+vmservice   NodePort    172.30.232.73   <none>       27017:30000/TCP    5m
+>>>>>>> fae45e2d81 (CNV-17636: Moved the service section to separate assembly)
 ----
 +
-
-.. Run the `oc create` command to create a second virtual machine, where `file.yaml` is the name of the virtual machine YAML:
-+
-
-[source,terminal]
+.Example output for `LoadBalancer` service
+[source, terminal]
 ----
-$ oc create -f <file.yaml>
+NAME        TYPE            CLUSTER-IP     EXTERNAL-IP                    PORT(S)           AGE
+vmservice   LoadBalancer    172.30.27.5   172.29.10.235,172.29.10.235     27017:31829/TCP   5s
 ----
+
+. Choose the appropriate method to connect to the virtual machine:
 +
-
-.. Start the virtual machine.
-
-.. Connect to the virtual machine by running the following `virtctl` command:
+* For a `ClusterIP` service, connect to the VM from within the cluster by using the service IP address and the service port. For example:
 +
-
-[source,terminal]
-----
-$ virtctl -n example-namespace console <new-vm-name>
-----
-+
-
-[NOTE]
-====
-For service type `LoadBalancer`, use the `vinagre` client to connect your
-virtual machine by using the public IP and port.
-External ports are dynamically allocated when using service type
-`LoadBalancer`.
-====
-+
-
-.. Run the `ssh` command to authenticate the connection, where `172.30.3.149` is the ClusterIP of the service and `fedora` is the user name of the virtual machine:
-+
-
 [source,terminal]
 ----
 $ ssh fedora@172.30.3.149 -p 27017
 ----
+* For a `NodePort` service, connect to the VM by specifying the node IP address and the node port outside the cluster network. For example:
 +
-
-.Verification
-* You receive the command prompt of the virtual machine backing the service you want to expose. You now have a service backed by a running virtual machine.
+[source,terminal]
+----
+$ ssh fedora@$NODE_IP -p 30000
+----
+* For a `LoadBalancer` service, use the `vinagre` client to connect to your virtual machine by using the public IP address and port. External ports are dynamically allocated.

--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -119,7 +119,7 @@ Deprecated features are included in the current release and supported. However, 
 [id="virt-4-8-changes"]
 == Notable technical changes
 //CNV-9052 OpenShift Virtualization now automatically configures IPv6 IP when running on dual-stack clusters.
-* {VirtProductName} now configures IPv6 addresses when running on clusters that have dual-stack networking enabled. You can xref:../virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc#virt-creating-a-service-from-a-virtual-machine_virt-using-the-default-pod-network-with-virt[create a service] that uses IPv4, IPv6, or both IP address families, if dual-stack networking is enabled for the underlying {product-title} cluster.
+* {VirtProductName} now configures IPv6 addresses when running on clusters that have dual-stack networking enabled. You can xref:../virt/virtual_machines/vm_networking/virt-creating-service-vm.adoc#virt-creating-service-vm[create a service] that uses IPv4, IPv6, or both IP address families, if dual-stack networking is enabled for the underlying {product-title} cluster.
 
 //CNV-9054 MAC address pool is now enabled on all namespaces by default.
 * KubeMacPool is now enabled by default when you install {VirtProductName}. You can xref:../virt/virtual_machines/vm_networking/virt-using-mac-address-pool-for-vms.adoc#virt-using-mac-address-pool-for-vms[disable a MAC address pool] for a namespace by adding the `mutatevirtualmachines.kubemacpool.io=ignore` label to the namespace. Re-enable KubeMacPool for the namespace by removing the label.

--- a/virt/virtual_machines/vm_networking/virt-creating-service-vm.adoc
+++ b/virt/virtual_machines/vm_networking/virt-creating-service-vm.adoc
@@ -1,0 +1,19 @@
+:_content-type: ASSEMBLY
+[id="virt-creating-service-vm"]
+= Creating a service to expose a virtual machine
+include::_attributes/common-attributes.adoc[]
+:context: virt-creating-service-vm
+
+toc::[]
+
+You can expose a virtual machine within the cluster or outside the cluster by using a `Service` object.
+
+include::modules/virt-about-services.adoc[leveloffset=+1]
+
+include::modules/virt-creating-a-service-from-a-virtual-machine.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_creating-service-vm"]
+== Additional resources
+* xref:../../../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc#configuring-ingress-cluster-traffic-nodeport[Configuring ingress cluster traffic using a NodePort]
+* xref:../../../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.adoc#configuring-ingress-cluster-traffic-load-balancer[Configuring ingress cluster traffic using a load balancer]

--- a/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
+++ b/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
@@ -11,5 +11,3 @@ You can connect a virtual machine to the default internal pod network by configu
 include::modules/virt-configuring-masquerade-mode-cli.adoc[leveloffset=+1]
 
 include::modules/virt-configuring-masquerade-mode-dual-stack.adoc[leveloffset=+1]
-
-include::modules/virt-creating-a-service-from-a-virtual-machine.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.8
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

<!--- Issue: --->
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

<!--- Link to docs preview: --->
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

<!--- QE review:
- [ ] QE has approved this change. --->
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Cherry picked from fae45e2d81de7d0f6283c1922010ff0aa5d35303 xref: https://github.com/openshift/openshift-docs/pull/49354
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
