### PR TITLE
adds the two fips modules for agent-based installer

### DIFF
--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -16,6 +16,18 @@ The Agent-based Installer also utilizes Zero Touch Provisioning (ZTP) custom res
 
 include::modules/understanding-agent-install.adoc[leveloffset=+1]
 
+include::modules/agent-installer-fips-compliance.adoc[leveloffset=+1]
+
+include::modules/agent-installer-configuring-fips-compliance.adoc[leveloffset=+1]
+
+[discrete]
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/articles/5059881[OpenShift Security Guide Book]
+
+* xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography]
+
 include::modules/agent-install-networking.adoc[leveloffset=+1]
 
 include::modules/agent-install-sample-config-bonds-vlans.adoc[leveloffset=+1]


### PR DESCRIPTION
- Applies to main and 4.12
- Adds the two modules in the assembly as per https://github.com/openshift/openshift-docs/pull/52701
- These two modules got missed out during a merge conflict
- @maxwelldb ptal