### PR TITLE
[enterprise-4.10] OSDOCS-4024: Add MT2892 Family SR-IOV hardware

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -86,6 +86,12 @@
 |MT28908 Family [ConnectX&#8209;6{nbsp}Lx]
 |15b3
 |101f
+
+|Mellanox
+|MT2892 Family [ConnectX&#8209;6{nbsp}Dx]
+|15b3
+|101d
+
 |===
 
 [NOTE]

--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -541,6 +541,7 @@ You can use the enhancement to run packet captures on multiple nodes at the same
 A new `--node-selector` argument provides a way to identify which nodes you are collecting packet captures for.
 
 For more information, see xref:../support/gathering-cluster-data.adoc#support-network-trace-methods_gathering-cluster-data[Network trace methods] and xref:../support/gathering-cluster-data.adoc#support-collecting-host-network-trace_gathering-cluster-data[Collecting a host network trace].
+
 [id="ocp-4-10-pod-level-bonding"]
 ==== Pod-level bonding for secondary networks (Technology Preview)
 Bonding at the pod level is vital to enable workloads inside pods that require high availability and more throughput. With pod-level bonding, you can create a bond interface from multiple single root I/O virtualization (SR-IOV) virtual function interfaces in kernel mode interface. The SR-IOV virtual functions are passed into the pod and attached to a kernel driver.
@@ -684,6 +685,10 @@ For more information, see xref:../networking/using-ptp.adoc#configuring-ptp-devi
 
 {product-title} now provides the Kubernetes NMState Operator for bare-metal, IBM Power, IBM Z, and LinuxONE installations. The Kubernetes NMState Operator is still a Technology Preview for all other platforms. See xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc[About the Kubernetes NMState Operator] for additional details.
 
+[id="ocp-4-10-support-for-mellanox-mt2892-cards"]
+==== SR-IOV support for Mellanox MT2892 cards
+
+SR-IOV support is now available for xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Mellanox MT2892 cards].
 
 [id="ocp-4-10-hardware"]
 === Hardware


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-4024

Refs https://github.com/openshift/openshift-docs/pull/49777.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
