### PR TITLE
modules/update-upgrading-cli: Use 'oc adm upgrade' for current status

### DIFF
--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -18,7 +18,6 @@ of the Customer Portal.
 
 * Install the OpenShift CLI (`oc`) that matches the version for your updated version.
 * Log in to the cluster as user with `cluster-admin` privileges.
-* Install the `jq` package.
 * Pause all `MachineHealthCheck` resources.
 
 .Procedure
@@ -116,75 +115,34 @@ $ oc adm upgrade --to=<version> <1>
 +
 [source,terminal]
 ----
-$ oc get clusterversion -o json|jq ".items[0].spec"
+$ oc adm upgrade
 ----
 +
 .Example output
 [source,terminal]
 ----
-{
-  "channel": "stable-4.10",
-  "clusterID": "990f7ab8-109b-4c95-8480-2bd1deec55ff",
-  "desiredUpdate": {
-    "force": false,
-    "image": "quay.io/openshift-release-dev/ocp-release@sha256:9c5f0df8b192a0d7b46cd5f6a4da2289c155fd5302dec7954f8f06c878160b8b",
-    "version": "4.10.13" <1>
-  }
-}
-----
-<1> If the `version` number in the `desiredUpdate` stanza matches the value that
-you specified, the update is in progress.
+info: An upgrade is in progress. Working towards 4.10.13: 9 of 827 done (1% complete)
 
-. Review the cluster version status history to monitor the status of the update.
-It might take some time for all the objects to finish updating.
-+
-[source,terminal]
+Upstream is unset, so the cluster will use an appropriate default.
+Channel: stable-4.10 (available channels: candidate-4.10, candidate-4.11, fast-4.10, fast-4.11, stable-4.10, stable-4.11)
+No updates available. You may force an upgrade to a specific release image, but doing so may not be supported and may result in downtime or data loss.
 ----
-$ oc get clusterversion -o json|jq ".items[0].status.history"
-----
-+
-.Example output
-[source,terminal]
-----
-[
-  {
-    "completionTime": null,
-    "image": "quay.io/openshift-release-dev/ocp-release@sha256:b8fa13e09d869089fc5957c32b02b7d3792a0b6f36693432acc0409615ab23b7",
-    "startedTime": "2021-01-28T20:30:50Z",
-    "state": "Partial",
-    "verified": true,
-    "version": "4.10.13"
-  },
-  {
-    "completionTime": "2021-01-28T20:30:50Z",
-    "image": "quay.io/openshift-release-dev/ocp-release@sha256:b8fa13e09d869089fc5957c32b02b7d3792a0b6f36693432acc0409615ab23b7",
-    "startedTime": "2021-01-28T17:38:10Z",
-    "state": "Completed",
-    "verified": false,
-    "version": "4.9.23"
-  }
-]
-----
-+
-The history contains a list of the most recent versions applied to the cluster.
-This value is updated when the CVO applies an update. The list is ordered by
-date, where the newest update is first in the list. Updates in the history have
-state `Completed` if the rollout completed and `Partial` if the update failed
-or did not complete.
-
 . After the update completes, you can confirm that the cluster version has
 updated to the new version:
 +
 [source,terminal]
 ----
-$ oc get clusterversion
+$ oc adm upgrade
 ----
 +
 .Example output
 [source,terminal]
 ----
-NAME      VERSION     AVAILABLE   PROGRESSING   SINCE     STATUS
-version   4.10.13      True        False         2m        Cluster version is 4.10.13
+Cluster version is 4.10.13
+
+Upstream is unset, so the cluster will use an appropriate default.
+Channel: stable-4.10 (available channels: candidate-4.10, candidate-4.11, fast-4.10, fast-4.11, stable-4.10, stable-4.11)
+No updates available. You may force an upgrade to a specific release image, but doing so may not be supported and may result in downtime or data loss.
 ----
 
 . If you are upgrading your cluster to the next minor version, like version 4.y to 4.(y+1), it is recommended to confirm your nodes are upgraded before deploying workloads that rely on a new feature:


### PR DESCRIPTION
It's our command-line interface for pretty-printing the current ClusterVersion status.  And customers may not have `jq` installed, and we shouldn't be asking them to install it.

[Preview](https://53054--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-cluster-cli.html).