### PR TITLE
OCPBUGS-2936: VPA uninstall instructions incomplete/complicated

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
@@ -33,50 +33,6 @@ After removing the VPA Operator, it is recommended that you remove other compone
 
 . Optional: Use the OpenShift CLI to remove the VPA components:
 
-.. Delete the VPA mutating webhook configuration: 
-+
-[source,terminal]
-----
-$ oc delete mutatingwebhookconfigurations/vpa-webhook-config
-----
-
-.. List any VPA custom resources: 
-+
-[source,terminal]
-----
-$ oc get verticalpodautoscalercheckpoints.autoscaling.k8s.io,verticalpodautoscalercontrollers.autoscaling.openshift.io,verticalpodautoscalers.autoscaling.k8s.io -o wide --all-namespaces
-----
-+
-.Example output
-[source,terminal]
-----
-NAMESPACE      NAME                                                                       AGE
-my-project     verticalpodautoscalercheckpoint.autoscaling.k8s.io/vpa-recommender-httpd   5m46s
-
-NAMESPACE                           NAME                                                               AGE
-openshift-vertical-pod-autoscaler   verticalpodautoscalercontroller.autoscaling.openshift.io/default   11m
-
-NAMESPACE      NAME                                                       MODE   CPU   MEM       PROVIDED   AGE
-my-project     verticalpodautoscaler.autoscaling.k8s.io/vpa-recommender   Auto   93m   262144k   True       9m15s
-----
-
-.. Delete the listed VPA custom resources. For example:
-+
-[source,terminal]
-----
-$ oc delete verticalpodautoscalercheckpoint.autoscaling.k8s.io/vpa-recommender-httpd -n my-project
-----
-+
-[source,terminal]
-----
-$ oc delete verticalpodautoscalercontroller.autoscaling.openshift.io/default -n openshift-vertical-pod-autoscaler
-----
-+
-[source,terminal]
-----
-$ oc delete verticalpodautoscaler.autoscaling.k8s.io/vpa-recommender -n my-project
-----
-
 .. List any VPA custom resource definitions (CRDs):
 +
 [source,terminal]
@@ -85,6 +41,7 @@ $ oc get crd
 ----
 +
 .Example output
++
 [source,terminal]
 ----
 NAME                                                              CREATED AT
@@ -93,16 +50,38 @@ verticalpodautoscalercheckpoints.autoscaling.k8s.io               2022-02-07T14:
 verticalpodautoscalercontrollers.autoscaling.openshift.io         2022-02-07T14:09:20Z
 verticalpodautoscalers.autoscaling.k8s.io                         2022-02-07T14:09:20Z
  ...
-----
+---
 
-.. Delete the listed VPA CRDs: 
+.. Delete the VPA mutating webhook configuration: 
 +
 [source,terminal]
 ----
-$ oc delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io verticalpodautoscalercontrollers.autoscaling.openshift.io verticalpodautoscalers.autoscaling.k8s.io
+$ oc delete mutatingwebhookconfigurations/vpa-webhook-config
+----
+
+.. Delete the VPA custom resources:
++
+[source,terminal]
+----
+$ oc delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io -n openshift-vertical-pod-autoscaler
+----
++
+[source,terminal]
+----
+$ oc delete crd verticalpodautoscalercontrollers.autoscaling.openshift.io -n openshift-vertical-pod-autoscaler
+----
++
+[source,terminal]
+----
+$ oc delete crd verticalpodautoscalers.autoscaling.k8s.io -n openshift-vertical-pod-autoscaler
 ----
 +
 Deleting the CRDs removes the associated roles, cluster roles, and role bindings. However, there might be a few cluster roles that must be manually deleted.
++
+[NOTE]
+====
+This action removes from the cluster all user-created VPA objects. If you re-install the VPA, you would need to create these objects again.
+====
 
 .. List any VPA cluster roles: 
 +
@@ -114,9 +93,9 @@ $ oc get clusterrole | grep openshift-vertical-pod-autoscaler
 .Example output
 [source,terminal]
 ----
-openshift-vertical-pod-autoscaler-6896f-admin        2022-02-02T15:29:55Z
-openshift-vertical-pod-autoscaler-6896f-edit         2022-02-02T15:29:55Z
-openshift-vertical-pod-autoscaler-6896f-view         2022-02-02T15:29:55Z
+openshift-vertical-pod-autoscaler-mc4wr-admin        2022-02-02T15:29:55Z
+openshift-vertical-pod-autoscaler-mc4wr-edit         2022-02-02T15:29:55Z
+openshift-vertical-pod-autoscaler-mc4wr-view         2022-02-02T15:29:55Z
 ----
 
 .. Delete the listed VPA cluster roles. For example:
@@ -132,3 +111,4 @@ $ oc delete clusterrole openshift-vertical-pod-autoscaler-6896f-admin openshift-
 ----
 $ oc delete operator/vertical-pod-autoscaler.openshift-vertical-pod-autoscaler
 ----
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-2936

The optional step 6 (parts a-h) under https://docs.openshift.com/container-platform/4.11/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-uninstall_nodes-pods-vertical-autoscaler should be replaced

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

