### PR TITLE
BZ#2115606: adding sudo to command

### DIFF
--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -48,7 +48,7 @@ system using available RHEL tools, such as `nmcli` or `nmtui`.
 +
 [source,terminal]
 ----
-$ coreos-installer install --copy-network \
+$ sudo coreos-installer install --copy-network \
      --ignition-url=http://host/worker.ign /dev/sda
 ----
 +


### PR DESCRIPTION
Versions 4.8+

[BZ#2115606](https://bugzilla.redhat.com/show_bug.cgi?id=2115606)

Adds sudo to an instruction prompting users to run the coreos-installer install command. Other instances of this command throughout the page already contain sudo.

Preview: https://52462--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-user-infra-machines-advanced_network_installing-platform-agnostic
