### PR TITLE
 TELCODOCS-597 - Add verification steps to configuring local image registry

### DIFF
--- a/modules/ztp-add-local-reg-for-sno-duprofile.adoc
+++ b/modules/ztp-add-local-reg-for-sno-duprofile.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// scalability_and_performance/ztp-advanced-policy-config.adoc
+// * scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
 
 :_module-type: CONCEPT
 [id="ztp-add-local-reg-for-sno-duprofile_{context}"]
@@ -9,13 +9,11 @@
 {product-title} manages image caching using a local registry. In edge computing use cases, clusters are often subject to bandwidth restrictions when communicating with centralized image registries, which might result in long image download times.
 
 Long download times are unavoidable during initial deployment. Over time, there is a risk that CRI-O will erase the `/var/lib/containers/storage` directory in the case of an unexpected shutdown.
+To address long image download times, you can create a local image registry on remote managed clusters using GitOps ZTP. This is useful in Edge computing scenarios where clusters are deployed at the far edge of the network.
 
-To address long image download times, you can create a local image registry on the remote managed cluster using GitOps ZTP. This is useful in Edge computing scenarios where clusters are deployed on the far edge of the network.
+Before you can set up the local image registry with GitOps ZTP, you need to configure disk partitioning in the `SiteConfig` CR that you use to install the remote managed cluster. After installation, you configure the local image registry using a `PolicyGenTemplate` CR. Then, the ZTP pipeline creates Persistent Volume (PV) and Persistent Volume Claim (PVC) CRs and patches the `imageregistry` configuration.
 
 [NOTE]
 ====
-The local image registry can only be used for user application images and cannot be used for the {product-title} or Operator Lifecycle Manager operator images. For information about working with these, see Topology Aware Lifecycle Manager (TALM) in Additional resources.
+The local image registry can only be used for user application images and cannot be used for the {product-title} or Operator Lifecycle Manager operator images.
 ====
-
-The first phase of setting up a local image registry is configuring disk partitioning using a `SiteConfig` CR. You can use the `SiteConfig` CR to generate the `MachineConfig` CR used for disk partitioning.
-The next phase is to configure the image registry using `PolicyGenTemplate` CRs. The ZTP pipeline uses `PolicyGenTemplate` CRs to create Persistent Volumes (PV) and Persistent Volume Claim (PVC) CRs and patch the `imageregistry` configuration.

--- a/modules/ztp-configuring-disk-partitioning.adoc
+++ b/modules/ztp-configuring-disk-partitioning.adoc
@@ -1,38 +1,46 @@
 // Module included in the following assemblies:
 //
-// scalability_and_performance/ztp-deploying-disconnected.adoc
+// * scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
 
 :_module-type: PROCEDURE
 [id="ztp-configuring-disk-partitioning_{context}"]
 = Configuring disk partitioning with SiteConfig
 
-Use a `SiteConfig` CR to generate the `MachineConfig` CR used for disk partitioning. Prior to installation, you need to modify values in the `SiteConfig` CR to reflect dependencies on the underlying disk.
+Configure disk partitioning for a managed cluster using a `SiteConfig` CR and GitOps ZTP. The  disk partition details in the `SiteConfig` CR must match the the underlying disk.
 
 [NOTE]
 ====
-You must use persistent naming for devices to avoid device names such as `/dev/sda` and `/dev/sdb` being switched at every reboot. You can use `rootDeviceHints` to choose the bootable device and then use same device for further partitioning: in this case, for Image registry.
+Use persistent naming for devices to avoid device names such as `/dev/sda` and `/dev/sdb` being switched at every reboot. You can use `rootDeviceHints` to choose the bootable device and then use same device for further partitioning.
 ====
 
 .Prerequisites
 
-* You have installed and configured Zero Touch Provisioning (ZTP). For information about this, see the topic on ZTP in Additional resources.
+* You have installed the OpenShift CLI (`oc`).
+
+* You have logged in to the hub cluster as a user with `cluster-admin` privileges.
+
+* You have created a Git repository where you manage your custom site configuration data for use with GitOps Zero Touch Provisioning (ZTP).
 
 .Procedure
 
