### PR TITLE
vSphere Windows Server 2022 support for WMCO 3.x Take 3

### DIFF
--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -19,7 +19,7 @@ You must use link:https://docs.microsoft.com/en-us/powershell/scripting/install/
 
 .Procedure
 
-. Create a new VM in the vSphere client using the Windows Server Semi-Annual Channel (SAC): Windows Server 20H2 ISO image that includes the link:https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351[Microsoft patch KB4565351]. This patch is required to set the VXLAN UDP port, which is required for clusters installed on vSphere. See the link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.hostclient.doc/GUID-77AB6625-F968-4983-A230-A020C0A70326.html[VMware documentation] for more information.
+. Create a new VM in the vSphere client using Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later.
 +
 [IMPORTANT]
 ====
@@ -153,3 +153,4 @@ An example `unattend.xml` is provided, which maintains all the changes needed fo
 After the Sysprep tool has completed, the Windows VM will power off. You must not use or power on this VM anymore.
 
 . Convert the Windows VM to link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-5B3737CC-28DB-4334-BD18-6E12011CDC9F.html[a template in vCenter].
+

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -7,6 +7,7 @@
 
 The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator. See the vSphere documentation for any information that is relevant to only that platform.
 
+[id="wmco-prerequisites_platforms_{context}"]
 == Supported platforms based on {product-title} and WMCO versions
 
 [cols="5",options="header"]
@@ -36,6 +37,7 @@ The following information details the supported platform versions, Windows Serve
 |Tech Preview
 |===
 
+[id="wmco-prerequisites_platforms_byoh_{context}"]
 == Supported platforms for Bring-Your-Own-Host (BYOH) instances based on {product-title} and WMCO versions
 
 [cols="5",options="header"]
@@ -75,6 +77,7 @@ The following information details the supported platform versions, Windows Serve
 1. This installation type is only supported when the `platform: none` field is set in the `install-config.yaml` file during cluster installation.
 --
 
+[id="wmco-prerequisites_versions_{context}"]
 == Supported Windows Server versions
 
 The following table lists the supported link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server version] based on the applicable platform. Any unlisted Windows Server version is not supported and will cause errors. To prevent these errors, only use the appropriate version according to the platform in use.
@@ -85,22 +88,27 @@ The following table lists the supported link:https://docs.microsoft.com/en-us/wi
 |Supported Windows Server version
 
 |Amazon Web Services (AWS)
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+|Windows Server 2019, version 1809
 
 |Microsoft Azure
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+|Windows Server 2019, version 1809
 
 |VMware vSphere
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2022 (OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later)
+a|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+
+[NOTE]
+====
+Windows Server 2019 is unsupported, because the link:https://support.microsoft.com/en-us/help/4565351/windows-10-update-kb4565351[KB4565351] patch is not included. 
+====
 
 |bare metal
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+|Windows Server 2019, version 1809
 |===
 
+[id="wmco-prerequisites_networking_{context}"]
 == Supported networking
 
 Hybrid networking with OVN-Kubernetes is the only supported networking configuration. See the additional resources below for more information on this functionality. The following tables outline the type of networking configuration and Windows Server versions to use based on your platform. You must specify the network configuration when you install the cluster. Be aware that OpenShift SDN networking is the default network for {product-title} clusters. However, OpenShift SDN is not supported by WMCO.
-
 
 .Platform networking support
 [cols="2",options="header"]
@@ -128,8 +136,9 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Supported Windows Server version
 
 |Default VXLAN port
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
+|Windows Server 2019, version 1809
 
 |Custom VXLAN port
-|Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2022 (OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later)
+|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
 |===
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-4351

Merge after WMCO 3.1.2 releases, planned Nov. 9 2022

Removed Long-Term Servicing Channel (LTSC) to match similar change in 6.0.0.
Added Windows 2019 not supported note for vShpere
Added back Windows Server 20H2