### PR TITLE
TELCODOCS-522 - enterprise-4.12 ClusterGroupUpgrade message is incorrect

### DIFF
--- a/modules/ztp-monitoring-policy-deployment-progress.adoc
+++ b/modules/ztp-monitoring-policy-deployment-progress.adoc
@@ -37,7 +37,7 @@ $ oc get clustergroupupgrades -n ztp-install $CLUSTER -o jsonpath='{.status.cond
 ----
 {
   "lastTransitionTime": "2022-11-09T07:28:09Z",
-  "message": "The ClusterGroupUpgrade CR has upgrade policies that are still non compliant",
+  "message": "Remediating non-compliant policies",
   "reason": "InProgress",
   "status": "True",
   "type": "Progressing"


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-522

Fixes incorrect status message for 4.12

Merge to enterprise-4.12 only.