### PR TITLE
Agent-189:  support for dual stack ipv4/ipv6 and single stack ipv6

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -16,7 +16,8 @@ include::modules/installing-ocp-agent.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
+* See xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-install-installation-workflow[Deploying with dual-stack networking].
+* See xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-install-installation-workflow[Configuring the install-config yaml file].
 * See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-three-node-cluster_installing-restricted-networks-bare-metal[Configuring a three-node cluster] to deploy three-node clusters in bare metal environments.
 * See xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints].
 * See link:https://nmstate.io/examples.html[NMState state examples].

--- a/modules/installation-bare-metal-agent-installer-config-yaml.adoc
+++ b/modules/installation-bare-metal-agent-installer-config-yaml.adoc
@@ -76,6 +76,41 @@ Class E CIDR range is reserved for a future use. To use the Class E CIDR range, 
 <9> The cluster network provider Container Network Interface (CNI) plug-in to install. The supported values are `OVNKubernetes` (default value) and `OpenShiftSDN` .
 <10> The IP address pool to use for service IP addresses. You can enter only one IP address pool. This block must not overlap with existing physical networks. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 <11> You must set the platform to `none` for a single-node cluster. You can also set the platform to `vSphere` and `baremetal`.
++
+[NOTE]
+====
+If you set the platform to `vSphere` or `baremetal`, you can configure IP address endpoints for cluster nodes in three ways:
+
+* IPv4
+* IPv6
+* IPv4 and IPv6 in parallel (dual-stack)
+
+.Example of dual-stack networking
+[source,yaml]
+----
+networking:
+  clusterNetwork:
+    - cidr: 172.21.0.0/16
+      hostPrefix: 23
+    - cidr: fd02::/48
+      hostPrefix: 64
+  machineNetwork:
+    - cidr: 192.168.11.0/16
+    - cidr: 2001:DB8::/32
+  serviceNetwork:
+    - 172.22.0.0/16
+    - fd03::/112
+  networkType: OVNKubernetes
+platform:
+  baremetal:
+    apiVIPs:
+    - 192.168.11.3
+    - 2001:DB8::4
+    ingressVIPs:
+    - 192.168.11.4
+    - 2001:DB8::5
+----
+====
 <12> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]

--- a/modules/installing-ocp-agent.adoc
+++ b/modules/installing-ocp-agent.adoc
@@ -83,6 +83,42 @@ sshKey: |
 <2> Enter your pull secret.
 <3> Enter your ssh public key.
 
++
+[NOTE]
+====
+If you set the platform to `vSphere` or `baremetal`, you can configure IP address endpoints for cluster nodes in three ways:
+
+* IPv4
+* IPv6
+* IPv4 and IPv6 in parallel (dual-stack)
+
+.Example of dual-stack networking
+[source,yaml]
+----
+networking:
+  clusterNetwork:
+    - cidr: 172.21.0.0/16
+      hostPrefix: 23
+    - cidr: fd02::/48
+      hostPrefix: 64
+  machineNetwork:
+    - cidr: 192.168.11.0/16
+    - cidr: 2001:DB8::/32
+  serviceNetwork:
+    - 172.22.0.0/16
+    - fd03::/112
+  networkType: OVNKubernetes
+platform:
+  baremetal:
+    apiVIPs:
+    - 192.168.11.3
+    - 2001:DB8::4
+    ingressVIPs:
+    - 192.168.11.4
+    - 2001:DB8::5
+----
+====
+
 . Create the `agent-config.yaml` file:
 +
 [source,yaml]
@@ -132,7 +168,6 @@ the number of hosts defined is 3. When 3 master nodes and 2 worker nodes are def
 <3> The optional `hostname` parameter overrides the hostname obtained from either the Dynamic Host Configuration Protocol (DHCP) or a reverse DNS lookup. Each host must have a unique hostname supplied by one of these methods.
 <4> The `rootDeviceHints` parameter enables provisioning of the Red Hat Enterprise Linux CoreOS (RHCOS) image to a particular device. It examines the devices in the order it discovers them, and compares the discovered values with the hint values. It uses the first discovered device that matches the hint value.
 <5> Set this optional parameter to configure the network interface of a host in NMState format.
-
 
 +
 . Create the Agent image by running the following command:
@@ -198,3 +233,37 @@ INFO To access the cluster as the system:admin user when using 'oc', run
 INFO     export KUBECONFIG=/home/core/installer/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.sno-cluster.test.example.com
 ----
+
+
+[NOTE]
+====
+If you are using the optional method of ZTP manifests, you can configure IP address endpoints for cluster nodes through the `AgentClusterInstall.yaml` file in three ways:
+
+* IPv4
+* IPv6
+* IPv4 and IPv6 in parallel (dual-stack)
+
+.Example of dual-stack networking
+[source,yaml]
+----
+apiVIP: 192.168.11.3
+ingressVIP: 192.168.11.4
+clusterDeploymentRef:
+  name: mycluster
+imageSetRef:
+  name: openshift-4.12
+networking:
+  clusterNetwork:
+  - cidr: 172.21.0.0/16
+    hostPrefix: 23
+  - cidr: fd02::/48
+    hostPrefix: 64
+  machineNetwork:
+  - cidr: 192.168.11.0/16
+  - cidr: 2001:DB8::/32
+  serviceNetwork:
+  - 172.22.0.0/16
+  - fd03::/112
+  networkType: OVNKubernetes
+----
+====


### PR DESCRIPTION
- Applies to main and 4.12
- [Jira](https://issues.redhat.com/browse/AGENT-189)
- [Preview 1](https://53269--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html)
- [Preview 2](https://53269--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#installation-bare-metal-agent-installer-config-yaml_preparing-to-install-with-agent-based-installer)
@bfournie ptal 