### PR TITLE
RHDEVDOCS-4744: Added a fixed issue in SBO 1.3.1 release notes

### DIFF
--- a/applications/connecting_applications_to_services/sbo-release-notes.adoc
+++ b/applications/connecting_applications_to_services/sbo-release-notes.adoc
@@ -41,6 +41,7 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 |*{servicebinding-title}* 2+|*API Group and Support Status*|*OpenShift Versions*
 
 |*Version*|*`binding.operators.coreos.com`* |*`servicebinding.io`* |
+|1.3.1    |GA                               |GA                    |4.9-4.11
 |1.3      |GA                               |GA                    |4.9-4.11
 |1.2      |GA                               |GA                    |4.7-4.11
 |1.1.1    |GA                               |TP                    |4.7-4.10
@@ -56,6 +57,7 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
 
 // Modules included, most to least recent
+include::modules/sbo-release-notes-1-3-1.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-3.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-2.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-1-1.adoc[leveloffset=+1]

--- a/modules/sbo-release-notes-1-3-1.adoc
+++ b/modules/sbo-release-notes-1-3-1.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assembly:
+//
+// * applications/connecting_applications_to_services/sbo-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="sbo-release-notes-1-3-1_{context}"]
+= Release notes for {servicebinding-title} 1.3.1
+
+{servicebinding-title} 1.3.1 is now available on {product-title} 4.9, 4.10, and 4.11.
+
+[id="fixed-issues-1-3-1_{context}"]
+== Fixed issues
+* Before this update, a security vulnerability `CVE-2022-32149` was noted for {servicebinding-title}. This update fixes the `CVE-2022-32149` error and updates the `golang.org/x/text` package from v0.3.7 to v0.3.8. link:https://issues.redhat.com/browse/APPSVC-1220[APPSVC-1220]


### PR DESCRIPTION
**Purpose**: To resolve this RN issue https://issues.redhat.com/browse/RHDEVDOCS-4744

**Aligned team**: Dev Tools

**OCP version for cherry-picking**: enterprise-4.11 and later

**Preview pages**: https://52921--docspreview.netlify.app/openshift-enterprise/latest/applications/connecting_applications_to_services/sbo-release-notes.html#sbo-release-notes-1-3-1_servicebinding-release-notes

**SME Review completed**: @sadlerap 
**QE review completed**: @pmacik 
**Peer-review completed**: @gabriel-rh  