### PR TITLE
OCPBUGS#3076 - adding oc mirror info

### DIFF
--- a/modules/update-mirror-repository-oc-mirror.adoc
+++ b/modules/update-mirror-repository-oc-mirror.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-restricted-network-cluster.adoc
+
+:_content-type: PROCEDURE
+[id="update-mirror-repository-oc-mirror_{context}"]
+= Mirroring resources using the oc-mirror plug-in
+
+Use the oc-mirror OpenShift CLI (`oc`) plug-in to mirror images onto a mirror registry. Compared to using `oc adm release mirror`, the oc-mirror plug-in has the following advantages:
+
+* It is simpler to use.
+
+* It can mirror content other than container images.
+
+* After mirroring images for the first time, it is easier to update images in the registry.
+
+.Procedure
+
+. Navigate to the _Mirroring images for a disconnected installation using the oc-mirror plug-in_ page of the documentation.
+
+. Follow the instructions on that page to mirror resources onto a mirror registry.
+
+** If you are using oc-mirror for the first time, follow the instructions on that page up until and including the section titled _Installing the ImageContentSourcePolicy and CatalogSource resources into the cluster_.
+
+** If you have already used oc-mirror to mirror resources onto a registry, follow the instructions in the section titled _Keeping your mirror registry content updated_.

--- a/modules/update-mirror-repository.adoc
+++ b/modules/update-mirror-repository.adoc
@@ -3,10 +3,8 @@
 // * updating/updating-restricted-network-cluster.adoc
 
 :_content-type: PROCEDURE
-[id="update-mirror-repository_{context}"]
-= Mirroring the {product-title} image repository
-
-Before you update a cluster on infrastructure that you provision in a restricted network, you must mirror the required container images into that environment. You can also use this procedure in unrestricted networks to ensure your clusters only use container images that have satisfied your organizational controls on external content.
+[id="update-mirror-repository-adm-release-mirror_{context}"]
+= Mirroring images using the oc adm release mirror command
 
 .Procedure
 

--- a/modules/update-service-mirror-release.adoc
+++ b/modules/update-service-mirror-release.adoc
@@ -1,6 +1,6 @@
 :_content-type: PROCEDURE
-[id="update-service-mirror-release_{context}"]
-= Mirroring the {product-title} image repository
+[id="update-service-mirror-release-adm-release-mirror_{context}"]
+= Mirroring images using the oc adm release mirror command
 
 The OpenShift Update Service requires a locally accessible registry containing update release payloads.
 

--- a/updating/updating-restricted-network-cluster.adoc
+++ b/updating/updating-restricted-network-cluster.adoc
@@ -38,11 +38,31 @@ include::modules/cli-installing-cli.adoc[leveloffset=+3]
 
 // this file doesn't exist, so I'm including the one that should pick up more changes from Clayton's PR - modules/installation-adding-mirror-registry-pull-secret.adoc[leveloffset=+1]
 
-include::modules/installation-adding-registry-pull-secret.adoc[leveloffset=+2]
+include::modules/installation-adding-registry-pull-secret.adoc[leveloffset=+3]
 
-include::modules/update-mirror-repository.adoc[leveloffset=+2]
+[id="update-mirror-repository_updating-restricted-network-cluster"]
+=== Mirroring the {product-title} image repository
 
-include::modules/machine-health-checks-pausing.adoc[leveloffset=+3]
+You must mirror container images onto a mirror registry before you can update a cluster in a restricted network environment. You can also use this procedure in unrestricted networks to ensure your clusters only use container images that have satisfied your organizational controls on external content.
+
+There are two supported methods for mirroring images onto a mirror registry:
+
+* Using the oc-mirror OpenShift CLI (`oc`) plug-in
+
+* Using the oc adm release mirror command
+
+Choose one of the following supported options.
+
+include::modules/update-mirror-repository-oc-mirror.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in]
+
+include::modules/update-mirror-repository.adoc[leveloffset=+3]
+
+include::modules/machine-health-checks-pausing.adoc[leveloffset=+2]
 
 include::modules/update-restricted.adoc[leveloffset=+2]
 
@@ -123,7 +143,35 @@ include::modules/update-service-install-cli.adoc[leveloffset=+2]
 
 include::modules/update-service-graph-data.adoc[leveloffset=+2]
 
-include::modules/update-service-mirror-release.adoc[leveloffset=+2]
+[id="update-service-mirror-release_updating-restricted-network-cluster"]
+=== Mirroring the {product-title} image repository
+
+You must mirror container images onto a mirror registry before you can update a cluster in a restricted network environment. You can also use this procedure in unrestricted networks to ensure your clusters only use container images that have satisfied your organizational controls on external content.
+
+There are two supported methods for mirroring images onto a mirror registry:
+
+* Using the oc-mirror OpenShift CLI (`oc`) plug-in
+
+* Using the oc adm release mirror command
+
+Choose one of the following supported options.
+
+//The module below is being used twice in this assembly, so this instance needs to have a unique context set in order for its ID to be unique. In the future, if and when the two main sections of this webpage are split into their own assemblies/pages, the context attributes below can be removed.
+
+:!context:
+:context: osus-restricted-network-cluster
+
+include::modules/update-mirror-repository-oc-mirror.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plug-in]
+
+:!context:
+:context: updating-restricted-network-cluster
+
+include::modules/update-service-mirror-release.adoc[leveloffset=+3]
 
 [id="update-service-create-service"]
 === Creating an OpenShift Update Service application


### PR DESCRIPTION
Versions 4.11+

[OCPBUGS-3076](https://issues.redhat.com/browse/OCPBUGS-3076)

This PR adds documentation for using oc mirror to mirror images onto a registry when upgrading in a restricted network environment. The new information adds a new section for oc mirror, while keeping the old section describing how to do the same thing with the "adm release mirror" command, which is still supported. The new section points readers to an existing page for disconnected installation with oc mirror, and instructs users to follow the procedures on that page that are relevant to updates.

(some smaller, out of scope changes have also been made to fix incorrect heading levels for adjacent sections)

Preview
Non-OSUS section: https://53575--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster.html#update-mirror-repository_updating-restricted-network-cluster

OSUS section: https://53575--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster.html#update-service-mirror-release_updating-restricted-network-cluster