### PR TITLE
OSDOCS-4012: Add platform Operator and RukPak docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1544,6 +1544,9 @@ Topics:
   - Name: Using OLM on restricted networks
     File: olm-restricted-networks
     Distros: openshift-origin,openshift-enterprise
+  - Name: Managing platform Operators
+    File: olm-managing-po
+    Distros: openshift-enterprise,openshift-origin
 - Name: Developing Operators
   Dir: operator_sdk
   Distros: openshift-origin,openshift-enterprise

--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -33,6 +33,17 @@ include::modules/arch-olm-operators.adoc[leveloffset=+2]
 * For more details on running add-on Operators in {product-title}, see the _Operators_ guide sections on xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager (OLM)] and xref:../operators/understanding/olm-understanding-operatorhub.adoc#olm-understanding-operatorhub[OperatorHub].
 * For more details on the Operator SDK, see xref:../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Operators].
 
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+include::modules/arch-platform-operators.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../operators/admin/olm-managing-po.adoc#olm-managing-po[Managing platform Operators]
+* xref:../operators/admin/olm-managing-po.adoc#olm-po-techpreview_olm-managing-po[Technology Preview restrictions for platform Operators]
+* xref:../operators/understanding/olm-packaging-format.adoc#olm-rukpak-about_olm-packaging-format[RukPak component and packaging format]
+* xref:../post_installation_configuration/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
+endif::[]
+
 include::modules/update-service-overview.adoc[leveloffset=+1]
 
 include::modules/understanding-machine-config-operator.adoc[leveloffset=+1]

--- a/modules/arch-platform-operators.adoc
+++ b/modules/arch-platform-operators.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * architecture/control-plane.adoc
+// * operators/admin/olm-managing-po.adoc
+
+:_content-type: CONCEPT
+
+ifeval::["{context}" == "control-plane"]
+[id="platform-operators_{context}"]
+= Platform Operators (Technology Preview)
+
+:FeatureName: The platform Operator type
+include::snippets/technology-preview.adoc[]
+endif::[]
+
+ifeval::["{context}" == "olm-managing-po"]
+[id="platform-operators_{context}"]
+= About platform Operators
+endif::[]
+
+Operator Lifecycle Manager (OLM) introduces a new type of Operator called _platform Operators_. A platform Operator is an OLM-based Operator that can be installed during or after an {product-title} cluster's Day 0 operations and participates in the cluster's lifecycle. As a cluster administrator, you can use platform Operators to further customize your {product-title} installation to meet your requirements and use cases.
+
+Using the existing cluster capabilities feature in {product-title}, cluster administrators can already disable a subset of Cluster Version Operator-based (CVO) components considered non-essential to the initial payload prior to cluster installation. Platform Operators iterate on this model by providing additional customization options. Through the platform Operator mechanism, which relies on resources from the RukPak component, OLM-based Operators can now be installed at cluster installation time and can block cluster rollout if the Operator fails to install successfully.
+
+In {product-title} 4.12, this Technology Preview release focuses on the basic platform Operator mechanism and builds a foundation for expanding the concept in upcoming releases. You can use the cluster-wide `PlatformOperator` API to configure Operators before or after cluster creation on clusters that have enabled the `TechPreviewNoUpgrades` feature set.

