### PR TITLE
BZ#2116612: adds SSH metric

### DIFF
--- a/modules/machine-config-daemon-metrics.adoc
+++ b/modules/machine-config-daemon-metrics.adoc
@@ -96,4 +96,9 @@ For further investigation, see the logs by running:
 For further investigation, see the logs by running:
 
 `$ oc logs -f -n openshift-machine-config-operator machine-config-daemon-<hash> -c machine-config-daemon`
+
+|`ssh_accessed`
+|
+|Displays a successful SSH login.
+|
 |===


### PR DESCRIPTION
- Applies to 4.8 and above versions
- [Bugzilla](2116612)
- [Preview](https://52727--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-machine-config-daemon-metrics.html)
- @cgwalters ptal and I could not find more information for the format and Notes column in the source code.Please let me know what I should add.