### PR TITLE
BZ2062718:Automatically allocating system-reserved define a custom label on MCP but not actuallly using it in the kubeletConfig CR

### DIFF
--- a/modules/nodes-cluster-overcommit-node-enforcing.adoc
+++ b/modules/nodes-cluster-overcommit-node-enforcing.adoc
@@ -18,54 +18,40 @@ If you disable CPU limit enforcement, it is important to understand the impact o
 
 .Prerequisites
 
-. Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure. Perform one of the following steps:
-
-.. View the machine config pool:
+. Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure by entering the following command:
 +
 [source,terminal]
 ----
-$ oc describe machineconfigpool <name>
+$ oc edit machineconfigpool <name>
 ----
 +
 For example:
 +
 [source,terminal]
 ----
-$ oc describe machineconfigpool worker
+$ oc edit machineconfigpool worker
 ----
 +
 .Example output
-[source,terminal]
-----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfigPool
-metadata:
-  creationTimestamp: 2019-02-08T14:52:39Z
-  generation: 1
-  labels:
-    custom-kubelet: small-pods <1>
-----
-<1> If a label has been added it appears under `labels`.
-
-.. If the label is not present, add a key/value pair:
-+
-[source,terminal]
-----
-$ oc label machineconfigpool worker custom-kubelet=small-pods
-----
-+
-[TIP]
-====
-You can alternatively apply the following YAML to add the label:
-
 [source,yaml]
 ----
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
+  creationTimestamp: "2022-11-16T15:34:25Z"
+  generation: 4
   labels:
-    custom-kubelet: small-pods
+    pools.operator.machineconfiguration.openshift.io/worker: "" <1>
   name: worker
+----
+<1> The label appears under Labels.
++
+[TIP]
+====
+If the label is not present, add a key/value pair such as:
+
+----
+$ oc label machineconfigpool worker custom-kubelet=small-pods
 ----
 ====
 
@@ -83,11 +69,18 @@ metadata:
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      custom-kubelet: small-pods <2>
+      pools.operator.machineconfiguration.openshift.io/worker: "" <2>
   kubeletConfig:
     cpuCfsQuota: <3>
       - "false"
 ----
 <1> Assign a name to CR.
-<2> Specify the label to apply the configuration change.
+<2> Specify the label from the machine config pool.
 <3> Set the `cpuCfsQuota` parameter to `false`.
+
+. Run the following command to create the CR:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----

--- a/modules/nodes-nodes-garbage-collection-configuring.adoc
+++ b/modules/nodes-nodes-garbage-collection-configuring.adoc
@@ -17,57 +17,46 @@ As an administrator, you can configure how {product-title} performs garbage coll
 
 You can configure any combination of the following:
 
-* Soft eviction for containers 
+* Soft eviction for containers
 * Hard eviction for containers
 * Eviction for images
 
 .Prerequisites
 
-. Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure.
-Perform one of the following steps:
-
-.. View the machine config pool:
+. Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure by entering the following command:
 +
 [source,terminal]
 ----
-$ oc describe machineconfigpool <name>
+$ oc edit machineconfigpool <name>
 ----
 +
 For example:
 +
 [source,terminal]
 ----
-$ oc describe machineconfigpool worker
+$ oc edit machineconfigpool worker
 ----
 +
 .Example output
 [source,yaml]
 ----
-Name:         worker
-Namespace:
-Labels:       custom-kubelet=small-pods <1>
-----
-<1> If a label has been added it appears under `Labels`.
-
-.. If the label is not present, add a key/value pair:
-+
-[source,terminal]
-----
-$ oc label machineconfigpool worker custom-kubelet=small-pods
-----
-+
-[TIP]
-====
-You can alternatively apply the following YAML to add the label:
-
-[source,yaml]
-----
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
+  creationTimestamp: "2022-11-16T15:34:25Z"
+  generation: 4
   labels:
