### PR TITLE
Release notes for OADP 1.1.1: OADP-778, 804, 939 and 975  (Replaces PR 51819)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2441,6 +2441,8 @@ Topics:
 - Name: Application backup and restore
   Dir: application_backup_and_restore
   Topics:
+  - Name: OADP release notes
+    File: oadp-release-notes
   - Name: OADP features and plugins
     File: oadp-features-plugins
   - Name: Installing and configuring OADP

--- a/backup_and_restore/application_backup_and_restore/oadp-advanced-topics.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-advanced-topics.adoc
@@ -3,7 +3,6 @@
 = Advanced OADP features and functionalities
 include::_attributes/common-attributes.adoc[]
 :context: oadp-advanced-topics
-:oadp-advanced-topics:
 
 toc::[]
 

--- a/backup_and_restore/application_backup_and_restore/oadp-api.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-api.adoc
@@ -254,7 +254,4 @@ link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#Features
 
 The OADP API is more fully detailed in link:https://pkg.go.dev/github.com/openshift/oadp-operator[OADP Operator].
 
-
-
-
-:oadp-api!:
+:!oadp-api:

--- a/backup_and_restore/application_backup_and_restore/oadp-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-release-notes.adoc
@@ -1,0 +1,13 @@
+:_content-type: ASSEMBLY
+[id="oadp-release-notes"]
+= OADP release notes
+include::_attributes/common-attributes.adoc[]
+:context: oadp-release-notes
+
+toc::[]
+
+The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
+
+include::modules/oadp-release-notes-1-1-1.adoc[leveloffset=+1]
+
+:!oadp-release-notes:

--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -3,7 +3,6 @@
 = Troubleshooting
 include::_attributes/common-attributes.adoc[]
 :context: oadp-troubleshooting
-:oadp-troubleshooting:
 :namespace: openshift-adp
 :local-product: OADP
 :must-gather: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.0

--- a/modules/oadp-release-notes-1-1-1.adoc
+++ b/modules/oadp-release-notes-1-1-1.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-oadp-release-notes-1-1-1_{context}"]
+= OADP 1.1.1 release notes
+
+The OADP 1.1.1 release notes include product recommendations and descriptions of known issues.
+
+== Product recommendations
+
+Before you install OADP 1.1.1, it is recommended to either install VolSync 0.5.1 or to upgrade to it.
+
+== Known issues
+
+This release has the following known issues:
+
+* OADP currently does not support backup and restore of AWS EFS volumes using restic in Velero (link:https://issues.redhat.com/browse/OADP-778[*OADP-778*]).
+
+* CSI backups might fail due to a Ceph limitation of `VolumeSnapshotContent` snapshots per PVC.
++
+You can create many snapshots of the same persistent volume claim (PVC) but cannot schedule periodic creation of snapshots:
++
+** For CephFS, you can create up to 100 snapshots per PVC.
+** For RADOS Block Device (RBD), you can create up to 512 snapshots for each PVC. (link:https://issues.redhat.com/browse/OADP-804[*OADP-804*]) and (link:https://issues.redhat.com/browse/OADP-975[*OADP-975*])
++
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.11/html/managing_and_allocating_storage_resources/volume-snapshots_rhodf[Volume Snapshots].


### PR DESCRIPTION
This PR replaces https://github.com/openshift/openshift-docs/pull/51819 -- My attempt to change its base from "main" to "enterprise 3-11" (instead of 4.11) closed that PR automatically. 

OADP 1.1.1; OCP 4.9+

Dev and QE have approved.

Resolves https://issues.redhat.com/browse/OADP-778, https://issues.redhat.com/browse/OADP-804, https://issues.redhat.com/browse/OADP-939, and https://issues.redhat.com/browse/OADP-975 by adding Release notes for OADP 1.1.1.

Preview: https://52659--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-release-notes.html