### PR TITLE
RHDEVDOCS-4642-distributed-tracing-2.7-RN

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -111,13 +111,13 @@ endif::[]
 //distributed tracing
 :DTProductName: Red Hat OpenShift distributed tracing
 :DTShortName: distributed tracing
-:DTProductVersion: 2.6
+:DTProductVersion: 2.7
 :JaegerName: Red Hat OpenShift distributed tracing platform
 :JaegerShortName: distributed tracing platform
-:JaegerVersion: 1.38
+:JaegerVersion: 1.39.0
 :OTELName: Red Hat OpenShift distributed tracing data collection
 :OTELShortName: distributed tracing data collection
-:OTELVersion: 0.60
+:OTELVersion: 0.63.1
 //logging
 :logging-title: logging subsystem for Red Hat OpenShift
 :logging-title-uc: Logging subsystem for Red Hat OpenShift

--- a/modules/distr-tracing-rn-fixed-issues.adoc
+++ b/modules/distr-tracing-rn-fixed-issues.adoc
@@ -14,7 +14,20 @@ Fix - What did we change to fix the problem?
 Result - How has the behavior changed as a result? Try to avoid “It is fixed” or “The issue is resolved” or “The error no longer presents”.
 ////
 
-* link:https://issues.redhat.com/browse/TRACING-2337[TRACING-2337] Jaeger is logging a repetitive warning message in the Jaeger logs similar to the following:
+* link:https://issues.redhat.com/browse/OSSM-1910[OSSM-1910]
+Because of an issue introduced in version 2.6, TLS connections could not be established with {product-title} {SMProductShortName}. 
+This update resolves the issue by changing the service port names to match conventions used by {product-title} {SMProductShortName} and Istio. 
+
+* link:https://issues.redhat.com/browse/OBSDA-208[OBSDA-208]
+ Before this update, the default 200m CPU and 256Mi memory resource limits could cause {OTELShortName} to restart continuously on large clusters.
+ This update resolves the issue by removing these resource limits.
+
+* link:https://issues.redhat.com/browse/OBSDA-222[OBSDA-222]
+Before this update, spans could be dropped in the {product-title} {JaegerShortName}. 
+To help prevent this issue from occurring, this release updates version dependencies.
+
+* link:https://issues.redhat.com/browse/TRACING-2337[TRACING-2337]
+Jaeger is logging a repetitive warning message in the Jaeger logs similar to the following:
 +
 [source,terminal]
 ----

--- a/modules/distr-tracing-rn-known-issues.adoc
+++ b/modules/distr-tracing-rn-known-issues.adoc
@@ -22,6 +22,9 @@ These limitations exist in {DTProductName}:
 
 These are the known issues for {DTProductName}:
 
+* link:https://issues.redhat.com/browse/OBSDA-220[OBSDA-220] In some cases, if you try to pull an image using {OTELShortName}, the image pull fails and a `Failed to pull image` error message appears. 
+There is no workaround for this issue.
+
 * link:https://issues.redhat.com/browse/TRACING-2057[TRACING-2057] The Kafka API has been updated to `v1beta2` to support the Strimzi Kafka Operator 0.23.0. However, this API version is not supported by AMQ Streams 1.6.3. If you have the following environment, your Jaeger services will not be upgraded, and you cannot create new Jaeger services or modify existing Jaeger services:
 
 ** Jaeger Operator channel: *1.17.x stable* or *1.20.x stable*

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -13,6 +13,24 @@ Result – If changed, describe the current user experience.
 
 This release adds improvements related to the following components and concepts.
 
+== New features and enhancements {DTProductName} 2.7
+
+This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
+
+=== Component versions supported in {DTProductName} version 2.7
+
+[options="header"]
+|===
+|Operator |Component |Version
+|{JaegerName}
+|Jaeger
+|1.39
+
+|{OTELName}
+|OpenTelemetry
+|0.63.1
+|===
+
 == New features and enhancements {DTProductName} 2.6
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.


### PR DESCRIPTION
Summary: This PR adds release notes content for the distributed tracing 2.7 release.

- Aligned team: DevTools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4642
- Direct link to doc preview: 
- - https://52818--docspreview.netlify.app/openshift-enterprise/latest/distr_tracing/distributed-tracing-release-notes.html#new-features-and-enhancements-red-hat-openshift-distributed-tracing-2-7
- - https://52818--docspreview.netlify.app/openshift-enterprise/latest/distr_tracing/distributed-tracing-release-notes.html#distr-tracing-rn-fixed-issues_distributed-tracing-release-notes
- - https://52818--docspreview.netlify.app/openshift-enterprise/latest/distr_tracing/distributed-tracing-release-notes.html#distr-tracing-rn-known-issues_distributed-tracing-release-notes
- SME review: @pavolloffay @rubenvp8510 @iblancasa 
- QE review: @jkandasa 
- Peer review: @ tbd