### PR TITLE
OCPBUGS#4263 RHEL 9 doesn't work for IPI

### DIFF
--- a/modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc
+++ b/modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc
@@ -8,3 +8,8 @@
 = Installing {op-system-base} on the provisioner node
 
 With the configuration of the prerequisites complete, the next step is to install {op-system-base} {op-system-version} on the provisioner node. The installer uses the provisioner node as the orchestrator while installing the {product-title} cluster. For the purposes of this document, installing {op-system-base} on the provisioner node is out of scope. However, options include but are not limited to using a RHEL Satellite server, PXE, or installation media.
+
+[NOTE]
+====
+Installing {product-title} {product-version} using installer-provisioned infrastructure does not support {op-system-base} 9. You must use {op-system-base} 8.x.
+====


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-4263

Link to docs preview:
[Setting up the environment for an OpenShift installation](https://53331--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#installing-rhel-on-the-provisioner-node_ipi-install-installation-workflow)

QE review:
- [ ] QE has approved this change.
