### PR TITLE
RHDEVDOCS-4785-fix-typo-in-header-for-alertmanager-item-in-4-12-RN

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -431,8 +431,8 @@ You can now use pod topology spread constraints to control how Prometheus, Thano
 You can now configure an optional kubelet service monitor for Prometheus Adapter (PA) that improves data consistency across multiple autoscaling requests.
 Enabling this service monitor eliminates the possibility that two queries sent at the same time to PA might yield different results because the underlying PromQL queries executed by PA might be on different Prometheus servers.
 
-[id="ocp-4-12-monitoring-update-to-alertmanager-template-configuration-for-additional-secret-keys"]
-==== Update to Alertmanager template configuration for additional secret keys
+[id="ocp-4-12-monitoring-update-to-alertmanager-configuration-for-additional-secret-keys"]
+==== Update to Alertmanager configuration for additional secret keys
 With this release, if you configure an Alertmanager secret to hold additional keys and if the Alertmanager configuration references these keys as files (such as templates, TLS certificates, or tokens), your configuration settings must point to these keys by using an absolute path rather than a relative path.
 These keys are available under the `/etc/alertmanager/config` directory.
 In earlier releases of {product-title}, you could use relative paths in your configuration to point to these keys because the Alertmanager configuration file was located in the same directory as the keys. 


### PR DESCRIPTION
Summary: This PR removes a word from the heading for a 4.12 RN item for alertmanager.

- Aligned team: DevTools
- For branches: 4.12 only
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4785
- Direct link to doc preview: https://53601--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-monitoring-update-to-alertmanager-configuration-for-additional-secret-keys
- SME review: @simonpasquier 
- QE review: @juzhao 
- Peer review: @gabriel-rh 