### PR TITLE
OSDOCS-4457: Bump OSDK version and dependencies

### DIFF
--- a/modules/osdk-common-prereqs.adoc
+++ b/modules/osdk-common-prereqs.adoc
@@ -36,7 +36,7 @@ endif::[]
 * Operator SDK CLI installed
 * OpenShift CLI (`oc`) v{product-version}+ installed
 ifdef::golang[]
-* link:https://golang.org/dl/[Go] v1.18+
+* link:https://golang.org/dl/[Go] v1.19+
 endif::[]
 ifdef::ansible[]
 * link:https://docs.ansible.com/ansible/2.9/index.html[Ansible] v2.9.0

--- a/modules/osdk-installing-cli-linux-macos.adoc
+++ b/modules/osdk-installing-cli-linux-macos.adoc
@@ -3,8 +3,7 @@
 // * cli_reference/osdk/cli-osdk-install.adoc
 // * operators/operator_sdk/osdk-installing-cli.adoc
 
-:ocp_ver: 4.11
-:osdk_ver: v1.22.0
+:osdk_ver: v1.25.1
 
 :_content-type: PROCEDURE
 [id="osdk-installing-cli-linux-macos_{context}"]
@@ -14,7 +13,7 @@ You can install the OpenShift SDK CLI tool on Linux.
 
 .Prerequisites
 
-* link:https://golang.org/dl/[Go] v1.18+
+* link:https://golang.org/dl/[Go] v1.19+
 ifdef::openshift-origin[]
 * link:https://docs.docker.com/install/[`docker`] v17.03+, link:https://github.com/containers/libpod/blob/master/install.md[`podman`] v1.2.0+, or link:https://github.com/containers/buildah/blob/master/install.md[`buildah`] v1.7+
 endif::[]
@@ -26,7 +25,7 @@ endif::[]
 
 . Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/[OpenShift mirror site].
 
-. From the latest {ocp_ver} directory, download the latest version of the tarball for Linux.
+. From the latest {product-version} directory, download the latest version of the tarball for Linux.
 
 . Unpack the archive:
 +
@@ -74,5 +73,4 @@ $ operator-sdk version
 operator-sdk version: "{osdk_ver}-ocp", ...
 ----
 
-:!ocp_ver:
 :!osdk_ver:

--- a/modules/osdk-scorecard-config.adoc
+++ b/modules/osdk-scorecard-config.adoc
@@ -2,7 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
-:osdk_ver: v1.16.0
+:osdk_ver: v1.25.1
 
 [id="osdk-scorecard-config_{context}"]
 = Scorecard configuration

--- a/modules/osdk-scorecard-output.adoc
+++ b/modules/osdk-scorecard-output.adoc
@@ -2,7 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
-:osdk_ver: v1.16.0
+:osdk_ver: v1.25.1
 
 [id="osdk-scorecard-output_{context}"]
 = Scorecard output

--- a/modules/osdk-scorecard-parallel.adoc
+++ b/modules/osdk-scorecard-parallel.adoc
@@ -2,7 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
-:osdk_ver: v1.16.0
+:osdk_ver: v1.25.1
 
 :_content-type: PROCEDURE
 [id="osdk-scorecard-parallel_{context}"]

--- a/modules/osdk-updating-projects.adoc
+++ b/modules/osdk-updating-projects.adoc
@@ -22,8 +22,8 @@ ifeval::["{context}" == "osdk-hybrid-helm-updating-projects"]
 :type: Hybrid Helm
 endif::[]
 
-:osdk_ver: 1.22.0
-:osdk_ver_n1: 1.16.0
+:osdk_ver: v1.25.1
+:osdk_ver_n1: v1.22.0
 
 :_content-type: PROCEDURE
 [id="osdk-upgrading-projects_{context}"]

--- a/operators/operator_sdk/ansible/osdk-ansible-updating-projects.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-updating-projects.adoc
@@ -4,9 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: osdk-ansible-updating-projects
 
-:osdk_ver: 1.22.0
-:osdk_ver_n1: 1.16.0
-:product-version-n1: 4.10
+:osdk_ver: v1.25.1
+:osdk_ver_n1: v1.22.0
 
 toc::[]
 
@@ -28,4 +27,3 @@ include::modules/osdk-updating-projects.adoc[leveloffset=+1]
 
 :!osdk_ver:
 :!osdk_ver_n1:
-:!product-version-n1:

--- a/operators/operator_sdk/golang/osdk-golang-updating-projects.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-updating-projects.adoc
@@ -4,9 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: osdk-golang-updating-projects
 
-:osdk_ver: 1.22.0
-:osdk_ver_n1: 1.16.0
-:product-version-n1: 4.10
+:osdk_ver: v1.25.1
+:osdk_ver_n1: v1.22.0
 
 toc::[]
 
@@ -28,4 +27,3 @@ include::modules/osdk-updating-projects.adoc[leveloffset=+1]
 
 :!osdk_ver:
 :!osdk_ver_n1:
-:!product-version-n1:

--- a/operators/operator_sdk/helm/osdk-helm-updating-projects.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-updating-projects.adoc
@@ -4,9 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: osdk-helm-updating-projects
 
-:osdk_ver: 1.22.0
-:osdk_ver_n1: 1.16.0
-:product-version-n1: 4.10
+:osdk_ver: v1.25.1
+:osdk_ver_n1: v1.22.0
 
 toc::[]
 
@@ -28,4 +27,3 @@ include::modules/osdk-updating-projects.adoc[leveloffset=+1]
 
 :!osdk_ver:
 :!osdk_ver_n1:
-:!product-version-n1:

