### PR TITLE
[enterprise-4.9] OSDOCS-4471: Adding cdn03.quay.io back to the list

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -38,13 +38,17 @@ There are no special configuration considerations for services running on only c
 |443, 80
 |Provides core container images
 
+|`cdn03.quay.io`
+|443, 80
+|Provides core container images
+
 |`sso.redhat.com`
 |443, 80
 |The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`
 
 |===
 +
-You can use the wildcard `\*.quay.io` instead of `cdn0[1-2].quay.io` in your allowlist. When you add a site, such as `quay.io`, to your allowlist, do not add a wildcard entry, such as `*.quay.io`, to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a hostname such as `cdn01.quay.io`.
+You can use the wildcard `\*.quay.io` instead of `cdn0[1-3].quay.io` in your allowlist. When you add a site, such as `quay.io`, to your allowlist, do not add a wildcard entry, such as `*.quay.io`, to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, image downloads are denied when the initial download request redirects to a hostname such as `cdn01.quay.io`.
 
 . Allowlist any site that provides resources for a language or framework that your builds require.
 


### PR DESCRIPTION
Manual CP of #53210.