### PR TITLE
PAO latency test param fix

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
@@ -42,7 +42,7 @@ $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
--e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 \
+-e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
 -e PERF_TEST_PROFILE=<performance_profile> registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
 /usr/bin/test-run.sh -ginkgo.focus="[performance]\ Latency\ Test"
 ----


### PR DESCRIPTION
Typo in latest cnf-tests docs.

merge to main, CP to 4.11+ only

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2065695