### PR TITLE
vSphere Windows Server 2022 support for WMCO 3.x Take 3

### DIFF
--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -153,3 +153,4 @@ An example `unattend.xml` is provided, which maintains all the changes needed fo
 After the Sysprep tool has completed, the Windows VM will power off. You must not use or power on this VM anymore.
 
 . Convert the Windows VM to link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-5B3737CC-28DB-4334-BD18-6E12011CDC9F.html[a template in vCenter].
+

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -141,3 +141,4 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Custom VXLAN port
 |Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
 |===
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-4351

Merge after WMCO 3.1.2 relesaes, planned Nov. 8 2022

Removed Long-Term Servicing Channel (LTSC) to match similar change in 6.0.0.
Added Windows 2019 not supported note for vShpere
Added back Windows Server 20H2

[Supported Windows Server versions](http://file.rdu.redhat.com/mburke/winc-windows-2022-3x/windows_containers/understanding-windows-container-workloads.html#supported-windows-server-versions)
[Supported networking](http://file.rdu.redhat.com/mburke/winc-windows-2022-3x/windows_containers/understanding-windows-container-workloads.html#supported-networking)


- [X] QE has approved this change.
