### PR TITLE
OCPBUGS 3004-49 Updating step_threshold for 49

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -101,7 +101,7 @@ spec:
       pi_integral_scale         0.0
       pi_integral_exponent      0.4
       pi_integral_norm_max      0.3
-      step_threshold              0
+      step_threshold            2.0
       first_step_threshold      0.00002
       max_frequency               900000000
       clock_servo                 pi

--- a/modules/sno-du-configuring-ptp.adoc
+++ b/modules/sno-du-configuring-ptp.adoc
@@ -89,7 +89,7 @@ spec:
         pi_integral_scale 0.0
         pi_integral_exponent 0.4
         pi_integral_norm_max 0.3
-        step_threshold 0.0
+        step_threshold 2.0
         first_step_threshold 0.00002
         max_frequency 900000000
         clock_servo pi


### PR DESCRIPTION
OCPBUGS-3004: step_threshold should be 2.0 in openshift docs

Version(s):

PR applies to all versions after a specific version: 4.9
Issue:
https://issues.redhat.com/browse/OCPBUGS-3004

Link to docs preview:

NOTE: Addressing merge conflict in https://github.com/openshift/openshift-docs/pull/52441 with this separate PR as merge conflict changes too expansive, which suggests feature not relevant to "Configuring linuxptp services as ordinary clock" as quite a lot of changes to this stanza. I confirmed with the original writer, and he agreed to make changes only where `step_threshold `exists in original 4.9 content. 