### PR TITLE
OSDOCS-4557: Changing heterogeneous to multi-architecture

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -508,8 +508,8 @@ Topics:
   File: configuring-private-cluster
 - Name: Bare metal configuration
   File: bare-metal-configuration
-- Name: Configuring a heterogeneous cluster
-  File: deploy-heterogeneous-configuration
+- Name: Configuring a multi-architecture cluster
+  File: multi-architecture-configuration
 - Name: Machine configuration tasks
   File: machine-configuration-tasks
 - Name: Cluster tasks

--- a/modules/multi-architecture-creating-arm64-bootimage.adoc
+++ b/modules/multi-architecture-creating-arm64-bootimage.adoc
@@ -3,16 +3,16 @@
 //post_installation_configuration/cluster-tasks.adoc
 
 :_content-type: PROCEDURE
-[id="mixed-arch-creating-arm64-bootimage_{context}"]
+[id="multi-architecture-creating-arm64-bootimage_{context}"]
 
 = Creating an `arm64` boot image using the Azure image gallery
  
-To configure your heterogeneous cluster, you must create an `arm64` boot image and add it to your Azure compute machine set. The following procedure describes how to manually generate an `arm64` boot image. 
+To configure your multi-architecture cluster, you must create an `arm64` boot image and add it to your Azure compute machine set. The following procedure describes how to manually generate an `arm64` boot image. 
  
 .Prerequisites
 
 * You installed the Azure CLI (`az`).
-* You created a single-architecture Azure installer-provisioned cluster with the heterogeneous installer binary. 
+* You created a single-architecture Azure installer-provisioned cluster with the multi-architecture installer binary. 
 
 .Procedure
 . Log in to your Azure account: 

--- a/modules/multi-architecture-modify-machine-set.adoc
+++ b/modules/multi-architecture-modify-machine-set.adoc
@@ -3,11 +3,11 @@
 //post_installation_configuration/cluster-tasks.adoc
 
 :_content-type: PROCEDURE
-[id="mixed-arch-modify-machine-set_{context}"]
+[id="multi-architecture-modify-machine-set_{context}"]
 
 = Adding a compute machine set to your cluster using the `arm64` boot image  
 
-To add `arm64` worker nodes to your heterogeneous cluster, you must create an Azure compute machine set that uses the `arm64` boot image. To create your own custom compute machine set on Azure, see "Creating a compute machine set on Azure". 
+To add `arm64` worker nodes to your multi-architecture cluster, you must create an Azure compute machine set that uses the `arm64` boot image. To create your own custom compute machine set on Azure, see "Creating a compute machine set on Azure". 
 
 .Prerequisites 
 

--- a/modules/multi-architecture-upgrade-mirrors.adoc
+++ b/modules/multi-architecture-upgrade-mirrors.adoc
@@ -3,11 +3,11 @@
 //post_installation_configuration/cluster-tasks.adoc
 
 :_content-type: PROCEDURE
-[id="mixed-arch-upgrade-mirrors_{context}"]
+[id="multi-architecture-upgrade-mirrors_{context}"]
 
-= Upgrading your heterogeneous cluster
+= Upgrading your multi-architecture cluster
 
-You must perform an explicit upgrade command to upgrade your existing cluster to a heterogeneous cluster.
+You must perform an explicit upgrade command to upgrade your existing cluster to a multi-architecture cluster.
 
 .Prerequisites
 
@@ -16,6 +16,7 @@ You must perform an explicit upgrade command to upgrade your existing cluster to
 .Procedure
 * To manually upgrade your cluster, use the following command: 
 [source, terminal]
++
 ----
 $ oc adm upgrade --allow-explicit-upgrade --to-image <image-pullspec> <1>
 ----

--- a/post_installation_configuration/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/multi-architecture-configuration.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-A multi-architecture cluster is a cluster that supports worker machines with different architectures. You can deploy a multi-architecture cluster by creating an Azure installer-provisioned cluster using the multi-architecture installer binary. For Azure installation, see xref:../installing/installing_azure/installing-azure-customizations.adoc[Installing on Azure with customizations].
+A multi-architecture cluster is a cluster that supports worker machines with different architectures. You can deploy a multi-architecture cluster by creating an Azure installer-provisioned cluster using the multi-architecture installer binary. For Azure installation, see xref:../installing/installing_azure/installing-azure-customizations.adoc[Installing a cluster on Azure with customizations].
 
 [WARNING]
 ====
@@ -25,6 +25,5 @@ include::modules/multi-architecture-modify-machine-set.adoc[leveloffset=+1]
 [role="_additional-resources"] 
 .Additional resources
 * xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc[Creating a compute machine set on Azure] 
-include::modules/multi-architecture-upgrade-mirrors.adoc[leveloffset=+1]
 
-include::modules/multi-architecture-import-imagestreams.adoc[leveloffset=+1]
+include::modules/multi-architecture-upgrade-mirrors.adoc[leveloffset=+1]


### PR DESCRIPTION
For versions 4.11+ 
Issue: [OSDOCS-4557](https://issues.redhat.com//browse/OSDOCS-4557)'

Description: Heterogeneous can be  confusing term, using multi-architecture to refer to heterogeneous clusters from now on

Preview: [Post-installation configuration -> Configuring a multi-architecture cluster](https://52785--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html) 

QE review:
- [x] QE has approved this change