### PR TITLE
OSDOCS-4632: Observing network traffic using Overview

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1297,6 +1297,8 @@ Topics:
   Topics:
   - Name: Installing Network Observability operators
     File: installing-operators
+  - Name: Observing the network traffic
+    File: observing-network-traffic
 ---
 Name: Storage
 Dir: storage

--- a/modules/network-observability-configuring-options-overview.adoc
+++ b/modules/network-observability-configuring-options-overview.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// network_observability/observing-network-traffic.adoc
+:_content-type: CONCEPT
+[id="network-observability-configuring-options-overview_{context}"]
+= Configuring advanced options
+You can customize the graphical view by using advanced options. To access the advanced options, click *Show advanced options*.You can configure the details in the graph by using the *Display options* dropdown. The options available are:
+
+* *Metric type*: The metrics to be shown in *Bytes* or *Packets*. The default value is *Bytes*.
+* *Scope*: To choose the detail of components between which the network traffic flows. You can set the scope to *Node*, *Namespace*, *Owner*, or *Resource*. *Owner* is an aggregation of resources. *Resource* can be a pod, service, node, in case of host-network traffic, or an unknown IP address. The default value is *Namespace*.
+* *Truncate labels*: Select the required width of the label from the drop-down list. The default value is *M*.
+
+.Managing panels
+You can select the required statistics to be displayed, and reorder them. To manage columns, click *Manage panels*.

--- a/modules/network-observability-overview.adoc
+++ b/modules/network-observability-overview.adoc
@@ -1,22 +1,7 @@
+// Module included in the following assemblies:
+//
+// network_observability/observing-network-traffic.adoc
+:_content-type: CONCEPT
+[id="network-observability-overview_{context}"]
 = Using Overview
 Overview displays the overall, aggregated metrics of the network traffic flow on the cluster. As an administrator, you can monitor the statistics with the available display options.
-
-== Working with Overview
-As an administrator, you can navigate to overview by using the following steps:
-
-. On the left navigation panel, click *Observe* → *Network Traffic*.
-. In the *Network Traffic* page, click the *Overview* tab.
-
-You can view the graphical representation of the flow rate statistics. You can configure the scope of each flow rate data by clicking the menu icon.
-
-== Configuring advanced options
-You can customize the graphical view by using advanced options. To access the advanced options, click *Show advanced options*.
-
-You can configure the details in the graph by using the *Display options* dropdown. The options available are:
-
-* *Metric type*: The metrics to be shown in *Bytes* or *Packets*. The default value is *Bytes*.
-* *Scope*: To choose the detail of components between which the network traffic flows. You can set the scope to *Node*, *Namespace*, *Owner*, or *Resource*. *Owner* is an aggregation of resources. *Resource* can be a pod, service, node, in case of host-network traffic, or an unknown IP address. The default value is *Namespace*.
-* *Truncate labels*: Select the required width of the label from the drop-down list. The default value is *M*.
-
-.Managing panels
-You can select the required statistics to be displayed, and reorder them. To manage columns, click *Manage panels*.

--- a/modules/network-observability-overview.adoc
+++ b/modules/network-observability-overview.adoc
@@ -14,8 +14,8 @@ You can customize the graphical view by using advanced options. To access the ad
 
 You can configure the details in the graph by using the *Display options* dropdown. The options available are:
 
-* *Metric type*: The metrics to be shown in graph. The default value is *Bytes*.
-* *Scope*: To choose the detail of components between which the network traffic flows. The default value is *Namespace*.
+* *Metric type*: The metrics to be shown in *Bytes* or *Packets*. The default value is *Bytes*.
+* *Scope*: To choose the detail of components between which the network traffic flows. You can set the scope to *Node*, *Namespace*, *Owner*, or *Resource*. *Owner* is an aggregation of resources. *Resource* can be a pod, node, in case of host-network traffic, or an unknown IP address. The default value is *Namespace*.
 * *Truncate labels*: Select the required width of the label from the drop-down list. The default value is *M*.
 
 .Managing panels

