### PR TITLE
OCPBUGS#2309: Specifying hardware/software RAID support status for BM

### DIFF
--- a/modules/bmo-about-the-baremetalhost-resource.adoc
+++ b/modules/bmo-about-the-baremetalhost-resource.adoc
@@ -90,7 +90,14 @@ raid:
   hardwareRAIDVolumes:
   softwareRAIDVolumes:
 ----
-a|  (Optional) Contains the information about the RAID configuration for bare metal hosts. If not specified, it retains the current configuration. Currently, `raid` is only supported by iRMC, iDRAC, and iLO5 BMCs. The fields are:
+a|  (Optional) Contains the information about the RAID configuration for bare metal hosts. If not specified, it retains the current configuration.  
+
+[NOTE]
+====
+{product-title} {product-version} supports hardware RAID for BMCs using the iRMC protocol only. {product-title} {product-version} does not support software RAID.
+====
+
+See the following configuration settings:
 
 * `hardwareRAIDVolumes`: Contains the list of logical drives for hardware RAID, and defines the desired volume configuration in the hardware RAID. If you don't specify `rootDeviceHints`, the first volume is the root volume. The sub-fields are:
 
@@ -102,7 +109,7 @@ a|  (Optional) Contains the information about the RAID configuration for bare me
 ** `rotational`: If set to `true`, it will only select rotational disk drives. If set to `false`, it will only select solid-state and NVMe drives. If not set, it selects any drive types, which is the default behavior.
 ** `sizeGibibytes`: The size of the logical drive as an integer to create in GiB. If unspecified or set to `0`, it will use the maximum capacity of physical drive for the logical drive.
 
-* `softwareRAIDVolumes`: Contains the list of logical disks for software RAID. If you don't specify `rootDeviceHints`, the first volume is the root volume. If you set `HardwareRAIDVolumes`, this item will be invalid. Software RAIDs will always be deleted. The number of created software RAID devices must be `1` or `2`. If there is only one software RAID device, it must be `RAID-1`. If there are two RAID devices, the first device must be `RAID-1`, while the RAID level for the second device can be `0`, `1`, or `1+0`. The first RAID device will be the deployment device. Therefore, enforcing `RAID-1` reduces the risk of a non-booting node in case of a device failure. The `softwareRAIDVolume` field defines the desired configuration of the volume in the software RAID. The sub-fields are:
+* `softwareRAIDVolumes`: {product-title} {product-version} does not support software RAID. The following information is for reference only. This configuration contains the list of logical disks for software RAID. If you don't specify `rootDeviceHints`, the first volume is the root volume. If you set `HardwareRAIDVolumes`, this item will be invalid. Software RAIDs will always be deleted. The number of created software RAID devices must be `1` or `2`. If there is only one software RAID device, it must be `RAID-1`. If there are two RAID devices, the first device must be `RAID-1`, while the RAID level for the second device can be `0`, `1`, or `1+0`. The first RAID device will be the deployment device. Therefore, enforcing `RAID-1` reduces the risk of a non-booting node in case of a device failure. The `softwareRAIDVolume` field defines the desired configuration of the volume in the software RAID. The sub-fields are:
 
 ** `level`: The RAID level for the logical drive. The following levels are supported: `0`,`1`,`1+0`.
 ** `physicalDisks`: A list of device hints. The number of items should be greater than or equal to `2`.

--- a/modules/ipi-install-configuring-the-raid.adoc
+++ b/modules/ipi-install-configuring-the-raid.adoc
@@ -10,8 +10,8 @@ The following procedure configures a redundant array of independent disks (RAID)
 
 [NOTE]
 ====
-. Only nodes with baseboard management controller (BMC) type `irmc` are supported. Other types of nodes are currently not supported.
-. If you want to configure a hardware RAID for the node, make sure the node has a RAID controller.
+. {product-title} supports hardware RAID for baseboard management controllers (BMCs) using the iRMC protocol only. {product-title} {product-version} does not support software RAID.
+. If you want to configure a hardware RAID for the node, verify that the node has a RAID controller.
 ====
 
 .Procedure
@@ -27,7 +27,7 @@ $ vim clusterconfigs/openshift/99_openshift-cluster-api_hosts-*.yaml
 +
 [NOTE]
 ====
-Because nodes with BMC type `irmc` do not support software RAID, the following RAID configuration uses hardware RAID as an example.
+The following example uses a hardware RAID configuration because {product-title} {product-version} does not support software RAID.
 ====
 +
 .. If you added a specific RAID configuration to the `spec` section, this causes the node to delete the original RAID configuration in the `preparing` phase and perform a specified configuration on the RAID. For example:


### PR DESCRIPTION
OCPBUGS#2309: Hardware/software RAID is currently not supported for bare metal across all hardware technologies. 
- We support hardware RAID on iRMC.
- We don't support hardware RAID using any other protocol.
- We don't support software RAID at all at this point.

This PR clarifies the above points in the documentation.

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-2309

Link to docs preview:
- http://file.emea.redhat.com/rohennes/OCPBUGS-2309-RAID-support/post_installation_configuration/bare-metal-configuration.html#the-baremetalhost-spec
- http://file.emea.redhat.com/rohennes/OCPBUGS-2309-RAID-support/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-the-raid_ipi-install-installation-workflow


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
