### PR TITLE
BZ2117154 Reword storage space for OpenShift Container Platform cluster on RHOSP

### DIFF
--- a/modules/installation-osp-bootstrap-machine.adoc
+++ b/modules/installation-osp-bootstrap-machine.adoc
@@ -14,4 +14,5 @@ The bootstrap machine requires:
 
 * An instance from the {rh-openstack} quota
 * A port from the {rh-openstack} quota
-* A flavor with at least 16 GB memory, 4 vCPUs, and 100 GB storage space
+* A flavor with at least 16 GB memory and 4 vCPUs
+* At least 100 GB storage space from the {rh-openstack} quota

--- a/modules/installation-osp-control-compute-machines.adoc
+++ b/modules/installation-osp-control-compute-machines.adoc
@@ -24,7 +24,8 @@ Each machine requires:
 
 * An instance from the {rh-openstack} quota
 * A port from the {rh-openstack} quota
-* A flavor with at least 16 GB memory, 4 vCPUs, and 100 GB storage space
+* A flavor with at least 16 GB memory and 4 vCPUs
+* At least 100 GB storage space from the {rh-openstack} quota
 
 [id="installation-osp-compute-machines_{context}"]
 = Compute machines
@@ -36,7 +37,8 @@ Each machine requires:
 
 * An instance from the {rh-openstack} quota
 * A port from the {rh-openstack} quota
-* A flavor with at least 8 GB memory, 2 vCPUs, and 100 GB storage space
+* A flavor with at least 8 GB memory and 2 vCPUs
+* At least 100 GB storage space from the {rh-openstack} quota
 
 [TIP]
 ====


### PR DESCRIPTION
Version(s):
4.9+

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2117154

Link to docs preview:
[Control plane](https://53698--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#installation-osp-control-machines_installing-openstack-installer-custom)
[Compute](https://53698--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#installation-osp-compute-machines_installing-openstack-installer-custom)
[Bootstrap](https://53698--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#installation-osp-bootstrap-machine_installing-openstack-installer-custom)

QE review:
- [X] QE has approved this change.
