### PR TITLE
OCPBUGS#2810: remove the table

### DIFF
--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -54,7 +54,7 @@ If you install {op-system} from an ISO image, you can add kernel arguments manua
 When adding networking arguments manually, you must also add the `rd.neednet=1` kernel argument to bring the network up in the initramfs.
 ====
 ifndef::ibm-z-kvm[]
-The following table provides examples for configuring networking and bonding on your {op-system} nodes for ISO installations. The examples describe how to use the `ip=`, `nameserver=`, and `bond=` kernel arguments.
+The following information provides examples for configuring networking and bonding on your {op-system} nodes for ISO installations. The examples describe how to use the `ip=`, `nameserver=`, and `bond=` kernel arguments.
 
 [NOTE]
 ====
@@ -63,10 +63,9 @@ Ordering is important when adding the kernel arguments: `ip=`, `nameserver=`, an
 
 The networking options are passed to the `dracut` tool during system boot. For more information about the networking options supported by `dracut`, see the `dracut.cmdline` manual page.
 
-.Networking and bonding options for ISO installations
 endif::ibm-z-kvm[]
 ifdef::ibm-z-kvm[]
-The following table provides examples for configuring networking on your {op-system} nodes for ISO installations. The examples describe how to use the `ip=` and `nameserver=` kernel arguments.
+The following information provides examples for configuring networking on your {op-system} nodes for ISO installations. The examples describe how to use the `ip=` and `nameserver=` kernel arguments.
 
 [NOTE]
 ====
@@ -74,139 +73,175 @@ Ordering is important when adding the kernel arguments: `ip=` and `nameserver=`.
 ====
 
 The networking options are passed to the `dracut` tool during system boot. For more information about the networking options supported by `dracut`, see the `dracut.cmdline` manual page.
-
-.Networking options for ISO installations
 endif::ibm-z-kvm[]
-|===
-|Description |Examples
 
-a|To configure an IP address, either use DHCP (`ip=dhcp`) or set an individual static IP address (`ip=<host_ip>`). If setting a static IP, you must then identify the DNS server IP address (`nameserver=<dns_ip>`) on each node. This example sets: +
+The following examples are the networking options for ISO installation.
 
-* The node's IP address to `10.10.10.2` +
-* The gateway address to `10.10.10.254` +
-* The netmask to `255.255.255.0` +
-* The hostname to `core0.example.com` +
+[discrete]
+=== Configuring DHCP or static IP addresses
+
+To configure an IP address, either use DHCP (`ip=dhcp`) or set an individual static IP address (`ip=<host_ip>`). If setting a static IP, you must then identify the DNS server IP address (`nameserver=<dns_ip>`) on each node. The following example sets:
+
+* The node's IP address to `10.10.10.2`
+* The gateway address to `10.10.10.254`
+* The netmask to `255.255.255.0`
+* The hostname to `core0.example.com`
 * The DNS server address to `4.4.4.41`
 * The auto-configuration value to `none`. No auto-configuration is required when IP networking is configured statically.
+
+[source,terminal]
+----
+ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none
+nameserver=4.4.4.41
+----
 
 [NOTE]
 ====
 When you use DHCP to configure IP addressing for the {op-system} machines, the machines also obtain the DNS server information through DHCP. For DHCP-based deployments, you can define the DNS server address that is used by the {op-system} nodes through your DHCP server configuration.
 ====
 
-a|
-----
-ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none
-nameserver=4.4.4.41
-----
+[discrete]
+=== Configuring an IP address without a static hostname
 
-a|You can configure an IP address without assigning a static hostname. If a static hostname is not set by the user, it will be picked up and automatically set by a reverse DNS lookup. To configure an IP address without a static hostname:
+You can configure an IP address without assigning a static hostname. If a static hostname is not set by the user, it will be picked up and automatically set by a reverse DNS lookup. To configure an IP address without a static hostname refer to the following example:
 
