### PR TITLE
CNV-15822: adding live migration metrics

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3570,8 +3570,6 @@ Topics:
     File: virt-migrate-vmi
   - Name: Migrating a virtual machine over a dedicated additional network
     File: virt-migrating-vm-on-secondary-network
-  - Name: Monitoring live migration
-    File: virt-monitor-vmi-migration
   - Name: Cancelling the live migration of a virtual machine instance
     File: virt-cancel-vmi-migration
   - Name: Configuring virtual machine eviction strategy
@@ -3601,6 +3599,8 @@ Topics:
     File: virt-logs
   - Name: Viewing events
     File: virt-events
+  - Name: Monitoring live migration
+    File: virt-monitor-vmi-migration
   - Name: Diagnosing data volumes using events and conditions
     File: virt-diagnosing-datavolumes-using-events-and-conditions
   - Name: Viewing information about virtual machine workloads

--- a/modules/virt-live-migration-metrics.adoc
+++ b/modules/virt-live-migration-metrics.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-monitor-vmi-migration.adoc
+// * virt/logging_events_monitoring/virt-prometheus-queries.adoc
+
+:_content-type: REFERENCE
+[id="virt-live-migration-metrics_{context}"]
+= Live migration metrics
+
+The following metrics can be queried to show live migration status:
+
+`kubevirt_migrate_vmi_data_processed_bytes`:: The amount of guest operating system (OS) data that has migrated to the new virtual machine (VM). Type: Gauge.
+
+`kubevirt_migrate_vmi_data_remaining_bytes`:: The amount of guest OS data that remains to be migrated. Type: Gauge.
+
+`kubevirt_migrate_vmi_dirty_memory_rate_bytes`:: The rate at which memory is becoming dirty in the guest OS. Dirty memory is data that has been changed but not yet written to disk. Type: Gauge.
+
+`kubevirt_migrate_vmi_pending_count`:: The number of pending migrations. Type: Gauge.
+
+`kubevirt_migrate_vmi_scheduling_count`:: The number of scheduling migrations. Type: Gauge.
+
+`kubevirt_migrate_vmi_running_count`:: The number of running migrations. Type: Gauge.
+
+`kubevirt_migrate_vmi_succeeded_total`:: The number of successfully completed migrations. Type: Gauge.
+
+`kubevirt_migrate_vmi_failed_total`:: The number of failed migrations. Type: Gauge.
+

--- a/modules/virt-monitoring-vm-migration-cli.adoc
+++ b/modules/virt-monitoring-vm-migration-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/live_migration/virt-monitor-vmi-migration.adoc
+// * virt/logging_events_monitoring/virt-monitor-vmi-migration.adoc
 
 :_content-type: PROCEDURE
 [id="virt-monitoring-vm-migration-cli_{context}"]

--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -18,7 +18,7 @@ The following examples use `topk` queries that specify a time period. If virtual
 The following query can identify virtual machines that are waiting for Input/Output (I/O):
 
 `kubevirt_vmi_vcpu_wait_seconds`::
-Returns the wait time (in seconds) for a virtual machine's vCPU.
+Returns the wait time (in seconds) for a virtual machine's vCPU. Type: Counter.
 
 A value above '0' means that the vCPU wants to run, but the host scheduler cannot run it yet. This inability to run indicates that there is an issue with I/O.
 
@@ -40,10 +40,10 @@ topk(3, sum by (name, namespace) (rate(kubevirt_vmi_vcpu_wait_seconds[6m]))) > 0
 The following queries can identify virtual machines that are saturating the network:
 
 `kubevirt_vmi_network_receive_bytes_total`::
-Returns the total amount of traffic received (in bytes) on the virtual machine's network.
+Returns the total amount of traffic received (in bytes) on the virtual machine's network. Type: Counter.
 
 `kubevirt_vmi_network_transmit_bytes_total`::
-Returns the total amount of traffic transmitted (in bytes) on the virtual machine's network.
+Returns the total amount of traffic transmitted (in bytes) on the virtual machine's network. Type: Counter.
 
 .Example network traffic query
 [source,promql]
