### PR TITLE
[OSDOCS-4487]: Allow setting cluster autoscaler verbosity (4.12 RN)

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -279,6 +279,11 @@ For more information, see xref:../networking/dns-operator.adoc#nw-dns-cache-tuni
 [id="ocp-4-12-machine-api"]
 === Machine API
 
+[id="ocp-4-12-mapi-autoscaler-verbosity"]
+==== Specifying cluster autoscaler log level verbosity
+
+{product-title} now supports setting the log level verbosity of the cluster autoscaler by setting the `logVerbosity` parameter in the `ClusterAutoscaler` custom resource. For more information, see the xref:../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[`ClusterAutoscaler` resource definition].
+
 [id="ocp-4-12-machine-config-operator"]
 === Machine Config Operator
 


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-4487](https://issues.redhat.com//browse/OSDOCS-4487)

Link to docs preview:
[Specifying cluster autoscaler log level verbosity](https://52498--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-mapi-autoscaler-verbosity)

QE review:
IMO, QE not required (main docs for the feature are [approved](https://github.com/openshift/openshift-docs/pull/52385#issuecomment-1302878239))

Additional information: