### PR TITLE
OCPBUGS#4456: Correct nmstate data for bmh.yaml

### DIFF
--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -62,38 +62,25 @@ metadata:
  name: openshift-worker-<num>-network-config-secret <2>
 type: Opaque
 stringData:
- nmstate: |
-  hosts:
-  - name: openshift-master-0
-    role: master
-    bmc:
-      address: redfish+http://<out_of_band_ip>/redfish/v1/Systems/
-      username: <user>
-      password: <password>
-      disableCertificateVerification: null
-    bootMACAddress: <NIC1_mac_address>
-    bootMode: UEFI
-    rootDeviceHints:
-      deviceName: "/dev/sda"
-    networkConfig: <3>
-      interfaces: <4>
-      - name: <nic1_name> <5>
-        type: ethernet
-        state: up
-        ipv4:
-          address:
-          - ip: <ip_address> <5>
-            prefix-length: 24
-          enabled: true
-      dns-resolver:
-        config:
-          server:
-          - <dns_ip_address> <5>
-      routes:
-        config:
-        - destination: 0.0.0.0/0
-          next-hop-address: <next_hop_ip_address> <5>
-          next-hop-interface: <next_hop_nic1_name> <5>
+ nmstate: | <3>
+  interfaces: <4>
+  - name: <nic1_name> <5>
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: <ip_address> <5>
+        prefix-length: 24
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - <dns_ip_address> <5>
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: <next_hop_ip_address> <5>
+      next-hop-interface: <next_hop_nic1_name> <5>
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: Incorrect nmstate data in bmh.yaml
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

https://53444--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-the-bare-metal-node_ipi-install-expanding

https://docs.openshift.com/container-platform/4.11/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-the-bare-metal-node_ipi-install-expanding
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