-    custom-kubelet: small-pods
+    pools.operator.machineconfiguration.openshift.io/worker: "" <1>
   name: worker
+----
+<1> The label appears under Labels.
++
+[TIP]
+====
+If the label is not present, add a key/value pair such as:
+
+----
+$ oc label machineconfigpool worker custom-kubelet=small-pods
 ----
 ====
 
@@ -90,7 +79,7 @@ metadata:
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      custom-kubelet: small-pods <2>
+      pools.operator.machineconfiguration.openshift.io/worker: "" <2>
   kubeletConfig:
     evictionSoft: <3>
       memory.available: "500Mi" <4>
@@ -116,7 +105,7 @@ spec:
     imageGCLowThresholdPercent: 75 <10>
 ----
 <1> Name for the object.
-<2> Selector label.
+<2> Specify the label from the machine config pool.
 <3> Type of eviction: `evictionSoft` or `evictionHard`.
 <4> Eviction thresholds based on a specific eviction trigger signal.
 <5> Grace periods for the soft eviction. This parameter does not apply to `eviction-hard`.
@@ -127,11 +116,11 @@ For `evictionHard` you must specify all of these parameters.  If you do not spec
 <9> The percent of disk usage (expressed as an integer) that triggers image garbage collection.
 <10> The percent of disk usage (expressed as an integer) that image garbage collection attempts to free.
 
-. Create the object:
+. Run the following command to create the CR:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
+$ oc create -f <file_name>.yaml
 ----
 +
 For example:
@@ -147,7 +136,9 @@ $ oc create -f gc-container.yaml
 kubeletconfig.machineconfiguration.openshift.io/gc-container created
 ----
 
-. Verify that garbage collection is active. The Machine Config Pool you specified in the custom resource appears with `UPDATING` as 'true` until the change is fully implemented:
+.Verification
+
+. Verify that garbage collection is active by entering the following command. The Machine Config Pool you specified in the custom resource appears with `UPDATING` as 'true` until the change is fully implemented:
 +
 [source,terminal]
 ----

--- a/modules/nodes-nodes-managing-max-pods-proc.adoc
+++ b/modules/nodes-nodes-managing-max-pods-proc.adoc
@@ -13,21 +13,18 @@ For example, if `podsPerCore` is set to `10` on a node with 4 processor cores, t
 
 .Prerequisites
 
-. Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure.
-Perform one of the following steps:
-
-.. View the machine config pool:
+. Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure by entering the following command:
 +
 [source,terminal]
 ----
-$ oc describe machineconfigpool <name>
+$ oc edit machineconfigpool <name>
 ----
 +
 For example:
 +
 [source,terminal]
 ----
-$ oc describe machineconfigpool worker
+$ oc edit machineconfigpool worker
 ----
 +
 .Example output
@@ -36,32 +33,20 @@ $ oc describe machineconfigpool worker
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
-  creationTimestamp: 2019-02-08T14:52:39Z
-  generation: 1
+  creationTimestamp: "2022-11-16T15:34:25Z"
+  generation: 4
   labels:
-    custom-kubelet: small-pods <1>
+    pools.operator.machineconfiguration.openshift.io/worker: "" <1>
+  name: worker
 ----
-<1> If a label has been added it appears under `labels`.
-
-.. If the label is not present, add a key/value pair:
-+
-[source,terminal]
-----
-$ oc label machineconfigpool worker custom-kubelet=small-pods
-----
+<1> The label appears under Labels.
 +
 [TIP]
 ====
-You can alternatively apply the following YAML to add the label:
+If the label is not present, add a key/value pair such as:
 
-[source,yaml]
 ----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfigPool
-metadata:
-  labels:
-    custom-kubelet: small-pods
-  name: worker
+$ oc label machineconfigpool worker custom-kubelet=small-pods
 ----
 ====
 
