### PR TITLE
OSDOCS-4320: Remove modules from Recommended host practices section of PerfScale

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1077,7 +1077,7 @@ Topics:
   - Name: Installing the AWS Load Balancer Operator
     File: install-aws-load-balancer-operator
   - Name: Installing the AWS Load Balancer Operator on Secure Token Service cluster
-    File: installing-albo-sts-cluster  
+    File: installing-albo-sts-cluster
   - Name: Creating an instance of the AWS Load Balancer Controller
     File: create-instance-aws-load-balancer-controller
   - Name: Serving Multiple Ingresses through a single AWS Load Balancer
@@ -1977,8 +1977,6 @@ Topics:
     File: cpmso-configuration
   #- Name: Using the Control Plane Machine Set Operator
   #  File: cpmso-using
-  - Name: Control plane resiliency and recovery
-    File: cpmso-resiliency
   #- Name: Troubleshooting the Control Plane Machine Set Operator
   #  File: cpmso-troubleshooting
 - Name: Deploying machine health checks
@@ -2328,10 +2326,7 @@ Name: Scalability and performance
 Dir: scalability_and_performance
 Distros: openshift-origin,openshift-enterprise,openshift-webscale,openshift-dpu
 Topics:
-- Name: Recommended installation practices
-  File: recommended-install-practices
-  Distros: openshift-origin,openshift-enterprise
-- Name: Recommended host practices
+- Name: Recommended performance and scalability practices
   File: recommended-host-practices
   Distros: openshift-origin,openshift-enterprise
 - Name: Recommended host practices for IBM Z & LinuxONE environments

--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -1,6 +1,5 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/recommended-host-practices.adoc
 // * post_installation_configuration/node-tasks.adoc
 // * post_installation_configuration/machine-configuration-tasks.adoc
 

--- a/modules/master-node-sizing.adoc
+++ b/modules/master-node-sizing.adoc
@@ -24,7 +24,7 @@ The control plane node resource requirements depend on the number and type of no
 | 27
 | 500
 | 4
-| 16
+| 24
 
 | 120
 | 1000
@@ -34,16 +34,16 @@ The control plane node resource requirements depend on the number and type of no
 | 252
 | 4000
 | 16
-| 64
+| 64, but 128 if using `OVNKubernetes`
 
 | 501
 | 4000
 | 16
-| 96
+| 96, but untested for `OVNKubernetes`
 
 |===
 
-On a large and dense cluster with three masters or control plane nodes, the CPU and memory usage will spike up when one of the nodes is stopped, rebooted or fails. The failures can be due to unexpected issues with power, network or underlying infrastructure in addition to intentional cases where the cluster is restarted after shutting it down to save costs. The remaining two control plane nodes must handle the load in order to be highly available which leads to increase in the resource usage. This is also expected during upgrades because the masters are cordoned, drained, and rebooted serially to apply the operating system updates, as well as the control plane Operators update. To avoid cascading failures, keep the overall CPU and memory resource usage on the control plane nodes to at most 60% of all available capacity to handle the resource usage spikes. Increase the CPU and memory on the control plane nodes accordingly to avoid potential downtime due to lack of resources.
+On a large and dense cluster with three control plane nodes, the CPU and memory usage will spike up when one of the nodes is stopped, rebooted or fails. The failures can be due to unexpected issues with power, network or underlying infrastructure in addition to intentional cases where the cluster is restarted after shutting it down to save costs. The remaining two control plane nodes must handle the load in order to be highly available which leads to increase in the resource usage. This is also expected during upgrades because the control plane nodes are cordoned, drained, and rebooted serially to apply the operating system updates, as well as the control plane Operators update. To avoid cascading failures, keep the overall CPU and memory resource usage on the control plane nodes to at most 60% of all available capacity to handle the resource usage spikes. Increase the CPU and memory on the control plane nodes accordingly to avoid potential downtime due to lack of resources.
 
 [IMPORTANT]
 ====

--- a/modules/modify-unavailable-workers.adoc
+++ b/modules/modify-unavailable-workers.adoc
@@ -1,6 +1,5 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/recommended-host-practices.adoc
 // * post_installation_configuration/node-tasks.adoc
 
 :_content-type: PROCEDURE

--- a/modules/recommended-node-host-practices.adoc
+++ b/modules/recommended-node-host-practices.adoc
@@ -1,6 +1,5 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/recommended-host-practices.adoc
 // * post_installation_configuration/node-tasks.adoc
 
 [id="recommended-node-host-practices_{context}"]
@@ -29,9 +28,9 @@ have 20 containers running.
 
 [NOTE]
 ====
-Disk IOPS throttling from the cloud provider might have an impact on CRI-O and kubelet. 
-They might get overloaded when there are large number of I/O intensive pods running on 
-the nodes. It is recommended that you monitor the disk I/O on the nodes and use volumes 
+Disk IOPS throttling from the cloud provider might have an impact on CRI-O and kubelet.
+They might get overloaded when there are large number of I/O intensive pods running on
+the nodes. It is recommended that you monitor the disk I/O on the nodes and use volumes
 with sufficient throughput for the workload.
 ====
 

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -1,23 +1,12 @@
 :_content-type: ASSEMBLY
 [id="recommended-host-practices"]
-= Recommended host practices
+= Recommended performance and scalability practices
 include::_attributes/common-attributes.adoc[]
 :context: recommended-host-practices
 
 toc::[]
 
-This topic provides recommended host practices for {product-title}.
-
-[IMPORTANT]
-====
-These guidelines apply to {product-title} with software-defined networking (SDN), not Open Virtual Network (OVN).
-====
-
-include::modules/recommended-node-host-practices.adoc[leveloffset=+1]
-
-include::modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc[leveloffset=+1]
-
-include::modules/modify-unavailable-workers.adoc[leveloffset=+1]
+This topic provides recommended performance and scalability for {product-title}.
 
 include::modules/master-node-sizing.adoc[leveloffset=+1]
 
@@ -31,7 +20,7 @@ include::modules/recommended-etcd-practices.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/solutions/4885641[How to use `fio` to check etcd disk performance in {product-title}] 
+* link:https://access.redhat.com/solutions/4885641[How to use `fio` to check etcd disk performance in {product-title}]
 
 include::modules/etcd-defrag.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-4320

Link to docs preview:
https://53005--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices.html
