### PR TITLE
[OSDOCS-4239]: CPMSO troubleshooting and removal

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1994,8 +1994,10 @@ Topics:
     File: cpmso-using
   - Name: Control plane resiliency and recovery
     File: cpmso-resiliency
-  #- Name: Troubleshooting the Control Plane Machine Set Operator
-  #  File: cpmso-troubleshooting
+  - Name: Troubleshooting the control plane machine set
+    File: cpmso-troubleshooting
+  - Name: Disabling the control plane machine set
+    File: cpmso-disabling
 - Name: Deploying machine health checks
   File: deploying-machine-health-checks
 ---

--- a/machine_management/control_plane_machine_management/cpmso-disabling.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-disabling.adoc
@@ -1,0 +1,26 @@
+:_content-type: ASSEMBLY
+[id="cpmso-disabling"]
+= Disabling the control plane machine set
+include::_attributes/common-attributes.adoc[]
+:context: cpmso-disabling
+
+toc::[]
+
+The `.spec.state` field in an activated `ControlPlaneMachineSet` custom resource (CR) cannot be changed from `Active` to `Inactive`. To disable the control plane machine set, you must delete the CR so that it is removed from the cluster.
+
+When you delete the CR, the Control Plane Machine Set Operator performs cleanup operations and disables the control plane machine set. The Operator then removes the CR from the cluster and creates an inactive control plane machine set with default settings. 
+
+//Deleting the control plane machine set
+include::modules/cpmso-deleting.adoc[leveloffset=+1]
+
+//Checking the control plane machine set custom resource status
+include::modules/cpmso-checking-status.adoc[leveloffset=+1]
+
+[id="cpmso-reenabling_{context}"]
+== Re-enabling the control plane machine set
+
+To re-enable the control plane machine set, you must ensure that the configuration in the CR is correct for your cluster and activate it.
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[Activating the control plane machine set custom resource]

--- a/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
@@ -57,7 +57,7 @@ The status of the Operator after installation depends on your cloud provider and
 //Checking the Control Plane Machine Set Operator status
 include::modules/cpmso-checking-status.adoc[leveloffset=+1]
 
-//Activating the Control Plane Machine Set Operator
+//Activating the control plane machine set custom resource
 include::modules/cpmso-activating.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc
@@ -1,19 +1,31 @@
 :_content-type: ASSEMBLY
 [id="cpmso-troubleshooting"]
-= Troubleshooting the Control Plane Machine Set Operator
+= Troubleshooting the control plane machine set
 include::_attributes/common-attributes.adoc[]
 :context: cpmso-troubleshooting
 
 toc::[]
 
-//todo: add Checking the Control Plane Machine Set Operator status
-//include::modules/cpmso-checking-status.adoc[leveloffset=+1]
+Use the information in this section to understand and recover from issues you might encounter.
 
-[id="cpmso_ts_ilb_missing_{context}"]
-== Internal load balancer missing form Azure provider specification
+//Checking the control plane machine set custom resource status
+include::modules/cpmso-checking-status.adoc[leveloffset=+1]
 
-The `internalLoadBalancer` parameter is required in both the `ControlPlaneMachineSet` and control plane `Machine` CRs, but might not be prepopulated. If this parameter is not populated in those CRs on your cluster, you must populate it on both CRs.
+[role="_additional-resources"]
+.Additional resources
+* xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[Activating the control plane machine set custom resource]
+* xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-creating-cr_cpmso-getting-started[Creating a control plane machine set custom resource]
 
-For more information on where this parameter is located in the Azure provider specification, see xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-yaml-provider-spec-azure_cpmso-configuration[Sample Azure provider specification].
+//Adding a missing Azure internal load balancer
+include::modules/cpmso-ts-ilb-missing.adoc[leveloffset=+1]
 
-//Would like to include some detail about the machine CR too, need to see if we have tha structure somewhere.
+[role="_additional-resources"]
+.Additional resources
+* xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-yaml-provider-spec-azure_cpmso-configuration[Sample Azure provider specification]
+
+//Recovering a degraded etcd Operator after a machine health check operation
+include::modules/cpmso-ts-mhc-etcd-degraded.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]

--- a/modules/cpmso-checking-status.adoc
+++ b/modules/cpmso-checking-status.adoc
@@ -1,12 +1,18 @@
 // Module included in the following assemblies:
 //
 // * machine_management/cpmso-getting-started.adoc
+// * machine_management/cpmso-troubleshooting.adoc
+// * machine_management/cpmso-disabling.adoc
+
+ifeval::["{context}" == "cpmso-disabling"]
+:cpmso-disabling:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="cpmso-checking-status_{context}"]
-= Checking the control plane machine set custom resource status
+= Checking the control plane machine set custom resource state
 
-You can verify the existence and status of the `ControlPlaneMachineSet` custom resource (CR).
+You can verify the existence and state of the `ControlPlaneMachineSet` custom resource (CR).
 
 .Procedure
 
@@ -23,10 +29,16 @@ $ oc get controlplanemachineset.machine.openshift.io cluster --namespace openshi
 
 ** A result of `NotFound` indicates that there is no existing `ControlPlaneMachineSet` CR.
 
+ifndef::cpmso-disabling[]
 .Next steps
 
-Before using the Operator, you must ensure that a `ControlPlaneMachineSet` CR with the correct settings for your cluster exists. 
+To use the control plane machine set, you must ensure that a `ControlPlaneMachineSet` CR with the correct settings for your cluster exists. 
 
 * If your cluster has an existing CR, you must verify that the configuration in the CR is correct for your cluster.
 
 * If your cluster does not have an existing CR, you must create one with the correct configuration for your cluster.
