### PR TITLE
Remove CMS configuration for Fujitsu iRMC

### DIFF
--- a/modules/ipi-install-configuring-nodes.adoc
+++ b/modules/ipi-install-configuring-nodes.adoc
@@ -88,32 +88,3 @@ To enable Secure Boot manually, refer to the hardware guide for the node and exe
 ====
 Red Hat does not support Secure Boot with self-generated keys.
 ====
-
-
-[discrete]
-[id="configuring-csm-for-fujitsu-irmc_{context}"]
-== Configuring the Compatibility Support Module for Fujitsu iRMC
-
-The Compatibility Support Module (CSM) configuration provides support for legacy BIOS backward compatibility with UEFI systems. You must configure the CSM when you deploy a cluster with Fujitsu iRMC, otherwise the installation might fail.
-
-[NOTE]
-====
-For information about configuring the CSM for your specific node type, refer to the hardware guide for the node.
-====
-
-.Prerequisites
-- Ensure that you have disabled Secure Boot Control. You can disable the feature under *Security* -> *Secure Boot Configuration* -> *Secure Boot Control*.
-
-.Procedure
-. Boot the node and select the BIOS menu.
-. Under the *Advanced* tab, select *CSM Configuration* from the list.
-. Enable the *Launch CSM* option and set the following values:
-+
-[options="header"]
-|===
-|Item |Value
-| *Boot option filter* | UEFI and Legacy
-| *Launch PXE OpROM Policy* | UEFI only
-| *Launch Storage OpROM policy* | UEFI only
-| *Other PCI device ROM priority* | UEFI only
-|===


### PR DESCRIPTION
At present, Fujitsu iRMC no longer needs to configure CSM, delete related configuration content.

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>
