### PR TITLE
OSDOCS-4579: Replace disconnected Operator KBase link w/ Ecosystem Catalog link

### DIFF
--- a/operators/admin/olm-restricted-networks.adoc
+++ b/operators/admin/olm-restricted-networks.adoc
@@ -27,9 +27,9 @@ While OLM can manage Operators from local sources, the ability for a given Opera
 * List any related images, or other container images that the Operator might require to perform their functions, in the `relatedImages` parameter of its `ClusterServiceVersion` (CSV) object.
 * Reference all specified images by a digest (SHA) and not by a tag.
 
-See the following Red Hat Knowledgebase Article for a list of Red Hat Operators that support running in disconnected mode:
+You can search on the Red Hat Ecosystem Catalog for a list of Red Hat Operators that support running in disconnected mode by selecting the *Disconnected* filter under *Infrastucture Features*:
 
-link:https://access.redhat.com/articles/4740011[]
+link:https://catalog.redhat.com/software/operators/search[]
 ====
 
 [role="_additional-resources"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-4579

Removing a KBase link that has a been a stopgap for years, but now the Customer Portal provides the same filtering search for "Disconnected" Operators as the OpenShift web console. 🙌 

Preview: https://52967--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html

Will also update the [KBase](https://access.redhat.com/login?redirectTo=https%3A%2F%2Faccess.redhat.com%2Farticles%2F4740011) to refer back to this updated section + the Portal link after this has been published.