### PR TITLE
[OSDOCS-3951]: adding module about sr-iov operator for hosted control planes

### DIFF
--- a/modules/sriov-operator-hosted-control-planes.adoc
+++ b/modules/sriov-operator-hosted-control-planes.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-sriov-operator.adoc
+
+:_content-type: PROCEDURE
+[id="sriov-operator-hosted-control-planes_{context}"]
+= Deploying the SR-IOV Operator for hosted control planes
+
+:FeatureName: Hosted control planes
+include::snippets/technology-preview.adoc[]
+
+[role="_abstract"]
+After you configure and deploy your hosting service cluster, you can create a subscription to the SR-IOV Operator on a hosted cluster. The SR-IOV pod runs on worker machines rather than the control plane.
+
+.Prerequisites
+
+You have link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/multicluster_engine/multicluster_engine_overview#hosted-control-planes-configure[configured and deployed] the hosted cluster.
+
+.Procedure
+
+. Create a namespace and an Operator group:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-sriov-network-operator
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: sriov-network-operators
+  namespace: openshift-sriov-network-operator
+spec:
+  targetNamespaces:
+  - openshift-sriov-network-operator
+----
+
+. Create a subscription to the SR-IOV Operator: 
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sriov-network-operator-subsription
+  namespace: openshift-sriov-network-operator
+spec:
+  channel: "4.12"
+  name: sriov-network-operator
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/worker: ""
+  source: s/qe-app-registry/redhat-operators
+  sourceNamespace: openshift-marketplace
+----
+
+.Verification
+
+. To verify that the SR-IOV Operator is ready, run the following command and view the resulting output:
++
+[source,terminal]
+----
+$ oc get csv -n openshift-sriov-network-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         DISPLAY                   VERSION               REPLACES                                     PHASE
+sriov-network-operator.4.12.0-202211021237   SR-IOV Network Operator   4.12.0-202211021237   sriov-network-operator.4.12.0-202210290517   Succeeded
+----
+
+. To verify that the SR-IOV pods are deployed, run the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-sriov-network-operator
+----

--- a/networking/hardware_networks/configuring-sriov-operator.adoc
+++ b/networking/hardware_networks/configuring-sriov-operator.adoc
@@ -10,6 +10,8 @@ The Single Root I/O Virtualization (SR-IOV) Network Operator manages the SR-IOV 
 
 include::modules/nw-sriov-configuring-operator.adoc[leveloffset=+1]
 
+include::modules/sriov-operator-hosted-control-planes.adoc[leveloffset=+2]
+
 [id="configuring-sriov-operator-next-steps"]
 == Next steps
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-3951
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://53560--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator.html#sriov-operator-hosted-control-planes_configuring-sriov-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This content was originally planned to be published in the HyperShift docs that are part of the RHACM docs, but after further review, the PM thought they were better suited to be published in the OCP docs. This content was reviewed/approved by SMEs and QE, as shown in the PR to publish it in the RHACM docs: https://github.com/stolostron/rhacm-docs/pull/4278
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