--- a/modules/olm-deleting-po.adoc
+++ b/modules/olm-deleting-po.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+//
+// * operators/admin/olm-managing-po.adoc
+
+:_content-type: PROCEDURE
+[id="olm-deleting-po_{context}"]
+= Deleting platform Operators
+
+As a cluster administrator, you can delete existing platform Operators. Operator Lifecycle Manager (OLM) performs a cascading deletion. First, OLM removes the bundle deployment for the platform Operator, which then deletes any objects referenced in the `registry+v1` type bundle.
+
+[NOTE]
+====
+The platform Operator manager and bundle deployment provisioner only manage objects that are referenced in the bundle, but not objects subsequently deployed by any bundle workloads themselves. For example, if a bundle workload creates a namespace and the Operator is not configured to clean it up before the Operator is removed, it is outside of the scope of OLM to remove the namespace during platform Operator deletion.
+====
+
+.Procedure
+
+. Get a list of installed platform Operators and find the name for the Operator you want to delete:
++
+[source,terminal]
+----
+$ oc get platformoperator
+----
+
+. Delete the `PlatformOperator` resource for the chosen Operator, for example, for the Quay Operator:
++
+[source,terminal]
+----
+$ oc delete platformoperator quay-operator
+----
++
+.Example output
+[source,terminal]
+----
+platformoperator.platform.openshift.io "quay-operator" deleted
+----
+
+.Verification
+
+. Verify the namespace for the platform Operator is eventually deleted, for example, for the Quay Operator:
++
+[source,terminal]
+----
+$ oc get ns quay-operator-system
+----
++
+.Example output
+[source,terminal]
+----
+Error from server (NotFound): namespaces "quay-operator-system" not found
+----
+
+. Verify the `platform-operators-aggregated` cluster Operator continues to report an `Available=True` status:
++
+[source,terminal]
+----
+$ oc get co platform-operators-aggregated
+----
++
+.Example output
+[source,terminal]
+----
+NAME                            VERSION     AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
+platform-operators-aggregated   4.12.0-0    True        False         False      70s
+----

--- a/modules/olm-installing-from-operatorhub-using-cli.adoc
+++ b/modules/olm-installing-from-operatorhub-using-cli.adoc
@@ -15,7 +15,7 @@ endif::[]
 [id="olm-installing-operator-from-operatorhub-using-cli_{context}"]
 = Installing from OperatorHub using the CLI
 
-Instead of using the {product-title} web console, you can install an Operator from OperatorHub using the CLI. Use the `oc` command to create or update a `Subscription` object.
+Instead of using the {product-title} web console, you can install an Operator from OperatorHub by using the CLI. Use the `oc` command to create or update a `Subscription` object.
 
 .Prerequisites
 

--- a/modules/olm-installing-from-operatorhub-using-web-console.adoc
+++ b/modules/olm-installing-from-operatorhub-using-web-console.adoc
@@ -32,7 +32,7 @@ endif::[]
 [id="olm-installing-from-operatorhub-using-web-console_{context}"]
 = Installing from OperatorHub using the web console
 
-You can install and subscribe to an Operator from OperatorHub using the {product-title} web console.
+You can install and subscribe to an Operator from OperatorHub by using the {product-title} web console.
 
 .Prerequisites
 

--- a/modules/olm-installing-operators-from-operatorhub.adoc
+++ b/modules/olm-installing-operators-from-operatorhub.adoc
@@ -18,14 +18,14 @@ endif::[]
 OperatorHub is a user interface for discovering Operators; it works in conjunction with Operator Lifecycle Manager (OLM), which installs and manages Operators on a cluster.
 
 ifndef::olm-user[]
-As a cluster administrator, you can install an Operator from OperatorHub using the {product-title}
+As a cluster administrator, you can install an Operator from OperatorHub by using the {product-title}
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 web console or CLI. Subscribing an Operator to one or more namespaces makes the Operator available to developers on your cluster.
 endif::[]
 endif::[]
 
 ifdef::olm-user[]
-As a user with the proper permissions, you can install an Operator from OperatorHub using the {product-title} web console or CLI.
+As a user with the proper permissions, you can install an Operator from OperatorHub by using the {product-title} web console or CLI.
 endif::[]
 
 During installation, you must determine the following initial settings for the Operator:

