### PR TITLE
[enterprise-4.9] adds description for targetPort

### DIFF
--- a/modules/nw-creating-a-route.adoc
+++ b/modules/nw-creating-a-route.adoc
@@ -60,12 +60,13 @@ metadata:
 spec:
   host: hello-openshift-hello-openshift.<Ingress_Domain> <1>
   port:
-    targetPort: 8080
+    targetPort: 8080 <2>
   to:
     kind: Service
     name: hello-openshift
 ----
 <1> `<Ingress_Domain>` is the default ingress domain name.
+<2> `targetPort` is the target port on pods that is selected by the service that this route points to.
 +
 [NOTE]
 ====


### PR DESCRIPTION
- Applies to 4.9
- Adds description for targetPort parameter.
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2115269)
@EricPonvelle 

Manual CP of #52285.