### PR TITLE
GH#52610 updating deprecated parameter name

### DIFF
--- a/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
+++ b/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
@@ -145,7 +145,7 @@ objects:
       protocol: TCP
       port: 80
       targetPort: 8080
-    portalIP: ''
+    clusterIP: ''
     type: ClusterIP
     sessionAffinity: None
   status:


### PR DESCRIPTION
Versions 4.8+

Fixes #52610

Replaces portalIP, which is deprecated according to the linked issue, with clusterIP.

Preview: https://52638--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html#how-to-plan-according-to-application-requirements_object-limits