--- a/modules/olm-installing-po-after.adoc
+++ b/modules/olm-installing-po-after.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * operators/admin/olm-managing-po.adoc
+
+:_content-type: PROCEDURE
+[id="olm-installing-po-after_{context}"]
+= Installing platform Operators after cluster creation
+
+As a cluster administrator, you can install platform Operators after cluster creation on clusters that have enabled the `TechPreviewNoUpgrades` feature set by using the cluster-wide `PlatformOperator` API.
+
+.Procedure
+
+. Choose a platform Operator from the supported set of OLM-based Operators. For the list of this set and details on current limitations, see "Technology Preview restrictions for platform Operators".
+
+. Create a `PlatformOperator` object YAML file for your chosen platform Operator, for example a `cert-manager.yaml` file for the {cert-manager-operator}:
++
+.Example `cert-manager.yaml` file
+[source,yaml]
+----
+apiVersion: platform.openshift.io/v1alpha1
+kind: PlatformOperator
+metadata:
+  name: cert-manager
+spec:
+  package:
+    name: openshift-cert-manager-operator
+----
+
+. Create the `PlatformOperator` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f cert-manager.yaml
+----
+
+.Verification
+
+. Check the status of the `cert-manager` platform Operator by running the following command:
++
+[source,terminal]
+----
+$ oc get platformoperator cert-manager -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+...
+status:
+  activeBundleDeployment:
+    name: cert-manager
+  conditions:
+  - lastTransitionTime: "2022-10-24T17:24:40Z"
+    message: Successfully applied the cert-manager BundleDeployment resource
+    reason: InstallSuccessful
+    status: "True" <1>
+    type: Installed 
+----
+<1> Wait until the `Installed` status condition reports `True`.
+
+. Verify that the `platform-operators-aggregated` cluster Operator is reporting an `Available=True` status:
++
+[source,terminal]
+----
+$ oc get clusteroperator platform-operators-aggregate -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+...
+status:
+  conditions:
+  - lastTransitionTime: "2022-10-24T17:43:26Z"
+    message: All platform operators are in a successful state
+    reason: AsExpected
+    status: "False"
+    type: Progressing
+  - lastTransitionTime: "2022-10-24T17:43:26Z"
+    status: "False"
+    type: Degraded
+  - lastTransitionTime: "2022-10-24T17:43:26Z"
+    message: All platform operators are in a successful state
+    reason: AsExpected
+    status: "True"
+    type: Available
+----

--- a/modules/olm-installing-po-during.adoc
+++ b/modules/olm-installing-po-during.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies:
+//
+// * operators/admin/olm-managing-po.adoc
+
+:_content-type: PROCEDURE
+[id="olm-installing-po-during_{context}"]
+= Installing platform Operators during cluster creation
+
+As a cluster administrator, you can install platform Operators by providing `FeatureGate` and `PlatformOperator` manifests during cluster creation.
+
+.Procedure
+
+. Choose a platform Operator from the supported set of OLM-based Operators. For the list of this set and details on current limitations, see "Technology Preview restrictions for platform Operators".
+
+. Select a cluster installation method and follow the instructions through creating an `install-config.yaml` file. For more details on preparing for a cluster installation, see "Selecting a cluster installation method and preparing it for users".
+
+. After you have created the `install-config.yaml` file and completed any modifications to it, change to the directory that contains the installation program and create the manifests:
++
+[source,terminal]
+----
+$ ./openshift-install create manifests --dir <installation_directory> <1>
+----
+<1> For `<installation_directory>`, specify the name of the directory that contains the `install-config.yaml` file for your cluster.
+
+. Create a `FeatureGate` object YAML file in the `<installation_directory>/manifests/` directory that enables the `TechPreviewNoUpgrade` feature set, for example a `feature-gate.yaml` file:
++
+.Example `feature-gate.yaml` file
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+  name: cluster
+spec:
+  featureSet: TechPreviewNoUpgrade <1>
+----
+<1> Enable the `TechPreviewNoUpgrade` feature set.
+
+. Create a `PlatformOperator` object YAML file for your chosen platform Operator in the `<installation_directory>/manifests/` directory, for example a `cert-manager.yaml` file for the {cert-manager-operator}:
++
+.Example `cert-manager.yaml` file
+[source,yaml]
+----
+apiVersion: platform.openshift.io/v1alpha1
+kind: PlatformOperator
+metadata:
+  name: cert-manager
+spec:
+  package:
+    name: openshift-cert-manager-operator
+----
+
+. When you are ready to complete the cluster install, refer to your chosen installation method and continue through running the `openshift-install create cluster` command.
++
+During cluster creation, your provided manifests are used to enable the `TechPreviewNoUpgrade` feature set and install your chosen platform Operator.
++
+[IMPORTANT]
+====
+Failure of the platform Operator to successfully install will block the cluster installation process.
+====
+
+.Verification
+
+. Check the status of the `cert-manager` platform Operator by running the following command:
++
+[source,terminal]
+----
+$ oc get platformoperator cert-manager -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+...
+status:
+  activeBundleDeployment:
+    name: cert-manager
+  conditions:
+  - lastTransitionTime: "2022-10-24T17:24:40Z"
+    message: Successfully applied the cert-manager BundleDeployment resource
+    reason: InstallSuccessful
+    status: "True" <1>
+    type: Installed 
+----
+<1> Wait until the `Installed` status condition reports `True`.
+
+. Verify that the `platform-operators-aggregated` cluster Operator is reporting an `Available=True` status:
++
+[source,terminal]
+----
+$ oc get clusteroperator platform-operators-aggregate -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+...
+status:
+  conditions:
+  - lastTransitionTime: "2022-10-24T17:43:26Z"
+    message: All platform operators are in a successful state
+    reason: AsExpected
+    status: "False"
+    type: Progressing
+  - lastTransitionTime: "2022-10-24T17:43:26Z"
+    status: "False"
+    type: Degraded
+  - lastTransitionTime: "2022-10-24T17:43:26Z"
+    message: All platform operators are in a successful state
+    reason: AsExpected
+    status: "True"
+    type: Available
+----

