### PR TITLE
OCPBUGS-4196 - 4.11, 4.12 vDU PerformanceProfile example is not synced with ZTP vDU profile

### DIFF
--- a/snippets/ztp-performance-profile.adoc
+++ b/snippets/ztp-performance-profile.adoc
@@ -8,8 +8,8 @@ metadata:
   name: openshift-node-performance-profile <1>
 spec:
   additionalKernelArgs:
-    - rcupdate.rcu_normal_after_boot=0
-    - "efi=runtime" <2>
+  - "rcupdate.rcu_normal_after_boot=0"
+  - "efi=runtime" <2>
   cpu:
     isolated: 2-51,54-103 <3>
     reserved: 0-1,52-53   <4>
@@ -18,14 +18,15 @@ spec:
     pages:
       - count: 32 <5>
         size: 1G  <6>
+        node: 0 <7>
   machineConfigPoolSelector:
     pools.operator.machineconfiguration.openshift.io/master: ""
   nodeSelector:
     node-role.kubernetes.io/master: ""
   numa:
-    topologyPolicy: restricted
+    topologyPolicy: "restricted"
   realTimeKernel:
-    enabled: true    <7>
+    enabled: true    <8>
 ----
 <1> Ensure that the value for `name` matches that specified in the `spec.profile.data` field of `TunedPerformancePatch.yaml` and the `status.configuration.source.name` field of `validatorCRs/informDuValidator.yaml`.
 <2> Configures UEFI secure boot for the cluster host.
@@ -38,4 +39,5 @@ The reserved and isolated CPU pools must not overlap and together must span all 
 <4> Set the reserved CPUs. When workload partitioning is enabled, system processes, kernel threads, and system container threads are restricted to these CPUs. All CPUs that are not isolated should be reserved.
 <5> Set the number of huge pages.
 <6> Set the huge page size.
-<7> Set `enabled` to `true` to install the real-time Linux kernel.
+<7> Set `node` to the NUMA node where the `hugepages` are allocated.
+<8> Set `enabled` to `true` to install the real-time Linux kernel.


### PR DESCRIPTION

Version(s): 4.11+

Issue: https://issues.redhat.com/browse/OCPBUGS-4196

Link to docs preview: https://53733--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.html#ztp-sno-du-configuring-performance-addons_sno-configure-for-vdu

QE review:
- [ ] QE has approved this change.
