### PR TITLE
OCPBUGS-2665: Added notice for configuring macvlan

### DIFF
--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -6,9 +6,9 @@
 = Configuration for a MACVLAN additional network
 
 The following object describes the configuration parameters for the macvlan CNI
-plug-in:
+plugin:
 
-.MACVLAN CNI plug-in JSON configuration object
+.MACVLAN CNI plugin JSON configuration object
 [cols=".^2,.^2,.^6",options="header"]
 |====
 |Field|Type|Description
@@ -23,7 +23,7 @@ plug-in:
 
 |`type`
 |`string`
-|The name of the CNI plug-in to configure: `macvlan`.
+|The name of the CNI plugin to configure: `macvlan`.
 
 |`mode`
 |`string`
@@ -31,7 +31,7 @@ plug-in:
 
 |`master`
 |`string`
-|The Ethernet, bonded, or VLAN interface to associate with the virtual interface. If a value is not specified, then the host system's primary Ethernet interface is used.
+|The host network interface to associate with the newly created macvlan interface. If a value is not specified, then the default route interface is used.
 
 |`mtu`
 |`string`
@@ -39,9 +39,14 @@ plug-in:
 
 |`ipam`
 |`object`
-|The configuration object for the IPAM CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
+|The configuration object for the IPAM CNI plugin. The plugin manages IP address assignment for the attachment definition.
 
 |====
+
+[NOTE]
+====
+If you specify the `master` key for the plugin configuration, use a different physical network interface than the one that is associated with your primary network plugin to avoid possible conflicts.
+====
 
 [id="nw-multus-macvlan-config-example_{context}"]
 == macvlan configuration example


### PR DESCRIPTION
Signed-off-by: nicklesimba <simha.nikhil@gmail.com>

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-2665
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://53535--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-macvlan-object_configuring-additional-network
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
