### PR TITLE
[OSDOCS-4538] Make the build script stop placing includes "above" the new master.adoc files

### DIFF
--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -19,9 +19,9 @@ import yaml
 import logging
 
 # See manual and pip3 install aura.tar.gz for logging
-# from aura import cli
-#
-# cli.init_logging(False, True)
+from aura import cli
+
+cli.init_logging(False, True)
 
 has_errors = False
 CLONE_DIR = "."

--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -19,9 +19,9 @@ import yaml
 import logging
 
 # See manual and pip3 install aura.tar.gz for logging
-from aura import cli
-
-cli.init_logging(False, True)
+# from aura import cli
+#
+# cli.init_logging(False, True)
 
 has_errors = False
 CLONE_DIR = "."
@@ -1090,6 +1090,39 @@ def parse_repo_config(config_file, distro, version):
     return repo_urls
 
 
+def collect_master_adoc_files(project_path=os.path.abspath(os.curdir)):
+    """Given the project path, return a list of all master.adoc file paths."""
+
+    master_adoc_collection = []
+
+    for project_dir, dirs, files in os.walk(project_path, topdown=True):
+        if "master.adoc" in files:
+            master_path = os.path.join(project_dir, "master.adoc")
+            master_adoc_collection.append(master_path)
+
+    return master_adoc_collection
+
+
+def create_symlinks_to_project_root_from_master_files(
+    list_of_master_file_paths, distro="openshift-enterprise"
+):
+    """Create symlinks for every master.adoc-containing
+    directory to the openshift-docs project root."""
+
+    drupal_build_path_includes_dir = os.path.join(
+        os.path.abspath(os.curdir), "drupal-build", distro, "includes"
+    )
+
+    if not os.path.exists(drupal_build_path_includes_dir):
+        os.mkdir(drupal_build_path_includes_dir)
+
+    for path in list_of_master_file_paths:
+        directory = os.path.split(path)[0]
+        book_includes_dir = os.path.join(directory, "includes")
+        if not os.path.isdir(book_includes_dir):
+            os.symlink(drupal_build_path_includes_dir, book_includes_dir)
+
+
 def main():
     parser = setup_parser()
     args = parser.parse_args()
@@ -1137,6 +1170,10 @@ def main():
     # Build the master files
     log.info("Building the drupal files")
     build_master_files(info)
+
+    create_symlinks_to_project_root_from_master_files(
+        collect_master_adoc_files(), args.distro
+    )
 
     # Copy the original data and reformat for drupal
     reformat_for_drupal(info)


### PR DESCRIPTION
Version(s):
n/a


Issue: [OSDOCS-4538](https://issues.redhat.com//browse/OSDOCS-4538)


Link to docs preview:


QE review: n/a
- [x] ~QE has approved this change.~


Linting/formatting/etc.:
- [x]  I ran the Black formatter before merging this.



Additional information: This is just a place for thinking right now. :) 

Current approach is to create symlinks in books to an omnibus project-root `includes` directory.
