### PR TITLE
[RHACS] add gitleaks ignore for example key

### DIFF
--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -1,0 +1,23 @@
+# Only [allowlist] is picked up by the LeakTK scanning service
+[allowlist]
+  description = "Repo Allowlist"
+  paths = [
+    'modules/custom-cert-new-install.adoc',
+    'modules/custom-cert-existing.adoc',
+    
+    # Some test ignores for working with the scanner's unit tests
+    '''ignore\.d''',
+    '''\.ignore\.txt$''',
+
+    # Ignore the .gitleaks.toml
+    '''\.gitleaks\.toml$''',
+  ]
+  regexes = [
+    # '''custom-regexes-to-ignore-here''',
+  ]
+
+# [[rules]] are not picked up by the LeakTK scanning service
+[[rules]]
+  description = "fake-leaks-custom-rule"
+  regex = '''asdfasdfasdfasdf'''
+  tags = ["fake-leaks-custom-rule"]


### PR DESCRIPTION
Version(s):
- `rhacs-docs`
- `rhacs-docs-3.71`
- `rhacs-docs-3.72`
- `rhacs-docs-3.73.0`

Issue: none - see https://source.redhat.com/departments/it/it-information-security/wiki/details_about_rover_github_information_security_and_scanning#how-can-i-tell-the-scanner-to-allow-certain-things-in-my-repo-

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change. *(N/A)*
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This file tells the `gitleaks` tool developed by IT to ignore the fake SSH key that is used as an example in our RHACS documentation.
