### PR TITLE
TELCODOCS-522 - Update ZTP redirects to fix URL typos

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -167,9 +167,9 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/4\.10/networking/external_dns_operator/nw-installing-external-dns-operator.html /container-platform/4.10/networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.html [NE,R=301]
 
     # Redirects for Telco ZTP changes delivered in https://github.com/openshift/openshift-docs/pull/35889
-    RewriteRule ^container-platform/(4\.10|4\.11)/scalability_and_performance/ztp-deploying-disconnected.html /container-platform/$1/scalability_and_performance/ztp-far-edge/ztp-deploying-far-edge-clusters-at-scale.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.10|4\.11)/scalability_and_performance/ztp-configuring-single-node-cluster-deployment-during-installation.html /container-platform/$1/scalability_and_performance/ztp-far-edge/ztp-manual-install.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.10|4\.11)/scalability_and_performance/ztp-vdu-validating-cluster-tuning.html /container-platform/$1/scalability_and_performance/ztp-far-edge/ztp-vdu-validating-cluster-tuning.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11)/scalability_and_performance/ztp-deploying-disconnected.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11)/scalability_and_performance/ztp-configuring-single-node-cluster-deployment-during-installation.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-manual-install.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11)/scalability_and_performance/ztp-vdu-validating-cluster-tuning.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.html [NE,R=302]
 
     # CNV scenarios based redirect
     RewriteRule ^container-platform/4\.8/virt/learn_more_about_ov.html /container-platform/4.8/virt/virt-learn-more-about-openshift-virtualization.html [NE,R=301]


### PR DESCRIPTION
ZTP redirects put in place for [TELCODOCS-522](https://issues.redhat.com//browse/TELCODOCS-522) had typos which caused the redirects to not work. This PR fixes the typos. 

Merge to main only.