### PR TITLE
OSDOCS-4502: Adding manifest list option to heterogeneous docs

### DIFF
--- a/modules/multi-architecture-import-imagestreams.adoc
+++ b/modules/multi-architecture-import-imagestreams.adoc
@@ -1,0 +1,72 @@
+//Module included in the following assemblies
+//
+//post_installation_configuration/cluster-tasks.adoc
+
+:_content-type: PROCEDURE
+[id="multi-architecture-import-imagestreams_{context}"]
+
+= Importing manifest lists in image streams on your multi-architecture cluster 
+
+On a {product-title} {product-version} multi-architecture cluster, the image streams in the cluster do not import manifest lists automatically. You must manually change the default `importMode` option to the `PreserveOriginal` option in order to import the manifest list.
+
+[IMPORTANT]
+====
+The `referencePolicy.type` field of your `ImageStream` object must be set to the `Source` type for this procedure to run successfully.
+[source,yaml]
+----
+referencePolicy:
+    type: Source 
+----
+====
+
+.Prerequisites 
+
+* You installed the {product-title} CLI (`oc`).
+
+.Procedure 
+
+* The following example command shows how to patch the `ImageStream` cli-artifacts so that the `cli-artifacts:latest` image stream tag is imported as a manifest list.
++
+[source,terminal]
+----
+oc patch is/cli-artifacts -n openshift -p '{"spec":{"tags":[{"name":"latest","importPolicy":{"importMode":"PreserveOriginal"}}]}}'
+----
+
+.Verification 
+
+* You can check that the manifest lists imported properly by inspecting the image stream tag. The following command will list the individual architecture manifests for a particular tag. 
++
+[source,terminal]
+----
+oc get istag cli-artifacts:latest -n openshift -oyaml
+----
+
++ 
+If the `dockerImageManifests` object is present, then the manifest list import was successful. 
+
++
+.Example output of the `dockerImageManifests` object
+[source, yaml]
+----
+dockerImageManifests:
+  - architecture: amd64
+    digest: sha256:16d4c96c52923a9968fbfa69425ec703aff711f1db822e4e9788bf5d2bee5d77
+    manifestSize: 1252
+    mediaType: application/vnd.docker.distribution.manifest.v2+json
+    os: linux
+  - architecture: arm64
+    digest: sha256:6ec8ad0d897bcdf727531f7d0b716931728999492709d19d8b09f0d90d57f626
+    manifestSize: 1252
+    mediaType: application/vnd.docker.distribution.manifest.v2+json
+    os: linux
+  - architecture: ppc64le
+    digest: sha256:65949e3a80349cdc42acd8c5b34cde6ebc3241eae8daaeea458498fedb359a6a
+    manifestSize: 1252
+    mediaType: application/vnd.docker.distribution.manifest.v2+json
+    os: linux
+  - architecture: s390x
+    digest: sha256:75f4fa21224b5d5d511bea8f92dfa8e1c00231e5c81ab95e83c3013d245d1719
+    manifestSize: 1252
+    mediaType: application/vnd.docker.distribution.manifest.v2+json
+    os: linux
+----

--- a/post_installation_configuration/deploy-heterogeneous-configuration.adoc
+++ b/post_installation_configuration/deploy-heterogeneous-configuration.adoc
@@ -27,3 +27,5 @@ include::modules/mixed-arch-modify-machine-set.adoc[leveloffset=+1]
 * xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc[Creating a compute machine set on Azure] 
 
 include::modules/mixed-arch-upgrade-mirrors.adoc[leveloffset=+1]
+
+include::modules/multi-architecture-import-imagestreams.adoc[leveloffset=+1]


### PR DESCRIPTION
Version: 4.12 
Issue: [OSDOCS-4502](https://issues.redhat.com/browse/OSDOCS-4502)

Preview:
[Configuring a heterogeneous cluster  -> Importing manifest lists on your heterogeneous cluster](https://52612--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/deploy-heterogeneous-configuration.html#mixed-arch-import-imagestreams_deploy-heterogeneous-configuration)

QE review:
- [x] QE has approved this change.

