### PR TITLE
OSDOCS-4471: Adding cdn03.quay.io back to the list

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -38,13 +38,17 @@ There are no special configuration considerations for services running on only c
 |443, 80
 |Provides core container images
 
+|`cdn03.quay.io`
+|443, 80
+|Provides core container images
+
 |`sso.redhat.com`
 |443, 80
 |The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`
 
 |===
 +
-You can use the wildcards `\*.quay.io` and `*.openshiftapps.com` instead of `cdn0[1-2].quay.io` in your allowlist. When you add a site, such as `quay.io`, to your allowlist, do not add a wildcard entry, such as `*.quay.io`, to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a hostname such as `cdn01.quay.io`.
+You can use the wildcards `\*.quay.io` and `*.openshiftapps.com` instead of `cdn0[1-3].quay.io` in your allowlist. When you add a site, such as `quay.io`, to your allowlist, do not add a wildcard entry, such as `*.quay.io`, to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, image downloads are denied when the initial download request redirects to a hostname such as `cdn01.quay.io`.
 
 . Allowlist any site that provides resources for a language or framework that your builds require.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s):
4.8+

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue:
https://issues.redhat.com/browse/OSDOCS-4471

Link to docs preview:
https://53210--docspreview.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html#configuring-firewall_configuring-firewall

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

Additional information:
Adds back in cdn01.quay.io that was removed by PR #51687
