### PR TITLE
[enterprise-4.10] OCPBUGS-2326: Memory manager requires capital S Staic policy

### DIFF
--- a/modules/cnf-deploying-the-numa-aware-scheduler.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler.adoc
@@ -38,10 +38,10 @@ spec:
     matchLabels:
       cnf-worker-tuning: enabled
   kubeletConfig:
-    cpuManagerPolicy: "static"
+    cpuManagerPolicy: "static" <1>
     cpuManagerReconcilePeriod: "5s"
     reservedSystemCPUs: "0,1"
-    memoryManagerPolicy: "Static"
+    memoryManagerPolicy: "Static" <2>
     evictionHard:
       memory.available: "100Mi"
     kubeReserved:
@@ -52,10 +52,12 @@ spec:
           memory: "1124Mi"
     systemReserved:
       memory: "512Mi"
-    topologyManagerPolicy: "single-numa-node" <1>
+    topologyManagerPolicy: "single-numa-node" <3>
     topologyManagerScope: "pod"
 ----
-<1> Set the `topologyManagerPolicy` field to `single-numa-node`.
+<1> For `cpuManagerPolicy`, `static` must use a lowercase `s`.
+<2> For `memoryManagerPolicy`, `Static` must use an uppercase `S`.
+<3> `topologyManagerPolicy` must be set to `single-numa-node`.
 
 .. Create the `KubeletConfig` custom resource (CR) by running the following command:
 +

--- a/modules/setting-up-cpu-manager.adoc
+++ b/modules/setting-up-cpu-manager.adoc
@@ -52,9 +52,9 @@ spec:
 ----
 <1> Specify a policy:
 * `none`. This policy explicitly enables the existing default CPU affinity scheme, providing no affinity beyond what the scheduler does automatically.
-* `static`. This policy allows pods with certain resource characteristics to be granted increased CPU affinity and exclusivity on the node.
+* `static`. This policy allows pods with certain resource characteristics to be granted increased CPU affinity and exclusivity on the node. If `static`, you must use a lowercase `s`.
 <2> Optional. Specify the CPU Manager reconcile frequency. The default is `5s`.
-
+ 
 . Create the dynamic kubelet config:
 +
 [source,terminal]

--- a/modules/setting-up-topology-manager.adoc
+++ b/modules/setting-up-topology-manager.adoc
@@ -39,6 +39,6 @@ spec:
      cpuManagerReconcilePeriod: 5s
      topologyManagerPolicy: single-numa-node <2>
 ----
-<1> This parameter must be `static`.
+<1> This parameter must be `static` with a lowercase `s`.
 <2> Specify your selected Topology Manager allocation policy. Here, the policy is `single-numa-node`.
 Acceptable values are: `default`, `best-effort`, `restricted`, `single-numa-node`.


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/51802