### PR TITLE
Fixing asciidoc build typos

### DIFF
--- a/modules/ztp-acm-adding-images-to-mirror-registry.adoc
+++ b/modules/ztp-acm-adding-images-to-mirror-registry.adoc
@@ -36,11 +36,11 @@ $ export ROOTFS_IMAGE_NAME=<rootfs_image_name> <2>
 +
 [source,terminal]
 ----
-$ export OCP_VERSION=<ocp_version> <2>
+$ export OCP_VERSION=<ocp_version> <3>
 ----
 <1> ISO image name, for example, `rhcos-{product-version}.1-x86_64-live.x86_64.iso`
 <2> RootFS image name, for example, `rhcos-{product-version}.1-x86_64-live-rootfs.x86_64.img`
-<3> {product-title} verison, for example, `{product-version}.1`
+<3> {product-title} version, for example, `{product-version}.1`
 
 .. Download the required images:
 +


### PR DESCRIPTION
Corrects typos that caused asciidoctor build errors. #49805

Version(s):
4.10+

Link to docs preview:
[Adding RHCOS ISO and RootFS images to the disconnected mirror host](http://file.rdu.redhat.com/antaylor/asciidoc-fix-2/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-acm-adding-images-to-mirror-registry_ztp-preparing-the-hub-cluster)