### PR TITLE
[enterprise-4.11] Changing cluster to compute machines

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -496,7 +496,7 @@ Topics:
   File: configuring-private-cluster
 - Name: Bare metal configuration
   File: bare-metal-configuration
-- Name: Configuring a multi-architecture cluster
+- Name: Configuring multi-architecture compute machines on an OpenShift cluster
   File: multi-architecture-configuration
 - Name: Machine configuration tasks
   File: machine-configuration-tasks

--- a/modules/multi-architecture-creating-arm64-bootimage.adoc
+++ b/modules/multi-architecture-creating-arm64-bootimage.adoc
@@ -5,9 +5,9 @@
 :_content-type: PROCEDURE
 [id="multi-architecture-creating-arm64-bootimage_{context}"]
 
-= Creating an `arm64` boot image using the Azure image gallery
- 
-To configure your multi-architecture cluster, you must create an `arm64` boot image and add it to your Azure compute machine set. The following procedure describes how to manually generate an `arm64` boot image. 
+= Creating an arm64 boot image using the Azure image gallery
+
+To configure your cluster with multi-architecture compute machines, you must create an `arm64` boot image and add it to your Azure compute machine set. The following procedure describes how to manually generate an `arm64` boot image.
  
 .Prerequisites
 

--- a/modules/multi-architecture-modify-machine-set.adoc
+++ b/modules/multi-architecture-modify-machine-set.adoc
@@ -5,9 +5,9 @@
 :_content-type: PROCEDURE
 [id="multi-architecture-modify-machine-set_{context}"]
 
-= Adding a machine set to your cluster using the `arm64` boot image  
+= Adding a multi-architecture compute machine set to your cluster using the arm64 boot image 
 
-To add `arm64` worker nodes to your multi-architecture cluster, you must create an Azure compute machine set that uses the `arm64` boot image. To create your own custom compute machine set on Azure, see "Creating a compute machine set on Azure". 
+To add `arm64` compute nodes to your cluster, you must create an Azure compute machine set that uses the `arm64` boot image. To create your own custom compute machine set on Azure, see "Creating a compute machine set on Azure". 
 
 .Prerequisites 
 

--- a/modules/multi-architecture-upgrade-mirrors.adoc
+++ b/modules/multi-architecture-upgrade-mirrors.adoc
@@ -5,9 +5,9 @@
 :_content-type: PROCEDURE
 [id="multi-architecture-upgrade-mirrors_{context}"]
 
-= Upgrading your multi-architecture cluster
+= Upgrading a cluster with multi-architecture compute machines
 
-You must perform an explicit upgrade command to upgrade your existing cluster to a multi-architecture cluster.
+You must perform an explicit upgrade command to upgrade your existing cluster to a cluster that supports multi-architecture compute machines.
 
 .Prerequisites
 

--- a/post_installation_configuration/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/multi-architecture-configuration.adoc
@@ -1,21 +1,21 @@
 :_content-type: ASSEMBLY
 :context: multi-architecture-configuration
 [id="post-install-multi-architecture-configuration"]
-= Configuring a multi-architecture cluster
+= Configuring multi-architecture compute machines on an {product-title} cluster
 include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-A multi-architecture cluster is a cluster that supports worker machines with different architectures. You can deploy a multi-architecture cluster by creating an Azure installer-provisioned cluster using the multi-architecture installer binary. For Azure installation, see xref:../installing/installing_azure/installing-azure-customizations.adoc[Installing a cluster on Azure with customizations].
+An {product-title} cluster with multi-architecture compute machines is a cluster that supports compute machines with different architectures. You can deploy a cluster with multi-architecture compute machines by creating an Azure installer-provisioned cluster using the multi-architecture installer binary. For Azure installation, see xref:../installing/installing_azure/installing-azure-customizations.adoc[Installing a cluster on Azure with customizations].
 
 [WARNING]
 ====
-The multi-architecture clusters Technology Preview feature has limited usability with installing, upgrading, and running payloads. 
+The multi-architecture compute machines Technology Preview feature has limited usability with installing, upgrading, and running payloads.
 ====
 
