### PR TITLE
Fix broken reference

### DIFF
--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -19,7 +19,7 @@ Instance types can vary for control plane and infrastructure nodes, depending on
 - Two `r5.xlarge` infrastructure nodes
 - Two `m5.xlarge` customizable worker nodes
 
-For further guidance on worker node counts, see the information about initial planning considerations in the "Instance types" topic listed in the "Additional resources" section of this page.
+For further guidance on worker node counts, see the information about initial planning considerations in the "Limits and scalability" topic listed in the "Additional resources" section of this page.
 
 [id="rosa-ebs-storage_{context}"]
 == AWS Elastic Block Store (EBS) storage


### PR DESCRIPTION
Version(s):
All

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Additional information:
There is no longer an `Instance types` topic which is referenced here: https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#rosa-ec2-instances_prerequisites. Pointing to the `Limits and scalability` section instead

```
"Instance types" topic listed in the "Additional resources" section of this page.
```
