### PR TITLE
BZ#2117604: Added guidance on enabling steal clock accounting

### DIFF
--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -170,10 +170,12 @@ $ govc vm.change -vm "<vm_name>" -e "guestinfo.afterburn.initrd.network-kargs=${
 *** Optional: In the event of cluster performance issues, from the *Latency Sensitivity* list, select *High*. Ensure that your VM's CPU and memory reservation have the following values:
 **** Memory reservation value must be equal to its configured memory size.
 **** CPU reservation value must be at least the number of low latency virtual CPUs multiplied by the measured physical CPU speed.
-*** Click *Edit Configuration*, and on the *Configuration Parameters* window, click *Add Configuration Params*. Define the following parameter names and values:
+*** Click *Edit Configuration*, and on the *Configuration Parameters* window, search the list of available parameters for steal clock accounting (`stealclock.enable`). If it is available, set its value to `TRUE`. Enabling steal clock accounting can help with troubleshooting cluster issues.
+*** Click *Add Configuration Params*. Define the following parameter names and values:
 **** `guestinfo.ignition.config.data`: Locate the base-64 encoded files that you created previously in this procedure, and paste the contents of the base64-encoded Ignition config file for this machine type.
 **** `guestinfo.ignition.config.data.encoding`: Specify `base64`.
 **** `disk.EnableUUID`: Specify `TRUE`.
+**** `stealclock.enable`: If this parameter was not defined, add it and specify `TRUE`.
 .. In the *Virtual Hardware* panel of the *Customize hardware* tab, modify the specified values as required. Ensure that the amount of RAM, CPU, and disk storage meets the minimum requirements for the
 machine type.
 .. Complete the configuration and power on the VM.


### PR DESCRIPTION
Version(s):
4.8+

Issue:
This PR addresses [bz#2117604](https://bugzilla.redhat.com/show_bug.cgi?id=2117604), which was originally submitted by @Rupesh-git-eng  (https://github.com/openshift/openshift-docs/pull/48551) It is the first of two [1] doc updates to recommend that steal clock accounting be enabled. This PR is for the vSphere UPI doc.

Link to docs preview:
[Installing RHCOS and starting the OpenShift Container Platform bootstrap process](https://53060--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-machines_installing-vsphere) > step 9 g.

QE review:
- [x] QE has approved this change.

[1] IPI doc https://github.com/openshift/openshift-docs/pull/53074