--- a/modules/olm-po-techpreview.adoc
+++ b/modules/olm-po-techpreview.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * operators/admin/olm-managing-po.adoc
+
+:_content-type: CONCEPT
+[id="olm-po-techpreview_{context}"]
+= Technology Preview restrictions for platform Operators
+
+During the Technology Preview release of the platform Operators feature in {product-title} 4.12, the following restrictions determine whether an Operator can be installed through the platform Operators mechanism:
+
+* Kubernetes manifests must be packaged using the Operator Lifecycle Manager (OLM) `registry+v1` bundle format.
+* The Operator cannot declare package or group/version/kind (GVK) dependencies.
+* The Operator cannot specify cluster service version (CSV) install modes other than `AllNamespaces`
+* The Operator cannot specify any `Webhook` or `APIService` definitions.
+* All package bundles must be in the `redhat-operators` catalog source.
+
+After considering these restrictions, the following Operators can be successfully installed:
+
+.OLM-based Operators installable as platform Operators
+[cols="1,1"]
+|===
+|3scale-operator
+|amq-broker-rhel8
+
+|amq-online
+|amq-streams
+
+|ansible-cloud-addons-operator
+|apicast-operator
+
+|container-security-operator
+|eap
+
+|file-integrity-operator
+|gatekeeper-operator-product
+
+|integration-operator
+|jws-operator
+
+|kiali-ossm
+|node-healthcheck-operator
+
+|odf-csi-addons-operator
+|odr-hub-operator
+
+|openshift-cert-manager-operator
+|openshift-custom-metrics-autoscaler-operator
+
+|openshift-gitops-operator
+|openshift-pipelines-operator-rh
+
+|quay-operator
+|red-hat-camel-k
+
+|rhpam-kogito-operator
+|service-registry-operator
+
+|servicemeshoperator
+|skupper-operator
+|===
+
+[NOTE]
+====
+The following features are not available during this Technology Preview release:
+
+* Automatically upgrading platform Operator packages after cluster rollout
+* Extending the platform Operator mechanism to support any optional, CVO-based components
+====

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -27,7 +27,7 @@ endif::[]
 
 :_content-type: PROCEDURE
 [id="olm-restricted-networks-operatorhub_{context}"]
-= Disabling the default OperatorHub sources
+= Disabling the default OperatorHub catalog sources
 
 Operator catalogs that source content provided by Red Hat and community projects are configured for OperatorHub by default during an {product-title} installation.
 ifndef::olm-managing-custom-catalogs[]

