### PR TITLE
GH52913: OKD - references to Redhat subscriptions for network tracing

### DIFF
--- a/modules/about-toolbox.adoc
+++ b/modules/about-toolbox.adoc
@@ -6,6 +6,12 @@
 [id="about-toolbox_{context}"]
 = About `toolbox`
 
+ifndef::openshift-origin[]
 `toolbox` is a tool that starts a container on a {op-system-first} system. The tool is primarily used to start a container that includes the required binaries and plug-ins that are needed to run commands such as `sosreport` and `redhat-support-tool`.
 
 The primary purpose for a `toolbox` container is to gather diagnostic information and to provide it to Red Hat Support. However, if additional diagnostic tools are required, you can add RPM packages or run an image that is an alternative to the standard support tools image.
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+`toolbox` is a tool that starts a container on a {op-system-first} system. The tool is primarily used to start a container that includes the required binaries and plug-ins that are needed to run your favorite debugging or admin tools.
+endif::openshift-origin[]

--- a/modules/gathering-data-audit-logs.adoc
+++ b/modules/gathering-data-audit-logs.adoc
@@ -36,6 +36,7 @@ endif::viewing[]
 $ oc adm must-gather -- /usr/bin/gather_audit_logs
 ----
 
+ifndef::openshift-origin[]
 . Create a compressed file from the `must-gather` directory that was just created in your working directory. For example, on a computer that uses a Linux operating system, run the following command:
 +
 [source,terminal]
@@ -45,7 +46,7 @@ $ tar cvaf must-gather.tar.gz must-gather.local.472290403699006248 <1>
 <1> Replace `must-gather-local.472290403699006248` with the actual directory name.
 
 . Attach the compressed file to your support case on the link:https://access.redhat.com[Red Hat Customer Portal].
-
+endif::openshift-origin[]
 
 ifeval::["{context}" == "gathering-cluster-data"]
 :!support:

--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -321,8 +321,6 @@ endif::openshift-dedicated[]
 ====
 endif::openshift-origin[]
 
-ifdef::openshift-origin[]
-
 . Run the `oc adm must-gather` command with one or more `--image` or `--image-stream` arguments. For example, the following command gathers both the default cluster data and information specific to KubeVirt:
 +
 [source,terminal]
@@ -334,8 +332,7 @@ $ oc adm must-gather \
 <1> The default {product-title} `must-gather` image
 <2> The must-gather image for KubeVirt
 
-endif::openshift-origin[]
-
+ifndef::openshift-origin[]
 . Create a compressed file from the `must-gather` directory that was just created in your working directory. For example, on a computer that uses a Linux
 operating system, run the following command:
 +
@@ -347,6 +344,7 @@ $ tar cvaf must-gather.tar.gz must-gather.local.5421342344627712289/ <1>
 actual directory name.
 
 . Attach the compressed file to your support case on the link:https://access.redhat.com[Red Hat Customer Portal].
+endif::openshift-origin[]
 
 ifeval::["{context}" == "gathering-cluster-data"]
 :!from-main-support-section:

--- a/modules/support-collecting-host-network-trace.adoc
+++ b/modules/support-collecting-host-network-trace.adoc
@@ -8,8 +8,15 @@
 
 Sometimes, troubleshooting a network-related issue is simplified by tracing network communication and capturing packets on multiple nodes at the same time.
 
+ifndef::openshift-origin[]
 You can use a combination of the `oc adm must-gather` command and the `registry.redhat.io/openshift4/network-tools-rhel8` container image to gather packet captures from nodes.
 Analyzing packet captures can help you troubleshoot network communication issues.
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+You can use a combination of the `oc adm must-gather` command and the `quay.io/openshift/origin-network-tools:latest` container image to gather packet captures from nodes.
+Analyzing packet captures can help you troubleshoot network communication issues.
+endif::openshift-origin[]
 
 The `oc adm must-gather` command is used to run the `tcpdump` command in pods on specific nodes.
 The `tcpdump` command records the packet captures in the pods.
@@ -29,6 +36,7 @@ However, you can run any command in the container image that is specified in the
 
 .Procedure
 
+ifndef::openshift-origin[]
 . Run a packet capture from the host network on some nodes by running the following command:
 +
 [source,terminal]
