### PR TITLE
OSDOCS-4506: Updated GCP marketplace doc with missing offers

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -95,6 +95,10 @@ endif::[]
 :odo-title: odo
 //alibaba cloud
 :alibaba: Alibaba Cloud
+//OpenShift Kubernetes Engine
+:oke: OpenShift Kubernetes Engine
+//OpenShift Platform Plus
+:opp: OpenShift Platform Plus
 //openshift virtualization (cnv)
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 4.11

--- a/modules/installation-creating-gcp-worker.adoc
+++ b/modules/installation-creating-gcp-worker.adoc
@@ -111,7 +111,7 @@ EOF
 <2> `infra_id` is the `INFRA_ID` infrastructure name from the extraction step.
 <3> `zone` is the zone to deploy the worker machine into, for example `us-central1-a`.
 <4> `compute_subnet` is the `selfLink` URL to the compute subnet.
-<5> `image` is the `selfLink` URL to the {op-system} image. To deploy using a GCP Marketplace image, specify `image: \https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145`.
+<5> `image` is the `selfLink` URL to the {op-system} image. ^1^
 <6> `machine_type` is the machine type of the instance, for example `n1-standard-4`.
 <7> `service_account_email` is the email address for the worker service account that you created.
 <8> `ignition` is the contents of the `worker.ign` file.
@@ -126,6 +126,14 @@ file.
 ----
 $ gcloud deployment-manager deployments create ${INFRA_ID}-worker --config 06_worker.yaml
 ----
+
+[.small]
+--
+1. To use a GCP Marketplace image, specify the offer to use:
+** {product-title}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145`
+** {opp}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-opp-48-x86-64-202206140145`
+** {oke}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-oke-48-x86-64-202206140145`
+--
 
 ifeval::["{context}" == "installing-gcp-user-infra-vpc"]
 :!shared-vpc:

--- a/modules/installation-gcp-marketplace.adoc
+++ b/modules/installation-gcp-marketplace.adoc
@@ -26,7 +26,11 @@ $ openshift-install create manifests --dir <installation_dir>
 ** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-1.yaml`
 ** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-2.yaml`
 
-. In each file, edit the `.spec.template.spec.providerSpec.value.disks[0].image` property to `projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145`.
+. In each file, edit the `.spec.template.spec.providerSpec.value.disks[0].image` property to reference the offer to use:
++
+{product-title}:: `projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145`
+{opp}:: `projects/redhat-marketplace-public/global/images/redhat-coreos-opp-48-x86-64-202206140145`
+{oke}:: `projects/redhat-marketplace-public/global/images/redhat-coreos-oke-48-x86-64-202206140145`
 
 .Example compute machine set with the GCP Marketplace image
 [source,yaml]


### PR DESCRIPTION
Version(s):
4.8+

Issue:
This PR addresses [osdocs-4506](https://issues.redhat.com/browse/OSDOCS-4506), which is a continuation of https://github.com/openshift/openshift-docs/pull/51678.

Link to docs preview:

- (IPI) [Using a GCP Marketplace image](https://52617--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-gcp-marketplace_installing-gcp-customizations)
- (UPI) [Creating additional worker machines in GCP](https://52617--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-creating-gcp-worker_installing-gcp-user-infra-vpc)

QE review:
- [yes] QE has approved this change.