### PR TITLE
SRVOCF-492 Manual CP to 4.8 for #53048

### DIFF
--- a/modules/serverless-functions-podman-macos.adoc
+++ b/modules/serverless-functions-podman-macos.adoc
@@ -4,20 +4,20 @@
 
 :_content-type: PROCEDURE
 [id="serverless-functions-podman-macos_{context}"]
-= Setting up podman on macOS
+= Setting up Podman on macOS
 
-To use advanced container management features, you might want to use podman with {FunctionsProductName}. To do so on macOS, you need to start the podman machine and configure the Knative (`kn`) CLI to connect to it.
+To use advanced container management features, you might want to use Podman with {FunctionsProductName}. To do so on macOS, you need to start the Podman machine and configure the Knative (`kn`) CLI to connect to it.
 
 .Procedure
 
-. Create the podman machine:
+. Create the Podman machine:
 +
 [source,terminal]
 ----
 $ podman machine init --memory=8192 --cpus=2 --disk-size=20
 ----
 
-. Start the podman machine, which serves the Docker API on a UNIX socket:
+. Start the Podman machine, which serves the Docker API on a UNIX socket:
 +
 [source,terminal]
 ----

--- a/modules/serverless-functions-podman.adoc
+++ b/modules/serverless-functions-podman.adoc
@@ -4,16 +4,16 @@
 
 :_content-type: PROCEDURE
 [id="serverless-functions-podman_{context}"]
-= Setting up podman
+= Setting up Podman
 
-To use advanced container management features, you might want to use podman with {FunctionsProductName}. To do so, you need to start the podman service and configure the Knative (`kn`) CLI to connect to it.
+To use advanced container management features, you might want to use Podman with {FunctionsProductName}. To do so, you need to start the Podman service and configure the Knative (`kn`) CLI to connect to it.
 
 .Procedure
 
 // This step might no longer be needed in the future, when automatic
 // podman startup is reliable.
 // https://github.com/openshift/openshift-docs/pull/46660/files#r907310116
-. Start the podman service that serves the Docker API on a UNIX socket at `${XDG_RUNTIME_DIR}/podman/podman.sock`:
+. Start the Podman service that serves the Docker API on a UNIX socket at `${XDG_RUNTIME_DIR}/podman/podman.sock`:
 +
 [source,terminal]
 ----

--- a/serverless/functions/serverless-functions-setup.adoc
+++ b/serverless/functions/serverless-functions-setup.adoc
@@ -27,7 +27,9 @@ Functions are deployed as a Knative service. If you want to use event-driven arc
 
 * You have the xref:../../serverless/cli_tools/installing-kn.adoc#installing-kn[Knative (`kn`) CLI] installed. Installing the Knative CLI enables the use of `kn func` commands which you can use to create and manage functions.
 
-* You have installed Docker Container Engine or podman version 3.4.7 or higher, and have access to an available image registry, such as the OpenShift Container Registry.
+* You have installed Docker Container Engine or Podman version 3.4.7 or higher.
+
+* You have access to an available image registry, such as the OpenShift Container Registry.
 
 * If you are using link:https://quay.io/[Quay.io] as the image registry, you must ensure that either the repository is not private, or that you have followed the {product-title} documentation on xref:../../openshift_images/managing_images/using-image-pull-secrets.adoc#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets[Allowing pods to reference images from other secured registries].
 
@@ -39,6 +41,10 @@ include::modules/serverless-functions-podman-macos.adoc[leveloffset=+1]
 [id="next-steps_serverless-functions-setup"]
 == Next steps
 
-* For more information about Docker Container Engine or podman, see xref:../../architecture/understanding-development.adoc#container-build-tool-options[Container build tool options].
+ifdef::openshift-enterprise[]
+* For more information about Docker Container Engine or Podman, see xref:../../architecture/understanding-development.adoc#container-build-tool-options[Container build tool options].
+endif::[]
+// need to wait til build tool docs are added to OSD and ROSA for this link to work
+// TODO: remove these conditionals once this is available
 
 * See xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-functions-getting-started[Getting started with functions].


### PR DESCRIPTION
Version(s):
4.8


Issue:
https://issues.redhat.com/browse/SRVOCF-492

Link to docs preview:
https://gabriel-rh.github.io/ocp-previews/manual-cp-%2353048-to-4.8/serverless/functions/serverless-functions-setup.html

QE review: Not needed

Manual CP of #53048
