### PR TITLE
OSDOCS-4108: OLM PSA label synchronization for `openshift-*` NS

### DIFF
--- a/modules/security-context-constraints-psa-opting.adoc
+++ b/modules/security-context-constraints-psa-opting.adoc
@@ -19,13 +19,15 @@ Namespaces that are defined as part of the cluster payload have pod security adm
 * `openshift`
 * All system-created namespaces that are prefixed with `openshift-`, except for `openshift-operators`
 
-By default, all namespaces that have an `openshift-` prefix are not synchronized. You can enable synchronization for any user-created [x-]`openshift-*` namespaces. You cannot enable synchronization for any system-created [x-]`openshift-*` namespaces, except for `openshift-operators`.
+By default, all namespaces that have an `openshift-` prefix are not synchronized. You can enable synchronization for any user-created [x-]`openshift-*` namespaces. You cannot enable synchronization for any system-created [x-]`openshift-*` namespaces, except for `openshift-operators`. 
+
+If an Operator is installed in a user-created `openshift-*` namespace, synchronization is turned on by default after a cluster service version (CSV) is created in the namespace. The synchronized label inherits the permissions of the service accounts in the namespace.
 ====
 
 .Procedure
 
 * For each namespace that you want to configure, set a value for the `security.openshift.io/scc.podSecurityLabelSync` label:
-** To disable pod security admission label sychronization in a namespace, set the value of the `security.openshift.io/scc.podSecurityLabelSync` label to `false`.
+** To disable pod security admission label synchronization in a namespace, set the value of the `security.openshift.io/scc.podSecurityLabelSync` label to `false`.
 +
 Run the following command:
 +
@@ -34,7 +36,7 @@ Run the following command:
 $ oc label namespace <namespace> security.openshift.io/scc.podSecurityLabelSync=false
 ----
 
-** To enable pod security admission label sychronization in a namespace, set the value of the `security.openshift.io/scc.podSecurityLabelSync` label to `true`.
+** To enable pod security admission label synchronization in a namespace, set the value of the `security.openshift.io/scc.podSecurityLabelSync` label to `true`.
 +
 Run the following command:
 +

--- a/modules/security-context-constraints-psa-synchronization.adoc
+++ b/modules/security-context-constraints-psa-synchronization.adoc
@@ -12,7 +12,7 @@ In addition to the global pod security admission control configuration, a contro
 
 [IMPORTANT]
 ====
-Namespaces that are defined as part of the cluster payload have pod security admission synchronization disabled permanently. You can enable pod security admission synchronization on other namespaces as necessary.
+Namespaces that are defined as part of the cluster payload have pod security admission synchronization disabled permanently. You can enable pod security admission synchronization on other namespaces as necessary. If an Operator is installed in a user-created `openshift-*` namespace, synchronization is turned on by default after a cluster service version (CSV) is created in the namespace. 
 ====
 
 The controller examines `ServiceAccount` object permissions to use security context constraints in each namespace. Security context constraints (SCCs) are mapped to pod security profiles based on their field values; the controller uses these translated profiles. Pod security admission `warn` and `audit` labels are set to the most privileged pod security profile found in the namespace to prevent warnings and audit logging as pods are created.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OCP 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-4108](https://issues.redhat.com//browse/OSDOCS-4108)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* [SCC synchronization with pod security standards](https://53484--docspreview.netlify.app/openshift-enterprise/latest/authentication/understanding-and-managing-pod-security-admission.html#security-context-constraints-psa-synchronization_understanding-and-managing-pod-security-admission)
* [Controlling PSA synchronization](https://53484--docspreview.netlify.app/openshift-enterprise/latest/authentication/understanding-and-managing-pod-security-admission.html#security-context-constraints-psa-synchronization_understanding-and-managing-pod-security-admission)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Documents the changes introduced in [OLM-2679](https://issues.redhat.com//browse/OLM-2679)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
