### PR TITLE
Telcodocs 1016 411 RN Adding Release note for bug 2050824 (redoing #53672 closed in error)

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -456,11 +456,11 @@ Enabling this service monitor eliminates the possibility that two queries sent a
 ==== Update to Alertmanager configuration for additional secret keys
 With this release, if you configure an Alertmanager secret to hold additional keys and if the Alertmanager configuration references these keys as files (such as templates, TLS certificates, or tokens), your configuration settings must point to these keys by using an absolute path rather than a relative path.
 These keys are available under the `/etc/alertmanager/config` directory.
-In earlier releases of {product-title}, you could use relative paths in your configuration to point to these keys because the Alertmanager configuration file was located in the same directory as the keys. 
+In earlier releases of {product-title}, you could use relative paths in your configuration to point to these keys because the Alertmanager configuration file was located in the same directory as the keys.
 
 [IMPORTANT]
 ====
-If you are upgrading to {product-title} {product-version} and have specified relative paths for additional Alertmanager secret keys that are referenced as files, you must change these relative paths to absolute paths in your Alertmanager configuration. 
+If you are upgrading to {product-title} {product-version} and have specified relative paths for additional Alertmanager secret keys that are referenced as files, you must change these relative paths to absolute paths in your Alertmanager configuration.
 Otherwise, alert receivers that use the files will fail to deliver notifications.
 ====
 
@@ -885,7 +885,7 @@ In the following tables, features are marked with the following statuses:
 
 |CSI Azure File Driver Operator
 |Technology Preview
-|General Availibility 
+|General Availibility
 |General Availibility
 
 |CSI automatic migration
@@ -943,7 +943,7 @@ In the following tables, features are marked with the following statuses:
 |IBM Cloud VPC clusters
 |Technology Preview
 |Technology Preview
-|General Availability 
+|General Availability
 
 |Selectable Cluster Inventory
 |Technology Preview
@@ -1078,7 +1078,7 @@ In the following tables, features are marked with the following statuses:
 |Dynamic Plug-ins
 |Technology Preview
 |Technology Preview
-|General Availability 
+|General Availability
 
 |====
 
@@ -1096,7 +1096,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Node Observability Operator
-|Not Available 
+|Not Available
 |Technology Preview
 |Technology Preview
 
@@ -1136,7 +1136,7 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 
 |Alerting rules based on platform monitoring metrics
-|Not Available 
+|Not Available
 |Technology Preview
 |Technology Preview
 
@@ -1348,6 +1348,8 @@ $ ./openshift-install wait-for install-complete
 * Due to the inclusion of old images in some image indexes, running `oc adm catalog mirror` and `oc image mirror` might result in the following error: `error: unable to retrieve source image`. As a temporary workaround, you can use the `--skip-missing` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed].
 
 * There is a known issue with Nutanix installation where the installation fails if you use 4096-bit certificates with Prism Central 2022.x. Instead, use 2048-bit certificates. (link:https://access.redhat.com/solutions/6976743[*KCS*])
+
+* Deleting the bidirectional forwarding detection (BFD) profile and removing the `bfdProfile` added to the border gateway protocol (BGP) peer resource does not disable the BFD. Instead, the BGP peer starts using the default BFD profile. To disable BFD from a BGP peer resource, delete the BGP peer configuration and recreate it without a BFD profile. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2050824[*BZ#2050824*])
 
 * Due to an unresolved metadata API issue, you cannot install clusters that use bare-metal workers on {rh-openstack} 16.1. Clusters on {rh-openstack} 16.2 are not impacted by this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033953[*BZ#2033953*])
 


### PR DESCRIPTION
[TELCODOCS-1016](https://issues.redhat.com//browse/TELCODOCS-1016): Deleting a BFDProfile object does not delete the corresponding running-conf from the MetalLB speakers

See also https://bugzilla.redhat.com/show_bug.cgi?id=2050824

Version(s):
4.12 RN

Preview: https://53712--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-known-issues

Already reviewed in https://github.com/openshift/openshift-docs/pull/53672 closed in error whilst fixing an issue.  