### PR TITLE
Agent-61: Adds FIPS compliance for Agent-based Installer

### DIFF
--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -16,6 +16,18 @@ The Agent-based Installer also utilizes Zero Touch Provisioning (ZTP) custom res
 
 include::modules/understanding-agent-install.adoc[leveloffset=+1]
 
+include::modules/agent-installer-fips-compliance.adoc[leveloffset=+1]
+
+include::modules/agent-installer-configuring-fips-compliance.adoc[leveloffset=+1]
+
+[discrete]
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/articles/5059881[OpenShift Security Guide Book].
+
+* xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography]
+
 include::modules/installation-bare-metal-agent-installer-config-yaml.adoc[leveloffset=+1]
 
 include::modules/validations-before-agent-iso-creation.adoc[leveloffset=+1]

--- a/modules/agent-installer-configuring-fips-compliance.adoc
+++ b/modules/agent-installer-configuring-fips-compliance.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_with_agent_bases_installer/preparing-to-install-with-agent-based-installer.adoc
+
+
+:_content-type: PROCEDURE
+[id="agent-installer-configuring-fips-compliance_{context}"]
+
+= Configuring FIPS through the Agent-based Installer
+
+During a cluster deployment, the Federal Information Processing Standards (FIPS) change is applied when the Red Hat Enterprise Linux CoreOS (RHCOS) machines are deployed in your cluster. For Red Hat Enterprise Linux (RHEL) machines, you must enable FIPS mode when you install the operating system on the machines that you plan to use as worker machines.
+
+You can enable FIPS mode through the preferred method of `install-config.yaml` and `agent.config.yaml`:
+
+. You must set value of the `fips` field to `True` in the `install-config.yaml` file:
++
+.Sample install-config.yaml.file
+
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: test.example.com
+metadata:
+  name: sno-cluster
+fips: True
+----
+
+. Optional: If you are using the ZTP manifests, you must set the value of `fips` as `True` in the `Agent-install.openshift.io/install-config-overrides` field in the `agent-cluster-install.yaml` file:
+
++
+.Sample agent-cluster-install.yaml file
+[source,yaml]
+----
+apiVersion: extensions.hive.openshift.io/v1beta1
+kind: AgentClusterInstall
+metadata:
+  annotations:
+    agent-install.openshift.io/install-config-overrides: '{"fips": True}'
+  name: sno-cluster
+  namespace: sno-cluster-test
+----

--- a/modules/agent-installer-fips-compliance.adoc
+++ b/modules/agent-installer-fips-compliance.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_with_agent_bases_installer/preparing-to-install-with-agent-based-installer.adoc
+
+
+:_content-type: CONCEPT
+[id="agent-installer-fips-compliance_{context}"]
+= About FIPS compliance
+
+For many {product-title} customers, regulatory readiness, or compliance, on some level is required before any systems can be put into production. That regulatory readiness can be imposed by national standards, industry standards or the organization's corporate governance framework.
+Federal Information Processing Standards (FIPS) compliance is one of the most critical components required in highly secure environments to ensure that only supported cryptographic technologies are allowed on nodes.
+
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====

--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing-with-agent/installing-with-agent.adoc
+// * installing/installing_with_agent_bases_installer/preparing-to-install-with-agent-based-installer.adoc
 
 :_content-type: CONCEPT
 [id="understanding-agent-install_{context}"]
@@ -35,7 +35,7 @@ One of the nodes runs the Assisted Service at the start of the boot process and 
 The Assisted Service ensures that all the hosts meet the requirements and triggers an {product-title} cluster deployement. All the nodes have the Red Hat Enterprise Linux CoreOS (RHCOS) image written to the disk. The non-bootstrap nodes reboot and initiate a cluster deployment.
 When the nodes are rebooted, **node 0** reboots and joins the cluster. The bootstrapping is complete and the cluster is deployed.
 
-.Node lifecycle workflow 
+.Node lifecycle workflow
 image::agent-based-installer-workflow.png[Agent-based installer workflow]
 
 You can install a disconnected {product-title} cluster through the `openshift-install agent create image` subcommand for the following topologies:


### PR DESCRIPTION
- Applies to main and 4.12
- [Agent-61](https://issues.redhat.com/browse/AGENT-61)
- [Preview](http://file.del.redhat.com/asakthiv/Agent-61/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#agent-installer-fips-compliance_preparing-to-install-with-agent-based-installer) Requires VPN
- @celebdor ptal Additionally note that in [Sample install-config.yaml](https://52701--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#installation-bare-metal-agent-installer-config-yaml_preparing-to-install-with-agent-based-installer) callout 12 defines FIPS.