@@ -79,13 +64,13 @@ metadata:
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      custom-kubelet: small-pods <2>
+      pools.operator.machineconfiguration.openshift.io/worker: "" <2>
   kubeletConfig:
     podsPerCore: 10 <3>
     maxPods: 250 <4>
 ----
 <1> Assign a name to CR.
-<2> Specify the label to apply the configuration change.
+<2> Specify the label from the machine config pool.
 <3> Specify the number of pods the node can run based on the number of processor cores on the node.
 <4> Specify the number of pods the node can run to a fixed value, regardless of the properties of the node.
 +
@@ -95,6 +80,15 @@ Setting `podsPerCore` to `0` disables this limit.
 ====
 +
 In the above example, the default value for `podsPerCore` is `10` and the default value for `maxPods` is `250`. This means that unless the node has 25 cores or more, by default, `podsPerCore` will be the limiting factor.
+
+. Run the following command to create the CR:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
+
+.Verification
 
 . List the `MachineConfigPool` CRDs to see if the change is applied. The `UPDATING` column reports `True` if the change is picked up by the Machine Config Controller:
 +

--- a/modules/nodes-nodes-resources-configuring-auto.adoc
+++ b/modules/nodes-nodes-resources-configuring-auto.adoc
@@ -6,7 +6,7 @@
 [id="nodes-nodes-resources-configuring-auto_{context}"]
 = Automatically allocating resources for nodes
 
-{product-title} can automatically determine the optimal `system-reserved` CPU and memory resources for nodes associated with a specific machine config pool and update the nodes with those values when the nodes start.
+{product-title} can automatically determine the optimal `system-reserved` CPU and memory resources for nodes associated with a specific machine config pool and update the nodes with those values when the nodes start. By default, the `system-reserved` CPU is `500m` and `system-reserved` memory is `1Gi`.
 
 To automatically determine and allocate the `system-reserved` resources on nodes, create a `KubeletConfig` custom resource (CR) to set the `autoSizingReserved: true` parameter. A script on each node calculates the optimal values for the respective reserved resources based on the installed CPU and memory capacity on each node. The script takes into account that increased capacity requires a corresponding increase in the reserved resources.
 
@@ -16,62 +16,41 @@ This feature is disabled by default.
 
 .Prerequisites
 
-. Obtain the label associated with the static `MachineConfigPool` object for the type of node you want to configure.
-Perform one of the following steps:
-
-.. View the machine config pool:
+. Obtain the label associated with the static `MachineConfigPool` object for the type of node you want to configure by entering the following command:
 +
 [source,terminal]
 ----
-$ oc describe machineconfigpool <name>
+$ oc edit machineconfigpool <name>
 ----
 +
 For example:
 +
 [source,terminal]
 ----
-$ oc describe machineconfigpool worker
+$ oc edit machineconfigpool worker
 ----
 +
 .Example output
 [source,yaml]
 ----
-Name:         worker
-Namespace:
-Labels:       machineconfiguration.openshift.io/mco-built-in=
-              pools.operator.machineconfiguration.openshift.io/worker=
-Annotations:  <none>
-API Version:  machineconfiguration.openshift.io/v1
-Kind:         MachineConfigPool
-Metadata:
- ...
-  creationTimestamp: 2019-02-08T14:52:39Z
-  generation: 1
-  labels:
-    pools.operator.machineconfiguration.openshift.io/worker: "" <1>
- ...
-----
-<1> If a label has been added it appears under `labels`.
-
-.. If the label is not present, add a key/value pair:
-+
-[source,terminal]
-----
-$ oc label machineconfigpool worker custom-kubelet=small-pods
-----
-+
-[TIP]
-====
-You can alternatively apply the following YAML to add the label:
-
-[source,yaml]
-----
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
+  creationTimestamp: "2022-11-16T15:34:25Z"
+  generation: 4
   labels:
-    custom-kubelet: small-pods
+    pools.operator.machineconfiguration.openshift.io/worker: "" <1>
   name: worker
