### PR TITLE
[OCPBUGS-2789] Known issue for "OVN provider does not support 'loadBalancerSourceRanges'"

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -2387,6 +2387,8 @@ $ ./openshift-install wait-for install-complete
 
 * Due to an unresolved metadata API issue, you cannot install clusters that use bare-metal workers on {rh-openstack} 16.1. Clusters on {rh-openstack} 16.2 are not impacted by this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033953[*BZ#2033953*])
 
+* The `loadBalancerSourceRanges` attribute is not supported, and is thus ignored, in load-balancer type services in clusters that run on {rh-openstack} and use the OVN Octavia provider. There is no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-2789[*OCPBUGS-2789*]) 
+
 * Platform Operator and RukPak known issues:
 
 ** Deleting a platform Operator results in a cascading deletion of the underlying resources. This cascading deletion logic can only delete resources that are defined in the Operator Lifecycle Manager-based (OLM) Operator's bundle format. In the case that a platform Operator creates resources that are defined outside of that bundle format, then the platform Operator is responsible for handling this cleanup interaction. This behavior can be observed when installing the cert-manager Operator as a platform Operator, and then removing it. The expected behavior is that a namespace is left behind that the cert-manager Operator created.


### PR DESCRIPTION
Addresses [OCPBUGS-2789](https://issues.redhat.com/browse/OCPBUGS-2789)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-2789
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://53661--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-known-issues
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
