### PR TITLE
OSDOCS-4488: Duplicated the Limits and Scalability topic for OSD

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -69,6 +69,8 @@ Name: Planning your environment
 Dir: osd_planning
 Distros: openshift-dedicated
 Topics:
+- Name: Limits and scalability
+  File: osd-limits-scalability
 - Name: Customer Cloud Subscriptions on AWS
   File: aws-ccs
 - Name: Customer Cloud Subscriptions on GCP

--- a/modules/sd-planning-cluster-maximums-environment.adoc
+++ b/modules/sd-planning-cluster-maximums-environment.adoc
@@ -2,8 +2,10 @@
 // Module included in the following assemblies:
 //
 // rosa_planning/rosa-planning-environment.adoc
+// 
+// osd_planning/osd-planning-environment.adoc
 
-[id="rosa-planning-cluster-maximums-environment_{context}"]
+[id="planning-cluster-maximums-environment-sd_{context}"]
 = OpenShift Container Platform testing environment and configuration
 
 The following table lists the OpenShift Container Platform environment and configuration on which the cluster maximums are tested for the AWS cloud platform.

--- a/modules/sd-planning-cluster-maximums.adoc
+++ b/modules/sd-planning-cluster-maximums.adoc
@@ -2,11 +2,24 @@
 // Module included in the following assemblies:
 //
 // rosa_planning/rosa-planning-environment.adoc
+//
+// osd_planning/osd-planning-environment.adoc
 
-[id="tested-cluster-maximums_{context}"]
+[id="tested-cluster-maximums-sd_{context}"]
 = ROSA tested cluster maximums
 
-Consider the following tested object maximums when you plan a {product-title} (ROSA) cluster installation. The table specifies the maximum limits for each tested type in a ROSA cluster.
+Consider the following tested object maximums when you plan a {product-title}
+ifdef::openshift-rosa[]
+(ROSA) 
+endif::[]
+cluster installation. The table specifies the maximum limits for each tested type in a 
+ifdef::openshift-rosa[]
+(ROSA) 
+endif::[]
+ifdef::openshift-dedicated[]
+{product-title}  
+endif::[]
+cluster.
 
 These guidelines are based on a cluster of 102 compute (also known as worker) nodes in a multiple availability zone configuration. For smaller clusters, the maximums are lower.
 

--- a/modules/sd-planning-considerations.adoc
+++ b/modules/sd-planning-considerations.adoc
@@ -2,11 +2,17 @@
 // Module included in the following assemblies:
 //
 // rosa_planning/rosa-limits-scalability.adoc
+//
+// osd_planning/osd-planning-environment.adoc
 
-[id="control-plane-and-infra-node-sizing-and-scaling_{context}"]
+[id="control-plane-and-infra-node-sizing-and-scaling-sd_{context}"]
 = Control plane and infrastructure node sizing and scaling
 
-When you install a {product-title} (ROSA) cluster, the sizing of the control plane and infrastructure nodes are automatically determined by the compute node count.
+When you install a {product-title} 
+ifdef::openshift-rosa[]
+(ROSA) 
+endif::[]
+cluster, the sizing of the control plane and infrastructure nodes are automatically determined by the compute node count.
 
 If you change the number of compute nodes in your cluster after installation, the Red Hat Site Reliability Engineering (SRE) team scales the control plane and infrastructure nodes as required to maintain cluster stability.
 
@@ -35,7 +41,14 @@ The following table lists the control plane and infrastructure node sizing that 
 |===
 [.small]
 --
-1. The maximum number of compute nodes on ROSA is 180.
+1. The maximum number of compute nodes on 
+ifdef::openshift-rosa[]
+ROSA 
+endif::[]
+ifdef::openshift-dedicated[]
+{product-title} 
+endif::[]
+is 180.
 --
 
 [id="node-scaling-after-installation_{context}"]
@@ -66,12 +79,21 @@ Resizing alerts are triggered for the infrastructure nodes in a cluster when eit
 +
 [NOTE]
 ====
-The maximum number of compute nodes on ROSA is 180.
+The maximum number of compute nodes on 
+ifdef::openshift-rosa[]
+ROSA 
+endif::[]
+ifdef::openshift-dedicated[]
+{product-title} 
+endif::[]
+is 180.
 ====
 
 The SRE team might scale the control plane and infrastructure nodes for additional reasons, for example to manage an increase in resource consumption on the nodes.
 
+ifdef::openshift-rosa[]
 When scaling is applied, the customer is notified through a service log entry. For more information about the service log, see _Accessing the service logs for ROSA clusters_.
+endif::[]
 
 [id="sizing-considerations-for-larger-clusters_{context}"]
 == Sizing considerations for larger clusters

--- a/osd_planning/osd-limits-scalability.adoc
+++ b/osd_planning/osd-limits-scalability.adoc
@@ -1,0 +1,14 @@
+:_content-type: ASSEMBLY
+include::_attributes/attributes-openshift-dedicated.adoc[]
+
+[id="osd-limits-scalability"]
+= Limits and scalability
+:context: osd-limits-scalability
+
+toc::[]
+
+This document details the tested cluster maximums for {product-title} clusters, along with information about the test environment and configuration used to test the maximums. Information about control plane and infrastructure node sizing and scaling is also provided.
+
+include::modules/sd-planning-cluster-maximums.adoc[leveloffset=+1]
+include::modules/sd-planning-cluster-maximums-environment.adoc[leveloffset=+1]
+include::modules/sd-planning-considerations.adoc[leveloffset=+1]

--- a/rosa_planning/rosa-limits-scalability.adoc
+++ b/rosa_planning/rosa-limits-scalability.adoc
@@ -9,9 +9,9 @@ toc::[]
 
 This document details the tested cluster maximums for {product-title} (ROSA) clusters, along with information about the test environment and configuration used to test the maximums. Information about control plane and infrastructure node sizing and scaling is also provided.
 
-include::modules/rosa-planning-cluster-maximums.adoc[leveloffset=+1]
-include::modules/rosa-planning-cluster-maximums-environment.adoc[leveloffset=+1]
-include::modules/rosa-planning-considerations.adoc[leveloffset=+1]
+include::modules/sd-planning-cluster-maximums.adoc[leveloffset=+1]
+include::modules/sd-planning-cluster-maximums-environment.adoc[leveloffset=+1]
+include::modules/sd-planning-considerations.adoc[leveloffset=+1]
 
 [id="next-steps_configuring-alert-notifications"]
 == Next steps


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-4488](https://issues.redhat.com/browse/OSDOCS-4488)

Link to docs preview:
- **[OSD](https://53678--docspreview.netlify.app/openshift-dedicated/latest/osd_planning/osd-limits-scalability.html)**
- **[ROSA](https://53678--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-limits-scalability.html)** should be unchanged

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR ports the Limits and Scalability topic from ROSA to OSD.