### PR TITLE
TELCODOCS-681 updating interface-specific systl allowlist

### DIFF
--- a/modules/nodes-safe-sysctls-list.adoc
+++ b/modules/nodes-safe-sysctls-list.adoc
@@ -57,9 +57,6 @@ a| This restricts `ICMP_PROTO` datagram sockets to users in the group range. The
 |===
 | sysctl | Description
 
-| `net.ipv4.conf.IFNAME.accept_ra`
-a|Accept IPv4 Router Advertisements; autoconfigure using them. It also determines whether or not to transmit router solicitations. Router solicitations are transmitted only if the functional setting is to accept router advertisements.
-
 | `net.ipv4.conf.IFNAME.accept_redirects`
 a| Accept IPv4 ICMP redirect messages.
 

--- a/modules/update-network-sysctl-allowlist.adoc
+++ b/modules/update-network-sysctl-allowlist.adoc
@@ -1,0 +1,222 @@
+// Module included in the following assemblies:
+//
+// * nodes/containers/nodes-containers-sysctls.adoc
+
+:_content-type: PROCEDURE
+[id="updating-interface-specific-safe-sysctls-list_{context}"]
+= Updating the interface-specific safe sysctls list
+
+{product-title} includes a predefined list of safe interface-specific `sysctls`. You can modify this list by updating the `cni-sysctl-allowlist` in the `openshift-multus` namespace.
+
+[IMPORTANT]
+====
+The support for updating the interface-specific safe sysctls list is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview
+features, see https://access.redhat.com/support/offerings/techpreview/.
+====
+
+Follow this procedure to modify the predefined list of safe `sysctls`. This procedure describes how to extend the default allow list.
+
+.Procedure
+
+. View the existing predefined list by running the following command:
++
+[source,terminal]
+----
+$ oc get cm -n openshift-multus cni-sysctl-allowlist -oyaml
+----
++
+.Expected output
++
+[source,terminal]
+----
+apiVersion: v1
+data:
+  allowlist.conf: |-
+    ^net.ipv4.conf.IFNAME.accept_redirects$
+    ^net.ipv4.conf.IFNAME.accept_source_route$
+    ^net.ipv4.conf.IFNAME.arp_accept$
+    ^net.ipv4.conf.IFNAME.arp_notify$
+    ^net.ipv4.conf.IFNAME.disable_policy$
+    ^net.ipv4.conf.IFNAME.secure_redirects$
+    ^net.ipv4.conf.IFNAME.send_redirects$
+    ^net.ipv6.conf.IFNAME.accept_ra$
+    ^net.ipv6.conf.IFNAME.accept_redirects$
+    ^net.ipv6.conf.IFNAME.accept_source_route$
+    ^net.ipv6.conf.IFNAME.arp_accept$
+    ^net.ipv6.conf.IFNAME.arp_notify$
+    ^net.ipv6.neigh.IFNAME.base_reachable_time_ms$
+    ^net.ipv6.neigh.IFNAME.retrans_time_ms$
+kind: ConfigMap
+metadata:
+  annotations:
+    kubernetes.io/description: |
+      Sysctl allowlist for nodes.
+    release.openshift.io/version: 4.12.0-0.nightly-2022-11-16-003434
+  creationTimestamp: "2022-11-17T14:09:27Z"
+  name: cni-sysctl-allowlist
+  namespace: openshift-multus
+  resourceVersion: "2422"
+  uid: 96d138a3-160e-4943-90ff-6108fa7c50c3
+----
+
+. Edit the list by using the following command:
++
+[source,terminal]
+----
+$ oc edit cm -n openshift-multus cni-sysctl-allowlist -oyaml
+----
++
+For example, to allow you to be able to implement stricter reverse path forwarding you need to add `^net.ipv4.conf.IFNAME.rp_filter$` and `^net.ipv6.conf.IFNAME.rp_filter$` to the list as shown here:
++
+[source,terminal]
+----
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: v1
+data:
+  allowlist.conf: |-
+    ^net.ipv4.conf.IFNAME.accept_redirects$
+    ^net.ipv4.conf.IFNAME.accept_source_route$
+    ^net.ipv4.conf.IFNAME.arp_accept$
+    ^net.ipv4.conf.IFNAME.arp_notify$
+    ^net.ipv4.conf.IFNAME.disable_policy$
+    ^net.ipv4.conf.IFNAME.secure_redirects$
+    ^net.ipv4.conf.IFNAME.send_redirects$
+    ^net.ipv4.conf.IFNAME.rp_filter$
+    ^net.ipv6.conf.IFNAME.accept_ra$
+    ^net.ipv6.conf.IFNAME.accept_redirects$
+    ^net.ipv6.conf.IFNAME.accept_source_route$
+    ^net.ipv6.conf.IFNAME.arp_accept$
+    ^net.ipv6.conf.IFNAME.arp_notify$
+    ^net.ipv6.neigh.IFNAME.base_reachable_time_ms$
+    ^net.ipv6.neigh.IFNAME.retrans_time_ms$
+    ^net.ipv6.conf.IFNAME.rp_filter$
+----
+
+. Save the changes to the file and exit.
++
+[NOTE]
+====
+The removal of `sysctls` is also supported. Edit the file, remove the `sysctl` or `sysctls` then save the changes and exit.
+====
+
+.Verification
+
+Follow this procedure to enforce stricter reverse path forwarding for IPv4.
+For more information on reverse path forwarding see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security_guide/sect-security_guide-server_security-reverse_path_forwarding[Reverse Path Forwarding
+].
+
+. Create a network attachment definition, such as `reverse-path-fwd-example.yaml`, with the following content:
++
+[source,yaml]
+----
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: tuningnad
+  namespace: default
+spec:
+  config: '{
+    "cniVersion": "0.4.0",
+    "name": "tuningnad",
+    "plugins": [{
+      "type": "bridge"
+      },
+      {
+      "type": "tuning",
+      "sysctl": {
+         "net.ipv4.conf.IFNAME.rp_filter": "1"
+        }
+    }
+  ]
+}'
+----
+
+. Apply the yaml by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f reverse-path-fwd-example.yaml
+----
++
+.Example output
+[source,terminal]
+----
+networkattachmentdefinition.k8.cni.cncf.io/tuningnad created
+----
+
+. Create a pod such as `examplepod.yaml` using the following YAML:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example
+  labels:
+    app: httpd
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/networks: tuningnad  <1>
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: httpd
+      image: 'image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest'
+      ports:
+        - containerPort: 8080
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+----
+<1> Specify the name of the configured `NetworkAttachmentDefinition`.
+
+. Apply the yaml by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f examplepod.yaml
+----
+
+. Verify that the pod is created by running the following command:
++
+[source,terminal]
+----
+$ oc get pod
+----
++
+.Example output
+[source,terminal]
+----
+NAME      READY   STATUS    RESTARTS   AGE
+example   1/1     Running   0          47s
+----
+
+. Log in to the pod by running the following command:
++
+[source,terminal]
+----
+$ oc rsh example
+----
+
+. Verify the value of the configured sysctl flag. For example, find the value `net.ipv4.conf.net1.rp_filter` by running the following command:
++
+[source,terminal]
+----
+sh-4.4# sysctl net.ipv4.conf.net1.rp_filter
+----
++
+.Expected output
+[source,terminal]
+----
+net.ipv4.conf.net1.rp_filter = 1
+----

--- a/nodes/containers/nodes-containers-sysctls.adoc
+++ b/nodes/containers/nodes-containers-sysctls.adoc
@@ -33,9 +33,13 @@ include::modules/nodes-namespaced-nodelevel-sysctls.adoc[leveloffset=+1]
 
 include::modules/nodes-safe-sysctls-list.adoc[leveloffset=+1]
 
+include::modules/update-network-sysctl-allowlist.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.kernel.org/networking/ip-sysctl.html[Linux networking documentation] 
+* xref:../../networking/setting-interface-level-network-sysctls.adoc#nw-configuring-tuning-cni_set-networkinterface-sysctls[Configuring the tuning CNI]
+
+* link:https://docs.kernel.org/networking/ip-sysctl.html[Linux networking documentation]
 
 include::modules/nodes-containers-start-pod-safe-sysctls.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[TELCODOCS-681](https://issues.redhat.com//browse/TELCODOCS-681): updating interface-specific systl allowlist

Version(s): 4.12 and main (TP)

Issue:
https://issues.redhat.com/browse/TELCODOCS-681

Link to docs preview: https://52932--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-sysctls.html#updating-interface-specific-safe-sysctls-list_nodes-containers-using


QE review:
- [x] QE has approved this change.

