### PR TITLE
CNV-21825: latency checkup permissions and API update

### DIFF
--- a/modules/virt-about-cluster-checkup-framework.adoc
+++ b/modules/virt-about-cluster-checkup-framework.adoc
@@ -8,15 +8,14 @@
 
 A _checkup_ is an automated test workload that allows you to verify if a specific cluster functionality works as expected. The cluster checkup framework uses native Kubernetes resources to configure and execute the checkup.
 
-By using predefined checkups, cluster administrators can improve cluster maintainability, troubleshoot unexpected behavior, minimize errors, and save time. They can also review the results of the checkup and share them with experts for further analysis. Vendors can write and publish checkups for features or services that they provide and verify that their customer environments are configured correctly.
+By using predefined checkups, cluster administrators and developers can improve cluster maintainability, troubleshoot unexpected behavior, minimize errors, and save time. They can also review the results of the checkup and share them with experts for further analysis. Vendors can write and publish checkups for features or services that they provide and verify that their customer environments are configured correctly.
 
-Running a predefined checkup in the cluster involves setting up the namespace and service account for the framework, creating the `ClusterRole` and `ClusterRoleBinding` objects for the service account, enabling permissions for the checkup, and creating the input config map and the checkup job. You can run a checkup multiple times.
+Running a predefined checkup in an existing namespace involves setting up a service account for the checkup, creating the `Role` and `RoleBinding` objects for the service account, enabling permissions for the checkup, and creating the input config map and the checkup job. You can run a checkup multiple times.
 
 [IMPORTANT]
 ====
 You must always:
 
 * Verify that the checkup image is from a trustworthy source before applying it.
-* Review the checkup permissions before creating the `ClusterRole` and `Role` objects.
-* Verify the name of the `ServiceAccount` in the config map. This is because the framework automatically binds these permissions to the checkup instance.
+* Review the checkup permissions before creating the `Role` and `RoleBinding` objects.
 ====

--- a/modules/virt-measuring-latency-vm-secondary-network.adoc
+++ b/modules/virt-measuring-latency-vm-secondary-network.adoc
@@ -6,7 +6,7 @@
 [id="virt-measuring-latency-vm-secondary-network_{context}"]
 = Checking network connectivity and latency for virtual machines on a secondary network
 
-As a cluster administrator, you use a predefined checkup to verify network connectivity and measure latency between virtual machines (VMs) that are attached to a secondary network interface.
+You use a predefined checkup to verify network connectivity and measure latency between two virtual machines (VMs) that are attached to a secondary network interface.
 
 To run a checkup for the first time, follow the steps in the procedure.
 
@@ -15,86 +15,11 @@ If you have previously run a checkup, skip to step 5 of the procedure because th
 .Prerequisites
 
 * You installed the OpenShift CLI (`oc`).
-* You logged in to the cluster as a user with the `cluster-admin` role.
 * The cluster has at least two worker nodes.
 * The Multus Container Network Interface (CNI) plug-in is installed on the cluster.
 * You configured a network attachment definition for a namespace.
 
 .Procedure
-
-. Create a configuration file that contains the resources to set up the framework. This includes a namespace and service account for the framework, and the `ClusterRole` and `ClusterRoleBinding` objects to define permissions for the service account.
-+
-.Example framework manifest file
-[%collapsible]
-====
-[source,yaml]
-----
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kiagnose
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kiagnose
-  namespace: kiagnose
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kiagnose
-rules:
-  - apiGroups: [ "" ]
-    resources: [ "configmaps" ]
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups: [ "rbac.authorization.k8s.io" ]
-    resources:
-      - roles
-      - rolebindings
-    verbs:
-      - get
-      - list
-      - create
-      - delete
-  - apiGroups: [ "batch" ]
-    resources: [ "jobs" ]
-    verbs:
-      - get
-      - list
-      - create
-      - delete
-      - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kiagnose
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kiagnose
-subjects:
-  - kind: ServiceAccount
-    name: kiagnose
-    namespace: kiagnose
-...
-----
-====
-
-. Apply the framework manifest:
-+
-[source,terminal]
-----
-$ oc apply -f <framework_manifest>.yaml
-----
 
 . Create a manifest file that contains the `ServiceAccount`, `Role`, and `RoleBinding` objects with permissions that the checkup requires for cluster access:
 +
