### PR TITLE
CNV-16414: RN that critical alerts are now GA

### DIFF
--- a/virt/virt-4-12-release-notes.adoc
+++ b/virt/virt-4-12-release-notes.adoc
@@ -46,15 +46,13 @@ The SVVP Certification applies to:
 
 //CNV-18488 SVVP for 4.12
 
+//CNV-16414
+* {VirtProductName} has xref:../virt/logging_events_monitoring/virt-virtualization-alerts.adoc#virt-virtualization-alerts[critical alerts] that inform you when a problem occurs that requires immediate attention. Now, each alert has a corresponding description of the problem, a reason for why the alert is occurring, a troubleshooting process to diagnose the source of the problem, and steps for resolving the alert. This feature was previously introduced as a Technology Preview and is now generally available.
 
 //CNV-17984 Comply with cluster-wide crypto policy
 
 
-<<<<<<< HEAD
-//CNV-17986 New alerts added
-=======
 //CNV-17986 Release note announcing new alerts added
->>>>>>> 08366e3b0f (rn update Jira query)
 
 
 //CNV-19780 CNV Maturity and dataVolumeTemplates
@@ -72,12 +70,9 @@ The SVVP Certification applies to:
 //CNV-18772 Virtualization Overview page redesign
 
 
-<<<<<<< HEAD
-=======
 //CNV-18432 UI create live migration page
 
 
->>>>>>> 08366e3b0f (rn update Jira query)
 //CNV-18453 Live migration with shared storage for work intensive workloads
 
 
@@ -93,15 +88,12 @@ The SVVP Certification applies to:
 //CNV-17809 Live migration with shared storage for work intensive workloads
 
 
-<<<<<<< HEAD
-=======
 //CNV-20936 UI - live YAML view
 
 
 //CNV-18459 UI - CNV settings page
 
 
->>>>>>> 08366e3b0f (rn update Jira query)
 //CNV-18462 Retire storage alpha apis
 
 
@@ -131,24 +123,11 @@ The SVVP Certification applies to:
 [id="virt-4-12-storage-new"]
 === Storage
 
-<<<<<<< HEAD
-=======
 //CNV-16785 Snapshot metrics
->>>>>>> 08366e3b0f (rn update Jira query)
 
 [id="virt-4-12-web-new"]
 === Web console
 
-<<<<<<< HEAD
-//CNV-20936 UI - live YAML view
-
-
-//CNV-18459 UI - CNV settings page
-
-
-//CNV-18432 UI create live migration page
-
-=======
 //CNV-18319 UI can switch between BIOS and UEFI
 * You can set the xref:../virt/virtual_machines/virt-edit-vms.adoc#virt-editing-vm-web_virt-edit-vms[boot mode] of templates and virtual machines to *BIOS*, *UEFI*, or *UEFI (secure)* by using the web console.
 
@@ -161,7 +140,6 @@ The SVVP Certification applies to:
 
 //CNV-17806 Updated design of the templates list page
 * You can access virtual machine templates by navigating to *Virtualization* -> *Templates* in the side menu. The updated *Virtual Machine Templates* page now provides useful information about each template, including workload profile, boot source, and CPU and memory configuration.
->>>>>>> 08366e3b0f (rn update Jira query)
 
 // NOTE: Comment out deprecated and removed features (and their IDs) if not used in a release
 [id="virt-4-12-deprecated-removed"]
@@ -175,16 +153,11 @@ Deprecated features are included in the current release and supported. However, 
 
 * In a future release, support for the legacy HPP custom resource, and the associated storage class, will be deprecated. Beginning in {VirtProductName} {VirtVersion}, the HPP Operator uses the Kubernetes Container Storage Interface (CSI) driver to configure local storage. The Operator continues to support the existing (legacy) format of the HPP custom resource and the associated storage class. If you use the HPP Operator, plan to xref:../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-configuring-local-storage-for-vms[create a storage class for the CSI driver] as part of your migration strategy.
 
-<<<<<<< HEAD
-=======
 //CNV-17665 Deprecate NMO
->>>>>>> 08366e3b0f (rn update Jira query)
 
 [id="virt-4-12-removed"]
 === Removed features
 
-<<<<<<< HEAD
-=======
 Removed features are not supported in the current release.
 
 //CNV-16317 NMState is no longer part of CNV
