### PR TITLE
OCP BUGS-1156: Adding download for macOS arm64 oc binary

### DIFF
--- a/modules/cli-installing-cli-web-console-macos.adoc
+++ b/modules/cli-installing-cli-web-console-macos.adoc
@@ -16,6 +16,12 @@ image::click-question-mark.png[]
 +
 image::CLI-list.png[]
 . Select the `oc` binary for macOS platform, and then click *Download oc for Mac for x86_64*.
++
+[NOTE]
+====
+For macOS arm64, click *Download oc for Mac for ARM 64*.
+====
+
 . Save the file.
 . Unpack and unzip the archive.
 . Move the `oc` binary to a directory on your PATH.

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -79,7 +79,7 @@ You can install the OpenShift CLI (`oc`) binary on Linux by using the following 
 .Procedure
 
 ifdef::openshift-origin[]
-. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
 . Download `oc.tar.gz`.
 endif::[]
 ifndef::openshift-origin[]
@@ -118,7 +118,7 @@ You can install the OpenShift CLI (`oc`) binary on Windows by using the followin
 .Procedure
 
 ifdef::openshift-origin[]
-. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
 . Download `oc.zip`.
 endif::[]
 ifndef::openshift-origin[]
@@ -151,13 +151,18 @@ You can install the OpenShift CLI (`oc`) binary on macOS by using the following 
 .Procedure
 
 ifdef::openshift-origin[]
-. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
 . Download `oc.tar.gz`.
 endif::[]
 ifndef::openshift-origin[]
 . Navigate to the link:https://access.redhat.com/downloads/content/290[{product-title} downloads page] on the Red Hat Customer Portal.
 . Select the appropriate version in the *Version* drop-down menu.
-. Click *Download Now* next to the *OpenShift v{product-version} MacOSX Client* entry and save the file.
+. Click *Download Now* next to the *OpenShift v{product-version} macOS Client* entry and save the file.
++
+[NOTE]
+====
+For macOS arm64, choose the *OpenShift v{product-version} macOS arm64 Client* entry.
+====
 endif::[]
 . Unpack and unzip the archive.
 . Move the `oc` binary to a directory on your PATH.
@@ -175,7 +180,6 @@ After you install the OpenShift CLI, it is available using the `oc` command:
 ----
 $ oc <command>
 ----
-
 
 ifeval::["{context}" == "updating-restricted-network-cluster"]
 :!restricted:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.11+

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
https://issues.redhat.com/browse/OCPBUGS-1156

Link to docs preview:
https://52911--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Ignore the "vBranch Build" in the preview. It will be replaced properly as "v4.12" etc when merged.

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
