### PR TITLE
TELCODOCS-522 - enterprise-4.11 ClusterGroupUpgrade message is incorrect

### DIFF
--- a/modules/ztp-monitoring-policy-deployment-progress.adoc
+++ b/modules/ztp-monitoring-policy-deployment-progress.adoc
@@ -38,9 +38,9 @@ $ oc get clustergroupupgrades -n ztp-install $CLUSTER -o jsonpath='{.status.cond
 {
   "lastTransitionTime": "2022-11-09T07:28:09Z",
   "message": "The ClusterGroupUpgrade CR has upgrade policies that are still non compliant",
-  "reason": "InProgress",
-  "status": "True",
-  "type": "Progressing"
+  "reason": "UpgradeNotCompleted",
+  "status": "False",
+  "type": "Ready"
 }
 ----
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-522

Fixes incorrect status message for 4.11

Merge to enterprise-4.11 only.