### PR TITLE
OCPBUGS#4332 Service Usage API is required, not optional

### DIFF
--- a/modules/installation-gcp-enabling-api-services.adoc
+++ b/modules/installation-gcp-enabling-api-services.adoc
@@ -52,6 +52,9 @@ in the GCP documentation.
 |Identity and Access Management (IAM) API
 |`iam.googleapis.com`
 
+|Service Usage API
+|`serviceusage.googleapis.com`
+
 |===
 +
 .Optional API services
@@ -69,9 +72,6 @@ endif::template[]
 
 |Service Management API
 |`servicemanagement.googleapis.com`
-
-|Service Usage API
-|`serviceusage.googleapis.com`
 
 |Google Cloud Storage JSON API
 |`storage-api.googleapis.com`


### PR DESCRIPTION
Version(s):
4.11 and 4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-4332

Link to docs preview:
https://53342--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-enabling-api-services_installing-gcp-account

QE review:
- [X] QE has approved this change.