@@ -108,13 +33,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vm-latency-checkup-sa
-  namespace: <target_namespace> <1>
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kubevirt-vm-latency-checker
-  namespace: <target_namespace>
 rules:
 - apiGroups: ["kubevirt.io"]
   resources: ["virtualmachineinstances"]
@@ -130,7 +53,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kubevirt-vm-latency-checker
-  namespace: <target_namespace>
 subjects:
 - kind: ServiceAccount
   name: vm-latency-checkup-sa
@@ -138,16 +60,37 @@ roleRef:
   kind: Role
   name: kubevirt-vm-latency-checker
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kiagnose-configmap-access
+rules:
+- apiGroups: [ "" ]
+  resources: [ "configmaps" ]
+  verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kiagnose-configmap-access
+subjects:
+- kind: ServiceAccount
+  name: vm-latency-checkup-sa
+roleRef:
+  kind: Role
+  name: kiagnose-configmap-access
+  apiGroup: rbac.authorization.k8s.io
 ----
 ====
-<1> Specify the namespace where the checkup is to be executed. This must be an existing namespace where the `NetworkAttachmentDefinition` object resides.
 
 . Apply the checkup roles manifest:
 +
 [source,terminal]
 ----
-$ oc apply -f <latency_roles>.yaml
+$ oc apply -n <target_namespace> -f <latency_roles>.yaml <1>
 ----
+<1> `<target_namespace>` is the namespace where the checkup is to be run. This must be an existing namespace where the `NetworkAttachmentDefinition` object resides.
 
 . Create a `ConfigMap` manifest that contains the input parameters for the checkup. The config map provides the input for the framework to run the checkup and also stores the results of the checkup.
 +
@@ -158,31 +101,26 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kubevirt-vm-latency-checkup-config
-  namespace: <target_namespace> <1>
 data:
-  spec.image: registry.redhat.io/container-native-virtualization/vm-network-latency-checkup:v4.12.0
   spec.timeout: 5m
-  spec.serviceAccountName: vm-latency-checkup-sa
-  spec.param.network_attachment_definition_namespace: <target_namespace> <2>
-  spec.param.network_attachment_definition_name: "bridge-network" <3>
-  spec.param.max_desired_latency_milliseconds: "10" <4>
-  spec.param.sample_duration_seconds: "5" <5>
-  spec.param.source_node: "worker1" <6>
-  spec.param.target_node: "worker2" <7>
+  spec.param.network_attachment_definition_namespace: <target_namespace>
+  spec.param.network_attachment_definition_name: "blue-network" <1>
+  spec.param.max_desired_latency_milliseconds: "10" <2>
+  spec.param.sample_duration_seconds: "5" <3>
+  spec.param.source_node: "worker1" <4>
+  spec.param.target_node: "worker2" <5>
 ----
-<1> The namespace where the checkup is to be executed. This must be an existing namespace where the `NetworkAttachmentDefinition` object resides.
-<2> The namespace where the `NetworkAttachmentDefinition` object resides.
-<3> The name of the `NetworkAttachmentDefinition` object.
-<4> Optional: The maximum desired latency, in milliseconds, between the virtual machines. If the measured latency exceeds this value, the checkup fails.
-<5> Optional: The duration of the latency check, in seconds.
-<6> Optional: When specified, latency is measured from this node to the target node. If the source node is specified, the `spec.param.target_node` field cannot be empty.
-<7> Optional: When specified, latency is measured from the source node to this node.
+<1> The name of the `NetworkAttachmentDefinition` object.
+<2> Optional: The maximum desired latency, in milliseconds, between the virtual machines. If the measured latency exceeds this value, the checkup fails.
+<3> Optional: The duration of the latency check, in seconds.
+<4> Optional: When specified, latency is measured from this node to the target node. If the source node is specified, the `spec.param.target_node` field cannot be empty.
+<5> Optional: When specified, latency is measured from the source node to this node.
 
