### PR TITLE
OADP-773:Velero version by OADP and OCP version

### DIFF
--- a/backup_and_restore/index.adoc
+++ b/backup_and_restore/index.adoc
@@ -34,7 +34,7 @@ You can always recover from a disaster situation by xref:../backup_and_restore/c
 
 As a cluster administrator, you can back up and restore applications running on {product-title} by using the OpenShift API for Data Protection (OADP).
 
-OADP backs up and restores Kubernetes resources and internal images, at the granularity of a namespace, by using link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]. OADP backs up and restores persistent volumes (PVs) by using snapshots or Restic. For details, see xref:../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-features_oadp-features-plugins[OADP features].
+OADP backs up and restores Kubernetes resources and internal images, at the granularity of a namespace, by using the version of Velero that is appropriate for the version of OADP you install, according to the table in xref:../backup_and_restore/application_backup_and_restore/troubleshooting.adoc#velero-obtaining-by-downloading_oadp-troubleshooting[Downloading the Velero CLI tool].  OADP backs up and restores persistent volumes (PVs) by using snapshots or Restic. For details, see xref:../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-features_oadp-features-plugins[OADP features].
 
 [id="oadp-requirements"]
 === OADP requirements

--- a/modules/velero-obtaining-by-downloading.adoc
+++ b/modules/velero-obtaining-by-downloading.adoc
@@ -23,16 +23,17 @@ The page includes instructions for:
 
 . Open a browser and navigate to link:https://{velero-domain}/docs/v{velero-version}/basic-install/#install-the-cli["Install the CLI" on the Velero website].
 . Follow the appropriate procedure for macOS, GitHub, or Windows.
-. Download the Velero version appropriate for your version of OADP, according to the table that follows:
+. Download the Velero version appropriate for your version of OADP and {product-title}  according to the table that follows:
 +
-.OADP-Velero version relationship
-[cols="2", options="header"]
+.OADP-Velero-{product-title} version relationship
+[cols="3", options="header"]
 |===
-|OADP version |Velero version
-|0.2.6 |1.6.0
-|0.5.5 |1.7.1
-|1.0.0 |1.7.1
-|1.0.1 |1.7.1
-|1.0.2 |1.7.1
-|1.0.3 |1.7.1
+|OADP version |Velero version |{product-title} version
+|1.0.0 |link:https://{velero-domain}/docs/v1.7/[1.7] |4.6 and later
+|1.0.1 |link:https://{velero-domain}/docs/v1.7/[1.7] |4.6 and later
+|1.0.2 |link:https://{velero-domain}/docs/v1.7/[1.7] |4.6 and later
+|1.0.3 |link:https://{velero-domain}/docs/v1.7/[1.7] |4.6 and later
+|1.1.0 |link:https://{velero-domain}/docs/v{velero-version}/[{velero-version}] |4.9 and later
+|1.1.1 |link:https://{velero-domain}/docs/v{velero-version}/[{velero-version}] |4.9 and later
+|1.1.2 |link:https://{velero-domain}/docs/v{velero-version}/[{velero-version}] |4.9 and later
 |===


### PR DESCRIPTION
OADP 1.1.0, OCP 4.6+

Resolves https://issues.redhat.com/browse/OADP-773 by changing the reference to Velero version 1.7 in https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html-single/backup_and_restore/index#application-backup-restore-operations-overview and by modfying the table in https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/backup_and_restore/application-backup-and-restore#velero-obtaining-by-downloading_oadp-troubleshooting

Previews:
1.  https://53184--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/index.html#application-backup-restore-operations-overview [reference to Velero version changed to reference to "Downloading the Velero CLI tool] 

2.  https://53184--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#velero-obtaining-by-downloading_oadp-troubleshooting [Table 4.2]