### PR TITLE
[OSDOCS-2971]: use GCP Marketplace image via machineset

### DIFF
--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -27,39 +27,36 @@ kind: MachineSet
 metadata:
   labels:
     machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-  name: <infrastructure_id>-w-a <1>
+  name: <infrastructure_id>-w-a
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-w-a <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-w-a
   template:
     metadata:
       creationTimestamp: null
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
         machine.openshift.io/cluster-api-machine-role: <role> <2>
-        machine.openshift.io/cluster-api-machine-type: <role> <2>
+        machine.openshift.io/cluster-api-machine-type: <role>
 endif::infra[]
 ifdef::infra[]
         machine.openshift.io/cluster-api-machine-role: <infra> <2>
-        machine.openshift.io/cluster-api-machine-type: <infra> <2>
+        machine.openshift.io/cluster-api-machine-type: <infra>
 endif::infra[]
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-w-a <1>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-w-a
     spec:
       metadata:
         labels:
 ifndef::infra[]
-          node-role.kubernetes.io/<role>: "" <2>
+          node-role.kubernetes.io/<role>: ""
 endif::infra[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <2>
-      taints: <3>
-      - key: node-role.kubernetes.io/infra
-        effect: NoSchedule
+          node-role.kubernetes.io/infra: ""
 endif::infra[]
       providerSpec:
         value:
@@ -71,21 +68,11 @@ endif::infra[]
           disks:
           - autoDelete: true
             boot: true
-ifndef::infra[]
             image: <path_to_image> <3>
-endif::infra[]
-ifdef::infra[]
-            image: <path_to_image> <4>
-endif::infra[]
             labels: null
             sizeGb: 128
             type: pd-ssd
-ifndef::infra[]
           gcpMetadata: <4>
-endif::infra[]
-ifdef::infra[]
-          gcpMetadata: <5>
-endif::infra[]
           - key: <custom_metadata_key>
             value: <custom_metadata_value>
           kind: GCPMachineProviderSpec
@@ -93,38 +80,37 @@ endif::infra[]
           metadata:
             creationTimestamp: null
           networkInterfaces:
-          - network: <infrastructure_id>-network <1>
-            subnetwork: <infrastructure_id>-worker-subnet <1>
-ifndef::infra[]
+          - network: <infrastructure_id>-network
+            subnetwork: <infrastructure_id>-worker-subnet
           projectID: <project_name> <5>
-endif::infra[]
-ifdef::infra[]
-          projectID: <project_name> <6>
-endif::infra[]
           region: us-central1
           serviceAccounts:
-ifndef::infra[]
-          - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com <1> <5>
-endif::infra[]
-ifdef::infra[]
-          - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com <1> <6>
-endif::infra[]
+          - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
           tags:
-          - <infrastructure_id>-worker <1>
+            - <infrastructure_id>-worker
           userDataSecret:
             name: worker-user-data
           zone: us-central1-a
+ifdef::infra[]
+      taints: <6>
+      - key: node-role.kubernetes.io/infra
+        effect: NoSchedule
+endif::infra[]
 ----
-<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
+<1> For `<infrastructure_id>`, specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 +
 [source,terminal]
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
 ifndef::infra[]
-<2> Specify the node label to add.
+<2> For `<node>`, specify the node label to add.
+endif::infra[]
+ifdef::infra[]
+<2> For `<infra>`, specify the `<infra>` node label.
+endif::infra[]
 <3> Specify the path to the image that is used in current compute machine sets. If you have the OpenShift CLI installed, you can obtain the path to the image by running the following command:
 +
 [source,terminal]
@@ -133,27 +119,20 @@ $ oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.disks[0].image}{"\n"}' \
     get machineset/<infrastructure_id>-worker-a
 ----
-<4> Optional: Specify custom metadata in the form of a `key:value` pair. For example use cases, see the GCP documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
-<5> Specify the name of the GCP project that you use for your cluster.
-endif::infra[]
-ifdef::infra[]
-<2> Specify the `<infra>` node label.
-<3> Specify a taint to prevent user workloads from being scheduled on infra nodes.
-<4> Specify the path to the image that is used in current compute machine sets. If you have the OpenShift CLI installed, you can obtain the path to the image by running the following command:
 +
-[source,terminal]
-----
-$ oc -n openshift-machine-api \
-    -o jsonpath='{.spec.template.spec.providerSpec.value.disks[0].image}{"\n"}' \
-    get machineset/<infrastructure_id>-worker-a
-----
-<5> Optional: Specify custom metadata in the form of a `key:value` pair. For example use cases, see the GCP documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
-<6> Specify the name of the GCP project that you use for your cluster.
+To use a GCP Marketplace image, specify the offer to use:
++
+--
+* {product-title}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145`
+* {opp}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-opp-48-x86-64-202206140145`
+* {oke}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-oke-48-x86-64-202206140145`
+--
+<4> Optional: Specify custom metadata in the form of a `key:value` pair. For example use cases, see the GCP documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
+<5> For `<project_name>`, specify the name of the GCP project that you use for your cluster.
+ifdef::infra[]
+<6> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
-:!infra:
-endif::[]
-ifeval::["{context}" == "cluster-tasks"]
 :!infra:
 endif::[]


### PR DESCRIPTION
Version(s):
4.8+

Issue:
[OSDOCS-2971](https://issues.redhat.com//browse/OSDOCS-2971)

Link to docs preview:
[Sample YAML for a compute machine set custom resource on GCP](https://52429--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-yaml-gcp_creating-machineset-gcp)

QE review:
- [ ] QE has approved this change.

Additional information:
- This will need to go into 4.12 first, then coordinate with @mjpytlak on cherrypicks
- Machine mgmt component to accompany install work in #51678
- Also took the opportunity to move the `taints` param to the bottom to make the YAML file easier to maintain
- Removed duplicate callouts from the YAML block to see if this resolves the formatting issue on the portal we are seeing in [CCS-6623](https://issues.redhat.com//browse/CCS-6623)