### PR TITLE
[enterprise-4.9] OCPBUGS-3407 - Workload partitioning wrong CRI-O configuration key - 4.9

### DIFF
--- a/modules/sno-du-enabling-workload-partitioning.adoc
+++ b/modules/sno-du-enabling-workload-partitioning.adoc
@@ -10,7 +10,7 @@ A key feature to enable as part of a {sno} installation is workload partitioning
 
 [NOTE]
 ====
-You can enable workload partitioning during the cluster installation process only. You cannot disable workload partitioning post-installation. However, you can reconfigure workload partitioning by updating the `cpu` value that you define in the `performanceprofile`, and in the MachineConfig CR in the following procedure. 
+You can enable workload partitioning during cluster installation only. You cannot disable workload partitioning post-installation. However, you can reconfigure workload partitioning by updating the `cpu` value that you define in the performance profile, and in the related `cpuset` value in the `MachineConfig` custom resource (CR).
 ====
 
 .Procedure
@@ -58,9 +58,11 @@ activation_annotation = "target.workload.openshift.io/management"
 annotation_prefix = "resources.workload.openshift.io"
 [crio.runtime.workloads.management.resources]
 cpushares = 0
-CPUs = "0-1, 52-53" <1>
+cpuset = "0-1, 52-53" <1>
 ----
-<1> The `CPUs` value varies based on the installation.
+<1> The `cpuset` value varies based on the installation.
++
+If Hyper-Threading is enabled, specify both threads for each core. The `cpuset` value must match the reserved CPUs that you define in the `spec.cpu.reserved` field in the performance profile.
 
 If Hyper-Threading is enabled, specify both threads of each core. The `CPUs` value must match the reserved CPU set specified in the performance profile.
 
@@ -77,6 +79,4 @@ This content should be base64 encoded and provided in the `01-workload-partition
   }
 }
 ----
-<1> The `cpuset` must match the `CPUs` value in `/etc/crio/crio.conf.d/01-workload-partitioning`.
-
-This content should be base64 encoded and provided in the `openshift-workload-pinning-content` in the preceding manifest.
+<1> The `cpuset` must match the `cpuset` value in `/etc/crio/crio.conf.d/01-workload-partitioning`.


### PR DESCRIPTION
This is a manual CP to 4.9 that Fixes #53510 

OCPBUGS-3407: There was an incorrect parameter (CPU vs cpuset) in a previous documentation update. The module has been updated since the bug was created, so CPU was not present but the formatting seemed different to the [schema](https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crioruntimeworkloadresources-table). So I updated the yaml to match the schema. And also changed the numbered callout from CPU to cpuset

Version(s):
4.9

Issue:
https://issues.redhat.com/browse/OCPBUGS-3407

Link to docs preview:
http://file.emea.redhat.com/rohennes/OCPBUGS-3407-workload-partitionin-yaml/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
