### PR TITLE
OSDOCS-4556: Added IBM Cloud VPC support for FIPS

### DIFF
--- a/installing/installing-fips.adoc
+++ b/installing/installing-fips.adoc
@@ -74,6 +74,7 @@ To install a cluster in FIPS mode, follow the instructions to install a customiz
 * xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[Microsoft Azure]
 * xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[Bare metal]
 * xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[Google Cloud Platform]
+* xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[IBM Cloud VPC]
 * xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#installing-openstack-installer-custom[{rh-openstack-first}]
 * xref:../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[VMware vSphere]
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
This issues addresses [osdocs-4556](https://issues.redhat.com/browse/OSDOCS-4556).

Link to docs preview:
Netlify appears to experiencing an issue. A public preview build did not kickoff.

(Requires that you are on the VPN) [Installing a cluster in FIPS mode](http://file.rdu.redhat.com/mpytlak/osdocs-4556/installing/installing-fips.html#installing-fips-mode_installing-fips)

QE review:
- [x] QE has approved this change.
