### PR TITLE
OCPBUGS 4322 Broken link in Low latency tuning module

### DIFF
--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -45,7 +45,7 @@ Establishing the right performance expectations refers to the fact that the real
 == Provisioning a worker with real-time capabilities
 
 . Optional: Add a node to the {product-title} cluster.
-See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/8/html-single/tuning_guide/index#Setting_BIOS_parameters[Setting BIOS parameters].
+See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/8/html/optimizing_rhel_8_for_real_time_for_low_latency_operation/setting-bios-parameters-for-system-tuning_optimizing-rhel8-for-real-time-for-low-latency-operation[Setting BIOS parameters for system tuning].
 
 . Add the label `worker-rt` to the worker nodes that require the real-time capability by using the `oc` command.
 


### PR DESCRIPTION
[OCPBUGS-4322]: Broken link in Low latency tuning module

Version(s):
4.11, 4.12 and main
Issue:
https://issues.redhat.com/browse/OCPBUGS-4322

Link to docs preview:


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
