### PR TITLE
NOISSUE: support building docs using podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-# Dockerfile
-FROM centos:8
-RUN dnf install git python3 python3-devel ruby rubygems -y
-RUN gem install asciidoctor asciidoctor-diagram
-COPY . $HOME/src/
-RUN pip3 install pyyaml /src/aura.tar.gz
+# Dockerfile for build tools
+FROM fedora
+# the ruby dependencies are needed to install asciidoctor and ascii_binder
+# gcc-c++ is needed to build native versions of some ruby plugins
+# git is needed by ascii_binder to find the branches in a repo
+RUN dnf install -y rubygems ruby-devel gcc-c++ make git
+RUN gem install asciidoctor asciidoctor-diagram ascii_binder

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+IMAGE_NAME="openshift-docs:ascii-binder"
+
+podman build --tag "${IMAGE_NAME}" -f ./Dockerfile
+
+# We do not want selinux relabeling done if we're on a Mac.
+# https://github.com/containers/podman/issues/13631
+systype=$(uname)
+if [ "$systype" = "Darwin" ]; then
+    selinux_suffix=""
+else
+    selinux_suffix=":Z"
+fi
+
+podman run \
+	   --rm=true \
+	   --tty \
+	   --workdir /workdir \
+	   --env LC_ALL=C.UTF-8 \
+	   -v $(pwd):/workdir${selinux_suffix} \
+	   "${IMAGE_NAME}" \
+       asciibinder build $@

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+IMAGE_NAME="openshift-docs:ascii-binder"
+
+podman run \
+	   --rm=true \
+	   --tty \
+	   --workdir /workdir \
+	   --env LC_ALL=C.UTF-8 \
+	   -v $(pwd):/workdir:Z \
+	   "${IMAGE_NAME}" \
+       asciibinder clean

--- a/contributing_to_docs/tools_and_setup.adoc
+++ b/contributing_to_docs/tools_and_setup.adoc
@@ -65,6 +65,7 @@ install the software and tools you will use to create the content. All OpenShift
 documentation is created in AsciiDoc, and is processed with https://github.com/redhataccess/ascii_binder[AsciiBinder],
 which is an http://asciidoctor.org/[AsciiDoctor]-based docs management system.
 
+NOTE: If you do not want to install the tools directly onto your system, you can use `build.sh` to run the tools in a container via podman on Fedora, CentOS, RHEL. While podman works on macOS, the documentation build tools still have issues running through podman there. See https://github.com/containers/podman/issues/13784 for details.
 
 === What you require
 The following are minimum requirements:

--- a/mod_docs_guide/_attributes
+++ b/mod_docs_guide/_attributes
@@ -1,1 +1,1 @@
-../../_attributes/
+../_attributes


### PR DESCRIPTION
Version(s): all

Issue: none

Link to docs preview: n/a

QE review:
- [ ] QE has approved this change.

Additional information:

This PR updates the existing Dockerfile and adds a shell script to use the resulting image to run asciibinder instead of requiring all of the dependencies be installed on the local system. I'm using this and thought it might be useful to others.

/assign @kalexand-rh
/cc @ShaunaDiaz
/cc @fzdarsky