### PR TITLE
Moving modules from working with nodes to mananging nodes

### DIFF
--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * nodes/nodes-nodes-working.adoc
+// * nodes/nodes-nodes-managing.adoc
 // * post_installation_configuration/machine-configuration-tasks.adoc
 
 :_content-type: PROCEDURE

--- a/modules/nodes-nodes-rtkernel-arguments.adoc
+++ b/modules/nodes-nodes-rtkernel-arguments.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * nodes/nodes/nodes-nodes-working.adoc
+// * nodes/nodes/nodes-nodes-managing.adoc
 // * post_installation_configuration/machine-configuration-tasks.adoc
 
 :_content-type: PROCEDURE

--- a/modules/nodes-nodes-working-master-schedulable.adoc
+++ b/modules/nodes-nodes-working-master-schedulable.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * nodes/nodes-nodes-working.adoc
+// * nodes/nodes-nodes-managing.adoc
 
 :_content-type: PROCEDURE
 [id="nodes-nodes-working-master-schedulable_{context}"]

--- a/modules/nodes-nodes-working-setting-booleans.adoc
+++ b/modules/nodes-nodes-working-setting-booleans.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes/nodes-nodes-managing.adoc
+
+
 :_content-type: PROCEDURE
 [id="nodes-nodes-working-setting-booleans"]
 

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -16,7 +16,7 @@ include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+1]
 ** xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration]
 ** xref:../../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_cluster-operators-ref[Cluster Cloud Controller Manager Operator]
 ** xref:../../cicd/builds/build-strategies.adoc#builds-using-build-volumes_build-strategies-s2i[Source-to-image (S2I) build volumes] and xref:../../cicd/builds/build-strategies.adoc#builds-using-build-volumes_build-strategies-docker[Docker build volumes]
-** xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-swap-memory_nodes-nodes-working[Swap memory on nodes]
+** xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-swap-memory_nodes-nodes-jobs[Swap memory on nodes]
 
 include::modules/nodes-cluster-enabling-features-install.adoc[leveloffset=+1]
 

--- a/nodes/index.adoc
+++ b/nodes/index.adoc
@@ -34,7 +34,7 @@ through several tasks:
 
 * xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Add or update node labels]. A label is a key-value pair applied to a `Node` object. You can control the scheduling of pods using labels.
 * Change node configuration using a custom resource definition (CRD), or the `kubeletConfig` object.
-* Configure nodes to allow or disallow the scheduling of pods. Healthy worker nodes with a `Ready` status allow pod placement by default while the control plane nodes do not; you can change this default behavior by xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-marking_nodes-nodes-working[configuring the worker nodes to be unschedulable] and xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-master-schedulable_nodes-nodes-working[the control plane nodes to be schedulable].
+* Configure nodes to allow or disallow the scheduling of pods. Healthy worker nodes with a `Ready` status allow pod placement by default while the control plane nodes do not; you can change this default behavior by xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-marking_nodes-nodes-working[configuring the worker nodes to be unschedulable] and xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-marking_nodes-nodes-working[the control plane nodes to be schedulable].
 * xref:../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring[Allocate resources for nodes] using the `system-reserved` setting. You can allow {product-title} to automatically determine the optimal `system-reserved` CPU and memory resources for your nodes, or you can manually determine and set the best resources for your nodes.
 * xref:../nodes/nodes/nodes-nodes-managing-max-pods.adoc#nodes-nodes-managing-max-pods-about_nodes-nodes-jobs[Configure the number of pods that can run on a node] based on the number of processor cores on the node, a hard limit, or both.
 * Reboot a node gracefully using xref:../nodes/nodes/nodes-nodes-rebooting.adoc#nodes-nodes-rebooting-affinity_nodes-nodes-rebooting[pod anti-affinity].
@@ -49,7 +49,7 @@ through several tasks:
 * Enable TLS security profiles on the node to protect communication between the kubelet and the Kubernetes API server.
 * xref:../nodes/jobs/nodes-pods-daemonsets.adoc#nodes-pods-daemonsets[Run background tasks on nodes automatically with daemon sets]. You can create and use daemon sets to create shared storage, run a logging pod on every node, or deploy a monitoring agent on all nodes.
 * xref:../nodes/nodes/nodes-nodes-garbage-collection.adoc#nodes-nodes-garbage-collection[Free node resources using garbage collection]. You can ensure that your nodes are running efficiently by removing terminated containers and the images not referenced by any running pods.
-* xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-kernel-arguments_nodes-nodes-working[Add kernel arguments to a set of nodes].
+* xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-kernel-arguments_nodes-nodes-jobs[Add kernel arguments to a set of nodes].
 * Configure an {product-title} cluster to have worker nodes at the network edge (remote worker nodes). For information on the challenges of having remote worker nodes in an {product-title} cluster and some recommended approaches for managing pods on a remote worker node, see xref:../nodes/edge/nodes-edge-remote-workers.adoc#nodes-edge-remote-workers[Using remote worker nodes at the network edge].
 
 

