### PR TITLE
Update to fix asciidoc builds

### DIFF
--- a/modules/infrastructure-moving-router.adoc
+++ b/modules/infrastructure-moving-router.adoc
@@ -61,7 +61,7 @@ $ oc edit ingresscontroller default -n openshift-ingress-operator
 ----
   spec:
     nodePlacement:
-      nodeSelector:
+      nodeSelector: <1>
         matchLabels:
           node-role.kubernetes.io/infra: ""
     tolerations:
@@ -72,7 +72,7 @@ $ oc edit ingresscontroller default -n openshift-ingress-operator
       key: node-role.kubernetes.io/infra
       value: reserved
 ----
-<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.  If you added a taint to the infrasructure node, also add a matching toleration.
+<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node. If you added a taint to the infrastructure node, also add a matching toleration.
 
 . Confirm that the router pod is running on the `infra` node.
 .. View the list of router pods and note the node name of the running pod:


### PR DESCRIPTION
Corrects typos that caused asciidoctor build errors. #51466

Version(s):
4.8+

Link to docs preview:
[Moving the router](http://file.rdu.redhat.com/antaylor/asciidoc-fix-1/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-router_creating-infrastructure-machinesets)