### PR TITLE
BZ-2008984: Clarifying that 0 is the lowest priority

### DIFF
--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -366,16 +366,16 @@ pod to fail.
 [id="scc-prioritization_{context}"]
 == Security context constraints prioritization
 
-Security context constraints (SCCs) have a priority field that affects the ordering when attempting to
-validate a request by the admission controller. A higher priority
-SCC is moved to the front of the set when sorting. When the complete set
-of available SCCs are determined they are ordered by:
+Security context constraints (SCCs) have a priority field that affects the ordering when attempting to validate a request by the admission controller.
 
-. Highest priority first, nil is considered a 0 priority
-. If priorities are equal, the SCCs will be sorted from most restrictive to least restrictive
-. If both priorities and restrictions are equal the SCCs will be sorted by name
+A priority value of `0` is the lowest possible priority. A nil priority is considered a `0`, or lowest, priority. Higher priority SCCs are moved to the front of the set when sorting.
+
+When the complete set of available SCCs is determined, the SCCs are ordered in the following manner:
+
+. The highest priority SCCs are ordered first.
+. If the priorities are equal, the SCCs are sorted from most restrictive to least restrictive.
+. If both the priorities and restrictions are equal, the SCCs are sorted by name.
 
 By default, the `anyuid` SCC granted to cluster administrators is given priority
 in their SCC set. This allows cluster administrators to run pods as any
-user by without specifying a `RunAsUser` on the pod's `SecurityContext`. The
-administrator may still specify a `RunAsUser` if they wish.
+user by specifying `RunAsUser` in the pod's `SecurityContext`.


### PR DESCRIPTION
New PR, originally started in #39177.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.8+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2008984

Link to docs preview:
https://52655--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html#scc-prioritization_configuring-internal-oauth

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
