### PR TITLE
Removed 3.72 version from redirect

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -144,7 +144,7 @@ AddType text/vtt                            vtt
     RewriteRule ^acs/(\D.*)$ /acs/3.73/$1 [NE,R=301]
     RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68|3\.69|3\.70|3\.71|3\.72|3\.73)/?$ /acs/$1/welcome/index.html [L,R=301]
     # redirect from ACS CLoud Service page
-    RewriteRule ^acs/3.72/installing/install-ocp-operator.html /acs/3.73/installing/installing_ocp/init-bundle-ocp.html [NE,R=301]
+    RewriteRule ^acs/installing/install-ocp-operator.html /acs/3.73/installing/installing_ocp/init-bundle-ocp.html [NE,R=301]
 
     # this pipeline redirect has to come before the latest kicks in generically
     RewriteRule ^container-platform/latest/pipelines/creating-applications-with-cicd-pipelines.html /container-platform/4.7/cicd/pipelines/creating-applications-with-cicd-pipelines.html [NE,R=301]


### PR DESCRIPTION
This is a fix for https://github.com/openshift/openshift-docs/pull/53540

The product does not use `3.72` in the URL. ACSCS uses `https://docs.openshift.com/acs/installing/install-ocp-operator.html#adding-a-new-cluster-to-rhacs` instead of `https://docs.openshift.com/acs/3.72/installing/install-ocp-operator.html#adding-a-new-cluster-to-rhacs`