### PR TITLE
OSDOCS-4501: Breaks the TP table up by component

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -770,296 +770,422 @@ Some features in this release are currently in Technology Preview. These experim
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
-In the table below, features are marked with the following statuses:
+In the following tables, features are marked with the following statuses:
 
-* *TP*: _Technology Preview_
-* *GA*: _General Availability_
-* *-*: _Not Available_
-* *DEP*: _Deprecated_
+* _Technology Preview_
+* _General Availability_
+* _Not Available_
+* _Deprecated_
 
-//TODO: remove anything that has been GA since 4.9?
+[discrete]
+=== Networking Technology Preview features
 
-.Technology Preview tracker
+.Networking Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |OCP 4.10 |OCP 4.11 | OCP 4.12
+|Feature |4.10 |4.11 | 4.12
 
 |PTP single NIC hardware configured as boundary clock
-|TP
-|GA
-|GA
+|Technology Preview
+|General Availability
+|General Availability
 
 |PTP dual NIC hardware configured as boundary clock
-|-
-|TP
-|TP
+|Not Available
+|Technology Preview
+|Technology Preview
 
 |PTP events with boundary clock
-|TP
-|GA
-|GA
+|Technology Preview
+|General Availability
+|General Availability
+
+|Pod-level bonding for secondary networks
+|Technology Preview
+|General Availability
+|General Availability
+
+|External DNS Operator
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|AWS Load Balancer Operator
+|Not Available
+|Technology Preview
+|Technology Preview
+
+|Cloud controller manager for VMware vSphere
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|====
+
+[discrete]
+=== Storage Technology Preview features
+
+.Storage Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
 
 |Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds
-|TP
-|TP
-|TP
+|Technology Preview
+|Technology Preview
+|Technology Preview
 
 |CSI volume expansion
-|TP
-|GA
-|GA
+|Technology Preview
+|General Availibility
+|General Availibility
 
 |CSI Azure File Driver Operator
-|TP
-|GA
-|GA
+|Technology Preview
+|General Availibility 
+|General Availibility
 
 |CSI automatic migration
 (AWS EBS, Azure file, GCP disk, VMware vSphere)
-|TP
-|TP
-|TP
+|Technology Preview
+|Technology Preview
+|Technology Preview
 
 |CSI automatic migration
 (Azure Disk, OpenStack Cinder)
-|TP
-|GA
-|GA
+|Technology Preview
+|General Availability
+|General Availability
 
 |CSI inline ephemeral volumes
-|TP
-|TP
-|TP
+|Technology Preview
+|Technology Preview
+|Technology Preview
 
 |CSI generic ephemeral volumes
-|-
-|GA
-|GA
+|Not Available
+|General Availability
+|General Availability
 
 |Shared Resource CSI Driver
-|TP
-|TP
-|TP
+|Technolgy Preview
+|Technology Preview
+|Technology Preview
 
 |Automatic device discovery and provisioning with Local Storage Operator
-|TP
-|TP
-|TP
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|====
+
+[discrete]
+=== Installation Technology Preview features
+
+.Installation Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
 
 |Adding kernel modules to nodes with kvc
-|TP
-|TP
-|TP
-
-|Non-preempting priority classes
-|TP
-|TP
-|TP
+|Technology Preview
+|Technology Preview
+|Technology Preview
 
 |Assisted Installer
-|TP
-|TP
-|TP
-
-|`kdump` on `x86_64` architecture
-|TP
-|GA
-|GA
-
-|`kdump` on `arm64` architecture
-|-
-|TP
-|TP
-
-|`kdump` on `s390x` architecture
-|TP
-|TP
-|TP
-
-|`kdump` on `ppc64le` architecture
-|TP
-|TP
-|TP
+|Technology Preview
+|Technology Preview
+|Technology Preview
 
 |IBM Cloud VPC clusters
-|TP
-|TP
-|GA
-
-|Serverless functions
-|TP
-|TP
-|TP
-
-|Cloud controller manager for Alibaba Cloud
-|TP
-|TP
-|TP
-
-|Cloud controller manager for Amazon Web Services
-|TP
-|TP
-|TP
-
-|Cloud controller manager for Google Cloud Platform
-|TP
-|TP
-|TP
-
-|Cloud controller manager for Microsoft Azure
-|TP
-|TP
-|TP
-
-|Cloud controller manager for {rh-openstack-first}
-|TP
-|TP
-|TP
-
-|Cloud controller manager for VMware vSphere
-|TP
-|TP
-|TP
-
-|Driver Toolkit
-|TP
-|TP
-|TP
-
-|Special Resource Operator (SRO)
-|TP
-|TP
-|TP
-
-|Node Health Check Operator
-|TP
-|GA
-|GA
-
-|Pod-level bonding for secondary networks
-|TP
-|GA
-|GA
-
-|Multicluster console
-|TP
-|TP
-|TP
+|Technology Preview
+|Technology Preview
+|General Availability 
 
 |Selectable Cluster Inventory
-|TP
-|TP
-|TP
+|Technology Preview
+|Technology Preview
+|Technology Preview
 
-|Heterogeneous clusters
-|-
-|TP
-|TP
-
-|Hyperthreading-aware CPU manager policy
-|TP
-|TP
-|TP
-
-|Heterogeneous Clusters
-|-
-|TP
-|TP
-
-|Dynamic Plug-ins
-|TP
-|TP
-|TP
-
-|Hybrid Helm Operator
-|TP
-|TP
-|TP
-
-|Alert routing for user-defined projects monitoring
-|TP
-|GA
-|GA
+|Multi-architecture clusters
+|Not Available
+|Tecnology Preview
+|Technology Preview
 
 |Disconnected mirroring with the oc-mirror CLI plug-in
