### PR TITLE
Updated the Travis CI config to allow failures for Vale and Netlify stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ cache: pip
 git:
   depth: 1
 jobs:
+  allow_failures:
+    env:
+      - CAN_FAIL=true
   include:
     - stage: build
       name: "Build openshift-enterprise distro"
@@ -50,6 +53,8 @@ jobs:
       script:
         - python3 build.py --distro microshift --product "MicroShift" --version 4 --no-upstream-fetch && python3 makeBuild.py
     - stage: check-with-vale
+      env:
+        - CAN_FAIL=true
       if: type IN (pull_request)
       name: "Run Vale against PR asciidoc files"
       before_script:
@@ -66,6 +71,8 @@ jobs:
     #   if: env(PR_AUTHOR)=openshift-cherrypick-robot
     #   script: bash ./automerge.sh
     - stage: netlify
+      env:
+        - CAN_FAIL=true
       language: minimal
       if: branch IN (main, enterprise-4.11, enterprise-4.12)
       script:


### PR DESCRIPTION
Added `allow_failures` to `check-with-vale` and `netlify` stages:
Based on the solution at https://github.com/travis-ci/travis-ci/issues/8998#issuecomment-657095023 we want allow failures for these stages. 

