### PR TITLE
Replacing PR 52419 - Documenting 2050824 in main body of text where deemed relevant

### DIFF
--- a/modules/nw-metallb-example-bgppeer.adoc
+++ b/modules/nw-metallb-example-bgppeer.adoc
@@ -49,6 +49,11 @@ spec:
   holdTime: "10s"
   bfdProfile: doc-example-bfd-profile-full
 ----
+//Dependency on RHEL bug 2054160 being addressed.Remove note when fixed.
+[NOTE]
+====
+Deleting the bidirectional forwarding detection (BFD) profile and removing the `bfdProfile` added to the border gateway protocol (BGP) peer resource does not disable the BFD. Instead, the BGP peer starts using the default BFD profile. To disable BFD from a BGP peer resource, delete the BGP peer configuration and recreate it without a BFD profile. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2050824[*BZ#2050824*].
+====
 
 [id="nw-metallb-example-dual-stack_{context}"]
 == Example: Specify BGP peers for dual-stack networking


### PR DESCRIPTION
[TELCODOCS-1016](https://issues.redhat.com//browse/TELCODOCS-1016): Deleting a BFDProfile object does not delete the corresponding running-conf from the MetalLB speakers

See also https://bugzilla.redhat.com/show_bug.cgi?id=2050824

Version(s):
main, 4.12, 4.11 and 4.10

Preview: http://file.emea.redhat.com/kquinn/TELCODOCS-1016-main-410/networking/metallb/metallb-configure-bgp-peers.html#nw-metallb-example-specify-bfd-profile_configure-metallb-bgp-peers

Adding note to relevant section where feature is mentioned as requested by SME. 
