### PR TITLE
Removing allow_ra sysctl per guidance in #1590

### DIFF
--- a/modules/nodes-safe-sysctls-list.adoc
+++ b/modules/nodes-safe-sysctls-list.adoc
@@ -57,9 +57,6 @@ a| This restricts `ICMP_PROTO` datagram sockets to users in the group range. The
 |===
 | sysctl | Description
 
-| `net.ipv4.conf.IFNAME.accept_ra`
-a|Accept IPv4 Router Advertisements; autoconfigure using them. It also determines whether or not to transmit router solicitations. Router solicitations are transmitted only if the functional setting is to accept router advertisements.
-
 | `net.ipv4.conf.IFNAME.accept_redirects`
 a| Accept IPv4 ICMP redirect messages.
 


### PR DESCRIPTION
[OCPBUGS-3872]: Removing the allow_ra sysctl for ipv4 from documented systl allowlist

Version(s): 4.11

Issue:
https://issues.redhat.com/browse/OCPBUGS-3872

Link to docs preview: https://53179--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-sysctls.html#safe_and_unsafe_sysctls_nodes-containers-using


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

