### PR TITLE
BZ1998059: Adding parameters to ingress controller

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -206,6 +206,43 @@ For request headers, these adjustments are applied only for routes that have the
 |`httpErrorCodePages`
 |`httpErrorCodePages` specifies custom HTTP error code response pages. By default, an IngressController uses error pages built into the IngressController image.
 
+|`httpCaptureCookies`
+|`httpCaptureCookies` specifies HTTP cookies that you want to capture in access logs. If the `httpCaptureCookies` field is empty, the access logs do not capture the cookies. 
+
+For any cookie that you want to capture, the following parameters must be in your `IngressController` configuration:
+
+* `name` specifies the name of the cookie.
+* `maxLength` specifies tha maximum length of the cookie.
+* `matchType` specifies if the field `name` of the cookie exactly matches the capture cookie setting or is a prefix of the capture cookie setting. The `matchType` field uses the `Exact` and `Prefix` parameters.
+
+For example: 
+[source,yaml]
+----
+  httpCaptureCookies:
+  - matchType: Exact
+    maxLength: 128
+    name: MYCOOKIE
+----
+
+|`httpCaptureHeaders`
+|`httpCaptureHeaders` specifies the HTTP headers that you want to capture in the access logs. If the `httpCaptureHeaders` field is empty, the access logs do not capture the headers. 
+
+`httpCaptureHeaders` contains two lists of headers to capture in the access logs. The two lists of header fields are `request` and `response`. In both lists, the `name` field must specify the header name and the `maxlength` field must specify the maximum length of the header. For example:
+
+[source,yaml]
+----
+  httpCaptureHeaders:
+    request:
+    - maxLength: 256
+      name: Connection
+    - maxLength: 128
+      name: User-Agent
+    response:
+    - maxLength: 256
+      name: Content-Type
+    - maxLength: 256
+      name: Content-Length
+----
 |`tuningOptions`
 |`tuningOptions` specifies options for tuning the performance of Ingress Controller pods.
 


### PR DESCRIPTION
For versions 4.8+
Issue: [BZ1998059](https://bugzilla.redhat.com/show_bug.cgi?id=1998059)

Preview: [Understanding the Ingress Operator -> Ingress Controller configuration parameters ](https://53441--docspreview.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->