### PR TITLE
BZ#2050304: Updated endpoint names for the Top Secret region

### DIFF
--- a/modules/installation-custom-aws-vpc.adoc
+++ b/modules/installation-custom-aws-vpc.adoc
@@ -69,9 +69,15 @@ endif::public[]
 ifndef::aws-china[]
 If you are working in a disconnected environment, you are unable to reach the public IP addresses for EC2 and ELB endpoints. To resolve this, you must create a VPC endpoint and attach it to the subnet that the clusters are using. The endpoints should be named as follows:
 
+.Government regions
 * `ec2.<region>.amazonaws.com`
 * `elasticloadbalancing.<region>.amazonaws.com`
 * `s3.<region>.amazonaws.com`
+
+.Top secret region
+* `ec2.<region>.c2s.ic.gov`
+* `elasticloadbalancing.<region>.c2s.ic.gov`
+* `s3.<region>.c2s.ic.gov`
 endif::aws-china[]
 
 ifdef::aws-china[]


### PR DESCRIPTION
Version(s):
4.9

Issue:
This PR address [bz-2050304](https://bugzilla.redhat.com/show_bug.cgi?id=2050304).

Link to docs preview:


[Requirements for using your VPC](http://file.rdu.redhat.com/mpytlak/bz-2050304-49/installing/installing_aws/installing-aws-government-region.html#installation-custom-aws-vpc-requirements_installing-aws-government-region) (Link requires access to RH VPN. A public build is not available for enterprise-4.9)

QE review:
- [x ] QE has approved this change.