### PR TITLE
Fixed .vale.ini and Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ git:
   depth: 1
 
 jobs:
+  allow_failures:
+    env:
+      - CAN_FAIL=true
   include:
     - stage: build
       name: "Build openshift-acs distro"
@@ -18,6 +21,8 @@ jobs:
       script:
         - python3 build.py --distro openshift-acs --product "Red Hat Advanced Cluster Security for Kubernetes" --version 3.72 --no-upstream-fetch && python3 makeBuild.py
     - stage: check-with-vale
+      env:
+        - CAN_FAIL=true
       if: type IN (pull_request)
       name: "Run Vale against PR asciidoc files"
       language: minimal

--- a/.vale.ini
+++ b/.vale.ini
@@ -2,13 +2,11 @@ StylesPath = .vale/styles
 
 MinAlertLevel = suggestion
 
-Packages = RedHat, \
-https://github.com/rohennes/ocp-rules/releases/latest/download/AsciiDoc.zip
-
+Packages = RedHat
 
 #ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
 [[!.]*.adoc]
-BasedOnStyles = RedHat, AsciiDoc
+BasedOnStyles = RedHat
 
 #optional: pass doc attributes to asciidoctor before linting
 #[asciidoctor]


### PR DESCRIPTION
To match Vale config and Travis CI config from the `main` branch.

Cherrypick to:
- rhacs-docs-3.71
- rhacs-docs-3.72
- rhacs-docs-3.73