### PR TITLE
OSDOCS-4507: Added instructions for removing a CA bundle from ROSA

### DIFF
--- a/modules/configmap-removing-ca.adoc
+++ b/modules/configmap-removing-ca.adoc
@@ -1,0 +1,99 @@
+// Module included in the following assemblies:
+//
+// * builds/setting-up-trusted-ca
+
+:_content-type: PROCEDURE
+[id="configmap-removing-ca_{context}"]
+= Removing certificate authorities on a {product-title} cluster
+
+You can remove certificate authorities (CA) from your cluster with the `rosa` CLI tool.
+
+.Prerequisites
+
+* You must have cluster administrator privileges.
+* You have installed the `rosa` CLI tool.
+* Your cluster has certificate authorities added. 
+
+.Procedure
+
+* Use the `rosa edit` command to modify the CA trust bundle. You must pass empty strings to the `--additional-trust-bundle-file` argument to clear the trust bundle from the cluster:
++
+[source,terminal]
+----
+$ rosa edit cluster -c <cluster_name> --additional-trust-bundle-file "" 
+----
++
+.Example Output
++
+[source,yaml]
+----
+I: Updated cluster <cluster_name>
+----
+
+.Verification
+
+* You can verify that the trust bundle has been removed from the cluster by using the `rosa describe` command: 
++
+[source,yaml]
+----
+$ rosa describe cluster -c <cluster_name>
+----
++
+Before removal, the Additional trust bundle section appears, redacting its value for security purposes:
++
+[source,yaml]
+----
+Name:                       <cluster_name>
+ID:                         <cluster_internal_id>
+External ID:                <cluster_external_id>
+OpenShift Version:          4.11.9
+Channel Group:              stable
+DNS:                        <dns>
+AWS Account:                <aws_account_id>
+API URL:                    <api_url>
+Console URL:                <console_url>
+Region:                     us-east-1
+Multi-AZ:                   false
+Nodes:
+ - Control plane:           3
+ - Infra:                   2
+ - Compute:                 2
+Network:
+ - Type:                    OVNKubernetes
+ - Service CIDR:            <service_cidr>
+ - Machine CIDR:            <machine_cidr>
+ - Pod CIDR:                <pod_cidr>
+ - Host Prefix:             <host_prefix>
+Proxy:
+ - HTTPProxy:               <proxy_url>
+Additional trust bundle:    REDACTED
+----
++
+After removing the proxy, the Additional trust bundle section is removed:
++
+[source,yaml]
+----
+Name:                       <cluster_name>
+ID:                         <cluster_internal_id>
+External ID:                <cluster_external_id>
+OpenShift Version:          4.11.9
+Channel Group:              stable
+DNS:                        <dns>
+AWS Account:                <aws_account_id>
+API URL:                    <api_url>
+Console URL:                <console_url>
+Region:                     us-east-1
+Multi-AZ:                   false
+Nodes:
+ - Control plane:           3
+ - Infra:                   2
+ - Compute:                 2
+Network:
+ - Type:                    OVNKubernetes
+ - Service CIDR:            <service_cidr>
+ - Machine CIDR:            <machine_cidr>
+ - Pod CIDR:                <pod_cidr>
+ - Host Prefix:             <host_prefix>
+Proxy:
+ - HTTPProxy:               <proxy_url>
+----

--- a/networking/configuring-cluster-wide-proxy.adoc
+++ b/networking/configuring-cluster-wide-proxy.adoc
@@ -86,7 +86,8 @@ include::modules/configuring-a-proxy-after-installation-cli.adoc[leveloffset=+2]
 [id="removing-cluster-wide-proxy_{context}"]
 == Removing a cluster-wide proxy
 
-You can remove your cluster-wide proxy by using the `rosa` CLI tool.
+You can remove your cluster-wide proxy by using the `rosa` CLI tool. After removing the cluster, you should also remove any trust bundles that are added to the cluster.
 
 include::modules/nw-rosa-proxy-remove-cli.adoc[leveloffset=+2]
+include::modules/configmap-removing-ca.adoc[leveloffset=+2]
 endif::openshift-rosa[]


### PR DESCRIPTION
Version(s):
Enterprise 4-11+

Issue:
[OSDOCS-4507](https://issues.redhat.com/browse/OSDOCS-4507)

Link to docs preview:
- [ROSA](https://52652--docspreview.netlify.app/openshift-rosa/latest/cicd/builds/setting-up-trusted-ca.html#configmap-removing-ca_setting-up-trusted-ca)
- [OCP](https://52652--docspreview.netlify.app/openshift-enterprise/latest/cicd/builds/setting-up-trusted-ca.html) and [OSD](https://52652--docspreview.netlify.app/openshift-dedicated/latest/cicd/builds/setting-up-trusted-ca.html) should be unchanged.

QE review:
- [ ] QE has approved this change.

Additional information:
