### PR TITLE
GH#52534: Adding missing step

### DIFF
--- a/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
+++ b/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
@@ -70,6 +70,13 @@ $ chmod +x openshift-install
 $ ISO_URL=$(./openshift-install coreos print-stream-json | grep location | grep $ARCH | grep iso | cut -d\" -f4)
 ----
 
+. Download the {op-system} ISO:
++
+[source,terminal]
+----
+$ curl -L $ISO_URL -o rhcos-live.iso
+----
+
 . Use the {op-system} ISO and the hosted `worker.ign` file to install the worker node:
 
 .. Boot the target host using the {op-system} ISO and your preferred method of installation.


### PR DESCRIPTION
Versions 4.11+

Fixes #52534

Per the linked issue, there is a step missing to download the RHOCS ISO in the modified procedure. This PR adds this step.

Preview: https://52646--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-sno-worker-nodes.html#sno-adding-worker-nodes-to-single-node-clusters-manually_add-workers