### PR TITLE
SRVCOM-2100 install serverless operator using cli

### DIFF
--- a/modules/serverless-install-cli.adoc
+++ b/modules/serverless-install-cli.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+// * /serverless/install/install-serverless-operator.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-install-cli_{context}"]
+= Installing the {ServerlessOperatorName} from the CLI
+
+You can install the {ServerlessOperatorName} from the OperatorHub by using the CLI. Installing this Operator enables you to install and use Knative components.
+
+.Prerequisites
+
+ifdef::openshift-enterprise[]
+* You have access to an {product-title} account with cluster administrator access.
+* Your cluster has the Marketplace capability enabled or the Red Hat Operator catalog source configured manually.
+endif::[]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to an {product-title} account with cluster or dedicated administrator access.
+endif::[]
+
+* You have logged in to the {product-title} cluster.
+
+.Procedure
+. Create a YAML file containing `Namespace`, `OperatorGroup`, and `Subscription` objects to subscribe a namespace to the {ServerlessOperatorName}. For example, create the file `serverless-subscription.yaml` with the following content:
++
+.Example subscription
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-serverless
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: serverless-operators
+  namespace: openshift-serverless
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: serverless-operator
+  namespace: openshift-serverless
+spec:
+  channel: stable <1>
+  name: serverless-operator <2>
+  source: redhat-operators <3>
+  sourceNamespace: openshift-marketplace <4>
+----
+<1> The channel name of the Operator. The `stable` channel enables installation of the most recent stable version of the {ServerlessOperatorName}.
+<2> The name of the Operator to subscribe to. For the {ServerlessOperatorName}, this is always `serverless-operator`.
+<3> The name of the CatalogSource that provides the Operator. Use `redhat-operators` for the default OperatorHub catalog sources.
+<4> The namespace of the CatalogSource. Use `openshift-marketplace` for the default OperatorHub catalog sources.
+
+. Create the `Subscription` object:
++
+----
+$ oc apply -f serverless-subscription.yaml
+----
+
+.Verification
+Check that the cluster service version (CSV) has reached the `Succeeded` phase:
+
+.Example command
+[source,yaml]
+----
+$ oc get csv
+----
+
+.Example output
+[source,yaml]
+----
+NAME                          DISPLAY                        VERSION   REPLACES                      PHASE
+serverless-operator.v1.25.0   Red Hat OpenShift Serverless   1.25.0    serverless-operator.v1.24.0   Succeeded
+----

--- a/modules/serverless-install-web-console.adoc
+++ b/modules/serverless-install-web-console.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="serverless-install-web-console_{context}"]
-= Installing the {ServerlessOperatorName}
+= Installing the {ServerlessOperatorName} from the web console
 
 You can install the {ServerlessOperatorName} from the OperatorHub by using the {product-title} web console. Installing this Operator enables you to install and use Knative components.
 

--- a/serverless/install/install-serverless-operator.adoc
+++ b/serverless/install/install-serverless-operator.adoc
@@ -43,6 +43,13 @@ include::modules/serverless-install-web-console.adoc[leveloffset=+1]
 If you want to xref:../../serverless/serverless-tracing.adoc#serverless-tracing[use {DTProductName} with {ServerlessProductName}], you must install and configure {DTProductName} before you install Knative Serving or Knative Eventing.
 ====
 
+include::modules/serverless-install-cli.adoc[leveloffset=+1]
+
+[IMPORTANT]
+====
+If you want to xref:../../serverless/serverless-tracing.adoc#serverless-tracing[use {DTProductName} with {ServerlessProductName}], you must install and configure {DTProductName} before you install Knative Serving or Knative Eventing.
+====
+
 [id="additional-resources_install-serverless-operator"]
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION

Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-2100

Link to docs preview:
https://52908--docspreview.netlify.app/openshift-enterprise/latest/serverless/install/install-serverless-operator.html#serverless-install-cli_install-serverless-operator

QE review:
- [ ] QE has approved this change.
