### PR TITLE
Change the chroot /host step for accuracy

### DIFF
--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -33,7 +33,7 @@ You can check whether the proxy is enabled by reviewing the output of `oc get pr
 $ oc debug node/<node_name>
 ----
 
-. Change your root directory to the host:
+. Change your root directory to `/host`:
 +
 [source,terminal]
 ----

--- a/modules/containers-signature-verify-enable.adoc
+++ b/modules/containers-signature-verify-enable.adoc
@@ -139,7 +139,7 @@ worker   rendered-worker-be3b3bce4f4aa52a62902304bac9da3c   False     True      
 $ oc debug node/<node_name>
 ----
 
-.. Change your root directory to the host:
+.. Change your root directory to `/host`:
 +
 [source,terminal]
 ----

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -150,7 +150,7 @@ Starting pod/ip-10-0-147-35ec2internal-debug ...
 To use host binaries, run `chroot /host`
 ----
 
-.. Access the node's files:
+.. Change your root directory to `/host`:
 +
 [source,terminal]
 ----

--- a/modules/nodes-nodes-rebooting-gracefully.adoc
+++ b/modules/nodes-nodes-rebooting-gracefully.adoc
@@ -55,7 +55,7 @@ $ oc adm drain <node1> --ignore-daemonsets --delete-emptydir-data --force --disa
 $ oc debug node/<node1>
 ----
 
-. Change your root directory to the host:
+. Change your root directory to `/host`:
 +
 [source,terminal]
 ----

--- a/modules/persistent-storage-local-removing-devices.adoc
+++ b/modules/persistent-storage-local-removing-devices.adoc
@@ -56,7 +56,7 @@ The following step involves accessing a node as the root user. Modifying the sta
 $ oc debug node/<node-name>
 ----
 
-.. Change your root directory to the host:
+.. Change your root directory to `/host`:
 +
 [source,terminal]
 ----

--- a/modules/registry-accessing-directly.adoc
+++ b/modules/registry-accessing-directly.adoc
@@ -25,7 +25,7 @@ $ oc get nodes
 $ oc debug nodes/<node_name>
 ----
 
-. To enable access to tools such as `oc` and `podman` on the node, run the following command:
+. To enable access to tools such as `oc` and `podman` on the node, change your root directory to `/host`:
 +
 [source,terminal]
 ----

--- a/modules/restore-replace-crashlooping-etcd-member.adoc
+++ b/modules/restore-replace-crashlooping-etcd-member.adoc
@@ -34,7 +34,7 @@ $ oc debug node/ip-10-0-131-183.ec2.internal <1>
 ----
 <1> Replace this with the name of the unhealthy node.
 
-.. Change your root directory to the host:
+.. Change your root directory to `/host`:
 +
 [source,terminal]
 ----

--- a/snippets/nodes-cluster-enabling-features-verification.adoc
+++ b/snippets/nodes-cluster-enabling-features-verification.adoc
@@ -15,7 +15,7 @@ You can verify that the feature gates are enabled by looking at the `kubelet.con
 
 . In the *Node details* page, click *Terminal*.
 
-. In the terminal window, change your root directory to the `/host` directory:
+. In the terminal window, change your root directory to `/host`:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Per @bscott-rh we should change the description in the `chroot /host` step for accuracy and clarity. See [comment](https://github.com/openshift/openshift-docs/pull/52548#discussion_r1015848045).

Previews
[Backing up etcd data. Step 2](https://52572--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#backing-up-etcd-data_post-install-cluster-tasks)
[Enabling signature verification for Red Hat Container Registries. Step 5b](https://52572--docspreview.netlify.app/openshift-enterprise/latest/security/container_security/security-container-signature.html#containers-signature-verify-enable_security-container-signature)
[Configuring image registry repository mirroring. Step 5c](https://52572--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/preparing-for-users.html#images-configuration-registry-mirror_post-install-preparing-for-users)
[Accessing registry directly from the cluster. Step 2](https://52572--docspreview.netlify.app/openshift-enterprise/latest/registry/accessing-the-registry.html#registry-accessing-directly_accessing-the-registry)
[Rebooting a node gracefully, Step 4](https://52572--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-rebooting.html#nodes-nodes-rebooting-gracefully_nodes-nodes-rebooting)
[Removing a local volume or local volume set, Step 3b](https://52572--docspreview.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local.html#local-removing-device_persistent-storage-local)
[Replacing an unhealthy etcd member whose etcd pod is crashlooping, Step 1b](https://52572--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member)
[Enabling feature sets at installation, Verification Step 4](https://52572--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-install_nodes-cluster-enabling)
