### PR TITLE
Fix incorrect symlinks in /ztp_far_edge

### DIFF
--- a/scalability_and_performance/ztp_far_edge/_attributes
+++ b/scalability_and_performance/ztp_far_edge/_attributes
@@ -1,1 +1,1 @@
-../_attributes/
+../../_attributes

--- a/scalability_and_performance/ztp_far_edge/images
+++ b/scalability_and_performance/ztp_far_edge/images
@@ -1,1 +1,1 @@
-../images
+../../images

--- a/scalability_and_performance/ztp_far_edge/modules
+++ b/scalability_and_performance/ztp_far_edge/modules
@@ -1,1 +1,1 @@
-../modules
+../../modules

--- a/scalability_and_performance/ztp_far_edge/snippets
+++ b/scalability_and_performance/ztp_far_edge/snippets
@@ -1,1 +1,1 @@
-../snippets
+../../snippets


### PR DESCRIPTION
symlinks in `scalability_and_performance/ztp_far_edge` were incorrect. This PR corrects the issue.

Preview: http://file.emea.redhat.com/aireilly/main/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.html

Merge to main, CP to 4.10+