### PR TITLE
Convert Feature Set Verification steps to snippet

### DIFF
--- a/modules/nodes-cluster-enabling-features-cli.adoc
+++ b/modules/nodes-cluster-enabling-features-cli.adoc
@@ -49,43 +49,4 @@ Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents mi
 
 .Verification
 
-You can verify that the feature gates are enabled by looking at the `kubelet.conf` file on a node after the nodes return to the ready state.
-
-. Start a debug session for a node:
-+
-[source,terminal]
-----
-$ oc debug node/<node_name>
-----
-
-. Change your root directory to the host:
-+
-[source,terminal]
-----
-sh-4.2# chroot /host
-----
-
-. View the `kubelet.conf` file:
-+
-[source,terminal]
-----
-sh-4.2# cat /etc/kubernetes/kubelet.conf
-----
-+
-.Sample output
-+
-[source,terminal]
-----
- ...
-featureGates:
-  InsightsOperatorPullingSCA: true,
-  LegacyNodeRoleBehavior: false
- ...
-----
-+
-The features that are listed as `true` are enabled on your cluster.
-+
-[NOTE]
-====
-The features listed vary depending upon the {product-title} version.
-====
+include::snippets/nodes-cluster-enabling-features-verification.adoc[]

--- a/modules/nodes-cluster-enabling-features-console.adoc
+++ b/modules/nodes-cluster-enabling-features-console.adoc
@@ -50,42 +50,4 @@ Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents mi
 
 .Verification
 
-You can verify that the feature gates are enabled by looking at the `kubelet.conf` file on a node after the nodes return to the ready state.
-
-. From the *Administrator* perspective in the web console, navigate to *Compute* -> *Nodes*.
-
-. Select a node.
-
-. In the *Node details* page, click *Terminal*.
-
-. In the terminal window, change your root directory to the host:
-+
-[source,terminal]
-----
-sh-4.2# chroot /host
-----
-
-. View the `kubelet.conf` file:
-+
-[source,terminal]
-----
-sh-4.2# cat /etc/kubernetes/kubelet.conf
-----
-+
-.Sample output
-+
-[source,terminal]
-----
- ...
-featureGates:
-  InsightsOperatorPullingSCA: true,
-  LegacyNodeRoleBehavior: false
- ...
-----
-+
-The features that are listed as `true` are enabled on your cluster.
-+
-[NOTE]
-====
-The features listed vary depending upon the {product-title} version.
-====
+include::snippets/nodes-cluster-enabling-features-verification.adoc[]

--- a/modules/nodes-cluster-enabling-features-install.adoc
+++ b/modules/nodes-cluster-enabling-features-install.adoc
@@ -47,43 +47,4 @@ Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents mi
 
 .Verification
 
-You can verify that the feature gates are enabled by looking at the `kubelet.conf` file on a node after the cluster is installed.
-
-. Start a debug session for a node:
-+
-[source,terminal]
-----
-$ oc debug node/<node_name>
-----
-
-. Change your root directory to the host:
-+
-[source,terminal]
-----
-sh-4.2# chroot /host
-----
-
-. View the `kubelet.conf` file:
-+
-[source,terminal]
-----
-sh-4.2# cat /etc/kubernetes/kubelet.conf
-----
-+
-.Sample output
-+
-[source,terminal]
-----
- ...
-featureGates:
-  TechPreviewNoUpgrade: true,
-  LegacyNodeRoleBehavior: false
- ...
-----
-+
-The features that are listed as `true` are enabled on your cluster.
-+
-[NOTE]
-====
-The features listed vary depending upon the {product-title} version.
-====
+include::snippets/nodes-cluster-enabling-features-verification.adoc[]

--- a/snippets/nodes-cluster-enabling-features-verification.adoc
+++ b/snippets/nodes-cluster-enabling-features-verification.adoc
@@ -1,0 +1,48 @@
+// Text snippet included in the following modules:
+//
+// * modules/clusters/nodes-cluster-enabling-features-install.adoc
+// * modules/clusters/nodes-cluster-enabling-features-console.adoc
+// * modules/nodes-cluster-enabling-features-cli.adoc
+
+:_content-type: SNIPPET
+
+
+You can verify that the feature gates are enabled by looking at the `kubelet.conf` file on a node after the nodes return to the ready state.
+
+. From the *Administrator* perspective in the web console, navigate to *Compute* -> *Nodes*.
+
+. Select a node.
+
+. In the *Node details* page, click *Terminal*.
+
+. In the terminal window, change your root directory to the `/host` directory:
++
+[source,terminal]
+----
+sh-4.2# chroot /host
+----
+
+. View the `kubelet.conf` file:
++
+[source,terminal]
+----
+sh-4.2# cat /etc/kubernetes/kubelet.conf
+----
++
+.Sample output
++
+[source,terminal]
+----
+ ...
+featureGates:
+  InsightsOperatorPullingSCA: true,
+  LegacyNodeRoleBehavior: false
+ ...
+----
++
+The features that are listed as `true` are enabled on your cluster.
++
+[NOTE]
+====
+The features listed vary depending upon the {product-title} version.
+====


### PR DESCRIPTION
All three modules in the Enabling features using feature gates assembly use the same verification steps. Converted the steps to a snippet and added to all three.

[Enabling feature sets at installation](http://file.rdu.redhat.com/~mburke/feature-gate-verification-snippet/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-install_nodes-cluster-enabling)
[Enabling feature sets using the web console](http://file.rdu.redhat.com/~mburke/feature-gate-verification-snippet/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-console_nodes-cluster-enabling)
[Enabling feature sets using the CLI](http://file.rdu.redhat.com/~mburke/feature-gate-verification-snippet/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-cli_nodes-cluster-enabling)