### PR TITLE
OCPBUGS#3812 Ingress autoscaling omit maxReplicaCount default should be 100 not 50

### DIFF
--- a/modules/nw-autoscaling-ingress-controller.adoc
+++ b/modules/nw-autoscaling-ingress-controller.adoc
@@ -197,7 +197,7 @@ spec:
       name: keda-trigger-auth-prometheus
 ----
 <1> The custom resource that you are targeting. In this case, the Ingress Controller.
-<2> Optional: The maximum number of replicas. If you omit this field, the default maximum is set to 50 replicas.
+<2> Optional: The maximum number of replicas. If you omit this field, the default maximum is set to 100 replicas.
 <3> The cluster address and port.
 <4> The Ingress Operator namespace.
 <5> This expression evaluates to however many worker nodes are present in the deployed cluster.


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-3812

Link to docs preview:
https://53683--docspreview.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-autoscaling-ingress-controller_configuring-ingress

QE review:
- [X] QE has approved this change.

