### PR TITLE
OSDOCS-4265: Updates some ROSA cli items for CloudFront

### DIFF
--- a/modules/rosa-deleting-cluster.adoc
+++ b/modules/rosa-deleting-cluster.adoc
@@ -70,11 +70,11 @@ State:                      ready
 Private:                    No
 Created:                    May 13 2022 11:26:15 UTC
 Details Page:               https://console.redhat.com/openshift/details/s/296kyEFwzoy1CREQicFRdZybrc0
-OIDC Endpoint URL:          https://rh-oidc.s3.us-east-1.amazonaws.com/1s5v4k39lhm8sm59m90mi0822o31844a <3>
+OIDC Endpoint URL:          https://dvbwgdztaeq9o.cloudfront.net/20eh31t5vaasiidbumcjfbnknb6c6883 <3>
 ----
 <1> Lists the cluster ID.
 <2> Specifies the ARNs for the cluster-specific Operator roles. For example, in the sample output the ARN for the role required by the Machine Config Operator is `arn:aws:iam::<aws_account_id>:role/mycluster-x4q9-openshift-machine-api-aws-cloud-credentials`.
-<3> Specifies the endpoint URL for the cluster-specific OIDC provider.
+<3> Displays the endpoint URL for the cluster-specific OIDC provider.
 +
 [IMPORTANT]
 ====

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -381,7 +381,7 @@ State:                      ready
 Private:                    No
 Created:                    Oct  1 2021 08:12:25 UTC
 Details Page:               https://console.redhat.com/openshift/details/s/<subscription_id>
-OIDC Endpoint URL:          https://rh-oidc.s3.<aws_region>.amazonaws.com/<cluster_id>
+OIDC Endpoint URL:           https://dvbwgdztaeq9o.cloudfront.net/<cluster_id>
 ----
 +
 The following `State` field changes are listed in the output as the cluster installation progresses:

--- a/modules/rosa-sts-oidc-provider-command.adoc
+++ b/modules/rosa-sts-oidc-provider-command.adoc
@@ -29,14 +29,15 @@ When using `manual` mode, the `aws` command is printed to the terminal for your 
 ====
 +
 .Command output
-[source,terminal]
+[source,textl]
 ----
 aws iam create-open-id-connect-provider \
-	--url https://rh-oidc.s3.<aws_region>.amazonaws.com/<cluster_id> \
+	--url https://<generated uid>.cloudfront.net/<cluster id> \// <1>
 	--client-id-list openshift sts.<aws_region>.amazonaws.com \
-	--thumbprint-list <thumbprint> <1>
+	--thumbprint-list <thumbprint> <2>
 ----
-<1> The thumbprint is generated automatically when you run the `rosa create oidc-provider` command. For more information about using thumbprints with AWS Identity and Access Management (IAM) OpenID Connect (OIDC) identity providers, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html[the AWS documentation].
+<1> The URL used to reach the OpenID Connect (OIDC) identity provider once the cluster is created.
+<2> The thumbprint is generated automatically when you run the `rosa create oidc-provider` command. For more information about using thumbprints with AWS Identity and Access Management (IAM) OpenID Connect (OIDC) identity providers, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html[the AWS documentation].
 
 ** Registered OIDC configurations use an OIDC configuration ID. Run the following command with your OIDC configuration ID:
 +

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
@@ -21,7 +21,7 @@ Alternatively, you can use `manual` mode, which outputs the `aws` commands neede
 .Next steps
 
 * Ensure that you have completed the xref:../rosa_planning/rosa-sts-aws-prereqs.adoc[AWS prerequisites].
-
+include::snippets/oidc-cloudfront.adoc[]
 include::modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc[leveloffset=+1]
 include::modules/rosa-sts-understanding-aws-account-association.adoc[leveloffset=+1]
 

--- a/snippets/oidc-cloudfront.adoc
+++ b/snippets/oidc-cloudfront.adoc
@@ -1,0 +1,12 @@
+
+//This snippet appears in the following assemblies:
+//
+// * ../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
+
+:_content-type: SNIPPET
+[NOTE]
+====
+ROSA CLI 1.2.7 introduces changes to the OIDC provider endpoint URL format for new clusters. {product-title} cluster OIDC provider URLs are no longer regional. The AWS CloudFront implementation provides improved access speed and resiliency and reduces latency.
+
+Because this change is only available to new clusters created by using ROSA CLI 1.2.7 or later, there are no supported migration paths for existing OIDC-provider configurations.
+====


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-4265](https://issues.redhat.com/browse/OSDOCS-4265)

Link to docs preview:
* Updated outputs
    * [Deleting a cluster example](https://file.rdu.redhat.com/eponvell/OSDOCS-4265_OIDC-CloudFront/rosa_install_access_delete_clusters/rosa-sts-deleting-cluster.html#rosa-deleting-cluster_rosa-sts-deleting-cluster)    
![image](https://user-images.githubusercontent.com/16167833/206022270-3daec9ea-9b0b-43e1-a910-efbde054e95c.png)
    * [Creating a cluster with customizations](https://file.rdu.redhat.com/eponvell/OSDOCS-4265_OIDC-CloudFront/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations)
![image](https://user-images.githubusercontent.com/16167833/211388180-60eab21b-d8d4-4df4-809f-493524caebba.png)
* [Updated section about creating your cluster and the endpoint being obscured](https://file.rdu.redhat.com/eponvell/OSDOCS-4265_OIDC-CloudFront/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-oidc-provider-for-operators-aws-cli_rosa-sts-about-iam-resources)
![image](https://user-images.githubusercontent.com/16167833/206023446-9d6a1bcb-cc46-47a5-8e3a-7ac8a7044e8b.png)

* [Added a new snippet to note that ROSA should be 1.2.7 and later.](https://file.rdu.redhat.com/eponvell/OSDOCS-4265_OIDC-CloudFront/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.html)

QE review:
- [ ] QE has approved this change.

Additional information:
Updated the documentation to ensure that users are on the latest version of ROSA to have their OIDC endpoints obscured with a CloudFront URL.