### PR TITLE
[RHACS] Updated release notes and version for 3.71.3 patch release

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -44,7 +44,7 @@ endif::[]
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 3.71.2
+:rhacs-version: 3.71.3
 :ocp-supported-version: 4.5
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 3.71

--- a/release_notes/371-release-notes.adoc
+++ b/release_notes/371-release-notes.adoc
@@ -31,6 +31,7 @@ To get Central back to working condition, follow the instructions at  link:https
 |`3.71.0` |25 July 2022
 |`3.71.1` |5 October 2022
 |`3.71.2` |17 October 2022
+|`3.71.3` |13 December 2022
 |====
 
 [id="new-features-371"]
@@ -295,6 +296,18 @@ In the table, features are marked with the following statuses:
 [id="bug-fixes-371"]
 == Bug fixes
 
+[id="bug-fixes-371-3"]
+=== Resolved in version 3.71.3
+
+Release date: 13 December 2022
+
+* Previously, if Central downloaded a corrupted CVE data file, it failed and
+entered a `CrashLoopBackOff` state. The patch release 3.71.3 fixes this issue.
+* This release contains security updates to address the following CVEs in the base images:
+
+** link:https://access.redhat.com/security/cve/CVE-2022-3515[CVE-2022-3515]: `libksba` Integer overflow may lead to remote code execution.
+** link:https://access.redhat.com/security/cve/CVE-2022-42898[CVE-2022-42898]: `krb5` Integer overflow vulnerabilities in PAC parsing.
+
 [id="bug-fixes-371-2"]
 === Resolved in version 3.71.2
 
@@ -310,9 +323,9 @@ Release date: 5 October 2022
 
 This release contains security updates to address the following CVEs in the base images:
 
-- link:https://access.redhat.com/security/cve/cve-2022-2526[CVE-2022-2526]: `systemd-resolved`: `use-after-free` when dealing with `DnsStream` in `resolved-dns-stream.c`
+* link:https://access.redhat.com/security/cve/cve-2022-2526[CVE-2022-2526]: `systemd-resolved`: `use-after-free` when dealing with `DnsStream` in `resolved-dns-stream.c`
 
-- link:https://access.redhat.com/security/cve/cve-2022-29154[CVE-2022-29154]: `rsync`: remote arbitrary files write inside the directories of connecting peers
+* link:https://access.redhat.com/security/cve/cve-2022-29154[CVE-2022-29154]: `rsync`: remote arbitrary files write inside the directories of connecting peers
 
 [id="bug-fixes-371-0"]
 === Resolved in version 3.71.0


### PR DESCRIPTION
Merge into `rhacs-docs-3.71`

No cherrypicks required.


---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