--- a/operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.adoc
+++ b/operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.adoc
@@ -4,9 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: osdk-hybrid-helm-updating-projects
 
-:osdk_ver: 1.22.0
-:osdk_ver_n1: 1.16.0
-:product-version-n1: 4.10
+:osdk_ver: v1.25.1
+:osdk_ver_n1: v1.22.0
 
 toc::[]
 
@@ -28,4 +27,3 @@ include::modules/osdk-updating-projects.adoc[leveloffset=+1]
 
 :!osdk_ver:
 :!osdk_ver_n1:
-:!product-version-n1:

--- a/operators/operator_sdk/osdk-installing-cli.adoc
+++ b/operators/operator_sdk/osdk-installing-cli.adoc
@@ -4,7 +4,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: osdk-installing-cli
 
-:osdk_ver: v1.22.0
+:osdk_ver: v1.25.1
 
 toc::[]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

* Bump OSDK to version 1.25.1
* Bump Go dependency to 1.19+
* Remove `product-version-n1` variable because it is no longer used
* [Minor update after SME and QE review] Replace `ocp_ver` variable with`{product-version}`, the standard way to define the OCP version in the repo

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: [OSDOCS-4457](https://issues.redhat.com//browse/OSDOCS-4457)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
**OSDK installation docs**
* [Installing the OSDK CLI](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-installing-cli.html) (Note admonition)
  * file: [`operators/operator_sdk/osdk-installing-cli.adoc`](https://github.com/openshift/openshift-docs/pull/52647/files#diff-4935ab3e5656397ebbd295e53757cf82feb7be47db4fede33e233d4f72cc1534)
* [Installing OSDK CLI on Linux and MacOS](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-installing-cli.html#osdk-installing-cli-linux-macos_osdk-installing-cli)
  * file: [`operators/operator_sdk/osdk-installing-cli.adoc`](https://github.com/openshift/openshift-docs/pull/52647/files#diff-9411c438386474c7e81cbb7e60a063b10c0b4083923aa46580a9378fd326834c)
  
**OSDK project migration docs**
* [Updating Go-based Operator projects](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-updating-projects.html)
  * file: [`operators/operator_sdk/golang/osdk-golang-updating-projects.adoc`](https://github.com/openshift/openshift-docs/pull/52647/files#diff-faecd9489ae0b9ca940985b8f6e900d6701664d6541209e2e74db2a7c9b35969)
* [Updating Ansible-based Operator projects](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-updating-projects.html)
  * file: [`operators/operator_sdk/ansible/osdk-ansible-updating-projects.adoc`](https://github.com/openshift/openshift-docs/pull/52647/files#diff-69ed593920a10e90485adc4572e5630da1bd3e3869627470235529abd0e7fcdf)
* [Updating Helm-based Operator projects](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-updating-projects.html)
  * file: [`operators/operator_sdk/helm/osdk-helm-updating-projects.adoc`](https://github.com/openshift/openshift-docs/pull/52647/files#diff-1b2a5a346fcac4c881fb0327724131bf8551109849f7463e3b351aa1c2a55b40)
* [Updating Hybrid Helm-based Operator projects](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.html)
  * file: [`operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.adoc`](https://github.com/openshift/openshift-docs/pull/52647/files)

**OSDK quickstarts and tutorials**
file: [`modules/osdk-common-prereqs.adoc`](https://github.com/openshift/openshift-docs/pull/52647/files#diff-2602d1db64bb34f790b289868d49463375a0fddbac17a2a766527ceb6aa95e0f)
* [Go quickstart](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-quickstart.html#osdk-common-prereqs_osdk-golang-quickstart)
* [Go tutorial](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html)
* [Ansible quickstart](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-quickstart.html#osdk-common-prereqs_osdk-ansible-quickstart)
* [Ansible tutorial](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-common-prereqs_osdk-ansible-tutorial)
* [Helm quickstart](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-quickstart.html#osdk-common-prereqs_osdk-helm-quickstart)
* [Helm tutorial](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-common-prereqs_osdk-helm-tutorial)
* [Hybrid Helm](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-hybrid-helm.html#osdk-common-prereqs_osdk-hybrid-helm)
* [Java quickstart](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/java/osdk-java-quickstart.html#osdk-common-prereqs_osdk-java-quickstart)
* [Java tutorial](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/java/osdk-java-tutorial.html#osdk-common-prereqs_osdk-java-tutorial)

**Scorecard docs**
 This changes the tag on the quay hosted image to 1.25.1.
 
![image](https://user-images.githubusercontent.com/82119979/201216321-609bf232-0a67-4c29-b3ee-d947fdd05904.png)

 
* [Scorecard config](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-scorecard.html#osdk-scorecard-config_osdk-scorecard)
  * file: [`modules/osdk-scorecard-config.adoc`](https://github.com/openshift/openshift-docs/pull/52647/files#diff-134d658e6dec394f52d0c22ba9ba347a965cc3a08e90d91fd385874483de0e8a)
* [Scorecard output](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-scorecard.html#osdk-scorecard-output_osdk-scorecard)
  * file: [`modules/osdk-scorecard-output.adoc`](https://github.com/openshift/openshift-docs/pull/52647/files#diff-25cd4a09255552059240143dcd97d44c962ee3ed5e66a6b4292bcbc631d4d984)
* [Scorecard parallel](https://52647--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-scorecard.html#osdk-scorecard-parallel_osdk-scorecard)
  * file: [`modules/osdk-scorecard-parallel.adoc`](https://github.com/openshift/openshift-docs/pull/52647/files#diff-07264f252d3f738c0937cecf313fb214be77784b13017fb62220f71f694540af)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
