### PR TITLE
OSDOCS-4474: Removed unsupported platform references

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -228,7 +228,7 @@ The string must be 14 characters or fewer long.
 endif::osp[]
 
 |`platform`
-|The configuration for the specific platform upon which to perform the installation: `alibabacloud`, `aws`, `baremetal`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `ovirt`, `vsphere`, or `{}`. For additional information about `platform.<platform>` parameters, consult the table for your specific platform that follows.
+|The configuration for the specific platform upon which to perform the installation: `aws`, `baremetal`, `azure`, `gcp`, `openstack`, `ovirt`, `vsphere`, or `{}`. For additional information about `platform.<platform>` parameters, consult the table for your specific platform that follows.
 |Object
 
 ifndef::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.9

Issue:
This PR addresses [osdocs-4474](https://issues.redhat.com/browse/OSDOCS-4474), which is a continuation of a manual cherry pick that introduced incorrect content [1]

Link to docs preview:
[Required configuration parameters](http://file.rdu.redhat.com/mpytlak/osdocs-4474/installing/installing_gcp/installing-gcp-customizations.html#installation-configuration-parameters-required_installing-gcp-customizations)

[1] https://github.com/openshift/openshift-docs/pull/52431