### PR TITLE
RHDEVDOCS-4352 - update-to-user-role-reqs-for-silencing-monitoring-alerts

### DIFF
--- a/modules/monitoring-silencing-alerts.adoc
+++ b/modules/monitoring-silencing-alerts.adoc
@@ -10,7 +10,11 @@ You can either silence a specific alert or silence alerts that match a specifica
 
 .Prerequisites
 
-* You have access to the cluster as a developer or as a user with `edit` permissions for the project that you are viewing metrics for.
+* You are a cluster administrator and have access to the cluster as a user with the `cluster-admin` cluster role.
+* You are a non-administator user and have access to the cluster as a user with the following user roles:
+** The `cluster-monitoring-view` cluster role, which allows you to access Alertmanager.
+** The `monitoring-alertmanager-edit` role, which permits you to create and silence alerts in the *Administrator* perspective in the web console.
+** The `monitoring-rules-edit` role, which permits you to create and silence alerts in the *Developer* perspective in the web console.
 
 .Procedure
 

--- a/monitoring/managing-alerts.adoc
+++ b/monitoring/managing-alerts.adoc
@@ -14,7 +14,13 @@ In {product-title} {product-version}, the Alerting UI enables you to manage aler
 
 [NOTE]
 ====
-The alerts, silences, and alerting rules that are available in the Alerting UI relate to the projects that you have access to. For example, if you are logged in with `cluster-administrator` privileges, all alerts, silences, and alerting rules are accessible.
+The alerts, silences, and alerting rules that are available in the Alerting UI relate to the projects that you have access to. For example, if you are logged in with `cluster-admin` privileges, you can access all alerts, silences, and alerting rules.
+
+If you are a non-administator user, you can create and silence alerts if you are assigned the following user roles: 
+
+* The `cluster-monitoring-view` role, which allows you to access Alertmanager
+* The `monitoring-alertmanager-edit` role, which permits you to create and silence alerts in the *Administrator* perspective in the web console
+* The `monitoring-rules-edit` role, which permits you to create and silence alerts in the *Developer* perspective in the web console
 ====
 
 // Accessing the Alerting UI in the Administrator and Developer perspectives


### PR DESCRIPTION
Summary: This PR updates information about the user permissions required to create and silence OCP monitoring alerts.

- Aligned team: DevTools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4352
- Direct link to doc preview:
- - https://53574--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts.html#silencing-alerts_managing-alerts
- - https://53574--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts.html
- SME review: @simonpasquier 
- QE review: @juzhao 
- Peer review: @rh-tokeefe 