### PR TITLE
[OSDOCS-4426]: Egress IP support on RHOSP 

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -18,10 +18,6 @@ The {product-title} egress IP address functionality allows you to ensure that th
 For example, you might have a pod that periodically queries a database that is hosted on a server outside of your cluster. To enforce access requirements for the server, a packet filtering device is configured to allow traffic only from specific IP addresses.
 To ensure that you can reliably allow access to the server from only that specific pod, you can configure a specific egress IP address for the pod that makes the requests to the server.
 
-[NOTE]
-====
-The {rh-openstack} egress IP address feature creates a neutron reservation port called `egressip-<IP address>`. You can assign a floating IP address to this reservation port to have a predictable SNAT address for egress traffic. When an egress IP address on an {rh-openstack} network is moved from one node to another, because of a node failover, for example, the neutron reservation port is removed and recreated. This means that the floating IP association is lost and you need to manually reassign the floating IP address to the new reservation port.
-====
 
 An egress IP address assigned to a namespace is different from an egress router, which is used to send traffic to specific destinations.
 
@@ -48,7 +44,7 @@ Support for the egress IP address functionality on various platforms is summariz
 
 | Bare metal | Yes
 | VMware vSphere | Yes
-| {rh-openstack-first} | No
+| {rh-openstack-first} | Yes
 | Amazon Web Services (AWS) | Yes
 | Google Cloud Platform (GCP) | Yes
 | Microsoft Azure | Yes
@@ -79,6 +75,13 @@ The annotation value is an array with a single object with fields that provide t
 * `interface`: Specifies the interface ID on AWS and Azure and the interface name on GCP.
 * `ifaddr`: Specifies the subnet mask for one or both IP address families.
 * `capacity`: Specifies the IP address capacity for the node. On AWS, the IP address capacity is provided per IP address family. On Azure and GCP, the IP address capacity includes both IPv4 and IPv6 addresses.
+
+Automatic attachment and detachment of egress IP addresses for traffic between nodes are available. This allows for traffic from many pods in namespaces to have a consistent source IP address to locations outside of the cluster. This also supports OpenShift SDN and OVN-Kubernetes, which is the default networking plug-in in Red Hat OpenShift Networking in {product-title} {product-version}.
+
+[NOTE]
+====
+The {rh-openstack} egress IP address feature creates a Neutron reservation port called `egressip-<IP address>`. Using the same {rh-openstack} user as the one used for the {product-title} cluster installation, you can assign a floating IP address to this reservation port to have a predictable SNAT address for egress traffic. When an egress IP address on an {rh-openstack} network is moved from one node to another, because of a node failover, for example, the Neutron reservation port is removed and recreated. This means that the floating IP association is lost and you need to manually reassign the floating IP address to the new reservation port.
+====
 
 The following examples illustrate the annotation from nodes on several public cloud providers. The annotations are indented for readability.
 


### PR DESCRIPTION
Version: 4.12+

Issue: [OSDOCS-3950](https://issues.redhat.com/browse/OSDOCS-3950)
Epic: [SDN-3027](https://issues.redhat.com/browse/SDN-3027)

Preview links: (updated 1/13): 
https://53440--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-public-cloud-platform-considerations_configuring-egress-ips-ovn

https://53440--docspreview.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/assigning-egress-ips.html#nw-egress-ips-public-cloud-platform-considerations_egress-ips

QE review:
- [x ] QE has approved this change. (Huiran Wang)
