### PR TITLE
OSDOCS-4167: Multi-architecture compute machines 4.12 release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -257,6 +257,13 @@ A new predefined set of cluster capabilities, `v4.12`, has been added. This incl
 
 For more information, see link: xref:../post_installation_configuration/enabling-cluster-capabilities.adoc[Enabling cluster capabilities].
 
+[id="ocp-4-12-ocp-with-multi-arch-compute-machines"]
+==== {product-title} with multi-architecture compute machines (Technology Preview)
+
+{product-title} {product-version} with multi-architecture compute machines now supports manifest listed images on image streams. For more information about manifest list images, see xref:../post_installation_configuration/multi-architecture-configuration.adoc[Configuring multi-architecture compute machines on an {product-title} cluster]. 
+
+On a cluster with multi-architecture compute machines, you can now override the node affinity in the Operator's `Subscription` object to schedule pods on nodes with architectures that the Operator supports. For more information, see xref:../nodes/scheduling/nodes-scheduler-node-affinity.adoc#olm-overriding-operator-pod-affinity_nodes-scheduler-node-affinity[Using node affinity to control where an Operator is installed].
+
 [id="ocp-4-12-web-console"]
 === Web console
 
@@ -2362,7 +2369,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Multi-architecture clusters
+|Multi-architecture compute machines 
 |Not Available
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
 For version 4.12
[OSDOCS-4167](https://issues.redhat.com//browse/OSDOCS-4167)

Preview:
[Post-installation configuration ->  OpenShift Container Platform on multi-architecture clusters (Technology Preview)](https://53216--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-post-installation)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

