### PR TITLE
SRVOCF-492 Podman not podman, and split pre-req

### DIFF
--- a/modules/serverless-functions-podman-macos.adoc
+++ b/modules/serverless-functions-podman-macos.adoc
@@ -4,20 +4,20 @@
 
 :_content-type: PROCEDURE
 [id="serverless-functions-podman-macos_{context}"]
-= Setting up podman on macOS
+= Setting up Podman on macOS
 
-To use advanced container management features, you might want to use podman with {FunctionsProductName}. To do so on macOS, you need to start the podman machine and configure the Knative (`kn`) CLI to connect to it.
+To use advanced container management features, you might want to use Podman with {FunctionsProductName}. To do so on macOS, you need to start the Podman machine and configure the Knative (`kn`) CLI to connect to it.
 
 .Procedure
 
-. Create the podman machine:
+. Create the Podman machine:
 +
 [source,terminal]
 ----
 $ podman machine init --memory=8192 --cpus=2 --disk-size=20
 ----
 
-. Start the podman machine, which serves the Docker API on a UNIX socket:
+. Start the Podman machine, which serves the Docker API on a UNIX socket:
 +
 [source,terminal]
 ----

--- a/modules/serverless-functions-podman.adoc
+++ b/modules/serverless-functions-podman.adoc
@@ -4,16 +4,16 @@
 
 :_content-type: PROCEDURE
 [id="serverless-functions-podman_{context}"]
-= Setting up podman
+= Setting up Podman
 
-To use advanced container management features, you might want to use podman with {FunctionsProductName}. To do so, you need to start the podman service and configure the Knative (`kn`) CLI to connect to it.
+To use advanced container management features, you might want to use Podman with {FunctionsProductName}. To do so, you need to start the Podman service and configure the Knative (`kn`) CLI to connect to it.
 
 .Procedure
 
 // This step might no longer be needed in the future, when automatic
 // podman startup is reliable.
 // https://github.com/openshift/openshift-docs/pull/46660/files#r907310116
-. Start the podman service that serves the Docker API on a UNIX socket at `${XDG_RUNTIME_DIR}/podman/podman.sock`:
+. Start the Podman service that serves the Docker API on a UNIX socket at `${XDG_RUNTIME_DIR}/podman/podman.sock`:
 +
 [source,terminal]
 ----

--- a/serverless/functions/serverless-functions-setup.adoc
+++ b/serverless/functions/serverless-functions-setup.adoc
@@ -34,7 +34,9 @@ endif::[]
 
 * You have the xref:../../serverless/cli_tools/installing-kn.adoc#installing-kn[Knative (`kn`) CLI] installed. Installing the Knative CLI enables the use of `kn func` commands which you can use to create and manage functions.
 
-* You have installed Docker Container Engine or podman version 3.4.7 or higher, and have access to an available image registry, such as the OpenShift Container Registry.
+* You have installed Docker Container Engine or Podman version 3.4.7 or higher.
+
+* You have access to an available image registry, such as the OpenShift Container Registry.
 
 ifdef::openshift-enterprise[]
 * If you are using link:https://quay.io/[Quay.io] as the image registry, you must ensure that either the repository is not private, or that you have followed the {product-title} documentation on xref:../../openshift_images/managing_images/using-image-pull-secrets.adoc#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets[Allowing pods to reference images from other secured registries].
@@ -61,7 +63,7 @@ include::modules/serverless-functions-podman-macos.adoc[leveloffset=+1]
 == Next steps
 
 ifdef::openshift-enterprise[]
-* For more information about Docker Container Engine or podman, see xref:../../architecture/understanding-development.adoc#container-build-tool-options[Container build tool options].
+* For more information about Docker Container Engine or Podman, see xref:../../architecture/understanding-development.adoc#container-build-tool-options[Container build tool options].
 endif::[]
 // need to wait til build tool docs are added to OSD and ROSA for this link to work
 // TODO: remove these conditionals once this is available


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVOCF-492

Link to docs preview:
https://53048--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-setup.html


QE review: Not required - fixing typos.
