### PR TITLE
BZ1852798: Removed etcd reference

### DIFF
--- a/modules/installation-aws-user-infra-requirements.adoc
+++ b/modules/installation-aws-user-infra-requirements.adoc
@@ -162,10 +162,6 @@ within the cluster.
 |`AWS::Route53::HostedZone`
 |The hosted zone for your internal DNS.
 
-|etcd record sets
-|`AWS::Route53::RecordSet`
-|The registration records for etcd for your control plane machines.
-
 |Public load balancer
 |`AWS::ElasticLoadBalancingV2::LoadBalancer`
 |The load balancer for your public subnets.


### PR DESCRIPTION
Version(s): 4.11+

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=1852798

Link to docs preview: https://52582--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-aws-user-infra-other-infrastructure_installing-aws-user-infra

QE review:
@pamoedom can you please approve this fix?
- [x] QE has approved this change.