### PR TITLE
[WIP]Agent-249: disconnected install through Agent-based Installer

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -302,6 +302,8 @@ Topics:
   Topics:
   - Name: Preparing to install with Agent-based installer
     File: preparing-to-install-with-agent-based-installer
+  - Name: Understanding disconnected installation Mirroring
+    File: understanding-disconnected-installation-mirroring
   - Name: Installing a cluster with Agent-based installer
     File: installing-with-agent-based-installer
 - Name: Installing on a single node

--- a/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
+++ b/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
@@ -1,0 +1,33 @@
+:_content-type: ASSEMBLY
+[id="understanding-disconnected-installation-mirroring"]
+= Understanding disconnected installation mirroring
+include::_attributes/common-attributes.adoc[]
+:context: understanding-disconnected-installation-mirroring
+
+toc::[]
+// Reusing applicable content from Disconnected installation mirroring assembly
+
+You can use a mirror registry to ensure that your clusters only use container images that satisfy your organizational controls on external content. Before you install a cluster on infrastructure that you provision in a disconnected environment, you must mirror the required container images into that environment. To mirror container images, you must have a registry for mirroring.
+
+[id="agent-install-mirroring-images-disconnected"]
+== Mirroring images for a disconnected installation through the Agent-based Installer
+
+You can use one of the following procedures to mirror your {product-title} image repository to your mirror registry:
+
+* xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
+* xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in]
+
+You can ensure your clusters only use container images that satisfy your organizational controls on external content. Before you install a cluster on infrastructure that you provision in a disconnected environment, you must mirror the required container images into that environment. To mirror container images, you must have a registry for mirroring.
+
+
+[id="agent-install-prerequisites-installation-images"]
+== Prerequisites
+* You read the documentation on xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
+* You must have a container image registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2[Docker v2-2] in the location that will host the {product-title} cluster
+* You have a configured mirror registry that is disconnected and can access the certificate and credentials.
+* If you use self-signed certificates, you have specified a Subject Alternative Name in the certificates.
+* You have downloaded the {product-title} CLI (oc) binary].
+* You downloaded the {cluster-manager-url-pull} and modified it to include authentication to your mirror repository.
+
+
+include::modules/agent-install-mirroring-for-disconnected-registry.adoc[leveloffset=+1]

