### PR TITLE
GH#53346: Removed vague language and included example for cloud provider variation ASH

### DIFF
--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -198,8 +198,36 @@ spec:
 ----
 endif::google-cloud-platform[]
 
-. Create YAML files for secrets in the `openshift-install` manifests directory that you generated previously. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object. The format for the secret data varies for each cloud provider.
+. Create YAML files for secrets in the `openshift-install` manifests directory that you generated previously. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object. 
 +
+ifdef::ash[] 
+.Sample `CredentialsRequest` object
+[source,yaml]
+----
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-image-registry-azure
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AzureProviderSpec
+    roleBindings:
+    - role: Contributor
+  secretRef:
+    name: installer-cloud-credentials
+    namespace: openshift-image-registry
+----
++
+endif::ash[] 
+
 [IMPORTANT]
 ====
 The release image includes `CredentialsRequest` objects for Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set. You can identify these objects by their use of the `release.openshift.io/feature-set: TechPreviewNoUpgrade` annotation.


### PR DESCRIPTION
Removed vague language ("The format for the secret data varies for each cloud provider.") from point 4 and included an example for cloud provider variation (Azure Stack Hub).

Version(s):
4.10+

Issue:
https://github.com/openshift/openshift-docs/issues/53346 

Link to docs preview:
https://53670--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.html#manually-create-iam_installing-azure-stack-hub-default

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
