### PR TITLE
TELCODOCS-1017: Image registry and image source policy setup in disco…

### DIFF
--- a/modules/ztp-acm-installing-disconnected-rhacm.adoc
+++ b/modules/ztp-acm-installing-disconnected-rhacm.adoc
@@ -15,6 +15,11 @@ Use {rh-rhacm-first}, {gitops-title}, and {cgu-operator-first} on the hub cluste
 * You have logged in as a user with `cluster-admin` privileges.
 
 * You have configured a disconnected mirror registry for use in the cluster.
++
+[NOTE]
+====
+The disconnected mirror registry that you create must contain a version of {cgu-operator} backup and pre-cache images that matches the version of {cgu-operator} running in the hub cluster. The spoke cluster must be able to resolve these images in the disconnected mirror registry.
+====
 
 .Procedure
 


### PR DESCRIPTION
…nnected environment for TALM precaching/backup features

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->[TELCODOCS-1017](https://issues.redhat.com//browse/TELCODOCS-1017): Image registry and image source policy setup in disconnected environment for TALM precaching/backup features


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Version(s): 4.12, 4.11, 4.10

Issue: https://issues.redhat.com/browse/TELCODOCS-1017
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://53711--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster#installing-disconnected-rhacm_ztp-preparing-the-hub-cluster
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
