### PR TITLE
BZ2115250: Removing duplicate in procedure

### DIFF
--- a/modules/nodes-scheduler-node-selectors-cluster.adoc
+++ b/modules/nodes-scheduler-node-selectors-cluster.adoc
@@ -127,29 +127,6 @@ $ oc scale --replicas=0 MachineSet ci-ln-l8nry52-f76d1-hl7m7-worker-c -n openshi
 $ oc scale --replicas=1 MachineSet ci-ln-l8nry52-f76d1-hl7m7-worker-c -n openshift-machine-api
 ----
 
-.. Verify that the labels are added to the `MachineSet` object by using the `oc edit` command:
-+
-For example:
-+
-[source,terminal]
-----
-$ oc edit MachineSet ci-ln-l8nry52-f76d1-hl7m7-worker-c -n openshift-machine-api
-----
-
-.. Redeploy the nodes associated with that compute machine set by scaling down to `0` and scaling up the nodes:
-+
-For example:
-+
-[source,terminal]
-----
-$ oc scale --replicas=0 MachineSet ci-ln-l8nry52-f76d1-hl7m7-worker-c -n openshift-machine-api
-----
-+
-[source,terminal]
-----
-$ oc scale --replicas=1 MachineSet ci-ln-l8nry52-f76d1-hl7m7-worker-c -n openshift-machine-api
-----
-
 .. When the nodes are ready and available, verify that the label is added to the nodes by using the `oc get` command:
 +
 [source,terminal]


### PR DESCRIPTION
For versions: 4.8+
Issue: [BZ2115250](https://bugzilla.redhat.com/show_bug.cgi?id=2115250)

Preview: [Cluster tasks -> Creating default cluster-wide node selectors](https://53622--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#nodes-scheduler-node-selectors-cluster_post-install-cluster-tasks) 

QE review:
- [x] QE has approved this change.

