### PR TITLE
 Add rolloutStrategy -  Image Registry Configuration

### DIFF
--- a/modules/registry-operator-configuration-resource-overview.adoc
+++ b/modules/registry-operator-configuration-resource-overview.adoc
@@ -58,6 +58,9 @@ hostname. If enabled, the route uses re-encrypt encryption. Defaults to `false`.
 |Array of additional routes to create. You provide the hostname and certificate
 for the route.
 
+|`rolloutStrategy`
+|Defines rollout strategy for the image registry deployment. Defaults to `RollingUpdate`.
+
 |`replicas`
 |Replica count for the registry.
 


### PR DESCRIPTION
Added rolloutStrategy Parameter as this is one of the configurable parameter with OCP internal image registry. Here is the information obtained from the OpenAPI Specification. 
~~~
oc explain configs.imageregistry.operator.openshift.io.spec.rolloutStrategy
KIND:     Config
VERSION:  imageregistry.operator.openshift.io/v1

FIELD:    rolloutStrategy <string>

DESCRIPTION:
     rolloutStrategy defines rollout strategy for the image registry deployment.
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