@@ -51,9 +59,36 @@ $ oc adm must-gather \
 <.> The `--host-network=true` argument is required so that the packet captures are performed on the network interfaces of the node.
 <.> The `--timeout` argument and value specify to run the debug pod for 30 seconds. If you do not specify the `--timeout` argument and a duration, the debug pod runs for 10 minutes.
 <.> The `-i any` argument for the `tcpdump` command specifies to capture packets on all network interfaces. As an alternative, you can specify a network interface name.
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+. Run a packet capture from the host network on some nodes by running the following command:
++
+[source,terminal]
+----
+$ oc adm must-gather \
+    --dest-dir /tmp/captures \  <.>
+    --source-dir '/tmp/tcpdump/' \  <.>
+    --image quay.io/openshift/origin-network-tools:latest \  <.>
+    --node-selector 'node-role.kubernetes.io/worker' \  <.>
+    --host-network=true \  <.>
+    --timeout 30s \  <.>
+    -- \
+    tcpdump -i any \  <.>
+    -w /tmp/tcpdump/%Y-%m-%dT%H:%M:%S.pcap -W 1 -G 300
+----
+<.> The `--dest-dir` argument specifies that `oc adm must-gather` stores the packet captures in directories that are relative to `/tmp/captures` on the client machine. You can specify any writable directory.
+<.> When `tcpdump` is run in the debug pod that `oc adm must-gather` starts, the `--source-dir` argument specifies that the packet captures are temporarily stored in the `/tmp/tcpdump` directory on the pod.
+<.> The `--image` argument specifies a container image that includes the `tcpdump` command.
+<.> The `--node-selector` argument and example value specifies to perform the packet captures on the worker nodes. As an alternative, you can specify the `--node-name` argument instead to run the packet capture on a single node. If you omit both the `--node-selector` and the `--node-name` argument, the packet captures are performed on all nodes.
+<.> The `--host-network=true` argument is required so that the packet captures are performed on the network interfaces of the node.
+<.> The `--timeout` argument and value specify to run the debug pod for 30 seconds. If you do not specify the `--timeout` argument and a duration, the debug pod runs for 10 minutes.
+<.> The `-i any` argument for the `tcpdump` command specifies to capture packets on all network interfaces. As an alternative, you can specify a network interface name.
+endif::openshift-origin[]
 
 . Perform the action, such as accessing a web application, that triggers the network communication issue while the network trace captures packets.
 
+ifndef::openshift-origin[]
 . Review the packet capture files that `oc adm must-gather` transferred from the pods to your client machine:
 +
 [source,text]
@@ -72,3 +107,25 @@ tmp/captures
 +
 <1> The packet captures are stored in directories that identify the hostname, container, and file name.
 If you did not specify the `--node-selector` argument, then the directory level for the hostname is not present.
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+. Review the packet capture files that `oc adm must-gather` transferred from the pods to your client machine:
++
+[source,text]
+----
+tmp/captures
+├── event-filter.html
+├── ip-10-0-192-217-ec2-internal  <1>
+│   └── quay.io/openshift/origin-network-tools:latest...
+│       └── 2022-01-13T19:31:31.pcap
+├── ip-10-0-201-178-ec2-internal  <1>
+│   └── quay.io/openshift/origin-network-tools:latest...
+│       └── 2022-01-13T19:31:30.pcap
+├── ip-...
+└── timestamp
+----
++
+<1> The packet captures are stored in directories that identify the hostname, container, and file name.
+If you did not specify the `--node-selector` argument, then the directory level for the hostname is not present.
+endif::openshift-origin[]

--- a/modules/support-installing-packages-to-a-toolbox-container.adoc
+++ b/modules/support-installing-packages-to-a-toolbox-container.adoc
@@ -6,7 +6,13 @@
 [id="installing-packages-to-a-toolbox-container_{context}"]
 = Installing packages to a `toolbox` container
 
+ifndef::openshift-origin[]
 By default, running the `toolbox` command starts a container with the `registry.redhat.io/rhel8/support-tools:latest` image. This image contains the most frequently used support tools. If you need to collect node-specific data that requires a support tool that is not part of the image, you can install additional packages.
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+By default, running the `toolbox` command starts a container with the `quay.io/fedora/fedora:36` image. This image contains the most frequently used support tools. If you need to collect node-specific data that requires a support tool that is not part of the image, you can install additional packages.
+endif::openshift-origin[]
 
 .Prerequisites
 

--- a/modules/support-starting-an-alternative-image-with-toolbox.adoc
+++ b/modules/support-starting-an-alternative-image-with-toolbox.adoc
@@ -6,7 +6,13 @@
 [id="starting-an-alternative-image-with-toolbox_{context}"]
 = Starting an alternative image with `toolbox`
 
