### PR TITLE
Update document with proper information

### DIFF
--- a/nodes/jobs/nodes-pods-daemonsets.adoc
+++ b/nodes/jobs/nodes-pods-daemonsets.adoc
@@ -14,7 +14,7 @@ As nodes are removed from the cluster, those pods are removed through garbage co
 You can use daemon sets to create shared storage, run a logging pod on every node in
 your cluster, or deploy a monitoring agent on every node.
 
-For security reasons, only cluster administrators can create daemon sets.
+For security reasons, the cluster administrators and the project administrators can create daemon sets.
 
 For more information on daemon sets, see the link:http://kubernetes.io/docs/admin/daemons/[Kubernetes documentation].
 


### PR DESCRIPTION
Currently the information mentioned in the document is : "For security reasons, only cluster administrators can create daemon sets." However this is not the correct information. ONLY cluster administrators do not have rights to create daemon sets. The project administrators can ALSO create daemon sets, as daemon set is a project scoped resource.
The statement in the document must be like this : "For security reasons, the cluster administrators and the project administrators can create daemon sets."

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
