### PR TITLE
[OSDOCS-4677]: Update relnote and install links for RHACS 3.73

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -10,6 +10,7 @@
 :imagesdir: images
 :prewrap!:
 :acs: Red Hat Advanced Cluster Security
+:acs-short: RHACS
 :quay: Red Hat Quay
 :rh-storage-essentials-first: Red Hat OpenShift Data Foundation Essentials
 :rh-storage-data-foundation: Red Hat OpenShift Data Foundation

--- a/modules/opp-architecture-compatibility-matrix.adoc
+++ b/modules/opp-architecture-compatibility-matrix.adoc
@@ -16,7 +16,7 @@
 |{rh-storage-essentials-first}
 
 |2.6
-|3.72
+|3.73
 |3.7
 |4.11
 |===

--- a/modules/opp-architecture-installation.adoc
+++ b/modules/opp-architecture-installation.adoc
@@ -10,6 +10,6 @@ To install {product-title}, you must install two products in a specific order. I
 
 * {ocp} - link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/installing/installing-preparing#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
 * {rh-rhacm} - link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/install/installing[Installing {rh-rhacm}]
-* {acs} - link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.72/html/installing/install-ocp-operator[Installing {acs} for Kubernetes by using an Operator]
+* {acs} - link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.73/html/installing/installing-rhacs-on-red-hat-openshift[Installing {acs-short} on Red Hat OpenShift]
 * {rh-storage-essentials-first} - link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.11[Deploying {rh-storage-data-foundation}]
 * {quay} - link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/deploy_red_hat_quay_on_openshift_with_the_quay_operator/index[Deploy {quay} on OpenShift with the Quay Operator]

--- a/modules/opp-architecture-relnotes.adoc
+++ b/modules/opp-architecture-relnotes.adoc
@@ -11,5 +11,5 @@ The release note information for each product is accessible from the following l
 * link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/release_notes/index[{ocp}]
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/release_notes/red-hat-advanced-cluster-management-for-kubernetes-release-notes[{rh-rhacm} for Kubernetes]
 * link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.7/html/red_hat_quay_release_notes/index[{quay}]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.72/html/release_notes/index[{acs} for Kubernetes]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.73/html/release_notes/release-notes-373[{acs} for Kubernetes 3.7.3]
 * link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.11/html/4.11_release_notes/index[{rh-storage-data-foundation}]


### PR DESCRIPTION
[OSDOCS-4677](https://issues.redhat.com/browse/OSDOCS-4677)

Version(s): This PR is based on the ‘opp-docs’ repo and when merged, it should be in that branch only. The OPP doc is not versioned.

Epic: [OSDOCS-4676](https://issues.redhat.com/browse/OSDOCS-4676)

Link to docs preview:
[Release notes](http://file.rdu.redhat.com/tlove/opp-osdocs-4677-tlove/architecture/opp-architecture.html#opp-architecture-relnotes_opp-architecture)
[Installing](http://file.rdu.redhat.com/tlove/opp-osdocs-4677-tlove/architecture/opp-architecture.html#opp-architecture-installation_opp-architecture)
[Release compatibility](http://file.rdu.redhat.com/tlove/opp-osdocs-4677-tlove/architecture/opp-architecture.html#opp-architecture-compatibility-matrix_opp-architecture)


QE review:
- [ ] QE: N/A for RHACS
