### PR TITLE
OSDOCS-4627: Adds notes for 4.11.18

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3007,3 +3007,39 @@ $ oc adm release info 4.11.17 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-18"]
+=== RHBA-2022:8698 - {product-title} 4.11.18 bug fix update
+
+Issued: 2022-12-05
+
+{product-title} release 4.11.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2022:8698[RHBA-2022:8698] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:8697[RHBA-2022:8697] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.18 --pullspecs
+----
+
+[id="ocp-4-11-18-enhancements"]
+==== Enhancements
+
+* IPv6 unsolicited neighbor advertisements and IPv4 gratuitous address resolution protocol now default on the SR-IOV CNI plug-in. Pods created with the Single Root I/O Virtualization (SR-IOV) CNI plug-in, where the IP address management CNI plug-in has assigned IPs, now send IPv6 unsolicited neighbor advertisements and/or IPv4 gratuitous address resolution protocol by default onto the network. This enhancement notifies hosts of the new pod's MAC address for a particular IP to refresh ARP/NDP caches with the correct information. For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
+
+[id="ocp-4-11-18-notable-technical-changes"]
+==== Notable Technical Changes
+
+* Previously named heterogeneous clusters are now refered to as multi-architecture in {product-title} documentation. For more information, see xref:../post_installation_configuration/multi-architecture-configuration.adoc[Configuring a multi-architecture cluster]
+
+[id="ocp-4-11-18-bug-fixes"]
+==== Bug fixes
+
+* Previously, some object storage instances responded with `204 No Content` when no content displayed. The {rh-openstack-first} SDK used in {product-title} did not handle 204s correctly. With this update, the installation program works around the issue when there are zero items to list. (link:https://issues.redhat.com/browse/OCPBUGS-4081[*OCPBUGS-4081*])
+
+* Previously, the rollout times for `kube-apiserver` on a loaded cluster were slow and sometimes exceeded the 5 min rollout timeout. With this update, the rollout times are shorter and within the 5 min threshold. (link:https://issues.redhat.com/browse/OCPBUGS-3182[*OCPBUGS-3182*])
+
+[id="ocp-4-11-18-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.11.18 release

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-4627

Link to docs preview:
https://53427--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-18

QE review:
- [ ] QE has approved this change.
* QE not needed for this change

Additional information:
Some links will not work yet.

#53431 will merge with this PR

Relates to: https://issues.redhat.com/browse/NHE-226

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
