### PR TITLE
RHDEVDOCS-4541: Adding default prunner configuration

### DIFF
--- a/cicd/pipelines/automatic-pruning-taskrun-pipelinerun.adoc
+++ b/cicd/pipelines/automatic-pruning-taskrun-pipelinerun.adoc
@@ -14,9 +14,11 @@ Stale `TaskRun` and `PipelineRun` objects and their executed instances occupy ph
 * Configuring automatic pruning by specifying annotations affects the entire namespace. You cannot selectively auto-prune individual task runs and pipeline runs in a namespace.
 ====
 
+include::modules/op-default-pruner-configuration.adoc[leveloffset=+1]
+
 include::modules/op-annotations-for-automatic-pruning-taskruns-pipelineruns.adoc[leveloffset=+1 ]
 
 [id="additional-resources_automatic-pruning-taskrun-pipelinerun"]
 == Additional resources
 
-* For information on manual pruning of various objects, see xref:../../applications/pruning-objects.adoc#prunning-objects[Pruning objects to reclaim resources].
+* For information on manual pruning of various objects, see xref:../../applications/pruning-objects.adoc#pruning-objects[Pruning objects to reclaim resources].

--- a/modules/op-annotations-for-automatic-pruning-taskruns-pipelineruns.adoc
+++ b/modules/op-annotations-for-automatic-pruning-taskruns-pipelineruns.adoc
@@ -6,7 +6,7 @@
 [id="annotations-for-automatic-pruning-taskruns-pipelineruns_{context}"]
 = Annotations for automatically pruning task runs and pipeline runs 
 
-To automatically prune task runs and pipeline runs in a namespace, you can set the following annotations in the namespace:
+To automatically prune the resources associated with task runs and pipeline runs in a namespace, you can set the following annotations in the namespace:
 
 * `operator.tekton.dev/prune.schedule`: If the value of this annotation is different from the value specified in the `TektonConfig` custom resource definition, a new cron job in that namespace is created.
 

--- a/modules/op-default-pruner-configuration.adoc
+++ b/modules/op-default-pruner-configuration.adoc
@@ -1,0 +1,27 @@
+// This module is included in the following assembly:
+//
+// cicd/pipelines/automatic-pruning-taskrun-pipelinerun.adoc
+
+:_content-type: REFERENCE
+[id="default-pruner-configuration_{context}"]
+= Default pruner configuration
+
+The default configuration for periodic pruning of resources associated with pipeline runs is as follows:
+
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+...
+spec:
+  pruner:
+    keep: 100
+    resources:
+    - pipelinerun
+    schedule: 0 8 * * *
+...
+----
+
+You can override the default pruner configuration for a namespace by using annotations on namespace.


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.11`, `enterprise-4.12`
- **JIRA issues**: [RHDEVDOCS-4541 Add default prunner configuration](https://issues.redhat.com/browse/RHDEVDOCS-4541)
- **Preview pages**: [Default prunner configuration](http://file.pnq.redhat.com/sosarkar/4541-add-default-prunner-settings/cicd/pipelines/automatic-pruning-taskrun-pipelinerun.html#default-prunner-configuration_automatic-pruning-taskrun-pipelinerun)
- **SME review**: @pradeepitm12  
- **QE review**: @ppitonak / @VeereshAradhya 