### PR TITLE
[OSDOCS-4466, OSDOCS-4407]: Backporting CCO feature announcements into 4.10.z

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3598,6 +3598,11 @@ $ oc adm release info 4.10.40 --pullspecs
 
 * Before this update, the `noAllowedAddressPairs` setting applied to all subnets on the same network. With this update, the `noAllowedAddressPairs` setting now only applies to its matching subnet. (link:https://issues.redhat.com/browse/OCPBUGS-1951)[*OCPBUGS-1951*])
 
+[id="ocp-4-10-40-notable-technical-changes"]
+==== Notable technical changes
+
+* The Cloud Credential Operator utility (`ccoctl`) now creates secrets that use regional endpoints for the xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc[AWS Security Token Service (AWS STS)]. This approach aligns with AWS recommended best practices. 
+
 [id="ocp-4-10-40-upgrading"]
 ==== Updating
 
@@ -3616,6 +3621,11 @@ You can view the container images in this release by running the following comma
 ----
 $ oc adm release info 4.10.41 --pullspecs
 ----
+
+[id="ocp-4-10-41-notable-technical-changes"]
+==== Notable technical changes
+
+* With this release, when you xref:../installing/installing_gcp/uninstalling-cluster-gcp.adoc#cco-ccoctl-deleting-sts-resources_uninstalling-cluster-gcp[delete GCP resources with the Cloud Credential Operator utility], you must specify the directory containing the files for the component `CredentialsRequest` objects. 
 
 [id="ocp-4-10-41-upgrading"]
 ==== Updating


### PR DESCRIPTION
Version(s):
4.10

Issue:
[OSDOCS-4466](https://issues.redhat.com//browse/OSDOCS-4466) and [OSDOCS-4407](https://issues.redhat.com//browse/OSDOCS-4407)

Link to docs preview:
- [4.10.40](http://file.rdu.redhat.com/~jrouth/OSDOCS-4466-4407-4.10-rn-cco-backports/release_notes/ocp-4-10-release-notes.html#ocp-4-10-40-notable-technical-changes)
- [4.10.41](http://file.rdu.redhat.com/~jrouth/OSDOCS-4466-4407-4.10-rn-cco-backports/release_notes/ocp-4-10-release-notes.html#ocp-4-10-41-notable-technical-changes)

QE review:
(see change mgmt acks below)

Additional information:
- Must follow #53487
- Must cherrypick #52348 and #52380 into 4.10 with this merge.
- Requires change management acks:
  - [x] Andrew Butcher
  - [x]  Jianping Shu
  - [x] @sferich888
  - [x] @kalexand-rh
  - [x] @julienlim