### PR TITLE
RHDEVDOCS-4542 Release Notes for Pipelines 1.8.1

### DIFF
--- a/modules/op-release-notes-1-8.adoc
+++ b/modules/op-release-notes-1-8.adoc
@@ -533,3 +533,69 @@ securityContext:
 * Before this update, pods for the prune cronjobs were not scheduled on infrastructure nodes, as expected. Instead, they were scheduled on worker nodes or not scheduled at all. With this update, these types of pods can now be scheduled on infrastructure nodes if configured in the `TektonConfig` custom resource (CR).
 // link:https://issues.redhat.com/browse/SRVKP-1806
 // Rupali Behera
+
+
+[id="release-notes-1-8-1_{context}"]
+== Release notes for {pipelines-title} General Availability 1.8.1
+
+With this update, {pipelines-title} General Availability (GA) 1.8.1 is available on {product-title} 4.10 and 4.11.
+
+[id="known-issues-1-8-1_{context}"]
+=== Known issues
+
+* When installer sets are in a failed state, the status of the `TektonConfig` custom resource is incorrectly displayed as `True` instead of `False`.
++
+.Example: Failed installer sets
+[source,terminal]
+----
+$ oc get tektoninstallerset 
+NAME                                     READY   REASON
+addon-clustertasks-nx5xz                 False   Error
+addon-communityclustertasks-cfb2p        True    
+addon-consolecli-ftrb8                   True    
+addon-openshift-67dj2                    True    
+addon-pac-cf7pz                          True    
+addon-pipelines-fvllm                    True    
+addon-triggers-b2wtt                     True    
+addon-versioned-clustertasks-1-8-hqhnw   False   Error
+pipeline-w75ww                           True    
+postpipeline-lrs22                       True    
+prepipeline-ldlhw                        True    
+rhosp-rbac-4dmgb                         True    
+trigger-hfg64                            True    
+validating-mutating-webhoook-28rf7       True 
+----
++
+.Example: Incorrect `TektonConfig` status
+[source,terminal]
+----
+$ oc get tektonconfig config
+NAME     VERSION   READY   REASON
+config   1.8.1     True 
+----
+
+// https://issues.redhat.com/browse/SRVKP-2556
+
+[id="fixed-issues-1-8-1_{context}"]
+=== Fixed issues
+
+* Before this update, the pruner deleted task runs of running pipelines and displayed the following warning: `some tasks were indicated completed without ancestors being done`. With this update, the pruner retains the task runs that are part of running pipelines.
+// https://issues.redhat.com/browse/SRVKP-2419
+
+* Before this update, `pipeline-1.8` was the default channel for installing the {pipelines-title} Operator 1.8.x. With this update, `latest` is the default channel.
+// https://issues.redhat.com/browse/SRVKP-2412
+
+* Before this update, the {pac} controller pods did not have access to certificates exposed by the user. With this update, {pac} can now access routes and Git repositories guarded by a self-signed or a custom certificate.
+// https://issues.redhat.com/browse/SRVKP-2470
+
+* Before this update, the task failed with RBAC errors after upgrading from {pipelines-title} 1.7.2 to 1.8.0. With this update, the tasks run successfully without any RBAC errors.
+// https://issues.redhat.com/browse/SRVKP-2472
+
+* Before this update, using the `tkn` CLI tool, you could not remove task runs and pipeline runs that contained a `result` object whose type was `array`. With this update, you can use the `tkn` CLI tool to remove task runs and pipeline runs that contain a `result` object whose type is `array`.
+// https://issues.redhat.com/browse/SRVKP-2478
+
+* Before this update, if a pipeline specification contained a task with an `ENV_VARS` parameter of `array` type, the pipeline run failed with the following error: `invalid input params for task func-buildpacks: param types don't match the user-specified type: [ENV_VARS]`. With this update, pipeline runs with such pipeline and task specifications do not fail.
+// https://issues.redhat.com/browse/SRVKP-2422
+
+* Before this update, cluster administrators could not provide a `config.json` file to the `Buildah` cluster task for accessing a container registry. With this update, cluster administrators can provide the `Buildah` cluster task with a `config.json` file by using the `dockerconfig` workspace.
+// https://issues.redhat.com/browse/SRVKP-2424


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.11`, `enterprise-4.12`
- **JIRA issues**: [RHDEVDOCS-4542 Release Notes for Pipelines 1.8.1](https://issues.redhat.com/browse/RHDEVDOCS-4542)
- **Preview pages**: [1.8.1 RN](http://file.pnq.redhat.com/sosarkar/4542-pipelines-1-8-1-RN/cicd/pipelines/op-release-notes.html#release-notes-1-8-1_op-release-notes)
- **SME review**: @rupalibehera 
- **QE review**: @VeereshAradhya 