### PR TITLE
Replacing removed flag with scheduler profile config

### DIFF
--- a/modules/nodes-custom-scheduler-deploying.adoc
+++ b/modules/nodes-custom-scheduler-deploying.adoc
@@ -21,6 +21,36 @@ Information on how to create a scheduler binary is outside the scope of this doc
 
 .Procedure
 
+. Create a file that contains a config map that holds the scheduler configuration file:
++
+.Example `scheduler-config-map.yaml`
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scheduler-config
+  namespace: kube-system <1>
+data:
+  scheduler-config.yaml: | <2>
+    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    kind: KubeSchedulerConfiguration
+    profiles:
+      - schedulerName: custom-scheduler <3>
+    leaderElection:
+      leaderElect: false
+----
+<1> This procedure uses the `kube-system` namespace, but you can use the namespace of your choosing.
+<2> When you define your `Deployment` resource later in this procedure, you pass this file in to the scheduler command by using the `--config` argument.
+<3> Define a scheduler profile for your custom scheduler. This scheduler name is used when defining the `schedulerName` in the `Pod` configuration.
+
+. Create the config map:
++
+[source,terminal]
+----
+$ oc create -f scheduler-config-map.yaml
+----
+
 . Create a file that contains the deployment resources for the custom scheduler:
 +
 .Example `custom-scheduler.yaml` file
@@ -83,32 +113,37 @@ spec:
       containers:
       - command:
         - /usr/local/bin/kube-scheduler
-        - --address=0.0.0.0
-        - --leader-elect=false
-        - --scheduler-name=custom-scheduler <2>
+        - --config=/etc/config/scheduler-config.yaml <2>
         image: "<namespace>/<image_name>:<tag>" <3>
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10251
+            port: 10259
+            scheme: HTTPS
           initialDelaySeconds: 15
         name: kube-second-scheduler
         readinessProbe:
           httpGet:
             path: /healthz
-            port: 10251
+            port: 10259
+            scheme: HTTPS
         resources:
           requests:
             cpu: '0.1'
         securityContext:
           privileged: false
-        volumeMounts: []
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
       hostNetwork: false
       hostPID: false
-      volumes: []
+      volumes:
+        - name: config-volume
+          configMap:
+            name: scheduler-config
 ----
 <1> This procedure uses the `kube-system` namespace, but you can use the namespace of your choosing.
-<2> The command for your custom scheduler might require different arguments. For example, you can pass configuration as a mounted volume using the `--config` argument.
+<2> The command for your custom scheduler might require different arguments.
 <3> Specify the container image that you created for the custom scheduler.
 
 . Create the deployment resources in the cluster:


### PR DESCRIPTION
This PR is a continuation of #36425. These docs were removed in 4.11, so this is only applicable in 4.10 and earlier.

Version(s):
4.8-4.10


Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=1993272

Link to docs preview:
http://file.rdu.redhat.com/~ahoffer/2022/BZ-1993272-410/nodes/scheduling/nodes-custom-scheduler.html#nodes-custom-scheduler-deploying_nodes-custom-scheduler

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
