### PR TITLE
OCPBUGS-3620 -  Update recommended cluster MachineConfig CRs

### DIFF
--- a/modules/ztp-recommended-cluster-kernel-config.adoc
+++ b/modules/ztp-recommended-cluster-kernel-config.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc
+
+:_module-type: REFERENCE
+[id="ztp-recommended-cluster-kernel-config_{context}"]
+= Recommended cluster kernel configuration
+
+Always use the latest supported real-time kernel version in your cluster. Ensure that you apply the following configurations in the cluster:
+
+. Ensure that the following `additionalKernelArgs` are set in the cluster performance profile:
++
+[source,yaml]
+----
+spec:
+  additionalKernelArgs:
+  - "rcupdate.rcu_normal_after_boot=0"
+  - "efi=runtime"
+----
+
+. Ensure that the `performance-patch` profile in the `Tuned` CR configures the correct CPU isolation set that matches the `isolated` CPU set in the related `PerformanceProfile` CR, for example:
++
+[source,yaml]
+----
+spec:
+  profile:
+    - name: performance-patch
+      # The 'include' line must match the associated PerformanceProfile name
+      # And the cmdline_crash CPU set must match the 'isolated' set in the associated PerformanceProfile
+      data: |
+        [main]
+        summary=Configuration changes profile inherited from performance created tuned
+        include=openshift-node-performance-openshift-node-performance-profile
+        [bootloader]
+        cmdline_crash=nohz_full=2-51,54-103 <1>
+        [sysctl]
+        kernel.timer_migration=1
+        [scheduler]
+        group.ice-ptp=0:f:10:*:ice-ptp.*
+        [service]
+        service.stalld=start,enable
+        service.chronyd=stop,disable
+----
+<1> Listed CPUs depend on the host hardware configuration, specifically the number of available CPUs in the system and the CPU topology.

--- a/modules/ztp-recommended-cluster-mc-crs.adoc
+++ b/modules/ztp-recommended-cluster-mc-crs.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc
+
+:_module-type: REFERENCE
+[id="ztp-recommended-cluster-mc-crs_{context}"]
+= Recommended cluster MachineConfig CRs
+
+Check that the `MachineConfig` custom resources (CRs) that you extract from the `ztp-site-generate` container are applied in the cluster. The CRs can be found in the extracted `out/source-crs/extra-manifest/` folder.
+
+The following `MachineConfig` CRs from the `ztp-site-generate` container configure the cluster host:
+
+.Recommended MachineConfig CRs
+[cols=2*, options="header"]
+|====
+|CR filename
+|Description
+
+|`02-workload-partitioning.yaml`
+|Configures workload partitioning for the cluster. Apply this `MachineConfig` CR when you install the cluster.
+
+|`03-sctp-machine-config-master.yaml`, `03-sctp-machine-config-worker.yaml`
+|Loads the SCTP kernel module. These `MachineConfig` CRs are optional and can be omitted if you do not require this kernel module.
+
+|`01-container-mount-ns-and-kubelet-conf-master.yaml`, `01-container-mount-ns-and-kubelet-conf-worker.yaml`
+|Configures the container mount namespace and Kubelet configuration.
+
+|`04-accelerated-container-startup-master.yaml`, `04-accelerated-container-startup-worker.yaml`
+|Configures accelerated startup for the cluster.
+
+|`06-kdump-master.yaml`, `06-kdump-worker.yaml`
+|Configures `kdump` for the cluster.
+|====

--- a/modules/ztp-recommended-cluster-operators.adoc
+++ b/modules/ztp-recommended-cluster-operators.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc
+
+:_module-type: REFERENCE
+[id="ztp-recommended-cluster-operators_{context}"]
+= Recommended cluster Operators
+
+The following Operators are required for clusters running virtualized distributed unit (vDU) applications and are a part of the baseline reference configuration:
+
+* Node Tuning Operator (NTO). NTO packages functionality that was previously delivered with the Performance Addon Operator, which is now a part of NTO.
+
+* PTP Operator
+
+* SR-IOV Network Operator
+
+* Red Hat OpenShift Logging Operator
+
+* Local Storage Operator

--- a/scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc
@@ -15,7 +15,21 @@ Before you can deploy virtual distributed unit (vDU) applications, you need to t
 
 include::modules/ztp-du-firmware-config-reference.adoc[leveloffset=+1]
 
-include::modules/ztp-du-cluster-config-reference.adoc[leveloffset=+1]
+[id="ztp-du-cluster-config-reference_{context}"]
+== Recommended cluster configurations to run vDU applications
+
+Clusters running virtualized distributed unit (vDU) applications require a highly tuned and optimized configuration. The following information describes the various elements that you require to support vDU workloads in {product-title} {product-version} clusters.
+
+include::modules/ztp-recommended-cluster-mc-crs.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-ztp-git-repository_ztp-preparing-the-hub-cluster[Extracting source CRs from the ztp-site-generate container]
+
+include::modules/ztp-recommended-cluster-operators.adoc[leveloffset=+2]
+
+include::modules/ztp-recommended-cluster-kernel-config.adoc[leveloffset=+2]
 
 include::modules/ztp-checking-kernel-rt-in-cluster.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Modularizes existing large ZTP topic and clarifies where to find the ZTP MC CRs.

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-3620


Link to docs preview:
https://53104--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.html#ztp-recommended-cluster-mc-crs_vdu-config-ref

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
