### PR TITLE
 Agent-10: Adds openshift-install agent wait-for bootstrap-complete  subcommand

### DIFF
--- a/modules/installing-ocp-agent.adoc
+++ b/modules/installing-ocp-agent.adoc
@@ -147,6 +147,30 @@ agent.iso  auth
 $ openshift-install agent create image
 ----
 
+. Optional:  To know  when the bootstrap node (** Node 0 **) reboots, run the following command:
+
++
+[source,terminal]
+----
+$ ./openshift-install --dir <manifests_directory> wait-for bootstrap-complete \ <1>
+    --log-level=info <2>
+----
+<1> For `<manifests_directory>`, specify the path to the directory that you stored the manifest files in.
+<2> To view different installation details, specify `warn`, `debug`, or `error` instead of `info`.
+
++
+.Example output
+[source,terminal]
+----
+INFO Waiting up to 30m0s for the Kubernetes API at https://api.test.example.com:6443...
+INFO API v1.25.0 up
+INFO Waiting up to 30m0s for bootstrapping to complete...
+INFO It is now safe to remove the bootstrap resources
+----
++
+The command succeeds when the Kubernetes API server signals that it has been
+bootstrapped on the control plane machines.
+
 . Boot the `agent.iso` image on the bare metal machines. You can run the image on any Linux distribution.
 
 . To track the progress and verify sucessful installation, run the following command:
@@ -167,3 +191,5 @@ INFO To access the cluster as the system:admin user when using 'oc', run
 INFO     export KUBECONFIG=/home/core/installer/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.sno-cluster.test.example.com
 ----
+
+


### PR DESCRIPTION
- Applies to main and 4.12
- [Jira](https://issues.redhat.com/browse/AGENT-10)
- [Preview](https://52973--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html)
- @lranjbar ptal and review.