### PR TITLE
OCPBUGS-2936: VPA uninstall instructions incomplete/complicated

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
@@ -10,10 +10,10 @@ You can remove the Vertical Pod Autoscaler Operator (VPA) from your {product-tit
 
 [NOTE]
 ====
-You can remove a specific VPA using the `oc delete vpa <vpa-name>` command. The same actions apply for resource requests as uninstalling the vertical pod autoscaler.
+You can remove a specific VPA CR by using the `oc delete vpa <vpa-name>` command. The same actions apply for resource requests as uninstalling the vertical pod autoscaler.
 ====
 
-After removing the VPA Operator, it is recommended that you remove other components associated with the Operator to avoid potential issues. 
+After removing the VPA Operator, it is recommended that you remove the other components associated with the Operator to avoid potential issues. 
 
 .Prerequisites
 
@@ -25,7 +25,7 @@ After removing the VPA Operator, it is recommended that you remove other compone
 
 . Switch to the *openshift-vertical-pod-autoscaler* project.
 
-. Find the *VerticalPodAutoscaler*  Operator and click the Options menu. Select *Uninstall Operator*.
+. For the *VerticalPodAutoscaler*  Operator, click the Options menu {kebab} and select *Uninstall Operator*.
 
 . Optional: To remove all operands associated with the Operator, in the dialog box, select *Delete all operand instances for this operator* checkbox.
 
@@ -33,98 +33,36 @@ After removing the VPA Operator, it is recommended that you remove other compone
 
 . Optional: Use the OpenShift CLI to remove the VPA components:
 
-.. Delete the VPA mutating webhook configuration: 
+.. Delete the VPA namespace: 
 +
 [source,terminal]
 ----
-$ oc delete mutatingwebhookconfigurations/vpa-webhook-config
+$ oc delete namespace openshift-vertical-pod-autoscaler
 ----
 
-.. List any VPA custom resources: 
+.. Delete the VPA custom resource definition (CRD) objects:
 +
 [source,terminal]
 ----
-$ oc get verticalpodautoscalercheckpoints.autoscaling.k8s.io,verticalpodautoscalercontrollers.autoscaling.openshift.io,verticalpodautoscalers.autoscaling.k8s.io -o wide --all-namespaces
-----
-+
-.Example output
-[source,terminal]
-----
-NAMESPACE      NAME                                                                       AGE
-my-project     verticalpodautoscalercheckpoint.autoscaling.k8s.io/vpa-recommender-httpd   5m46s
-
-NAMESPACE                           NAME                                                               AGE
-openshift-vertical-pod-autoscaler   verticalpodautoscalercontroller.autoscaling.openshift.io/default   11m
-
-NAMESPACE      NAME                                                       MODE   CPU   MEM       PROVIDED   AGE
-my-project     verticalpodautoscaler.autoscaling.k8s.io/vpa-recommender   Auto   93m   262144k   True       9m15s
-----
-
-.. Delete the listed VPA custom resources. For example:
-+
-[source,terminal]
-----
-$ oc delete verticalpodautoscalercheckpoint.autoscaling.k8s.io/vpa-recommender-httpd -n my-project
+$ oc delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 ----
 +
 [source,terminal]
 ----
-$ oc delete verticalpodautoscalercontroller.autoscaling.openshift.io/default -n openshift-vertical-pod-autoscaler
+$ oc delete crd verticalpodautoscalercontrollers.autoscaling.openshift.io
 ----
 +
 [source,terminal]
 ----
-$ oc delete verticalpodautoscaler.autoscaling.k8s.io/vpa-recommender -n my-project
-----
-
-.. List any VPA custom resource definitions (CRDs):
-+
-[source,terminal]
-----
-$ oc get crd
+$ oc delete crd verticalpodautoscalers.autoscaling.k8s.io
 ----
 +
-.Example output
-[source,terminal]
-----
-NAME                                                              CREATED AT
- ...
-verticalpodautoscalercheckpoints.autoscaling.k8s.io               2022-02-07T14:09:20Z
-verticalpodautoscalercontrollers.autoscaling.openshift.io         2022-02-07T14:09:20Z
-verticalpodautoscalers.autoscaling.k8s.io                         2022-02-07T14:09:20Z
- ...
-----
-
-.. Delete the listed VPA CRDs: 
+Deleting the CRDs removes the associated roles, cluster roles, and role bindings. 
 +
-[source,terminal]
-----
-$ oc delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io verticalpodautoscalercontrollers.autoscaling.openshift.io verticalpodautoscalers.autoscaling.k8s.io
-----
-+
-Deleting the CRDs removes the associated roles, cluster roles, and role bindings. However, there might be a few cluster roles that must be manually deleted.
-
-.. List any VPA cluster roles: 
-+
-[source,terminal]
-----
-$ oc get clusterrole | grep openshift-vertical-pod-autoscaler
-----
-+
-.Example output
-[source,terminal]
-----
-openshift-vertical-pod-autoscaler-6896f-admin        2022-02-02T15:29:55Z
-openshift-vertical-pod-autoscaler-6896f-edit         2022-02-02T15:29:55Z
-openshift-vertical-pod-autoscaler-6896f-view         2022-02-02T15:29:55Z
-----
-
-.. Delete the listed VPA cluster roles. For example:
-+
-[source,terminal]
-----
-$ oc delete clusterrole openshift-vertical-pod-autoscaler-6896f-admin openshift-vertical-pod-autoscaler-6896f-edit openshift-vertical-pod-autoscaler-6896f-view
-----
+[NOTE]
+====
+This action removes from the cluster all user-created VPA CRs. If you re-install the VPA, you must create these objects again.
+====
 
 .. Delete the VPA Operator:
 +
@@ -132,3 +70,4 @@ $ oc delete clusterrole openshift-vertical-pod-autoscaler-6896f-admin openshift-
 ----
 $ oc delete operator/vertical-pod-autoscaler.openshift-vertical-pod-autoscaler
 ----
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-2936

The optional step 6 (parts a-h) under https://docs.openshift.com/container-platform/4.11/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-uninstall_nodes-pods-vertical-autoscaler should be replaced

Preview: [Uninstalling the Vertical Pod Autoscaler Operator](https://53447--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-uninstall_nodes-pods-vertical-autoscaler)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

