### PR TITLE
[RHACS] Replace ACS Cloud Service field trial text with approved snippet

### DIFF
--- a/release_notes/373-release-notes.adoc
+++ b/release_notes/373-release-notes.adoc
@@ -35,12 +35,9 @@ toc::[]
 
 Red Hat Advanced Cluster Security Cloud Service (ACSCS) is a Red Hat managed service that simplifies and accelerates {product-title-short} deployments.
 
-[IMPORTANT]
-====
-ACSCS is available as a Field Trial release.
-A Field Trial provides approved customers access to a release with general availability-level quality and limited support.
-For more information about accessing ACSCS, contact link:https://www.redhat.com/en/contact[Red Hat Sales].
-====
+:FeatureName: {product-title-managed-short}
+include::snippets/field-trial.adoc[leveloffset=+1]
+
 
 With ACSCS, Red Hat hosts and maintains your {product-title-short} Central instance.
 Red Hat assures high availability of your instance with an industry-standard service level agreement (SLA).


### PR DESCRIPTION
Version(s):

- `rhacs-docs-3.73`

Issue: none

[Link to docs preview](https://openshift-docs-js07lvntn-kcarmichael08.vercel.app/openshift-acs/master/release_notes/373-release-notes.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change. **(N/A)**
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Update Release Notes to use the text (in snippet) for Field Trial that was approved by Legal.

