### PR TITLE
docs.openshift.com UX improvements - move search to nav

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -29,7 +29,7 @@ nav#main {
     filter: drop-shadow(0.6em 0.01em 0.2em);
   }
 }
-    
+
 .navbar.navbar-default.navbar-openshift .navbar-brand.origin {
   background: url("../_images/okd_logo.svg") no-repeat scroll 0% 95%;
   background-size: 140px;
@@ -438,7 +438,7 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
     margin-left: 5px;
     display: flex;
     flex-flow: column;
-    top: 190px;
+    top: 160px;
     bottom: 10px;
     display: block;
     -webkit-animation: fadein 0.35s ease-in; /* Safari, Chrome and Opera > 12.1 */
@@ -446,19 +446,6 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
         -ms-animation: fadein 0.35s ease-in; /* Internet Explorer */
          -o-animation: fadein 0.35s ease-in; /* Opera < 12.1 */
             animation: fadein 0.35s ease-in;
-  }
-
-  #hc-search {
-    position: fixed;
-    top: 160px;
-    width: 358px;
-  }
-
-  #hc-search-btn {
-      border: 1px solid lightgrey;
-      font-size: 12px;
-      height: 25px;
-      width: 31px;
   }
 
   .breadcrumb {
@@ -661,6 +648,38 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
   overflow-wrap: break-word;
 }
 
+#hc-search-btn {
+    font-family: 'Material Icons Outlined';
+    border: none;
+    font-weight: normal;
+    font-style: normal;
+    font-weight: normal;
+    font-size: 24px;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    height: unset;
+    width: 28px;
+    background-color: transparent;
+    -webkit-font-feature-settings: 'liga';
+    -webkit-font-smoothing: antialiased;
+}
+
+#hc-search-input {
+    border: 1px solid lightgrey;
+    font-size: 16px;
+    height: unset;
+    width: 50%;
+    position: relative;
+    margin-right: -5px;
+    top: -6px;
+}
+
+
 /*tablet browsers*/
 
 @media (max-width: 1424px) {
@@ -692,7 +711,7 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
     margin-left: 5px;
     display: flex;
     flex-flow: column;
-    top: 190px;
+    top: 160px;
     bottom: 10px;
     display: block;
     -webkit-animation: fadein 0.35s ease-in; /* Safari, Chrome and Opera > 12.1 */
@@ -700,26 +719,6 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
         -ms-animation: fadein 0.35s ease-in; /* Internet Explorer */
          -o-animation: fadein 0.35s ease-in; /* Opera < 12.1 */
             animation: fadein 0.35s ease-in;
-  }
-
-  #hc-search {
-    position: fixed;
-    top: 160px;
-    width: 305px;
-  }
-
-  #hc-search-btn {
-    border: 1px solid lightgrey;
-    font-size: 12px;
-    height: 25px;
-    width: 30px;
-    padding: 1px;
-  }
-
-  #hc-search-input {
-      border: 1px solid lightgrey;
-      font-size: 12px;
-      height: 25px;
   }
 
   .breadcrumb {
@@ -940,10 +939,6 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
       width: 100%;
   }
 
-  .nav {
-    padding-top: 15px;
-  }
-
   #toc:before {
     display: none;
   }
@@ -1036,17 +1031,8 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
     margin-bottom: 3px;
   }
 
-  .btn-close {
-    padding: 2px;
-  }
-
   .close-btn-sm {
     display: unset;
-  }
-
-  #hc-search {
-    top: 40px;
-    position: unset;
   }
 
 }

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -184,7 +184,14 @@
         <%= breadcrumb_topic %>
       </li>
       <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro" && distro_key != "openshift-acs") %>
