### PR TITLE
OSDOCS-4073: Release notes for the dynamic plug-in

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -164,6 +164,19 @@ The `console-operator` now scans all nodes and builds a set of all architecture 
 
 For more information about multi-architechture compute machines, see xref:../post_installation_configuration/multi-architecture-configuration.adoc[Configuring a multi-architecture compute machine on an OpenShift cluster].
 
+[id="ocp-4-12-dynamic-plug-in-updates"]
+===== Dynamic plug-in generally available
+
+This feature was previously introduced as a Technology Preview in {product-title} 4.10 and is now generally available in {product-title} 4.12. With the dynamic plug-in you can build high quality and unique user experiences natively in the web console. You can:
+
+* Add custom pages. 
+* Add perspectives beyond administrator and developer.
+* Add navigation items.
+* Add tabs and actions to resource pages.
+* Extend existing pages.
+
+For more information, see xref:../../web_console/dynamic-plug-in/dynamic-plug-in.html#dynamic-plug-in-overview[Overview of dynamic-plug-ins].
+
 [id="ocp-4-12-developer-perspective"]
 ==== Developer Perspective
 
@@ -471,7 +484,7 @@ For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k
 
 In {product-title} 4.12, the External DNS Operator modifies the format of the ExternalDNS wildcard TXT records on AzureDNS. The External DNS Operator replaces the asterisk with `any` in ExternalDNS wildcard TXT records. You must avoid the ExternalDNS wildcard A and CNAME records having `any` leftmost subdomain because this might cause a conflict.
 
-The upstream version of `ExternalDNS` for {product-title} 4.12 is v0.13.1.
+The upstream version of `ExternalDNS` for an {product-title} 4.12 is v0.13.1. 
 
 [id="ocp-4-12-nw-metrics-telemetry"]
 ==== Capturing metrics and telemetry associated with the use of routes and shards
@@ -547,15 +560,6 @@ For more information, see xref:../networking/ingress-controller-dnsmgt.adoc#ingr
 * Silicom STS Family
 
 For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
-
-[id="ocp-4-12-multi-network-policy-supported-for-sr-iov"]
-==== Multi-network-policy supported for SR-IOV (Technology Preview)
-
-{product-title} 4.12 adds support for configuring multi-network policy for SR-IOV devices.
-
-You can now configure multi-network for SR-IOV additional networks. Configuring SR-IOV additional networks is a Technology Preview feature and is only supported with kernel network interface cards (NICs).
-
-For more information, see xref:../networking/multiple_networks/configuring-multi-network-policy.adoc#configuring-multi-network-policy[Configuring multi-network policy].
 
 [id="ocp-4-12-switch-aws-load-balancer"]
 ==== Switch between AWS load balancer types without deleting the Ingress Controller
@@ -688,7 +692,7 @@ $ operator-sdk run bundle \
 === Machine API
 
 [id="ocp-4-12-mapi-control-plane-machine-sets"]
-==== Control plane machine sets
+==== Control plane machine sets 
 
 {product-title} 4.12 introduces control plane machine sets. Control plane machine sets provide management capabilities for control plane machines that are similar to what compute machine sets provide for compute machines. For more information, see xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[Managing control plane machines].
 
@@ -716,17 +720,6 @@ For more information, see xref:../post_installation_configuration/coreos-layerin
 
 [id="ocp-4-12-nodes"]
 === Nodes
-
-[id="ocp-4-12-updating-interface-specific-list"]
-==== Updating the interface-specific safe list (Technology Preview)
-
-{product-title} now supports updating the default interface-specific safe `sysctls`.
-
-You can add or remove `sysctls` from the predefined list.
-When you add `sysctls`, they can be set across all nodes.
-Updating the interface-specific safe `sysctls` list is a Technology Preview feature only.
-
-For more information, see xref:../nodes/containers/nodes-containers-sysctls.adoc#updating-interface-specific-safe-sysctls-list_nodes-containers-using[Updating the interface-specific safe sysctls list].
 
 [id="ocp-4-12-node-cron-job-time-zone"]
 ==== Cron job time zones (Technology Preview)


### PR DESCRIPTION
[OSDOCS-4073](https://issues.redhat.com//browse/OSDOCS-4073): Adds notes for the dynamic plug-in and moves to GA.

Version(s):
4.12 only

Issue:
[OSDOCS-4073](https://issues.redhat.com/browse/OSDOCS-4073)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
