### PR TITLE
OCPBUGS#3213: adds api version to agent-config file

### DIFF
--- a/modules/installing-ocp-agent.adoc
+++ b/modules/installing-ocp-agent.adoc
@@ -88,6 +88,7 @@ sshKey: |
 [source,yaml]
 ----
   cat > agent-config.yaml << EOF
+  apiVersion: v1alpha1
   kind: AgentConfig
   metadata:
     name: sno-cluster


### PR DESCRIPTION
- Applies to main and 4.12
- Adds apiversion to the agent-config file
- [OCPBUGS](https://issues.redhat.com/browse/OCPBUGS-3213)
- [Preview](https://52621--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html)
- @mhanss ptal