### PR TITLE
TELCODOCS-1029: First instance of namespace: openshift-operators removed from example

### DIFF
--- a/modules/eco-node-health-check-operator-about.adoc
+++ b/modules/eco-node-health-check-operator-about.adoc
@@ -20,7 +20,6 @@ apiVersion: remediation.medik8s.io/v1alpha1
 kind: NodeHealthCheck
 metadata:
   name: nodehealthcheck-sample
-  namespace: openshift-operators
 spec:
   minHealthy: 51% <1>
   pauseRequests: <2>


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-1029 NodeHealthCheck example has namespace

Applies to OpenShift version : 4.9, 4.10, 4.11, 4.12 +

Preview: [About the Node Health Check Operator](http://file.emea.redhat.com/pogrady/TELCODOCS-1029/nodes/nodes/eco-node-health-check-operator.html#about-node-health-check-operator_node-health-check-operator)

Dev review complete/approved by @slintes
QE review complete/approved by @anna-savina
Peer review complete/approved by @mburke5678 

Thank you.