### PR TITLE
BZ2117138 Reducing recommended vCPU and RAM values for OCP on OpenStack

### DIFF
--- a/modules/installation-osp-default-deployment.adoc
+++ b/modules/installation-osp-default-deployment.adoc
@@ -17,8 +17,8 @@ To support an {product-title} installation, your {rh-openstack-first} quota must
 |Ports                 | 15
 |Routers               | 1
 |Subnets               | 1
-|RAM                   | 112 GB
-|vCPUs                 | 28
+|RAM                   | 88 GB
+|vCPUs                 | 22
 |Volume storage        | 275 GB
 |Instances             | 7
 |Security groups       | 3


### PR DESCRIPTION
Version(s):
4.9+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2117138

Link to docs preview:
https://53697--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#installation-osp-default-deployment_installing-openstack-installer-custom

QE review:
- [X] QE has approved this change.

Reporter also wants to know if we should be lowering the "Volume Storage" recommendation from 275 GB to a lower value but did not know where that calculation came from.