### PR TITLE
cluster-logging-feature-reference.adoc has unbalanced markdown causing rendering issues

### DIFF
--- a/modules/cluster-logging-feature-reference.adoc
+++ b/modules/cluster-logging-feature-reference.adoc
@@ -2,7 +2,7 @@
 //cluster-logging-loki.adoc
 :_content-type: REFERENCE
 [id="logging-feature-ref_{context}"]
-id="cluster-logging-about-vector"]
+[id="cluster-logging-about-vector"]
 = About Vector
 Vector is a log collector offered as an alternative to Fluentd for the {logging}.
 


### PR DESCRIPTION
cluster-logging-feature-reference.adoc has unbalanced markdown causing rendering issues

```
id="cluster-logging-about-vector"] = About Vector Vector is a log collector offered as an alternative to Fluentd for the logging subsystem.
```

![image](https://user-images.githubusercontent.com/3016328/204380579-948019f2-2fbc-4cab-81b1-d95832243d61.png)

Version(s):
4.11

Issue:
n/a

Link to docs preview:
n/a

QE review:
- [ ] QE has approved this change.

Additional information:
n/a