-|TP
-|GA
-|GA
+|Technology Preview
+|General Availability
+|General Availability
 
 |Mount shared entitlements in BuildConfigs in RHEL
-|TP
-|TP
-|TP
+|Technology Preview
+|Technology Preview
+|Technology Preview
 
-|Support for {rh-openstack} DCN
-|TP
-|TP
-|TP
+|====
 
-|Support for external cloud providers for clusters on {rh-openstack}
-|TP
-|TP
-|TP
+[discrete]
+=== Node Technology Preview features
 
-|OVS hardware offloading for clusters on {rh-openstack}
-|TP
-|GA
-|GA
+.Nodes Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
 
-|External DNS Operator
-|TP
-|TP
-|TP
+|Non-preempting priority classes
+|Technology Preview
+|Technology Preview
+|Technology Preview
 
-|Alerting rules based on platform monitoring metrics
-|-
-|TP
-|TP
-
-|AWS Load Balancer Operator
-|-
-|TP
-|TP
-
-|Node Observability Operator
-|-
-|TP
-|TP
-
-|Java-based Operator
-|-
-|TP
-|TP
-
-|Hosted control planes for {product-title}
-|-
-|TP
-|TP
-
-|Managing machines with the Cluster API
-|-
-|TP
-|TP
+|Node Health Check Operator
+|Technology Preview
+|General Availability
+|General Availability
 
 |Linux Control Group version 2 (cgroup v2)
-|-
-|-
-|TP
+|Not Available
+|Not Available
+|Technology Preview
 
 |crun container runtime
-|-
-|-
-|TP
+|Not Available
+|Not Available
+|Technology Preview
+
+|====
+
+[discrete]
+=== Support Technology Preview features
+
+.Support Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|`kdump` on `x86_64` architecture
+|Technology Preview
+|General Availability
+|General Availability
+
+|`kdump` on `arm64` architecture
+|Not Available
+|Technology Preview
+|Technology Preview
+
+|`kdump` on `s390x` architecture
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|`kdump` on `ppc64le` architecture
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|====
+
+[discrete]
+=== Serverless Technology Preview features
+
+.Serverless Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Serverless functions
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|====
+
+[discrete]
+=== Specialized hardware and driver enablement Technology Preview features
+
+.Specialized hardware and driver enablement Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Driver Toolkit
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Special Resource Operator (SRO)
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|====
+
+[discrete]
+=== Web console Technology Preview features
+
+.Web console Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Multicluster console
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Dynamic Plug-ins
+|Technology Preview
+|Technology Preview
+|General Availability 
+
+|====
+
+[discrete]
+=== Scalability and performance Technology Preview features
+
+.Scalability and performance Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Hyperthreading-aware CPU manager policy
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Node Observability Operator
+|Not Available 
+|Technology Preview
+|Technology Preview
+
+|====
+
+[discrete]
+=== Operators Technology Preview features
+
+.Operators Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Hybrid Helm Operator
+|Tecnology Preview
+|Technology Preview
+|Technology Preview
+
+|Java-based Operator
+|Not Available
+|Technology Preview
+|Technology Preview
+
+|====
+
+[discrete]
+=== Monitoring Technology Preview features
+
+.Monitoring Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Alert routing for user-defined projects monitoring
+|Technology Preview
+|General Availability
+|General Availability
+
+|Alerting rules based on platform monitoring metrics
+|Not Available 
+|Technology Preview
+|Technology Preview
+
+|====
+
+[discrete]
+=== {rh-openstack-first} Technology Preview features
+
+.{rh-openstack} Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Support for {rh-openstack} DCN
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Support for external cloud providers for clusters on {rh-openstack}
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|OVS hardware offloading for clusters on {rh-openstack}
+|Technology Preview
+|General Availability
+|General Availability
+
+|====
+
+[discrete]
+=== Architecture Technology Preview features
+
+.Architecture Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Hosted control planes for {product-title}
+|Not Available
+|Technology Preview
+|Technology Preview
+
+|====
+
+[discrete]
+=== Machine management Technology Preview features
+
+.Machine management Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Managing machines with the Cluster API
+|Not Available
+|Technology Preview
+|Technology Preview
 
 |Cron job time zones
-|-
-|-
-|TP
+|Not Available
+|Not Available
+|Technology Preview
+
+|Cloud controller manager for Alibaba Cloud
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Cloud controller manager for Amazon Web Services
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Cloud controller manager for Google Cloud Platform
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Cloud controller manager for Microsoft Azure
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Cloud controller manager for {rh-openstack-first}
+|Technology Preview
+|Technology Preview
+|Technology Preview
 
 |Custom Metrics Autoscaler Operator
-|-
-|TP
-|TP
+|Not Available
+|Technology Preview
+|Technology Preview
 
 |====
 


### PR DESCRIPTION
Breaks the TP table up by component

Version(s):
4.12 (can visit backporting at a later date if this format works)

Issue:
[OSDOCS-4501](https://issues.redhat.com/browse/OSDOCS-4501)

Link to docs preview:
https://52611--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-technology-preview

QE review:
- [ ] QE has approved this change.
* QE will not be needed for this change.

Additional information:
Some components may not be 100%. Will need the help of the team to ensure the components listed are correct and they have the correct contents. 

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
