### PR TITLE
OCPBUGS-3533 Adding note about vfio-pci

### DIFF
--- a/modules/nw-sriov-interface-level-sysctl-basic-node-policy.adoc
+++ b/modules/nw-sriov-interface-level-sysctl-basic-node-policy.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="nw-basic-example-setting-one-sysctl-flag-node-policy_{context}"]
-= Setting one sysctl flag on nodes with SR-IOV network devices 
+= Setting one sysctl flag on nodes with SR-IOV network devices
 
-The SR-IOV Network Operator adds the `SriovNetworkNodePolicy.sriovnetwork.openshift.io` custom resource definition (CRD) to {product-title}. You can configure an SR-IOV network device by creating a `SriovNetworkNodePolicy` custom resource (CR).  
+The SR-IOV Network Operator adds the `SriovNetworkNodePolicy.sriovnetwork.openshift.io` custom resource definition (CRD) to {product-title}. You can configure an SR-IOV network device by creating a `SriovNetworkNodePolicy` custom resource (CR).
 
 [NOTE]
 ====
@@ -15,11 +15,11 @@ When applying the configuration specified in a `SriovNetworkNodePolicy` object, 
 It can take several minutes for a configuration change to apply.
 ====
 
-Follow this procedure to create a `SriovNetworkNodePolicy` custom resource (CR).  
+Follow this procedure to create a `SriovNetworkNodePolicy` custom resource (CR).
 
 .Procedure
 
-. Create an `SriovNetworkNodePolicy` custom resource (CR). For example, save the following YAML as the file `policyoneflag-sriov-node-network.yaml`: 
+. Create an `SriovNetworkNodePolicy` custom resource (CR). For example, save the following YAML as the file `policyoneflag-sriov-node-network.yaml`:
 +
 [source,yaml]
 ----
@@ -49,13 +49,17 @@ spec:
 <7> The NIC selector identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally.
 If you specify `rootDevices`, you must also specify a value for `vendor`, `deviceID`, or `pfNames`. If you specify both `pfNames` and `rootDevices` at the same time, ensure that they refer to the same device. If you specify a value for `netFilter`, then you do not need to specify any other parameter because a network ID is unique.
 <8> Optional: An array of one or more physical function (PF) names for the device.
-<9> Optional: The driver type for the virtual functions. The only allowed values are `netdevice` and `vfio-pci`. The default value is `netdevice`.
-For a Mellanox NIC to work in DPDK mode on bare metal nodes, use the `netdevice` driver type and set `isRdma` to `true`.
+<9> Optional: The driver type for the virtual functions. The only allowed value is `netdevice`.
+For a Mellanox NIC to work in DPDK mode on bare metal nodes, set `isRdma` to `true`.
 <10> Optional: Configures whether to enable remote direct memory access (RDMA) mode. The default value is `false`.
 If the `isRdma` parameter is set to `true`, you can continue to use the RDMA-enabled VF as a normal network device. A device can be used in either mode.
 Set `isRdma` to `true` and additionally set `needVhostNet` to `true` to configure a Mellanox NIC for use with Fast Datapath DPDK applications.
 +
-
+[NOTE]
+====
+The `vfio-pci` driver type is not supported.
+====
++
 . Create the `SriovNetworkNodePolicy` object:
 +
 [source,terminal]
@@ -72,7 +76,7 @@ After applying the configuration update, all the pods in `sriov-network-operator
 $ oc get sriovnetworknodestates -n openshift-sriov-network-operator <node_name> -o jsonpath='{.status.syncStatus}'
 ----
 +
-.Example output 
+.Example output
 [source,terminal]
 ----
 Succeeded

--- a/modules/nw-sriov-interface-level-sysctl-bonded-node-policy.adoc
+++ b/modules/nw-sriov-interface-level-sysctl-bonded-node-policy.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: CONCEPT
 [id="nw-setting-all-sysctls-flag-node-policy-bonded_{context}"]
-= Setting all sysctl flag on nodes with bonded SR-IOV network devices 
+= Setting all sysctl flag on nodes with bonded SR-IOV network devices
 
-The SR-IOV Network Operator adds the `SriovNetworkNodePolicy.sriovnetwork.openshift.io` custom resource definition (CRD) to {product-title}. You can configure an SR-IOV network device by creating a `SriovNetworkNodePolicy` custom resource (CR). 
+The SR-IOV Network Operator adds the `SriovNetworkNodePolicy.sriovnetwork.openshift.io` custom resource definition (CRD) to {product-title}. You can configure an SR-IOV network device by creating a `SriovNetworkNodePolicy` custom resource (CR).
 
 [NOTE]
 ====
@@ -15,7 +15,7 @@ When applying the configuration specified in a SriovNetworkNodePolicy object, th
 It might take several minutes for a configuration change to apply.
 ====
 
-Follow this procedure to create a `SriovNetworkNodePolicy` custom resource (CR).  
+Follow this procedure to create a `SriovNetworkNodePolicy` custom resource (CR).
 
 .Procedure
 
@@ -49,13 +49,17 @@ spec:
 <7> The NIC selector identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally.
 If you specify `rootDevices`, you must also specify a value for `vendor`, `deviceID`, or `pfNames`. If you specify both `pfNames` and `rootDevices` at the same time, ensure that they refer to the same device. If you specify a value for `netFilter`, then you do not need to specify any other parameter because a network ID is unique.
 <8> Optional: An array of one or more physical function (PF) names for the device.
-<9> Optional: The driver type for the virtual functions. The only allowed values are `netdevice` and `vfio-pci`. The default value is `netdevice`.
-For a Mellanox NIC to work in DPDK mode on bare metal nodes, use the `netdevice` driver type and set `isRdma` to `true`.
+<9> Optional: The driver type for the virtual functions. The only allowed value is `netdevice`.
+For a Mellanox NIC to work in DPDK mode on bare metal nodes, set `isRdma` to `true`.
 <10> Optional: Configures whether to enable remote direct memory access (RDMA) mode. The default value is `false`.
 If the `isRdma` parameter is set to `true`, you can continue to use the RDMA-enabled VF as a normal network device. A device can be used in either mode.
 Set `isRdma` to `true` and additionally set `needVhostNet` to `true` to configure a Mellanox NIC for use with Fast Datapath DPDK applications.
 +
-
+[NOTE]
+====
+The `vfio-pci` driver type is not supported.
+====
++
 . Create the SriovNetworkNodePolicy object:
 +
 [source,terminal]


### PR DESCRIPTION
[OCPBUGS-3638]: sysctl configuration does not support vfio-pci as a driver type

Version(s):
4.11, 4.12 and main

Issue: https://issues.redhat.com/browse/OCPBUGS-3638

Link to docs preview: 

- https://52851--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-interface-sysctl-sriov-device.html#nw-basic-example-setting-one-sysctl-flag-node-policy_configuring-sysctl-interface-sriov-device
- https://52851--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-interface-sysctl-sriov-device.html#nw-setting-all-sysctls-flag-node-policy-bonded_configuring-sysctl-interface-sriov-device


QE review:
- [ ] QE has approved this change.


