### PR TITLE
OSDOCS-4572: Added guidance on identifying min set of AWS permissions

### DIFF
--- a/installing/installing_aws/installing-aws-account.adoc
+++ b/installing/installing_aws/installing-aws-account.adoc
@@ -24,7 +24,16 @@ include::modules/installation-aws-iam-user.adoc[leveloffset=+1]
 
 * See xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[Manually creating IAM for AWS] for steps to set the Cloud Credential Operator (CCO) to manual mode prior to installation. Use this mode in environments where the cloud identity and access management (IAM) APIs are not reachable, or if you prefer not to store an administrator-level credential secret in the cluster `kube-system` project.
 
-include::modules/installation-aws-permissions-iam-roles.adoc[leveloffset=+1]
+include::modules/installation-aws-iam-policies-about.adoc[leveloffset=+1]
+
+include::modules/installation-aws-permissions-iam-roles.adoc[leveloffset=+2]
+include::modules/installation-aws-add-iam-roles.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* See xref:../../installing/installing_aws/installing-aws-customizations.adoc#installation-launching-installer_installing-aws-customizations[Deploying the cluster].
+
+include::modules/installation-aws-access-analyzer.adoc[leveloffset=+2]
 
 include::modules/installation-aws-marketplace.adoc[leveloffset=+1]
 

--- a/modules/installation-aws-access-analyzer.adoc
+++ b/modules/installation-aws-access-analyzer.adoc
@@ -1,0 +1,29 @@
+:_content-type: PROCEDURE
+[id="create-custom-permissions-for-iam-instance-profiles_{context}"]
+= Using AWS IAM Analyzer to create policy templates
+
+The minimal set of permissions that the control plane and compute instance profiles require depends on how the cluster is configured for its daily operation.
+
+One way to determine which permissions the cluster instances require is to use the AWS Identity and Access Management Access Analyzer (IAM Access Analyzer) to create a policy template:
+
+* A policy template contains the permissions the cluster has used over a specified period of time.
+* You can then use the template to create policies with fine-grained permissions.
+
+.Procedure
+
+The overall process could be:
+
+. Ensure that CloudTrail is enabled. CloudTrail records all of the actions and events in your AWS account, including the API calls that are required to create a policy template. For more information, see the AWS documentation for https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-getting-started.html[working with CloudTrail].
+. Create an instance profile for control plane instances and an instance profile for compute instances. Be sure to assign each role a permissive policy, such as PowerUserAccess. For more information, see the AWS documentation for
+https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html[creating instance profile roles].
+. Install the cluster in a development environment and configure it as required. Be sure to deploy all of applications the cluster will host in a production environment.
+. Test the cluster thoroughly. Testing the cluster ensures that all of the required API calls are logged.
+. Use the IAM Access Analyzer to create a policy template for each instance profile. For more information, see the AWS documentation for https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-policy-generation.html[generating policies based on the CloudTrail logs].
+. Create and add a fine-grained policy to each instance profile.
+. Remove the permissive policy from each instance profile.
+. Deploy a production cluster using the existing instance profiles with the new policies.
+
+[NOTE]
+====
+You can add https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html[IAM Conditions] to your policy to make it more restrictive and compliant with your organization security requirements.
+====

--- a/modules/installation-aws-add-iam-roles.adoc
+++ b/modules/installation-aws-add-iam-roles.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-account.adoc
+
+:_content-type: PROCEDURE
+[id="specify-an-existing-iam-role_{context}"]
+= Specifying an existing IAM role
+
+Instead of allowing the installation program to create IAM instance profiles with the default permissions, you can use the `install-config.yaml` file to specify an existing IAM role for control plane and compute instances.
+
+.Prerequisites
+
+* You have an existing `install-config.yaml` file.
+
+.Procedure
+
+. Update `compute.platform.aws.iamRole` with an existing role for the control plane machines.
++
+.Sample `install-config.yaml` file with an IAM role for compute instances
+[source,yaml]
+----
+compute:
+- hyperthreading: Enabled
+  name: worker
+  platform:
+    aws:
+      iamRole: ExampleRole
+----
+. Update `controlPlane.platform.aws.iamRole` with an existing role for the compute machines.
++
+.Sample `install-config.yaml` file with an IAM role for control plane instances
+[source,yaml]
+----
+controlPlane:
+  hyperthreading: Enabled
+  name: master
+  platform:
+    aws:
+      iamRole: ExampleRole
+----
+. Save the file and reference it when installing the {product-title} cluster.

