### PR TITLE
[OSDOCS-4610]: CPMSO content crosslinking

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-about.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-about.adoc
@@ -42,3 +42,10 @@ Attempting to deploy control plane machines as AWS Spot Instances or Azure Spot 
 ====
 
 * Making changes to the control plane machine set during or prior to installation is not supported. You must make any changes to the control plane machine set only after installation.
+
+[role="_additional-resources"]
+[id="additional-resources_cpmso-about"]
+== Additional resources
+
+* xref:../../operators/operator-reference.adoc#control-plane-machine-set-operator_cluster-operators-ref[Control Plane Machine Set Operator reference]
+* xref:../../rest_api/machine_apis/controlplanemachineset-machine-openshift-io-v1.adoc#controlplanemachineset-machine-openshift-io-v1[`ControlPlaneMachineSet` custom resource]

--- a/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
@@ -22,7 +22,6 @@ Clusters without a generated CR:: For clusters that do not include a generated C
 
 If you are uncertain about the state of the `ControlPlaneMachineSet` CR in your cluster, you can xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-checking-status_cpmso-getting-started[verify the CR status]. 
 
-[discrete]
 [id="cpmso-platform-matrix_{context}"]
 == Supported cloud providers
 

--- a/modules/control-plane-machine-set-operator.adoc
+++ b/modules/control-plane-machine-set-operator.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * operators/operator-reference.adoc
+
+[id="control-plane-machine-set-operator_{context}"]
+= Control Plane Machine Set Operator
+
+[NOTE]
+====
+This Operator is available for Amazon Web Services (AWS), Microsoft Azure, and VMware vSphere.
+====
+
+[discrete]
+== Purpose
+
+The Control Plane Machine Set Operator automates the management of control plane machine resources within an {product-title} cluster.
+
+[discrete]
+== Project
+
+link:https://github.com/openshift/cluster-control-plane-machine-set-operator[cluster-control-plane-machine-set-operator]
+
+[discrete]
+== CRDs
+
+* `controlplanemachineset.machine.openshift.io`
+** Scope: Namespaced
+** CR: `ControlPlaneMachineSet`
+** Validation: Yes

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -31,8 +31,8 @@ include::modules/cloud-credential-operator.adoc[leveloffset=+1]
 [id="additional-resources_cluster-op-ref-cco"]
 === Additional resources
 
-* xref:../rest_api/security_apis/credentialsrequest-cloudcredential-openshift-io-v1.adoc#credentialsrequest-cloudcredential-openshift-io-v1[CredentialsRequest custom resource]
 * xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator]
+* xref:../rest_api/security_apis/credentialsrequest-cloudcredential-openshift-io-v1.adoc#credentialsrequest-cloudcredential-openshift-io-v1[`CredentialsRequest` custom resource]
 
 include::modules/cluster-authentication-operator.adoc[leveloffset=+1]
 include::modules/cluster-autoscaler-operator.adoc[leveloffset=+1]
@@ -56,6 +56,16 @@ include::modules/cluster-version-operator.adoc[leveloffset=+1]
 * xref:../architecture/control-plane.adoc#operators-overview_control-plane[Operators in {product-title}]
 
 include::modules/console-operator.adoc[leveloffset=+1]
+include::modules/control-plane-machine-set-operator.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[discrete]
+[id="additional-resources_cluster-op-ref-cpmso"]
+=== Additional resources
+
+* xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[About the Control Plane Machine Set Operator]
+* xref:../rest_api/machine_apis/controlplanemachineset-machine-openshift-io-v1.adoc#controlplanemachineset-machine-openshift-io-v1[`ControlPlaneMachineSet` custom resource]
+
 include::modules/cluster-dns-operator.adoc[leveloffset=+1]
 include::modules/etcd-operator.adoc[leveloffset=+1]
 include::modules/ingress-operator.adoc[leveloffset=+1]

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -512,6 +512,11 @@ include::modules/nodes-cluster-worker-latency-profiles-about.adoc[leveloffset=+2
 
 include::modules/nodes-cluster-worker-latency-profiles-using.adoc[leveloffset=+2]
 
+[id="post-install-cpms-setup"]
+== Managing control plane machines
+
+xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[Control plane machine sets] provide management capabilities for control plane machines that are similar to what compute machine sets provide for compute machines. The availability and initial status of control plane machine sets on your cluster depend on your cloud provider and the version of {product-title} that you installed. For more information, see xref:../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with the Control Plane Machine Set Operator].
+
 [id="post-install-creating-infrastructure-machinesets-production"]
 == Creating infrastructure machine sets for production environments
 
@@ -521,7 +526,7 @@ In a production deployment, it is recommended that you deploy at least three com
 
 For information on infrastructure nodes and which components can run on infrastructure nodes, see xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets].
 
-To create an infrastructure node, you can xref:../post_installation_configuration/cluster-tasks.adoc#machineset-creating_post-install-cluster-tasks[use a machine set], post_installation_configuration/cluster-tasks.adoc#creating-an-infra-node_post-install-cluster-tasks[assign a label to the nodes], or xref:../post_installation_configuration/cluster-tasks.adoc#creating-infra-machines_post-install-cluster-tasks[use a machine config pool].  
+To create an infrastructure node, you can xref:../post_installation_configuration/cluster-tasks.adoc#machineset-creating_post-install-cluster-tasks[use a machine set], xref:../post_installation_configuration/cluster-tasks.adoc#creating-an-infra-node_post-install-cluster-tasks[assign a label to the nodes], or xref:../post_installation_configuration/cluster-tasks.adoc#creating-infra-machines_post-install-cluster-tasks[use a machine config pool].  
 
 For sample machine sets that you can use with these procedures, see xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets-clouds[Creating machine sets for different clouds].
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-4610](https://issues.redhat.com//browse/OSDOCS-4610)

Link to docs preview:
- [Managing control plane machines](https://53287--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#post-install-cpms-setup)
- [Control Plane Machine Set Operator](https://53287--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#control-plane-machine-set-operator_cluster-operators-ref)

QE review:
- [x] QE has approved this change.

Additional information: