### PR TITLE
Add OpenShift SDN network policy fully supported in matrix

### DIFF
--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -26,7 +26,7 @@ ifeval::["{context}" == "about-ovn-kubernetes"]
 
 |IPv6|Supported ^[3]^|Not supported
 
-|Kubernetes network policy|Supported|Partially supported ^[4]^
+|Kubernetes network policy|Supported|Supported
 
 |Kubernetes network policy logs|Supported|Not supported
 
@@ -49,7 +49,7 @@ ifeval::["{context}" == "about-openshift-sdn"]
 
 |IPv6|Not supported|Supported ^[3]^
 
-|Kubernetes network policy|Partially supported ^[4]^|Supported
+|Kubernetes network policy|Supported|Supported
 
 |Kubernetes network policy logs|Not supported|Supported
 
@@ -65,6 +65,4 @@ endif::[]
 2. Egress router for OVN-Kubernetes supports only redirect mode.
 
 3. IPv6 is supported only on bare metal, IBM Power, and {ibmzProductName} clusters.
-
-4. Network policy for OpenShift SDN does not support egress rules and some `ipBlock` rules.
 --


### PR DESCRIPTION
Refs https://github.com/openshift/openshift-docs/pull/52717.

Previews:
- https://53254--docspreview.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/about-openshift-sdn.html
- https://53254--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html#nw-ovn-kubernetes-matrix_about-ovn-kubernetes

Use for 4.13:

> 3. IPv6 is supported only on bare metal, IBM Power, and {ibmzProductName} clusters.

For <= 4.11, use:

> 3. IPv6 is supported only on bare metal clusters.