### PR TITLE
RHDEVDOCS-4492: Create release note for Doc enterprise-4.12 : Resource type updates-Import from Git & deploy image

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -107,6 +107,7 @@ With this release, there are several updates to the *Developer* perspective of t
 * Export your application in the ZIP file format to another project or cluster by using the *Export application* option on the *+Add* page.
 * Create a Kafka event sink to receive events from a particular source and send them to a Kafka topic.
 * Set the default resource preference in the *User Preferences* -> *Applications* page. In addition, you can select another resource type to be the default.
+** Optionally, set another resource type from the *Add* page by clicking *Import from Git* -> *Advanced options* -> *Resource type* and selecting the resource from the drop-down list.
 * Make the `status.HostIP` node IP address for pods visible in the *Details* tab of the *Pods* page.
 * See the resource quota alert label on the *Topology* and *Add* pages whenever any resource reaches the quota. The alert label link takes you to the *ResourceQuotas* list page. If the alert label link is for a single resource quota, it takes you to the *ResourceQuota details* page.
 ** For deployments, an alert is displayed in the topology node side panel if any errors are associated with resource quotas. Also, a yellow border is displayed around the deployment nodes when the resource quota is exceeded.


### PR DESCRIPTION
[RHDEVDOCS-4492](https://issues.redhat.com//browse/RHDEVDOCS-4492): Create release note for Doc: Resource type updates-Import from Git & deploy image

Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.12 only
JIRA issues: [RHDEVDOCS-4492](https://issues.redhat.com//browse/RHDEVDOCS-4492)
Preview pages: [Download to see the preview in your browser](https://drive.google.com/file/d/1rpv7SxFeVKXqvSYpt9HGFV0nCySlbyyW/view?usp=share_link)
SME review needed: @divyanshiGupta 
QE review needed: @sanketpathak 
Peer review needed: @sounix000 and @DebarghoGhosh 