### PR TITLE
TELCODOCS-597: Adding a local registry to a SNO DU profile

### DIFF
--- a/modules/ztp-add-local-registry-for-edge-clusters.adoc
+++ b/modules/ztp-add-local-registry-for-edge-clusters.adoc
@@ -6,7 +6,7 @@
 [id="ztp-add-local-registry-for-edge-clusters_{context}"]
 = Creating a local image registry on a managed cluster
 
-{product-title} manages image caching using a local registry. In edge computing use cases, clusters are often subject to bandwidth restrictions when communicating with centralized image registries. This can lead to long image download times. This is unavoidable for the initial deployment. In the case of a disorderly cluster shutdown, there is also the potential that the CRI-O cluster process wipes the content of `/var/lib/containers/storage`.
+{product-title} manages image caching using a local registry. In edge computing use cases, clusters are often subject to bandwidth restrictions when communicating with centralized image registries, which might result in long image download times. Long download times are unavoidable for the initial deployment. Over time, there is also the potential that `crio` will erase the content of the `/var/lib/containers/storage` folder in the case of an unexpected cluster shutdown.
 
 To address these issues, you can create a local image registry on the remote managed cluster using GitOps ZTP. This is useful in Edge computing scenarios where clusters are deployed on the far edge of the network.
 

--- a/modules/ztp-add-local-registry-for-edge-clusters.adoc
+++ b/modules/ztp-add-local-registry-for-edge-clusters.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
+
+:_module-type: CONCEPT
+[id="ztp-add-local-registry-for-edge-clusters_{context}"]
+= Creating a local image registry on a managed cluster
+
+{product-title} manages image caching using a local registry. In edge computing use cases, clusters are often subject to bandwidth restrictions when communicating with centralized image registries. This can lead to long image download times. This is unavoidable for the initial deployment. In the case of a disorderly cluster shutdown, there is also the potential that the CRI-O cluster process wipes the content of `/var/lib/containers/storage`.
+
+To address these issues, you can create a local image registry on the remote managed cluster using GitOps ZTP. This is useful in Edge computing scenarios where clusters are deployed on the far edge of the network.
+
+[NOTE]
+====
+The local image registry can only be used for user application images and cannot be used for {product-title} or Operator Lifecycle Manager operator images.
+====
+
+At a high level, you configure local caching of images for a cluster as follows:
+
+. Deploy the cluster using ZTP GitOps and a `SiteConfig` CR that references a `MachineConfig` CR that configures disk partitioning on the cluster.
+. Configure the local image registry using `PolicyGenTemplate` (PGT) CRs that create `PersistentVolume` (PV) and `PersistentVolumeClaim` (PVC) CRs.
+. Patch the `imageregistry` configuration.

--- a/modules/ztp-configuring-disk-partitioning.adoc
+++ b/modules/ztp-configuring-disk-partitioning.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.adoc
+
+:_module-type: PROCEDURE
+[id="ztp-configuring-disk-partitioning_{context}"]
+= Configuring disk partitioning with SiteConfig CRs
+
+Create a persistent disk partition in the managed cluster by configuring the `SiteConfig` CR that you use to deploy the cluster. The values you specify must match the configuration of the underlying disk on the cluster host and must be established prior to cluster installation.
+
+[NOTE]
+====
+Use persistent naming for devices to prevent reboot errors occuring when you have more than one disk and device names such as `/dev/sda` and `/dev/sdb`. You can use `rootDeviceHints` to choose the bootable device.
+====
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You have logged in as a user with `cluster-admin` privileges.
+
+* Create a Git repository where you manage your custom site configuration data for use with GitOps Zero Touch Provisioning (ZTP). The repository must be accessible from the hub cluster and be defined as a source repository for the Argo CD application.
+
+.Procedure
+
+. Add the following YAML to the `SiteConfig` CR that you use to install the cluster:
++
+[source,yaml]
+----
+nodes:
+  - rootDeviceHints:
+      wwn: "0x62cea7f05c98c2002708a0a22ff480ea" <1>
+    diskPartition:
+    - device: /dev/disk/by-id/wwn-0x62cea7f05c98c2002708a0a22ff480ea <2>
+      partitions:
+       - mount_point: /var/imageregistry <3>
+         size: 102500 <4>
+         start: 344844 <5>
+----
+<1> `wwn` is used here, but you can specify a different root device hint as required.
+<2> This setting depends on the hardware. The setting can be a serial number or device name. The value must match the value set in `rootDeviceHints`.
+<3> Mount point name. If you are configuring a local image registry, this value should match what you set in the related `PolicyGenTemplate` CR that configures the storage class.
+<3> The minimum value for `size` is 102500 MiB.
+<4> The minimum value for `start` is 25000 MiB. The total value of `size` and `start` must not exceed the disk size, or the installation will fail.
+
+. Save the `SiteConfig` CR and push it to the site configuration repo.
++
+The ZTP pipeline provisions the cluster using the `SiteConfig` CR  and configures the disk partition.

