### PR TITLE
Agent-5-11: adds static networking and dhcp

### DIFF
--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -16,17 +16,9 @@ The Agent-based Installer also utilizes Zero Touch Provisioning (ZTP) custom res
 
 include::modules/understanding-agent-install.adoc[leveloffset=+1]
 
-include::modules/agent-installer-fips-compliance.adoc[leveloffset=+1]
+include::modules/agent-install-networking.adoc[leveloffset=+1]
 
-include::modules/agent-installer-configuring-fips-compliance.adoc[leveloffset=+1]
-
-[discrete]
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://access.redhat.com/articles/5059881[OpenShift Security Guide Book].
-
-* xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography]
+include::modules/agent-install-sample-config-bonds-vlans.adoc[leveloffset=+1]
 
 include::modules/installation-bare-metal-agent-installer-config-yaml.adoc[leveloffset=+1]
 

--- a/modules/agent-install-networking.adoc
+++ b/modules/agent-install-networking.adoc
@@ -1,0 +1,150 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-with-agent-based-installer/preparing-to-install-with-agent-based-installer.adoc
+
+:_content-type: CONCEPT
+[id="agent-install-networking_{context}"]
+= About networking
+
+During the initial boot, the machines require an IP address configuration that is set either through a Dynamic Host Configuration Protocol(DHCP) server or statically by
+selecting the below options. If you provide the IP address for the `rendezvousIP` field through the DHCP option, then ensure that it is for the machine's IP address that is going to be used for deployment.
+This IP address is required for a node to be identified as ** node 0 **. A ** node 0 ** runs the required services for the Agent-based Installer.
+
+== DHCP
+
+.Preferred method: `install-config.yaml` and `agent.config.yaml`
+
+You must specify only the value for the `rendezvousIP` field and `networkConfig` field must be left blank:
+
+.Sample agent-config.yaml.file
+
+[source,yaml]
+----
+  cat > agent-config.yaml << EOF
+  apiVersion: v1alpha1
+  kind: AgentConfig
+  metadata:
+    name: sno-cluster
+  rendezvousIP: 192.168.111.80 <1>
+----
+<1> The IP address for ** node 0**.
+
+== Static networking
+
+.. Preferred method: `install-config.yaml` and `agent.config.yaml`
++
+.Scenario-1
+
+When you specify the value for the `rendezvousIP` and `networkConfig` fields, the `rendezvousIP` field is utilized.
+
++
+.Sample agent-config.yaml.file
++
+[source,yaml]
+----
+  cat > agent-config.yaml << EOF
+  apiVersion: v1alpha1
+  kind: AgentConfig
+  metadata:
+    name: sno-cluster
+  rendezvousIP: 192.168.111.80
+  hosts:
+    - hostname: master-0
+      interfaces:
+        - name: eno1
+          macAddress: 00:ef:44:21:e6:a5
+      networkConfig:
+        interfaces:
+          - name: eno1
+            type: ethernet
+            state: up
+            mac-address: 00:ef:44:21:e6:a5
+            ipv4:
+              enabled: true
+              address:
+                - ip: 192.168.111.80
+                  prefix-length: 23
+----
+
++
+.Scenario-2
+When you specify the values for the `networkConfig` field, the value from the `interfaces` field is utilized. This is when there is no `rendezvousIP` field.
++
+[source,yaml]
+----
+  cat > agent-config.yaml << EOF
+  apiVersion: v1alpha1
+  kind: AgentConfig
+  hosts:
+    - hostname: master-0
+      interfaces:
+        - name: eno1
+          macAddress: 00:ef:44:21:e6:a5
+      networkConfig:
+        interfaces:
+          - name: eno1
+            type: ethernet
+            state: up
+            mac-address: 00:ef:44:21:e6:a5
+            ipv4:
+              enabled: true
+              address:
+                - ip: 192.168.111.80 <1>
+                  prefix-length: 23 <2>
+----
+<1> The static IP address of the target bare-metal host.
+<2> The static IP address’s subnet prefix for the target bare-metal host.
++
+Note that the lowest value IP is utilized for the IP address of ** node 0**.
+
++
+.. Optional method: ZTP manifests
+
++
+The optional method of the ZTP custom resources comprises 6 custom resources; you can configure static IPs in the `NMStateConfig.yaml.file`.
+
++
+[source,yaml]
+----
+apiVersion: agent-install.openshift.io/v1beta1
+kind: NMStateConfig
+metadata:
+  name: master-0
+  namespace: openshift-machine-api
+  labels:
+    cluster0-nmstate-label-name: cluster0-nmstate-label-value
+spec:
+  config:
+    interfaces:
+      - name: eth0
+        type: ethernet
+        state: up
+        mac-address: 52:54:01:aa:aa:a1
+        ipv4:
+          enabled: true
+          address:
+            - ip: 192.168.122.2 <1>
+              prefix-length: 23 <2>
+          dhcp: false
+    dns-resolver:
+      config:
+        server:
+          - 192.168.122.1 <3>
+    routes:
+      config:
+        - destination: 0.0.0.0/0
+          next-hop-address: 192.168.122.1 <4>
+          next-hop-interface: eth0
+          table-id: 254
+  interfaces:
+    - name: "eth0" <5>
+      macAddress: 52:54:01:aa:aa:a1 <6>
+----
+<1> The static IP address of the target bare-metal host.
+<2> The static IP address’s subnet prefix for the target bare-metal host.
+<3> The DNS server for the target bare-metal host.
+<4> Next hop address for the node traffic. This must be in the same subnet as the IP address set for the specified interface.
+<5> The `interfaces` field must have the same name.
+<6> The mac address of the interface.
++
+Note that the lowest value IP is utilized for the IP address of ** node 0**.

