### PR TITLE
[OSDOCS-4594]: Adding vSphere CPMS config details

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-configuration.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-configuration.adoc
@@ -20,10 +20,8 @@ The `<platform_failure_domains>` and `<platform_provider_spec>` sections of the 
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-aws_cpmso-configuration[Sample YAML snippets for configuring Amazon Web Services clusters]
 
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-azure_cpmso-configuration[Sample YAML snippets for configuring Microsoft Azure clusters]
-////
-//todo: need vSphere content for this section, omitting for now.
-* xr@f:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-vsphere_cpmso-configuration[Sample YAML snippets for configuring VMware vSphere clusters]
-////
+
+* xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-vsphere_cpmso-configuration[Sample YAML snippets for configuring VMware vSphere clusters]
 
 
 [id="cpmso-sample-yaml-aws_{context}"]
@@ -47,8 +45,7 @@ include::modules/cpmso-yaml-failure-domain-azure.adoc[leveloffset=+2]
 
 //Sample Azure provider specification
 include::modules/cpmso-yaml-provider-spec-azure.adoc[leveloffset=+2]
-////
-//todo: need vSphere content for this section, omitting for now.
+
 [id="cpmso-sample-yaml-vsphere_{context}"]
 == Sample YAML for configuring VMware vSphere clusters
 
@@ -56,4 +53,3 @@ Some sections of the control plane machine set CR are provider-specific. The exa
 
 //Sample VMware vSphere provider specification
 include::modules/cpmso-yaml-provider-spec-vsphere.adoc[leveloffset=+2]
-////

--- a/modules/cpmso-yaml-failure-domain-aws.adoc
+++ b/modules/cpmso-yaml-failure-domain-aws.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * machine_management/control-plane-machine-management.adoc
+// * machine_management/cpmso-configuration.adoc
 
 :_content-type: REFERENCE
 [id="cpmso-yaml-failure-domain-aws_{context}"]

--- a/modules/cpmso-yaml-failure-domain-azure.adoc
+++ b/modules/cpmso-yaml-failure-domain-azure.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * machine_management/control-plane-machine-management.adoc
+// * machine_management/cpmso-configuration.adoc
 
 :_content-type: REFERENCE
 [id="cpmso-yaml-failure-domain-azure_{context}"]

--- a/modules/cpmso-yaml-provider-spec-aws.adoc
+++ b/modules/cpmso-yaml-provider-spec-aws.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * machine_management/control-plane-machine-management.adoc
+// * machine_management/cpmso-configuration.adoc
 
 :_content-type: REFERENCE
 [id="cpmso-yaml-provider-spec-aws_{context}"]

--- a/modules/cpmso-yaml-provider-spec-azure.adoc
+++ b/modules/cpmso-yaml-provider-spec-azure.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * machine_management/control-plane-machine-management.adoc
+// * machine_management/cpmso-configuration.adoc
 
 :_content-type: REFERENCE
 [id="cpmso-yaml-provider-spec-azure_{context}"]

--- a/modules/cpmso-yaml-provider-spec-vsphere.adoc
+++ b/modules/cpmso-yaml-provider-spec-vsphere.adoc
@@ -1,22 +1,53 @@
 // Module included in the following assemblies:
 //
-// * machine_management/control-plane-machine-management.adoc
+// * machine_management/cpmso-configuration.adoc
 
 :_content-type: REFERENCE
 [id="cpmso-yaml-provider-spec-vsphere_{context}"]
 = Sample vSphere provider specification
 
-When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane `machine` CR that is created by the installation program. You can omit any field that is set in the failure domain section of the CR.
-
-In the following example, `<cluster_id>` is the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
-
-[source,terminal]
-----
-$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
-----
+When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane `machine` CR that is created by the installation program. 
 
 .Sample vSphere `providerSpec` values
 [source,yaml]
 ----
-
+providerSpec:
+  value:
+    apiVersion: machine.openshift.io/v1beta1
+    credentialsSecret:
+      name: vsphere-cloud-credentials <1>
+    diskGiB: 120 <2>
+    kind: VSphereMachineProviderSpec <3>
+    memoryMiB: 16384 <4>
+    metadata:
+      creationTimestamp: null
+    network: <5>
+      devices:
+      - networkName: <vm_network_name>
+    numCPUs: 4 <6>
+    numCoresPerSocket: 4 <7>
+    snapshot: ""
+    template: <vm_template_name> <8>
+    userDataSecret:
+      name: master-user-data <9>
+    workspace: 
+      datacenter: <vcenter_datacenter_name> <10>
+      datastore: <vcenter_datastore_name> <11>
+      folder: <path_to_vcenter_vm_folder> <12>
+      resourcePool: <vsphere_resource_pool> <13>
+      server: <vcenter_server_ip> <14>
 ----
+<1> Specifies the secret name for the cluster. Do not change this value.
+<2> Specifies the VM disk size for the control plane machines.
+<3> Specifies the cloud provider platform type. Do not change this value. 
+<4> Specifies the memory allocated for the control plane machines.
+<5> Specifies the network on which the control plane is deployed.
+<6> Specifies the number of CPUs allocated for the control plane machines.
+<7> Specifies the number of cores for each control plane CPU.
+<8> Specifies the vSphere VM template to use, such as `user-5ddjd-rhcos`.
+<9> Specifies the control plane user data secret. Do not change this value.
+<10> Specifies the vCenter Datacenter for the control plane.
+<11> Specifies the vCenter Datastore for the control plane.
+<12> Specifies the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
+<13> Specifies the vSphere resource pool for your VMs.
+<14> Specifies the vCenter server IP or fully qualified domain name.

--- a/modules/cpmso-yaml-sample-cr.adoc
+++ b/modules/cpmso-yaml-sample-cr.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * machine_management/control-plane-machine-management.adoc
+// * machine_management/cpmso-configuration.adoc
 
 :_content-type: REFERENCE
 [id="cpmso-yaml-sample-cr_{context}"]
@@ -54,11 +54,15 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 +
 [IMPORTANT]
 ====
-Before you activate the Operator, you must ensure that the `ControlPlaneMachineSet` CR configuration is correct for your cluster requirements.
-//For more information about activating the Control Plane Machine Set Operator, see "Getting started with the Control Plane Machine Set Operator".
+Before you activate the Operator, you must ensure that the `ControlPlaneMachineSet` CR configuration is correct for your cluster requirements. For more information about activating the Control Plane Machine Set Operator, see "Getting started with the Control Plane Machine Set Operator".
 ====
 <5> Specifies the update strategy for the cluster. The allowed values are `OnDelete` and `RollingUpdate`. The default value is `RollingUpdate`. 
 //For more information about update strategies, see "Updating the control plane configuration".
 <6> Specifies the cloud provider platform name. Do not change this value.
 <7> Specifies the `<platform_failure_domains>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample failure domain configuration for your cloud provider.
++
+[NOTE]
+====
+VMware vSphere does not support failure domains.
+====
 <8> Specifies the `<platform_provider_spec>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample provider specification for your cloud provider.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-4594](https://issues.redhat.com//browse/OSDOCS-4594)

Link to docs preview:
[Sample YAML for configuring VMware vSphere clusters](https://53107--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration.html#cpmso-sample-yaml-vsphere_cpmso-configuration)

QE review:
- [ ] QE has approved this change.

Additional information:
Also fixes incorrect metadata on the other YAML reference modules