### PR TITLE
PSAP-900: added tuned release note update

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -326,6 +326,11 @@ For more information, see xref:../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-j
 [id="ocp-4-12-scalability-and-performance"]
 === Scalability and performance
 
+[id="ocp-4-12-tuned"]
+==== Tuned profile
+
+The `tuned` profile now defines the `fs.aio-max-nr` `sysctl` value by default, improving asynchronous I/O performance for default node profiles.
+
 [id="tuning-of-power-states"]
 ==== Power-saving configurations
 


### PR DESCRIPTION
Version(s):
4.12

Issue:
[PSAP-900](https://issues.redhat.com//browse/PSAP-900)

Link to docs preview:
[Tuned profile](http://file.rdu.redhat.com/antaylor/psap-900/release_notes/ocp-4-12-release-notes.html#ocp-4-12-tuned)

Additional information:
Documenting a new setting enabled by default in the 4.12 release notes.