### PR TITLE
RHDEVDOCS-4751 1.8.1 RN patch

### DIFF
--- a/modules/op-release-notes-1-8.adoc
+++ b/modules/op-release-notes-1-8.adoc
@@ -550,6 +550,10 @@ With this update, {pipelines-title} General Availability (GA) 1.8.1 is available
 [id="known-issues-1-8-1_{context}"]
 === Known issues
 
+* By default, the containers have restricted permissions for enhanced security. The restricted permissions apply to all controller pods in the {pipelines-title} Operator, and to some cluster tasks. Due to restricted permissions, the `git-clone` cluster task fails under certain configurations. 
++
+Workaround: None. You can track the issue link:https://issues.redhat.com/browse/SRVKP-2634[SRVKP-2634].
+
 * When installer sets are in a failed state, the status of the `TektonConfig` custom resource is incorrectly displayed as `True` instead of `False`.
 +
 .Example: Failed installer sets


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.11`, `enterprise-4.12`
- **JIRA issues**: [RHDEVDOCS-4751 Patch 1.8.1 RN](https://issues.redhat.com/browse/RHDEVDOCS-4751)
- **Preview pages**: [Known issues - 1.8.1 RN](https://52925--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#known-issues-1-8-1_op-release-notes)
- **SME review**: @concaf  
- **QE review**: @VeereshAradhya 