### PR TITLE
[OSDOCS-4608]: Document limitation for the RHOSP egress ip neutron port

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -18,6 +18,11 @@ The {product-title} egress IP address functionality allows you to ensure that th
 For example, you might have a pod that periodically queries a database that is hosted on a server outside of your cluster. To enforce access requirements for the server, a packet filtering device is configured to allow traffic only from specific IP addresses.
 To ensure that you can reliably allow access to the server from only that specific pod, you can configure a specific egress IP address for the pod that makes the requests to the server.
 
+[NOTE]
+====
+The {rh-openstack} egress IP address feature creates a neutron reservation port called `egressip-<IP address>`. You can assign a floating IP address to this reservation port to have a predictable SNAT address for egress traffic. When an egress IP address on an {rh-openstack} network is moved from one node to another, because of a node failover, for example, the neutron reservation port is removed and recreated. This means that the floating IP association is lost and you need to manually reassign the floating IP address to the new reservation port.
+====
+
 An egress IP address assigned to a namespace is different from an egress router, which is used to send traffic to specific destinations.
 
 In some cluster configurations, application pods and ingress router pods run on the same node. If you configure an egress IP address for an application project in this scenario, the IP address is not used when you send a request to a route from the application project.


### PR DESCRIPTION
[OSDOCS-4608](https://issues.redhat.com/browse/OSDOCS-3950)

Version(s): 4.12+

Issue: [SDN-3027](https://issues.redhat.com/browse/SDN-3027)

Preview links Updated 12/15:

- [OpenShift SDN default CNI network provider](http://file.rdu.redhat.com/tlove/sdn-neutron-4608-tlove/networking/openshift_sdn/assigning-egress-ips.html)
- [OVN-Kubernetes default CNI network provider](http://file.rdu.redhat.com/tlove/sdn-neutron-4608-tlove/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-about_configuring-egress-ips-ovn)

QE review:
- [ x] QE has approved this change.
- [x ]  SME approval.

Additional information:
This PR applies to RHOSP on RHOCP.


