### PR TITLE
[SRVCOM-2063] Add Serverless 1.26.0 release notes, update feature tables

### DIFF
--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -15,7 +15,7 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 .Deprecated and removed features tracker
 [cols="3,1,1,1",options="header"]
 |====
-|Feature |1.20|1.21|1.22 to 1.25
+|Feature |1.20|1.21|1.22 to 1.26
 
 |`KafkaBinding` API
 |Deprecated
@@ -35,14 +35,16 @@ ifdef::openshift-rosa[]
 .Deprecated and removed features tracker
 [cols="3,1,1,1",options="header"]
 |====
-|Feature |1.23|1.24|1.25
+|Feature |1.23|1.24|1.25|1.26
 
 |`KafkaBinding` API
 |Removed
 |Removed
 |Removed
+|Removed
 
 |`kn func emit` (`kn func invoke` in 1.21+)
+|Removed
 |Removed
 |Removed
 |Removed

--- a/modules/serverless-domain-mapping-custom-tls-cert.adoc
+++ b/modules/serverless-domain-mapping-custom-tls-cert.adoc
@@ -7,7 +7,15 @@
 [id="serverless-domain-mapping-custom-tls-cert_{context}"]
 = Securing a service with a custom domain by using a TLS certificate
 
-After you have configured a custom domain for a Knative service, you can use a TLS certificate to secure the mapped service. To do this, you must create a Kubernetes TLS secret, and then update the `DomainMapping` CR to use the TLS secret that you have created.
+After you have configured a custom domain for a Knative service, you can use a TLS certificate to secure the mapped service. To do this, you must create a Kubernetes TLS secret, and then update the `DomainMapping` CR to use the TLS secret that you
+have created.
+
+[NOTE]
+====
+If you use `net-istio` for Ingress and enable mTLS via SMCP using `security.dataPlane.mtls: true`, Service Mesh deploys `DestinationRules` for the `*.local` host, which does not allow `DomainMapping` for {ServerlessProductName}.
+
+To work around this issue, enable mTLS by deploying `PeerAuthentication` instead of using `security.dataPlane.mtls: true`.
+====
 
 .Prerequisites
 

--- a/modules/serverless-rn-1-23-0.adoc
+++ b/modules/serverless-rn-1-23-0.adoc
@@ -63,3 +63,8 @@ spec:
 * If you are using link:https://buildpacks.io/[Cloud Native Buildpacks] as the local build strategy for a function, `kn func` is unable to automatically start podman or use an SSH tunnel to a remote daemon. The workaround for these issues is to have a Docker or podman daemon already running on the local development computer before deploying a function.
 
 * On-cluster function builds currently fail for Quarkus and Golang runtimes. They work correctly for Node, Typescript, Python, and Springboot runtimes.
+
+* If you use `net-istio` for Ingress and enable mTLS via SMCP using `security.dataPlane.mtls: true`, Service Mesh deploys `DestinationRules` for the `*.local` host, which does not allow `DomainMapping` for {ServerlessProductName}.
++
+To work around this issue, enable mTLS by deploying `PeerAuthentication` instead of using `security.dataPlane.mtls: true`.
+

