### PR TITLE
TELCODOCS-1070: Ensure that the Console plugin  is set to Enable.

### DIFF
--- a/modules/eco-node-health-check-operator-installation-web-console.adoc
+++ b/modules/eco-node-health-check-operator-installation-web-console.adoc
@@ -17,6 +17,7 @@ You can use the {product-title} web console to install the Node Health Check Ope
 . In the {product-title} web console, navigate to *Operators* -> *OperatorHub*.
 . Search for the Node Health Check Operator, then click *Install*.
 . Keep the default selection of *Installation mode* and *namespace* to ensure that the Operator will be installed to the `openshift-operators` namespace.
+. Ensure that the *Console plug-in* is set to `Enable`.
 . Click *Install*.
 
 .Verification


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-1070 Doc: Enable NHC Console plugin

Applies to OpenShift version : 4.12 +

Preview: [Installing the Node Health Check Operator by using the web console](http://file.emea.redhat.com/pogrady/TELCODOCS-1070/nodes/nodes/eco-node-health-check-operator.html#installing-node-health-check-operator-using-web-console_node-health-check-operator)

Dev review complete/approved by @slintes
UI review complete/approved by @batzionb
QE review complete/approved by @anna-savina
Peer review complete/approved @tmalove 

Thank you.