### PR TITLE
OSDOCS-4671: Adds notes for 4.10.45

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3669,3 +3669,27 @@ $ oc adm release info 4.10.43 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-45"]
+=== RHBA-2022:8882 - {product-title} 4.10.45 bug fix update
+
+Issued: 2022-12-14
+
+{product-title} release 4.10.45 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:8882[RHBA-2022:8882] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:8881[RHBA-2022:8881] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.45 --pullspecs
+----
+
+[id="ocp-4-10-45-bug-fixes"]
+==== Bug fixes
+
+* Previously, some object storage instances responded with `204 No Content` when no content displayed. The {rh-openstack-first} SDK used in {product-title} did not handle 204s correctly. With this update, the installation program works around the issue when there are zero items to list. (link:https://issues.redhat.com/browse/OCPBUGS-4160[*OCPBUGS-4160*])
+
+[id="ocp-4-10-45-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4671](https://issues.redhat.com//browse/OSDOCS-4671): Adds notes for 4.10.45

Version(s):
4.10 only

Issue:
https://issues.redhat.com/browse/OSDOCS-4671

Link to docs preview (VPN req):
http://file.rdu.redhat.com/opayne/OSDOCS-4671/release_notes/ocp-4-10-release-notes.html#ocp-4-10-45

QE review:
- [ ] QE has approved this change.
* QE is not needed for this PR

Additional information:
Links will not work at the moment

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