-. Add the following YAML to the `SiteConfig` CR that you use to generate the `MachineConfig` CR for disk partitioning:
+. Add the following YAML that describes the host disk partitioning to the `SiteConfig` CR that you use to install the managed cluster:
 +
 [source,yaml]
 ----
 nodes:
-  - rootDeviceHints:
+    rootDeviceHints:
       wwn: "0x62cea7f05c98c2002708a0a22ff480ea"
     diskPartition:
-    - device: /dev/disk/by-id/wwn-0x62cea7f05c98c2002708a0a22ff480ea <1>
-      partitions:
-       - mount_point: /var/imageregistry
-         size: 102500 <2>
-         start: 344844 <3>
+      - device: /dev/disk/by-id/wwn-0x62cea7f05c98c2002708a0a22ff480ea <1>
+        partitions:
+          - mount_point: /var/imageregistry
+            size: 102500 <2>
+            start: 344844 <3>
 ----
-<1> This setting depends on the hardware. The setting can be a serial number or device name. The value must match the entry for `rootDeviceHint`.
+<1> This setting depends on the hardware. The setting can be a serial number or device name. The value must match the value set for `rootDeviceHints`.
 <2> The minimum value for `size` is 102500 MiB.
 <3> The minimum value for `start` is 25000 MiB. The total value of `size` and `start` must not exceed the disk size, or the installation will fail.
+
+. Save the `SiteConfig` CR and push it to the site configuration repo.
+
+The ZTP pipeline provisions the cluster using the `SiteConfig` CR and configures the disk partition.

--- a/modules/ztp-configuring-pgt-image-registry.adoc
+++ b/modules/ztp-configuring-pgt-image-registry.adoc
@@ -1,101 +1,170 @@
 // Module included in the following assemblies:
 //
-// scalability_and_performance/ztp-advanced-policy-config.adoc
+// * scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
 
 :_module-type: PROCEDURE
 [id="ztp-configuring-pgt-image-registry_{context}"]
 = Configuring the image registry using PolicyGenTemplate CRs
 
-You can use `PolicyGenTemplate` to apply to create the PV and PVC and patch `imageregistry` configuration. Select the appropriate `PolicyGenTemplate` for each `source-cr`. See Additional Resources for more help.
+Use `PolicyGenTemplate` (PGT) CRs to apply the CRs required to configure the image registry and patch the `imageregistry` configuration.
 
 .Prerequisites
 
-* You have installed and configured Zero Touch Provisioning (ZTP). For information about this, see the topic on ZTP in Additional resources.
+* You have configured a disk partition in the managed cluster.
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You have logged in to the hub cluster as a user with `cluster-admin` privileges.
+
+* You have created a Git repository where you manage your custom site configuration data for use with GitOps Zero Touch Provisioning (ZTP).
 
 .Procedure
 
-. Configure the storage class, persistent volume claim, persistent volume, and image registry configuration in the appropriate `PolicyGenTemplate` CR. For example, to configure an individual site, use the following YAML:
+. Configure the storage class, persistent volume claim, persistent volume, and image registry configuration in the appropriate `PolicyGenTemplate` CR. For example, to configure an individual site, add the following YAML to the file `example-sno-site.yaml`:
 +
 [source,yaml]
 ----
 sourceFiles:
-   # storage class
-   - fileName: StorageClass.yaml
-     policyName: "sc-for-image-registry"
-     metadata:
-       name: image-registry-sc
-       annotations:
-         ran.openshift.io/ztp-deploy-wave: "100" <1>
+  # storage class
+  - fileName: StorageClass.yaml
+    policyName: "sc-for-image-registry"
+    metadata:
+      name: image-registry-sc
+      annotations:
+        ran.openshift.io/ztp-deploy-wave: "100" <1>
   # persistent volume claim