--- a/modules/ztp-configuring-disk-partitioning.adoc
+++ b/modules/ztp-configuring-disk-partitioning.adoc
@@ -6,9 +6,11 @@
 [id="ztp-configuring-disk-partitioning_{context}"]
 = Configuring disk partitioning with SiteConfig CRs
 
-Create a persistent disk partition in the managed cluster by configuring the `SiteConfig` CR that you use to deploy the cluster. The values you specify must match the configuration of the underlying disk on the cluster host and must be established prior to cluster installation.
+Create a persistent disk partition in the managed cluster by configuring the `SiteConfig` CR that you use to deploy the cluster.
 
-[NOTE]
+The values you specify must match the configuration of the underlying disk on the cluster host and must be established prior to cluster installation.
+
+[IMPORTANT]
 ====
 Use persistent naming for devices to prevent reboot errors occuring when you have more than one disk and device names such as `/dev/sda` and `/dev/sdb`. You can use `rootDeviceHints` to choose the bootable device.
 ====
@@ -19,7 +21,7 @@ Use persistent naming for devices to prevent reboot errors occuring when you hav
 
 * You have logged in as a user with `cluster-admin` privileges.
 
-* Create a Git repository where you manage your custom site configuration data for use with GitOps Zero Touch Provisioning (ZTP). The repository must be accessible from the hub cluster and be defined as a source repository for the Argo CD application.
+* Create a Git repository where you manage your custom site configuration data for use with GitOps Zero Touch Provisioning (ZTP).
 
 .Procedure
 
@@ -40,8 +42,8 @@ nodes:
 <1> `wwn` is used here, but you can specify a different root device hint as required.
 <2> This setting depends on the hardware. The setting can be a serial number or device name. The value must match the value set in `rootDeviceHints`.
 <3> Mount point name. If you are configuring a local image registry, this value should match what you set in the related `PolicyGenTemplate` CR that configures the storage class.
-<3> The minimum value for `size` is 102500 MiB.
-<4> The minimum value for `start` is 25000 MiB. The total value of `size` and `start` must not exceed the disk size, or the installation will fail.
+<4> The minimum value for `size` is 102500 MiB.
+<5> The minimum value for `start` is 25000 MiB. The total value of `size` and `start` must not exceed the disk size, or the installation will fail.
 
 . Save the `SiteConfig` CR and push it to the site configuration repo.
 +

--- a/modules/ztp-configuring-pgt-image-registry.adoc
+++ b/modules/ztp-configuring-pgt-image-registry.adoc
@@ -14,7 +14,7 @@ Use `PolicyGenTemplate` CRs to apply the CRs required to configure the image reg
 
 * You have logged in as a user with `cluster-admin` privileges.
 
-* Create a Git repository where you manage your custom site configuration data for use with GitOps Zero Touch Provisioning (ZTP). The repository must be accessible from the hub cluster and be defined as a source repository for the Argo CD application.
+* You have created a Git repository where you manage your custom site configuration data for use with GitOps Zero Touch Provisioning (ZTP).
 
 * You have configured a disk partition in the managed cluster that you provisioned with GitOps ZTP.
 
@@ -67,7 +67,7 @@ sourceFiles:
 
 .Verification
 
