### PR TITLE
RHDEVDOCS-4755: Added new parameters in the Pipeline as Code configur…

### DIFF
--- a/modules/op-customizing-pipelines-as-code-configuration.adoc
+++ b/modules/op-customizing-pipelines-as-code-configuration.adoc
@@ -17,14 +17,32 @@ To customize {pac}, cluster administrators can configure the following parameter
 
 | `application-name` | The name of the application. For example, the name displayed in the GitHub Checks labels. | `"Pipelines as Code CI"` 
 
-| `max-keep-days` | The number of the days for which the executed pipeline runs are kept in the `pipelines-as-code namespace`. 
+| `max-keep-days` | The number of the days for which the executed pipeline runs are kept in the `pipelines-as-code` namespace. 
 
-Note that this configmap setting does not affect the cleanups of a user's pipeline runs, which are controlled by the annotations on the pipeline run definition in the user's GitHub repository. |
+Note that this `ConfigMap` setting does not affect the cleanups of a user's pipeline runs, which are controlled by the annotations on the pipeline run definition in the user's GitHub repository. |  NA
 
 | `secret-auto-create` | Indicates whether or not a secret should be automatically created using the token generated in the GitHub application. This secret can then be used with private repositories. | `enabled` 
 
 | `remote-tasks` | When enabled, allows remote tasks from pipeline run annotations. | `enabled`
 
 | `hub-url` | The base URL for the link:https://api.hub.tekton.dev/v1[Tekton Hub API]. | `https://hub.tekton.dev/`
+
+| `hub-catalog-name` | The Tekton Hub catalog name. | `tekton`
+
+| `tekton-dashboard-url` | The URL of the Tekton Hub dashboard. Pipelines as Code uses this URL to generate a `PipelineRun` URL on the Tekton Hub dashboard.  | NA
+
+| `bitbucket-cloud-check-source-ip` | Indicates whether to secure the service requests by querying IP ranges for a public bitbucket. Changing the parameter's default value might result into a security issue. | `enabled`
+
+| `bitbucket-cloud-additional-source-ip` | Indicates whether to provide an additional set of IP ranges or networks, which are separated by commas. | NA
+
+| `max-keep-run-upper-limit` | A maximum limit for the `max-keep-run` value for a pipeline run. | NA
+
+| `default-max-keep-runs` | A default limit for the `max-keep-run` value for a pipeline run. If defined, the value is applied to all pipeline runs that do not have a `max-keep-run` annotation. | NA
+
+| `auto-configure-new-github-repo` | Configures new GitHub repositories automatically. Pipelines as Code sets up a namespace and creates a custom resource for your repository. This parameter is only supported with GitHub applications. | `disabled`
+
+| `auto-configure-repo-namespace-template` | Configures a template to automatically generate the namespace for your new repository, if `auto-configure-new-github-repo` is enabled. | `{repo_name}-pipelines`
+
+| `error-log-snippet` | Enables or disables the view of a log snippet for the failed tasks, with an error in a pipeline. You can disable this parameter in the case of data leakage from your pipeline. | `enabled` 
 
 |===


### PR DESCRIPTION
**Purpose**: To resolve this issue: https://issues.redhat.com/browse/RHDEVDOCS-4755

**Aligned team**: Dev Tools

**OCP version this PR applies to**: enterprise-4.11 and later

**Content for preview**: https://53076--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/using-pipelines-as-code.html#customizing-pipelines-as-code-configuration_using-pipelines-as-code

**SME review completed**: @savitaashture @chmouel 

**QE review completed**:  @ppitonak

**Peer review completed**: @gabriel-rh 