### PR TITLE
Documenting 2050824 in main body of text where deemed relevant

### DIFF
--- a/modules/nw-metallb-example-bgppeer.adoc
+++ b/modules/nw-metallb-example-bgppeer.adoc
@@ -51,7 +51,7 @@ spec:
 //Dependency on RHEL bug 2054160 being addressed.Remove note when fixed.
 [NOTE]
 ====
-Deleting the bidirectional forwarding detection (BFD) profile and removing the `bfdProfile` added to the border gateway protocol (BGP) peer resource does not disable the BFD. Instead, the BGP peer starts using the default BFD profile. To disable BFD from a BGP peer resource, delete the BGP peer configuration and recreate it without a BFD profile.
+Deleting the bidirectional forwarding detection (BFD) profile and removing the `bfdProfile` added to the border gateway protocol (BGP) peer resource does not disable the BFD. Instead, the BGP peer starts using the default BFD profile. To disable BFD from a BGP peer resource, delete the BGP peer configuration and recreate it without a BFD profile. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2050824[*BZ#2050824*].
 ====
 
 [id="nw-metallb-example-dual-stack_{context}"]

--- a/modules/nw-metallb-example-bgppeer.adoc
+++ b/modules/nw-metallb-example-bgppeer.adoc
@@ -48,6 +48,11 @@ spec:
   holdTime: "10s"
   bfdProfile: doc-example-bfd-profile-full
 ----
+//Dependency on RHEL bug 2054160 being addressed.Remove note when fixed.
+[NOTE]
+====
+Deleting the bidirectional forwarding detection (BFD) profile and removing the `bfdProfile` added to the border gateway protocol (BGP) peer resource does not disable the BFD. Instead, the BGP peer starts using the default BFD profile. To disable BFD from a BGP peer resource, delete the BGP peer configuration and recreate it without a BFD profile.
+====
 
 [id="nw-metallb-example-dual-stack_{context}"]
 == Example: Specify BGP peers for dual-stack networking

--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2518,7 +2518,7 @@ In the table below, features are marked with the following statuses:
 // TODO: This known issue should carry forward to 4.8 and beyond! This needs some SME/QE review before being updated for 4.9.
 * In {product-title} 4.1, anonymous users could access discovery endpoints. Later releases revoked this access to reduce the possible attack surface for security exploits because some discovery endpoints are forwarded to aggregated API servers. However, unauthenticated access is preserved in upgraded clusters so that existing use cases are not broken.
 +
-If you are a cluster administrator for a cluster that has been upgraded from {product-title} 4.1 to 4.8, you can either revoke or continue to allow unauthenticated access. It is recommended to revoke unauthenticated access unless there is a specific need for it. If you do continue to allow unauthenticated access, be aware of the increased risks.
+If you are a cluster administrator for a cluster that has been upgraded from {product-title} 4.1 to {product-version}, you can either revoke or continue to allow unauthenticated access. It is recommended to revoke unauthenticated access unless there is a specific need for it. If you do continue to allow unauthenticated access, be aware of the increased risks.
 +
 [WARNING]
 ====

--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2518,7 +2518,7 @@ In the table below, features are marked with the following statuses:
 // TODO: This known issue should carry forward to 4.8 and beyond! This needs some SME/QE review before being updated for 4.9.
 * In {product-title} 4.1, anonymous users could access discovery endpoints. Later releases revoked this access to reduce the possible attack surface for security exploits because some discovery endpoints are forwarded to aggregated API servers. However, unauthenticated access is preserved in upgraded clusters so that existing use cases are not broken.
 +
-If you are a cluster administrator for a cluster that has been upgraded from {product-title} 4.1 to {product-version}, you can either revoke or continue to allow unauthenticated access. It is recommended to revoke unauthenticated access unless there is a specific need for it. If you do continue to allow unauthenticated access, be aware of the increased risks.
+If you are a cluster administrator for a cluster that has been upgraded from {product-title} 4.1 to 4.8, you can either revoke or continue to allow unauthenticated access. It is recommended to revoke unauthenticated access unless there is a specific need for it. If you do continue to allow unauthenticated access, be aware of the increased risks.
 +
 [WARNING]
 ====


### PR DESCRIPTION
[TELCODOCS-1016](https://issues.redhat.com//browse/TELCODOCS-1016): Deleting a BFDProfile object does not delete the corresponding running-conf from the MetalLB speakers

See also https://bugzilla.redhat.com/show_bug.cgi?id=2050824

Version(s):
4.10

Preview: http://file.emea.redhat.com/kquinn/TELCODOCS-1016/networking/metallb/metallb-configure-bgp-peers.html#nw-metallb-example-specify-bfd-profile_configure-metallb-bgp-peers

