### PR TITLE
OCPBUGS 3321 detaching the node from provisioning prior to commencing downtime

### DIFF
--- a/modules/removing-bare-metal-hosts-from-provisioner.adoc
+++ b/modules/removing-bare-metal-hosts-from-provisioner.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// scalability_and_performance/managing-bare-metal-hosts.adoc
+
+:_content-type: PROCEDURE
+[id="removing-bare-metal-hosts-from-provisioner_{context}"]
+= Removing bare metal hosts from the provisioner node
+
+In certain circumstances, you might want to temporarily remove bare metal hosts from the provisioner node.
+For example, during provisioning when a bare metal host reboot is triggered by using the {product-title} administration console or as a result of a Machine Config Pool update, {product-title} logs into the integrated Dell Remote Access Controller (iDrac) and issues a delete of the job queue.
+
+To prevent the management of the number of `Machine` objects that matches the number of available `BareMetalHost` objects, add a `baremetalhost.metal3.io/detached` annotation to the `MachineSet` object.
+[NOTE]
+====
+This annotation has an effect for only `BareMetalHost` objects that are in either `Provisioned`, `ExternallyProvisioned` or `Ready/Available` state.
+====
+
+.Prerequisites
+
+* Install {op-system} bare metal compute machines for use in the cluster and create corresponding `BareMetalHost` objects.
+* Install the {product-title} CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Annotate the compute machine set that you want to remove from the provisioner node by adding the `baremetalhost.metal3.io/detached` annotation.
++
+[source,terminal]
+----
+$ oc annotate machineset <machineset> -n openshift-machine-api 'baremetalhost.metal3.io/detached'
+----
++
+Wait for the new machines to start.
++
+[NOTE]
+====
+When you use a `BareMetalHost` object to create a machine in the cluster and labels or selectors are subsequently changed on the `BareMetalHost`, the `BareMetalHost` object continues be counted against the `MachineSet` that the `Machine` object was created from.
+====
+
+. In the provisioning use case, remove the annotation after the reboot is complete by using the following command:
++
+[source,terminal]
+----
+$ oc annotate machineset <machineset> -n openshift-machine-api 'baremetalhost.metal3.io/detached-'
+----

--- a/scalability_and_performance/managing-bare-metal-hosts.adoc
+++ b/scalability_and_performance/managing-bare-metal-hosts.adoc
@@ -19,6 +19,7 @@ include::modules/maintaining-bare-metal-hosts.adoc[leveloffset=+1]
 include::modules/adding-bare-metal-host-to-cluster-using-web-console.adoc[leveloffset=+2]
 include::modules/adding-bare-metal-host-to-cluster-using-yaml.adoc[leveloffset=+2]
 include::modules/automatically-scaling-machines-to-available-bare-metal-hosts.adoc[leveloffset=+2]
+include::modules/removing-bare-metal-hosts-from-provisioner.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
[OCPBUGS-3321]: Detaching the node from provisioning prior to commencing downtime

Version(s):
  * PR applies to multiple specific versions : 4.8, 4.9, 4.10, 4.11, 4.12 and main 

Issue:
https://issues.redhat.com/browse/OCPBUGS-3321

Link to docs preview: https://53207--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/managing-bare-metal-hosts.html#removing-bare-metal-hosts-from-provisioner_managing-bare-metal-hosts

QE review:
- [x] QE has approved this change.
