### PR TITLE
OSDOCS-3921: Multi-architecture compute machines on the web console

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -113,6 +113,13 @@ With this release, there are several updates to the *Administrator* perspective 
 * The {product-title} web console displays a `ConsoleNotification` if the cluster is upgrading. Once the upgrade is done, the notification is removed.
 * A *_restart rollout_* option for the `Deployment` resource and a *_retry rollouts_* option for the `DeploymentConfig` resource are available on the *Action* and *Kebab* menus.
 
+[id="ocp-4-12-multi-arch-console"]
+===== Multi-architecture compute machines on the {product-title} web console
+
+The `console-operator` now scans all nodes and builds a set of all architecture types that cluster nodes run on and pass it to the `console-config.yaml`. The `console-operator` can be installed on nodes with architectures of the values `amd64`, `arm64`, `ppc64le`, or `s390x`.
+
+For more information about multi-architechture compute machines, see xref:../post_installation_configuration/multi-architecture-configuration.adoc[Configuring a multi-architecture compute machine on an OpenShift cluster].
+
 [id="ocp-4-12-developer-perspective"]
 ==== Developer Perspective
 


### PR DESCRIPTION
Adds notes for using multi-architecture compute machines on the web console

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-3921

Link to docs preview:
https://53620--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-multi-arch-console

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

