### PR TITLE
TELCODOCS-1049 - removes biosConfigRef from 4.11 and 4.12 docs

### DIFF
--- a/snippets/ztp-example-siteconfig.adoc
+++ b/snippets/ztp-example-siteconfig.adoc
@@ -34,17 +34,15 @@ spec:
     nodes:
       - hostName: "example-node.example.com" <6>
         role: "master"
-        #biosConfigRef:
-        #  filePath: "example-hw.profile" <7>
-        bmcAddress: idrac-virtualmedia://<out_of_band_ip>/<system_id>/ <8>
+        bmcAddress: idrac-virtualmedia://<out_of_band_ip>/<system_id>/ <7>
         bmcCredentialsName:
-          name: "bmh-secret" <9>
+          name: "bmh-secret" <8>
         bootMACAddress: "AA:BB:CC:DD:EE:11"
-        bootMode: "UEFI" <10>
+        bootMode: "UEFI" <9>
         rootDeviceHints:
           wwn: "0x11111000000asd123"
-        cpuset: "0-1,52-53"  <11>
-        nodeNetwork: <12>
+        cpuset: "0-1,52-53"  <10>
+        nodeNetwork: <11>
           interfaces:
             - name: eno1
               macAddress: "AA:BB:CC:DD:EE:11"
@@ -56,7 +54,7 @@ spec:
                 macAddress: "AA:BB:CC:DD:EE:11"
                 ipv4:
                   enabled: false
-                ipv6: <13>
+                ipv6: <12>
                   enabled: true
                   address:
                   - ip: 1111:2222:3333:4444::aaaa:1
@@ -80,10 +78,9 @@ spec:
 <4> Cluster labels must correspond to the `bindingRules` field in the `PolicyGenTemplate` CRs that you define. For example, `policygentemplates/common-ranGen.yaml` applies to all clusters with `common: true` set, `policygentemplates/group-du-sno-ranGen.yaml` applies to all clusters with `group-du-sno: ""` set.
 <5> Optional. The CR specifed under `KlusterletAddonConfig` is used to override the default `KlusterletAddonConfig` that is created for the cluster.
 <6> For single-node deployments, define a single host. For three-node deployments, define three hosts. For standard deployments, define three hosts with `role: master` and two or more hosts defined with `role: worker`.
-<7> Optional. Use `biosConfigRef` to configure desired firmware for the host.
-<8> Applies to all cluster types. Specifies the BMC address. ZTP supports iPXE and virtual media booting by using Redfish or IPMI protocols.
-<9> Create the `bmh-secret` CR that specifies the BMC credentials. Use the same namespace as the `SiteConfig` CR.
-<10> Use `UEFISecureBoot` to enable secure boot on the host.
-<11> `cpuset` should match the value set in the cluster `PerformanceProfile` CR `.spec.cpu.reserved` field for workload partitioning.
-<12> Specifies the network settings for the node.
-<13> Configures the IPv6 address for the host. For {sno} clusters with static IP addresses, the node-specific API and Ingress IPs should be the same.
+<7> BMC address that you use to access the host. Applies to all cluster types. ZTP supports iPXE and virtual media booting by using Redfish or IPMI protocols.
+<8> Name of the `bmh-secret` CR that you separately create with the host BMC credentials. When creating the `bmh-secret` CR, use the same namespace as the `SiteConfig` CR that provisions the host.
+<9> Configures the boot mode for the host. The default value is `UEFI`. Use `UEFISecureBoot` to enable secure boot on the host.
+<10> `cpuset` must match the value set in the cluster `PerformanceProfile` CR `spec.cpu.reserved` field for workload partitioning.
+<11> Specifies the network settings for the node.
+<12> Configures the IPv6 address for the host. For {sno} clusters with static IP addresses, the node-specific API and Ingress IPs should be the same.


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-1049

Removes biosConfigRef which was incorrectly added to 4.11 and 4.12 docs

Merge to main, CP to 4.11+

Preview: https://53523--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.html#ztp-deploying-a-site_ztp-deploying-far-edge-sites