--- a/modules/olm-rukpak-about.adoc
+++ b/modules/olm-rukpak-about.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_content-type: CONCEPT
+[id="olm-rukpak-about_{context}"]
+= RukPak (Technology Preview)
+
+:FeatureName: RukPak
+include::snippets/technology-preview.adoc[]
+
+{product-title} 4.12 introduces the _platform Operator_ type as a Technology Preview feature. The platform Operator mechanism relies on the RukPak component, also introduced in {product-title} 4.12, and its resources to manage content.
+
+RukPak consists of a series of controllers, known as _provisioners_, that install and manage content on a Kubernetes cluster. RukPak also provides two primary APIs: `Bundle` and `BundleDeployment`. These components work together to bring content onto the cluster and install it, generating resources within the cluster.
+
+A provisioner places a watch on both `Bundle` and `BundleDeployment` resources that refer to the provisioner explicitly. For a given bundle, the provisioner unpacks the contents of the `Bundle` resource onto the cluster. Then, given a `BundleDeployment` resource referring to that bundle, the provisioner installs the bundle contents and is responsible for managing the lifecycle of those resources.
+
+Two provisioners are currently implemented and bundled with RukPak: the _plain provisioner_ that sources and unpacks `plain+v0` bundles, and the _registry provisioner_ that sources and unpacks Operator Lifecycle Manager (OLM) `registry+v1` bundles.

--- a/modules/olm-rukpak-bd.adoc
+++ b/modules/olm-rukpak-bd.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_content-type: CONCEPT
+[id="olm-rukpak-bd_{context}"]
+= BundleDeployment
+
+[WARNING]
+====
+A `BundleDeployment` object changes the state of a Kubernetes cluster by installing and removing objects. It is important to verify and trust the content that is being installed and limit access, by using RBAC, to the `BundleDeployment` API to only those who require those permissions.
+====
+
+The RukPak `BundleDeployment` API points to a `Bundle` object and indicates that it should be active. This includes pivoting from older versions of an active bundle. A `BundleDeployment` object might also include an embedded spec for a desired bundle.
+
+Much like pods generate instances of container images, a bundle deployment generates a deployed version of a bundle. A bundle deployment can be seen as a generalization of the pod concept.
+
+The specifics of how a bundle deployment makes changes to a cluster based on a referenced bundle is defined by the provisioner that is configured to watch that bundle deployment.
+
+.Example `BundleDeployment` object configured to work with the plain provisioner
+[source,yaml]
+----
+apiVersion: core.rukpak.io/v1alpha1
+kind: BundleDeployment
+metadata:
+  name: my-bundle-deployment
+spec:
+  provisionerClassName: core-rukpak-io-plain
+  template:
+    metadata:
+      labels:
+        app: my-bundle
+    spec:
+      source:
+        type: image
+        image:
+          ref: my-bundle@sha256:xyz123
+      provisionerClassName: core-rukpak-io-plain
+----

--- a/modules/olm-rukpak-bundle-immutability.adoc
+++ b/modules/olm-rukpak-bundle-immutability.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_content-type: CONCEPT
+[id="olm-rukpak-bundle-immutability_{context}"]
+= Bundle immutability
+
+After a `Bundle` object is accepted by the API server, the bundle is considered an immutable artifact by the rest of the RukPak system. This behavior enforces the notion that a bundle represents some unique, static piece of content to source onto the cluster. A user can have confidence that a particular bundle is pointing to a specific set of manifests and cannot be updated without creating a new bundle. This property is true for both standalone bundles and dynamic bundles created by an embedded `BundleTemplate` object.
+
+Bundle immutability is enforced by the core RukPak webhook. This webhook watches `Bundle` object events and, for any update to a bundle, checks whether the `spec` field of the existing bundle is semantically equal to that in the proposed updated bundle. If they are not equal, the update is rejected by the webhook. Other `Bundle` object fields, such as `metadata` or `status`, are updated during the bundle's lifecycle; it is only the `spec` field that is considered immutable.
+
+Applying a `Bundle` object and then attempting to update its spec should fail. For example, the following example creates a bundle:
+
+[source,terminal]
+----
+$ oc apply -f -<<EOF
+apiVersion: core.rukpak.io/v1alpha1
+kind: Bundle
+metadata:
+  name: combo-tag-ref
+spec:
+  source:
+    type: git
+    git:
+      ref:
+        tag: v0.0.2
+      repository: https://github.com/operator-framework/combo
+  provisionerClassName: core-rukpak-io-plain
+EOF
+----
+
+.Example output
+[source,terminal]
+----
+bundle.core.rukpak.io/combo-tag-ref created
+----
+
+Then, patching the bundle to point to a newer tag returns an error:
+
+[source,terminal]
+----
+$ oc patch bundle combo-tag-ref --type='merge' -p '{"spec":{"source":{"git":{"ref":{"tag":"v0.0.3"}}}}}'
+----
+
+.Example output
+[source,terminal]
+----
+Error from server (bundle.spec is immutable): admission webhook "vbundles.core.rukpak.io" denied the request: bundle.spec is immutable
+----
+
+The core RukPak admission webhook rejected the patch because the spec of the bundle is immutable. The recommended method to change the content of a bundle is by creating a new `Bundle` object instead of updating it in-place.
+
+[discrete]
+[id="olm-rukpak-bundle-immutability-considerations_{context}"]
+== Further immutability considerations
+
+While the `spec` field of the `Bundle` object is immutable, it is still possible for a `BundleDeployment` object to pivot to a newer version of bundle content without changing the underlying `spec` field. This unintentional pivoting could occur in the following scenario:
+
+. A user sets an image tag, a Git branch, or a Git tag in the `spec.source` field of the `Bundle` object.
+. The image tag moves to a new digest, a user pushes changes to a Git branch, or a user deletes and re-pushes a Git tag on a different commit.
+. A user does something to cause the bundle unpack pod to be re-created, such as deleting the unpack pod.
+
+If this scenario occurs, the new content from step 2 is unpacked as a result of step 3. The bundle deployment detects the changes and pivots to the newer version of the content.
+
+This is similar to pod behavior, where one of the pod's container images uses a tag, the tag is moved to a different digest, and then at some point in the future the existing pod is rescheduled on a different node. At that point, the node pulls the new image at the new digest and runs something different without the user explicitly asking for it.
+
+To be confident that the underlying `Bundle` spec content does not change, use a digest-based image or a Git commit reference when creating the bundle.

