### PR TITLE
GH#53347: Updated description for file installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc(Resource Group needs to be empty)

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1041,7 +1041,7 @@ Additional Azure configuration parameters are described in the following table:
 |String, for example `production_cluster`.
 
 |`platform.azure.resourceGroupName`
-| The name of an already existing resource group to install your cluster to. This resource group must be empty and only used for this specific cluster; the cluster components assume ownership of all resources in the resource group. If you limit the service principal scope of the installation program to this resource group, you must ensure all other resources used by the installation program in your environment have the necessary permissions, such as the public DNS zone and virtual network. Destroying the cluster using the installation program deletes this resource group.
+| The name of an already existing resource group to install your cluster to. This resource group must be empty and only used for this specific cluster; the cluster components assume ownership of all resources in the resource group. If you limit the service principal scope of the installation program to this resource group, you must ensure all other resources used by the installation program in your environment have the necessary permissions, such as the public DNS zone and virtual network. Destroying the cluster by using the installation program deletes this resource group.
 |String, for example `existing_resource_group`.
 
 |`platform.azure.outboundType`
@@ -1659,7 +1659,7 @@ Additional Azure configuration parameters are described in the following table:
 |String
 
 |`platform.azure.resourceGroupName`
-| The name of an already existing resource group to install your cluster to. If undefined, a new resource group is created for the cluster.
+|The name of an already existing resource group to install your cluster to. This resource group must be empty and only used for this specific cluster; the cluster components assume ownership of all resources in the resource group. If you limit the service principal scope of the installation program to this resource group, you must ensure all other resources used by the installation program in your environment have the necessary permissions, such as the public DNS zone and virtual network. Destroying the cluster by using the installation program deletes this resource group.
 |String, for example `existing_resource_group`.
 
 |`platform.azure.outboundType`


### PR DESCRIPTION
Updated documentation for installing azure stack hub (platform.azure.resourceGroupName). The previous definition did not include the requirement for the Resource Group to be empty.

Replaced documentation to match the following:

"The name of an already existing resource group to install your cluster to. This resource group must be empty and only used for this specific cluster; the cluster components assume ownership of all resources in the resource group. If you limit the service principal scope of the installation program to this resource group, you must ensure all other resources used by the installation program in your environment have the necessary permissions, such as the public DNS zone and virtual network. Destroying the cluster using the installation program deletes this resource group."

*** Please note: the text wrapping issue is a known problem with this table. A necessary value in the 3rd column of this table causes a wrapping issue in asciibinder. If the table formatting issue outweighs the information update, this bug would need to be closed.

Version(s):
4.10+

Issue:
https://github.com/openshift/openshift-docs/issues/53347

Link to docs preview:
[Additional Azure Stack Hub configuration parameters]( https://53428--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.html#installation-configuration-parameters-additional-azure-stack-hub_installing-azure-stack-hub-network-customizations)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
