### PR TITLE
CFE-712: Adds the procedure to configure AWS Load Balancer Operator on STS cluster by using predefined credentials

### DIFF
--- a/modules/bootstrap-aws-load-balancer-operator.adoc
+++ b/modules/bootstrap-aws-load-balancer-operator.adoc
@@ -7,7 +7,7 @@
 
 .Prerequisites
 
-* You must extract and prepare the `coctl` binary.
+* You must extract and prepare the `ccoctl` binary.
 
 .Procedure
 

--- a/modules/configuring-albo-on-sts-cluster-predefined-credentials.adoc
+++ b/modules/configuring-albo-on-sts-cluster-predefined-credentials.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+// * networking/installing-albo-sts-cluster.adoc
+
+:_content-type: PROCEDURE
+[id="nw-installing-albo-on-sts-cluster-predefined-credentials_{context}"]
+= Configuring the AWS Load Balancer Operator on Secure Token Service cluster by using specific credentials
+
+You can specify the credential secret by using the `spec.credentials` field in the AWS Load Balancer Controller custom resource (CR). You can use the predefined  `CredentialsRequest` object of the controller to know which roles are required.
+
+.Prerequisites
+
+* You must extract and prepare the `ccoctl` binary.
+
+.Procedure
+
+. Download the CredentialsRequest custom resource (CR) of the AWS Load Balancer Controller, and create a directory to store it by running the following command:
++
+[source,terminal]
+----
+$ curl --create-dirs -o <path-to-credrequests-dir>/cr.yaml https://raw.githubusercontent.com/openshift/aws-load-balancer-operator/main/hack/controller/controller-credentials-request.yaml
+----
+
+. Use the `ccoctl` tool to process the `CredentialsRequest` object of the controller:
++
+[source,terminal]
+----
+$ ccoctl aws create-iam-roles \
+        --name <name> --region=<aws_region> \
+        --credentials-requests-dir=<path-to-credrequests-dir> \
+        --identity-provider-arn <oidc-arn>
+----
+
+. Apply the secrets to your cluster:
++
+[source,terminal]
+----
+$ ls manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
+----
+
+. Verify the credentials secret has been created for use by the controller:
++
+[source,terminal]
+----
+$ oc -n aws-load-balancer-operator get secret aws-load-balancer-controller-manual-cluster --template='{{index .data "credentials"}}' | base64 -d
+----
++
+.Example output
+----
+[default]
+    sts_regional_endpoints = regional
+    role_arn = arn:aws:iam::999999999999:role/aws-load-balancer-operator-aws-load-balancer-controller
+    web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+----
+
+. Create the `AWSLoadBalancerController` resource YAML file, for example, `sample-aws-lb-manual-creds.yaml`, as follows:
++
+[source,yaml]
+----
+apiVersion: networking.olm.openshift.io/v1alpha1
+kind: AWSLoadBalancerController <1>
+metadata:
+  name: cluster <2>
+spec:
+  credentials:
+    name: <secret-name> <3>
+----
+<1> Defines the `AWSLoadBalancerController` resource.
+<2> Defines the AWS Load Balancer Controller instance name. This instance name gets added as a suffix to all related resources.
+<3> Specifies the secret name containing AWS credentials that the controller uses.
+
+

--- a/modules/configuring-albo-on-sts-cluster.adoc
+++ b/modules/configuring-albo-on-sts-cluster.adoc
@@ -3,11 +3,11 @@
 
 :_content-type: PROCEDURE
 [id="nw-installing-albo-on-sts-cluster_{context}"]
-= Configuring AWS Load Balancer Operator on Secure Token Service cluster
+= Configuring AWS Load Balancer Operator on Secure Token Service cluster by using managed `CredentialsRequest` objects
 
 .Prerequisites
 
-* You must extract and prepare the `coctl` binary.
+* You must extract and prepare the `ccoctl` binary.
 
 .Procedure
 

--- a/networking/aws_load_balancer_operator/installing-albo-sts-cluster.adoc
+++ b/networking/aws_load_balancer_operator/installing-albo-sts-cluster.adoc
@@ -8,11 +8,15 @@ toc::[]
 
 You can install the AWS Load Balancer Operator on the Secure Token Service (STS) cluster.
 
-The AWS Load Balancer Operator relies on `CredentialsRequest` to bootstrap the Operator and for each `AWSLoadBalancerController` instance. The AWS Load Balancer Operator waits until the required secrets are created and available. The Cloud Credential Operator does not provision the secrets automatically in the STS cluster. You must set the credentials secrets manually by using the `ccoctl` binary. 
+The AWS Load Balancer Operator relies on `CredentialsRequest` to bootstrap the Operator and for each `AWSLoadBalancerController` instance. The AWS Load Balancer Operator waits until the required secrets are created and available. The Cloud Credential Operator does not provision the secrets automatically in the STS cluster. You must set the credentials secrets manually by using the `ccoctl` binary.
+
+If you do not want to provision credential secret by using the Cloud Credential Operator, you can configure the `AWSLoadBalancerController` instance on the STS cluster by specifying the credential secret in the AWS load Balancer Controller custom resource (CR).
 
 include::modules/bootstrap-aws-load-balancer-operator.adoc[leveloffset=+1]
 
 include::modules/configuring-albo-on-sts-cluster.adoc[leveloffset=+1]
+
+include::modules/configuring-albo-on-sts-cluster-predefined-credentials.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
Adds the procedure to configure AWS Load Balancer Operator on STS cluster by using predefined credentials

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/CFE-712
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://53666--docspreview.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/installing-albo-sts-cluster.html#nw-installing-albo-on-sts-cluster-predefined-credentials_albo-sts-cluster
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
