### PR TITLE
RHDEVDOCS-4711: Updated the installation procedure for PAC on an Open…

### DIFF
--- a/cicd/pipelines/using-pipelines-as-code.adoc
+++ b/cicd/pipelines/using-pipelines-as-code.adoc
@@ -7,7 +7,6 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 :FeatureName: Pipelines as Code
-include::snippets/technology-preview.adoc[]
 
 [role="_abstract"]
 With {pac}, cluster administrators and users with the required privileges can define pipeline templates as part of source code Git repositories. When triggered by a source code push or a pull request for the configured Git repository, the feature runs the pipeline and reports the status.   

--- a/modules/op-configuring-pipelines-as-code-for-a-git-repository-hosting-service-provider.adoc
+++ b/modules/op-configuring-pipelines-as-code-for-a-git-repository-hosting-service-provider.adoc
@@ -9,8 +9,9 @@
 [role="_abstract"]
 After installing {pac}, cluster administrators can configure a Git repository hosting service provider. Currently, the following services are supported:
 
-* Github App
-* Github Webhook
+* GitHub App
+* GitHub Webhook
+* GitLab
 * Bitbucket Server
 * Bitbucket Cloud
 

--- a/modules/op-configuring-pipelines-as-code-for-a-github-app.adoc
+++ b/modules/op-configuring-pipelines-as-code-for-a-github-app.adoc
@@ -33,11 +33,11 @@ To create and configure a GitHub App manually for {pac}, perform the following s
 
 * **GitHub Application Name**: `OpenShift Pipelines`
 * **Homepage URL**: OpenShift Console URL 
-* **Webhook URL**: The {pac} route or ingress URL. You can find it by executing the command `echo https://$(oc get route -n pipelines-as-code el-pipelines-as-code-interceptor -o jsonpath='{.spec.host}')`.
+* **Webhook URL**: The {pac} route or ingress URL. You can find it by running the command `echo https://$(oc get route -n openshift-pipelines pipelines-as-code-controller -o jsonpath='{.spec.host}')`.
 +
 [NOTE]
 ====
-For {pac} installated by default using the {pipelines-title} Operator, use the `openshift-pipelines` namespace instead of `pipelines-as-code`.
+If {pac} is installed without using the {pipelines-title} Operator, use the `pipelines-as-code` namespace instead of `openshift-pipelines`.
 ====
 +
 * **Webhook secret**: An arbitrary secret. You can generate a secret by executing the command `openssl rand -hex 20`.
@@ -57,11 +57,9 @@ For {pac} installated by default using the {pipelines-title} Operator, use the `
 
 . Select the following **User permissions**:
 
-* **Commit comment**
+* **Check run**
 * **Issue comment**
 * **Pull request**
-* **Pull request review**
-* **Pull request review comment**
 * **Push**
 
 . Click **Create GitHub App**.
@@ -70,20 +68,22 @@ For {pac} installated by default using the {pipelines-title} Operator, use the `
 
 . In the **Private keys** section, click **Generate Private key** to automatically generate and download a private key for the GitHub app. Securely store the private key for future reference and usage.
 
+. Install the created App on a repository that you want to use with Pipelines as Code.
+
 
 [id="configuring-pac-for-github-app"]
 == Configuring {pac} to access a GitHub App
 
 To configure {pac} to access the newly created GitHub App, execute the following command:
-+
+
 [source,terminal]
 ----
-$ oc -n <pipelines-as-code> create secret generic pipelines-as-code-secret \ <1>
+$ oc -n openshift-pipelines create secret generic pipelines-as-code-secret \ <1>
         --from-literal github-private-key="$(cat <PATH_PRIVATE_KEY>)" \ <2>
         --from-literal github-application-id="<APP_ID>" \ <3>
         --from-literal webhook.secret="<WEBHOOK_SECRET>" <4>
 ----
-<1> For {pac} installated by default using the {pipelines-title} Operator, use the `openshift-pipelines` namespace instead of `pipelines-as-code`.
+<1> If {pac} is installed without using the {pipelines-title} Operator, use the `pipelines-as-code` namespace instead of `openshift-pipelines`.
 <2> The path to the private key you downloaded while configuring the GitHub App.
 <3> The **App ID** of the GitHub App.
 <4> The webhook secret provided when you created the GitHub App. 

