### PR TITLE
OSDOCS-4475: Removed unsupported platform and GCP param

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -253,7 +253,7 @@ The string must be 14 characters or fewer long.
 endif::osp[]
 
 |`platform`
-|The configuration for the specific platform upon which to perform the installation: `alibabacloud`, `aws`, `baremetal`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `ovirt`, `vsphere`, or `{}`. For additional information about `platform.<platform>` parameters, consult the table for your specific platform that follows.
+|The configuration for the specific platform upon which to perform the installation: `alibabacloud`, `aws`, `baremetal`, `azure`, `gcp`, `ibmcloud`, `openstack`, `ovirt`, `vsphere`, or `{}`. For additional information about `platform.<platform>` parameters, consult the table for your specific platform that follows.
 |Object
 
 ifndef::openshift-origin[]
@@ -1061,10 +1061,6 @@ Additional GCP configuration parameters are described in the following table:
 
 |`platform.gcp.network`
 |The name of the existing VPC that you want to deploy your cluster to.
-|String.
-
-|`platform.gcp.projectID`
-|The name of the GCP project where the installation program installs the cluster.
 |String.
 
 |`platform.gcp.region`


### PR DESCRIPTION
Version(s):
4.10

Issue:
This PR addresses [osdocs-4474](https://issues.redhat.com/browse/OSDOCS-4475), which is a continuation of a manual cherry pick that introduced incorrect content [1]

Link to docs preview:

- [Required installation parameters](http://file.rdu.redhat.com/mpytlak/osdocs-4475/installing/installing_gcp/installing-gcp-customizations.html#installation-configuration-parameters-required_installing-gcp-customizations)
- [Additional Google Cloud Platform (GCP) configuration parameters](http://file.rdu.redhat.com/mpytlak/osdocs-4475/installing/installing_gcp/installing-gcp-customizations.html#installation-configuration-parameters-additional-gcp_installing-gcp-customizations)

[1] https://github.com/openshift/openshift-docs/pull/52430