--- a/modules/agent-install-sample-config-bonds-vlans.adoc
+++ b/modules/agent-install-sample-config-bonds-vlans.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-with-agent-based-installer/preparing-to-install-with-agent-based-installer.adoc
+
+:_content-type: REFERENCE
+[id="agent-install-sample-config-bonds-vlans_{context}"]
+= Example: Bonds and VLAN interface node network configuration
+
+The following `agent-config.yaml` file is an example of a manifest for bond and VLAN interfaces.
+
+[source,yaml]
+----
+  apiVersion: v1alpha1
+  kind: AgentConfig
+  rendezvousIP: 10.10.10.14
+  hosts:
+    - hostname: master0
+      role: master
+      interfaces:
+       - name: enp0s4
+         macAddress: 00:21:50:90:c0:10
+       - name: enp0s5
+         macAddress: 00:21:50:90:c0:20
+      networkConfig:
+        interfaces:
+          - name: bond0.300 <1>
+            type: vlan <2>
+            state: up
+            vlan:
+              base-iface: bond0
+              id: 300
+            ipv4:
+              enabled: true
+              address:
+                - ip: 10.10.10.14
+                  prefix-length: 24
+              dhcp: false
+          - name: bond0 <1>
+            type: bond <3>
+            state: up
+            mac-address: 00:21:50:90:c0:10 <4>
+            ipv4:
+              enabled: false
+            ipv6:
+              enabled: false
+            link-aggregation:
+              mode: active-backup <5>
+              options:
+                miimon: "150" <6>
+              port:
+               - enp0s4
+               - enp0s5
+        dns-resolver: <7>
+          config:
+            server:
+              - 10.10.10.11
+              - 10.10.10.12
+        routes:
+          config:
+            - destination: 0.0.0.0/0
+              next-hop-address: 10.10.10.10 <8>
+              next-hop-interface: bond0.300 <9>
+              table-id: 254
+----
+<1> Name of the interface.
+<2> The type of interface. This example creates a VLAN.
+<3> The type of interface. This example creates a bond.
+<4> The mac address of the interface.
+<5> The `mode` attribute specifies the bonding mode.
+<6> Specifies the MII link monitoring frequency in milliseconds. This example inspects the bond link every 150 milliseconds.
+<7> Optional: Specifies the search and server settings for the DNS server.
+<8> Next hop address for the node traffic. This must be in the same subnet as the IP address set for the specified interface.
+<9> Next hop interface for the node traffic.


### PR DESCRIPTION
- Applies to main and 4.12
- [Agent-5](https://issues.redhat.com/browse/AGENT-5)
- [Agent-11](https://issues.redhat.com/browse/AGENT-11)
- [Preview](https://52811--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#agent-install-networking_preparing-to-install-with-agent-based-installer) 

@pawanpinjarkar please review
@mhanss ptal 

NOTE : Branch name was causing preview generation errors, had to rename the branch. Has SME/QE ack in the attached PR.