### PR TITLE
OCPBUGS#4333 Sample install config file should not recommend None for capability set

### DIFF
--- a/modules/installation-alibaba-config-yaml.adoc
+++ b/modules/installation-alibaba-config-yaml.adoc
@@ -52,10 +52,6 @@ publish: External
 pullSecret: '{"auths": {"cloud.openshift.com": {"auth": ... }' <5>
 sshKey: |
   ssh-rsa AAAA... <6>
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 <1> Required. The installation program prompts you for a cluster name.
 <2> Optional. Specify parameters for machine pools that do not define their own platform configuration.

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -278,11 +278,6 @@ imageContentSources: <15>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 endif::restricted[]
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
-
 ----
 ifndef::gov,secret,china[]
 <1> Required. The installation program prompts you for this value.

--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -178,10 +178,6 @@ ifdef::openshift-origin[]
 publish: Internal <16>
 endif::openshift-origin[]
 endif::gov[]
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 ifndef::gov[]
 <1> Required. The installation program prompts you for this value.

--- a/modules/installation-azure-stack-hub-config-yaml.adoc
+++ b/modules/installation-azure-stack-hub-config-yaml.adoc
@@ -84,10 +84,6 @@ additionalTrustBundle: | <10>
     -----END CERTIFICATE-----
 sshKey: ssh-ed25519 AAAA... <11>
 endif::openshift-origin[]
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 <1> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
 <2> You can specify the size of the disk to use in GB. Minimum recommendation for control plane nodes is 1024 GB.
@@ -183,10 +179,6 @@ endif::openshift-origin[]
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-capabilities:
-    baselineCapabilitySet: None
-    additionalEnabledCapabilities:
-    - openshift-samples
 ----
 <1> Required.
 <2> If you do not provide these parameters and values, the installation program provides the default value.

--- a/modules/installation-bare-metal-agent-installer-config-yaml.adoc
+++ b/modules/installation-bare-metal-agent-installer-config-yaml.adoc
@@ -35,10 +35,6 @@ platform:
 fips: false <12>
 pullSecret: '{"auths": ...}' <13>
 sshKey: 'ssh-ed25519 AAAA...' <14>
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
 <2> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -205,10 +205,6 @@ ifndef::ibm-z,ibm-z-kvm[]
 endif::ibm-z,ibm-z-kvm[]
 endif::openshift-origin[]
 endif::restricted[]
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
 <2> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -184,10 +184,6 @@ imageContentSources: <13>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 endif::restricted[]
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 <1> Required. The installation program prompts you for this value.
 <2> If you do not provide these parameters and values, the installation program provides the default value.

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -76,10 +76,6 @@ ifdef::openshift-origin[]
 sshKey: ssh-ed25519 AAAA... <8>
 publish: Internal <9>
 endif::openshift-origin[]
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 <1> Specify the public DNS on the host project.
 <2> If you do not provide these parameters and values, the installation program provides the default value.

--- a/modules/installation-ibm-cloud-config-yaml.adoc
+++ b/modules/installation-ibm-cloud-config-yaml.adoc
@@ -80,10 +80,6 @@ endif::openshift-origin[]
 ifdef::openshift-origin[]
 sshKey: ssh-ed25519 AAAA... <5>
 endif::openshift-origin[]
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 <1> Required. The installation program prompts you for this value.
 <2> If you do not provide these parameters and values, the installation program provides the default value.
@@ -169,10 +165,6 @@ endif::openshift-origin[]
 ifdef::openshift-origin[]
 sshKey: ssh-ed25519 AAAA... <10>
 endif::openshift-origin[]
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 <1> Required. The installation program prompts you for this value.
 <2> If you do not provide these parameters and values, the installation program provides the default value.
@@ -263,10 +255,6 @@ endif::openshift-origin[]
 ifdef::openshift-origin[]
 sshKey: ssh-ed25519 AAAA... <12>
 endif::openshift-origin[]
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 <1> Required.
 <2> If you do not provide these parameters and values, the installation program provides the default value.

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -113,10 +113,6 @@ imageContentSources: <12>
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::restricted[]
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this
 base and include the cluster name.

--- a/modules/installation-osp-config-yaml.adoc
+++ b/modules/installation-osp-config-yaml.adoc
@@ -54,8 +54,4 @@ fips: false
 endif::openshift-origin[]
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----

--- a/modules/installation-osp-kuryr-config-yaml.adoc
+++ b/modules/installation-osp-kuryr-config-yaml.adoc
@@ -52,10 +52,6 @@ platform:
     octaviaSupport: true <2>
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 <1> The Amphora Octavia driver creates two ports per load balancer. As a
 result, the service subnet that the installer creates is twice the size of the

--- a/modules/installation-osp-restricted-config-yaml.adoc
+++ b/modules/installation-osp-restricted-config-yaml.adoc
@@ -71,8 +71,4 @@ imageContentSources:
 - mirrors:
   - <mirror_registry>/<repo_name>/release
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -102,10 +102,6 @@ imageContentSources: <18>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 endif::restricted[]
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this
 base and include the cluster name.

--- a/modules/installing-rhv-example-install-config-yaml.adoc
+++ b/modules/installing-rhv-example-install-config-yaml.adoc
@@ -78,10 +78,6 @@ platform:
 publish: External
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed12345 AAAA...
-capabilities:
-  baselineCapabilitySet: None
-  additionalEnabledCapabilities:
-  - openshift-samples
 ----
 
 <1> Setting this option to `false` enables preallocation of disks. The default is `true`. Setting `sparse` to `true` with `format` set to `raw` is not available for block storage domains. The `raw` format writes the entire virtual disk to the underlying physical disk.


### PR DESCRIPTION
Version(s):
4.11 and 4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-4333

Link to docs preview:
[Alibaba](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-network-customizations.html#installation-alibaba-config-yaml_installing-alibaba-network-customizations)
[AWS](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html#installation-aws-config-yaml_installing-aws-network-customizations)
[Azure](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-network-customizations.html#installation-azure-config-yaml_installing-azure-network-customizations)
[Azure Stack Hub](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.html#installation-azure-stack-hub-config-yaml_installing-azure-stack-hub-network-customizations)
[GCP](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-network-customizations.html#installation-gcp-config-yaml_installing-gcp-network-customizations)
[IBM Cloud VPC](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.html#installation-ibm-cloud-config-yaml_installing-ibm-cloud-network-customizations)
[Bare metal](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-bare-metal-config-yaml_installing-bare-metal-network-customizations)
[Bare metal IPI](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-the-install-config-file_ipi-install-installation-workflow)
[RHOSP](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#installation-osp-config-yaml_installing-openstack-installer-custom)
[RHOSP Kuryr](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-kuryr.html#installation-osp-kuryr-config-yaml_installing-openstack-installer-kuryr)
[RHV](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-customizations.html#installing-rhv-example-install-config-yaml_installing-rhv-customizations)
[vSphere](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#installation-installer-provisioned-vsphere-config-yaml_installing-vsphere-installer-provisioned-network-customizations)
[VMC](https://53345--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-network-customizations.html#installation-installer-provisioned-vsphere-config-yaml_installing-vmc-network-customizations)

QE review:
- [X] QE has approved this change.

Additional information:
Moving the sample yaml changes from https://github.com/openshift/openshift-docs/pull/52965 to this PR so they can be merged in the short term while the larger PR is in progress.