### PR TITLE
[OSDOCS-4535]: Enabling Azure boot diagnostics (4.12 RN)

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -347,6 +347,11 @@ For the OVN-Kubernetes network plug-in, egress firewalls support audit logging u
 
 {product-title} now supports setting the log level verbosity of the cluster autoscaler by setting the `logVerbosity` parameter in the `ClusterAutoscaler` custom resource. For more information, see the xref:../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[`ClusterAutoscaler` resource definition].
 
+[id="ocp-4-12-azure-boot-diagnostics"]
+==== Enabling Azure boot diagnostics
+
+{product-title} now supports enabling boot diagnostics on Azure machines that your machine set creates. For more information, see "Enabling Azure boot diagnostics" for xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-azure-boot-diagnostics_creating-machineset-azure[compute machines] or xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#machineset-azure-boot-diagnostics_cpmso-using[control plane machines].
+
 [id="ocp-4-12-machine-config-operator"]
 === Machine Config Operator
 


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-4535](https://issues.redhat.com//browse/OSDOCS-4535)

Link to docs preview:
[Enabling Azure boot diagnostics](https://52833--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-azure-boot-diagnostics)

QE review:
- [x] QE has approved this change.

Additional information:
:heavy_check_mark: ~~Bulid will fail until #52831 merges~~