### PR TITLE
OSDOCS-4629:adds zstream release for 4.9.53

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -3301,7 +3301,7 @@ To update an existing {product-title} 4.9 cluster to this latest release, see xr
 
 Issued: 2022-11-23
 
-{product-title} release 4.9.52 is now available. 4.9.52 contains no IBM Power build options. IBM Power build options will be included in the next z-stream release. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:8485[RHBA-2022:8485] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:8582[RHBA-2022:8582] advisory.
+{product-title} release 4.9.52 is now available. There is no IBM powerbuild for this release. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:8485[RHBA-2022:8485] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:8582[RHBA-2022:8582] advisory.
 
 You can view the container images in this release by running the following command:
 
@@ -3311,6 +3311,30 @@ $ oc adm release info 4.9.52 --pullspecs
 ----
 
 [id="ocp-4-9-52-updating"]
+==== Updating
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-9-53"]
+=== RHBA-2022:8714 - {product-title} 4.9.53 bug fix update
+
+Issued: 2022-12-7
+
+{product-title} release 4.9.53 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:8714[RHBA-2022:8714] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:8713[RHBA-2022:8713] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.9.53 --pullspecs
+----
+
+[id="ocp-4-9-53-enhancements"]
+==== Enhancements
+
+* IPv6 unsolicited neighbor advertisements and IPv4 gratuitous address resolution protocol now default on the SR-IOV CNI plug-in. Pods created with the Single Root I/O Virtualization (SR-IOV) CNI plug-in, where the IP address management CNI plug-in has assigned IPs, now send IPv6 unsolicited neighbor advertisements and/or IPv4 gratuitous address resolution protocol by default onto the network. This enhancement notifies hosts of the new pod's MAC address for a particular IP to refresh ARP/NDP caches with the correct information. For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
+
+[id="ocp-4-9-53-updating"]
 ==== Updating
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4629](https://issues.redhat.com//browse/OSDOCS-4629): updates zstream for 4.9.53 and matches IBM power build language in 4.9.52 with 4.11.13.
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.9
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[Jira](https://issues.redhat.com/browse/OSDOCS-4629)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Preview](https://joealdinger.github.io/openshift-docs/OSDOCS-4629/release_notes/ocp-4-9-release-notes.html#ocp-4-9-53)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Also adds zstream backport to [Announce IPv4/IPv6 on pod creation](https://issues.redhat.com/browse/NHE-226)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
