### PR TITLE
CNV-16414: RN that runbooks are now GA

### DIFF
--- a/virt/virt-4-12-release-notes.adoc
+++ b/virt/virt-4-12-release-notes.adoc
@@ -46,6 +46,8 @@ The SVVP Certification applies to:
 
 //CNV-18488 SVVP for 4.12
 
+//CNV-16414
+{VirtProductName} has xref:../virt/logging_events_monitoring/virt-runbooks.adoc#virt-runbooks[runbooks] to help you troubleshoot issues that trigger alerts. The alerts are displayed on the Virtualization > Overview page of the web console. Each runbook describes the meaning and impact of an alert and provides procedures to diagnose and resolve the issue. This feature was previously introduced as a Technology Preview and is now generally available.
 
 //CNV-17984 Comply with cluster-wide crypto policy
 


### PR DESCRIPTION
Version(s): 4.12

Issue: [CNV-16414](https://issues.redhat.com//browse/CNV-16414)
Replacement to issue: https://github.com/openshift/openshift-docs/pull/52994

Link to docs preview: No preview available until https://github.com/openshift/openshift-docs/pull/53142 is merged.
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Current text:

```
//CNV-16414
{VirtProductName} has xref:../virt/logging_events_monitoring/virt-runbooks.adoc#virt-runbooks[runbooks] to help you troubleshoot issues that trigger alerts. The alerts are displayed on the *Virtualization* > *Overview* page of the web console. Each runbook describes the meaning and impact of an alert and provides procedures to diagnose and resolve the issue. This feature was previously introduced as a Technology Preview and is now generally available.
```


QE review: 

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->