--- a/modules/olm-rukpak-bundle.adoc
+++ b/modules/olm-rukpak-bundle.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_content-type: CONCEPT
+[id="olm-rukpak-bundle_{context}"]
+= Bundle
+
+A RukPak `Bundle` object represents content to make available to other consumers in the cluster. Much like the contents of a container image must be pulled and unpacked in order for pod to start using them, `Bundle` objects are used to reference content that might need to be pulled and unpacked. In this sense, a bundle is a generalization of the image concept and can be used to represent any type of content.
+
+Bundles cannot do anything on their own; they require a provisioner to unpack and make their content available in the cluster. They can be unpacked to any arbitrary storage medium, such as a `tar.gz` file in a directory mounted into the provisioner pods. Each `Bundle` object has an associated `spec.provisionerClassName` field that indicates the `Provisioner` object that watches and unpacks that particular bundle type.
+
+.Example `Bundle` object configured to work with the plain provisioner
+[source,yaml]
+----
+apiVersion: core.rukpak.io/v1alpha1
+kind: Bundle
+metadata:
+  name: my-bundle
+spec:
+  source:
+    type: image
+    image:
+      ref: my-bundle@sha256:xyz123
+  provisionerClassName: core-rukpak-io-plain
+----
+
+[NOTE]
+====
+Bundles are considered immutable after they are created.
+====

--- a/modules/olm-rukpak-plain-bundle.adoc
+++ b/modules/olm-rukpak-plain-bundle.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_content-type: CONCEPT
+[id="olm-rukpak-plain-bundle_{context}"]
+= Plain bundle spec
+
+A plain bundle in RukPak is a collection of static, arbitrary, Kubernetes YAML manifests in a given directory.
+
+The currently implemented plain bundle format is the `plain+v0` format. The name of the bundle format, `plain+v0`, combines the type of bundle (`plain`) with the current schema version (`v0`).
+
+[NOTE]
+====
+The `plain+v0` bundle format is at schema version `v0`, which means it is an experimental format that is subject to change.
+====
+
+For example, the following shows the file tree in a `plain+v0` bundle. It must have a `manifests/` directory containing the Kubernetes resources required to deploy an application.
+
+.Example `plain+v0` bundle file tree
+[source,terminal]
+----
+manifests
+├── namespace.yaml
+├── cluster_role.yaml
+├── role.yaml
+├── serviceaccount.yaml
+├── cluster_role_binding.yaml
+├── role_binding.yaml
+└── deployment.yaml
+----
+
+The static manifests must be located in the `manifests/` directory with at least one resource in it for the bundle to be a valid `plain+v0` bundle that the provisioner can unpack. The `manifests/` directory must also be flat; all manifests must be at the top-level with no subdirectories.
+
+[IMPORTANT]
+====
+Do not include any content in the `manifests/` directory of a plain bundle that are not static manifests. Otherwise, a failure will occur when creating content on-cluster from that bundle. Any file that would not successfully apply with the `oc apply` command will result in an error. Multi-object YAML or JSON files are valid, as well.
+====