--- a/modules/serverless-rn-1-24-0.adoc
+++ b/modules/serverless-rn-1-24-0.adoc
@@ -50,3 +50,7 @@ To work around this issue, manually delete `kafkabindings.webhook.kafka.sources.
 ----
 $ oc delete mutatingwebhookconfiguration kafkabindings.webhook.kafka.sources.knative.dev
 ----
+
+* If you use `net-istio` for Ingress and enable mTLS via SMCP using `security.dataPlane.mtls: true`, Service Mesh deploys `DestinationRules` for the `*.local` host, which does not allow `DomainMapping` for {ServerlessProductName}.
++
+To work around this issue, enable mTLS by deploying `PeerAuthentication` instead of using `security.dataPlane.mtls: true`.

--- a/modules/serverless-rn-1-25-0.adoc
+++ b/modules/serverless-rn-1-25-0.adoc
@@ -35,4 +35,13 @@ It is recommended to not use the MT-Channel-Broker, but the Knative Kafka broker
 == Known issues
 
 * The Federal Information Processing Standards (FIPS) mode is disabled for Kafka broker, Kafka source, and Kafka sink.
+
 * The `SinkBinding` object does not support custom revision names for services.
+
+* The Knative Serving Controller pod adds a new informer to watch secrets in the cluster. The informer includes the secrets in the cache, which increases memory consumption of the controller pod.
++
+If the pod runs out of memory, you can work around the issue by increasing the memory limit for the deployment.
+
+* If you use `net-istio` for Ingress and enable mTLS via SMCP using `security.dataPlane.mtls: true`, Service Mesh deploys `DestinationRules` for the `*.local` host, which does not allow `DomainMapping` for {ServerlessProductName}.
++
+To work around this issue, enable mTLS by deploying `PeerAuthentication` instead of using `security.dataPlane.mtls: true`.

--- a/modules/serverless-rn-1-26-0.adoc
+++ b/modules/serverless-rn-1-26-0.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-26_{context}"]
+= Release notes for Red Hat {ServerlessProductName} 1.26
+
+{ServerlessProductName} 1.26 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+[id="new-features-1.26_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.5.
+* {ServerlessProductName} now uses Knative Eventing 1.5.
+* {ServerlessProductName} now uses Kourier 1.5.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.5.
+* {ServerlessProductName} now uses Knative Kafka 1.5.
+* {ServerlessProductName} now uses Knative Operator 1.3.
+* The `kn func` CLI plug-in now uses `func` 1.8.1.
+
+* Persistent volume claims (PVCs) are now GA. PVCs provide permanent data storage for your Knative services.
+
+* The new trigger filters feature is now available as a Developer Preview. It allows users to specify a set of filter expressions, where each expression evaluates to either true or false for each event.
++
+To enable new trigger filters, add the `new-trigger-filters: enabled` entry in the section of the `KnativeEventing` type in the operator config map:
++
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+...
+...
+spec:
+  config:
+    features:
+      new-trigger-filters: enabled
+...
+----
+
+* Knative Operator 1.3 adds the updated `v1beta1` version of the API for `operator.knative.dev`.
++
+To update from `v1alpha1` to `v1beta1` in your `KnativeServing` and `KnativeEventing` custom resource config maps, edit the `apiVersion` key:
++
+.Example `KnativeServing` custom resource config map
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+...
+----
++
+.Example `KnativeEventing` custom resource config map
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+...
+----
+
+[id="fixed-issues-1.26_{context}"]
+== Fixed issues
+
+* Previously, Federal Information Processing Standards (FIPS) mode was disabled for Kafka broker, Kafka source, and Kafka sink. This has been fixed, and FIPS mode is now available.
+
+[id="known-issues-1.26_{context}"]
+== Known issues
+
+* If you use `net-istio` for Ingress and enable mTLS via SMCP using `security.dataPlane.mtls: true`, Service Mesh deploys `DestinationRules` for the `*.local` host, which does not allow `DomainMapping` for {ServerlessProductName}.
++
+To work around this issue, enable mTLS by deploying `PeerAuthentication` instead of using `security.dataPlane.mtls: true`.

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -13,16 +13,18 @@ The following table provides information about which {ServerlessProductName} fea
 // OCP + OSD table
 ifdef::openshift-enterprise,openshift-dedicated[]
 .Generally Available and Technology Preview features tracker
-[cols="3,1,1,1",options="header"]
+[cols="3,1,1,1,1",options="header"]
 |====
-|Feature |1.23|1.24|1.25
+|Feature |1.23|1.24|1.25|1.26
 
 |`kn func`
 |TP
 |TP
 |TP
+|GA
 
 |Service Mesh mTLS
+|GA
 |GA
 |GA
 |GA
@@ -31,8 +33,10 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |GA
 |GA
 |GA
+|GA
 
 |HTTPS redirection
+|GA
 |GA
 |GA
 |GA
@@ -41,14 +45,17 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |TP
 |TP
 |GA
+|GA
 
 |Kafka sink
 |TP
 |TP
 |GA
+|GA
 
 |Init containers support for Knative services
 |TP
+|GA
 |GA
 |GA
 
@@ -56,10 +63,12 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |TP
 |TP
 |TP
+|GA
 
 |TLS for internal traffic
 |-
 |-
+|TP
 |TP
 
 |====
@@ -68,16 +77,18 @@ endif::[]
 // ROSA table
 ifdef::openshift-rosa[]
 .Generally Available and Technology Preview features tracker
-[cols="3,1,1,1",options="header"]
+[cols="3,1,1,1,1",options="header"]
 |====
-|Feature |1.23|1.24|1.25
+|Feature |1.23|1.24|1.25|1.26
 
 |`kn func`
 |TP
 |TP
 |TP
+|GA
 
 |Service Mesh mTLS
+|GA
 |GA
 |GA
 |GA
@@ -86,8 +97,10 @@ ifdef::openshift-rosa[]
 |GA
 |GA
 |GA
+|GA
 
 |HTTPS redirection
+|GA
 |GA
 |GA
 |GA
@@ -96,8 +109,10 @@ ifdef::openshift-rosa[]
 |TP
 |TP
 |GA
+|GA
 
 |Kafka sink
+|TP
 |TP
 |TP
 |TP
@@ -106,15 +121,18 @@ ifdef::openshift-rosa[]
 |TP
 |GA
 |GA
+|GA
 
 |PVC support for Knative services
 |TP
 |TP
 |TP
+|GA
 
 |TLS for internal traffic
 |-
 |-
+|TP
 |TP
 
 |====

--- a/serverless/discover/about-serverless.adoc
+++ b/serverless/discover/about-serverless.adoc
@@ -8,6 +8,13 @@ toc::[]
 
 {ServerlessProductName} provides Kubernetes native building blocks that enable developers to create and deploy serverless, event-driven applications on {product-title}. {ServerlessProductName} is based on the open source link:https://knative.dev/docs/[Knative project], which provides portability and consistency for hybrid and multi-cloud environments by enabling an enterprise-grade serverless platform.
 
+[NOTE]
+====
+Because {ServerlessProductName} releases on a different cadence from {product-title}, the {ServerlessProductName} documentation does not maintain separate documentation sets for minor versions of the product. The current documentation set applies to all currently supported versions of {ServerlessProductName} unless version-specific limitations are called out in a particular topic or for a particular feature.
+
+For additional information about the {ServerlessProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift#ossrvless[Platform Life Cycle Policy].
+====
+
 // Knative Serving
 include::modules/about-knative-serving.adoc[leveloffset=+1]
 

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -6,6 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[NOTE]
+====
+For additional information about the {ServerlessProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift#ossrvless[Platform Life Cycle Policy].
+====
+
 Release notes contain information about new and deprecated features, breaking changes, and known issues. The following release notes apply for the most recent {ServerlessProductName} releases on {product-title}.
 
 For an overview of {ServerlessProductName} functionality, see xref:../serverless/discover/about-serverless.adoc#about-serverless[About {ServerlessProductName}].
@@ -22,6 +27,13 @@ include::modules/serverless-tech-preview-features.adoc[leveloffset=+1]
 include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
+// OCP + OSD + ROSA
+include::modules/serverless-rn-1-26-0.adoc[leveloffset=+1]
+// 1.26.0 additional resources
+[role="_additional-resources"]
+.Additional resources
+* link:https://knative.dev/docs/eventing/experimental-features/new-trigger-filters/[Knative documentation on new trigger filters]
+
 // OCP + OSD + ROSA
 include::modules/serverless-rn-1-25-0.adoc[leveloffset=+1]
 // 1.25.0 additional resources, OCP docs


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-2063

Link to docs preview:
* Generally Available and Technology Preview features:
** https://53365--docspreview.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-tech-preview-features_serverless-release-notes
* Deprecated and removed features:
** https://53365--docspreview.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-deprecated-removed-features_serverless-release-notes
* Release notes for 1.26:
** https://53365--docspreview.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-rn-1-26_serverless-release-notes
* Securing a service with a custom domain by using a TLS certificate
** https://53365--docspreview.netlify.app/openshift-enterprise/latest/serverless/security/serverless-config-tls.html#serverless-domain-mapping-custom-tls-cert_serverless-config-tls

QE review:
- [x] QE has approved this change.

Additional information:
There is a number of FIXMEs throughout, in need of info or confirmations.