### PR TITLE
logging: Fix ClusterLogging example in LokiStack howto

### DIFF
--- a/modules/cluster-logging-forwarding-lokistack.adoc
+++ b/modules/cluster-logging-forwarding-lokistack.adoc
@@ -9,7 +9,7 @@ To configure log forwarding to the LokiStack gateway, you must create a ClusterL
 .Prerequisites
 
 * {logging-title-uc}: 5.5 and later
-* `LokiOperator` Operator
+* `Loki Operator` Operator
 
 .Procedure
 
@@ -23,10 +23,11 @@ metadata:
   name: instance
   namespace: openshift-logging
 spec:
+  managementState: Managed
   logStore:
     type: lokistack
     lokistack:
-      name: lokistack-dev
+      name: logging-loki
   collection:
     type: vector
 ----

--- a/modules/cluster-logging-loki-deploy.adoc
+++ b/modules/cluster-logging-loki-deploy.adoc
@@ -12,11 +12,11 @@ You can use the {product-title} web console to deploy the LokiStack.
 
 .Procedure
 
-. Install the `LokiOperator` Operator:
+. Install the `Loki Operator` Operator:
 
 .. In the {product-title} web console, click *Operators* -> *OperatorHub*.
 
-.. Choose  *LokiOperator* from the list of available Operators, and click *Install*.
+.. Choose  *Loki Operator* from the list of available Operators, and click *Install*.
 
 .. Under *Installation Mode*, select *All namespaces on the cluster*.
 
@@ -40,9 +40,9 @@ You must select this option to ensure that cluster monitoring scrapes the `opens
 
 .. Click *Install*.
 
-.. Verify that you installed the LokiOperator. Visit the *Operators* → *Installed Operators* page and look for *LokiOperator*.
+.. Verify that you installed the Loki Operator. Visit the *Operators* → *Installed Operators* page and look for *Loki Operator*.
 
-.. Ensure that *LokiOperator* is listed with *Status* as *Succeeded* in all the projects.
+.. Ensure that *Loki Operator* is listed with *Status* as *Succeeded* in all the projects.
 +
 . Create a `Secret` YAML file that uses the `access_key_id` and `access_key_secret` fields to specify your AWS credentials and `bucketnames`, `endpoint` and `region` to define the object storage location. For example:
 +
@@ -65,23 +65,23 @@ stringData:
 +
 [source,yaml]
 ----
-  apiVersion: loki.grafana.com/v1
-  kind: LokiStack
-  metadata:
-    name: logging-loki
-    namespace: openshift-logging
-  spec:
-    size: 1x.small
-    storage:
-      schemas:
-      - version: v12
-        effectiveDate: '2022-06-01'
-      secret:
-        name: logging-loki-s3
-        type: s3
-    storageClassName: gp2
-    tenants:
-      mode: openshift-logging
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  size: 1x.small
+  storage:
+    schemas:
+    - version: v12
+      effectiveDate: "2022-06-01"
+    secret:
+      name: logging-loki-s3
+      type: s3
+  storageClassName: gp2
+  tenants:
+    mode: openshift-logging
 ----
 +
 .. Apply the configuration:
@@ -95,19 +95,19 @@ oc apply -f logging-loki.yaml
 +
 [source,yaml]
 ----
-  apiVersion: logging.openshift.io/v1
-  kind: ClusterLogging
-  metadata:
-    name: instance
-    namespace: openshift-logging
-  spec:
-    managementState: Managed
-    logStore:
-      type: lokistack
-      lokistack:
-        name: logging-loki
-      collection:
-        type: "vector"
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  managementState: Managed
+  logStore:
+    type: lokistack
+    lokistack:
+      name: logging-loki
+  collection:
+    type: vector
 ----
 +
 .. Apply the configuration:

--- a/modules/cluster-logging-loki-tech-preview.adoc
+++ b/modules/cluster-logging-loki-tech-preview.adoc
@@ -16,20 +16,20 @@ Loki is a horizontally scalable, highly available, multi-tenant log aggregation 
 * link:https://grafana.com/docs/loki/latest/[Loki Documentation]
 
 == Deploying the Lokistack
-You can use the {product-title} web console to install the LokiOperator.
+You can use the {product-title} web console to install the Loki Operator.
 
 .Prerequisites
 
 * {product-title}: 4.11
 * {logging-title-uc}: 5.4
 
-To install the LokiOperator using the {product-title} web console:
+To install the Loki Operator using the {product-title} web console:
 
-. Install the LokiOperator:
+. Install the Loki Operator:
 
 .. In the {product-title} web console, click *Operators* -> *OperatorHub*.
 
-.. Choose  *LokiOperator* from the list of available Operators, and click *Install*.
+.. Choose  *Loki Operator* from the list of available Operators, and click *Install*.
 
 .. Under *Installation Mode*, select *All namespaces on the cluster*.
 
@@ -54,6 +54,6 @@ scrapes the `openshift-operators-redhat` namespace.
 
 .. Click *Install*.
 
-.. Verify that you installed the LokiOperator. Visit the *Operators* → *Installed Operators* page and look for "LokiOperator."
+.. Verify that you installed the Loki Operator. Visit the *Operators* → *Installed Operators* page and look for "Loki Operator."
 
-.. Ensure that *LokiOperator* is listed in all the projects whose *Status* is *Succeeded*.
+.. Ensure that *Loki Operator* is listed in all the projects whose *Status* is *Succeeded*.

--- a/modules/cluster-logging-rn-5.5.adoc
+++ b/modules/cluster-logging-rn-5.5.adoc
@@ -17,7 +17,7 @@ JSON formatting of logs varies by application. Because creating too many indices
 
 * With this update, clusters with AWS Security Token Service (STS) enabled may use STS authentication to forward logs to Amazon CloudWatch. (link:https://issues.redhat.com/browse/LOG-1976[LOG-1976])
 
-* With this update, the 'LokiOperator' Operator and Vector collector move from Technical Preview to General Availability. Full feature parity with prior releases are pending, and some APIs remain Technical Previews. See the *Logging with the LokiStack* section for details.
+* With this update, the 'Loki Operator' Operator and Vector collector move from Technical Preview to General Availability. Full feature parity with prior releases are pending, and some APIs remain Technical Previews. See the *Logging with the LokiStack* section for details.
 
 [id="openshift-logging-5-5-0-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+

Issue:

Link to docs preview:

QE review:
- [ ] QE has approved this change.

Additional information:

While having a look at the LokiStack howto in the context of a customer case, I noticed that the `ClusterLogging` example was not correct, as `collection` is not on the correct indentation level.

This PR fixes this issue and also does the following other cleanups I noticed while reading through the howto:

- `Loki Operator` has a space in the operator catalog, corrected in the docs for easier copying
- Removed two-spaces indentation of the example manifests in LokiStack howto
- Replaced example ClusterLogging in "Forwarding to LokiStack" howto with the version from "Deploying the LokiStack" to have parity.

I can also split this up into multiple PRs if this is preferred.

cc @libander 
