### PR TITLE
[enterprise-4.11] OSDOCS-4024: Add MT2892 Family SR-IOV hardware

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -87,6 +87,11 @@
 |15b3
 |101f
 
+|Mellanox
+|MT2892 Family [ConnectX&#8209;6{nbsp}Dx]
+|15b3
+|101d
+
 |Pensando ^[1]^
 |DSC-25 dual-port 25G distributed services card for ionic driver
 |0x1dd8
@@ -97,6 +102,7 @@
 |0x1dd8
 |0x1003
 |===
+
 [.small]
 --
 1. OpenShift SR-IOV is supported, but you must set a static, Virtual Function (VF) media access control (MAC) address using the SR-IOV CNI config file when using SR-IOV.

--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -573,9 +573,14 @@ A new PTP events API endpoint is available, `api/cloudNotifications/v1/publisher
 For more information, see xref:../networking/using-ptp.adoc#cnf-fast-event-notifications-api-refererence_using-ptp[Subscribing DU applications to PTP events REST API reference].
 
 [id="ocp-4-11-support-for-pensando-dsc-cards"]
-==== SR-IOV Support for Pensando DSC cards
+==== SR-IOV support for Pensando DSC cards
 
 SR-IOV support is now available for xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Pensando DSC cards]. OpenShift SR-IOV is supported, but you must set a static, Virtual Function (VF) media access control (MAC) address using the SR-IOV CNI config file when using SR-IOV.
+
+[id="ocp-4-11-support-for-mellanox-mt2892-cards"]
+==== SR-IOV support for Mellanox MT2892 cards
+
+SR-IOV support is now available for xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Mellanox MT2892 cards].
 
 [id="ocp-4-11-cidr-ranges-for-network"]
 ==== {product-title} CIDR Ranges for Networks


### PR DESCRIPTION
[OSDOCS-4024](https://issues.redhat.com//browse/OSDOCS-4024): Add MT2892 Family SR-IOV hardware

This was added for 4.12 and subsequently became available for use on 4.11 and 4.10 as well.
    
- https://issues.redhat.com/browse/OSDOCS-4024

Refs https://github.com/openshift/openshift-docs/pull/49777.