### PR TITLE
[SRVCOM-2062] Add probe configuration info for Knative deployments

### DIFF
--- a/modules/knative-eventing-CR-system-deployments.adoc
+++ b/modules/knative-eventing-CR-system-deployments.adoc
@@ -6,7 +6,7 @@
 [id="knative-eventing-CR-system-deployments_{context}"]
 = Overriding Knative Eventing system deployment configurations
 
-You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeEventing` custom resource (CR). Currently, overriding default configuration settings is supported for the `eventing-controller`, `eventing-webhook`, and `imc-controller` fields.
+You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeEventing` custom resource (CR). Currently, overriding default configuration settings is supported for the `eventing-controller`, `eventing-webhook`, and `imc-controller` fields, as well as for the `readiness` and `liveness` fields for probes.
 
 [IMPORTANT]
 ====
@@ -15,6 +15,7 @@ The `replicas` spec cannot override the number of replicas for deployments that 
 
 In the following example, a `KnativeEventing` CR overrides the `eventing-controller` deployment so that:
 
+* The `readiness` probe timeout `eventing-controller` is set to be 10 seconds.
 * The deployment has specified CPU and memory resource limits.
 * The deployment has 3 replicas.
 * The `example-label: label` label is added.
@@ -32,6 +33,9 @@ metadata:
 spec:
   deployments:
   - name: eventing-controller
+    readinessProbes: <1>
+      - container: controller
+        timeoutSeconds: 10
     resources:
     - container: eventing-controller
       requests:
@@ -48,6 +52,7 @@ spec:
     nodeSelector:
       disktype: hdd
 ----
+<1> You can use the `readiness` and `liveness` probe overrides to override all fields of a probe in a container of a deployment as specified in the Kubernetes API except for the fields related to the probe handler: `exec`, `grpc`, `httpGet`, and `tcpSocket`.
 
 [NOTE]
 ====

--- a/modules/knative-serving-CR-system-deployments.adoc
+++ b/modules/knative-serving-CR-system-deployments.adoc
@@ -6,10 +6,11 @@
 [id="knative-serving-CR-system-deployments_{context}"]
 = Overriding Knative Serving system deployment configurations
 
-You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeServing` custom resource (CR). Currently, overriding default configuration settings is supported for the `resources`, `replicas`, `labels`, `annotations`, and `nodeSelector` fields.
+You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeServing` custom resource (CR). Currently, overriding default configuration settings is supported for the `resources`, `replicas`, `labels`, `annotations`, and `nodeSelector` fields, as well as for the `readiness` and `liveness` fields for probes.
 
 In the following example, a `KnativeServing` CR overrides the `webhook` deployment so that:
 
+* The `readiness` probe timeout for `net-kourier-controller` is set to be 10 seconds.
 * The deployment has specified CPU and memory resource limits.
 * The deployment has 3 replicas.
 * The `example-label: label` label is added.
@@ -33,6 +34,10 @@ spec:
   high-availability:
     replicas: 2
   deployments:
+  - name: net-kourier-controller
+    readinessProbes: <1>
+      - container: controller
+        timeoutSeconds: 10
   - name: webhook
     resources:
     - container: webhook
@@ -50,3 +55,4 @@ spec:
     nodeSelector:
       disktype: hdd
 ----
+<1> You can use the `readiness` and `liveness` probe overrides to override all fields of a probe in a container of a deployment as specified in the Kubernetes API except for the fields related to the probe handler: `exec`, `grpc`, `httpGet`, and `tcpSocket`.

--- a/serverless/admin_guide/serverless-configuration.adoc
+++ b/serverless/admin_guide/serverless-configuration.adoc
@@ -34,7 +34,16 @@ include::modules/serverless-scale-to-zero-grace-period.adoc[leveloffset=+1]
 You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeServing` and `KnativeEventing` custom resources (CRs).
 
 include::modules/knative-serving-CR-system-deployments.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#probe-v1-core[Probe configuration section of the Kubernetes API documentation]
+
 include::modules/knative-eventing-CR-system-deployments.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#probe-v1-core[Probe configuration section of the Kubernetes API documentation]
 
 // enable emptydirs
 include::modules/serverless-config-emptydir.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-2062

Link to docs preview:
https://53270--docspreview.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-configuration.html#serverless-configuration-CR-system-deployments

QE review:
- [x] QE has approved this change.