### PR TITLE
RHDEVDOCS-4583 Document changes in installation and upgrade channels

### DIFF
--- a/modules/op-installing-pipelines-operator-in-web-console.adoc
+++ b/modules/op-installing-pipelines-operator-in-web-console.adoc
@@ -41,12 +41,12 @@ The supported profiles are:
 
 .. Select an *Update Channel*.
 
-*** The `pipelines-<version>` channel is the default channel to install the {pipelines-title} Operator. For example, the default channel to install the {pipelines-title} Operator version `1.7` is `pipelines-1.7`.
-*** The `latest` channel enables installation of the most recent stable version of the {pipelines-title} Operator. 
+*** The `latest` channel enables installation of the most recent stable version of the {pipelines-title} Operator. Currently, it is the default channel for installing the {pipelines-title} Operator.
+*** To install a specific version of the {pipelines-title} Operator, cluster administrators can use the corresponding `pipelines-<version>` channel. For example, to install the {pipelines-title} Operator version `1.8.x`, you can use the `pipelines-1.8` channel.
 +
 [NOTE]
 ====
-The `preview` and `stable` channels will be deprecated and removed in a future release.
+Starting with {product-title} 4.11, the `preview` and `stable` channels for installing and upgrading the {pipelines-title} Operator are not available. However, in {product-title} 4.10 and earlier versions, you can use the `preview` and `stable` channels for installing and upgrading the Operator.
 ====  
 
 . Click *Install*. You will see the Operator listed on the *Installed Operators* page.

--- a/modules/op-release-notes-1-8.adoc
+++ b/modules/op-release-notes-1-8.adoc
@@ -313,6 +313,13 @@ $ oc get route -n openshift-pipelines pipelines-as-code-controller \
 [id="deprecated-features-1-8_{context}"]
 == Deprecated and removed features
 
+* Starting with {product-title} 4.11, the `preview` and `stable` channels for installing and upgrading the {pipelines-title} Operator are removed. To install and upgrade the Operator, use the appropriate `pipelines-<version>` channel, or the `latest` channel for the most recent stable version. For example, to install the {pipelines-shortname} Operator version `1.8.x`, use the `pipelines-1.8` channel. 
++
+[NOTE]
+====
+In {product-title} 4.10 and earlier versions, you can use the `preview` and `stable` channels for installing and upgrading the Operator.
+====
+
 * Support for the `tekton.dev/v1alpha1` API version, which was deprecated in {pipelines-title} GA 1.6, is planned to be removed in the upcoming {pipelines-title} GA 1.9 release.
 +
 This change affects the pipeline component, which includes the `TaskRun`, `PipelineRun`, `Task`, `Pipeline`, and similar `tekton.dev/v1alpha1` resources. As an alternative, update existing resources to use `apiVersion: tekton.dev/v1beta1` as described in link:https://tekton.dev/docs/pipelines/migrating-v1alpha1-to-v1beta1/[Migrating From Tekton v1alpha1 to Tekton v1beta1].


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.11`, `enterprise-4.12`
- **JIRA issues**: [RHDEVDOCS-4583 Document changes in installation and upgrade channels](https://issues.redhat.com/browse/RHDEVDOCS-4583)
- **Preview pages**: 
  - [Installation page](http://file.pnq.redhat.com/sosarkar/4583-operator-channels/cicd/pipelines/installing-pipelines.html#op-installing-pipelines-operator-in-web-console_installing-pipelines): See the bullet point "Select an Update Channel." in the **Procedure**.
  - [1.8 RN](http://file.pnq.redhat.com/sosarkar/4583-operator-channels/cicd/pipelines/op-release-notes.html#deprecated-features-1-8_op-release-notes)
- **SME + QE review**: @VeereshAradhya 