### PR TITLE
[OSDOCS-4165]: Enabling Azure boot diagnostics on compute machines

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc
@@ -20,5 +20,8 @@ include::modules/machineset-yaml-azure-stack-hub.adoc[leveloffset=+1]
 //Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 
+//Enabling Azure boot diagnostics on compute machines
+include::modules/machineset-azure-boot-diagnostics.adoc[leveloffset=+1]
+
 //Enabling customer-managed encryption keys for a compute machine set
 include::modules/machineset-customer-managed-encryption-azure.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-azure.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure.adoc
@@ -23,6 +23,9 @@ include::modules/machineset-creating.adoc[leveloffset=+1]
 //Selecting an Azure Marketplace image
 include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+1]
 
+//Enabling Azure boot diagnostics on compute machines
+include::modules/machineset-azure-boot-diagnostics.adoc[leveloffset=+1]
+
 //Machine sets that deploy machines as Spot VMs
 include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
 

--- a/modules/machineset-azure-boot-diagnostics.adoc
+++ b/modules/machineset-azure-boot-diagnostics.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-azure.adoc
+// * machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc
+
+ifeval::["{context}" == "creating-machineset-azure-stack-hub"]
+:ash:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="machineset-azure-boot-diagnostics_{context}"]
+= Enabling Azure boot diagnostics on compute machines
+
+You can enable boot diagnostics on Azure machines that your compute machine set creates.
+
+.Prerequisites
+
+* Have an existing Microsoft Azure
+ifdef::ash[Stack Hub]
+cluster.
+
+.Procedure
+
+* Add the `diagnostics` configuration that is applicable to your storage type to the `providerSpec` field in your compute machine set YAML file:
+
+** For an Azure Managed storage account:
++
+[source,yaml]
+----
+providerSpec:
+  diagnostics:
+    boot:
+      storageAccountType: AzureManaged <1>
+----
++
+<1> Specifies an Azure Managed storage account.
+
+** For an Azure Unmanaged storage account:
++
+[source,yaml]
+----
+providerSpec:
+  diagnostics:
+    boot:
+      storageAccountType: CustomerManaged <1>
+      customerManaged:
+        storageAccountURI: https://<storage-account>.blob.core.windows.net <2>
+----
++
+<1> Specifies an Azure Unmanaged storage account.
+<2> Replace `<storage-account>` with the name of your storage account. 
++
+[NOTE]
+====
+Only the Azure Blob Storage data service is supported.
+====
+
+.Verification
+
+* On the Microsoft Azure portal, review the *Boot diagnostics* page for a machine deployed by the compute machine set, and verify that you can see the serial logs for the machine.
+
+ifeval::["{context}" == "creating-machineset-azure-stack-hub"]
+:!ash:
+endif::[]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-4165](https://issues.redhat.com//browse/OSDOCS-4165)

Link to docs preview:
- [Enabling Azure boot diagnostics on compute machines](http://file.rdu.redhat.com/~jrouth/OSDOCS-4165-azure-worker-boot-diagnostics/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-azure-boot-diagnostics_creating-machineset-azure) (for global Azure)
- [Enabling Azure boot diagnostics on compute machines](http://file.rdu.redhat.com/~jrouth/OSDOCS-4165-azure-worker-boot-diagnostics/machine_management/creating_machinesets/creating-machineset-azure-stack-hub.html#machineset-azure-boot-diagnostics_creating-machineset-azure-stack-hub) (for Azure Stack Hub)

QE review:
- [x] QE has approved this change.

Additional information: