### PR TITLE
bz#2117604: Added section on steal clock accounting

### DIFF
--- a/installing/installing_vmc/installing-restricted-networks-vmc.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc.adoc
@@ -85,6 +85,8 @@ include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+3]
 
+include::modules/installation-vsphere-steal-clock-accounting.adoc[leveloffset=+1]
+
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_vmc/installing-vmc-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-customizations.adoc
@@ -82,6 +82,8 @@ For instructions about configuring registry storage so that it references the co
 
 include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-steal-clock-accounting.adoc[leveloffset=+1]
+
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_vmc/installing-vmc-network-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-network-customizations.adoc
@@ -87,6 +87,8 @@ For instructions about configuring registry storage so that it references the co
 
 include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-steal-clock-accounting.adoc[leveloffset=+1]
+
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_vmc/installing-vmc.adoc
+++ b/installing/installing_vmc/installing-vmc.adoc
@@ -71,6 +71,8 @@ For instructions about configuring registry storage so that it references the co
 
 include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-steal-clock-accounting.adoc[leveloffset=+1]
+
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -82,6 +82,8 @@ include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+3]
 
+include::modules/installation-vsphere-steal-clock-accounting.adoc[leveloffset=+1]
+
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -77,6 +77,8 @@ For instructions about configuring registry storage so that it references the co
 
 include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-steal-clock-accounting.adoc[leveloffset=+1]
+
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -86,6 +86,8 @@ For instructions about configuring registry storage so that it references the co
 
 include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-steal-clock-accounting.adoc[leveloffset=+1]
+
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
@@ -70,6 +70,8 @@ For instructions about configuring registry storage so that it references the co
 
 include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-steal-clock-accounting.adoc[leveloffset=+1]
+
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/installation-vsphere-steal-clock-accounting.adoc
+++ b/modules/installation-vsphere-steal-clock-accounting.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+// * installing/installing_vmc/installing-restricted-networks-vmc.adoc
+// * installing/installing_vmc/installing-vmc-customizations.adoc
+// * installing/installing_vmc/installing-vmc-network-customizations.adoc
+// * installing/installing_vmc/installing-vmc.adoc
+
+:_content-type: CONCEPT
+[id="installation-vsphere-steal-clock-accounting_{context}"]
+= Steal clock accounting
+
+By default, the installation program provisions the cluster's virtual machines without enabling the steal clock accounting parameter (`stealclock.enabled`). Enabling steal clock accounting can help with troubleshooting cluster issues. After the cluster is deployed, use the vSphere Client to enable this parameter on each of the virtual machines.
+
+For more information, see this link:https://access.redhat.com/solutions/302283[Red Hat knowledge base article].


### PR DESCRIPTION
Version(s):
4.8, 4.9

Issue:
This PR addresses [bz#2117604](https://bugzilla.redhat.com/show_bug.cgi?id=2117604), which was originally submitted by @Rupesh-git-eng  (https://github.com/openshift/openshift-docs/pull/48551) It is the second of two [1] doc updates to recommend that steal clock accounting be enabled. This PR is for the vSphere IPI doc.

It is worth noting that that beginning with 4.10 [2], the installation program automatically enables steal clock accounting in the virtual machines it provisions.

Link to doc preview
[Steal clock accounting](https://53074--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-vsphere-steal-clock-accounting_installing-vsphere-installer-provisioned-customizations)

QE review:
- [x] QE has approved this change

[1] UPI doc https://github.com/openshift/openshift-docs/pull/53060
[2] https://github.com/openshift/openshift-docs/pull/48551#issuecomment-1320008076