--- a/modules/olm-rukpak-provisioner.adoc
+++ b/modules/olm-rukpak-provisioner.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_content-type: CONCEPT
+[id="olm-rukpak-provisioner_{context}"]
+= Provisioner
+
+A RukPak provisioner is a controller that understands the `BundleDeployment` and `Bundle` APIs and can take action. Each provisioner is assigned a unique ID and is responsible for reconciling `Bundle` and `BundleDeployment` objects with a `spec.provisionerClassName` field that matches that particular ID.
+
+For example, the plain provisioner is able to unpack a given `plain+v0` bundle onto a cluster and then instantiate it, making the content of the bundle available in the cluster.

--- a/modules/olm-rukpak-registry-bundle.adoc
+++ b/modules/olm-rukpak-registry-bundle.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-packaging-format.adoc
+
+:_content-type: CONCEPT
+[id="olm-rukpak-registry-bundle_{context}"]
+= Registry bundle spec
+
+A registry bundle, or `registry+v1` bundle, contains a set of static Kubernetes YAML manifests organized in the legacy Operator Lifecycle Manger (OLM) bundle format.

--- a/operators/admin/olm-adding-operators-to-cluster.adoc
+++ b/operators/admin/olm-adding-operators-to-cluster.adoc
@@ -9,7 +9,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Cluster administrators can install Operators to an {product-title} cluster by subscribing Operators to namespaces with OperatorHub.
+Using Operator Lifecycle Manager (OLM), cluster administrators can install OLM-based Operators to an {product-title} cluster.
 
 ifdef::openshift-origin[]
 [id="olm-adding-operators-to-a-cluster-prereqs"]

--- a/operators/admin/olm-creating-policy.adoc
+++ b/operators/admin/olm-creating-policy.adoc
@@ -24,7 +24,7 @@ include::modules/olm-policy-catalog-access.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-restricted-networks-operatorhub_olm-managing-custom-catalogs[Disabling the default OperatorHub sources]
+* xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-restricted-networks-operatorhub_olm-managing-custom-catalogs[Disabling the default OperatorHub catalog sources]
 * xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-creating-catalog-from-index_olm-managing-custom-catalogs[Adding a catalog source to a cluster]
 
 include::modules/olm-policy-troubleshooting.adoc[leveloffset=+1]

--- a/operators/admin/olm-managing-po.adoc
+++ b/operators/admin/olm-managing-po.adoc
@@ -1,0 +1,55 @@
+:_content-type: ASSEMBLY
+[id="olm-managing-po"]
+= Managing platform Operators (Technology Preview)
+include::_attributes/common-attributes.adoc[]
+:context: olm-managing-po
+
+toc::[]
+
+A platform Operator is an OLM-based Operator that can be installed during or after an OpenShift Container Platform cluster's Day 0 operations and participates in the cluster's lifecycle. As a cluster administrator, you can manage platform Operators by using the `PlatformOperator` API.
+
+:FeatureName: The platform Operator type
+include::snippets/technology-preview.adoc[]
+
+include::modules/arch-platform-operators.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operators/understanding/olm-packaging-format.adoc#olm-rukpak-about_olm-packaging-format[RukPak component and packaging format]
+* xref:../../post_installation_configuration/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
+
+include::modules/olm-po-techpreview.adoc[leveloffset=+2]
+
+[id="prerequisites_olm-managing-po"]
+== Prerequisites
+
+- Access to an {product-title} cluster using an account with `cluster-admin` permissions.
+- The `TechPreviewNoUpgrades` feature set enabled on the cluster.
++
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
+====
+- Only the `redhat-operators` catalog source enabled on the cluster. This is a restriction during the Technology Preview release.
+- The `oc` command installed on your workstation.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-restricted-networks-operatorhub_olm-managing-custom-catalogs[Disabling the default OperatorHub catalog sources]
+
+include::modules/olm-installing-po-during.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../operators/admin/olm-managing-po.adoc#olm-po-techpreview_olm-managing-po[Technology Preview restrictions for platform Operators]
+
+include::modules/olm-installing-po-after.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operators/admin/olm-managing-po.adoc#olm-po-techpreview_olm-managing-po[Technology Preview restrictions for platform Operators]
+
+include::modules/olm-deleting-po.adoc[leveloffset=+1]

