### PR TITLE
TELCODOCS-1037: Add instructions for nmstate network settings

### DIFF
--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -76,24 +76,24 @@ stringData:
     rootDeviceHints:
       deviceName: "/dev/sda"
     networkConfig: <3>
-      interfaces:
-      - name: <nic1_name> <4>
+      interfaces: <4>
+      - name: <nic1_name> <5>
         type: ethernet
         state: up
         ipv4:
           address:
-          - ip: <ip_address> <4>
+          - ip: <ip_address> <5>
             prefix-length: 24
           enabled: true
       dns-resolver:
         config:
           server:
-          - <dns_ip_address> <4>
+          - <dns_ip_address> <5>
       routes:
         config:
         - destination: 0.0.0.0/0
-          next-hop-address: <next_hop_ip_address> <4>
-          next-hop-interface: <next_hop_nic1_name> <4>
+          next-hop-address: <next_hop_ip_address> <5>
+          next-hop-interface: <next_hop_nic1_name> <5>
 ---
 apiVersion: v1
 kind: Secret
@@ -102,8 +102,8 @@ metadata:
   namespace: openshift-machine-api
 type: Opaque
 data:
-  username: <base64_of_uid> <5>
-  password: <base64_of_pwd> <5>
+  username: <base64_of_uid> <6>
+  password: <base64_of_pwd> <6>
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -112,39 +112,45 @@ metadata:
   namespace: openshift-machine-api
 spec:
   online: True
-  bootMACAddress: <nic1_mac_address> <6>
+  bootMACAddress: <nic1_mac_address> <7>
   bmc:
-    address: <protocol>://<bmc_url> <7>
+    address: <protocol>://<bmc_url> <8>
     credentialsName: openshift-worker-<num>-bmc-secret <2>
-    disableCertificateVerification: True <8>
-    username: <bmc_username> <9>
-    password: <bmc_password> <9>
+    disableCertificateVerification: True <9>
+    username: <bmc_username> <10>
+    password: <bmc_password> <10>
   rootDeviceHints:
-    deviceName: <root_device_hint> <10>
-  preprovisioningNetworkDataName: openshift-worker-<num>-network-config-secret <11>
+    deviceName: <root_device_hint> <11>
+  preprovisioningNetworkDataName: openshift-worker-<num>-network-config-secret <12>
 ----
 +
+--
 <1> To configure the network interface for a newly created node, specify the name of the secret that contains the network configuration. Follow the `nmstate` syntax to define the network configuration for your node. See "Optional: Configuring host network interfaces in the install-config.yaml file" for details on configuring NMState syntax.
-+
 <2> Replace `<num>` for the worker number of the bare metal node in the `name` fields, the `credentialsName` field, and the `preprovisioningNetworkDataName` field.
-+
 <3> Add the NMState YAML syntax to configure the host interfaces.
+<4> Optional: If you have configured the network interface with `nmstate`, and you want to disable an interface, set `state: up` with the IP addresses set to `enabled: false` as shown:
 +
-<4> Replace `<nic1_name>`, `<ip_address>`, `<dns_ip_address>`, `<next_hop_ip_address>` and `<next_hop_nic1_name>` with appropriate values.
-+
-<5> Replace `<base64_of_uid>` and  `<base64_of_pwd>` with the base64 string of the user name and password.
-+
-<6> Replace `<nic1_mac_address>` with the MAC address of the bare metal node's first NIC. See the "BMC addressing" section for additional BMC configuration options.
-+
-<7> Replace `<protocol>` with the BMC protocol, such as IPMI, RedFish, or others. Replace `<bmc_url>` with the URL of the bare metal node's baseboard management controller.
-+
-<8> To skip certificate validation, set `disableCertificateVerification` to true.
-+
-<9> Replace `<bmc_username>` and `<bmc_password>` with the string of the BMC user name and password.
-+
-<10> Optional: Replace `<root_device_hint>` with a device path if you specify a root device hint.
-+
-<11> Optional: If you have configured the network interface for the newly created node, provide the network configuration secret name in the `preprovisioningNetworkDataName` of the BareMetalHost CR.
+[source,yaml,]
+----
+---
+   interfaces:
+   - name: <nic_name>
+     type: ethernet
+     state: up
+     ipv4:
+       enabled: false
+     ipv6:
+       enabled: false
+----
+<5> Replace `<nic1_name>`, `<ip_address>`, `<dns_ip_address>`, `<next_hop_ip_address>` and `<next_hop_nic1_name>` with appropriate values.
+<6> Replace `<base64_of_uid>` and  `<base64_of_pwd>` with the base64 string of the user name and password.
+<7> Replace `<nic1_mac_address>` with the MAC address of the bare metal node's first NIC. See the "BMC addressing" section for additional BMC configuration options.
+<8> Replace `<protocol>` with the BMC protocol, such as IPMI, RedFish, or others. Replace `<bmc_url>` with the URL of the bare metal node's baseboard management controller.
+<9> To skip certificate validation, set `disableCertificateVerification` to true.
+<10> Replace `<bmc_username>` and `<bmc_password>` with the string of the BMC user name and password.
+<11> Optional: Replace `<root_device_hint>` with a device path if you specify a root device hint.
+<12> Optional: If you have configured the network interface for the newly created node, provide the network configuration secret name in the `preprovisioningNetworkDataName` of the BareMetalHost CR.
+--
 
 * *DHCP configuration* `bmh.yaml`:
 +


### PR DESCRIPTION
[TELCODOCS-1037](https://issues.redhat.com//browse/TELCODOCS-1037): This PR adds instructions for nmstate network settings. 

Version(s):
OpenShift 4.11+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1037

Link to docs preview:
https://53122--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-the-bare-metal-node_ipi-install-expanding
(Added the instruction as callout 4 under _step 4 > Static configuration of the bmh.yml_)


QE review:
- [x] QE has approved this change.


