### PR TITLE
OSDOCS-4686: Created a table for the VPC requirements

### DIFF
--- a/modules/osd-aws-vpc-required-resources.adoc
+++ b/modules/osd-aws-vpc-required-resources.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
+// * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+//
+:_content-type: REFERENCE
+[id="osd-aws-vpc-required-resources_{context}"]
+= Amazon VPC Requirements for non-PrivateLink ROSA clusters
+
+To create an Amazon VPC, You must have the following:
+
+* An internet gateway,
+* A NAT gateway,
+* Private and public subnets that have internet connectivity provided to install required components. 
+
+You must have at least one single private and public subnet for Single-AZ clusters, and you need at least three private and public subnets for Multi-AZ clusters.

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
@@ -30,6 +30,14 @@ include::modules/rosa-sts-understanding-aws-account-association.adoc[leveloffset
 
 * For detailed steps to create and link the {cluster-manager} and user IAM roles, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-associating-your-aws-account_rosa-sts-creating-a-cluster-quickly[Associating your AWS account with your Red Hat organization].
 
+include::modules/osd-aws-vpc-required-resources.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about the default components required for an AWS cluster, see link:https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html[Default VPCs] in the AWS documentation.
+* For instructions on creating a VPC in the AWS console, see link:https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html[Create a VPC] in the AWS documentation.
+
 include::modules/rosa-sts-creating-a-cluster-quickly-ocm.adoc[leveloffset=+1]
 include::modules/rosa-sts-associating-your-aws-account.adoc[leveloffset=+2]
 include::modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+2]

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -30,6 +30,14 @@ include::modules/rosa-sts-arn-path-customization-for-iam-roles-and-policies.adoc
 //* TBC - ROSA CLI reference.
 
 include::modules/rosa-sts-support-considerations.adoc[leveloffset=+1]
+include::modules/osd-aws-vpc-required-resources.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about the default components required for an AWS cluster, see link:https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html[Default VPCs] in the AWS documentation.
+* For instructions on creating a VPC in the AWS console, see link:https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html[Create a VPC] in the AWS documentation.
+
 include::modules/rosa-sts-creating-a-cluster-using-customizations.adoc[leveloffset=+1]
 include::modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
Enterprise-4.13+

Issue:
[OSDOCS-4686](https://issues.redhat.com/browse/OSDOCS-4686)

Link to docs preview:
- **[Creating a ROSA cluster with customizations](https://53699--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#osd-aws-vpc-required-resources_rosa-sts-creating-a-cluster-with-customizations)**
- **[Creating a ROSA cluster quickly](https://53699--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.html#osd-aws-vpc-required-resources_rosa-sts-creating-a-cluster-quickly)**

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Created a new section for VPC requirements.