### PR TITLE
[enterprise-4.10] NE-989: Add nw-ingress-edge-route-default-certificate

### DIFF
--- a/modules/nw-ingress-edge-route-default-certificate.adoc
+++ b/modules/nw-ingress-edge-route-default-certificate.adoc
@@ -1,0 +1,71 @@
+// This is included in the following assemblies:
+//
+// networking/routes/route-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="creating-edge-route-with-default-certificate_{context}"]
+= Creating a route using the default certificate through an Ingress object
+
+If you create an Ingress object without specifying any TLS configuration, {product-title} generates an insecure route. To create an Ingress object that generates a secure, edge-terminated route using the default ingress certificate, you can specify an empty TLS configuration as follows.
+
+.Prerequisites
+
+* You have a service that you want to expose.
+* You have access to the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Create a YAML file for the Ingress object.  In this example, the file is called `example-ingress.yaml`:
++
+.YAML definition of an Ingress object
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend
+  ...
+spec:
+  rules:
+    ...
+  tls:
+  - {} <1>
+----
++
+<1> Use this exact syntax to specify TLS without specifying a custom certificate.
+
+. Create the Ingress object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f example-ingress.yaml
+----
+
+.Verification
+* Verify that {product-title} has created the expected route for the Ingress object by running the following command:
++
+[source,terminal]
+----
+$ oc get routes -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: v1
+items:
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: frontend-j9sdd <1>
+    ...
+  spec:
+  ...
+    tls: <2>
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge <3>
+  ...
+----
+<1> The name of the route includes the name of the Ingress object followed by a random suffix.
+<2> In order to use the default certificate, the route should not specify `spec.certificate`.
+<3> The route should specify the `edge` termination policy.

--- a/networking/routes/route-configuration.adoc
+++ b/networking/routes/route-configuration.adoc
@@ -43,4 +43,6 @@ include::modules/nw-route-admission-policy.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-creating-a-route-via-an-ingress.adoc[leveloffset=+1]
 
+include::modules/nw-ingress-edge-route-default-certificate.adoc[leveloffset=+1]
+
 include::modules/nw-router-configuring-dual-stack.adoc[leveloffset=+1]


### PR DESCRIPTION
Add an example of creating an ingress object that uses the default certificate.  The required syntax to do this is subtle and non-obvious.

* `modules/nw-ingress-edge-route-default-certificate.adoc`: New file.
* `networking/routes/route-configuration.adoc`: Include the new module.

-------

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.6+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/NE-989

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
This is a manual cherry-pick of #48054 to the enterprise-4.10 branch.  The automatic cherry-pick process failed due to a conflict introduced by #46330 (which is in enterprise-4.11 and later but not in enterprise-4.10).