### PR TITLE
[enterprise-4.9] TELCODOCS-1029: First instance of namespace: openshift-operators remo…

### DIFF
--- a/modules/eco-node-health-check-operator-about.adoc
+++ b/modules/eco-node-health-check-operator-about.adoc
@@ -8,9 +8,9 @@
 
 The Node Health Check Operator deploys the `NodeHealthCheck` controller, which in turn creates the `NodeHealthCheck` custom resource (CR). The Node Health Check Operator also installs the Poison Pill Operator as a default remediation provider.
 
-The Operator uses the controller to detect the health of a node in the cluster. The controller creates a `NodeHealthCheck` custom resource (CR), which defines a set of criteria and thresholds to determine the node's health. 
+The Operator uses the controller to detect the health of a node in the cluster. The controller creates a `NodeHealthCheck` custom resource (CR), which defines a set of criteria and thresholds to determine the node's health.
 
-When node health check detects an unhealthy node, it creates a remediation CR that triggers the remediation provider. For example, the node health check creates the `PoisonPillRemediation` CR, which triggers the Poison Pill Operator to remediate the unhealthy node. 
+When node health check detects an unhealthy node, it creates a remediation CR that triggers the remediation provider. For example, the node health check creates the `PoisonPillRemediation` CR, which triggers the Poison Pill Operator to remediate the unhealthy node.
 
 The `NodeHealthCheck` CR resembles the following YAML file:
 
@@ -20,11 +20,10 @@ apiVersion: remediation.medik8s.io/v1alpha1
 kind: NodeHealthCheck
 metadata:
   name: nodehealthcheck-sample
-  namespace: openshift-operators
 spec:
   minHealthy: 51% <1>
   pauseRequests: <2>
-    - <pause-test-cluster> 
+    - <pause-test-cluster>
   remediationTemplate: <3>
     apiVersion: poison-pill.medik8s.io/v1alpha1
     name: group-x
@@ -50,9 +49,9 @@ spec:
 ====
 During the upgrade process, nodes in the cluster might become temporarily unavailable and get identified as unhealthy. In the case of worker nodes, when the Operator detects that the cluster is upgrading, it stops remediating new unhealthy nodes to prevent such nodes from rebooting.
 ====
-<3> Specifies a remediation template from the remediation provider. For example, from the Poison Pill Operator. 
+<3> Specifies a remediation template from the remediation provider. For example, from the Poison Pill Operator.
 <4> Specifies a `selector` that matches labels or expressions that you want to check. The default value is empty, which selects all nodes.
-<5> Specifies a list of the conditions that determine whether a node is considered unhealthy. 	
+<5> Specifies a list of the conditions that determine whether a node is considered unhealthy.
 <6> Specifies the timeout duration for a node condition. If a condition is met for the duration of the timeout, the node will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy node.
 
 [id="understanding-nhc-operator-workflow_{context}"]
@@ -60,5 +59,38 @@ During the upgrade process, nodes in the cluster might become temporarily unavai
 
 When a node is identified as unhealthy, the Operator checks how many other nodes are unhealthy. If the number of healthy nodes exceeds the amount that is specified in the `minHealthy` field of the `NodeHealthCheck` CR, the controller creates a remediation CR from the details that are provided in the external remediation template by the remediation provider. After remediation, the node's health status is updated accordingly.
 
-When the node turns healthy, the controller deletes the external remediation template
-and updates the node's health status.
+When the node turns healthy, the controller deletes the external remediation template.
+
+[id="how-nhc-prevent-conflict-with-mhc_{context}"]
+== About how node health checks prevent conflicts with machine health checks
+
+When both, node health checks and machine health checks are deployed, the node health check avoids conflict with the machine health check.
+
+[NOTE]
+====
+{product-title} deploys `machine-api-termination-handler` as the default `MachineHealthCheck` resource.
+====
+
+The following list summarizes the system behavior when node health checks and machine health checks are deployed:
+
+* If only the default machine health check exists, the node health check continues to identify unhealthy nodes. However, the node health check ignores unhealthy nodes in a Terminating state. The default machine health check handles the unhealthy nodes with a Terminating state.
++
+.Example log message
+[source,terminal]
+----
+INFO MHCChecker	ignoring unhealthy Node, it is terminating and will be handled by MHC	{"NodeName": "node-1.example.com"}
+----
+
+* If the default machine health check is modified (for example, the `unhealthyConditions` is  `Ready`), or if additional machine health checks are created, the node health check is disabled.
++
+.Example log message
+----
+INFO controllers.NodeHealthCheck disabling NHC in order to avoid conflict with custom MHCs configured in the cluster {"NodeHealthCheck": "/nhc-worker-default"}
+----
+
+* When, again, only the default machine health check exists, the node health check is re-enabled.
++
+.Example log message
+----
+INFO controllers.NodeHealthCheck re-enabling NHC, no conflicting MHC configured in the cluster {"NodeHealthCheck": "/nhc-worker-default"}
+----


### PR DESCRIPTION
NOTE: This is a manual cherry-pick of PR https://github.com/openshift/openshift-docs/pull/52848 for OCP Version 4.9

https://issues.redhat.com/browse/TELCODOCS-1029 NodeHealthCheck example has namespace

Applies to OpenShift version : 4.9

Preview: [About the Node Health Check Operator](http://file.emea.redhat.com/pogrady/TELCODOCS-1029/nodes/nodes/eco-node-health-check-operator.html#about-node-health-check-operator_node-health-check-operator)

Dev review complete/approved by @slintes
QE review complete/approved by @anna-savina
Peer review complete/approved by @mburke5678

Thank you.