### PR TITLE
BZ2117171 fix typo in image stream doc

### DIFF
--- a/modules/images-imagestream-use.adoc
+++ b/modules/images-imagestream-use.adoc
@@ -19,7 +19,7 @@ image.
 The source images can be stored in any of the following:
 
 * {product-title}'s integrated registry.
-* An external registry, for example registry.redhat.io or Quay.io.
+* An external registry, for example registry.redhat.io or quay.io.
 * Other image streams in the {product-title} cluster.
 
 When you define an object that references an image stream tag, such as a build or deployment configuration, you point to an image stream tag and not the repository. When you build or deploy your application, {product-title} queries the repository using the image stream tag to locate the associated ID of the image and uses that exact image.


### PR DESCRIPTION
BZ-2117171, fix "quay.io" typo.

Question for peer review: these registries are not back-ticked to be written in terminal font. Should they be?

Version(s):
PR applies to: 4.9+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2117171

Preview link:
https://53443--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/index.html#images-imagestream-use_overview-of-images

QE review:
- QE requested this change.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
