### PR TITLE
OSDOCS-3530: Added links to Google Docs for VPC information.

### DIFF
--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -75,7 +75,7 @@ For more information about creating a key for your GCP service account and expor
 ====
 * Consider having *Production Support* or higher from GCP.
 * To prevent potential conflicts, consider having no other resources provisioned in the project prior to installing {product-title}.
-* If you are configuring a cluster-wide proxy, you have verified that the proxy is accessible from the VPC that the cluster is being installed into. The proxy must also be accessible from the private subnets of the VPC.
+* If you are configuring a cluster-wide proxy, you have verified that the proxy is accessible from the VPC that the cluster is being installed into.
 endif::osd-on-gcp[]
 
 .Procedure
@@ -199,7 +199,7 @@ endif::osd-on-aws[]
 ifdef::osd-on-gcp[]
 GCP
 endif::osd-on-gcp[]
-VPC, provide your *Virtual Private Cloud (VPC) subnet settings* and select *Next*.
+VPC, provide your *Virtual Private Cloud (VPC) subnet settings* and select *Next*. You must have created the Cloud network address translation (NAT) and a Cloud router. See the additional resources for information about Cloud NATs and Google VPCs.
 ifdef::osd-on-aws[]
 +
 [NOTE]

--- a/osd_install_access_delete_cluster/creating-a-gcp-cluster.adoc
+++ b/osd_install_access_delete_cluster/creating-a-gcp-cluster.adoc
@@ -26,3 +26,6 @@ include::modules/osd-create-cluster-red-hat-account.adoc[leveloffset=+1]
 * For information about load balancers for {product-title}, see the xref:../osd_architecture/osd_policy/osd-service-definition.adoc#load-balancers_osd-service-definition[Load balancers] section in the {product-title} service definition.
 * For more information about etcd encryption, see the xref:../osd_architecture/osd_policy/osd-service-definition.adoc#etcd-encryption_osd-service-definition[etcd encryption service definition].
 * For information about the end-of-life dates for {product-title} versions, see the xref:../osd_architecture/osd_policy/osd-life-cycle.adoc#osd-life-cycle[{product-title} update life cycle].
+* For general information on Cloud network address translation(NAT) that is required for cluster-wide proxy, see link:https://cloud.google.com/nat/docs/overview[Cloud NAT overview] in the Google documentation.
+* For general information on Cloud routers that are required for the cluster-wide proxy, see link:https://cloud.google.com/network-connectivity/docs/router/concepts/overview[Cloud Router overview] in the Google documentation.
+* For information on creating VPCs within your Google Cloud Provider account, see link:https://cloud.google.com/vpc/docs/create-modify-vpc-networks[Create and manage VPC networks] in the Google documentation.


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-3530](https://issues.redhat.com/browse/OSDOCS-3530)

Link to docs preview:
- [OSD](https://52750--docspreview.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#additional-resources_osd-creating-a-cluster-on-gcp)

Added this reference to the prerequisites:
![UpdatedPreReq](https://user-images.githubusercontent.com/16167833/202542969-955467c5-5ff7-4eac-8790-1e171efd4565.png)

Additional information:
Added two links to the Google documentation in the additional resources in the GPC cluster creation topic.