### PR TITLE
[SRVCOM-2150] Add the Knative Serving informer known issue

### DIFF
--- a/modules/serverless-rn-1-25-0.adoc
+++ b/modules/serverless-rn-1-25-0.adoc
@@ -36,3 +36,6 @@ It is recommended to not use the MT-Channel-Broker, but the Knative Kafka broker
 
 * The Federal Information Processing Standards (FIPS) mode is disabled for Kafka broker, Kafka source, and Kafka sink.
 * The `SinkBinding` object does not support custom revision names for services.
+* The Knative Serving Controller pod adds a new informer to watch secrets in the cluster. The informer includes the secrets in the cache, which increases memory consumption of the controller pod.
++
+If the pod runs out of memory, you can work around the issue by increasing the memory limit for the deployment.

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -24,10 +24,14 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
 include::modules/serverless-rn-1-25-0.adoc[leveloffset=+1]
-// 1.25.0 additional resources, OCP docs
-ifdef::openshift-enterprise[]
+
+// 1.25.0 additional resources
 [role="_additional-resources"]
 .Additional resources
+* xref:../serverless/admin_guide/serverless-configuration.adoc#knative-serving-CR-system-deployments_serverless-configuration[Overriding Knative Serving system deployment configurations]
+
+// 1.25.0 additional resources, OCP docs only
+ifdef::openshift-enterprise[]
 * xref:../serverless/security/serverless-config-tls.adoc#serverless-config-tls[Configuring TLS authentication]
 endif::[]
 


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-2150

Link to docs preview:
https://52588--docspreview.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#known-issues-1.25.0_serverless-release-notes