### PR TITLE
OCPBUGS3004: updating step_threshold from 0.0 to 2.0 across doc set

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -105,7 +105,7 @@ spec:
       pi_integral_scale                 0.0
       pi_integral_exponent              0.4
       pi_integral_norm_max              0.3
-      step_threshold                    0
+      step_threshold                    2.0
       first_step_threshold              0.00002
       max_frequency                     900000000
       clock_servo                       pi

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -101,7 +101,7 @@ spec:
       pi_integral_scale                  0.0
       pi_integral_exponent               0.4
       pi_integral_norm_max               0.3
-      step_threshold                     0.0
+      step_threshold                     2.0
       first_step_threshold               0.00002
       max_frequency                      900000000
       clock_servo                        pi

--- a/modules/sno-du-configuring-ptp.adoc
+++ b/modules/sno-du-configuring-ptp.adoc
@@ -89,7 +89,7 @@ spec:
         pi_integral_scale 0.0
         pi_integral_exponent 0.4
         pi_integral_norm_max 0.3
-        step_threshold 0.0
+        step_threshold 2.0
         first_step_threshold 0.00002
         max_frequency 900000000
         clock_servo pi


### PR DESCRIPTION
OCPBUGS-3004: step_threshold should be 2.0 in openshift docs

Version(s):

  * PR applies to all versions after a specific version: 4.9+ (4.9, 4.10,4.11, 4.12 and main)
Issue:
https://issues.redhat.com/browse/OCPBUGS-3004

Link to docs preview:

- https://52441--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-configuring-single-node-cluster-deployment-during-installation.html
- https://52441--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#configuring-linuxptp-services-as-ordinary-clock_using-ptp
- https://52441--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#configuring-linuxptp-services-as-boundary-clock_using-ptp




QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Dev has approved this change 