--- a/modules/network-observability-overview.adoc
+++ b/modules/network-observability-overview.adoc
@@ -1,0 +1,22 @@
+= Using Overview
+Overview displays the overall, aggregated metrics of the network traffic flow on the cluster. As an administrator, you can monitor the statistics with the available display options.
+
+== Working with Overview
+As an administrator, you can navigate to overview by using the following steps:
+
+. On the left navigation panel, click *Observe* → *Network Traffic*.
+. In the *Network Traffic* page, click the *Overview* tab.
+
+You can view the graphical representation of the flow rate statistics. You can configure the scope of each flow rate data by clicking the menu icon.
+
+== Configuring advanced options
+You can customize the graphical view by using advanced options. To access the advanced options, click *Show advanced options*.
+
+You can configure the details in the graph by using the *Display options* dropdown. The options available are:
+
+* *Metric type*: The metrics to be shown in graph. The default value is *Bytes*.
+* *Scope*: To choose the detail of components between which the network traffic flows. The default value is *Namespace*.
+* *Truncate labels*: Select the required width of the label from the drop-down list. The default value is *M*.
+
+.Managing panels
+You can select the required statistics to be displayed, and reorder them. To manage columns, click *Manage panels*.

--- a/modules/network-observability-overview.adoc
+++ b/modules/network-observability-overview.adoc
@@ -15,7 +15,7 @@ You can customize the graphical view by using advanced options. To access the ad
 You can configure the details in the graph by using the *Display options* dropdown. The options available are:
 
 * *Metric type*: The metrics to be shown in *Bytes* or *Packets*. The default value is *Bytes*.
-* *Scope*: To choose the detail of components between which the network traffic flows. You can set the scope to *Node*, *Namespace*, *Owner*, or *Resource*. *Owner* is an aggregation of resources. *Resource* can be a pod, node, in case of host-network traffic, or an unknown IP address. The default value is *Namespace*.
+* *Scope*: To choose the detail of components between which the network traffic flows. You can set the scope to *Node*, *Namespace*, *Owner*, or *Resource*. *Owner* is an aggregation of resources. *Resource* can be a pod, service, node, in case of host-network traffic, or an unknown IP address. The default value is *Namespace*.
 * *Truncate labels*: Select the required width of the label from the drop-down list. The default value is *M*.
 
 .Managing panels

--- a/modules/network-observability-working-with-overview.adoc
+++ b/modules/network-observability-working-with-overview.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// network_observability/observing-network-traffic.adoc
+:_content-type: PROCEDURE
+[id="network-observability-working-with-overview_{context}"]
+= Working with Overview
+As an administrator, you can navigate to overview by using the following steps:
+
+. On the left navigation panel, click *Observe* → *Network Traffic*.
+. In the *Network Traffic* page, click the *Overview* tab.
+
+You can view the graphical representation of the flow rate statistics. You can configure the scope of each flow rate data by clicking the menu icon.

--- a/networking/network_observability/observing-network-traffic.adoc
+++ b/networking/network_observability/observing-network-traffic.adoc
@@ -1,3 +1,4 @@
+:_content-type: ASSEMBLY
 [id="nw-observe-network-traffic"]
 = Observing the network traffic
 include::_attributes/common-attributes.adoc[]
@@ -6,3 +7,5 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 include::modules/network-observability-overview.adoc[leveloffset=+1]
+include::modules/network-observability-working-with-overview.adoc[leveloffset=+1]
+include::modules/network-observability-configuring-options-overview.adoc[leveloffset=+1]

--- a/networking/network_observability/observing-network-traffic.adoc
+++ b/networking/network_observability/observing-network-traffic.adoc
@@ -5,4 +5,4 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-include::modules/network-observability-trafficflow.adoc[leveloffset=+1]
+include::modules/network-observability-overview.adoc[leveloffset=+1]

--- a/networking/network_observability/observing-network-traffic.adoc
+++ b/networking/network_observability/observing-network-traffic.adoc
@@ -1,0 +1,8 @@
+[id="nw-observe-network-traffic"]
+= Observing the network traffic
+include::_attributes/common-attributes.adoc[]
+:context: nw-observe-network-traffic
+
+toc::[]
+
+include::modules/network-observability-trafficflow.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):4.12

Issue: https://issues.redhat.com/browse/OSDOCS-4632

Link to docs preview: https://53405--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/observing-network-traffic.html

QE review:
- [x] QE has approved this change.