### PR TITLE
OSDOCS-4675: Updating bootimage procedure

### DIFF
--- a/modules/multi-architecture-creating-arm64-bootimage.adoc
+++ b/modules/multi-architecture-creating-arm64-bootimage.adoc
@@ -42,13 +42,13 @@ $ az storage container create -n ${CONTAINER_NAME} --account-name ${STORAGE_ACCO
 +
 [source,terminal]
 ----
-$ RHCOS_VHD_ORIGIN_URL=$(./openshift-install coreos print-stream-json | jq -r '.architectures.aarch64."rhel-coreos-extensions"."azure-disk".url')
+$ RHCOS_VHD_ORIGIN_URL=$(oc -n openshift-machine-config-operator get configmap/coreos-bootimages -o jsonpath='{.data.stream}' | jq -r '.architectures.aarch64."rhel-coreos-extensions"."azure-disk".url')
 ----
 .. Extract the `aarch64` VHD name and set it to `BLOB_NAME` as the file name by running the following command:
 +
 [source,terminal]
 ----
-$ BLOB_NAME=rhcos-$(./openshift-install coreos print-stream-json | jq -r '.architectures.aarch64."rhel-coreos-extensions"."azure-disk".release')-azure.aarch64.vhd
+$ BLOB_NAME=rhcos-$(oc -n openshift-machine-config-operator get configmap/coreos-bootimages -o jsonpath='{.data.stream}' | jq -r '.architectures.aarch64."rhel-coreos-extensions"."azure-disk".release')-azure.aarch64.vhd
 ----
 . Generate a shared access signature (SAS) token. Use this token to upload the {op-system} VHD to your storage container with the following commands: 
 +


### PR DESCRIPTION
For version 4.11+
Issue: [OSDOCS-4675](https://issues.redhat.com//browse/OSDOCS-4675)

Preview:

[Configuring a multi-architecture cluster -> Creating an arm64 boot image using the Azure image gallery ](https://53688--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html#multi-architecture-creating-arm64-bootimage_multi-architecture-configuration)

QE review:
- [x] QE has approved this change.