-. Check that the CRD `Config` of the group `imageregistry.operator.openshift.io` instance is not reporting errors. Run the following command from the hub cluster.
+. Check that the `Config` CRD of the group `imageregistry.operator.openshift.io` instance is not reporting errors. Run the following command from the hub cluster.
 //need to follow up with SME, what do we need to run, and if possible get an example of an error
 +
 [source,terminal]
@@ -76,7 +76,7 @@ $ oc get image.config.openshift.io cluster -o yaml
 ----
 +
 .Example output
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: config.openshift.io/v1
 kind: Image
@@ -104,19 +104,25 @@ spec:
 $ oc get pv image-registry-sc
 ----
 
-. Check that the `registry*` pod is up and located under the `openshift-image-registry` namespace:
+. Check that the `registry` pod is up and located under the `openshift-image-registry` namespace:
 
-.. Log in to the managed cluster and verify successful login to the registry with `podman`:
+.. Log in to the managed cluster:
 +
 [source,terminal]
 ----
-  oc login -u kubeadmin -p <password_from_install_log> https://api-int.<cluster_name>.<base_domain>:6443
-  podman login -u kubeadmin -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000
+$ oc login -u kubeadmin -p <password_from_install_log> https://api-int.<cluster_name>.<base_domain>:6443
+----
+
+.. Log in to the image registry:
++
+[source,terminal]
+----
+$ podman login -u kubeadmin -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000
 ----
 
 . Check that disk partitioning is correctly configured:
 