-. Apply the config map manifest in the framework’s namespace:
+. Apply the config map manifest in the target namespace:
 +
 [source,terminal]
 ----
-$ oc apply -f <latency_config_map>.yaml
+$ oc apply -n <target_namespace> -f <latency_config_map>.yaml
 ----
 
 . Create a `Job` object to run the checkup:
@@ -194,16 +132,22 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: kubevirt-vm-latency-checkup
-  namespace: kiagnose
 spec:
   backoffLimit: 0
   template:
     spec:
-      serviceAccount: kiagnose
+      serviceAccountName: vm-latency-checkup-sa
       restartPolicy: Never
       containers:
-        - name: framework
-          image: registry.redhat.io/container-native-virtualization/checkup-framework:v4.12.0
+        - name: vm-latency-checkup
+          image: registry.redhat.io/container-native-virtualization/vm-network-latency-checkup:v4.12.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            seccompProfile:
+              type: "RuntimeDefault"
           env:
             - name: CONFIGMAP_NAMESPACE
               value: <target_namespace>
@@ -215,14 +159,14 @@ spec:
 +
 [source,terminal]
 ----
-$ oc apply -f <latency_job>.yaml
+$ oc apply -n <target_namespace> -f <latency_job>.yaml
 ----
 
 . Wait for the job to complete:
 +
 [source,terminal]
 ----
-$ oc wait job kubevirt-vm-latency-checkup -n kiagnose --for condition=complete --timeout 6m
+$ oc wait job kubevirt-vm-latency-checkup -n <target_namespace> --for condition=complete --timeout 6m
 ----
 
 . Review the results of the latency checkup by running the following command. If the maximum measured latency is greater than the value of the `spec.param.max_desired_latency_milliseconds` attribute, the checkup fails and returns an error.
@@ -241,11 +185,9 @@ metadata:
   name: kubevirt-vm-latency-checkup-config
   namespace: <target_namespace>
 data:
-  spec.image: registry.redhat.io/container-native-virtualization/vm-network-latency-checkup:v4.12.0
   spec.timeout: 5m
-  spec.serviceAccountName: vm-latency-checkup-sa
   spec.param.network_attachment_definition_namespace: <target_namespace>
-  spec.param.network_attachment_definition_name: "bridge-network"
+  spec.param.network_attachment_definition_name: "blue-network"
   spec.param.max_desired_latency_milliseconds: "10"
   spec.param.sample_duration_seconds: "5"
   spec.param.source_node: "worker1"
@@ -267,14 +209,14 @@ data:
 +
 [source,terminal]
 ----
-$ oc logs job.batch/kubevirt-vm-latency-checkup -n kiagnose
+$ oc logs job.batch/kubevirt-vm-latency-checkup -n <target_namespace>
 ----
 
 . Delete the job and config map resources that you previously created by running the following commands:
 +
 [source,terminal]
 ----
-$ oc delete job -n kiagnose kubevirt-vm-latency-checkup
+$ oc delete job -n <target_namespace> kubevirt-vm-latency-checkup
 ----
 +
 [source,terminal]

--- a/virt/logging_events_monitoring/virt-running-cluster-checkups.adoc
+++ b/virt/logging_events_monitoring/virt-running-cluster-checkups.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{VirtProductName} {VirtVersion} includes a diagnostic framework to run predefined checkups that can be used for cluster maintenance and troubleshooting.
+{VirtProductName} includes predefined checkups that can be used for cluster maintenance and troubleshooting.
 
 :FeatureName: The {product-title} cluster checkup framework
 include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-21825](https://issues.redhat.com//browse/CNV-21825)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://53437--docspreview.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-running-cluster-checkups.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
