### PR TITLE
OCPBUGS-3407 - Workload partitioning wrong CRI-O configuration key

### DIFF
--- a/modules/sno-du-enabling-workload-partitioning.adoc
+++ b/modules/sno-du-enabling-workload-partitioning.adoc
@@ -10,7 +10,7 @@ During {sno} cluster installation, you must enable workload partitioning. This l
 
 [NOTE]
 ====
-You can enable workload partitioning only during cluster installation. You cannot disable workload partitioning post-installation. However, you can reconfigure workload partitioning by updating the `cpu` value that you define in the performance profile, and in the related `MachineConfig` custom resource (CR).
+You can enable workload partitioning only during cluster installation. You cannot disable workload partitioning post-installation. However, you can reconfigure workload partitioning by updating the `cpu` value that you define in the performance profile, and in the related `cpuset` value in the `MachineConfig` custom resource (CR).
 ====
 
 * The base64-encoded CR that enables workload partitioning contains the CPU set that the management workloads are constrained to. Encode host-specific values for `crio.conf` and `kubelet.conf` in base64. This content must be adjusted to match the CPU set that is specified in the cluster performance profile and must be accurate for the number of cores in the cluster host.
@@ -52,11 +52,13 @@ spec:
 [crio.runtime.workloads.management]
 activation_annotation = "target.workload.openshift.io/management"
 annotation_prefix = "resources.workload.openshift.io"
-resources = { "cpushares" = 0, "cpuset" = "0-1,52-53" } <1>
+[crio.runtime.workloads.management.resources]
+cpushares = 0
+cpuset = "0-1, 52-53" <1>
 ----
-<1> The `CPUs` value varies based on the installation.
+<1> The `cpuset` value varies based on the installation.
 +
-If Hyper-Threading is enabled, specify both threads for each core. The `CPUs` value must match the reserved CPU set specified in the performance profile.
+If Hyper-Threading is enabled, specify both threads for each core. The `cpuset` value must match the reserved CPUs that you define in the `spec.cpu.reserved` field in the performance profile.
 
 * When configured in the cluster, the contents of `/etc/kubernetes/openshift-workload-pinning` should look like this:
 +
@@ -68,4 +70,4 @@ If Hyper-Threading is enabled, specify both threads for each core. The `CPUs` va
   }
 }
 ----
-<1> The `cpuset` must match the `CPUs` value in `/etc/crio/crio.conf.d/01-workload-partitioning`.
+<1> The `cpuset` must match the `cpuset` value in `/etc/crio/crio.conf.d/01-workload-partitioning`.


### PR DESCRIPTION
OCPBUGS-3407: There was an incorrect parameter (`CPU` vs `cpuset`) in a previous documentation update. The module has been updated since the bug was created, so `CPU` was not present but the formatting seemed different to the [schema](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crioruntimeworkloadresources-table). So I updated the yaml to match the schema. And also changed the numbered callout from `CPU` to `cpuset`

Version(s): 
4.9+

Issue:
https://issues.redhat.com/browse/OCPBUGS-3407

Link to docs preview:
http://file.emea.redhat.com/rohennes/OCPBUGS-3407-workload-partitionin-yaml/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
