### PR TITLE
TELCODOCS-522 - fix enterprise-4.12 ZTP version

### DIFF
--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -6,7 +6,7 @@
 [id="ztp-telco-ran-software-versions_{context}"]
 = Telco RAN {product-version} validated solution software versions
 
-The Red Hat Telco Radio Access Network (RAN) version {product-version} solution has been validated using the following Red Hat software products versions.
+The Red Hat Telco Radio Access Network (RAN) version {product-version} solution has been validated using the following Red Hat software products.
 
 .Telco RAN {product-version} validated solution software
 [cols=2*, width="80%", options="header"]
@@ -14,15 +14,18 @@ The Red Hat Telco Radio Access Network (RAN) version {product-version} solution 
 |Product
 |Software version
 
-|ZTP GitOps plugin
-|4.11
+|Hub cluster {product-title} version
+|4.12
+
+|GitOps ZTP plugin
+|4.10, 4.11, or 4.12
 
 |{rh-rhacm-first}
-|{rh-rhacm-version}
+|2.6
 
 |{gitops-title}
-|1.6.0
+|1.6
 
 |{cgu-operator-first}
-|4.10 (Technology Preview)
+|4.11 or 4.12
 |====


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-522

Fixes ZTP software versions for enterprise-4.12. 

Merge to enterprise-4.12 only.

Preview: https://53229--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-telco-ran-software-versions_ztp-preparing-the-hub-cluster