### PR TITLE
OSDOCS-4596: Adds notes for 4.10.43 release

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3640,3 +3640,22 @@ $ oc adm release info 4.10.42 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-43"]
+=== RHBA-2022:8623 - {product-title} 4.10.43 bug fix update
+
+Issued: 2022-11-29
+
+{product-title} release 4.10.43 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:8623[RHBA-2022:8623] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:8622[RHBA-2022:8622] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.43 --pullspecs
+----
+
+[id="ocp-4-10-43-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.10.43 release

Version(s):
4.10 only

Issue:
https://issues.redhat.com/browse/OSDOCS-4596

Link to docs preview:
http://file.rdu.redhat.com/opayne/RN-4.10.43/release_notes/ocp-4-10-release-notes.html#ocp-4-10-43

QE review:
- [ ] QE has approved this change.
* Qe not needed for this change


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
