### PR TITLE
4.10 backport for GCP required/optional API split

### DIFF
--- a/modules/installation-gcp-enabling-api-services.adoc
+++ b/modules/installation-gcp-enabling-api-services.adoc
@@ -28,7 +28,7 @@ to complete {product-title} installation.
 .Procedure
 
 * Enable the following required API services in the project that hosts your
-cluster. See
+cluster. You can also enable optional API services which are not required for installation. See
 link:https://cloud.google.com/service-usage/docs/enable-disable#enabling[Enabling services]
 in the GCP documentation.
 +
@@ -37,16 +37,8 @@ in the GCP documentation.
 |===
 |API service |Console service name
 
-ifdef::template[]
-|Cloud Deployment Manager V2 API
-|`deploymentmanager.googleapis.com`
-endif::template[]
-
 |Compute Engine API
 |`compute.googleapis.com`
-
-|Google Cloud APIs
-|`cloudapis.googleapis.com`
 
 |Cloud Resource Manager API
 |`cloudresourcemanager.googleapis.com`
@@ -60,11 +52,26 @@ endif::template[]
 |Identity and Access Management (IAM) API
 |`iam.googleapis.com`
 
-|Service Management API
-|`servicemanagement.googleapis.com`
-
 |Service Usage API
 |`serviceusage.googleapis.com`
+
+|===
++
+.Optional API services
+[cols="2a,3a",options="header"]
+|===
+|API service |Console service name
+
+ifdef::template[]
+|Cloud Deployment Manager V2 API
+|`deploymentmanager.googleapis.com`
+endif::template[]
+
+|Google Cloud APIs
+|`cloudapis.googleapis.com`
+
+|Service Management API
+|`servicemanagement.googleapis.com`
 
 |Google Cloud Storage JSON API
 |`storage-api.googleapis.com`


### PR DESCRIPTION
4.10 backport of https://github.com/openshift/openshift-docs/pull/49559 and https://github.com/openshift/openshift-docs/pull/53342. 

Version(s):
4.10

Link to docs preview:
https://bscott-rh.github.io/openshift-docs/gcp-required-apis-4.10/installing/installing_gcp/installing-gcp-account.html#installation-gcp-enabling-api-services_installing-gcp-account

QE review:
- [X] QE has approved this change.
