### PR TITLE
[OSDOCS-4297]: adding module about versioning support for hosted control planes

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -50,3 +50,9 @@ include::modules/hosted-control-planes-overview.adoc[leveloffset=+1]
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/multicluster_engine/advanced-config-engine#hypershift-addon-intro[Hypershift add-on (Technology Preview)]
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/clusters/managing-your-clusters#hosted-control-plane-intro[Leveraging hosted control plane clusters (Technology Preview)]
+
+include::modules/hosted-control-planes-version-support.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* For more information about the `HostedCluster` and `NodePool` resources, see the link:https://hypershift-docs.netlify.app/reference/api/[HyperShift API Reference].

--- a/modules/hosted-control-planes-version-support.adoc
+++ b/modules/hosted-control-planes-version-support.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * architecture/control-plane.adoc
+
+
+:_content-type: CONCEPT
+[id="hosted-control-planes-version-support_{context}"]
+= Versioning support for hosted control planes
+
+With each major, minor, or patch version release of {product-title}, the following components of hosted control planes are released:
+
+* HyperShift Operator
+* `HostedCluster` and `NodePool` API resources
+* Command-line interface (CLI)
+
+The HyperShift Operator manages the lifecycle of hosted clusters that are represented by `HostedCluster` resources. The HyperShift Operator is released with each {product-title} release. Any HyperShift Operator that is released with a minor _n_ version of {product-title} must support _n_, _n-1_, and _n-2_ minor versions of {product-title}.
+
+The CLI is a helper utility for development purposes. The CLI is released as part of any HyperShift Operator release. No compatibility policies are guaranteed.
+
+The API, `hypershift.openshift.io`, provides a way to create and manage lightweight, flexible, heterogeneous {product-title} clusters at scale. The API exposes two user-facing resources: `HostedCluster` and `NodePool`. A `HostedCluster` resource encapsulates the control plane and common data plane configuration. When you create a `HostedCluster` resource, you have a fully functional control plane with no attached nodes. A `NodePool` resource is a scalable set of worker nodes that is attached to a `HostedCluster` resource.
+
+The `HostedCluster` and `NodePool` resources are released with each {product-title} release. Any `HostedCluster` or `NodePool` resources that are released for a minor _n_ version of {product-title} must support _n_, _n-1_, and _n-2_ minor versions of {product-title}. The API version policy generally aligns with the link:https://kubernetes.io/docs/reference/using-api/#api-versioning[Kubernetes API versioning]. 
+
+
+


### PR DESCRIPTION
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-4297
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://53369--docspreview.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#hosted-control-planes-version-support_control-plane
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
