### PR TITLE
Moved the RHACS Cloud Service rewrite rule to execute before other rules kick

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -141,10 +141,10 @@ AddType text/vtt                            vtt
     RewriteRule ^acs/?$ /acs/3.73/welcome/index.html [R=301]
     # redirect to the latest release notes
     RewriteRule ^acs/release_notes/?$ /acs/3.73/release_notes/373-release-notes.html [R=301,NE]
-    RewriteRule ^acs/(\D.*)$ /acs/3.73/$1 [NE,R=301]
-    RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68|3\.69|3\.70|3\.71|3\.72|3\.73)/?$ /acs/$1/welcome/index.html [L,R=301]
     # redirect from ACS CLoud Service page
     RewriteRule ^acs/installing/install-ocp-operator.html /acs/3.73/installing/installing_ocp/init-bundle-ocp.html [NE,R=301]
+    RewriteRule ^acs/(\D.*)$ /acs/3.73/$1 [NE,R=301]
+    RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68|3\.69|3\.70|3\.71|3\.72|3\.73)/?$ /acs/$1/welcome/index.html [L,R=301]
 
     # this pipeline redirect has to come before the latest kicks in generically
     RewriteRule ^container-platform/latest/pipelines/creating-applications-with-cicd-pipelines.html /container-platform/4.7/cicd/pipelines/creating-applications-with-cicd-pipelines.html [NE,R=301]


### PR DESCRIPTION
Further work related to https://github.com/openshift/openshift-docs/pull/53628 

Since this was later in the chain, site was matching `RewriteRule ^acs/(\D.*)$ /acs/3.73/$1 [NE,R=301]` and making the url `https://docs.openshift.com/acs/3.73/installing/install-ocp-operator.html#adding-a-new-cluster-to-rhacs` 

Moving the rule upwards make sure it executes first.