### PR TITLE
BZ2116612: removes the label as it creates a bug

### DIFF
--- a/modules/machine-config-daemon-metrics.adoc
+++ b/modules/machine-config-daemon-metrics.adoc
@@ -42,7 +42,7 @@ ifdef::openshift-origin[]
 endif::openshift-origin[]
 
 |`mcd_drain_err*`
-|`{"drain_time", "err"}`
+|
 |Logs errors received during failed drain. *
 |While drains might need multiple tries to succeed, terminal failed drains prevent updates from proceeding. The `drain_time` metric, which shows how much time the drain took, might help with troubleshooting.
 
@@ -71,7 +71,7 @@ Alternatively, you can run this command to only see the logs from the `machine-c
 `$ oc logs -f -n openshift-machine-config-operator machine-config-daemon-<hash> -c machine-config-daemon`
 
 |`mcd_kubelet_state*`
-|`[]string{"err"}`
+|
 |Logs kubelet health failures.  *
 |This is expected to be empty, with failure count of 0. If failure count exceeds 2, the error indicating threshold is exceeded. This indicates a possible issue with the health of the kubelet.
 


### PR DESCRIPTION
- The scope of this PR removes the label for the metric _mcd_kubelet_state_ and mcd_drain_err
- Applies to 4.11 and above
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2116612)
- [Preview](https://53556--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-machine-config-daemon-metrics.html)
