### PR TITLE
BZ1913738: Added max volume details for cinder - enterprise-4.9

### DIFF
--- a/modules/persistent-storage-cinder-maximum-volume.adoc
+++ b/modules/persistent-storage-cinder-maximum-volume.adoc
@@ -1,0 +1,7 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent_storage-cinder.adoc
+:_content-type: CONCEPT
+[id="persistent-storage-cinder-maximum-volume_{context}"]
+= Maximum number of Cinder volumes on a node
+By default, {product-title} supports a maximum of 256 Cinder volumes attached to one node, and the Cinder predicate that limits attachable volumes is disabled. To enable the predicate, add `MaxCinderVolumeCount` string to the `predicates` field in the scheduler policy.

--- a/storage/persistent_storage/persistent-storage-cinder.adoc
+++ b/storage/persistent_storage/persistent-storage-cinder.adoc
@@ -34,3 +34,9 @@ include::modules/persistent-storage-cinder-creating-pv.adoc[leveloffset=+2]
 include::modules/persistent-storage-cinder-pv-format.adoc[leveloffset=+2]
 
 include::modules/persistent-storage-cinder-volume-security.adoc[leveloffset=+2]
+
+include::modules/persistent-storage-cinder-maximum-volume.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* For more information on modifying the scheduler policy, see xref:../../nodes/scheduling/nodes-scheduler-default.adoc#nodes-scheduler-default-modifying_nodes-scheduler-default[Modifying scheduler policies].


### PR DESCRIPTION
Links to #52803 
Version(s): 4.9

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=1913738

Link to docs preview: http://file.rdu.redhat.com/snarayan/BZ1913738_cindervolume_4_9/storage/persistent_storage/persistent-storage-cinder.html#persistent-storage-cinder-maximum-volume_persistent-storage-cinder