### PR TITLE
OSDOCS-4533: CIT Remove xrefs in module and clean up 

### DIFF
--- a/modules/osdk-common-prereqs.adoc
+++ b/modules/osdk-common-prereqs.adoc
@@ -33,24 +33,24 @@ endif::[]
 [id="osdk-common-prereqs_{context}"]
 = Prerequisites
 
-- xref:../../../operators/operator_sdk/osdk-installing-cli.adoc#osdk-installing-cli[Operator SDK CLI installed]
-- xref:../../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[OpenShift CLI (`oc`) v{product-version}+ installed]
+* Operator SDK CLI installed
+* OpenShift CLI (`oc`) v{product-version}+ installed
 ifdef::golang[]
-- link:https://golang.org/dl/[Go] v1.18+
+* link:https://golang.org/dl/[Go] v1.18+
 endif::[]
 ifdef::ansible[]
-- link:https://docs.ansible.com/ansible/2.9/index.html[Ansible] v2.9.0
-- link:https://ansible-runner.readthedocs.io/en/latest/install.html[Ansible Runner] v2.0.2+
-- link:https://github.com/ansible/ansible-runner-http[Ansible Runner HTTP Event Emitter plug-in] v1.0.0+
-- link:https://www.python.org/downloads/[Python] 3.8.6+
-- link:https://pypi.org/project/openshift/[OpenShift Python client] v0.12.0+
+* link:https://docs.ansible.com/ansible/2.9/index.html[Ansible] v2.9.0
+* link:https://ansible-runner.readthedocs.io/en/latest/install.html[Ansible Runner] v2.0.2+
+* link:https://github.com/ansible/ansible-runner-http[Ansible Runner HTTP Event Emitter plug-in] v1.0.0+
+* link:https://www.python.org/downloads/[Python] 3.8.6+
+* link:https://pypi.org/project/openshift/[OpenShift Python client] v0.12.0+
 endif::[]
 ifdef::java[]
-- link:https://java.com/en/download/help/download_options.html[Java] v11+
-- link:https://maven.apache.org/install.html[Maven] v3.6.3+
+* link:https://java.com/en/download/help/download_options.html[Java] v11+
+* link:https://maven.apache.org/install.html[Maven] v3.6.3+
 endif::[]
-- Logged into an {product-title} {product-version} cluster with `oc` with an account that has `cluster-admin` permissions
-- To allow the cluster to pull the image, the repository where you push your image must be set as public, or you must configure an image pull secret
+* Logged into an {product-title} {product-version} cluster with `oc` with an account that has `cluster-admin` permissions
+* To allow the cluster to pull the image, the repository where you push your image must be set as public, or you must configure an image pull secret
 
 ifeval::["{context}" == "osdk-ansible-quickstart"]
 :!ansible:

--- a/operators/operator_sdk/ansible/osdk-ansible-quickstart.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-quickstart.adoc
@@ -11,6 +11,12 @@ The Operator SDK includes options for generating an Operator project that levera
 To demonstrate the basics of setting up and running an link:https://docs.ansible.com/ansible/latest/index.html[Ansible]-based Operator using tools and libraries provided by the Operator SDK, Operator developers can build an example Ansible-based Operator for Memcached, a distributed key-value store, and deploy it to a cluster.
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/operator_sdk/osdk-installing-cli.adoc#osdk-installing-cli[Installing the Operator SDK CLI]
+* xref:../../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the OpenShift CLI]
+
 include::modules/osdk-quickstart.adoc[leveloffset=+1]
 
 [id="osdk-ansible-quickstart-next-steps"]

--- a/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
@@ -25,6 +25,11 @@ This tutorial goes into greater detail than xref:../../../operators/operator_sdk
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/operator_sdk/osdk-installing-cli.adoc#osdk-installing-cli[Installing the Operator SDK CLI]
+* xref:../../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the OpenShift CLI]
+
 include::modules/osdk-create-project.adoc[leveloffset=+1]
 include::modules/osdk-project-file.adoc[leveloffset=+2]
 
@@ -48,5 +53,5 @@ include::modules/osdk-create-cr.adoc[leveloffset=+1]
 [id="osdk-ansible-tutorial-addtl-resources"]
 == Additional resources
 
