### PR TITLE
Windows node failed to become ready after a while (trunk port limitation)

### DIFF
--- a/modules/windows-containers-release-notes-limitations.adoc
+++ b/modules/windows-containers-release-notes-limitations.adoc
@@ -29,6 +29,8 @@ Note the following limitations when working with Windows nodes managed by the WM
 
 * Windows nodes are not supported in clusters that are in a disconnected environment.
 
+* {productwinc} does not support adding Windows nodes to a cluster through a trunk port. The only supported networking configuration for adding Windows nodes is through an access port that carries traffic for the VLAN.
+
 * {productwinc} supports only in-tree storage drivers for all cloud providers.
 
 * Kubernetes has identified the following link:https://kubernetes.io/docs/concepts/windows/intro/#limitations[node feature limitations] :


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-4285

Adding Known Limitation in https://github.com/openshift/windows-machine-config-operator/pull/1338

Preview: WINC Release Notes -> [Known Limitations](https://53341--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-6-x.html#windows-containers-release-notes-limitations_windows-containers-release-notes)