@@ -197,17 +170,13 @@ Removed features are not supported in the current release.
 --
 +
 To preserve and support your existing nmstate configuration, install the xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState Operator] before updating to {VirtProductName} {VirtVersion}. You can install it from the *OperatorHub* in the {product-title} web console, or by using the OpenShift CLI (`oc`).
->>>>>>> 08366e3b0f (rn update Jira query)
 
 [id="virt-4-12-changes"]
 == Notable technical changes
 
-<<<<<<< HEAD
-=======
 * The *Create a Virtual Machine* wizard in the web console is now xref:../virt/virtual_machines/virt-create-vms.adoc#virt-quick-creating-vm_virt-create-vms[replaced by the *Catalog* screen], which lists available templates that you can use to create a virtual machine. You can use a template with an available boot source to quickly create a virtual machine or you can customize a template to create a virtual machine.
 
 //CNV-18323 VM templates can be made public i.e. available to all users
->>>>>>> 08366e3b0f (rn update Jira query)
 
 [id="virt-4-12-technology-preview"]
 == Technology Preview features
@@ -216,16 +185,9 @@ Some features in this release are currently in Technology Preview. These experim
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
-<<<<<<< HEAD
-//CNV-20963
-* You can now use Microsoft Windows 11 as a guest operating system. However, {VirtProductName} {VirtVersion} does not support USB disks, which are required for a critical function of BitLocker recovery. To protect recovery keys, use other methods described in the link:https://learn.microsoft.com/en-us/windows/security/information-protection/bitlocker/bitlocker-recovery-guide-plan[BitLocker recovery guide].
-=======
 * You can now use the Red Hat Enterprise Linux 9 Alpha template to create virtual machines.
->>>>>>> 08366e3b0f (rn update Jira query)
 
 * You can now link:https://access.redhat.com/articles/6409731[deploy {VirtProductName} on AWS bare metal nodes].
-
-* {VirtProductName} has xref:../virt/logging_events_monitoring/virt-virtualization-alerts.adoc#virt-virtualization-alerts[critical alerts] that inform you when a problem occurs that requires immediate attention. Now, each alert has a corresponding description of the problem, a reason for why the alert is occurring, a troubleshooting process to diagnose the source of the problem, and steps for resolving the alert.
 
 * Administrators can now declaratively xref:../virt/virtual_machines/advanced_vm_management/virt-configuring-mediated-devices.adoc#virt-configuring-mediated-devices[create and expose mediated devices] such as virtual graphics processing units (vGPUs) by editing the `HyperConverged` CR. Virtual machine owners can then assign these devices to VMs.
 
@@ -249,7 +211,6 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 [id="virt-4-12-bug-fixes"]
 == Bug fixes
 
-<<<<<<< HEAD
 [id="virt-4-12-known-issues"]
 == Known issues
 
@@ -279,48 +240,6 @@ This step is optional if you specified a value for `spec.dataVolumeTemplates`.
 ** As a workaround, you can disable the image limit by xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing[editing the `KubeletConfig` object] and setting the value of `nodeStatusMaxImages` to `-1`.
 
 //BZ-1885605
