### PR TITLE
SRVCOM-2151 remove references to buildpacks

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3673,10 +3673,6 @@ Topics:
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions
     File: serverless-developing-typescript-functions
-  - Name: Developing Go functions
-    File: serverless-developing-go-functions
-  - Name: Developing Python functions
-    File: serverless-developing-python-functions
   - Name: Developing Quarkus functions
     File: serverless-developing-quarkus-functions
   - Name: Using functions with Knative Eventing

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -372,10 +372,6 @@ Topics:
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions
     File: serverless-developing-typescript-functions
-  - Name: Developing Go functions
-    File: serverless-developing-go-functions
-  - Name: Developing Python functions
-    File: serverless-developing-python-functions
   - Name: Developing Quarkus functions
     File: serverless-developing-quarkus-functions
   - Name: Using functions with Knative Eventing

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -573,10 +573,6 @@ Topics:
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions
     File: serverless-developing-typescript-functions
-  - Name: Developing Go functions
-    File: serverless-developing-go-functions
-  - Name: Developing Python functions
-    File: serverless-developing-python-functions
   - Name: Developing Quarkus functions
     File: serverless-developing-quarkus-functions
   - Name: Using functions with Knative Eventing

--- a/modules/serverless-build-func-kn.adoc
+++ b/modules/serverless-build-func-kn.adoc
@@ -21,14 +21,6 @@ By default, `kn func build` creates a container image by using Red Hat Source-to
 $ kn func build
 ----
 
-You can use link:https://buildpacks.io/[CNCF Cloud Native Buildpacks] technology instead, by adding the `--builder` flag to the command and specifying the `pack` strategy:
-
-.Example build command using CNCF Cloud Native Buildpacks
-[source,terminal]
-----
-$ kn func build --builder pack
-----
-
 [id="serverless-build-func-kn-image-registries_{context}"]
 == Image registry types
 

--- a/serverless/discover/serverless-functions-about.adoc
+++ b/serverless/discover/serverless-functions-about.adoc
@@ -18,8 +18,6 @@ include::snippets/technology-preview.adoc[leveloffset=+2]
 
 // add xref links to docs once added
 * xref:../../serverless/functions/serverless-developing-nodejs-functions.adoc#serverless-developing-nodejs-functions[Node.js]
-* xref:../../serverless/functions/serverless-developing-python-functions.adoc#serverless-developing-python-functions[Python]
-* xref:../../serverless/functions/serverless-developing-go-functions.adoc#serverless-developing-go-functions[Go]
 * xref:../../serverless/functions/serverless-developing-quarkus-functions.adoc#serverless-developing-quarkus-functions[Quarkus]
 * xref:../../serverless/functions/serverless-developing-typescript-functions.adoc#serverless-developing-typescript-functions[TypeScript]
 

--- a/serverless/functions/serverless-functions-reference-guide.adoc
+++ b/serverless/functions/serverless-functions-reference-guide.adoc
@@ -15,8 +15,6 @@ Templates for the following runtimes are available:
 
 // add xref links to docs once added
 * xref:../../serverless/functions/serverless-developing-nodejs-functions.adoc#serverless-developing-nodejs-functions[Node.js]
-* xref:../../serverless/functions/serverless-developing-python-functions.adoc#serverless-developing-python-functions[Python]
-* xref:../../serverless/functions/serverless-developing-go-functions.adoc#serverless-developing-go-functions[Go]
 * xref:../../serverless/functions/serverless-developing-quarkus-functions.adoc#serverless-developing-quarkus-functions[Quarkus]
 * xref:../../serverless/functions/serverless-developing-typescript-functions.adoc#serverless-developing-typescript-functions[TypeScript]
 //* SpringBoot - TBC


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-2151

Link to docs preview:
https://52742--docspreview.netlify.app/openshift-enterprise/latest/serverless/cli_tools/kn-func-ref.html

https://52742--docspreview.netlify.app/openshift-enterprise/latest/serverless/discover/serverless-functions-about.html
https://52742--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-reference-guide.html


 QE has approved this change.


