### PR TITLE
OSDOCS-4650 adding relnotes template adoc to MicroShift 4.12

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -1,13 +1,20 @@
+:_content-type: ASSEMBLY
 [id="microshift-4-12-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/attributes-microshift.adoc[]
 :context: release-notes
 
-Do not add or edit release notes here. Edit release notes directly in the branch
-that they are relevant for.
+toc::[]
 
-Release note changes should be added/edited in their own PR.
+// Update All for MicroShift; text is FPO (for placement only)
+Red Hat {product-title} provides developers and IT organizations with small form factor and edge computing, delivered as an application that customers can deploy on top of their managed {op-system-first} devices at the edge. Built on {op-system-first} and Kubernetes, {product-title} provides an efficient way to operate single-node clusters in low-resource edge environments.
 
-This file is here to allow builds to work.
+{product-title} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
 
-//We do not have version branches yet. Stub for merge pending process clarification.
+//[id="microshift-4-12-about-this-release"]
+== About this release
+
+// TODO: Update with the relevant information/ links.
+{product-title} is now available as a Developer Preview. Features and known issues that pertain to {product-title} {product-version} are included in this topic.
+
+{product-title} {product-version} is supported on {op-system-first} 4.12 and {op-system-base-full} 8.4 and 8.5.


### PR DESCRIPTION
[OSDOCS-4650](https://issues.redhat.com//browse/OSDOCS-4650) adding relnotes template adoc to MicroShift 4.12

Applies to: 4.12 only

Issue:
https://issues.redhat.com/browse/OSDOCS-4650

Link to docs preview:
https://53503--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html

Additional information: This is a placeholder for later additions. Thank you!

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