-.. Open a remote shell to the managed cluster by running the following command:
+.. SSH into the managed cluster by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/ztp-configuring-pgt-image-registry.adoc
+++ b/modules/ztp-configuring-pgt-image-registry.adoc
@@ -1,0 +1,146 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
+
+:_module-type: PROCEDURE
+[id="ztp-configuring-pgt-image-registry_{context}"]
+= Configuring the image registry using PolicyGenTemplate CRs
+
+Use `PolicyGenTemplate` CRs to apply the CRs required to configure the image registry and patch the `imageregistry` configuration.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You have logged in as a user with `cluster-admin` privileges.
+
+* Create a Git repository where you manage your custom site configuration data for use with GitOps Zero Touch Provisioning (ZTP). The repository must be accessible from the hub cluster and be defined as a source repository for the Argo CD application.
+
+* You have configured a disk partition in the managed cluster that you provisioned with GitOps ZTP.
+
+.Procedure
+
+. Configure the storage class, persistent volume claim, persistent volume, and image registry configuration in the appropriate `PolicyGenTemplate` CR. For example, to configure an individual site, use the following YAML:
++
+[source,yaml]
+----
+sourceFiles:
+  - fileName: StorageClass.yaml
+    policyName: "sc-for-image-registry"
+    metadata:
+      name: image-registry-sc
+      annotations:
+        ran.openshift.io/ztp-deploy-wave: "100" <1>
+  - fileName: StoragePVC.yaml
+    policyName: "pvc-for-image-registry"
+    metadata:
+      name: image-registry-pvc
+      namespace: openshift-image-registry
+      annotations:
+         ran.openshift.io/ztp-deploy-wave: "100"
+    spec:
+      accessModes:
+        - ReadWriteMany
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: image-registry-sc
+      volumeMode: Filesystem
+  - fileName: ImageRegistryPV.yaml
+    policyName: "pv-for-image-registry"
+    metadata:
+      annotations:
+        ran.openshift.io/ztp-deploy-wave: "100"
+  - fileName: ImageRegistryConfig.yaml
+    policyName: "config-for-image-registry"
+    complianceType: musthave <2>
+    metadata:
+      annotations:
+        ran.openshift.io/ztp-deploy-wave: "100"
+    spec:
+      storage:
+        pvc:
+          claim: "image-registry-pvc"
+----
+<1> Set the appropriate value for `ztp-deploy-wave` depending on whether you are configuring image registries at the site, common, or group level. `ztp-deploy-wave: "100"` is appropriate for an individual site.
+<2> Do not set `complianceType: mustlyonlyhave`. `mustlyonlyhave` causes the registry pod deployment to fail.
+
+.Verification
+
+. Check that the CRD `Config` of the group `imageregistry.operator.openshift.io` instance is not reporting errors. Run the following command from the hub cluster.
+//need to follow up with SME, what do we need to run, and if possible get an example of an error
++
+[source,terminal]
+----
+$ oc get image.config.openshift.io cluster -o yaml
+----
++
+.Example output
+[source,terminal]
+----
+apiVersion: config.openshift.io/v1
+kind: Image
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+  creationTimestamp: "2021-10-08T19:02:39Z"
+  generation: 5
+  name: cluster
+  resourceVersion: "688678648"
+  uid: 0406521b-39c0-4cda-ba75-873697da75a4
+spec:
+  additionalTrustedCA:
+    name: acm-ice
+----
+
+. Check that the `PersistentVolumeClaim` on the mananged cluster is populated with data. Run the following command when logged in to the managed cluster:
+//need to follow up with SME, what do we need to run and where, what is an example of expected result
++
+[source,terminal]
+----
+$ oc get pv image-registry-sc
+----
+
+. Check that the `registry*` pod is up and located under the `openshift-image-registry` namespace:
+
+.. Log in to the managed cluster and verify successful login to the registry with `podman`:
++
+[source,terminal]
+----
+  oc login -u kubeadmin -p <password_from_install_log> https://api-int.<cluster_name>.<base_domain>:6443
+  podman login -u kubeadmin -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000
+----
+
+. Check that disk partitioning is correctly configured:
+
+.. Open a remote shell to the managed cluster by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/sno-1.example.com
+----
+
+.. Check for disk partitioning using `lsblk` to list the blocks:
++
+[source,terminal]
+----
+sh-4.4# lsblk
+----
++
+.Example output
+[source,terminal]
+----
+NAME   MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
+sda      8:0    0 446.6G  0 disk
+  |-sda1   8:1    0     1M  0 part
+  |-sda2   8:2    0   127M  0 part
+  |-sda3   8:3    0   384M  0 part /boot
+  |-sda4   8:4    0 336.3G  0 part /sysroot
+  `-sda5   8:5    0 100.1G  0 part /var/imageregistry <1>
+sdb      8:16   0 446.6G  0 disk
+sr0     11:0    1   104M  0 rom
+----
+<1> `/var/imageregistry` indicates that you have successfully listed the block.

--- a/scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.adoc
@@ -11,3 +11,5 @@ You can use `SiteConfig` custom resources (CRs) to deploy custom functionality a
 include::modules/ztp-customizing-the-install-extra-manifests.adoc[leveloffset=+1]
 
 include::modules/ztp-filtering-ai-crs-using-siteconfig.adoc[leveloffset=+1]
+
+include::modules/ztp-configuring-disk-partitioning.adoc[leveloffset=+1]

--- a/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
@@ -51,3 +51,12 @@ include::modules/ztp-configuring-hwevents-using-pgt.adoc[leveloffset=+1]
 .Additional resources
 
 * For more information about how to create the username, password, and host IP address for the BMC secret, see xref:../../monitoring/using-rfhe.adoc#nw-rfhe-creating-hardware-event_using-rfhe[Creating the bare-metal event and Secret CRs].
+
+include::modules/ztp-add-local-registry-for-edge-clusters.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.adoc#ztp-configuring-disk-partitioning_ztp-advanced-install-ztp[Configuring disk partitioning with SiteConfig CRs]
+
+include::modules/ztp-configuring-pgt-image-registry.adoc[leveloffset=+2]


### PR DESCRIPTION
[TELCODOCS-597](https://issues.redhat.com//browse/TELCODOCS-597) 

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: https://issues.redhat.com/browse/TELCODOCS-597
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://53083--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.html#ztp-configuring-disk-partitioning_ztp-advanced-install-ztp
https://53083--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.html#ztp-add-local-registry-for-edge-clusters_ztp-advanced-policy-config
https://53083--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.html#ztp-configuring-pgt-image-registry_ztp-advanced-policy-config

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information: Original PR: https://github.com/openshift/openshift-docs/pull/50904
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
