### PR TITLE
BZ1894063: Added important block on using pods deployment in SSC

### DIFF
--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -319,6 +319,11 @@ user identity and groups that the user belongs to. Additionally, if the pod
 specifies a service account, the set of allowable SCCs includes any constraints
 accessible to the service account.
 
+[IMPORTANT]
+====
+When creating pods directly, SCCs admission considers SCC permissions of both the caller and the Service Account that runs the pod. When a pod is created by a pod controller such as a deployment or a job, only Service Account SCC permissions are considered.
+====
+
 Admission uses the following approach to create the final security context for
 the pod:
 


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1894063

OCP version: 4.8+

Preview: https://53264--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html#security-context-constraints-about_configuring-internal-oauth

@stlaz @cardil PTAL and let me know your feedback.

@wangke19 PTAL for QA review.

QE review: lgtm