--- a/operators/understanding/olm-packaging-format.adoc
+++ b/operators/understanding/olm-packaging-format.adoc
@@ -8,12 +8,6 @@ toc::[]
 
 This guide outlines the packaging format for Operators supported by Operator Lifecycle Manager (OLM) in {product-title}.
 
-[NOTE]
-====
-Support for the legacy _package manifest format_ for Operators is removed in {product-title} 4.8 and later. Existing Operator projects in the package manifest format can be migrated to the bundle format by using the Operator SDK `pkgman-to-bundle` command. See xref:../../operators/operator_sdk/osdk-pkgman-to-bundle.adoc#osdk-pkgman-to-bundle[Migrating package manifest projects to bundle format] for more details.
-====
-//Consider updating this during the 4.10 to 4.11 version scrub.
-
 include::modules/olm-bundle-format.adoc[leveloffset=+1]
 include::modules/olm-dependencies.adoc[leveloffset=+2]
 
@@ -62,3 +56,23 @@ For instructions about creating file-based catalogs by using the `opm` CLI, see 
 For reference documentation about the `opm` CLI commands related to managing file-based catalogs, see xref:../../cli_reference/opm/cli-opm-ref.adoc#cli-opm-ref[CLI tools].
 
 include::modules/olm-fb-catalogs-automation.adoc[leveloffset=+2]
+
+include::modules/olm-rukpak-about.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operators/admin/olm-managing-po.adoc#olm-managing-po[Managing platform Operators]
+* xref:../../operators/admin/olm-managing-po.adoc#olm-po-techpreview_olm-managing-po[Technology Preview restrictions for platform Operators]
+
+include::modules/olm-rukpak-bundle.adoc[leveloffset=+2]
+include::modules/olm-rukpak-bundle-immutability.adoc[leveloffset=+3]
+include::modules/olm-rukpak-plain-bundle.adoc[leveloffset=+3]
+include::modules/olm-rukpak-registry-bundle.adoc[leveloffset=+3]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operators/understanding/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[Legacy OLM bundle format]
+
+include::modules/olm-rukpak-bd.adoc[leveloffset=+2]
+include::modules/olm-rukpak-provisioner.adoc[leveloffset=+2]
+


### PR DESCRIPTION
Tech preview feature for OCP 4.12.

Related release notes PR: https://github.com/openshift/openshift-docs/pull/53859

[OSDOCS-4016](https://issues.redhat.com/browse/OSDOCS-4016) (PO arch overview)
[OSDOCS-4019](https://issues.redhat.com/browse/OSDOCS-4019) (Enable TP)
[OSDOCS-4672](https://issues.redhat.com/browse/OSDOCS-4672) (Install after cluster)
[OSDOCS-4022](https://issues.redhat.com/browse/OSDOCS-4022) (Uninstall)
[OSDOCS-4017](https://issues.redhat.com/browse/OSDOCS-4017) (RukPak concepts)

Preview:

* [Architecture / Control plane architecture / Platform Operators (Technology Preview)](https://52907--docspreview.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#platform-operators_control-plane)
* [Operators / Administrator tasks / Managing platform Operators](https://52907--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-po.html)
* [Operators / Understanding Operators / Packaging format / RukPak (Technology Preview)](https://52907--docspreview.netlify.app/openshift-enterprise/latest/operators/understanding/olm-packaging-format.html#olm-rukpak-about_olm-packaging-format)

Docs epic: https://issues.redhat.com/browse/OSDOCS-4012