### PR TITLE
Add version number in selector for RHACS 3.73

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -129,6 +129,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="3.73">3.73</option>
               <option value="3.72">3.72</option>
               <option value="3.71">3.71</option>
               <option value="3.70">3.70</option>


### PR DESCRIPTION
Fixes the missing version selector on docs. This is in addition to https://github.com/openshift/openshift-docs/pull/53539