### PR TITLE
[enterprise-4.9] TELCODOCS-935 - PTP adding Intel Fortville NIC boundary_clock_jbod note for BC config

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -128,7 +128,7 @@ spec:
       delay_filter_length  10
       egressLatency          0
       ingressLatency         0
-      boundary_clock_jbod  1
+      boundary_clock_jbod  0 <9>
       #
       # Clock description
       #
@@ -137,15 +137,15 @@ spec:
       manufacturerIdentity  00:00:00
       userDescription         ;
       timeSource              0xA0
-    phc2sysOpts: "-a -r" <9>
-    ptpSchedulingPolicy: SCHED_OTHER <10>
-    ptpSchedulingPriority: 10 <11>
-  recommend: <12>
-  - profile: "profile1" <13>
-    priority: 10 <14>
-    match: <15>
-    - nodeLabel: "node-role.kubernetes.io/worker" <16>
-      nodeName: "compute-0.example.com" <17>
+    phc2sysOpts: "-a -r" <10>
+    ptpSchedulingPolicy: SCHED_OTHER <11>
+    ptpSchedulingPriority: 10 <12>
+  recommend: <13>
+  - profile: "profile1" <14>
+    priority: 10 <15>
+    match: <16>
+    - nodeLabel: "node-role.kubernetes.io/worker" <17>
+      nodeName: "compute-0.example.com" <18>
 ----
 <1> The name of the `PtpConfig` CR.
 <2> Specify an array of one or more `profile` objects.
@@ -155,15 +155,16 @@ spec:
 <6> Specify the needed configuration to start `ptp4l` as boundary clock. For example, `ens1f0` synchronizes from a grandmaster clock and `ens1f3` synchronizes connected devices.
 <7> The interface name to synchronize from.
 <8> The interface to synchronize devices connected to the interface.
-<9> Specify system config options for the `phc2sys` service, for example `-a -r`. If this field is empty the PTP Operator does not start the `phc2sys` service.
-<10> Scheduling policy for ptp4l and phc2sys processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
-<11> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes when `ptpSchedulingPolicy` is set to `SCHED_FIFO`. The `ptpSchedulingPriority` field is not used when `ptpSchedulingPolicy` is set to `SCHED_OTHER`.
-<12> Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
-<13> Specify the `profile` object name defined in the `profile` section.
-<14> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
-<15> Specify `match` rules with `nodeLabel` or `nodeName`.
-<16> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command.
-<17> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command.
+<9> For Intel Columbiaville 800 Series NICs, ensure `boundary_clock_jbod` is set to `0`. For Intel Fortville X710 Series NICs, ensure `boundary_clock_jbod` is set to `1`.
+<10> Specify system config options for the `phc2sys` service, for example `-a -r`. If this field is empty the PTP Operator does not start the `phc2sys` service.
+<11> Scheduling policy for ptp4l and phc2sys processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
+<12> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes when `ptpSchedulingPolicy` is set to `SCHED_FIFO`. The `ptpSchedulingPriority` field is not used when `ptpSchedulingPolicy` is set to `SCHED_OTHER`.
+<13> Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
+<14> Specify the `profile` object name defined in the `profile` section.
+<15> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
+<16> Specify `match` rules with `nodeLabel` or `nodeName`.
+<17> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command.
+<18> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command.
 
 . Create the CR by running the following command:
 +


### PR DESCRIPTION
4.9 manual CP for https://github.com/openshift/openshift-docs/pull/51518

Documentation should be updated to indicate that the boundary_clock_jbod parameter should be set to 0 by default if the intent is to only deploy the service on E810 NICs or add a note that indicates that boundary_clock_jbod should only be set if the service is being deployed on a Fortville (X710) NIC. In other words, the boundary_clock_jbod parameter should be set to "0" for the Intel E810 NIC.

https://issues.redhat.com/browse/TELCODOCS-935

Version(s):
enterprise-4.9
