### PR TITLE
CNV-18399: Guest agent ping probe

### DIFF
--- a/modules/virt-about-readiness-liveness-probes.adoc
+++ b/modules/virt-about-readiness-liveness-probes.adoc
@@ -18,3 +18,5 @@ You can configure readiness and liveness probes by setting the `spec.readinessPr
 HTTP GET:: The probe determines the health of the VMI by using a web hook. The test is successful if the HTTP response code is between 200 and 399. You can use an HTTP GET test with applications that return HTTP status codes when they are completely initialized.
 
 TCP socket:: The probe attempts to open a socket to the VMI. The VMI is only considered healthy if the probe can establish a connection. You can use a TCP socket test with applications that do not start listening until initialization is complete.
+
+Guest agent ping:: The probe uses the `guest-ping` command to determine if the QEMU guest agent is running on the virtual machine.

--- a/modules/virt-define-guest-agent-ping-probe.adoc
+++ b/modules/virt-define-guest-agent-ping-probe.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-monitoring-vm-health.adoc
+
+:_content-type: PROCEDURE
+[id="virt-define-guest-agent-ping-probe_{context}"]
+
+= Defining a guest agent ping probe
+
+Define a guest agent ping probe by setting the `spec.readinessProbe.guestAgentPing` field of the virtual machine instance (VMI) configuration.
+
+:FeatureName: The guest agent ping probe
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* The QEMU guest agent must be installed and enabled on the virtual machine.
+
+.Procedure
+
+. Include details of the guest agent ping probe in the VMI configuration file. For example:
++
+
+.Sample guest agent ping probe
+[source,yaml]
+----
+# ...
+spec:
+  readinessProbe:
+    guestAgentPing: {} <1>
+    initialDelaySeconds: 120 <2>
+    periodSeconds: 20 <3>
+    timeoutSeconds: 10 <4>
+    failureThreshold: 3 <5>
+    successThreshold: 3 <6>
+# ...
+----
+<1> The guest agent ping probe to connect to the VMI.
+<2> Optional: The time, in seconds, after the VMI starts before the guest agent probe is initiated.
+<3> Optional: The delay, in seconds, between performing probes. The default delay is 10 seconds. This value must be greater than `timeoutSeconds`.
+<4> Optional: The number of seconds of inactivity after which the probe times out and the VMI is assumed to have failed. The default value is 1. This value must be lower than `periodSeconds`.
+<5> Optional: The number of times that the probe is allowed to fail. The default is 3. After the specified number of attempts, the pod is marked `Unready`.
+<6> Optional: The number of times that the probe must report success, after a failure, to be considered successful. The default is 1.
+
+. Create the VMI by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----

--- a/virt/logging_events_monitoring/virt-monitoring-vm-health.adoc
+++ b/virt/logging_events_monitoring/virt-monitoring-vm-health.adoc
@@ -9,10 +9,17 @@ toc::[]
 A virtual machine instance (VMI) can become unhealthy due to transient issues such as connectivity loss, deadlocks, or problems with external dependencies. A health check periodically performs diagnostics on a VMI by using any combination of the readiness and liveness probes.
 
 include::modules/virt-about-readiness-liveness-probes.adoc[leveloffset=+1]
+
 include::modules/virt-define-http-readiness-probe.adoc[leveloffset=+1]
+
 include::modules/virt-define-tcp-readiness-probe.adoc[leveloffset=+1]
+
 include::modules/virt-define-http-liveness-probe.adoc[leveloffset=+1]
+
+include::modules/virt-define-guest-agent-ping-probe.adoc[leveloffset=+1]
+
 include::modules/virt-template-vm-probe-config.adoc[leveloffset=+1]
+
 
 [id="additional-resources_monitoring-vm-health"]
 [role="_additional-resources"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch. --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

<!-- Version examples:
  * PR applies to all versions after a specific version (e.g. 4.8): 4.8+
  * PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+
  * PR applies only to a specific single version (e.g. 4.10): 4.10
  * PR applies to multiple specific versions (e.g. 4.8-4.10): 4.8, 4.9, 4.10 --->

Issue: [CNV-18399](https://issues.redhat.com//browse/CNV-18399)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [About readiness and liveness probes](https://53249--docspreview.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-monitoring-vm-health.html#virt-about-readiness-liveness-probes_virt-monitoring-vm-health)

[Defining a guest agent ping probe](https://53249--docspreview.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-monitoring-vm-health.html#virt-define-guest-agent-ping-probe_virt-monitoring-vm-health)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!-- NOTE:
Automatic preview functionality is currently only available for some branches. For PRs that update the rendered build in any way against branches that do not create an automated preview:
  * OpenShift documentation team members (core and aligned) must include a link to a locally generated preview.
  * External contributors can request a generated preview from the OpenShift documentation team. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- Next steps after opening your PR:

* Ask for review from the OpenShift docs team:
  - For community authors: Request a review by tagging @openshift/team-documentation in a GitHub comment.
  - For Red Hat associates:
    * For normal peer requests, add a comment that contains this text: /label peer-review-needed
    * For normal merge review requests, add a comment that contains this text: /label merge-review-needed
    * For urgent peer review requests, ping @peer-review-squad requesting a review in the #forum-docs-review channel (CoreOS Slack workspace) and provide the following information:
      * A link to the PR.
      * The size of the PR that the GitHub bot assigns (ex: XS, S, M, L, XL).
      * Details about how the PR is urgent.
    * For urgent merge requests, ping @merge-review-squad in the #forum-docs-review channel (CoreOS Slack workspace).
    * Except for changes that do not impact the meaning of the content, QE review is required before content is merged.

* IMPORTANT:
  - All documentation changes must be verified by a QE team associate before merging.
  - Squash to one commit before submitting your PR for peer review.

* For more information about verifying your content, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content

* For more information about contributing to OpenShift documentation, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc

Additional resources

The OpenShift docs repo adheres to the following style guides:

- OpenShift documentation guidelines (OSDOCS)
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc
- Red Hat Supplementary Style Guide (SSG)
  https://redhat-documentation.github.io/supplementary-style-guide/
- Modular Documentation Reference Guide (Mod Docs)
  https://redhat-documentation.github.io/modular-docs/
- IBM Style Guide (ISG)
  https://www.ibm.com/docs/en/ibm-style

You can log in to the ISG by using your @redhat.com id and single sign-on (SSO) credentials. --->
