### PR TITLE
[OSDOCS-4610]: Control plane machine sets (4.12 RN)

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -328,6 +328,11 @@ For the OVN-Kubernetes network plug-in, egress firewalls support audit logging u
 [id="ocp-4-12-machine-api"]
 === Machine API
 
+[id="ocp-4-12-mapi-control-plane-machine-sets"]
+==== Control plane machine sets 
+
+{product-title} 4.12 introduces control plane machine sets. Control plane machine sets provide management capabilities for control plane machines that are similar to what compute machine sets provide for compute machines. For more information, see xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[Managing control plane machines].
+
 [id="ocp-4-12-mapi-autoscaler-verbosity"]
 ==== Specifying cluster autoscaler log level verbosity
 


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-4610](https://issues.redhat.com//browse/OSDOCS-4610), [OSDOCS-4160](https://issues.redhat.com//browse/OSDOCS-4160)

Link to docs preview:
[Control plane machine sets](https://53252--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-mapi-control-plane-machine-sets)

QE review:
- [ ] QE has approved this change.