-* The node's IP address to `10.10.10.2` +
-* The gateway address to `10.10.10.254` +
-* The netmask to `255.255.255.0` +
+* The node's IP address to `10.10.10.2`
+* The gateway address to `10.10.10.254`
+* The netmask to `255.255.255.0`
 * The DNS server address to `4.4.4.41`
 * The auto-configuration value to `none`. No auto-configuration is required when IP networking is configured statically.
 
-a|
+[source,terminal]
 ----
 ip=10.10.10.2::10.10.10.254:255.255.255.0::enp1s0:none
 nameserver=4.4.4.41
 ----
 
-a|Specify multiple network interfaces by specifying multiple `ip=` entries.
+[discrete]
+=== Specifying multiple network interfaces
 
-a|
+You can specify multiple network interfaces by setting multiple `ip=` entries.
+
+[source,terminal]
 ----
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none
 ip=10.10.10.3::10.10.10.254:255.255.255.0:core0.example.com:enp2s0:none
 ----
 
-a|Optional: You can configure routes to additional networks by setting an `rd.route=` value.
+[discrete]
+=== Configuring default gateway and route
 
+Optional: You can configure routes to additional networks by setting an `rd.route=` value.
+
+[NOTE]
+====
 When you configure one or multiple networks, one default gateway is required. If the additional network gateway is different from the primary network gateway, the default gateway must be the primary network gateway.
-a|
-To configure the default gateway:
+====
 
+* Run the following command to configure the default gateway:
++
+[source,terminal]
 ----
 ip=::10.10.10.254::::
 ----
 
-To configure the route for the additional network:
-
+* Enter the following command to configure the route for the additional network:
++
+[source,terminal]
 ----
 rd.route=20.20.20.0/24:20.20.20.254:enp2s0
 ----
 
-a|Disable DHCP on a single interface, such as when there are two or more network interfaces and only one interface is being used. In the example, the `enp1s0` interface has a static networking configuration and DHCP is disabled for `enp2s0`, which is not used.
-a|
+[discrete]
+=== Disabling DHCP on a single interface
+
+You can disable DHCP on a single interface, such as when there are two or more network interfaces and only one interface is being used. In the example, the `enp1s0` interface has a static networking configuration and DHCP is disabled for `enp2s0`, which is not used:
+
+[source,terminal]
 ----
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none
 ip=::::core0.example.com:enp2s0:none
 ----
 
-a|You can combine DHCP
-and static IP configurations on systems with
-multiple network interfaces.
-a|
+[discrete]
+=== Combining DHCP and static IP configurations
+
+You can combine DHCP and static IP configurations on systems with multiple network interfaces, for example:
+
+[source,terminal]
 ----
 ip=enp1s0:dhcp
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp2s0:none
 ----
 
-a|Optional: You can configure VLANs on individual interfaces by using the `vlan=` parameter.
-a|
-To configure a VLAN on a network interface and use a static IP address:
+[discrete]
+=== Configuring VLANs on individual interfaces
 
+Optional: You can configure VLANs on individual interfaces by using the `vlan=` parameter.
+
+* To configure a VLAN on a network interface and use a static IP address, run the following command:
++
+[source,terminal]
 ----
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp2s0.100:none
 vlan=enp2s0.100:enp2s0
 ----
 
-To configure a VLAN on a network interface and to use DHCP:
-
+* To configure a VLAN on a network interface and to use DHCP, run the following command:
++
+[source,terminal]
 ----
 ip=enp2s0.100:dhcp
 vlan=enp2s0.100:enp2s0
 ----
 
-a|You can provide multiple DNS servers by adding a `nameserver=` entry for each server.
-a|
+[discrete]
+=== Providing multiple DNS servers
+
+You can provide multiple DNS servers by adding a `nameserver=` entry for each server, for example:
+
+[source,terminal]
 ----
 nameserver=1.1.1.1
 nameserver=8.8.8.8
 ----
 ifndef::ibm-z-kvm[]
