### PR TITLE
OSDOCS-4658: Cluster to compute machines

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -508,7 +508,7 @@ Topics:
   File: configuring-private-cluster
 - Name: Bare metal configuration
   File: bare-metal-configuration
-- Name: Configuring a multi-architecture cluster
+- Name: Configuring multi-architecture compute machines on an OpenShift cluster
   File: multi-architecture-configuration
 - Name: Machine configuration tasks
   File: machine-configuration-tasks

--- a/modules/multi-architecture-creating-arm64-bootimage.adoc
+++ b/modules/multi-architecture-creating-arm64-bootimage.adoc
@@ -5,9 +5,9 @@
 :_content-type: PROCEDURE
 [id="multi-architecture-creating-arm64-bootimage_{context}"]
 
-= Creating an `arm64` boot image using the Azure image gallery
+= Creating an arm64 boot image using the Azure image gallery
  
-To configure your multi-architecture cluster, you must create an `arm64` boot image and add it to your Azure compute machine set. The following procedure describes how to manually generate an `arm64` boot image. 
+To configure your cluster with multi-architecture compute machines, you must create an `arm64` boot image and add it to your Azure compute machine set. The following procedure describes how to manually generate an `arm64` boot image. 
  
 .Prerequisites
 

--- a/modules/multi-architecture-import-imagestreams.adoc
+++ b/modules/multi-architecture-import-imagestreams.adoc
@@ -5,9 +5,9 @@
 :_content-type: PROCEDURE
 [id="multi-architecture-import-imagestreams_{context}"]
 
-= Importing manifest lists in image streams on your multi-architecture cluster 
+= Importing manifest lists in image streams on your multi-architecture compute machines 
 
-On a {product-title} {product-version} multi-architecture cluster, the image streams in the cluster do not import manifest lists automatically. You must manually change the default `importMode` option to the `PreserveOriginal` option in order to import the manifest list.
+On an {product-title} {product-version} cluster with multi-architecture compute machines, the image streams in the cluster do not import manifest lists automatically. You must manually change the default `importMode` option to the `PreserveOriginal` option in order to import the manifest list.
 
 [IMPORTANT]
 ====

--- a/modules/multi-architecture-modify-machine-set.adoc
+++ b/modules/multi-architecture-modify-machine-set.adoc
@@ -5,9 +5,9 @@
 :_content-type: PROCEDURE
 [id="multi-architecture-modify-machine-set_{context}"]
 
-= Adding a compute machine set to your cluster using the `arm64` boot image  
+= Adding a multi-architecture compute machine set to your cluster using the arm64 boot image  
 
-To add `arm64` worker nodes to your multi-architecture cluster, you must create an Azure compute machine set that uses the `arm64` boot image. To create your own custom compute machine set on Azure, see "Creating a compute machine set on Azure". 
+To add `arm64` compute nodes to your cluster, you must create an Azure compute machine set that uses the `arm64` boot image. To create your own custom compute machine set on Azure, see "Creating a compute machine set on Azure". 
 
 .Prerequisites 
 

--- a/modules/multi-architecture-upgrade-mirrors.adoc
+++ b/modules/multi-architecture-upgrade-mirrors.adoc
@@ -5,9 +5,9 @@
 :_content-type: PROCEDURE
 [id="multi-architecture-upgrade-mirrors_{context}"]
 
-= Upgrading your multi-architecture cluster
+= Upgrading a cluster with multi-architecture compute machines
 
-You must perform an explicit upgrade command to upgrade your existing cluster to a multi-architecture cluster.
+You must perform an explicit upgrade command to upgrade your existing cluster to a cluster that supports multi-architecture compute machines.
 
 .Prerequisites
 

--- a/post_installation_configuration/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/multi-architecture-configuration.adoc
@@ -1,21 +1,21 @@
 :_content-type: ASSEMBLY
 :context: multi-architecture-configuration
 [id="post-install-multi-architecture-configuration"]
-= Configuring a multi-architecture cluster
+= Configuring multi-architecture compute machines on an {product-title} cluster 
 include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-A multi-architecture cluster is a cluster that supports worker machines with different architectures. You can deploy a multi-architecture cluster by creating an Azure installer-provisioned cluster using the multi-architecture installer binary. For Azure installation, see xref:../installing/installing_azure/installing-azure-customizations.adoc[Installing a cluster on Azure with customizations].
+An {product-title} cluster with multi-architecture compute machines is a cluster that supports compute machines with different architectures. You can deploy a cluster with multi-architecture compute machines by creating an Azure installer-provisioned cluster using the multi-architecture installer binary. For Azure installation, see xref:../installing/installing_azure/installing-azure-customizations.adoc[Installing a cluster on Azure with customizations].
 
 [WARNING]
 ====
-The multi-architecture clusters Technology Preview feature has limited usability with installing, upgrading, and running payloads. 
+The multi-architecture compute machines Technology Preview feature has limited usability with installing, upgrading, and running payloads. 
 ====
 
-The following procedures explain how to generate an `arm64` boot image and create an Azure compute machine set with the `arm64` boot image. This will add `arm64` worker nodes to your multi-architecture cluster and deploy the desired amount of ARM64 virtual machines (VM). This section also shows how to upgrade your existing cluster to a multi-architecture cluster. Multi-architecture clusters are only available on Azure installer-provisioned infrastructures with `x86_64` control planes. 
+The following procedures explain how to generate an `arm64` boot image and create an Azure compute machine set with the `arm64` boot image. This adds `arm64` compute nodes to your cluster and deploys the desired amount of `arm64` virtual machines (VM). This section also shows how to upgrade your existing cluster to a cluster that supports multi-architecture compute machines. Clusters with multi-architecture compute machines are only available on Azure installer-provisioned infrastructures with `x86_64` control plane machines. 
 
-:FeatureName: Multi-architecture clusters for {product-title} on Azure installer-provisioned infrastructure installations
+:FeatureName: {product-title} clusters with multi-architecture compute machines on Azure installer-provisioned infrastructure installations
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
 include::modules/multi-architecture-creating-arm64-bootimage.adoc[leveloffset=+1]
@@ -27,3 +27,5 @@ include::modules/multi-architecture-modify-machine-set.adoc[leveloffset=+1]
 * xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc[Creating a compute machine set on Azure] 
 
 include::modules/multi-architecture-upgrade-mirrors.adoc[leveloffset=+1]
+
+include::modules/multi-architecture-import-imagestreams.adoc[leveloffset=+1]


### PR DESCRIPTION
**For Versions:** 4.12+
**Issue:** [OSDOCS-4658](https://issues.redhat.com//browse/OSDOCS-4658)

**Description:** Update wording on "multi-architecture clusters" to "multi-architecture compute machines" to clearer description of the feature

**Preview:** 
[Post-installation configuration -> Configuring multi-architecture compute machines on a OpenShift Container Platform cluster](https://53552--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html)

**QE review:**
- [x] QE has approved this change.

**Additional info:**
4.11 PR #53558 

