### PR TITLE
Agent-29: adds host configurations per node

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -18,6 +18,8 @@ include::modules/installing-ocp-agent.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-three-node-cluster_installing-restricted-networks-bare-metal[Configuring a three-node cluster] to deploy three-node clusters in bare metal environments.
+* See xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints].
+* See link:https://nmstate.io/examples.html[NMState state examples].
 
 include::modules/sample-ztp-custom-resources.adoc[leveloffset=+1]
 

--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -36,6 +36,8 @@ include::modules/installation-bare-metal-agent-installer-config-yaml.adoc[levelo
 
 include::modules/validations-before-agent-iso-creation.adoc[leveloffset=+1]
 
+include::modules/agent-install-ipi-install-root-device-hints.adoc[leveloffset=+1]
+
 [id="agent-based-installation-next-steps"]
 == Next steps
 

--- a/modules/agent-install-ipi-install-root-device-hints.adoc
+++ b/modules/agent-install-ipi-install-root-device-hints.adoc
@@ -1,0 +1,47 @@
+// This is included in the following assemblies:
+//
+// ipi-install-configuration-files.adoc
+
+:_content-type: REFERENCE
+[id='root-device-hints_{context}']
+= About root device hints
+
+The `rootDeviceHints` parameter enables the installer to provision the {op-system-first} image to a particular device. The installer examines the devices in the order it discovers them, and compares the discovered values with the hint values. The installer uses the first discovered device that matches the hint value. The configuration can combine multiple hints, but a device must match all hints for the installer to select it.
+
+.Subfields
+
+|===
+| Subfield | Description
+
+| `deviceName` | A string containing a Linux device name like `/dev/vda`. The hint must match the actual value exactly.
+
+| `hctl` | A string containing a SCSI bus address like `0:0:0:0`. The hint must match the actual value exactly.
+
+| `model` | A string containing a vendor-specific device identifier. The hint can be a substring of the actual value.
+
+| `vendor` | A string containing the name of the vendor or manufacturer of the device. The hint can be a sub-string of the actual value.
+
+| `serialNumber` | A string containing the device serial number. The hint must match the actual value exactly.
+
+| `minSizeGigabytes` | An integer representing the minimum size of the device in gigabytes.
+
+| `wwn` | A string containing the unique storage identifier. The hint must match the actual value exactly.
+
+| `rotational` | A boolean indicating whether the device should be a rotating disk (true) or not (false).
+
+|===
+
+.Example usage
+
+[source,yaml]
+----
+     - name: master-0
+       role: master
+       bmc:
+         address: ipmi://10.10.0.3:6203
+         username: admin
+         password: redhat
+       bootMACAddress: de:ad:be:ef:00:40
+       rootDeviceHints:
+         deviceName: "/dev/sda"
+----

--- a/modules/installing-ocp-agent.adoc
+++ b/modules/installing-ocp-agent.adoc
@@ -6,7 +6,7 @@
 [id="installing-ocp-agent_{context}"]
 = Installing {product-title} with the Agent-based Installer
 
-The following procedure deploys a single-node {product-title}. You can use this procedure as a basis and modify according to your requirements.
+The following procedure deploys a single-node {product-title} in a disconnected environment. You can use this procedure as a basis and modify according to your requirements.
 
 .Procedure
 
@@ -94,11 +94,13 @@ sshKey: |
     name: sno-cluster
   rendezvousIP: 192.168.111.80 <1>
   hosts: <2>
-    - hostname: master-0
+    - hostname: master-0 <3>
       interfaces:
         - name: eno1
           macAddress: 00:ef:44:21:e6:a5
-      networkConfig:
+      rootDeviceHints: <4>
+        deviceName: /dev/sdb
+      networkConfig: <5>
         interfaces:
           - name: eno1
             type: ethernet
@@ -127,6 +129,10 @@ sshKey: |
 You must provide the IP address when you do not specify the node's IP addresses in the `networkConfig` parameter. If this address is not provided, one IP address is selected from the provided nodes's `networkConfig`.
 <2> The number of hosts defined must match the total number of hosts defined in the `install-config.yaml` file, which is the sum of the values of the `compute.replicas` and `controlPlane.replicas` parameters. When 3 master nodes and 0 worker nodes are defined in the `install-config.yaml` file,
 the number of hosts defined is 3. When 3 master nodes and 2 worker nodes are defined in the `install-config.yaml` file, the number of hosts defined is 5.
+<3> The optional `hostname` parameter overrides the hostname obtained from either the Dynamic Host Configuration Protocol (DHCP) or a reverse DNS lookup. Each host must have a unique hostname supplied by one of these methods.
+<4> The `rootDeviceHints` parameter enables provisioning of the Red Hat Enterprise Linux CoreOS (RHCOS) image to a particular device. It examines the devices in the order it discovers them, and compares the discovered values with the hint values. It uses the first discovered device that matches the hint value.
+<5> Set this optional parameter to configure the network interface of a host in NMState format.
+
 
 +
 . Create the Agent image by running the following command:
@@ -146,8 +152,10 @@ agent.iso  auth
 ----
 $ openshift-install agent create image
 ----
++
+NOTE: Red Hat Enterprise Linux CoreOS (RHCOS) supports multipathing on the primary disk, allowing stronger resilience to hardware failure to achieve higher host availability. Multipathing is enabled by default in the `agent.iso` image, with a default `/etc/multipath.conf` configuration.
 
-. Optional:  To know  when the bootstrap node (** Node 0 **) reboots, run the following command:
+. Optional: To know when the bootstrap node (** node 0 **) reboots, run the following command:
 
 +
 [source,terminal]
@@ -168,8 +176,7 @@ INFO Waiting up to 30m0s for bootstrapping to complete...
 INFO It is now safe to remove the bootstrap resources
 ----
 +
-The command succeeds when the Kubernetes API server signals that it has been
-bootstrapped on the control plane machines.
+The command succeeds when the Kubernetes API server signals that it has been bootstrapped on the control plane machines.
 
 . Boot the `agent.iso` image on the bare metal machines. You can run the image on any Linux distribution.
 
@@ -191,5 +198,3 @@ INFO To access the cluster as the system:admin user when using 'oc', run
 INFO     export KUBECONFIG=/home/core/installer/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.sno-cluster.test.example.com
 ----
-
-


### PR DESCRIPTION
-The scope of this PR covers : hostname, networkConfig,rootDeviceHints and multipathd. Also add a link to root device hints. Please add if I am missing anything @zaneb  @celebdor .
- Applies to main and 4.12
- [Jira](https://issues.redhat.com/browse/AGENT-29)
- [Preview](https://53004--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html)