--- a/modules/agent-install-mirroring-for-disconnected-registry.adoc
+++ b/modules/agent-install-mirroring-for-disconnected-registry.adoc
@@ -1,0 +1,253 @@
+// Module included in the following assemblies:
+//
+// * list of assemblies where this module is included
+// * installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
+// re-use of applicable content from disconnected install mirroring
+
+:_content-type: PROCEDURE
+[id="agent-install-mirroring-for-disconnected-registry_{context}"]
+= Mirroring the {product-title} image repository for a disconnected registry
+
+Mirror the {product-title} image repository to your registry to use during cluster installation.
+
+.Procedure
+
+. Review the
+link:https://access.redhat.com/downloads/content/290/[{product-title} downloads page]
+to determine the version of {product-title} that you want to install and determine the corresponding tag on the link:https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags[Repository Tags] page.
+
+. Set the required environment variables:
+.. Export the release version:
++
+[source,terminal]
+----
+$ OCP_RELEASE=<release_version>
+----
++
+For `<release_version>`, specify the tag that corresponds to the version of {product-title} to
+install, such as `4.5.4`.
+
+.. Export the local registry name and host port:
++
+[source,terminal]
+----
+$ LOCAL_REGISTRY='<local_registry_host_name>:<local_registry_host_port>'
+----
++
+For `<local_registry_host_name>`, specify the registry domain name for your mirror
+repository, and for `<local_registry_host_port>`, specify the port that it
+serves content on.
+
+.. Export the local repository name:
++
+[source,terminal]
+----
+$ LOCAL_REPOSITORY='<local_repository_name>'
+----
++
+For `<local_repository_name>`, specify the name of the repository to create in your
+registry, such as `ocp4/openshift4`.
+
+.. Export the name of the repository to mirror:
++
+[source,terminal]
+----
+$ PRODUCT_REPO='openshift-release-dev'
+----
++
+For a production release, you must specify `openshift-release-dev`.
++
+[source,terminal]
+----
+$ PRODUCT_REPO='openshift'
+----
+
+
+.. Export the path to your registry pull secret:
++
+[source,terminal]
+----
+$ LOCAL_SECRET_JSON='<path_to_pull_secret>'
+----
++
+For `<path_to_pull_secret>`, specify the absolute path to the file name of the pull secret for your mirror registry that you created.
+
+.. Export the release mirror:
++
+[source,terminal]
+----
+$ RELEASE_NAME="ocp-release"
+----
++
+For a production release, you must specify `ocp-release`.
++
+[source,terminal]
+----
+$ RELEASE_NAME="okd"
+----
+
+.. Export the type of architecture for your server, such as `x86_64`:
++
+[source,terminal]
+----
+$ ARCHITECTURE=<server_architecture>
+----
+
+.. Export the path to the directory to host the mirrored images:
++
+[source,terminal]
+----
+$ REMOVABLE_MEDIA_PATH=<path> <1>
+----
+<1> Specify the full path, including the initial forward slash (/) character.
+
+. Because your mirror host does not have internet access, perform the following actions:
+.. Connect the removable media to a system that is connected to the internet.
+.. Review the images and configuration manifests to mirror, by running the following command:
++
+[source,terminal]
+----
+$ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
+     --from=quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE} \
+     --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} \
+     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE} --dry-run
+----
+. In the `install-config.yaml` file, set the following parameters:
+
++
+[source,yaml]
+----
+  pullSecret: "<pull_secret>" <1>
+  sshKey: 'ssh-rsa <ssh_pub_key>'
+  imageContentSources: <2>
+  - mirrors:
+    - my-registry:443/ocp4-release/openshift
+    source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+  - mirrors:
+    - my-registry:443/ocp4-release/openshift
+    source: quay.io/openshift-release-dev/ocp-release
+  additionalTrustBundle: | <3>
+      -----BEGIN CERTIFICATE-----
+      <MY_TRUSTED_CA_CERT>
+      -----END CERTIFICATE-----
+----
+<1> A pull secret for the mirror registry.
+<2> Mirrors for sources and repositories for the release-image content. The certificate file can be an existing, trusted certificate authority,
+or the self-signed certificate that you generated for the mirror registry.
+<3> The certificate file used for the mirror registry.
+
+. Create the `agent-config.yaml` file:
++
+[source,yaml]
+----
+  cat > agent-config.yaml << EOF
+  apiVersion: v1alpha1
+  kind: AgentConfig
+  metadata:
+    name: sno-cluster
+  rendezvousIP: 192.168.111.80 <1>
+  hosts: <2>
+    - hostname: master-0
+      interfaces:
+        - name: eno1
+          macAddress: 00:ef:44:21:e6:a5
+      networkConfig:
+        interfaces:
+          - name: eno1
+            type: ethernet
+            state: up
+            mac-address: 00:ef:44:21:e6:a5
+            ipv4:
+              enabled: true
+              address:
+                - ip: 192.168.111.80
+                  prefix-length: 23
+              dhcp: false
+        dns-resolver:
+          config:
+            server:
+              - 192.168.111.1
+        routes:
+          config:
+            - destination: 0.0.0.0/0
+              next-hop-address: 192.168.111.2
+              next-hop-interface: eno1
+              table-id: 254
+  EOF
+----
++
+<1> This IP address is used to determine which node performs the bootstrapping process as well as running the `assisted-service` component.
+You must provide the IP address when you do not specify the node's IP addresses in the `networkConfig` parameter. If this address is not provided, one IP address is selected from the provided nodes's `networkConfig`.
+<2> The number of hosts defined must match the total number of hosts defined in the `install-config.yaml` file, which is the sum of the values of the `compute.replicas` and `controlPlane.replicas` parameters. When 3 master nodes and 0 worker nodes are defined in the `install-config.yaml` file,
+the number of hosts defined is 3. When 3 master nodes and 2 worker nodes are defined in the `install-config.yaml` file, the number of hosts defined is 5.
+
+. Mirror the images to a directory on the removable media:
++
+[source,terminal]
+----
+$ oc adm release mirror -a ${LOCAL_SECRET_JSON} --to-dir=${REMOVABLE_MEDIA_PATH}/mirror quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE}-${ARCHITECTURE}
+----
+
+. Upload the images to the local container registry from the removable media:
++
+[source,terminal]
+----
+$ oc image mirror -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mirror "file://openshift/release:${OCP_RELEASE}*" ${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} <1>
+----
++
+<1> For `REMOVABLE_MEDIA_PATH`, you must use the same path that you specified when you mirrored the images.
+
+. Create the Agent image by running the following command:
++
+[source,terminal]
+----
+$ openshift-install agent create image
+----
+
+. Boot the `agent.iso` image on the bare metal machines. You can run the image on any Linux distribution.
+
+. To track the progress and verify sucessful installation, run the following command:
++
+[source,terminal]
+----
+$ openshift-install agent wait-for install-complete
+----
++
+.Example output
+[source,terminal]
+----
+...................................................................
+...................................................................
+INFO Cluster is installed
+INFO Install complete!
+INFO To access the cluster as the system:admin user when using 'oc', run
+INFO     export KUBECONFIG=/home/core/installer/auth/kubeconfig
+INFO Access the OpenShift web-console here: https://console-openshift-console.apps.sno-cluster.test.example.com
+----
+
++
+[IMPORTANT]
+====
+If you are using the optional method of the ZTP manifests, there are two mirror configuration files: `registries.conf` and `ca-bundle.crt` file. The `registries.conf` file must be added to `mirror/ directory` for the subcommand `openshift-install create-image command` to execute sucessfully.
+
+.Sample `registries.conf` file
+[source,yaml]
+----
+[[registry]]
+location = "registry.ci.openshift.org/ocp/release"
+mirror-by-digest-only = false
+
+
+[[registry.mirror]]
+location = "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
+
+
+[[registry]]
+location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+mirror-by-digest-only = false
+
+
+[[registry.mirror]]
+location = "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
+----
+====

