### PR TITLE
TELCODOCS 681 RN for updating default interface specific sysctls

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -184,7 +184,7 @@ For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k
 
 In {product-title} 4.12, the External DNS Operator modifies the format of the ExternalDNS wildcard TXT records on AzureDNS. The External DNS Operator replaces the asterisk with `any` in ExternalDNS wildcard TXT records. You must avoid the ExternalDNS wildcard A and CNAME records having `any` leftmost subdomain because this might cause a conflict.
 
-The upstream version of `ExternalDNS` for an {product-title} 4.12 is v0.13.1.
+The upstream version of `ExternalDNS` for {product-title} 4.12 is v0.13.1.
 
 [id="ocp-4-12-nw-metrics-telemetry"]
 ==== Capturing metrics and telemetry associated with the use of routes and shards
@@ -338,7 +338,7 @@ For the OVN-Kubernetes network plug-in, egress firewalls support audit logging u
 === Machine API
 
 [id="ocp-4-12-mapi-control-plane-machine-sets"]
-==== Control plane machine sets 
+==== Control plane machine sets
 
 {product-title} 4.12 introduces control plane machine sets. Control plane machine sets provide management capabilities for control plane machines that are similar to what compute machine sets provide for compute machines. For more information, see xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[Managing control plane machines].
 
@@ -352,6 +352,17 @@ For the OVN-Kubernetes network plug-in, egress firewalls support audit logging u
 
 [id="ocp-4-12-nodes"]
 === Nodes
+
+[id="ocp-4-12-updating-interface-specific-list"]
+==== Updating the interface-specific safe list (Technology Preview)
+
+{product-title} now supports updating the default interface-specific safe `sysctls`.
+
+You can add or remove `sysctls` from the predefined list.
+When you add `sysctls`, they can be set across all nodes.
+Updating the interface-specific safe `sysctls` list is a Technology Preview feature only.
+
+For more information, see xref:../nodes/containers/nodes-containers-sysctls.adoc#updating-interface-specific-safe-sysctls-list_nodes-containers-using[Updating the interface-specific safe sysctls list].
 
 [id="ocp-4-12-node-cron-job-time-zone"]
 ==== Cron job time zones (Technology Preview)


### PR DESCRIPTION
[TELCODOCS-681](https://issues.redhat.com//browse/TELCODOCS-681): RN new feature description for updating interface-specific systl allowlist

Version(s): 4.12 

Issue:
https://issues.redhat.com/browse/TELCODOCS-681

Link to docs preview: https://53031--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-updating-interface-specific-list

QE review:
- [x] QE has approved this change.