-   - fileName: StoragePVC.yaml
+  - fileName: StoragePVC.yaml
     policyName: "pvc-for-image-registry"
     metadata:
       name: image-registry-pvc
       namespace: openshift-image-registry
-        annotations:
-          ran.openshift.io/ztp-deploy-wave: "100"  <2>
+      annotations:
+        ran.openshift.io/ztp-deploy-wave: "100"
     spec:
       accessModes:
-        ReadWriteMany
+        - ReadWriteMany
       resources:
         requests:
           storage: 100Gi
       storageClassName: image-registry-sc
       volumeMode: Filesystem
   # persistent volume
-  - fileName: ImageRegistryPV.yaml <3>
+  - fileName: ImageRegistryPV.yaml <2>
     policyName: "pv-for-image-registry"
     metadata:
       annotations:
-        ran.openshift.io/ztp-deploy-wave: "100"  <4>
-  # image registry config
-  - fileName: ImageRegistryConfig.yaml <5>
+        ran.openshift.io/ztp-deploy-wave: "100"
+  - fileName: ImageRegistryConfig.yaml
     policyName: "config-for-image-registry"
-    complianceType: musthave <5>
+    complianceType: musthave
     metadata:
       annotations:
-        ran.openshift.io/ztp-deploy-wave: "100" <6>
+        ran.openshift.io/ztp-deploy-wave: "100"
     spec:
       storage:
         pvc:
           claim: "image-registry-pvc"
 ----
-<1> Set the appropriate value for `ztp-deploy-wave` depending on whether you are configuring image registries at the site, common, or group level. `ztp-deploy-wave: "100"` is appropriate for an individual site.  ZTP deploy waves are used to order how policies are applied to the spoke cluster. All policies created by `PolicyGen` have a ztp deploy wave by default.
-<2> Set the appropriate value for `ztp-deploy-wave` as in note 1.
-<3> This assumes that `mount_point` is set to `/var/imageregistry` in `SiteConfig` using StorageClass `image-registry-sc` (see the topic on configuring disk partitioning with `SiteConfig`).
-<4> Set the appropriate value for `ztp-deploy-wave` as in note 1.
-<5> Configure registry to point to the PVC created above.
-<6> Set the appropriate value for `ztp-deploy-wave` as in note 1.
+<1> Set the appropriate value for `ztp-deploy-wave` depending on whether you are configuring image registries at the site, common, or group level. `ztp-deploy-wave: "100"` is suitable for development or testing because it allows you to group the referenced source files together.
+<2> In `ImageRegistryPV.yaml`, ensure that the `spec.local.path` field is set to `/var/imageregistry` to match the value set for the `mount_point` field in the `SiteConfig` CR.
+
++
+[IMPORTANT]
+====
+Do not set `complianceType: mustonlyhave` for the `- fileName: ImageRegistryConfig.yaml` configuration. This can cause the registry pod deployment to fail.
+====
+
+. Commit the `PolicyGenTemplate` change in Git, and then push to the Git repository being monitored by the GitOps ZTP ArgoCD application.
 
 .Verification
 
-. Check that the `Config` CRD of the group `imageregistry.operator.openshift.io` instance is not reporting errors. Run the following command:
+Use the following steps to troubleshoot errors with the local image registry on the managed clusters:
 
-. Check that the `PersistentVolumeClaim` on the managed cluster is populated with data. Run the following command:
+* Verify successful login to the registry while logged in to the managed cluster. Run the following commands:
 
-. Check that the `registry*` pod is up correctly located under the `openshift-image-registry` namespace.
-
-. Verify successful login to the registry with `podman`:
+.. Export the managed cluster name:
 +
 [source,terminal]
 ----
-$ oc login -u kubeadmin -p <password_from_install_log> https://api-int.<cluster_name>.<base_domain>:6443
+$ cluster=<managed_cluster_name>
 ----
+
+.. Get the managed cluster `kubeconfig` details:
 +
 [source,terminal]
 ----