-The following procedures explain how to generate an `arm64` boot image and create an Azure compute machine set with the `arm64` boot image. This will add `arm64` worker nodes to your multi-architecture cluster and deploy the desired amount of ARM64 virtual machines (VM). This section also shows how to upgrade your existing cluster to a multi-architecture cluster. Multi-architecture clusters are only available on Azure installer-provisioned infrastructures with `x86_64` control planes. 
+The following procedures explain how to generate an `arm64` boot image and create an Azure compute machine set with the `arm64` boot image. This adds `arm64` compute nodes to your cluster and deploys the desired amount of `arm64` virtual machines (VM). This section also shows how to upgrade your existing cluster to a cluster that supports multi-architecture compute machines. Clusters with multi-architecture compute machines are only available on Azure installer-provisioned infrastructures with `x86_64` control plane machines.
 
-:FeatureName: Multi-architecture clusters for {product-title} on Azure installer-provisioned infrastructure installations
+:FeatureName: {product-title} clusters with multi-architecture compute machines on Azure installer-provisioned infrastructure installations
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
 include::modules/multi-architecture-creating-arm64-bootimage.adoc[leveloffset=+1]

--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -219,12 +219,12 @@ As a cluster administrator, you can enable cluster capabilities to select or des
 For more information, see xref:../post_installation_configuration/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities].
 
 [id="ocp-4-11-heterogeneous-tech-preview"]
-==== {product-title} on multi-architecture clusters (Technology Preview)
-{product-title} 4.11 introduces multi-architecture cluster support using Azure installer-provisioned infrastructure in Technology Preview. This feature offers, as a day-two operation, the ability to add `arm64` worker nodes to an existing `x86_64` Azure cluster that is installer provisioned with a multi-architecture installer binary. You can add `arm64` workers to your multi-architecture cluster by creating a custom Azure machine set that uses a manually generated `arm64` boot image. Control planes on `arm64` architectures are not currently supported. For more information, see xref:../post_installation_configuration/multi-architecture-configuration.adoc[Configuring a multi-architecture cluster].
+==== {product-title} clusters with multi-architecture compute machines (Technology Preview)
+{product-title} 4.11 introduces clusters with multi-architecture compute machines support using Azure installer-provisioned infrastructure in Technology Preview. This feature offers, as a day-two operation, the ability to add `arm64` compute nodes to an existing `x86_64` Azure cluster that is installer provisioned with a multi-architecture installer binary. You can add `arm64` compute nodes to your cluster by creating a custom Azure machine set that uses a manually generated `arm64` boot image. Control planes on `arm64` architectures are not currently supported. For more information, see xref:../post_installation_configuration/multi-architecture-configuration.adoc[Configuring a multi-architecture cluster].
 
 [NOTE]
 ====
-You can manually upgrade your cluster to the latest multi-architecture release image by using the release `image-pullsec`. For more information, see xref:../post_installation_configuration/multi-architecture-configuration.adoc#multi-architecture-upgrade-mirrors_multi-architecture-configuration[Upgrading your multi-architecture cluster].
+You can manually upgrade your cluster to the latest multi-architecture release image by using the release `image-pullsec`. For more information, see xref:../post_installation_configuration/multi-architecture-configuration.adoc#multi-architecture-upgrade-mirrors_multi-architecture-configuration[Upgrading your multi-architecture compute machines].
 ====
 
 [id="ocp-4-11-web-console"]


### PR DESCRIPTION
**For version:** 4.11
**Issue:** 
4.11 version of [OSDOCS-4658](https://issues.redhat.com//browse/OSDOCS-4658). There are some different files that are elusively for 4.12 that are not included in this PR

**Description:** 
Update wording on "multi-architecture clusters" to "multi-architecture compute machines" to clearer description of the feature. Updates 4.11 only

**Preview:** 
[Post-installation configuration -> Configuring multi-architecture compute machines on a OpenShift cluster](https://53558--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html)

**QE review:**
- [x] QE has approved this change.

**Additional Info:** 
Links to PR #53552