### PR TITLE
Update instructions for running Rsync as root for PSA-enabled clusters

### DIFF
--- a/migration_toolkit_for_containers/installing-mtc-restricted.adoc
+++ b/migration_toolkit_for_containers/installing-mtc-restricted.adoc
@@ -37,6 +37,33 @@ include::modules/migration-configuring-proxies.adoc[leveloffset=+2]
 
 For more information, see xref:../networking/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object_config-cluster-wide-proxy[Configuring the cluster-wide proxy].
 
+[id="migration-rsync-root-non-root_{context}"]
+== Running Rsync as either root or non-root
+
+[IMPORTANT]
+====
+This section applies only when you are working with the OpenShift API, not the web console.
+====
+
+OpenShift environments have the `PodSecurityAdmission` controller enabled by default. This controller requires cluster administrators to enforce Pod Security Standards by means of namespace labels. All workloads in the cluster are expected to run one of the following Pod Security Standard levels: `Privileged`, `Baseline` or `Restricted`. Every cluster has its own default policy set.
+
+To guarantee successful data transfer in all environments, {mtc-full} ({mtc-short}) 1.7.5 introduced changes in Rsync pods, including running Rsync pods as non-root user by default. This ensures that data transfer is possible even for workloads that do not necessarily require higher privileges. This change was made because it is best to run workloads with the lowest level of privileges possible.
+
+==== Manually overriding default non-root operation for data trannsfer
+
+Although running Rsync pods as non-root user works in most cases, data transfer might fail when when you run workloads as root user on the source side. {mtc-short} provides two ways to manually override default non-root operation for data transfer:
+
+* Configure all migrations to run an Rsync pod as root on the destination cluster for all migrations.
+* Run an Rsync pod as root on the destination cluster per migration.
+
+In both cases, you must set the following labels on the source side of any namespaces that are running workloads with higher privileges prior to migration: `enforce`, `audit`, and `warn.`
+
+To learn more about Pod Security Admission and setting values for labels, see xref:../authentication/understanding-and-managing-pod-security-admission.adoc#security-context-constraints-psa-opting_understanding-and-managing-pod-security-admission[Controlling pod security admission synchronization].
+
+include::modules/migration-rsync-migration-controller-root-non-root.adoc[leveloffset=+1]
+
+include::modules/migration-rsync-mig-migration-root-non-root.adoc[leveloffset=+1]
+
 [id="configuring-replication-repository_{context}"]
 == Configuring a replication repository
 

--- a/migration_toolkit_for_containers/installing-mtc.adoc
+++ b/migration_toolkit_for_containers/installing-mtc.adoc
@@ -28,6 +28,33 @@ include::modules/migration-configuring-proxies.adoc[leveloffset=+2]
 
 For more information, see xref:../networking/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object_config-cluster-wide-proxy[Configuring the cluster-wide proxy].
 
+[id="migration-rsync-root-non-root_{context}"]
+=== Running Rsync as either root or non-root
+
+[IMPORTANT]
+====
+This section applies only when you are working with the OpenShift API, not the web console.
+====
+
+OpenShift environments have the `PodSecurityAdmission` controller enabled by default. This controller requires cluster administrators to enforce Pod Security Standards by means of namespace labels. All workloads in the cluster are expected to run one of the following Pod Security Standard levels: `Privileged`, `Baseline` or `Restricted`. Every cluster has its own default policy set.
+
+To guarantee successful data transfer in all environments, {mtc-full} ({mtc-short}) 1.7.5 introduced changes in Rsync pods, including running Rsync pods as non-root user by default. This ensures that data transfer is possible even for workloads that do not necessarily require higher privileges. This change was made because it is best to run workloads with the lowest level of privileges possible.
+
+==== Manually overriding default non-root operation for data trannsfer
+
+Although running Rsync pods as non-root user works in most cases, data transfer might fail when when you run workloads as root user on the source side. {mtc-short} provides two ways to manually override default non-root operation for data transfer:
+
+* Configure all migrations to run an Rsync pod as root on the destination cluster for all migrations.
+* Run an Rsync pod as root on the destination cluster per migration.
+
+In both cases, you must set the following labels on the source side of any namespaces that are running workloads with higher privileges prior to migration: `enforce`, `audit`, and `warn.`
+
+To learn more about Pod Security Admission and setting values for labels, see xref:../authentication/understanding-and-managing-pod-security-admission.adoc#security-context-constraints-psa-opting_understanding-and-managing-pod-security-admission[Controlling pod security admission synchronization].
+
+include::modules/migration-rsync-migration-controller-root-non-root.adoc[leveloffset=+2]
+
+include::modules/migration-rsync-mig-migration-root-non-root.adoc[leveloffset=+2]
+
 [id="configuring-replication-repository_{context}"]
 == Configuring a replication repository
 

--- a/modules/migration-rsync-mig-migration-root-non-root.adoc
+++ b/modules/migration-rsync-mig-migration-root-non-root.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/installing-mtc.adoc
+// * migration_toolkit_for_containers/installing-mtc-restricted.adoc
+[id="migration-rsync-mig-migration-root-non-root_{context}"]
+== Configuring the MigMigration CR as root or non-root per migration
+
+On the destination cluster, you can configure the `MigMigration` CR to run Rsync as root or non-root, with the following non-root options:
+
+* As a specific user ID (UID)
+* As a specific group ID (GID)
+
+.Procedure
+
+. To run Rsync as root, configure the `MigMigration` CR according to this example:
++
+[source,yaml]
+----
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigMigration
+metadata:
+  name: migration-controller
+  namespace: openshift-migration
+spec:
+  [...]
+  runAsRoot: true
+----
+
+. To run Rsync as a specific User ID (UID) or as a specific Group ID (GID), configure the `MigMigration` CR according to this example:
++
+[source,yaml]
+----
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigMigration
+metadata:
+  name: migration-controller
+  namespace: openshift-migration
+spec:
+  [...]
+  runAsUser: 10010001
+  runAsGroup: 3
+----

--- a/modules/migration-rsync-migration-controller-root-non-root.adoc
+++ b/modules/migration-rsync-migration-controller-root-non-root.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/installing-mtc.adoc
+// * migration_toolkit_for_containers/installing-mtc-restricted.adoc
+[id="migration-rsync-migration-controller-root-non-root_{context}"]
+== Configuring the MigrationController CR as root or non-root for all migrations
+
+By default, Rsync runs as non-root.
+
+On the destination cluster, you can configure the `MigrationController` CR to run Rsync as root.
+
+.Procedure
+
+* Configure the `MigrationController` CR as follows:
++
+[source,yaml]
+----
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigrationController
+metadata:
+  name: migration-controller
+  namespace: openshift-migration
+spec:
+  [...]
+  migration_rsync_privileged: true
+----
++
+This configuration will apply to all future migrations.


### PR DESCRIPTION
MTC 1.7.5+,  OCP 4.11+

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2136284 by adding https://github.com/migtools/mig-operator/pull/856 to the downstream documentation.

Preview: https://53359--docspreview.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc.html#migration-rsync-root-non-root_installing-mtc

Same in "Installing the Migration Toolkit for Containers in a restricted environment." 