### PR TITLE
TELCODOCS-522 - fix enterprise-4.11 ZTP version

### DIFF
--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -14,15 +14,18 @@ The Red Hat Telco Radio Access Network (RAN) version {product-version} solution 
 |Product
 |Software version
 
-|ZTP GitOps plugin
+|Hub cluster {product-title} version
 |4.11
 
+|GitOps ZTP plugin
+|4.9, 4.10, or 4.11
+
 |{rh-rhacm-first}
-|{rh-rhacm-version}
+|2.5 or 2.6
 
 |{gitops-title}
-|1.6.0
+|1.5
 
 |{cgu-operator-first}
-|4.10 (Technology Preview)
+|4.10 or 4.11
 |====


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-522

Fixes ZTP software versions for enterprise-4.11. 

Merge to enterprise-4.11 only.

Preview: https://53228--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-telco-ran-software-versions_ztp-preparing-the-hub-cluster
