### PR TITLE
[RHACS] Fix error in Auth Provider for OCP docs in RHACS

### DIFF
--- a/modules/configure-ocp-oauth-identity-provider.adoc
+++ b/modules/configure-ocp-oauth-identity-provider.adoc
@@ -19,10 +19,8 @@ The following procedure configures only a single main route named `central` for 
 
 .Procedure
 . On the {product-title-short} portal, navigate to *Platform Configuration* -> *Access Control*.
-. Click *Create auth provider* and select *Auth0* from the drop-down list.
+. Click *Create auth provider* and select *OpenShift Auth* from the drop-down list.
 . Enter a name for the authentication provider in the *Name* field.
-. Enter the *Auth0 tenant*, or the container where your `Auth0` data is configured and stored. The *Auth0 tenant* is in the form of a domain name (for example, `your-tenant.auth0.com`).
-. Enter the *Client ID*, or the unique identifier that you are using for authentication of your application.
 . Assign a *Minimum access role* for users that access {product-title-short} using the selected identity provider. A user must have the permissions granted to this role or a role with higher permissions to log in to {product-title-short}.
 +
 [TIP]


### PR DESCRIPTION
Version(s):

- `rhacs-docs`
- `rhacs-docs-3.72`
- `rhacs-docs-3.72.0`
- `rhacs-docs-3.72.1`
- `rhacs-docs-3.72.2`
- `rhacs-docs-3.73.0`

Issue: none (reported via G-chat)

[Link to docs preview](https://openshift-docs-j1lx0sgx8-kcarmichael08.vercel.app/openshift-acs/master/operating/manage-user-access/configure-ocp-oauth.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Fix error that was introduced during changes for a previous release.

