### PR TITLE
RHDEVDOCS-3669-add-link-to-cmo-runbooks

### DIFF
--- a/monitoring/managing-alerts.adoc
+++ b/monitoring/managing-alerts.adoc
@@ -26,6 +26,10 @@ include::modules/monitoring-searching-alerts-silences-and-alerting-rules.adoc[le
 // Getting information about alerts, silences and alerting rules
 include::modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* See the link:https://github.com/openshift/runbooks/tree/master/alerts/cluster-monitoring-operator[Cluster Monitoring Operator runbooks] to help diagnose and resolve issues that trigger specific {product-title} monitoring alerts.
+
 // Managing silences
 include::modules/monitoring-managing-silences.adoc[leveloffset=+1]
 include::modules/monitoring-silencing-alerts.adoc[leveloffset=+2]


### PR DESCRIPTION
Summary: This PR adds a link to the CMO runbooks to the "Managing alerts" topic. 

- Aligned team: DevTools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3669
- Direct link to doc preview: See the "Additional resources" section at the end of https://53522--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts.html#getting-information-about-alerts-silences-and-alerting-rules_managing-alerts
- SME review: n/a
- QE review: n/a (No QE review required because the PR only adds a link to the 'Additional resources' section )
- Peer review: @gabriel-rh 

- GitHub link approval: Per @rkratky's comment in https://issues.redhat.com/browse/RHDEVDOCS-3669, adding a link to this Github page has been approved by Support