--- a/modules/installing-ocp-agent.adoc
+++ b/modules/installing-ocp-agent.adoc
@@ -155,7 +155,11 @@ $ openshift-install agent create image
 +
 NOTE: Red Hat Enterprise Linux CoreOS (RHCOS) supports multipathing on the primary disk, allowing stronger resilience to hardware failure to achieve higher host availability. Multipathing is enabled by default in the `agent.iso` image, with a default `/etc/multipath.conf` configuration.
 
+<<<<<<< HEAD
 . Optional: To know when the bootstrap node (** node 0 **) reboots, run the following command:
+=======
+. Optional: To know  when the bootstrap node (** Node 0 **) reboots, run the following command:
+>>>>>>> 9b021c1041 (disconnected install through Agent-based Installer)
 
 +
 [source,terminal]


### PR DESCRIPTION
- Applies to main and 4.12
- [Jira](https://issues.redhat.com/browse/AGENT-249)
- [Preview](https://53132--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.html#agent-install-mirroring-for-disconnected-registry_understanding-disconnected-installation-mirroring)
- **Questions**
- Do we want to mention the optional subcommand to create clusters?
- Is there a sample ca-bundle.crt file i should add ?
- Also is there anything I have missed?
- Please provide a tech review for the pre-reqs/procedure.

@bfournie  ptal  