-$ podman login -u kubeadmin -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000
+$ oc get secret -n $cluster $cluster-admin-password -o jsonpath='{.data.password}' | base64 -d > kubeadmin-password-$cluster
 ----
 
-. Check for disk partitioning using `lsblk` to list your blocks:
+.. Download and export the cluster `kubeconfig`:
++
+[source,terminal]
+----
+$ oc get secret -n $cluster $cluster-admin-kubeconfig -o jsonpath='{.data.kubeconfig}' | base64 -d > kubeconfig-$cluster && export KUBECONFIG=./kubeconfig-$cluster
+----
+
+.. Verify access to the image registry from the managed cluster. See "Accessing the registry".
+
+* Check that the `Config` CRD in the `imageregistry.operator.openshift.io` group instance is not reporting errors. Run the following command while logged in to the managed cluster:
++
+[source,terminal]
+----
+$ oc get image.config.openshift.io cluster -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Image
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+  creationTimestamp: "2021-10-08T19:02:39Z"
+  generation: 5
+  name: cluster
+  resourceVersion: "688678648"
+  uid: 0406521b-39c0-4cda-ba75-873697da75a4
+spec:
+  additionalTrustedCA:
+    name: acm-ice
+----
+
+* Check that the `PersistentVolumeClaim` on the managed cluster is populated with data. Run the following command while logged in to the managed cluster:
++
+[source,terminal]
+----
+$ oc get pv image-registry-sc
+----
+
+* Check that the `registry*` pod is running and is located under the `openshift-image-registry` namespace.
++
+[source,terminal]
+----
+$ oc get pods -n openshift-image-registry | grep registry*
+----
++
+.Example output
+[source,terminal]
+----
+cluster-image-registry-operator-68f5c9c589-42cfg   1/1     Running     0          8d
+image-registry-5f8987879-6nx6h                     1/1     Running     0          8d
+----
+
+* Check that the disk partition on the managed cluster is correct:
+
+.. Open a debug shell to the managed cluster:
 +
 [source,terminal]
 ----
 $ oc debug node/sno-1.example.com
 ----
 
-. When you enter the node, run the following command:
-
+.. Run `lsblk` to check the host disk partitions:
++
 [source,terminal]
 ----
 sh-4.4# lsblk
@@ -109,4 +178,4 @@ sda      8:0    0 446.6G  0 disk
 sdb      8:16   0 446.6G  0 disk
 sr0     11:0    1   104M  0 rom
 ----
-<1> This setting will appear if you have successfully listed your block.
+<1> `/var/imageregistry` indicates that the disk is correctly partitioned.

--- a/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
@@ -42,6 +42,11 @@ include::modules/ztp-configuring-ptp-fast-events.adoc[leveloffset=+1]
 
 include::modules/ztp-add-local-reg-for-sno-duprofile.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about container image registries, see xref:../../registry/index.adoc#registry-overview[{product-title} registry overview].
+
 include::modules/ztp-configuring-disk-partitioning.adoc[leveloffset=+2]
 
 include::modules/ztp-configuring-pgt-image-registry.adoc[leveloffset=+2]
@@ -49,9 +54,7 @@ include::modules/ztp-configuring-pgt-image-registry.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about configuring GitOps ZTP on the hub cluster, see xref:../../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-hub-cluster[Preparing the hub cluster for ZTP] 
-
-* For more information about container image registries, see xref:../../registry/index.adoc#registry-overview[{product-title} registry overview].
+* xref:../../registry/accessing-the-registry.adoc#accessing-the-registry[Accessing the registry]
 
 include::modules/ztp-configuring-hwevents-using-pgt.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Adds some extra details and verification steps for [TELCODOCS-597](https://issues.redhat.com//browse/TELCODOCS-597). 

Merge to main, CP to enterprise-4.12 only.

Preview: 

* [Configuring the Image Registry Operator for local caching of images](https://53498--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.html#ztp-add-local-reg-for-sno-duprofile_ztp-advanced-policy-config)

QE review:
- [ ] QE has approved this change.

