### PR TITLE
CNV-19563: Web console procedure to copy VM SSH access command

### DIFF
--- a/modules/virt-copying-the-ssh-command.adoc
+++ b/modules/virt-copying-the-ssh-command.adoc
@@ -4,12 +4,15 @@
 
 :_content-type: PROCEDURE
 [id="virt-copying-the-ssh-command_{context}"]
-= Copying the SSH command from the web console
+= Copying the SSH command using the web console
 
-Copy the command to access a running virtual machine (VM) via SSH.
+Copy the command to connect to a virtual machine (VM) terminal via SSH.
+
 
 .Procedure
 
 . In the {product-title} console, click *Virtualization* -> *VirtualMachines* from the side menu.
-. Use the search and filters to find your VM in the list.
-. Click the *Options* menu {kebab} for your virtual machine and select *Copy SSH command*. You can now paste this command onto the OpenShift CLI (oc).
+
+. Click the *Options* menu {kebab} for your virtual machine and select *Copy SSH command*.
+
+. Paste it in the terminal to access the VM.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: [CNV-19563](https://issues.redhat.com//browse/CNV-19563)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://52576--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-consoles.html#virt-copying-the-ssh-command_virt-accessing-vm-consoles
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

<!--- QE review:
- [ ] QE has approved this change. --->
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

 Additional information: Minor edits to the existing procedure. No QE required.
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
