### PR TITLE
[OCPBBUGS-3634]: Correct the ACS installation link in the OPP doc

### DIFF
--- a/modules/opp-architecture-installation.adoc
+++ b/modules/opp-architecture-installation.adoc
@@ -6,10 +6,10 @@
 [id="opp-architecture-installation_{context}"]
 = Install {product-title} products
 
-To install {product-title}, you must install five products in a specific order. Install {ocp} first. Then, install {rh-rhacm}. It does not matter what order you install the remaining products: {quay}, {rh-storage-essentials-first}, and {acs}. See the following detailed installation information for each product:
+To install {product-title}, you must install two products in a specific order. Install {ocp} first. Then, install {rh-rhacm}. It does not matter what order you install the remaining products: {quay}, {rh-storage-essentials-first}, and {acs}. See the following detailed installation information for each product:
 
 * {ocp} - link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/installing/installing-preparing#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
 * {rh-rhacm} - link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/install/installing[Installing {rh-rhacm}]
-* {acs} - link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.71/html/installing/install-ocp-operator[Installing {acs} for Kubernetes by using an Operator]
+* {acs} - link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.72/html/installing/install-ocp-operator[Installing {acs} for Kubernetes by using an Operator]
 * {rh-storage-essentials-first} - link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.11[Deploying {rh-storage-data-foundation}]
 * {quay} - link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/deploy_red_hat_quay_on_openshift_with_the_quay_operator/index[Deploy {quay} on OpenShift with the Quay Operator]


### PR DESCRIPTION
Issue: [OCPBUGS-3634](https://issues.redhat.com/browse/OCPBUGS-3634): The installation link in the OPP pointed to the previous release.

Additional information: This PR is based on the 'opp-docs' repo.

Version(s): just opp-docs

Link to docs preview: http://file.rdu.redhat.com/tlove/opp-ocpbugs-3634-tlove/architecture/opp-architecture.html#opp-architecture-installation_opp-architecture

SME reviews: (General OPP update)

- [ x] QE (Adam Scerra)
- [ x] SME (Bill Dettleback)

