### PR TITLE
OSDOCS-4448: OSDK 1.25.1 Project migration docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1577,6 +1577,8 @@ Topics:
       File: osdk-java-tutorial
     - Name: Project layout
       File: osdk-java-project-layout
+    - Name: Updating Java-based projects
+      File: osdk-java-updating-projects
   - Name: Defining cluster service versions (CSVs)
     File: osdk-generating-csvs
   - Name: Working with bundle images

--- a/modules/osdk-updating-v1220-to-v1251.adoc
+++ b/modules/osdk-updating-v1220-to-v1251.adoc
@@ -1,0 +1,337 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/golang/osdk-golang-updating-projects.adoc
+// * operators/operator_sdk/ansible/osdk-ansible-updating-projects.adoc
+// * operators/operator_sdk/helm/osdk-helm-updating-projects.adoc
+// * operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.adoc
+// * operators/operator_sdk/java/osdk-java-updating-projects.adoc
+
+ifeval::["{context}" == "osdk-golang-updating-projects"]
+:golang:
+:type: Go
+endif::[]
+ifeval::["{context}" == "osdk-ansible-updating-projects"]
+:ansible:
+:type: Ansible
+endif::[]
+ifeval::["{context}" == "osdk-helm-updating-projects"]
+:helm:
+:type: Helm
+endif::[]
+ifeval::["{context}" == "osdk-hybrid-helm-updating-projects"]
+:hybrid:
+:type: Hybrid Helm
+endif::[]
+ifeval::["{context}" == "osdk-java-updating-projects"]
+:java:
+:type: Java
+endif::[]
+
+:osdk_ver: v1.25.1
+:osdk_ver_n1: v1.22.0
+
+:_content-type: PROCEDURE
+[id="osdk-upgrading-projects_{context}"]
+= Updating {type}-based Operator projects for Operator SDK {osdk_ver}
+
+The following procedure updates an existing {type}-based Operator project for compatibility with {osdk_ver}.
+
+.Prerequisites
+
+* Operator SDK {osdk_ver} installed
+* An Operator project created or maintained with Operator SDK {osdk_ver_n1}
+
+.Procedure
+
+. Make the following changes to the `config/default/manager_auth_proxy_patch.yaml` file: 
++
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12 <1>
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=0"
+...
+----
+<1> Update the tag version from `v4.11` to `v4.12`.
+
+. Make the following changes to your `Makefile`:
+
+.. To enable multi-architecture build support, add the `docker-buildx` target to your project `Makefile`:
++
+.Example `Makefile`
+[source,make]
+----
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# To properly provided solutions that supports more than one platform you should use this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: test ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx rm project-v3-builder
+	rm Dockerfile.cross
+----
+ifdef::ansible,helm[]
+.. To enable support for `arm64` architectures in your Operator project, make the following changes to your `Makefile`:
++
+.Old `Makefile`
+[source,make]
+----
+OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH := $(shell uname -m | sed 's/x86_64/amd64/')
+----
++
+.New `Makefile`
+[source,make]
+----
+OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH := $(shell uname -m | sed 's/x86_64/amd64/' |  sed 's/aarch64/arm64/')
+----
+
+.. Update the Kustomize version to `v4.5.5` as shown in the following example:
++
+.Old `Makefile`
+[source,make]
+----
+.PHONY: kustomize
+KUSTOMIZE = $(shell pwd)/bin/kustomize
+kustomize: ## Download kustomize locally if necessary.
+ifeq (,$(wildcard $(KUSTOMIZE)))
+ifeq (,$(shell which kustomize 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(KUSTOMIZE)) ;\
+	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.7/kustomize_v3.8.7_$(OS)_$(ARCH).tar.gz | \
+	tar xzf - -C bin/ ;\
+	}
+else
+----
++
+.New `Makefile`
+[source,make]
+----
+.PHONY: kustomize
+KUSTOMIZE = $(shell pwd)/bin/kustomize
+kustomize: ## Download kustomize locally if necessary.
+ifeq (,$(wildcard $(KUSTOMIZE)))
+ifeq (,$(shell which kustomize 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(KUSTOMIZE)) ;\
+	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.5/kustomize_v4.5.5_$(OS)_$(ARCH).tar.gz | \ <1>
+	tar xzf - -C bin/ ;\
+	}
+else
+----
+<1> Update version `v3.8.7` to `v4.5.5`.
++
+[IMPORTANT]
+====
+Kustomize version `4.0.0` removed the `go-getter` plugin and introduced breaking changes that are not backwards compatible with earlier versions. Operator projects that rely on older versions of Kustomize might not work with newer releases.
+====
+endif::[]
+
+ifdef::golang[]
+.. Update your project scaffolding to support changes in `kubebuilder` as shown in the following example:
++
+.Old `Makefile`
+[source,make]
+----
+.PHONY: test
+test: manifests generate fmt vet envtest ## Run tests.
+ 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+----
++
+.New `Makefile`
+[source,make]
+----
+.PHONY: test
+test: manifests generate fmt vet envtest ## Run tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)"  go test $(go list ./... | grep -v /test/) -coverprofile cover.out
+----
+
+.. To ensure `Makefile` targets do not download binaries already in your binary path, make the following changes to your `Makefile`:
++
+.Old `Makefile`
+[source,make]
+----
+KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
+$(KUSTOMIZE): $(LOCALBIN)
+	{ curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
+$(CONTROLLER_GEN): $(LOCALBIN)
+	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+ 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+----
++
+.New `Makefile`
+[source,make]
+----
+KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
+$(KUSTOMIZE): $(LOCALBIN)
+	test -s $(LOCALBIN)/kustomize || { curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); } <1>
+
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
+$(CONTROLLER_GEN): $(LOCALBIN)
+	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION) <1>
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest <1>
+----
+<1> Add `test -s $(LOCALBIN)/<binary-name> ||` before the instruction to download a binary.
+
+.. Update `controller-tools` to version `v0.9.2` as shown in the following example:
++
+.Example `Makefile
+[source,make]
+----
+## Tool Versions
+KUSTOMIZE_VERSION ?= v3.8.7
+CONTROLLER_TOOLS_VERSION ?= v0.9.2 <1>
+----
+<1> Update version  `v0.9.0` to `v0.9.2`.
+endif::[]
+
+.. To apply the changes to your `Makefile` and rebuild your Operator, enter the following command:
++
+[source,terminal]
+----
+$ make
+----
+
+ifdef::ansible,helm[]
+. Update your `config/default/kustomizations.yaml` file as shown in the following examples:
++
+.Example `kustomizations.yaml` file
+[source,yaml]
+----
+# Adds namespace to all resources.
+namespace: memcached-operator-system
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: memcached-operator-
+
+# Labels to add to all resources and selectors.
+#labels: <1>
+#- includeSelectors: true <2>
+#  pairs:
+#    someName: someValue
+
+resources: <3>
+- ../crd
+- ../rbac
+- ../manager
+----
+<1> Replace the `commonLabels` field with the `labels` field.
+<2> Add `includeSelectors: true`.
+<3> Replace the `bases` field with the `resources` field.
+endif::[]
+
+ifdef::ansible[]
+. Update your `molecule/default/kustomize.yml` file with the following changes:
++
+.Example `molecule/default/kustomize.yml` file
+[source,yaml]
+----
+---
+- name: Build kustomize testing overlay
+  # load_restrictor must be set to none so we can load patch files from the default overlay
+  command: '{{ kustomize }} build --load-restrictor LoadRestrictionsNone' <1>
+  args:
+    chdir: '{{ config_dir }}/testing'
+  register: resources
+  changed_when: false
+----
+<1> Replace `--load_restrictor none .` with `--load-restrictor LoadRestrictionNone`.
+endif::[]
+
+ifdef::golang,hybrid[]
+. To update Go and its dependencies, make the following changes to your `go.mod` file:
++
+[source,golang]
+----
+go 1.19 <1>
+
+require (
+  github.com/onsi/ginkgo/v2 v2.1.4 <2>
+  github.com/onsi/gomega v1.19.0 <3>
+  k8s.io/api v0.25.0 <4>
+  k8s.io/apimachinery v0.25.0 <4>
+  k8s.io/client-go v0.25.0 <4>
+  sigs.k8s.io/controller-runtime v0.13.0 <5>
+)
+----
+<1> Update version `1.18` to `1.19`.
+<2> Update version `v1.16.5` to `v2.1.4`.
+<3> Update version `v1.18.1` to `v1.19.0`.
+<4> Update version `v0.24.0` to `v0.25.0`.
+<5> Update version `v0.12.1` to `v0.13.0`.
+
+. To download the updated versions, clean up the dependencies, and apply the changes in your `go.mod` file, run the following command:
++
+[source,terminal]
+----
+$ go mod tidy
+----
+endif::[]
+
+:!osdk_ver:
+:!osdk_ver_n1:
+
+ifeval::["{context}" == "osdk-golang-updating-projects"]
+:!golang:
+:!type:
+endif::[]
+ifeval::["{context}" == "osdk-ansible-updating-projects"]
+:!ansible:
+:!type:
+endif::[]
+ifeval::["{context}" == "osdk-helm-updating-projects"]
+:!helm:
+:!type:
+endif::[]
+ifeval::["{context}" == "osdk-hybrid-helm-updating-projects"]
+:!hybrid:
+:!type:
+endif::[]
+ifeval::["{context}" == "osdk-java-updating-projects"]
+:!java:
+:!type:
+endif::[]

--- a/operators/operator_sdk/ansible/osdk-ansible-updating-projects.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-updating-projects.adoc
@@ -13,7 +13,7 @@ toc::[]
 
 However, to ensure your existing Operator projects maintain compatibility with Operator SDK {osdk_ver}, update steps are required for the associated breaking changes introduced since {osdk_ver_n1}. You must perform the update steps manually in any of your Operator projects that were previously created or maintained with {osdk_ver_n1}.
 
-include::modules/osdk-updating-projects.adoc[leveloffset=+1]
+include::modules/osdk-updating-v1220-to-v1251.adoc[leveloffset=+1]
 
 [id="additional-resources_osdk-ansible-upgrading-projects"]
 [role="_additional-resources"]

--- a/operators/operator_sdk/golang/osdk-golang-updating-projects.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-updating-projects.adoc
@@ -13,7 +13,7 @@ toc::[]
 
 However, to ensure your existing Operator projects maintain compatibility with Operator SDK {osdk_ver}, update steps are required for the associated breaking changes introduced since {osdk_ver_n1}. You must perform the update steps manually in any of your Operator projects that were previously created or maintained with {osdk_ver_n1}.
 
-include::modules/osdk-updating-projects.adoc[leveloffset=+1]
+include::modules/osdk-updating-v1220-to-v1251.adoc[leveloffset=+1]
 
 [id="additional-resources_osdk-upgrading-projects-golang"]
 [role="_additional-resources"]

--- a/operators/operator_sdk/helm/osdk-helm-updating-projects.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-updating-projects.adoc
@@ -13,7 +13,7 @@ toc::[]
 
 However, to ensure your existing Operator projects maintain compatibility with Operator SDK {osdk_ver}, update steps are required for the associated breaking changes introduced since {osdk_ver_n1}. You must perform the update steps manually in any of your Operator projects that were previously created or maintained with {osdk_ver_n1}.
 
-include::modules/osdk-updating-projects.adoc[leveloffset=+1]
+include::modules/osdk-updating-v1220-to-v1251.adoc[leveloffset=+1]
 
 [id="additional-resources_osdk-helm-upgrading-projects"]
 [role="_additional-resources"]

--- a/operators/operator_sdk/java/osdk-java-updating-projects.adoc
+++ b/operators/operator_sdk/java/osdk-java-updating-projects.adoc
@@ -1,8 +1,8 @@
 :_content-type: ASSEMBLY
-[id="osdk-hybrid-helm-updating-projects"]
-= Updating Hybrid Helm-based projects for newer Operator SDK versions
+[id="osdk-java-updating-projects"]
+= Updating projects for newer Operator SDK versions
 include::_attributes/common-attributes.adoc[]
-:context: osdk-hybrid-helm-updating-projects
+:context: osdk-java-updating-projects
 
 :osdk_ver: v1.25.1
 :osdk_ver_n1: v1.22.0
@@ -15,15 +15,11 @@ However, to ensure your existing Operator projects maintain compatibility with O
 
 include::modules/osdk-updating-v1220-to-v1251.adoc[leveloffset=+1]
 
-[id="additional-resources_osdk-hybrid-helm-upgrading-projects"]
+[id="additional-resources_osdk-java-upgrading-projects"]
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../../../operators/operator_sdk/osdk-pkgman-to-bundle.adoc#osdk-pkgman-to-bundle[Migrating package manifest projects to bundle format]
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html-single/operators/index#osdk-upgrading-v1101-to-v1160_osdk-upgrading-projects[Upgrading projects for Operator SDK 1.16.0]
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/operators/developing-operators#osdk-upgrading-v180-to-v1101_osdk-upgrading-projects[Upgrading projects for Operator SDK v1.10.1]
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/html/operators/developing-operators#osdk-upgrading-v130-to-v180_osdk-upgrading-projects[Upgrading projects for Operator SDK v1.8.0]
-
 
 :!osdk_ver:
 :!osdk_ver_n1:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->
This PR updates the Operator SDK's project migration docs for the latest downstream `operator-sdk` release for OCP 4.12. The OSDK version for this release is 1.25.1. Updating a previously created Operator project requires manually updating the configuration files based on the different Operator types. 

NOTE: SME and QE reviewers, this project uses modular documentation tools as part of our `asciidoctor` tool chain. It might be easier to review the changes in the provided preview links before reviewing the markup changes.

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: [OSDOCS-4448](https://issues.redhat.com//browse/OSDOCS-4448)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview (VPN required):

- [Updating Go-based Operator projects](http://file.rdu.redhat.com/mipeter/OSDOCS-4448-OSDK-1.25.1-Project-migration-docs/operators/operator_sdk/golang/osdk-golang-updating-projects.html)
- [Updating Ansible-based Operator projects](http://file.rdu.redhat.com/mipeter/OSDOCS-4448-OSDK-1.25.1-Project-migration-docs/operators/operator_sdk/ansible/osdk-ansible-updating-projects.html)
- [Updating Helm-based Operator projects](http://file.rdu.redhat.com/mipeter/OSDOCS-4448-OSDK-1.25.1-Project-migration-docs/operators/operator_sdk/helm/osdk-helm-updating-projects.html)
- [Updating Hybrid Helm-based Operator projects](http://file.rdu.redhat.com/mipeter/OSDOCS-4448-OSDK-1.25.1-Project-migration-docs/operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.html)
- [Updating Java-based Operator projects](http://file.rdu.redhat.com/mipeter/OSDOCS-4448-OSDK-1.25.1-Project-migration-docs/operators/operator_sdk/java/osdk-java-updating-projects.html)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