+ifndef::openshift-origin[]
 By default, running the `toolbox` command starts a container with the `registry.redhat.io/rhel8/support-tools:latest` image. You can start an alternative image by creating a `.toolboxrc` file and specifying the image to run.
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+By default, running the `toolbox` command starts a container with the `quay.io/fedora/fedora:36` image. You can start an alternative image by creating a `.toolboxrc` file and specifying the image to run.
+endif::openshift-origin[]
 
 .Prerequisites
 

--- a/support/gathering-cluster-data.adoc
+++ b/support/gathering-cluster-data.adoc
@@ -9,6 +9,7 @@ endif::[]
 
 toc::[]
 
+ifndef::openshift-origin[]
 When opening a support case, it is helpful to provide debugging
 information about your cluster to Red Hat Support.
 
@@ -16,12 +17,19 @@ It is recommended to provide:
 
 * xref:../support/gathering-cluster-data.adoc#support_gathering_data_gathering-cluster-data[Data gathered using the `oc adm must-gather` command]
 * The  xref:../support/gathering-cluster-data.adoc#support-get-cluster-id_gathering-cluster-data[unique cluster ID]
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+You can use the following tools to get debugging information about your {product-title} cluster. 
+endif::openshift-origin[]
 
 // About the must-gather tool
 include::modules/about-must-gather.adoc[leveloffset=+1]
 
+ifndef::openshift-origin[]
 // Gathering data about your cluster for Red Hat Support
 include::modules/support-gather-data.adoc[leveloffset=+2]
+endif::openshift-origin[]
 
 // Gathering data about specific features
 include::modules/gathering-data-specific-features.adoc[leveloffset=+2]
@@ -29,6 +37,7 @@ include::modules/gathering-data-specific-features.adoc[leveloffset=+2]
 // Gathering audit logs
 include::modules/gathering-data-audit-logs.adoc[leveloffset=+2]
 
+ifndef::openshift-origin[]
 // Obtain your cluster identifier
 include::modules/support-get-cluster-id.adoc[leveloffset=+1]
 
@@ -37,6 +46,7 @@ include::modules/about-sosreport.adoc[leveloffset=+1]
 
 // Generating a `sosreport` archive for an {product-title} cluster node
 include::modules/support-generating-a-sosreport-archive.adoc[leveloffset=+1]
+endif::openshift-origin[]
 
 // Querying bootstrap node journal logs
 include::modules/querying-bootstrap-node-journal-logs.adoc[leveloffset=+1]
@@ -44,6 +54,7 @@ include::modules/querying-bootstrap-node-journal-logs.adoc[leveloffset=+1]
 // Querying cluster node journal logs
 include::modules/querying-cluster-node-journal-logs.adoc[leveloffset=+1]
 
+ifndef::openshift-origin[]
 // Network trace methods
 include::modules/support-network-trace-methods.adoc[leveloffset=+1]
 
@@ -52,9 +63,17 @@ include::modules/support-collecting-host-network-trace.adoc[leveloffset=+1]
 
 // Collecting a network trace from an {product-title} node or container
 include::modules/support-collecting-network-trace.adoc[leveloffset=+1]
+endif::openshift-origin[]
 
+ifdef::openshift-origin[]
+// Collecting a host network trace
+include::modules/support-collecting-host-network-trace.adoc[leveloffset=+1]
+endif::openshift-origin[]
+
+ifndef::openshift-origin[]
 // Providing diagnostic data to Red Hat Support
 include::modules/support-providing-diagnostic-data-to-red-hat.adoc[leveloffset=+1]
+endif::openshift-origin[]
 
 // About `toolbox`
 include::modules/about-toolbox.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-4507

Reference to Redhat subscriptions and Redhat portal accounts.

Also on the same base page are references to a network troubleshooting image
registry.redhat.io/openshift4/network-tools-rhel8:latest
This requires an account and a Pull secret.
There is an alternative image that we used but I cannot find it at this time.

Hiding modules, text, and steps not relevant to OKD with ifdefs. Changed a few image names for OKD.

Previews 
OKD: (VPN required; no OKD preview in Netlify): [Gathering data about your cluster](http://file.rdu.redhat.com/mburke/okd-remove-network-tracing/support/gathering-cluster-data.html) 
OCP: [Gathering data about your cluster](https://53495--docspreview.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