+ ...
+----
+<1> The label appears under `Labels`.
++
+[TIP]
+====
+If the label is not present, add a key/value pair such as:
+
+----
+$ oc label machineconfigpool worker custom-kubelet=small-pods
 ----
 ====
 
@@ -87,7 +66,8 @@ kind: KubeletConfig
 metadata:
   name: dynamic-node <1>
 spec:
-  autoSizingReserved: true <2>
+  kubeletConfig:
+    autoSizingReserved: true <2>
   machineConfigPoolSelector:
     matchLabels:
       pools.operator.machineconfiguration.openshift.io/worker: "" <3>
@@ -98,26 +78,36 @@ spec:
 +
 The previous example enables automatic resource allocation on all worker nodes. {product-title} drains the nodes, applies the kubelet config, and restarts the nodes.
 
-. Verify the `system-reserved` value:
+. Create the CR by entering the following command:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
 
-.. Log in to a node you configured:
+.Verification
+
+. Log in to a node you configured by entering the following command:
 +
 [source,terminal]
 ----
 $ oc debug node/<node_name>
 ----
 
-.. View details on the kubelet process:
+. Set `/host` as the root directory within the debug shell:
 +
 [source,terminal]
 ----
-# ps -ef | grep kubelet
+# chroot /host
 ----
+
+. View the `/etc/node-sizing.env` file:
 +
 .Example output
 [source,terminal]
 ----
-root        1613       1 11 06:49 ?        00:00:05 kubelet --config=/etc/kubernetes/kubelet.conf --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig --kubeconfig=/var/lib/kubelet/kubeconfig --container-runtime=remote --container-runtime-endpoint=/var/run/crio/crio.sock --runtime-cgroups=/system.slice/crio.service --node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=rhcos --node-ip= --minimum-container-ttl-duration=6m0s --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec --cloud-provider=azure --cloud-config=/etc/kubernetes/cloud.conf --pod-infra-container-image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:7b8e2e2857d8ac3499c9eb4e449cc3296409f1da21aa21d0140134d611e65b84 --system-reserved=cpu=0.07,memory=2.5Gi --v=2
+SYSTEM_RESERVED_MEMORY=3Gi
+SYSTEM_RESERVED_CPU=0.08
 ----
 +
-In the previous example, the worker nodes are allocated `0.07` CPU and 2.5 Gi of memory. It can take several minutes for the optimal values to appear.
+The kubelet uses the `system-reserved` values in the `/etc/node-sizing.env` file. In the previous example, the worker nodes are allocated `0.08` CPU and 3 Gi of memory. It can take several minutes for the optimal values to appear.

--- a/modules/nodes-nodes-resources-configuring-setting.adoc
+++ b/modules/nodes-nodes-resources-configuring-setting.adoc
@@ -6,30 +6,27 @@
 [id="nodes-nodes-resources-configuring-setting_{context}"]
 = Manually allocating resources for nodes
 
-{product-title} supports the CPU and memory resource types for allocation. The `ephemeral-resource` resource type is supported as well. For the `cpu` type, the resource quantity is specified in units of cores, such as `200m`, `0.5`, or `1`. For `memory` and `ephemeral-storage`, it is specified in units of bytes, such as `200Ki`, `50Mi`, or `5Gi`.
+{product-title} supports the CPU and memory resource types for allocation. The `ephemeral-resource` resource type is supported as well. For the `cpu` type, the resource quantity is specified in units of cores, such as `200m`, `0.5`, or `1`. For `memory` and `ephemeral-storage`, it is specified in units of bytes, such as `200Ki`, `50Mi`, or `5Gi`. By default, the `system-reserved` CPU is `500m` and `system-reserved` memory is `1Gi`.
 
 As an administrator, you can set these using a custom resource (CR) through a set of `<resource_type>=<resource_quantity>` pairs
