### PR TITLE
Agent-249: disconnected install via a mirror through Agent-based Installer

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -305,6 +305,8 @@ Topics:
   Topics:
   - Name: Preparing to install with Agent-based installer
     File: preparing-to-install-with-agent-based-installer
+  - Name: Understanding disconnected installation mirroring
+    File: understanding-disconnected-installation-mirroring
   - Name: Installing a cluster with Agent-based installer
     File: installing-with-agent-based-installer
 - Name: Installing on a single node

--- a/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
+++ b/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
@@ -1,0 +1,20 @@
+:_content-type: ASSEMBLY
+[id="understanding-disconnected-installation-mirroring"]
+= Understanding disconnected installation mirroring
+include::_attributes/common-attributes.adoc[]
+:context: understanding-disconnected-installation-mirroring
+
+toc::[]
+// Reusing applicable content from Disconnected installation mirroring assembly
+
+You can use a mirror registry for disconnected installations and to ensure that your clusters only use container images that satisfy your organization's controls on external content. Before you install a cluster on infrastructure that you provision in a disconnected environment, you must mirror the required container images into that environment. To mirror container images, you must have a registry for mirroring.
+
+[id="agent-install-mirroring-images-disconnected"]
+== Mirroring images for a disconnected installation through the Agent-based Installer
+
+You can use one of the following procedures to mirror your {product-title} image repository to your mirror registry:
+
+* xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
+* xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in]
+
+include::modules/agent-install-about-mirroring-for-disconnected-registry.adoc[leveloffset=+1]

--- a/modules/agent-install-about-mirroring-for-disconnected-registry.adoc
+++ b/modules/agent-install-about-mirroring-for-disconnected-registry.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * list of assemblies where this module is included
+// * installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
+// re-use of applicable content from disconnected install mirroring
+
+:_content-type: CONCEPT
+[id="agent-install-about-mirroring-for-disconnected-registry_{context}"]
+= About mirroring the {product-title} image repository for a disconnected registry
+
+To use mirror images for a disconnected installation with the Agent-based Installer, you must modify the `install-config.yaml` file.
+
+You can mirror the release image by using the output of either the `oc adm release mirror` or `oc mirror` command.
+This is dependent on which command you used to set up the mirror registry. The following example shows the output of the `oc adm release mirror` command.
+
+
+[source,terminal]
+----
+$ oc adm release mirror
+----
+
+.Example output
+
+[source,terminal]
+----
+To use the new mirrored repository to install, add the following
+section to the install-config.yaml:
+
+imageContentSources:
+
+mirrors:
+virthost.ostest.test.metalkube.org:5000/localimages/local-release-image
+source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+mirrors:
+virthost.ostest.test.metalkube.org:5000/localimages/local-release-image
+source: registry.ci.openshift.org/ocp/release
+----
+Use the output of the command to update the `imageContentSources` field in the `install-config.yaml` file. Additionally, add the certificate file used for the mirror registry to the `additionalTrustBundle` field.
+
+.Example `install-config.yaml` file
+
+[source,yaml]
+----
+  additionalTrustBundle: |
+    -----BEGIN CERTIFICATE-----
+    ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+    -----END CERTIFICATE-----
+----
+
+The value must be the contents of the certificate file that you used for your mirror registry. The certificate file can be an existing, trusted certificate authority, or the self-signed certificate that you generated for the mirror registry.
+
+If you are using the optional method of the ZTP manifests, there are two mirror configuration files: `registries.conf` and `ca- bundle.crt` . These files must be added to the `mirror/directory` path to add the mirror configuration in the agent ISO image.
+
+You can create the `registries.conf` file from the output of either the `oc adm release mirror` or `oc mirror` command. The format of the `/etc/containers/registries.conf` file has changed . It is now version 2 and in TOML format.
+
+.Example `registries.conf` file
+
+[source,toml]
+----
+[[registry]]
+location = "registry.ci.openshift.org/ocp/release" mirror-by-digest-only = true
+
+[[registry.mirror]] location = "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
+
+[[registry]]
+location = "quay.io/openshift-release-dev/ocp-v4.0- art-dev" mirror-by-digest-only = true
+
+[[registry.mirror]] location = "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
+----


### PR DESCRIPTION
- Applies to main and 4.12
- [Jira](https://issues.redhat.com/browse/AGENT-249)
- [Preview](https://53404--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.html) 
- Update: Implemented feedback from the gdoc. Please check if the mirror/sources are matching.
@bfournie  

[](url)