-=======
-* Previously, on a large cluster, the {VirtProductName} MAC pool manager would take too much time to boot and {VirtProductName} might not become ready. With this update, the pool initialization and startup latency is reduced. As a result, VMs can now be successfully defined. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2035344[*BZ#2035344*])
-
-* If a Windows VM crashes or hangs during shutdown, you can now manually issue a force shutdown request to stop the VM. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2040766[*BZ#2040766*])
-
-* The YAML examples in the VM wizard have now been updated to contain the latest upstream changes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2055492[*BZ#2055492*])
-
-* The *Add Network Interface* button on the VM *Network Interfaces* tab is no longer disabled for non-privileged users. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2056420[*BZ#2056420*])
-
-* A non-privileged user can now successfully add disks to a VM without getting a RBAC rule error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2056421[*BZ#2056421*])
-
-* The web console now successfully displays virtual machine templates that are deployed to a custom namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054650[*BZ#2054650*])
-
-* Previously, updating a Single Node OpenShift (SNO) cluster failed if the `spec.evictionStrategy` field was set to `LiveMigrate` for a VMI. For live migration to succeed, the cluster must have more than one compute node. With this update, the `spec.evictionStrategy` field is removed from the virtual machine template in a SNO environment. As a result, cluster update is now successful. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2073880[*BZ#2073880*])
-
-
-[id="virt-4-12-known-issues"]
-== Known issues
-
-//New known issues for 4.11 go above this comment
-
-* If a single node contains more than 50 images, pod scheduling might be imbalanced across nodes. This is because the list of images on a node is shortened to 50 by default. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1984442[*BZ#1984442*])
-** As a workaround, you can disable the image limit by xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing[editing the `KubeletConfig` object] and setting the value of `nodeStatusMaxImages` to `-1`.
-
-* If you deploy the xref:../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-configuring-local-storage-for-vms[hostpath provisioner] on a cluster where any node has a fully qualified domain name (FQDN) that exceeds 42 characters, the provisioner fails to bind PVCs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057157[*BZ#2057157*])
-+
---
-.Example error message
-[source,terminal]
-----
-E0222 17:52:54.088950       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1beta1.CSIStorageCapacity: failed to list *v1beta1.CSIStorageCapacity: unable to parse requirement: values[0][csi.storage.k8s.io/managed-by]: Invalid value: "external-provisioner-<node_FQDN>": must be no more than 63 characters <1>
-----
-<1> Though the error message refers to a maximum of 63 characters, this includes the `external-provisioner-` string that is prefixed to the node's FQDN.
---
-** As a workaround, disable the `storageCapacity` option in the hostpath provisioner CSI driver by running the following command:
-+
-[source,terminal]
-----
-$ oc patch csidriver kubevirt.io.hostpath-provisioner --type merge --patch '{"spec": {"storageCapacity": false}}'
-----
-
->>>>>>> 08366e3b0f (rn update Jira query)
 * If your {product-title} cluster uses OVN-Kubernetes as the default Container Network Interface (CNI) provider, you cannot attach a Linux bridge or bonding device to a host's default interface because of a change in the host network topology of OVN-Kubernetes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1885605[*BZ#1885605*])
 ** As a workaround, you can use a secondary network interface connected to your host, or switch to the OpenShift SDN default CNI provider.
 

--- a/virt/virt-4-12-release-notes.adoc
+++ b/virt/virt-4-12-release-notes.adoc
@@ -50,7 +50,11 @@ The SVVP Certification applies to:
 //CNV-17984 Comply with cluster-wide crypto policy
 
 
+<<<<<<< HEAD
 //CNV-17986 New alerts added
+=======
+//CNV-17986 Release note announcing new alerts added
+>>>>>>> 08366e3b0f (rn update Jira query)
 
 
 //CNV-19780 CNV Maturity and dataVolumeTemplates
@@ -68,6 +72,12 @@ The SVVP Certification applies to:
 //CNV-18772 Virtualization Overview page redesign
 
 
+<<<<<<< HEAD
+=======
+//CNV-18432 UI create live migration page
+
+
+>>>>>>> 08366e3b0f (rn update Jira query)
 //CNV-18453 Live migration with shared storage for work intensive workloads
 
 
@@ -83,6 +93,15 @@ The SVVP Certification applies to:
 //CNV-17809 Live migration with shared storage for work intensive workloads
 
 
+<<<<<<< HEAD
+=======
+//CNV-20936 UI - live YAML view
+
+
+//CNV-18459 UI - CNV settings page
+
+
+>>>>>>> 08366e3b0f (rn update Jira query)
 //CNV-18462 Retire storage alpha apis
 
 
@@ -112,10 +131,15 @@ The SVVP Certification applies to:
 [id="virt-4-12-storage-new"]
 === Storage
 
+<<<<<<< HEAD
+=======
+//CNV-16785 Snapshot metrics
+>>>>>>> 08366e3b0f (rn update Jira query)
 
 [id="virt-4-12-web-new"]
 === Web console
 
+<<<<<<< HEAD
 //CNV-20936 UI - live YAML view
 
 
@@ -124,6 +148,20 @@ The SVVP Certification applies to:
 
 //CNV-18432 UI create live migration page
 
+=======
+//CNV-18319 UI can switch between BIOS and UEFI
+* You can set the xref:../virt/virtual_machines/virt-edit-vms.adoc#virt-editing-vm-web_virt-edit-vms[boot mode] of templates and virtual machines to *BIOS*, *UEFI*, or *UEFI (secure)* by using the web console.
+
+* You can now enable and disable the descheduler from the web console on the *Scheduling* tab of the xref:../virt/virtual_machines/virt-create-vms.adoc#virt-vm-fields-web_virt-create-vms[*VirtualMachine details*] page.
+
+//CNV-17805 Single VM Overview page
+* You can access virtual machines by navigating to *Virtualization* -> *VirtualMachines* in the side menu. Each virtual machine now has an xref:../virt/logging_events_monitoring/virt-viewing-information-about-vm-workloads.adoc#virt-about-the-vm-dashboard_virt-viewing-information-about-vm-workloads[updated *Overview* tab] that provides information about the virtual machine configuration, alerts, snapshots, network interfaces, disks, usage data, and hardware devices.
+
+* If your Windows virtual machine has a vGPU attached, you can now xref:../virt/virtual_machines/virt-accessing-vm-consoles.adoc#virt-switching-displays_virt-accessing-vm-consoles[switch between the default display and the vGPU display] by using the web console.
+
+//CNV-17806 Updated design of the templates list page
+* You can access virtual machine templates by navigating to *Virtualization* -> *Templates* in the side menu. The updated *Virtual Machine Templates* page now provides useful information about each template, including workload profile, boot source, and CPU and memory configuration.
+>>>>>>> 08366e3b0f (rn update Jira query)
 
 // NOTE: Comment out deprecated and removed features (and their IDs) if not used in a release
 [id="virt-4-12-deprecated-removed"]
@@ -137,14 +175,39 @@ Deprecated features are included in the current release and supported. However, 
 
 * In a future release, support for the legacy HPP custom resource, and the associated storage class, will be deprecated. Beginning in {VirtProductName} {VirtVersion}, the HPP Operator uses the Kubernetes Container Storage Interface (CSI) driver to configure local storage. The Operator continues to support the existing (legacy) format of the HPP custom resource and the associated storage class. If you use the HPP Operator, plan to xref:../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-configuring-local-storage-for-vms[create a storage class for the CSI driver] as part of your migration strategy.
 
+<<<<<<< HEAD
+=======
+//CNV-17665 Deprecate NMO
+>>>>>>> 08366e3b0f (rn update Jira query)
 
 [id="virt-4-12-removed"]
 === Removed features
 
+<<<<<<< HEAD
+=======
+Removed features are not supported in the current release.
+
+//CNV-16317 NMState is no longer part of CNV
+* {VirtProductName} {VirtVersion} removes support for link:https://nmstate.io/[nmstate], including the following objects:
++
+--
+** `NodeNetworkState`
+** `NodeNetworkConfigurationPolicy`
+** `NodeNetworkConfigurationEnactment`
+--
++
+To preserve and support your existing nmstate configuration, install the xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState Operator] before updating to {VirtProductName} {VirtVersion}. You can install it from the *OperatorHub* in the {product-title} web console, or by using the OpenShift CLI (`oc`).
+>>>>>>> 08366e3b0f (rn update Jira query)
 
 [id="virt-4-12-changes"]
 == Notable technical changes
 
+<<<<<<< HEAD
+=======
+* The *Create a Virtual Machine* wizard in the web console is now xref:../virt/virtual_machines/virt-create-vms.adoc#virt-quick-creating-vm_virt-create-vms[replaced by the *Catalog* screen], which lists available templates that you can use to create a virtual machine. You can use a template with an available boot source to quickly create a virtual machine or you can customize a template to create a virtual machine.
+
+//CNV-18323 VM templates can be made public i.e. available to all users
+>>>>>>> 08366e3b0f (rn update Jira query)
 
 [id="virt-4-12-technology-preview"]
 == Technology Preview features
@@ -153,8 +216,12 @@ Some features in this release are currently in Technology Preview. These experim
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
+<<<<<<< HEAD
 //CNV-20963
 * You can now use Microsoft Windows 11 as a guest operating system. However, {VirtProductName} {VirtVersion} does not support USB disks, which are required for a critical function of BitLocker recovery. To protect recovery keys, use other methods described in the link:https://learn.microsoft.com/en-us/windows/security/information-protection/bitlocker/bitlocker-recovery-guide-plan[BitLocker recovery guide].
+=======
+* You can now use the Red Hat Enterprise Linux 9 Alpha template to create virtual machines.
+>>>>>>> 08366e3b0f (rn update Jira query)
 
 * You can now link:https://access.redhat.com/articles/6409731[deploy {VirtProductName} on AWS bare metal nodes].
 
@@ -182,6 +249,7 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 [id="virt-4-12-bug-fixes"]
 == Bug fixes
 
+<<<<<<< HEAD
 [id="virt-4-12-known-issues"]
 == Known issues
 
@@ -211,6 +279,48 @@ This step is optional if you specified a value for `spec.dataVolumeTemplates`.
 ** As a workaround, you can disable the image limit by xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing[editing the `KubeletConfig` object] and setting the value of `nodeStatusMaxImages` to `-1`.
 
 //BZ-1885605
+=======
+* Previously, on a large cluster, the {VirtProductName} MAC pool manager would take too much time to boot and {VirtProductName} might not become ready. With this update, the pool initialization and startup latency is reduced. As a result, VMs can now be successfully defined. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2035344[*BZ#2035344*])
+
+* If a Windows VM crashes or hangs during shutdown, you can now manually issue a force shutdown request to stop the VM. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2040766[*BZ#2040766*])
+
+* The YAML examples in the VM wizard have now been updated to contain the latest upstream changes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2055492[*BZ#2055492*])
+
+* The *Add Network Interface* button on the VM *Network Interfaces* tab is no longer disabled for non-privileged users. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2056420[*BZ#2056420*])
+
+* A non-privileged user can now successfully add disks to a VM without getting a RBAC rule error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2056421[*BZ#2056421*])
+
+* The web console now successfully displays virtual machine templates that are deployed to a custom namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2054650[*BZ#2054650*])
+
+* Previously, updating a Single Node OpenShift (SNO) cluster failed if the `spec.evictionStrategy` field was set to `LiveMigrate` for a VMI. For live migration to succeed, the cluster must have more than one compute node. With this update, the `spec.evictionStrategy` field is removed from the virtual machine template in a SNO environment. As a result, cluster update is now successful. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2073880[*BZ#2073880*])
+
+
+[id="virt-4-12-known-issues"]
+== Known issues
+
+//New known issues for 4.11 go above this comment
+
+* If a single node contains more than 50 images, pod scheduling might be imbalanced across nodes. This is because the list of images on a node is shortened to 50 by default. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1984442[*BZ#1984442*])
+** As a workaround, you can disable the image limit by xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing[editing the `KubeletConfig` object] and setting the value of `nodeStatusMaxImages` to `-1`.
+
+* If you deploy the xref:../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-configuring-local-storage-for-vms[hostpath provisioner] on a cluster where any node has a fully qualified domain name (FQDN) that exceeds 42 characters, the provisioner fails to bind PVCs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057157[*BZ#2057157*])
++
+--
+.Example error message
+[source,terminal]
+----
+E0222 17:52:54.088950       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1beta1.CSIStorageCapacity: failed to list *v1beta1.CSIStorageCapacity: unable to parse requirement: values[0][csi.storage.k8s.io/managed-by]: Invalid value: "external-provisioner-<node_FQDN>": must be no more than 63 characters <1>
+----
+<1> Though the error message refers to a maximum of 63 characters, this includes the `external-provisioner-` string that is prefixed to the node's FQDN.
+--
+** As a workaround, disable the `storageCapacity` option in the hostpath provisioner CSI driver by running the following command:
++
+[source,terminal]
+----
+$ oc patch csidriver kubevirt.io.hostpath-provisioner --type merge --patch '{"spec": {"storageCapacity": false}}'
+----
+
+>>>>>>> 08366e3b0f (rn update Jira query)
 * If your {product-title} cluster uses OVN-Kubernetes as the default Container Network Interface (CNI) provider, you cannot attach a Linux bridge or bonding device to a host's default interface because of a change in the host network topology of OVN-Kubernetes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1885605[*BZ#1885605*])
 ** As a workaround, you can use a secondary network interface connected to your host, or switch to the OpenShift SDN default CNI provider.
 


### PR DESCRIPTION
*** New version can be found here: https://github.com/openshift/openshift-docs/pull/53538 ***

Version(s): 4.12

Issue: [CNV-16414](https://issues.redhat.com//browse/CNV-16414)

Link to docs preview: https://52994--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-4-12-release-notes.html#virt-4-12-new
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not required

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->