### PR TITLE
BZ1939774 duplicate permission records in configuring an AWS account document

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -272,8 +272,6 @@ If you use an existing VPC, your account does not require these permissions to d
 * `iam:ListAccessKeys`
 * `iam:PutUserPolicy`
 * `iam:TagUser`
-* `iam:GetUserPolicy`
-* `iam:ListAccessKeys`
 * `s3:PutBucketPublicAccessBlock`
 * `s3:GetBucketPublicAccessBlock`
 * `s3:PutLifecycleConfiguration`


### PR DESCRIPTION
Version(s):
4.9+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=1939774

Link to docs preview:
https://53684--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-permissions-iam-roles_installing-aws-account

QE review:
- [X] QE has approved this change.

