### PR TITLE
[OSDOCS-4465, OSDOCS-4406]: Backporting CCO feature announcements into 4.11.z

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2940,7 +2940,7 @@ $ oc adm release info 4.11.12 --pullspecs
 * If a cluster is incrementally updated from a version less than or equal to 4.9, the `openshift-dns` `namespace` may not contain the required pod-security labels required for future version updates. (link:https://issues.redhat.com/browse/OCPBUGS-1549[*OCPBUGS-1549*])
 
 [id="ocp-4-11-12-notable-technical-changes"]
-==== Notable Technical Changes
+==== Notable technical changes
 
 * With this release, when the service account issuer is changed to a custom one, existing bound service tokens are no longer invalidated immediately. Instead, when the service account issuer is changed, the previous service account issuer continues to be trusted for 24 hours.
 
@@ -2965,6 +2965,11 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.11.13 --pullspecs
 ----
 
+[id="ocp-4-11-13-notable-technical-changes"]
+==== Notable technical changes
+
+* The Cloud Credential Operator utility (`ccoctl`) now creates secrets that use regional endpoints for the xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc[AWS Security Token Service (AWS STS)]. This approach aligns with AWS recommended best practices. 
+
 [id="ocp-4-11-13-updating"]
 ==== Updating
 
@@ -2983,6 +2988,11 @@ You can view the container images in this release by running the following comma
 ----
 $ oc adm release info 4.11.16 --pullspecs
 ----
+
+[id="ocp-4-11-16-notable-technical-changes"]
+==== Notable technical changes
+
+* With this release, when you xref:../installing/installing_gcp/uninstalling-cluster-gcp.adoc#cco-ccoctl-deleting-sts-resources_uninstalling-cluster-gcp[delete GCP resources with the Cloud Credential Operator utility], you must specify the directory containing the files for the component `CredentialsRequest` objects.
 
 [id="ocp-4-11-16-updating"]
 ==== Updating
@@ -3028,7 +3038,7 @@ $ oc adm release info 4.11.18 --pullspecs
 * IPv6 unsolicited neighbor advertisements and IPv4 gratuitous address resolution protocol now default on the SR-IOV CNI plug-in. Pods created with the Single Root I/O Virtualization (SR-IOV) CNI plug-in, where the IP address management CNI plug-in has assigned IPs, now send IPv6 unsolicited neighbor advertisements and/or IPv4 gratuitous address resolution protocol by default onto the network. This enhancement notifies hosts of the new pod's MAC address for a particular IP to refresh ARP/NDP caches with the correct information. For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
 
 [id="ocp-4-11-18-notable-technical-changes"]
-==== Notable Technical Changes
+==== Notable technical changes
 
 * Previously named heterogeneous clusters are now refered to as multi-architecture in {product-title} documentation. For more information, see xref:../post_installation_configuration/multi-architecture-configuration.adoc[Configuring a multi-architecture cluster]
 


### PR DESCRIPTION
Version(s):
4.11

Issue:
[OSDOCS-4465](https://issues.redhat.com//browse/OSDOCS-4465) and [OSDOCS-4406](https://issues.redhat.com//browse/OSDOCS-4406)

Link to docs preview:
- [4.11.13](https://53487--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-13-notable-technical-changes)
- [4.11.16](https://53487--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-16-notable-technical-changes)

QE review:
(see change mgmt acks below)

Additional information:
- Must cherrypick #52348 and #52380 into 4.11 with this merge.
- Requires change management acks:
  - [x] Andrew Butcher
  - [x]  Jianping Shu
  - [x] @sferich888
  - [x] @kalexand-rh
  - [x] @julienlim