-a|Optional: Bonding multiple network interfaces to a single interface is supported
-using the `bond=` option.  In these two examples:
+
+[discrete]
+=== Bonding multiple network interfaces to a single interface
+
+Optional: You can bond multiple network interfaces to a single interface by using the `bond=` option. Refer to the following examples:
 
 * The syntax for configuring a bonded interface is: `bond=name[:network_interfaces][:options]`
 +
 _name_ is the bonding device name (`bond0`), _network_interfaces_
 represents a comma-separated list of physical (ethernet) interfaces (`em1,em2`),
 and _options_ is a comma-separated list of bonding options. Enter `modinfo bonding` to see available options.
-* When you
-create a bonded interface using `bond=`, you must specify how the IP address
-is assigned and other
-information for the bonded interface.
-a|
-To configure the bonded interface to use DHCP, set the bond's IP address
-to `dhcp`. For example:
 
+* When you create a bonded interface using `bond=`, you must specify how the IP address is assigned and other
+information for the bonded interface.
+
+* To configure the bonded interface to use DHCP, set the bond's IP address to `dhcp`. For example:
++
+[source,terminal]
 ----
 bond=bond0:em1,em2:mode=active-backup
 ip=bond0:dhcp
 ----
 
-To configure the bonded interface to use a static IP address,
+* To configure the bonded interface to use a static IP address,
 enter the specific IP address you want and related information. For example:
 ifndef::ibm-z[]
++
+[source,terminal]
 ----
 bond=bond0:em1,em2:mode=active-backup
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
 ----
 endif::ibm-z[]
 ifdef::ibm-z[]
+
+[source,terminal]
 ----
 bond=bond0:em1,em2:mode=active-backup,fail_over_mac=1
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
@@ -215,25 +250,31 @@ ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
 Always set option `fail_over_mac=1` in active-backup mode, to avoid problems when shared OSA/RoCE cards are used.
 endif::ibm-z[]
 
-a|Optional: You can configure VLANs on bonded interfaces by using the `vlan=` parameter.
-a|
-To configure the bonded interface with a VLAN and to use DHCP:
+[discrete]
+=== Bonding multiple network interfaces to a single interface
 
+Optional: You can configure VLANs on bonded interfaces by using the `vlan=` parameter and to use DHCP, for example:
+
+[source,terminal]
 ----
 ip=bond0.100:dhcp
 bond=bond0:em1,em2:mode=active-backup
 vlan=bond0.100:bond0
 ----
 
-To configure the bonded interface with a VLAN and to use a static IP address:
+Use the following example to configure the bonded interface with a VLAN and to use a static IP address:
 
+[source,terminal]
 ----
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0.100:none
 bond=bond0:em1,em2:mode=active-backup
 vlan=bond0.100:bond0
 ----
 
-a|Optional: Network teaming can be used as an alternative to bonding by using the `team=` parameter. In this example:
+[discrete]
+=== Using network teaming
+
+Optional: You can use a network teaming as an alternative to bonding by using the `team=` parameter:
 
 * The syntax for configuring a team interface is: `team=name[:network_interfaces]`
 +
@@ -244,15 +285,15 @@ _name_ is the team device name (`team0`) and _network_interfaces_ represents a c
 Teaming is planned to be deprecated when {op-system} switches to an upcoming version of {op-system-base}. For more information, see this https://access.redhat.com/solutions/6509691[Red Hat Knowledgebase Article].
 ====
 
-a|
-To configure a network team:
+Use the following example to configure a network team:
 
+[source,terminal]
 ----
 team=team0:em1,em2
 ip=team0:dhcp
 ----
 endif::ibm-z-kvm[]
-|===
+
 ifndef::ibm-z,ibm-z-kvm,ibm-power[]
 [id="installation-user-infra-machines-coreos-installer-options_{context}"]
 == `coreos-installer` options for ISO and PXE installations


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->
The PR removes the table because there is too much information in the table.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.8+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/OCPBUGS-2810
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://52917--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-user-infra-machines-static-network_installing-platform-agnostic
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