--- a/modules/op-installing-pipelines-as-code-on-an-openshift-cluster.adoc
+++ b/modules/op-installing-pipelines-as-code-on-an-openshift-cluster.adoc
@@ -7,70 +7,27 @@
 = Installing {pac} on an {product-title}
 
 [role="_abstract"]
-{pac} is installed by default when you install the {pipelines-title} Operator. If you are using {pipelines-shortname} 1.7 or later versions, skip the procedure for manual installation of {pac}.
+{pac} is installed in the `openshift-pipelines` namespace when you install the {pipelines-title} Operator. For more details, see _Installing OpenShift Pipelines_ in the _Additional resources_ section.
 
-However, if you want to disable the default installation of {pac} with the {pipelines-title} Operator, set the value of the `enablePipelinesAsCode` field as `false` in the `TektonConfig` custom resource.
+To enable the default installation of {pac} with the {pipelines-title} Operator, set the value of the `enable` parameter to `true` in the `TektonConfig` custom resource:
 
 [source,yaml]
 ----
 ...
-spec:
-    addon:
-      enablePipelinesAsCode: false
+ spec:
+    platforms:
+      openshift:
+        pipelinesAsCode:
+          enable: true
+          settings:
+            application-name: Pipelines as Code CI
+            auto-configure-new-github-repo: "false"
+            bitbucket-cloud-check-source-ip: "true"
+            hub-catalog-name: tekton
+            hub-url: https://api.hub.tekton.dev/v1
+            remote-tasks: "true"
+            secret-auto-create: "true"
 ...
 ----
 
-To install {pac} using the Operator, set the value of the `enablePipelinesAsCode` field to `true`.
-
-[discrete]
-.Procedure
-
-. To _manually_ install {pac} on a {product-title} cluster instead of the default installation with the {pipelines-title} Operator, run the following command:
-+
-[source,terminal]
-----
-$ VERSION=0.5.4
-$ oc apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/release-$VERSION/release-$VERSION.yaml
-----
-+
-[NOTE]
-====
-For the latest stable version, check the link:https://github.com/openshift-pipelines/pipelines-as-code/releases[release page]. In addition, check the {pipelines-title} release notes to ensure that the {pac} version is compatible with the {pipelines-title} version.
-====
-+
-This command installs {pac} in the `pipelines-as-code` namespace and creates user roles and the route URL for the {pac} event listener.
-
-. Note the route URL for the {pac} controller created on the cluster:
-+
-[source,terminal]
-----
-$ echo https://$(oc get route -n pipelines-as-code el-pipelines-as-code-interceptor -o jsonpath='{.spec.host}')
-----
-+
-This URL will be needed later when you configure the Git repository hosting service provider.
-
-. (Optional) To allow non-administrative users to create repository custom resource definitions (CRDs) in their respective namespaces, create a `RoleBinding` object with the name `openshift-pipeline-as-code-clusterrole` in the namespace. For example, to allow a user to create a repository CRD in the `user-ci` namespace, run the following command:
-+
-[source,terminal]
-----
-$ oc adm policy add-role-to-user openshift-pipeline-as-code-clusterrole user -n user-ci
-----
-+
-Alternatively, apply the following YAML file using the `oc apply -f <RoleBinding.yaml>` command: 
-+
-[source,yaml]
-----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: openshift-pipeline-as-code-clusterrole
-  namespace: user-ci
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: openshift-pipeline-as-code-clusterrole
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: user
----- 
+If you want to disable the default installation of {pac} with the Operator, set the value of the `enable` parameter to `false`.


### PR DESCRIPTION
**Purpose**: To resolve this issue: https://issues.redhat.com/browse/RHDEVDOCS-4711

**Aligned team**: DevTools

**OCP version this PR applies to**: enterprise-4.11 and later

**Content for preview**: https://53080--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/using-pipelines-as-code.html#installing-pipelines-as-code-on-an-openshift-cluster_using-pipelines-as-code

**SME review completed**:  @sm43 

**QE review completed**:  @VeereshAradhya 

**Peer review completed**: @bburt-rh 