### PR TITLE
servicemesh: Fix indentations in a section about 3scale integration

### DIFF
--- a/modules/ossm-threescale-webassembly-module-examples-for-credentials-use-cases.adoc
+++ b/modules/ossm-threescale-webassembly-module-examples-for-credentials-use-cases.adoc
@@ -163,19 +163,19 @@ For {SMProductShortName} and the 3scale Istio adapter, you must deploy a `Reques
 [source,yaml]
 ----
 apiVersion: security.istio.io/v1beta1
-  kind: RequestAuthentication
-  metadata:
-    name: jwt-example
-    namespace: bookinfo
-  spec:
-    selector:
-      matchLabels:
-        app: productpage
-    jwtRules:
-    - issuer: >-
-        http://keycloak-keycloak.34.242.107.254.nip.io/auth/realms/3scale-keycloak
-      jwksUri: >-
-        http://keycloak-keycloak.34.242.107.254.nip.io/auth/realms/3scale-keycloak/protocol/openid-connect/certs
+kind: RequestAuthentication
+metadata:
+  name: jwt-example
+  namespace: bookinfo
+spec:
+  selector:
+    matchLabels:
+      app: productpage
+  jwtRules:
+  - issuer: >-
+      http://keycloak-keycloak.34.242.107.254.nip.io/auth/realms/3scale-keycloak
+    jwksUri: >-
+      http://keycloak-keycloak.34.242.107.254.nip.io/auth/realms/3scale-keycloak/protocol/openid-connect/certs
 ----
 
 When you apply the `RequestAuthentication`, it configures `Envoy` with a link:https://www.envoyproxy.io/docs/envoy/v1.19.0/api-v3/extensions/filters/http/jwt_authn/v3/config.proto.html[native plug-in] to validate `JWT` tokens. The proxy validates everything before running the module so any requests that fail do not make it to the 3scale WebAssembly module.

--- a/modules/ossm-threescale-webassembly-module-minimal-working-configuration.adoc
+++ b/modules/ossm-threescale-webassembly-module-minimal-working-configuration.adoc
@@ -42,30 +42,30 @@ spec:
       token: service_token
       authorities:
       - "*"
-        credentials:
-          app_id:
-            - header:
-                keys:
-                  - app_id
-            - query_string:
-                keys:
-                  - app_id
-                  - application_id
-          app_key:
-            - header:
-                keys:
-                  - app_key
-            - query_string:
-                keys:
-                  - app_key
-                  - application_key
-          user_key:
-            - query_string:
-                keys:
-                  - user_key
-            - header:
-                keys:
-                  - user_key
+      credentials:
+        app_id:
+        - header:
+            keys:
+            - app_id
+        - query_string:
+            keys:
+            - app_id
+            - application_id
+        app_key:
+        - header:
+            keys:
+            - app_key
+        - query_string:
+            keys:
+            - app_key
+            - application_key
+        user_key:
+        - query_string:
+            keys:
+            - user_key
+        - header:
+            keys:
+            - user_key
       mapping_rules:
       - method: GET
         pattern: "/"


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

Version(s): 4.8+

QE review:
- [X] QE has approved this change.

Additional information:

This pr fixes invalid indentations in [3scale WebAssembly for 2.1](https://docs.openshift.com/container-platform/4.8/service_mesh/v2x/ossm-threescale-webassembly-module.html) section, because current samples can't work.

Incorrect YAMLs:
1. https://docs.openshift.com/container-platform/4.8/service_mesh/v2x/ossm-threescale-webassembly-module.html#openid-connect-use-case_ossm-threescale-webassembly-module
2. https://docs.openshift.com/container-platform/4.8/service_mesh/v2x/ossm-threescale-webassembly-module.html#ossm-threescale-webassembly-module-minimal-working-configuration_ossm-threescale-webassembly-module
