### PR TITLE
logging: Add region to LokiStack example secret

### DIFF
--- a/modules/cluster-logging-loki-deploy.adoc
+++ b/modules/cluster-logging-loki-deploy.adoc
@@ -44,7 +44,7 @@ You must select this option to ensure that cluster monitoring scrapes the `opens
 
 .. Ensure that *LokiOperator* is listed with *Status* as *Succeeded* in all the projects.
 +
-. Create a `Secret` YAML file that uses the `access_key_id` and `access_key_secret` fields to specify your base64-encoded AWS credentials. For example:
+. Create a `Secret` YAML file that uses the `access_key_id` and `access_key_secret` fields to specify your AWS credentials and `bucketnames`, `endpoint` and `region` to define the object storage location. For example:
 +
 [source,yaml]
 ----
@@ -53,16 +53,13 @@ kind: Secret
 metadata:
   name: logging-loki-s3
   namespace: openshift-logging
-data:
-  access_key_id: QUtJQUlPU0ZPRE5ON0VYQU1QTEUK <1>
-  access_key_secret: d0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWQo= <2>
-  bucketnames: czMtYnVja2V0LW5hbWU= <3>
-  endpoint: aHR0cHM6Ly9zMy5ldS1jZW50cmFsLTEuYW1hem9uYXdzLmNvbQ== <4>
+stringData:
+  access_key_id: AKIAIOSFODNN7EXAMPLE
+  access_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+  bucketnames: s3-bucket-name
+  endpoint: https://s3.eu-central-1.amazonaws.com
+  region: eu-central-1
 ----
-<1> Base64-encoded access key id
-<2> Base64-encoded access key secret
-<3> Base64-encoded bucket name
-<4> Base64-encoded S3 API endpoint
 +
 . Create the `LokiStack` custom resource:
 +
@@ -106,11 +103,11 @@ oc apply -f logging-loki.yaml
   spec:
     managementState: Managed
     logStore:
-       type: lokistack
-       lokistack:
-         name: logging-loki
-       collection: 
-         type: "vector"
+      type: lokistack
+      lokistack:
+        name: logging-loki
+      collection:
+        type: "vector"
 ----
 +
 .. Apply the configuration:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:

The example secret listed in the "Deploying the LokiStack" section is missing the `region` attribute. I originally thought this was optional, but this does not seem to be the case as people are getting errors when specifying a secret without region.

While looking at that part of the docs I also noticed that it might be better to list the secret using `stringData` instead of `data`, so that the verbatim values are visible instead of the base64-encoded content. This should show an easier way of creating the secret instead of having to manually base64-encode all the values beforehand. Using `stringData` will not change how the secret is saved in Kubernetes.

/cc @libander 

<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
