### PR TITLE
OCPBUGS-2599 Added tuningOptions to Performance Opt. Section

### DIFF
--- a/modules/router-performance-optimizations.adoc
+++ b/modules/router-performance-optimizations.adoc
@@ -5,10 +5,7 @@
 :_content-type: Procedure
 [id="router-performance-optimizations_{context}"]
 = Ingress Controller (router) performance optimizations
-
-{product-title} no longer supports modifying Ingress Controller deployments by setting environment variables such as `ROUTER_THREADS`, `ROUTER_DEFAULT_TUNNEL_TIMEOUT`, `ROUTER_DEFAULT_CLIENT_TIMEOUT`, `ROUTER_DEFAULT_SERVER_TIMEOUT`, and `RELOAD_INTERVAL`.
-
-You can modify the Ingress Controller deployment, but if the Ingress Operator is enabled, the configuration is overwritten.
+{product-title} no longer supports modifying Ingress Controller deployments by setting environment variables such as `ROUTER_THREADS`, `ROUTER_DEFAULT_TUNNEL_TIMEOUT`, `ROUTER_DEFAULT_CLIENT_TIMEOUT`, `ROUTER_DEFAULT_SERVER_TIMEOUT`, and `RELOAD_INTERVAL`. However, {product-title} does support modifying Ingress Controller deployments by using `tuningOptions` to set environment variables. `tuningOptions` specifies options for tuning the performance of Ingress Controller pods.
 
 == Configuring Ingress Controller liveness, readiness, and startup probes
 

--- a/scalability_and_performance/routing-optimization.adoc
+++ b/scalability_and_performance/routing-optimization.adoc
@@ -13,3 +13,5 @@ include::modules/baseline-router-performance.adoc[leveloffset=+1]
 For more information on Ingress sharding, see xref:../networking/ingress-operator.adoc#nw-ingress-sharding-route-labels_configuring-ingress[Configuring Ingress Controller sharding by using route labels] and xref:../networking/ingress-operator.adoc#nw-ingress-sharding-namespace-labels_configuring-ingress[Configuring Ingress Controller sharding by using namespace labels].
 
 include::modules/router-performance-optimizations.adoc[leveloffset=+1]
+
+For more information on `tuningOptions,` see xref:../networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration parameters].


### PR DESCRIPTION
**OCPBUGS-2599**
Added tuningOptions to router performance optimizations section

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

**Version(s):**
* PR applies only to enterprise-4.11

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

**Issue:**
https://issues.redhat.com/browse/OCPBUGS-2599

**Link to docs preview:**

- https://52998--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/routing-optimization.html#router-performance-optimizations_routing-optimization

**QE review:  @juzhao **
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

**Additional information:**
N/A

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