+endif::[]
+
+ifeval::["{context}" == "cpmso-disabling"]
+:!cpmso-disabling:
+endif::[]

--- a/modules/cpmso-deleting.adoc
+++ b/modules/cpmso-deleting.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cpmso-disabling.adoc
+
+:_content-type: PROCEDURE
+[id="cpmso-deleting_{context}"]
+= Deleting the control plane machine set
+
+To stop managing control plane machines with the control plane machine set on your cluster, you must delete the `ControlPlaneMachineSet` custom resource (CR).
+
+.Procedure
+
+* Delete the control plane machine set CR by running the following command:
++
+[source,terminal]
+----
+$ oc delete controlplanemachineset.machine.openshift.io cluster --namespace openshift-machine-api
+----
+
+.Verification
+
+* Check the control plane machine set custom resource state. A result of `Inactive` indicates that the removal and replacement process is successful. A `ControlPlaneMachineSet` CR exists but is not activated.

--- a/modules/cpmso-ts-ilb-missing.adoc
+++ b/modules/cpmso-ts-ilb-missing.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cpmso-troubleshooting.adoc
+
+:_content-type: PROCEDURE
+[id="cpmso-ts-ilb-missing_{context}"]
+= Adding a missing Azure internal load balancer
+
+The `internalLoadBalancer` parameter is required in both the `ControlPlaneMachineSet` and control plane `Machine` custom resources (CRs) for Azure. If this parameter is not preconfigured on your cluster, you must add it to both CRs.
+
+For more information about where this parameter is located in the Azure provider specification, see the sample Azure provider specification. The placement in the control plane `Machine` CR is similar.
+
+.Procedure
+
+. List the control plane machines in your cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get machines -l machine.openshift.io/cluster-api-machine-role==master -n openshift-machine-api
+----
+
+. For each control plane machine, edit the CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit machine <control_plane_machine_name>
+----
+
+. Add the `internalLoadBalancer` parameter with the correct details for your cluster and save your changes.
+
+. Edit your control plane machine set CR by running the following command:
++
+[source,terminal]
+----
+$ oc --namespace openshift-machine-api edit controlplanemachineset.machine.openshift.io cluster
+----
+
+. Add the `internalLoadBalancer` parameter with the correct details for your cluster and save your changes.
+
+.Next steps
+
+* For clusters that use the default `RollingUpdate` update strategy, the Operator automatically propagates the changes to your control plane configuration.
+
+* For clusters that are configured to use the `OnDelete` update strategy, you must replace your control plane machines manually.

--- a/modules/cpmso-ts-mhc-etcd-degraded.adoc
+++ b/modules/cpmso-ts-mhc-etcd-degraded.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cpmso-troubleshooting.adoc
+
+:_content-type: PROCEDURE
+[id="cpmso-ts-etcd-degraded_{context}"]
+= Recovering a degraded etcd Operator
+
+Certain situations can cause the etcd Operator to become degraded. 
+
+For example, while performing remediation, the machine health check might delete a control plane machine that is hosting etcd. If the etcd member is not reachable at that time, the etcd Operator becomes degraded. 
+
+When the etcd Operator is degraded, manual intervention is required to force the Operator to remove the failed member and restore the cluster state.
+
+.Procedure
+
+. List the control plane machines in your cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get machines -l machine.openshift.io/cluster-api-machine-role==master -n openshift-machine-api -o wide
+----
++
+Any of the following conditions might indicate a failed control plane machine:
++
+--
+** The `STATE` value is `stopped`.
+** The `PHASE` value is `Failed`.
+** The `PHASE` value is `Deleting` for more than ten minutes.
+--
++
+[IMPORTANT]
+====
+Before continuing, ensure that your cluster has two healthy control plane machines. Performing the actions in this procedure on more than one control plane machine risks losing etcd quorum and can cause data loss.
+
+If you have lost the majority of your control plane hosts, leading to etcd quorum loss, then you must follow the disaster recovery procedure "Restoring to a previous cluster state" instead of this procedure.
+====
+
+. Edit the machine CR for the failed control plane machine by running the following command:
++
+[source,terminal]
+----
+$ oc edit machine <control_plane_machine_name>
+----
+
+. Remove the contents of the `lifecycleHooks` parameter from the failed control plane machine and save your changes.
++
+The etcd Operator removes the failed machine from the cluster and can then safely add new etcd members.

--- a/modules/cpmso-yaml-provider-spec-azure.adoc
+++ b/modules/cpmso-yaml-provider-spec-azure.adoc
@@ -59,7 +59,7 @@ providerSpec:
 <1> Specifies the secret name for the cluster. Do not change this value.
 <2> Specifies the image details for your control plane machine set.
 <3> Specifies an image that is compatible with your instance type. The Hyper-V generation V2 images created by the installation program have a `-gen2` suffix, while V1 images have the same name without the suffix.
-<4> Specifies the internal load balancer for the control plane. This field might not be prepopulated but is required in both the `ControlPlaneMachineSet` and control plane `Machine` CRs.
+<4> Specifies the internal load balancer for the control plane. This field might not be preconfigured but is required in both the `ControlPlaneMachineSet` and control plane `Machine` CRs.
 <5> Specifies the cloud provider platform type. Do not change this value. 
 <6> Specifies the region to place control plane machines on.
 <7> Specifies the disk configuration for the control plane.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-4239](https://issues.redhat.com//browse/OSDOCS-4239)

Link to docs preview:
- [Troubleshooting the control plane machine set](https://53344--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-troubleshooting.html)
- [Disabling the control plane machine set](https://53344--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-disabling.html)

QE review:
- [ ] QE has approved this change.

Additional information:
