### PR TITLE
[RHACS] ROX-13330 add QRadar and ServiceNow integrations

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -215,6 +215,10 @@ Topics:
   File: integrate-with-slack
 - Name: Integrating by using generic webhooks
   File: integrate-using-generic-webhooks
+- Name: Integrating with QRadar
+  File: integrate-with-qradar
+- Name: Integrating with ServiceNow
+  File: integrate-with-servicenow
 - Name: Integrating with Sumo Logic
   File: integrate-with-sumologic
 - Name: Integrating with Google Cloud Storage

--- a/integration/integrate-with-qradar.adoc
+++ b/integration/integrate-with-qradar.adoc
@@ -1,0 +1,27 @@
+:_content-type: ASSEMBLY
+[id="integrate-with-qradar"]
+= Integrating with QRadar
+include::modules/common-attributes.adoc[]
+:context: integrate-with-qradar
+
+toc::[]
+
+[role="_abstract"]
+You can configure {product-title} to send events to QRadar by configuring a generic webhook integration in {product-title-short}.
+
+The following steps represent a high-level workflow for integrating {product-title-short} with QRadar:
+
+. In {product-title-short}:
+.. Configure the generic webhook. 
++
+[NOTE]
+====
+When configuring the integration in {product-title-short}, in the *Endpoint* field, use the following example as a guide: `<URL to QRadar Box>:<Port of Integration>`.
+====
+.. Identify policies for which you want to send notifications, and update the notification settings for those policies. 
+. If QRadar does not automatically detect the log source, add an {product-title-short} log source on the QRadar Console. For more information on configuring QRadar and {product-title-short}, see the link:https://www.ibm.com/docs/en/dsm?topic=configuration-red-hat-advanced-cluster-security-kubernetes[Red Hat Advanced Cluster Security for Kubernetes] IBM resource.
+
+include::modules/webhook-configuring-acs.adoc[leveloffset=+1]
+
+:toolname: webhook
+include::modules/configure-policy-notifications.adoc[leveloffset=+1]

--- a/integration/integrate-with-servicenow.adoc
+++ b/integration/integrate-with-servicenow.adoc
@@ -1,0 +1,22 @@
+:_content-type: ASSEMBLY
+[id="integrate-with-servicenow"]
+= Integrating with ServiceNow
+include::modules/common-attributes.adoc[]
+:context: integrate-with-servicenow
+
+toc::[]
+
+[role="_abstract"]
+You can configure {product-title} to send events to ServiceNow by configuring a generic webhook integration in {product-title-short}.
+
+The following steps represent a high-level workflow for integrating {product-title-short} with ServiceNow:
+
+. In ServiceNow, configure a REST API endpoint to use in {product-title-short}. For more information that includes steps for ServiceNow configuration, see link:https://www.redhat.com/en/blog/how-integrate-red-hat-advanced-cluster-security-kubernetes-servicenow[How to integrate Red Hat Advanced Cluster Security for Kubernetes with ServiceNow].
+. In {product-title-short}:
+.. Configure the generic webhook.
+.. Identify policies for which you want to send notifications, and update the notification settings for those policies. 
+
+include::modules/webhook-configuring-acs.adoc[leveloffset=+1]
+
+:toolname: webhook
+include::modules/configure-policy-notifications.adoc[leveloffset=+1]

--- a/modules/webhook-configuring-acs.adoc
+++ b/modules/webhook-configuring-acs.adoc
@@ -3,7 +3,7 @@
 // * integration/integrate-using-generic-webhooks.adoc
 :_module-type: PROCEDURE
 [id="webhook-configuring-acs_{context}"]
-= Configuring {product-title}
+= Configuring integrations by using webhooks
 
 [role="_abstract"]
 Create a new integration in {product-title} by using the webhook URL.


### PR DESCRIPTION
Version(s):

- `rhacs-docs`
- `rhacs-docs-3.73`
- `rhacs-docs-3.72`
- `rhacs-docs-3.71`
- `rhacs-docs-3.74`

[Issue](https://issues.redhat.com/browse/ROX-13330)

Link to docs preview:

- [Integrating with QRadar](https://openshift-docs-oci65apfm-kcarmichael08.vercel.app/openshift-acs/master/integration/integrate-with-qradar.html)
- [Integrating with ServiceNow](https://openshift-docs-oci65apfm-kcarmichael08.vercel.app/openshift-acs/master/integration/integrate-with-servicenow.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change. (**N/A** - ACS has no QE, but SME approved via Slack.)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Note** External links approved by Support via Slack.


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
