### PR TITLE
OCPBUGS#984 cluster identity should be granted 'Contributor' role to disk-encryption-set in azure install

### DIFF
--- a/modules/installation-azure-finalizing-encryption.adoc
+++ b/modules/installation-azure-finalizing-encryption.adoc
@@ -41,6 +41,39 @@ $ az role assignment create --role "<privileged_role>" \// <1>
 <1> Specifies an Azure role that has read/write permissions to the disk encryption set. You can use the `Owner` role or a custom role with the necessary permissions.
 <2> Specifies the identity of the cluster resource group.
 +
+. Obtain the `id` of the disk encryption set you created prior to installation by running the following command:
++
+[source,terminal]
+----
+$ az disk-encryption-set show -n <disk_encryption_set_name> \// <1>
+     --resource-group <resource_group_name> <2>
+----
+<1> Specifies the name of the disk encryption set.
+<2> Specifies the resource group that contains the disk encryption set.
+The `id` is in the format of `"/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/diskEncryptionSets/..."`.
++
+. Obtain the identity of the cluster service principal by running the following command:
++
+[source,terminal]
+----
+$ az identity show -g <cluster_resource_group> \// <1>
+     -n <cluster_service_principal_name> \// <2> 
+     --query principalId --out tsv
+----
+<1> Specifies the name of the cluster resource group created by the installation program.
+<2> Specifies the name of the cluster service principal created by the installation program.
+The identity is in the format of `12345678-1234-1234-1234-1234567890`.
+. Create a role assignment that grants the cluster service principal `Contributor` privileges to the disk encryption set by running the following command:
++
+[source,terminal]
+----
+$ az role assignment create --assignee <cluster_service_principal_id> \// <1>
+     --role 'Contributor' \//
+     --scope <disk_encryption_set_id> \// <2>
+----
+<1> Specifies the ID of the cluster service principal obtained in the previous step.
+<2> Specifies the ID of the disk encryption set.
++
 . Create a storage class that uses the user-managed disk encryption set:
 .. Save the following storage class definition to a file, for example `storage-class-definition.yaml`:
 +
@@ -55,7 +88,7 @@ parameters:
   skuname: Premium_LRS
   kind: Managed
   diskEncryptionSetID: "<disk_encryption_set_ID>" <1>
-  resourceGroup: <resource_group_name> <2>
+  resourceGroup: "<resource_group_name>" <2>
 reclaimPolicy: Delete
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
OCPBUGS-984: Azure disk encryption feature was missing a role in post-install procedure

Applies to 4.11+

https://issues.redhat.com/browse/OCPBUGS-984

Docs preview: https://52550--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations.html#finalizing-encryption_installing-azure-customizations

QE review:
- [X] QE has approved this change.
