### PR TITLE
OSDOCS-4083: Added OVN-Kubernetes as the default networking plug-in

### DIFF
--- a/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
@@ -148,6 +148,13 @@ If your {product-title} 3.11 cluster used the `ovs-subnet` or `ovs-multitenant` 
 
 For more information, see xref:../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy].
 
+[discrete]
+==== OVN-Kubernetes as the default networking plug-in in Red Hat OpenShift Networking
+
+In {product-title} 3.11, OpenShift SDN was the the default networking plug-in in Red Hat OpenShift Networking. In {product-title} {product-version}, OVN-Kubernetes is now the default networking plug-in.
+
+For information on migrating to OVN-Kubernetes from OpenShift SDN, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#migrate-from-openshift-sdn[Migrating from the OpenShift SDN network plug-in].
+
 [id="migration-preparing-logging"]
 === Logging considerations
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4083

Link to docs preview:
https://53625--docspreview.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/planning-migration-3-4.html#migration-preparing-networking

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
