### PR TITLE
CNF 5456 Revision of the networking stack pinning

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -456,17 +456,27 @@ Enabling this service monitor eliminates the possibility that two queries sent a
 ==== Update to Alertmanager configuration for additional secret keys
 With this release, if you configure an Alertmanager secret to hold additional keys and if the Alertmanager configuration references these keys as files (such as templates, TLS certificates, or tokens), your configuration settings must point to these keys by using an absolute path rather than a relative path.
 These keys are available under the `/etc/alertmanager/config` directory.
-In earlier releases of {product-title}, you could use relative paths in your configuration to point to these keys because the Alertmanager configuration file was located in the same directory as the keys. 
+In earlier releases of {product-title}, you could use relative paths in your configuration to point to these keys because the Alertmanager configuration file was located in the same directory as the keys.
 
 [IMPORTANT]
 ====
-If you are upgrading to {product-title} {product-version} and have specified relative paths for additional Alertmanager secret keys that are referenced as files, you must change these relative paths to absolute paths in your Alertmanager configuration. 
+If you are upgrading to {product-title} {product-version} and have specified relative paths for additional Alertmanager secret keys that are referenced as files, you must change these relative paths to absolute paths in your Alertmanager configuration.
 Otherwise, alert receivers that use the files will fail to deliver notifications.
 ====
 
 
 [id="ocp-4-12-scalability-and-performance"]
 === Scalability and performance
+
+[id="ocp-4-12-rsp-workload-hints"]
+==== Disabling realtime using workload hints removes Receive Packet Steering from the cluster
+At the cluster level by default, a systemd service sets a Receive Packet Steering (RPS) mask for virtual network interfaces. The RPS mask routes interrupt requests from virtual network interfaces according to the list of reserved CPUs defined in the performance profile. At the container level, a `CRI-O` hook script also sets an RPS mask for all virtual network devices.
+
+With this update, if you set `spec.workloadHints.realTime` in the performance profile to `False`, the system also disables both the systemd service and the `CRI-O` hook script which set the RPS mask. The system disables these RPS functions because RPS is typically relevant to use cases requiring low-latency, realtime workloads only.
+
+To retain RPS functions even when you set `spec.workloadHints.realTime` to `False`, see the _RPS Settings_ section of the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/5532341[Performance addons operator advanced configuration].
+
+For more information about configuring workload hints, see xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#cnf-understanding-workload-hints_cnf-master[Understanding workload hints].
 
 [id="ocp-4-12-tuned"]
 ==== Tuned profile
@@ -885,7 +895,7 @@ In the following tables, features are marked with the following statuses:
 
 |CSI Azure File Driver Operator
 |Technology Preview
-|General Availibility 
+|General Availibility
 |General Availibility
 
 |CSI automatic migration
@@ -943,7 +953,7 @@ In the following tables, features are marked with the following statuses:
 |IBM Cloud VPC clusters
 |Technology Preview
 |Technology Preview
-|General Availability 
+|General Availability
 
 |Selectable Cluster Inventory
 |Technology Preview
@@ -1078,7 +1088,7 @@ In the following tables, features are marked with the following statuses:
 |Dynamic Plug-ins
 |Technology Preview
 |Technology Preview
-|General Availability 
+|General Availability
 
 |====
 
@@ -1096,7 +1106,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Node Observability Operator
-|Not Available 
+|Not Available
 |Technology Preview
 |Technology Preview
 
@@ -1136,7 +1146,7 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 
 |Alerting rules based on platform monitoring metrics
-|Not Available 
+|Not Available
 |Technology Preview
 |Technology Preview
 


### PR DESCRIPTION
[CNF-5456]: Revision of the networking stack pinning

Version(s):
4.12 RN entry
Issue:
https://issues.redhat.com/browse/CNF-5456

Link to docs preview:
https://53716--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-rsp-workload-hints

QE review:

 QE has approved this change.