### PR TITLE
OADP-935: Incorrect Backup apiVersion in "Using Data Mover for CSI snapshots"

### DIFF
--- a/modules/oadp-using-data-mover-for-csi-snapshots.adoc
+++ b/modules/oadp-using-data-mover-for-csi-snapshots.adoc
@@ -144,7 +144,7 @@ spec:
 +
 [source,yaml]
 ----
-apiVersion: {velero-domain}/v1
+apiVersion: velero.io/v1
 kind: Backup
 metadata:
   name: <backup_name>


### PR DESCRIPTION
OADP 1.0.6; OCP 4.9+ 

Bug reported by QE; PR approived by QE.

Resolves https://issues.redhat.com/browse/OADP-935 by changing the Backup apiVersion in the Back GR codeblock in "Using Data Mover for CSI snapshots."

Preview: See step 3a in https://53198--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-using-data-mover-for-csi-snapshots_backing-up-applications