### PR TITLE
TELCODOCS-972 - update ptpClockThreshold description - enterprise-4.9 manual CP

### DIFF
--- a/modules/cnf-configuring-the-ptp-fast-event-publisher.adoc
+++ b/modules/cnf-configuring-the-ptp-fast-event-publisher.adoc
@@ -49,19 +49,15 @@ spec:
   profile:
   - name: "profile1"
     interface: "enp5s0f0"
-    ptp4lOpts: "-2 -s --summary_interval -4"
-    phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16" <1>
-  ptpClockThreshold:
-    holdOverTimeout: 5 <2>
-    maxOffsetThreshold: 100 <3>
-    minOffsetThreshold: -100 <4>
-  recommend:
-  - profile: "profile1"
-    priority: 4
-    match:
-    - nodeLabel: "node-role.kubernetes.io/worker"
+    ptp4lOpts: "-2 -s --summary_interval -4" <1>
+    phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16" <2>
+    ptp4lConf: ""                            <3>
+  ptpClockThreshold:                         <4>
+    holdOverTimeout: 5
+    maxOffsetThreshold: 100
+    minOffsetThreshold: -100
 ----
-<1> Required `phc2sysOpts` values. `-m` prints messages to `stdout`. The `linuxptp-daemon` `DaemonSet` parses the logs and generates Prometheus metrics.
-<2> Number of seconds to stay in the clock holdover state. Holdover state is the period between local and master clock synchronizations.
-<3> Maximum offset value in nanoseconds. Offset is the time difference between the local and master clock.
-<4> Minimum offset value in nanoseconds.
+<1> Append `--summary_interval -4` to use PTP fast events.
+<2> Required `phc2sysOpts` values. `-m` prints messages to `stdout`. The `linuxptp-daemon` `DaemonSet` parses the logs and generates Prometheus metrics.
+<3> Specify a string that contains the configuration to replace the default /etc/ptp4l.conf file. To use the default configuration, leave the field empty.
+<4> Optional. If the `ptpClockThreshold` stanza is not present, default values are used for the `ptpClockThreshold` fields. The stanza shows default `ptpClockThreshold` values. The `ptpClockThreshold` values configure how long after the PTP master clock is disconnected before PTP events are triggered. `holdOverTimeout` is the time value in seconds before the PTP clock event state changes to `FREERUN` when the PTP master clock is disconnected. The `maxOffsetThreshold` and `minOffsetThreshold` settings configure offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`). When the `ptp4l` or `phc2sys` offset value is outside this range, the PTP clock state is set to `FREERUN`. When the offset value is within this range, the PTP clock state is set to `LOCKED`.


### PR DESCRIPTION
Manual CP for enterprise-4.9. Fixes https://issues.redhat.com/browse/TELCODOCS-972 by correcting ptpClockThreshold description.

Merge to 4.9, manual CP for https://github.com/openshift/openshift-docs/pull/52188