### PR TITLE
OSDOCS-4404: Removed some unneeded constraints from OSD documentation

### DIFF
--- a/modules/ccs-gcp-customer-procedure.adoc
+++ b/modules/ccs-gcp-customer-procedure.adoc
@@ -12,7 +12,6 @@ The Customer Cloud Subscription (CCS) model allows Red Hat to deploy and manage 
 To use {product-title} in your GCP project, the following GCP organizational policy constraints cannot be in place:
 
 * `constraints/iam.allowedPolicyMemberDomains`
-* `constraints/storage.uniformBucketLevelAccess`
 * `constraints/compute.restrictLoadBalancerCreationForTypes`
 * `constraints/compute.vmExternalIpAccess` (This policy constraint is unsupported only during installation. You can re-enable the policy constraint after installation.)
 ====


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-4404](https://issues.redhat.com/browse/OSDOCS-4404)

Link to docs preview:
- [OSD](https://52761--docspreview.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs.html#ccs-gcp-customer-procedure_gcp-ccs)

Additional information:
Removed the `constraints/storage.uniformBucketLevelAccess` constraint as it is not actually a limitation. Assessing how to replace the `constraints/compute.restrictLoadBalancerCreationForTypes` constraint.