### PR TITLE
rephrase the definition of agent-based installer

### DIFF
--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 == About the Agent-based Installer
-The Agent-based Installer is a combination of the Assisted Installer (AI) technology and the installer-provisioned infrastructure (IPI). It is a subcommand that resides in the {product-title} installer and also utilizes the {product-title} installer for the input asset management.
+The Agent-based Installer provides the flexibility of user-provided infrastructure (UPI) installation and the ease of use of the Assisted Installer (AI). It is a subcommand that resides in the {product-title} installer, and also uses the {product-title} installer for the input asset management.
 It generates a bootable image containing all of the information required to deploy an {product-title} cluster.
 
 The Agent-based Installer is a sub-command that generates a live {op-system-first} ISO. The live ISO runs all of the required components that are running in containers pulled from the {product-title} release payload.


### PR DESCRIPTION
- Applies to main and 4.12
- No bz/jira as its a small fix for the original content I wrote
- The scope of this PR is to re-phrase the definition of the agent-based installer.  
ref : https://docs.google.com/presentation/d/1Y7fzI6CztB2plojHyy8b9vxxo_ghKbsJMA-VSqw88GU/edit#slide=id.g618db5fab6_0_372
- [Preview](https://53167--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html)
-QE not required.