### PR TITLE
OCPBUGS#3544: added a consideration for scale before migrating to OVN-K

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -3,10 +3,9 @@
 // * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
 
 [id="nw-ovn-kubernetes-migration-about_{context}"]
-= Migration to the OVN-Kubernetes network provider
+= Migration to the OVN-Kubernetes network plug-in
 
 Migrating to the OVN-Kubernetes network plug-in is a manual process that includes some downtime during which your cluster is unreachable. Although a rollback procedure is provided, the migration is intended to be a one-way process.
-
 
 A migration to the OVN-Kubernetes network plug-in is supported on the following platforms:
 
@@ -20,30 +19,24 @@ A migration to the OVN-Kubernetes network plug-in is supported on the following 
 * VMware vSphere
 
 [id="considerations-migrating-ovn-kubernetes-network-provider_{context}"]
-== Considerations for migrating to the OVN-Kubernetes network provider
+== Considerations for migrating to the OVN-Kubernetes network plug-in
+
+If you have more than 150 nodes in your {product-title} cluster, then open a support case for consultation on your migration to the OVN-Kubernetes network plug-in.
 
 The subnets assigned to nodes and the IP addresses assigned to individual pods are not preserved during the migration.
 
-While the OVN-Kubernetes network provider implements many of the capabilities present in the OpenShift SDN network provider, the configuration is not the same.
+While the OVN-Kubernetes network plug-in implements many of the capabilities present in the OpenShift SDN network plug-in, the configuration is not the same.
 
-* If your cluster uses any of the following OpenShift SDN capabilities, the migration to OVN-Kubernetes migrates the configuration for these features as well:
-+
---
-* Egress IPs
-* Egress firewall
-* Multicast
---
-
-* If your cluster uses any of the following OpenShift SDN capabilities, you must manually configure the same capability in OVN-Kubernetes:
+* If your cluster uses any of the following OpenShift SDN network plug-in capabilities, you must manually configure the same capability in the OVN-Kubernetes network plug-in:
 +
 --
 * Namespace isolation
 * Egress router pods
 --
 
-* If your cluster uses any part of the 100.64.0.0/16 IP address range, you must specify an alternative IP address range for OVN-Kubernetes during the migration to avoid a conflict because OVN-Kubernetes uses this IP address range internally.
+* If your cluster or surrounding network uses any part of the `100.64.0.0/16` address range, you must choose another unused IP range by specifying the `v4InternalSubnet` spec under the `spec.defaultNetwork.ovnKubernetesConfig` object definition. OVN-Kubernetes uses the IP range `100.64.0.0/16` internally by default.
 
-The following sections highlight the differences in configuration between the aforementioned capabilities in OVN-Kubernetes and OpenShift SDN.
+The following sections highlight the differences in configuration between the aforementioned capabilities in OVN-Kubernetes and OpenShift SDN network plug-ins.
 
 [discrete]
 [id="namespace-isolation_{context}"]
@@ -53,7 +46,7 @@ OVN-Kubernetes supports only the network policy isolation mode.
 
 [IMPORTANT]
 ====
-If your cluster uses OpenShift SDN configured in either the multitenant or subnet isolation modes, you cannot migrate to the OVN-Kubernetes network provider.
+If your cluster uses OpenShift SDN configured in either the multitenant or subnet isolation modes, you cannot migrate to the OVN-Kubernetes network plug-in.
 ====
 
 [discrete]


### PR DESCRIPTION
Version(s):
4.12+ for updated language aligned with the rebrand in https://github.com/openshift/openshift-docs/pull/51663

A separate PR will add the "If you have more than 150 nodes in your {product-title} cluster..." note with the correct language for 4.8 - 4.11 

Issue:
https://issues.redhat.com/browse/OCPBUGS-3544

Link to docs preview:
https://52819--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#considerations-migrating-ovn-kubernetes-network-provider_migrate-from-openshift-sdn