### PR TITLE
OSDOCS-4322: Updates to Using the Node Tuning Operator topic

### DIFF
--- a/modules/cluster-node-tuning-operator-default-profiles-set.adoc
+++ b/modules/cluster-node-tuning-operator-default-profiles-set.adoc
@@ -16,14 +16,19 @@ metadata:
   name: default
   namespace: openshift-cluster-node-tuning-operator
 spec:
+  profile:
+  - data: |
+      [main]
+      summary=Optimize systems running OpenShift (provider specific parent profile)
+      include=-provider-${f:exec:cat:/var/lib/tuned/provider},openshift
+    name: openshift
   recommend:
-  - profile: "openshift-control-plane"
+  - profile: openshift-control-plane
     priority: 30
     match:
-    - label: "node-role.kubernetes.io/master"
-    - label: "node-role.kubernetes.io/infra"
-
-  - profile: "openshift-node"
+    - label: node-role.kubernetes.io/master
+    - label: node-role.kubernetes.io/infra
+  - profile: openshift-node
     priority: 40
 ----
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-4322

Preview build:
https://53621--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-node-tuning-operator.html#custom-tuning-default-profiles-set_node-tuning-operator
