### PR TITLE
Mark RHACS 3.70 docs as unsupported

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -41,7 +41,7 @@
 <body onload="selectVersion('<%= version %>');">
   <%= render("_templates/_topnav.html.erb", :distro_key => distro_key) %>
   <%
-    unsupported_versions = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "3.65", "3.66", "3.67", "3.68", "3.69"];
+    unsupported_versions = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "3.65", "3.66", "3.67", "3.68", "3.69", "3.70"];
   %>
   <div class="container">
     <button id="hc-open-btn" class="open-btn-sm" onclick="openNav()" aria-label="Open"><span class="fa fa-bars" /></button>


### PR DESCRIPTION
RHACS 3.70 version reached its EOL on 2 Dec 2022. This PR adds the version number to the unsupported version list to show up the unsupported banner on the docs page.

Similar to https://github.com/openshift/openshift-docs/pull/50625 