--- a/nodes/nodes/nodes-nodes-managing.adoc
+++ b/nodes/nodes/nodes-nodes-managing.adoc
@@ -21,3 +21,13 @@ configuration of nodes. By creating an instance of a `KubeletConfig` object, a m
 // assemblies.
 
 include::modules/nodes-nodes-managing-about.adoc[leveloffset=+1]
+include::modules/nodes-nodes-working-master-schedulable.adoc[leveloffset=+1]
+include::modules/nodes-nodes-working-setting-booleans.adoc[leveloffset=+1]
+include::modules/nodes-nodes-kernel-arguments.adoc[leveloffset=+1]
+ifdef::openshift-webscale[]
+include::modules/nodes-nodes-rtkernel-arguments.adoc[leveloffset=+1]
+endif::openshift-webscale[]
+
+include::modules/nodes-nodes-swap-memory.adoc[leveloffset=+1]
+include::modules/nodes-control-plane-osp-migrating.adoc[leveloffset=+1]
+

--- a/nodes/nodes/nodes-nodes-working.adoc
+++ b/nodes/nodes/nodes-nodes-working.adoc
@@ -20,8 +20,6 @@ include::modules/nodes-nodes-working-updating.adoc[leveloffset=+1]
 
 include::modules/nodes-nodes-working-marking.adoc[leveloffset=+1]
 
-include::modules/nodes-nodes-working-master-schedulable.adoc[leveloffset=+1]
-
 == Deleting nodes
 
 include::modules/nodes-nodes-working-deleting.adoc[leveloffset=+2]
@@ -34,16 +32,3 @@ see xref:../../machine_management/manually-scaling-machineset.adoc#machineset-ma
 
 include::modules/nodes-nodes-working-deleting-bare-metal.adoc[leveloffset=+2]
 
-include::modules/nodes-nodes-working-setting-booleans.adoc[leveloffset=+1]
-include::modules/nodes-nodes-kernel-arguments.adoc[leveloffset=+1]
-ifdef::openshift-webscale[]
-include::modules/nodes-nodes-rtkernel-arguments.adoc[leveloffset=+1]
-endif::openshift-webscale[]
-
-[role="_additional-resources"]
-.Additional resources
-
-* For information about enabling cgroup v2 during installation, see the xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-configuration-parameters-optional_installing-bare-metal[Optional parameters table] in the *Installation configuration parameters* section of your installation process.
-
-include::modules/nodes-nodes-swap-memory.adoc[leveloffset=+1]
-include::modules/nodes-control-plane-osp-migrating.adoc[leveloffset=+1]

--- a/security/container_security/security-hardening.adoc
+++ b/security/container_security/security-hardening.adoc
@@ -41,7 +41,7 @@ include::modules/security-hardening-how.adoc[leveloffset=+1]
 * xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-generate-k8s-manifest-ignition_installing-bare-metal[Creating the Kubernetes manifest and Ignition config files]
 * xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-machines-iso_installing-bare-metal[Installing {op-system} by using an ISO image]
 * xref:../../installing/install_config/installing-customizing.adoc#installing-customizing[Customizing nodes]
-* xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-kernel-arguments_nodes-nodes-working[Adding kernel arguments to Nodes]
+* xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-kernel-arguments_nodes-nodes-jobs[Adding kernel arguments to Nodes]
 ifndef::openshift-origin[]
 * xref:../../installing/installing_aws/installing-aws-customizations.adoc#installation-configuration-parameters_installing-aws-customizations[Installation configuration parameters] - see `fips`
 * xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography]


### PR DESCRIPTION
The first several topics in Working with Nodes are all about running CLI against a node. The next set of modules all involve using CRs against a node, like the assemblies in Managing Nodes. This PR moves those topics from Working to Managing to keep similar procedures together. 

Preview:
Nodes -> Nodes -> [Managing the nodes](https://53073--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html) (Added modules after Modifying nodes)
Nodes -> Nodes -> [Working with nodes](https://53073--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-working.html) (Removed nodes)

Updated links in:
Nodes -> Overview of nodes -> Management operations -> [the control plane nodes to be unschedulable](https://53073--docspreview.netlify.app/openshift-enterprise/latest/nodes/index.html) (3rd bullet)
Nodes -> Overview of nodes -> Management operations -> [the control plane nodes to be schedulable](https://53073--docspreview.netlify.app/openshift-enterprise/latest/nodes/index.html) (3rd bullet)

Nodes -> Overview of nodes -> Enhancement operations -> [Add kernel arguments to a set of nodes](https://53073--docspreview.netlify.app/openshift-enterprise/latest/nodes/index.html) (5th bullet)
Nodes -> Working with clusters -> Understanding feature gates -> Additional information -> [Swap memory on nodes](https://53073--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)
Security -> Container security -> Security hardening -> Additional resources -> [Adding kernel arguments to Nodes](https://53073--docspreview.netlify.app/openshift-enterprise/latest/security/container_security/security-hardening.html)