### PR TITLE
OSDOCS-4476: Removed unsupported GCP parameter

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1086,10 +1086,6 @@ Additional GCP configuration parameters are described in the following table:
 |The name of the existing VPC that you want to deploy your cluster to.
 |String.
 
-|`platform.gcp.projectID`
-|The name of the GCP project where the installation program installs the cluster.
-|String.
-
 |`platform.gcp.region`
 |The name of the GCP region that hosts your cluster.
 |Any valid region name, such as `us-central1`.


### PR DESCRIPTION
Version(s):
4.11

Issue:
This PR addresses [osdocs-4476](https://issues.redhat.com/browse/OSDOCS-4476), which is a continuation of a manual cherry pick that introduced incorrect content [1]

Link to docs preview:

[Additional Google Cloud Platform (GCP) configuration parameters](https://52435--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-configuration-parameters-additional-gcp_installing-gcp-customizations)

[1] https://github.com/openshift/openshift-docs/pull/52412