-- See xref:../../../operators/operator_sdk/ansible/osdk-ansible-project-layout.adoc#osdk-ansible-project-layout[Project layout for Ansible-based Operators] to learn about the directory structures created by the Operator SDK.
-- If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).
+* See xref:../../../operators/operator_sdk/ansible/osdk-ansible-project-layout.adoc#osdk-ansible-project-layout[Project layout for Ansible-based Operators] to learn about the directory structures created by the Operator SDK.
+* If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).

--- a/operators/operator_sdk/golang/osdk-golang-quickstart.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-quickstart.adoc
@@ -9,6 +9,12 @@ toc::[]
 To demonstrate the basics of setting up and running a Go-based Operator using tools and libraries provided by the Operator SDK, Operator developers can build an example Go-based Operator for Memcached, a distributed key-value store, and deploy it to a cluster.
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/operator_sdk/osdk-installing-cli.adoc#osdk-installing-cli[Installing the Operator SDK CLI]
+* xref:../../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the OpenShift CLI]
+
 include::modules/osdk-quickstart.adoc[leveloffset=+1]
 
 [id="osdk-golang-quickstart-next-steps"]

--- a/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
@@ -21,6 +21,11 @@ This tutorial goes into greater detail than xref:../../../operators/operator_sdk
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/operator_sdk/osdk-installing-cli.adoc#osdk-installing-cli[Installing the Operator SDK CLI]
+* xref:../../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the OpenShift CLI]
+
 include::modules/osdk-create-project.adoc[leveloffset=+1]
 include::modules/osdk-project-file.adoc[leveloffset=+2]
 include::modules/osdk-golang-manager.adoc[leveloffset=+2]
@@ -57,5 +62,5 @@ include::modules/osdk-create-cr.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-- See xref:../../../operators/operator_sdk/golang/osdk-golang-project-layout.adoc#osdk-golang-project-layout[Project layout for Go-based Operators] to learn about the directory structures created by the Operator SDK.
-- If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).
+* See xref:../../../operators/operator_sdk/golang/osdk-golang-project-layout.adoc#osdk-golang-project-layout[Project layout for Go-based Operators] to learn about the directory structures created by the Operator SDK.
+* If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).

--- a/operators/operator_sdk/helm/osdk-helm-quickstart.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-quickstart.adoc
@@ -11,6 +11,12 @@ The Operator SDK includes options for generating an Operator project that levera
 To demonstrate the basics of setting up and running an link:https://helm.sh/docs/[Helm]-based Operator using tools and libraries provided by the Operator SDK, Operator developers can build an example Helm-based Operator for Nginx and deploy it to a cluster.
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/operator_sdk/osdk-installing-cli.adoc#osdk-installing-cli[Installing the Operator SDK CLI]
+* xref:../../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the OpenShift CLI]
+
 include::modules/osdk-quickstart.adoc[leveloffset=+1]
 
 [id="osdk-helm-quickstart-next-steps"]

--- a/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
@@ -25,6 +25,11 @@ This tutorial goes into greater detail than xref:../../../operators/operator_sdk
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/operator_sdk/osdk-installing-cli.adoc#osdk-installing-cli[Installing the Operator SDK CLI]
+* xref:../../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the OpenShift CLI]
+
 include::modules/osdk-create-project.adoc[leveloffset=+1]
 include::modules/osdk-helm-existing-chart.adoc[leveloffset=+2]
 include::modules/osdk-project-file.adoc[leveloffset=+2]
@@ -50,5 +55,5 @@ include::modules/osdk-create-cr.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-- See xref:../../../operators/operator_sdk/helm/osdk-helm-project-layout.adoc#osdk-helm-project-layout[Project layout for Helm-based Operators] to learn about the directory structures created by the Operator SDK.
-- If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).
+* See xref:../../../operators/operator_sdk/helm/osdk-helm-project-layout.adoc#osdk-helm-project-layout[Project layout for Helm-based Operators] to learn about the directory structures created by the Operator SDK.
+* If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).

--- a/operators/operator_sdk/helm/osdk-hybrid-helm.adoc
+++ b/operators/operator_sdk/helm/osdk-hybrid-helm.adoc
@@ -18,11 +18,16 @@ include::snippets/technology-preview.adoc[]
 
 This tutorial walks through the following process using the Hybrid Helm Operator:
 
