### PR TITLE
OSDOCS#4551: Add the common terms for networking book

### DIFF
--- a/modules/nw-networking-glossary-terms.adoc
+++ b/modules/nw-networking-glossary-terms.adoc
@@ -1,0 +1,118 @@
+// Module included in the following assemblies:
+//
+// * networking/understanding-networking.adoc
+
+:_content-type: REFERENCE
+[id="nw-networking-glossary-terms_{context}"]
+= Common networking terms
+
+This glossary defines common terms that are used in the networking content.
+
+authentication::
+To control access to an {product-title} cluster, a cluster administrator can configure user authentication and ensure only approved users access the cluster. To interact with an {product-title} cluster, you must authenticate to the {product-title} API. You can authenticate by providing an OAuth access token or an X.509 client certificate in your requests to the {product-title} API.
+
+AWS Load Balancer Operator::
+The AWS Load Balancer (ALB) Operator deploys and manages an instance of the `aws-load-balancer-controller`.
+
+Cluster Network Operator::
+The Cluster Network Operator (CNO) deploys and manages the cluster network components in an {product-title} cluster. This includes deployment of the Container Network Interface (CNI) default network provider plug-in selected for the cluster during installation.
+
+config map::
+A config map provides a way to inject configuration data into pods. You can reference the data stored in a config map in a volume of type `ConfigMap`. Applications running in a pod can use this data.
+
+custom resource (CR)::
+A CR is extension of the Kubernetes API. You can create custom resources.
+
+DNS::
+Cluster DNS is a DNS server which serves DNS records for Kubernetes services. Containers started by Kubernetes automatically include this DNS server in their DNS searches.
+
+DNS Operator::
+The DNS Operator deploys and manages CoreDNS to provide a name resolution service to pods. This enables DNS-based Kubernetes Service discovery in {product-title}.
+
+deployment::
+A Kubernetes resource object that maintains the life cycle of an application.
+
+domain::
+Domain is a DNS name serviced by the Ingress Controller.
+
+egress::
+The process of data sharing externally through a network’s outbound traffic from a pod.
+
+External DNS Operator::
+The External DNS Operator deploys and manages ExternalDNS to provide the name resolution for services and routes from the external DNS provider to {product-title}.
+
+HTTP-based route::
+An HTTP-based route is an unsecured route that uses the basic HTTP routing protocol and exposes a service on an unsecured application port.
+
+Ingress::
+The Kubernetes Ingress resource in {product-title} implements the Ingress Controller with a shared router service that runs as a pod inside the cluster.
+
+Ingress Controller::
+The Ingress Operator manages Ingress Controllers. Using an Ingress Controller is the most common way to allow external access to an {product-title} cluster.
+
+installer-provisioned infrastructure::
+The installation program deploys and configures the infrastructure that the cluster runs on.
+
+kubelet::
+A primary node agent that runs on each node in the cluster to ensure that containers are running in a pod.
+
+Kubernetes NMState Operator::
+The Kubernetes NMState Operator provides a Kubernetes API for performing state-driven network configuration across the {product-title} cluster’s nodes with NMState.
+
+kube-proxy::
+Kube-proxy is a proxy service which runs on each node and helps in making services available to the external host. It helps in forwarding the request to correct containers and is capable of performing primitive load balancing.
+
+load balancers::
+{product-title} uses load balancers for communicating from outside the cluster with services running in the cluster.
+
+MetalLB Operator::
+As a cluster administrator, you can add the MetalLB Operator to your cluster so that when a service of type `LoadBalancer` is added to the cluster, MetalLB can add an external IP address for the service.
+
+multicast::
+With IP multicast, data is broadcast to many IP addresses simultaneously.
+
+namespaces::
+A namespace isolates specific system resources that are visible to all processes. Inside a namespace, only processes that are members of that namespace can see those resources.
+
+networking::
+Network information of a {product-title} cluster.
+
+node::
+A worker machine in the {product-title} cluster. A node is either a virtual machine (VM) or a physical machine.
+
+{product-title} Ingress Operator::
+The Ingress Operator implements the `IngressController` API and is the component responsible for enabling external access to {product-title} services.
+
+pod::
+One or more containers with shared resources, such as volume and IP addresses, running in your {product-title} cluster.
+A pod is the smallest compute unit defined, deployed, and managed.
+
+PTP Operator::
+The PTP Operator creates and manages the `linuxptp` services.
+
+route::
+The {product-title} route provides Ingress traffic to services in the cluster. Routes provide advanced features that might not be supported by standard Kubernetes Ingress Controllers, such as TLS re-encryption, TLS passthrough, and split traffic for blue-green deployments.
+
+scaling::
+Increasing or decreasing the resource capacity.
+
+service::
+Exposes a running application on a set of pods.
+
+Single Root I/O Virtualization (SR-IOV) Network Operator::
+The Single Root I/O Virtualization (SR-IOV) Network Operator manages the SR-IOV network devices and network attachments in your cluster.
+
+software-defined networking (SDN)::
+{product-title} uses a software-defined networking (SDN) approach to provide a unified cluster network that enables communication between pods across the {product-title} cluster.
+
+Stream Control Transmission Protocol (SCTP)::
+SCTP is a reliable message based protocol that runs on top of an IP network.
+
+taint::
+Taints and tolerations ensure that pods are scheduled onto appropriate nodes. You can apply one or more taints on a node.
+
+toleration::
+You can apply tolerations to pods. Tolerations allow the scheduler to schedule pods with matching taints.
+
+web console::
+A user interface (UI) to manage {product-title}.

--- a/networking/understanding-networking.adoc
+++ b/networking/understanding-networking.adoc
@@ -25,3 +25,4 @@ If you allow a pod host network access, you grant the pod privileged access to t
 include::modules/nw-ne-openshift-dns.adoc[leveloffset=+1]
 include::modules/nw-ne-openshift-ingress.adoc[leveloffset=+1]
 include::modules/nw-ne-comparing-ingress-route.adoc[leveloffset=+2]
+include::modules/nw-networking-glossary-terms.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.8+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/OSDOCS-4551
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://52972--docspreview.netlify.app/openshift-enterprise/latest/networking/understanding-networking.html#nw-networking-glossary-terms_understanding-networking
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->

This content has QE acks from this [PR](https://github.com/openshift/openshift-docs/pull/52765) which got automatically closed.