### PR TITLE
CNV-18350: Adding info about load balancing with MetalLB

### DIFF
--- a/modules/virt-about-services.adoc
+++ b/modules/virt-about-services.adoc
@@ -13,24 +13,8 @@ ClusterIP:: Exposes the service on an internal IP address within the cluster. `C
 NodePort:: Exposes the service on the same port of each selected node in the cluster. `NodePort` makes a service accessible from outside the cluster.
 
 LoadBalancer:: Creates an external load balancer in the current cloud (if supported) and assigns a fixed, external IP address to the service.
-
-
-[id="services-dual-stack-cluster_{context}"]
-== Dual-stack support
-
-If IPv4 and IPv6 dual-stack networking is enabled for your cluster, you can create a service that uses IPv4, IPv6, or both, by defining the `spec.ipFamilyPolicy` and the `spec.ipFamilies` fields in the `Service` object.
-
-The `spec.ipFamilyPolicy` field can be set to one of the following values:
-
-SingleStack:: The control plane assigns a cluster IP address for the service based on the first configured service cluster IP range.
-
-PreferDualStack:: The control plane assigns both IPv4 and IPv6 cluster IP addresses for the service on clusters that have dual-stack configured.
-
-RequireDualStack:: This option fails for clusters that do not have dual-stack networking enabled. For clusters that have dual-stack configured, the behavior is the same as when the value is set to `PreferDualStack`. The control plane allocates cluster IP addresses from both IPv4 and IPv6 address ranges.
-
-You can define which IP family to use for single-stack or define the order of IP families for dual-stack by setting the `spec.ipFamilies` field to one of the following array values:
-
-* `[IPv4]`
-* `[IPv6]`
-* `[IPv4, IPv6]`
-* `[IPv6, IPv4]`
++
+[NOTE]
+====
+For on-premise clusters, you can configure a load balancing service by using the MetalLB Operator in layer 2 mode. The BGP mode is not supported. The MetalLB Operator is installed in the `metallb-system` namespace.
+====

--- a/modules/virt-dual-stack-support-services.adoc
+++ b/modules/virt-dual-stack-support-services.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-creating-service-vm.adoc
+
+
+:_content-type: REFERENCE
+[id="virt-dual-stack-support-services_{context}"]
+== Dual-stack support
+
+If IPv4 and IPv6 dual-stack networking is enabled for your cluster, you can create a service that uses IPv4, IPv6, or both, by defining the `spec.ipFamilyPolicy` and the `spec.ipFamilies` fields in the `Service` object.
+
+The `spec.ipFamilyPolicy` field can be set to one of the following values:
+
+SingleStack:: The control plane assigns a cluster IP address for the service based on the first configured service cluster IP range.
+
+PreferDualStack:: The control plane assigns both IPv4 and IPv6 cluster IP addresses for the service on clusters that have dual-stack configured.
+
+RequireDualStack:: This option fails for clusters that do not have dual-stack networking enabled. For clusters that have dual-stack configured, the behavior is the same as when the value is set to `PreferDualStack`. The control plane allocates cluster IP addresses from both IPv4 and IPv6 address ranges.
+
+You can define which IP family to use for single-stack or define the order of IP families for dual-stack by setting the `spec.ipFamilies` field to one of the following array values:
+
+* `[IPv4]`
+* `[IPv6]`
+* `[IPv4, IPv6]`
+* `[IPv6, IPv4]`

--- a/virt/virtual_machines/vm_networking/virt-creating-service-vm.adoc
+++ b/virt/virtual_machines/vm_networking/virt-creating-service-vm.adoc
@@ -10,6 +10,13 @@ You can expose a virtual machine within the cluster or outside the cluster by us
 
 include::modules/virt-about-services.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../networking/metallb/metallb-operator-install.adoc#metallb-operator-install[Installing the MetalLB Operator]
+* xref:../../../networking/metallb/metallb-configure-services.adoc#metallb-configure-services[Configuring services to use MetalLB]
+
+include::modules/virt-dual-stack-support-services.adoc[leveloffset=+1]
+
 include::modules/virt-creating-a-service-from-a-virtual-machine.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: [CNV-18350](https://issues.redhat.com//browse/CNV-18350)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://53075--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-creating-service-vm.html#virt-about-services_virt-creating-service-vm
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
