### PR TITLE
[enterprise-4.11]SRVCOM-2141 Revert to earlier version of Installing Operator docs

### DIFF
--- a/modules/serverless-cluster-sizing-req-additional.adoc
+++ b/modules/serverless-cluster-sizing-req-additional.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * /serverless/install/install-serverless-operator.adoc
+
+:_content-type: REFERENCE
+[id="serverless-cluster-sizing-req-additional_{context}"]
+= Additional requirements for advanced use-cases
+
+For more advanced use-cases such as logging or metering on {product-title}, you must deploy more resources. Recommended requirements for such use-cases are 24 CPUs and 96GB of memory.
+
+If you have high availability (HA) enabled on your cluster, this requires between 0.5 - 1.5 cores and between 200MB - 2GB of memory for each replica of the Knative Serving control plane.
+HA is enabled for some Knative Serving components by default. You can disable HA by following the documentation on "Configuring high availability replicas".

--- a/modules/serverless-cluster-sizing-req.adoc
+++ b/modules/serverless-cluster-sizing-req.adoc
@@ -6,13 +6,14 @@
 [id="serverless-cluster-sizing-req_{context}"]
 = Defining cluster size requirements
 
-To install and use {ServerlessProductName}, the {product-title} cluster must be sized correctly. The total size requirements to run {ServerlessProductName} are dependent on the components that are installed and the applications that are deployed, and might vary depending on your deployment.
+To install and use {ServerlessProductName}, the {product-title} cluster must be sized correctly. 
 
 [NOTE]
 ====
 The following requirements relate only to the pool of worker machines of the {product-title} cluster. Control plane nodes are not used for general scheduling and are omitted from the requirements.
 ====
 
-By default, each pod requests approximately 400m of CPU, so the minimum requirements are based on this value. Lowering the actual CPU request of applications can increase the number of possible replicas.
+The minimum requirement to use {ServerlessProductName} is a cluster with 10 CPUs and 40GB memory.
+By default, each pod requests ~400m of CPU, so the minimum requirements are based on this value.
 
-If you have high availability (HA) enabled on your cluster, this requires between 0.5 - 1.5 cores and between 200MB - 2GB of memory for each replica of the Knative Serving control plane.
+The total size requirements to run {ServerlessProductName} are dependent on the components that are installed and the applications that are deployed, and might vary depending on your deployment.

--- a/serverless/install/install-serverless-operator.adoc
+++ b/serverless/install/install-serverless-operator.adoc
@@ -26,6 +26,12 @@ include::modules/serverless-cluster-sizing-req.adoc[leveloffset=+2]
 
 You can use the {product-title} `MachineSet` API to manually scale your cluster up to the desired size. The minimum requirements usually mean that you must scale up one of the default machine sets by two additional machines. See xref:../../machine_management/manually-scaling-machineset.adoc#manually-scaling-machineset[Manually scaling a machine set].
 
+include::modules/serverless-cluster-sizing-req-additional.adoc[leveloffset=+3]
+
+[id="additional-resources_serverless-cluster-sizing-req-additional"]
+.Additional resources
+xref:../../serverless/admin_guide/serverless-ha.adoc#serverless-ha[Configuring high availability replicas on {ServerlessProductName}].
+
 // TODO: Add OSD specific docs for auto scaling machine sets? These docs aren't available for OSD so we need to look into what's required to doc here.
 // QE thread related: https://coreos.slack.com/archives/CD87JDUB0/p1643986092796179
 endif::[]


### PR DESCRIPTION


Version(s):
4.11

Issue:
https://issues.redhat.com/browse/SRVCOM-2141

Link to docs preview:


QE has approved this change.


Additional information:
Cherry pick to 4.11 for https://github.com/openshift/openshift-docs/pull/52773