-      <span text-align="right" style="float: right !important">
+      <!--Moving search to the secondary nav bar -->
+      <span text-align="right" style="float: right !important;     margin-right: -40px;">
+
+        <input id="hc-search-input" type="text" aria-label="search" placeholder="Start searching...">
+        <button id="hc-search-btn" aria-label="search">
+          <span class="material-icons-outlined">search</span>
+        </button>
+
         <a href="https://github.com/openshift/openshift-docs/commits/<%=
         ((distro_key == "openshift-enterprise") ? "enterprise-#{version}"
           : (distro_key == "openshift-aro") ? "aro-work"
@@ -236,15 +243,6 @@
     </ol>
     <div class="row row-offcanvas row-offcanvas-left">
       <div class="col-xs-8 col-sm-3 col-md-3 sidebar sidebar-offcanvas hide-for-print">
-        <div class="row-fluid">
-          <div id="btn-close">
-            <button id="hc-close-btn" onclick="closeNav()" class="close-btn-sm" aria-label="close"><span class="fa fa-times" /></button>
-          </div>
-          <div id="hc-search">
-            <input id="hc-search-input" type="text" aria-label="search">
-            <button id="hc-search-btn" aria-label="search"><span class="fa fa-search" /></button>
-          </div>
-        </div>
         <%= render("_templates/_nav_openshift.html.erb", :distro_key => distro_key, :navigation => navigation, :group_id => group_id, :topic_id => topic_id, :subgroup_id => subgroup_id, :subtopic_shim => subtopic_shim, :subsubgroup_id => subsubgroup_id) %>
       </div>
       <div id="hc-search-modal">
@@ -375,7 +373,6 @@
         adjustMain();
       } else if ($(window).width() < 1008) {
         sidebar.classList.remove('wide');
-        document.querySelector('#hc-search').classList.remove('wide');
         if (sidebar.classList.contains('open')) {
           sidebar.style.display = 'block';
         } else {
@@ -387,21 +384,19 @@
 
     function adjustSide() {
       sidebar.classList.add('wide');
-      document.querySelector('#hc-search').classList.add('wide');
       sidebar.style.display = 'block';
-      document.querySelector('.sidebar').style.top = parseInt((document.querySelector('.breadcrumb').offsetHeight + 125), 10) + "px";
-      document.querySelector('#hc-search').style.top = parseInt((document.querySelector('.breadcrumb').offsetHeight + 95), 10) + "px";
+      document.querySelector('.sidebar').style.top = parseInt((document.querySelector('.breadcrumb').offsetHeight + 91), 10) + "px";
     }
 
     function adjustToc() {
       if (document.querySelector('#toc') !== null) {
-        document.querySelector('#toc').style.top = parseInt((document.querySelector('.breadcrumb').offsetHeight + 90), 10) + "px";
+        document.querySelector('#toc').style.top = parseInt((document.querySelector('.breadcrumb').offsetHeight + 91), 10) + "px";
       }
     }
 
     function adjustMain() {
-      document.querySelector('html').style.scrollPaddingTop = parseInt((document.querySelector('.breadcrumb').offsetHeight + 90), 10) + "px";
-      document.querySelector('.main').style.paddingTop = parseInt((document.querySelector('.breadcrumb').offsetHeight - 70), 10) + "px";
+      document.querySelector('html').style.scrollPaddingTop = parseInt((document.querySelector('.breadcrumb').offsetHeight + 87), 10) + "px";
+      document.querySelector('.main').style.paddingTop = parseInt((document.querySelector('.breadcrumb').offsetHeight - 63), 10) + "px";
     }
 
   </script>
@@ -437,6 +432,8 @@
 
   <!-- open/close the nav -->
   <script type="text/javascript">
+    main = document.querySelector('.main')
+
     function closeNav() {
       let sidebar = document.querySelector(".sidebar");
       sidebar.style.display = "none";
@@ -451,6 +448,14 @@
       hc_search.style.top = 'unset';
       sidebar.classList.add('open');
     }
+
+    //Close nav when users clicks outside the nav on mobile/tablet viewports
+    main.addEventListener('click', () => {
+      if ($(window).width() < 1008) {
+        closeNav()
+      };
+    })
+
   </script>
 
   <!-- clear and add toc-active to clicked toc link -->


### PR DESCRIPTION
Updates: 
1. Moved search bar into the right-hand side of the breadcrumb nav bar.
2. Clicking on main area of page closes the TOC on smaller viewports

Preview (needs VPN): http://file.emea.redhat.com/aireilly/fix-search-css-safari/welcome/index.html

Merge to main, all branches 

Merge alongside https://github.com/openshift/openshift-docs/pull/54344