@@ -61,10 +61,10 @@ topk(3, sum by (name, namespace) (rate(kubevirt_vmi_network_receive_bytes_total[
 The following queries can identify VMs that are writing large amounts of data:
 
 `kubevirt_vmi_storage_read_traffic_bytes_total`::
-Returns the total amount (in bytes) of the virtual machine's storage-related traffic.
+Returns the total amount (in bytes) of the virtual machine's storage-related traffic. Type: Counter.
 
 `kubevirt_vmi_storage_write_traffic_bytes_total`::
-Returns the total amount of storage writes (in bytes) of the virtual machine's storage-related traffic.
+Returns the total amount of storage writes (in bytes) of the virtual machine's storage-related traffic. Type: Counter.
 
 .Example storage-related traffic query
 [source,promql]
@@ -77,10 +77,10 @@ topk(3, sum by (name, namespace) (rate(kubevirt_vmi_storage_read_traffic_bytes_t
 === Storage snapshot data
 
 `kubevirt_vmsnapshot_disks_restored_from_source_total`::
-Returns the total number of virtual machine disks restored from the source virtual machine.
+Returns the total number of virtual machine disks restored from the source virtual machine. Type: Gauge.
 
 `kubevirt_vmsnapshot_disks_restored_from_source_bytes`::
-Returns the amount of space in bytes restored from the source virtual machine.
+Returns the amount of space in bytes restored from the source virtual machine. Type: Gauge.
 
 .Examples of storage snapshot data queries
 [source,promql]
@@ -101,10 +101,10 @@ kubevirt_vmsnapshot_disks_restored_from_source_bytes{vm_name="simple-vm", vm_nam
 The following queries can determine the I/O performance of storage devices:
 
 `kubevirt_vmi_storage_iops_read_total`::
-Returns the amount of write I/O operations the virtual machine is performing per second.
+Returns the amount of write I/O operations the virtual machine is performing per second. Type: Counter.
 
 `kubevirt_vmi_storage_iops_write_total`::
-Returns the amount of read I/O operations the virtual machine is performing per second.
+Returns the amount of read I/O operations the virtual machine is performing per second. Type: Counter.
 
 .Example I/O performance query
 [source,promql]
@@ -119,10 +119,10 @@ topk(3, sum by (name, namespace) (rate(kubevirt_vmi_storage_iops_read_total[6m])
 The following queries can identify which swap-enabled guests are performing the most memory swapping:
 
 `kubevirt_vmi_memory_swap_in_traffic_bytes_total`::
-Returns the total amount (in bytes) of memory the virtual guest is swapping in.
+Returns the total amount (in bytes) of memory the virtual guest is swapping in. Type: Gauge.
 
 `kubevirt_vmi_memory_swap_out_traffic_bytes_total`::
-Returns the total amount (in bytes) of memory the virtual guest is swapping out.
+Returns the total amount (in bytes) of memory the virtual guest is swapping out. Type: Gauge.
 
 .Example memory swapping query
 [source,promql]

--- a/virt/live_migration/virt-live-migration.adoc
+++ b/virt/live_migration/virt-live-migration.adoc
@@ -13,5 +13,6 @@ include::modules/virt-about-live-migration.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../../virt/live_migration/virt-migrate-vmi.adoc#virt-migrate-vmi[Migrating a virtual machine instance to another node]
+* xref:../../virt/logging_events_monitoring/virt-monitor-vmi-migration.adoc#virt-monitor-vmi-migration[Monitoring live migration]
 * xref:../../virt/live_migration/virt-live-migration-limits.adoc#virt-live-migration-limits[Live migration limiting]
 * xref:../../virt/virtual_machines/virtual_disks/virt-creating-data-volumes.adoc#virt-customizing-storage-profile_virt-creating-data-volumes[Customizing the storage profile]

--- a/virt/live_migration/virt-migrate-vmi.adoc
+++ b/virt/live_migration/virt-migrate-vmi.adoc
@@ -14,10 +14,12 @@ If a virtual machine uses a host model CPU, you can perform live migration of th
 ====
 
 include::modules/virt-initiating-vm-migration-web.adoc[leveloffset=+1]
+
 include::modules/virt-initiating-vm-migration-cli.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources:
+[id="virt-migrate-vmi_additional-resources"]
+== Additional resources
 
-* xref:../../virt/live_migration/virt-monitor-vmi-migration.adoc#virt-monitor-vmi-migration[Monitoring live migration of a virtual machine instance]
+* xref:../../virt/logging_events_monitoring/virt-monitor-vmi-migration.adoc#virt-monitor-vmi-migration[Monitoring live migration]
 * xref:../../virt/live_migration/virt-cancel-vmi-migration.adoc#virt-cancel-vmi-migration[Cancelling the live migration of a virtual machine instance]

--- a/virt/logging_events_monitoring/virt-monitor-vmi-migration.adoc
+++ b/virt/logging_events_monitoring/virt-monitor-vmi-migration.adoc
@@ -16,3 +16,10 @@ You can monitor the progress of all live migrations on the xref:../../virt/virt-
 You can view the migration metrics of a virtual machine on the xref:../../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-metrics_virt-web-console-overview[*VirtualMachine details -> Metrics* tab] in the web console.
 
 include::modules/virt-monitoring-vm-migration-cli.adoc[leveloffset=+1]
+
+[id="metrics_virt-monitor-vmi-migration"]
+== Metrics
+
+You can use xref:../../virt/logging_events_monitoring/virt-prometheus-queries.adoc#virt-prometheus-queries[Prometheus queries] to monitor live migration.
+
+include::modules/virt-live-migration-metrics.adoc[leveloffset=+2]

--- a/virt/logging_events_monitoring/virt-prometheus-queries.adoc
+++ b/virt/logging_events_monitoring/virt-prometheus-queries.adoc
@@ -3,15 +3,11 @@
 = Prometheus queries for virtual resources
 include::_attributes/common-attributes.adoc[]
 :context: virt-prometheus-queries
+:toclevels: 4
 
 toc::[]
 
-{VirtProductName} provides metrics for monitoring how infrastructure resources are consumed in the cluster. The metrics cover the following resources:
-
-* vCPU
-* Network
-* Storage
-* Guest memory swapping
+{VirtProductName} provides metrics that you can use to monitor the consumption of cluster infrastructure resources, including vCPU, network, storage, and guest memory swapping. You can also use metrics to query live migration status.
 
 Use the {product-title} monitoring dashboard to query virtualization metrics.
 
@@ -30,8 +26,14 @@ include::modules/monitoring-querying-metrics-for-user-defined-projects-as-a-deve
 
 include::modules/virt-querying-metrics.adoc[leveloffset=+1]
 
+include::modules/virt-live-migration-metrics.adoc[leveloffset=+1]
+
 [id="additional-resources_virt-prometheus-queries"]
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../../monitoring/monitoring-overview.adoc#monitoring-overview[Monitoring overview]
+
+* link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Querying Prometheus]
+
+* link:https://prometheus.io/docs/prometheus/latest/querying/examples/[Prometheus query examples]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12+ AFAIK
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/CNV-15822
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://53017--docspreview.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-monitor-vmi-migration.html
- https://53017--docspreview.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-prometheus-queries.html#virt-prometheus-queries
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->


<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