-- Create a `Memcached` deployment through a Helm chart if it does not exist
-- Ensure that the deployment size is the same as specified by `Memcached` custom resource (CR) spec
-- Create a `MemcachedBackup` deployment by using the Go API
+* Create a `Memcached` deployment through a Helm chart if it does not exist
+* Ensure that the deployment size is the same as specified by `Memcached` custom resource (CR) spec
+* Create a `MemcachedBackup` deployment by using the Go API
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/operator_sdk/osdk-installing-cli.adoc#osdk-installing-cli[Installing the Operator SDK CLI]
+* xref:../../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the OpenShift CLI]
 
 include::modules/osdk-hh-create-project.adoc[leveloffset=+1]
 .Additional resources

--- a/operators/operator_sdk/java/osdk-java-quickstart.adoc
+++ b/operators/operator_sdk/java/osdk-java-quickstart.adoc
@@ -11,6 +11,12 @@ toc::[]
 To demonstrate the basics of setting up and running a Java-based Operator using tools and libraries provided by the Operator SDK, Operator developers can build an example Java-based Operator for Memcached, a distributed key-value store, and deploy it to a cluster.
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/operator_sdk/osdk-installing-cli.adoc#osdk-installing-cli[Installing the Operator SDK CLI]
+* xref:../../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the OpenShift CLI]
+
 include::modules/osdk-quickstart.adoc[leveloffset=+1]
 
 [id="next-steps_osdk-java-quickstart"]

--- a/operators/operator_sdk/java/osdk-java-tutorial.adoc
+++ b/operators/operator_sdk/java/osdk-java-tutorial.adoc
@@ -23,6 +23,11 @@ This tutorial goes into greater detail than xref:../../../operators/operator_sdk
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/operator_sdk/osdk-installing-cli.adoc#osdk-installing-cli[Installing the Operator SDK CLI]
+* xref:../../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the OpenShift CLI]
+
 include::modules/osdk-create-project.adoc[leveloffset=+1]
 include::modules/osdk-project-file.adoc[leveloffset=+2]
 
@@ -53,5 +58,5 @@ include::modules/osdk-deploy-olm.adoc[leveloffset=+3]
 [id="additional-resources_osdk-java-tutorial"]
 == Additional resources
 
-- See xref:../../../operators/operator_sdk/java/osdk-java-project-layout.adoc#osdk-java-project-layout[Project layout for Java-based Operators] to learn about the directory structures created by the Operator SDK.
-- If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).
+* See xref:../../../operators/operator_sdk/java/osdk-java-project-layout.adoc#osdk-java-project-layout[Project layout for Java-based Operators] to learn about the directory structures created by the Operator SDK.
+* If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).


### PR DESCRIPTION
Remove the `xrefs` in `modules/osdk-common-prereq.adoc` and replace `-` bullets with `*` in associated modules and assemblies.

Peer & merge review squad: I think that this PR does not need SME or QE review because it only fixes `xrefs` in modules and the bullet type. There are no changes to technical content. If you disagree, please let me know and I can get acks.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: [OSDOCS-4533](https://issues.redhat.com//browse/OSDOCS-4533)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* [Ansible quickstart](https://52711--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-quickstart.html#osdk-common-prereqs_osdk-ansible-quickstart)
* [Ansible tutorial](https://52711--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-common-prereqs_osdk-ansible-tutorial)
* [Go quickstart](https://52711--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-quickstart.html#osdk-common-prereqs_osdk-golang-quickstart)
* [Go tutorial](https://52711--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-common-prereqs_osdk-golang-tutorial)
* [Helm quickstart](https://52711--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-quickstart.html#osdk-common-prereqs_osdk-helm-quickstart)
* [Helm tutorial](https://52711--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-common-prereqs_osdk-helm-tutorial)
* [Hybrid helm](https://52711--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-hybrid-helm.html#osdk-common-prereqs_osdk-hybrid-helm)
* [Java quickstart](https://52711--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/java/osdk-java-quickstart.html#osdk-common-prereqs_osdk-java-quickstart)
* [Java tutorial
](https://52711--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/java/osdk-java-tutorial.html#osdk-common-prereqs_osdk-java-tutorial)
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
* Issue for OCP 4.8 to 4.10: [OSDOCS-4534](https://issues.redhat.com//browse/OSDOCS-4534) (Backlog)

Doc clean up of list formatting and removing xrefs from a module.
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
