### PR TITLE
Osdocs-4240 Added "only if you are using non-STS." to init command info for ROSA

### DIFF
--- a/modules/dedicated-aws-vpc-initiating-peering.adoc
+++ b/modules/dedicated-aws-vpc-initiating-peering.adoc
@@ -21,7 +21,7 @@ peering request:
 matches the CIDR block for the Customer VPC, then peering between these two VPCs
 is not possible; see the Amazon VPC
 link:https://docs.aws.amazon.com/vpc/latest/peering/invalid-peering-configurations.html[Unsupported VPC Peering Configurations]
-documentation for details. If the CIDR blocks do not overlap, you can procedure
+documentation for details. If the CIDR blocks do not overlap, you can continue
 with the procedure.
 
 .Procedure

--- a/modules/rosa-initialize.adoc
+++ b/modules/rosa-initialize.adoc
@@ -7,7 +7,7 @@
 = Initializing {product-title}
 
 
-Use the `init` command to initialize {product-title} (ROSA).
+Use the `init` command to initialize {product-title} (ROSA) only if you are using non-STS.
 
 [id="rosa-init_{context}"]
 == init


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-4240

Link to docs preview:
https://53482--docspreview.netlify.app/openshift-rosa/latest/rosa_cli/rosa-get-started-cli.html#rosa-initialize_rosa-getting-started-cli

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
