### PR TITLE
OSDOCS-4083: Adding new entries for types migrated to CSI

### DIFF
--- a/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
@@ -127,7 +127,9 @@ For more information, see xref:../storage/understanding-persistent-storage.adoc#
 
 {product-title} 4 is migrating in-tree volume plug-ins to their Container Storage Interface (CSI) counterparts. In {product-title} {product-version}, CSI drivers are the new default for the following in-tree volume types:
 
+* Amazon Web Services (AWS) Elastic Block Storage (EBS)
 * Azure Disk
+* Google Cloud Platform Persistent Disk (GCP PD)
 * OpenStack Cinder
 
 All aspects of volume lifecycle, such as creation, deletion, mounting, and unmounting, is handled by the CSI driver.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4083

Link to docs preview:
https://53676--docspreview.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/planning-migration-3-4.html#migration-preparing-storage

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