--- a/modules/installation-aws-iam-policies-about.adoc
+++ b/modules/installation-aws-iam-policies-about.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-account.adoc
+
+:_content-type: CONCEPT
+[id="iam-policies-and-aws-authentication_{context}"]
+= IAM Policies and AWS authentication
+
+By default, the installation program creates instance profiles for the bootstrap, control plane, and compute instances with the necessary permissions for the cluster to operate.
+
+However, you can create your own IAM roles and specify them as part of the installation process. You might need to specify your own roles to deploy the cluster or to manage the cluster after installation. For example:
+
+* Your organization's security policies require that you use a more restrictive set of permissions to install the cluster.
+* After the installation, the cluster is configured with an Operator that requires access to additional services.
+
+If you choose to specify your own IAM roles, you can take the following steps:
+
+* Begin with the default policies and adapt as required. For more information, see "Default permissions for IAM instance profiles".
+* Use the AWS Identity and Access Management Access Analyzer (IAM Access Analyzer) to create a policy template that is based on the cluster's activity. For more information see, "Using AWS IAM Analyzer to create policy templates".

--- a/modules/installation-aws-permissions-iam-roles.adoc
+++ b/modules/installation-aws-permissions-iam-roles.adoc
@@ -3,16 +3,15 @@
 // * installing/installing_aws/installing-aws-account.adoc
 
 [id="installation-aws-permissions-iam-roles_{context}"]
-= Required AWS permissions for IAM roles
+= Default permissions for IAM instance profiles
 
-You have the option of defining your own IAM roles that are applied to the instance profiles of your machines created by the installation program. You can specify existing IAM roles by defining the `controlPlane.platform.aws.iamRole` and `compute.platform.aws.iamRoleThis` fields in the `install-config.yaml` file. You can use these fields to match naming schemes and include predefined permissions boundaries for your IAM roles.
+By default, the installation program creates IAM instance profiles for the bootstrap, control plane and worker instances with the necessary permissions for the cluster to operate.
 
-The control plane and compute machines require the following IAM role permissions:
+The following lists specify the default permissions for control plane and compute machines:
 
-.Required IAM role permissions for control plane instance profiles
+.Default IAM role permissions for control plane instance profiles
 [%collapsible]
 ====
-* `sts:AssumeRole`
 * `ec2:AttachVolume`
 * `ec2:AuthorizeSecurityGroupIngress`
 * `ec2:CreateSecurityGroup`
@@ -53,10 +52,9 @@ The control plane and compute machines require the following IAM role permission
 * `kms:DescribeKey`
 ====
 
-.Required IAM role permissions for compute instance profiles
+.Default IAM role permissions for compute instance profiles
 [%collapsible]
 ====
-* `sts:AssumeRole`
 * `ec2:DescribeInstances`
 * `ec2:DescribeRegions`
 ====


### PR DESCRIPTION
Version(s):
4.8+

Issue:
This PR addresses [osdocs-4572](https://issues.redhat.com/browse/OSDOCS-4572), which is a continuation of https://github.com/openshift/openshift-docs/pull/50937.

Link to docs preview:
[IAM Policies and AWS authentication](https://52928--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#iam-policies-and-aws-authentication_installing-aws-account)
IAM Policies and AWS authentication > [Default permissions for IAM instance profiles](https://52928--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-permissions-iam-roles_installing-aws-account)
IAM Policies and AWS authentication > [Specifying an existing IAM role](https://52928--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#specify-an-existing-iam-role_installing-aws-account)
IAM Policies and AWS authentication > [Using AWS IAM Analyzer to create policy templates](https://52928--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#create-custom-permissions-for-iam-instance-profiles_installing-aws-account)

QE review:
- [ ] QE has approved this change.