### PR TITLE
OSDOCS-4401: Added clarity for CIDR ranges

### DIFF
--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -13,6 +13,10 @@ You must specify non-overlapping ranges for the following CIDR ranges.
 Machine CIDR ranges cannot be changed after creating your cluster.
 ====
 
+ifdef::openshift-rosa,openshift-dedicated[]
+When specifying subnet CIDR ranges, ensure that the subnet CIDR range is within the defined Machine CIDR. You must verify that the subnet CIDR ranges allow for enough IP addresses for all intended workloads, including at least eight IP addresses for possible AWS Load Balancers.
+endif::[]
+
 [id="machine-cidr-description"]
 == Machine CIDR
 In the Machine CIDR field, you must specify the IP address range for machines or cluster nodes. This range must encompass all CIDR address ranges for your virtual private cloud (VPC) subnets. Subnets must be contiguous. A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones. The default is `10.0.0.0/16`. This range must not conflict with any connected networks.


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-4401](https://issues.redhat.com/browse/OSDOCS-4401)

Link to docs preview:
- [ROSA](https://52724--docspreview.netlify.app/openshift-rosa/latest/networking/cidr-range-definitions.html)
- [OSD](https://52724--docspreview.netlify.app/openshift-dedicated/latest/networking/cidr-range-definitions.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added a paragraph informing users to save room for at least eight IP addresses within a specified CIDR range.