### PR TITLE
RHDEVDOCS-4661 - Added 1.6.2, 1.4.13 1nd 1.5.7 release notes

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,9 +23,13 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-6-2.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-6-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-6-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-5-7.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-5-6.adoc[leveloffset=+1]
 
@@ -40,6 +44,8 @@ include::modules/gitops-release-notes-1-5-2.adoc[leveloffset=+1]
 include::modules/gitops-release-notes-1-5-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-5-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-4-13.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-4-12.adoc[leveloffset=+1]
 

--- a/modules/gitops-release-notes-1-4-13.adoc
+++ b/modules/gitops-release-notes-1-4-13.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-4-13_{context}"]
+= Release notes for {gitops-title} 1.4.13
+
+{gitops-title} 1.4.13 is now available on {product-title} 4.7, 4.8, 4.9, 4.10 and 4.11.
+
+[id="fixed-issues-1-4-13_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* From {product-title} 4.12, it is optional to install the console. This fix updates the {gitops-title} Operator to prevent errors with the Operator if the console is not installed. link:https://issues.redhat.com/browse/GITOPS-2354[GITOPS-2354]

--- a/modules/gitops-release-notes-1-5-7.adoc
+++ b/modules/gitops-release-notes-1-5-7.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-5-7_{context}"]
+= Release notes for {gitops-title} 1.5.7
+
+{gitops-title} 1.5.7 is now available on {product-title} 4.8, 4.9, 4.10 and 4.11.
+
+[id="fixed-issues-1-5-7_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* From {product-title} 4.12, it is optional to install the console. This fix updates the {gitops-title} Operator to prevent errors with the Operator if the console is not installed. link:https://issues.redhat.com/browse/GITOPS-2353[GITOPS-2353]

--- a/modules/gitops-release-notes-1-6-2.adoc
+++ b/modules/gitops-release-notes-1-6-2.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-6-2_{context}"]
+= Release notes for {gitops-title} 1.6.2
+
+{gitops-title} 1.6.2 is now available on {product-title} 4.8, 4.9, 4.10 and 4.11.
+
+[id="fixed-issues-1-6-2_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, the subscription health check was marked *degraded* for missing *InstallPlan* when more than 5 Operators were installed in a project. This update fixes the issue. link:https://issues.redhat.com/browse/GITOPS-2018[GITOPS-2018]
+
+* Before this update, the {gitops-title} Operator would spam the cluster with a deprecation notice warning whenever it detected that an Argo CD instance used deprecated fields. This update fixes this issue and shows only one warning event for each instance that detects a field. link:https://issues.redhat.com/browse/GITOPS-2230[GITOPS-2230]
+
+* From {product-title} 4.12, it is optional to install the console. This fix updates the {gitops-title} Operator to prevent errors with the Operator if the console is not installed. link:https://issues.redhat.com/browse/GITOPS-2352[GITOPS-2352]
+ 
+


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise- 4.8-4.12

JIRA issue:
https://issues.redhat.com/browse/RHDEVDOCS-4661

Preview pages: https://52437--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-6-2_gitops-release-notes

SME+QE review: @varshab1210 @iam-veeramalla 
Peer-review: @jc-berger 