-(e.g., `cpu=200m,memory=512Mi`). 
+(e.g., `cpu=200m,memory=512Mi`).
 
 For details on the recommended `system-reserved` values, refer to the link:https://access.redhat.com/solutions/5843241[recommended system-reserved values].
 
 .Prerequisites
 
-. Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure.
-Perform one of the following steps:
-
-.. View the Machine Config Pool:
+. Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure by entering the following command:
 +
 [source,terminal]
 ----
-$ oc describe machineconfigpool <name>
+$ oc edit machineconfigpool <name>
 ----
 +
 For example:
 +
 [source,terminal]
 ----
-$ oc describe machineconfigpool worker
+$ oc edit machineconfigpool worker
 ----
 +
 .Example output
@@ -38,32 +35,20 @@ $ oc describe machineconfigpool worker
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
-  creationTimestamp: 2019-02-08T14:52:39Z
-  generation: 1
+  creationTimestamp: "2022-11-16T15:34:25Z"
+  generation: 4
   labels:
-    custom-kubelet: small-pods <1>
+    pools.operator.machineconfiguration.openshift.io/worker: "" <1>
+  name: worker
 ----
-<1> If a label has been added it appears under `labels`.
-
-.. If the label is not present, add a key/value pair:
-+
-[source,terminal]
-----
-$ oc label machineconfigpool worker custom-kubelet=small-pods
-----
+<1> The label appears under Labels.
 +
 [TIP]
 ====
-You can alternatively apply the following YAML to add the label:
+If the label is not present, add a key/value pair such as:
 
-[source,yaml]
 ----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfigPool
-metadata:
-  labels:
-    custom-kubelet: small-pods
-  name: worker
+$ oc label machineconfigpool worker custom-kubelet=small-pods
 ----
 ====
 
@@ -81,12 +66,19 @@ metadata:
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      custom-kubelet: small-pods <2>
+      pools.operator.machineconfiguration.openshift.io/worker: "" <2>
   kubeletConfig:
     systemReserved: <3>
       cpu: 1000m
       memory: 1Gi
 ----
 <1> Assign a name to CR.
-<2> Specify the label from the Machine Config Pool.
+<2> Specify the label from the machine config pool.
 <3> Specify the resources to reserve for the node components and system components.
+
+. Run the following command to create the CR:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----

--- a/modules/nodes-pods-plugins-install.adoc
+++ b/modules/nodes-pods-plugins-install.adoc
@@ -13,7 +13,7 @@ hardware without any upstream code changes.
 Device Manager provides a mechanism for advertising specialized node hardware resources
 with the help of plug-ins known as device plug-ins.
 
-. Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure.
+. Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure by entering the following command.
 Perform one of the following steps:
 
 .. View the machine config:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2062718

Removed an incorrect TIP in five modules.
Added new TIP in the same places.
Added a `oc create` step to a all five modules
Added .Verification where needed.
A few various editorial changes.

**Previews**
Updated the Prerequites and Procedure in:
[Automatically allocating resources for nodes](http://file.rdu.redhat.com/~mburke/mco-custom-label/nodes/nodes/nodes-nodes-resources-configuring.html#nodes-nodes-resources-configuring-auto_nodes-nodes-resources-configuring)
[Manually allocating resources for nodes](http://file.rdu.redhat.com/~mburke/mco-custom-label/nodes/nodes/nodes-nodes-resources-configuring.html#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring)
[Configuring garbage collection for containers and images](http://file.rdu.redhat.com/~mburke/mco-custom-label/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring)
[Configuring the maximum number of pods per node](http://file.rdu.redhat.com/~mburke/mco-custom-label/nodes/nodes/nodes-nodes-managing-max-pods.html#nodes-nodes-managing-max-pods-about_nodes-nodes-jobs)
[Disabling or enforcing CPU limits using CPU CFS quotas](http://file.rdu.redhat.com/~mburke/mco-custom-label/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-overcommit-node-enforcing_nodes-cluster-overcommit)