### PR TITLE
TELCODOCS-1033: Remove (Optional) from module configuring ingressVIP to run on control plane nodes.

### DIFF
--- a/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
+++ b/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
@@ -4,9 +4,14 @@
 
 :_content-type: PROCEDURE
 [id='configure-network-components-to-run-on-the-control-plane_{context}']
-= Optional: Configuring network components to run on the control plane
+= Configuring network components to run on the control plane
 
-You can configure networking components to run exclusively on the control plane nodes. By default, {product-title} allows any node in the machine config pool to host the `ingressVIP` virtual IP address. However, some environments deploy worker nodes in separate subnets from the control plane nodes. When deploying remote workers in separate subnets, you must place the `ingressVIP` virtual IP address exclusively with the control plane nodes.
+You can configure networking components to run exclusively on the control plane nodes. By default, {product-title} allows any node in the machine config pool to host the `ingressVIP` virtual IP address. However, some environments deploy worker nodes in separate subnets from the control plane nodes, which requires configuring the `ingressVIP` virtual IP address to run on the control plane nodes. 
+
+[IMPORTANT]
+====
+When deploying remote workers in separate subnets, you must place the `ingressVIP` virtual IP address exclusively with the control plane nodes.
+====
 
 image::161_OpenShift_Baremetal_IPI_Deployment_updates_0521.svg[Installer-provisioned networking]
 


### PR DESCRIPTION
Removed "Optional" from the title and placed the last sentence into an admonishment block. This PR replaces https://github.com/openshift/openshift-docs/pull/52585

Fixes: [TELCODOCS-1033](https://issues.redhat.com//browse/TELCODOCS-1033)

See https://issues.redhat.com/browse/TELCODOCS-1033 for additional details.

Preview URL: http://jowilkin.com:8080/TELCODOCS-1033/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configure-network-components-to-run-on-the-control-plane_ipi-install-installation-workflow

QE Review:
- [ ] QE has approved this change.

For release(s): 4.11+
Signed-off-by: John Wilkins <jowilkin@redhat.com>
