### PR TITLE
Updating the Compliance Operator supported profiles

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -86,14 +86,12 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.47+
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
- `ppc64le`
 
 |ocp4-pci-dss-node
 |PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
 |0.1.47+
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
- `ppc64le`
 
 |ocp4-high
 |NIST 800-53 High-Impact Baseline for Red Hat OpenShift - Platform level


### PR DESCRIPTION
Version(s):
4.8+

Issue:
Power (and s390) support is not available at this time and will be added at a later date.

Link to docs preview:
[Supported compliance profiles](http://file.rdu.redhat.com/antaylor/co-support/security/compliance_operator/compliance-operator-supported-profiles.html)