### PR TITLE
GH#52440: attribute switch

### DIFF
--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -65,8 +65,8 @@ metadata:
   name: control-plane-<num>-bmc-secret <1> 
   namespace: openshift-machine-api
 data:
-  password: <base64_of_uid> <2>
-  username: <base64_of_pwd> <3>
+  username: <base64_of_uid> <2>
+  password: <base64_of_pwd> <3>
 type: Opaque
 ---
 apiVersion: metal3.io/v1alpha1


### PR DESCRIPTION
Versions 4.8+

Fixes #52440 

Switches the username and password attribute names in example code text. The two names were previously mixed up.

Preview: https://52479--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#replacing-a-bare-metal-control-plane-node_ipi-install-expanding