### PR TITLE
TELCODOCS-405-RN RN for support for multi-network policy and SR-IOV

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -180,7 +180,7 @@ For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k
 
 In {product-title} 4.12, the External DNS Operator modifies the format of the ExternalDNS wildcard TXT records on AzureDNS. The External DNS Operator replaces the asterisk with `any` in ExternalDNS wildcard TXT records. You must avoid the ExternalDNS wildcard A and CNAME records having `any` leftmost subdomain because this might cause a conflict.
 
-The upstream version of `ExternalDNS` for an {product-title} 4.12 is v0.13.1. 
+The upstream version of `ExternalDNS` for an {product-title} 4.12 is v0.13.1.
 
 [id="ocp-4-12-nw-metrics-telemetry"]
 ==== Capturing metrics and telemetry associated with the use of routes and shards
@@ -247,6 +247,15 @@ For more information, see xref:../networking/ingress-controller-dnsmgt.adoc#ingr
 * Silicom STS Family
 
 For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
+
+[id="ocp-4-12-multi-network-policy-supported-for-sr-iov"]
+==== Multi-network-policy supported for SR-IOV (Technology Preview)
+
+{product-title} 4.12 adds support for configuring multi-network policy for SR-IOV devices.
+
+You can now configure multi-network for SR-IOV additional networks. Configuring SR-IOV additional networks is a Technology Preview feature and is only supported with kernel network interface cards (NICs).
+
+For more information, see xref:../networking/multiple_networks/configuring-multi-network-policy.adoc#configuring-multi-network-policy[Configuring multi-network policy].
 
 [id="ocp-4-12-switch-aws-load-balancer"]
 ==== Switch between AWS load balancer types without deleting the Ingress Controller


### PR DESCRIPTION
[TELCODOCS-405]: RN for describing support for multiple network policies for SR-IOV networks

Version(s): 4..12 


Issue:
https://issues.redhat.com/browse/TELCODOCS-405

Link to docs preview: https://53027--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-multi-network-policy-supported-for-sr-iov

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

