### PR TITLE
RHDEVDOCS-4785-add-note-about-alertmanager-config-update-to-4-12-RN

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -394,6 +394,7 @@ For more information, see xref:../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-j
 
 The monitoring stack for this release includes the following new and modified features.
 
+[id="ocp-4-12-monitoring-updates-to-monitoring-stack-compnents-and-dependencies"]
 ==== Updates to monitoring stack components and dependencies
 This release includes the following version updates for monitoring stack components and dependencies:
 
@@ -405,6 +406,7 @@ This release includes the following version updates for monitoring stack compone
 * prometheus-operator to 0.60.1
 * Thanos to 0.28.1
 
+[id="ocp-4-12-monitoring-changes-to-alerting-rules"]
 ==== Changes to alerting rules
 
 [NOTE]
@@ -420,12 +422,27 @@ Red Hat does not guarantee backward compatibility for recording rules or alertin
 ** The `NodeRAIDDegraded` and `NodeRAIDDiskFailure` alerts now include a device label filter to match only the value returned by `mmcblk.p.+|nvme.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+`.
 ** The `PrometheusHighQueryLoad` and `ThanosQueryOverload` alerts now also trigger when a high querying load exists on the query layer.
 
+[id="ocp-4-12-monitoring-new-option-to-specify-pod-topology-spread-constraints-for-monitoring-components"]
 ==== New option to specify pod topology spread constraints for monitoring components
 You can now use pod topology spread constraints to control how Prometheus, Thanos Ruler, and Alertmanager pods are spread across a network topology when {product-title} pods are deployed in multiple availability zones.
 
+[id="ocp-4-12-monitoring-new-option-to-improve-data-consistency-for-prometheus-adapter"]
 ==== New option to improve data consistency for Prometheus Adapter
 You can now configure an optional kubelet service monitor for Prometheus Adapter (PA) that improves data consistency across multiple autoscaling requests.
 Enabling this service monitor eliminates the possibility that two queries sent at the same time to PA might yield different results because the underlying PromQL queries executed by PA might be on different Prometheus servers.
+
+[id="ocp-4-12-monitoring-update-to-alertmanager-template-configuration-for-additional-secret-keys"]
+==== Update to Alertmanager template configuration for additional secret keys
+With this release, if you configure an Alertmanager secret to hold additional keys and if the Alertmanager configuration references these keys as files (such as templates, TLS certificates, or tokens), your configuration settings must point to these keys by using an absolute path rather than a relative path.
+These keys are available under the `/etc/alertmanager/config` directory.
+In earlier releases of {product-title}, you could use relative paths in your configuration to point to these keys because the Alertmanager configuration file was located in the same directory as the keys. 
+
+[IMPORTANT]
+====
+If you are upgrading to {product-title} {product-version} and have specified relative paths for additional Alertmanager secret keys that are referenced as files, you must change these relative paths to absolute paths in your Alertmanager configuration. 
+Otherwise, alert receivers that use the files will fail to deliver notifications.
+====
+
 
 [id="ocp-4-12-scalability-and-performance"]
 === Scalability and performance


### PR DESCRIPTION
Summary: This PR adds an item to the 4.12 Release Notes about a change to Alertmanager configuration in OCP monitoring.

- Aligned team: DevTools
- For branches: 4.12 only
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4785
- Direct link to doc preview: https://53561--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-monitoring-update-to-alertmanager-template-configuration-for-additional-secret-keys
- SME review: @simonpasquier 
- QE review: @juzhao 
- Peer review: @gabriel-rh 