### PR TITLE
Clarify language of OVN as default for SNO

### DIFF
--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -12,10 +12,7 @@ OVN-Kubernetes is based on Open Virtual Network (OVN) and provides an overlay-ba
 A cluster that uses the OVN-Kubernetes network provider also runs Open vSwitch (OVS) on each node.
 OVN configures OVS on each node to implement the declared network configuration.
 
-[NOTE]
-====
-OVN-Kubernetes is the default networking solution for {sno} deployments.
-====
+OVN-Kubernetes is the default networking solution for {sno} deployments only.
 
 include::modules/nw-ovn-kubernetes-features.adoc[leveloffset=+1]
 

--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2968,7 +2968,7 @@ $ oc adm release info 4.11.13 --pullspecs
 [id="ocp-4-11-13-notable-technical-changes"]
 ==== Notable technical changes
 
-* The Cloud Credential Operator utility (`ccoctl`) now creates secrets that use regional endpoints for the xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc[AWS Security Token Service (AWS STS)]. This approach aligns with AWS recommended best practices. 
+* The Cloud Credential Operator utility (`ccoctl`) now creates secrets that use regional endpoints for the xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc[AWS Security Token Service (AWS STS)]. This approach aligns with AWS recommended best practices.
 
 [id="ocp-4-11-13-updating"]
 ==== Updating


### PR DESCRIPTION
This relates to [OSDOCS-1805](https://issues.redhat.com/browse/OSDOCS-1805)
As discussed with @mcurry-rh 

Version(s):
4.11 only. These statements are correct in main and 4.12.

Preview Build (Must be on VPN to review):
[About the OVN-Kubernetes default Container Network Interface (CNI) network provider ](https://53559--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html)