### PR TITLE
RelNotes for Compliance Operator 0.1.59

### DIFF
--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -13,6 +13,27 @@ These release notes track the development of the Compliance Operator in the {pro
 
 For an overview of the Compliance Operator, see xref:../../security/compliance_operator/compliance-operator-understanding.adoc#understanding-compliance-operator[Understanding the Compliance Operator].
 
+[id="compliance-operator-release-notes-0-1-59"]
+== OpenShift Compliance Operator 0.1.59
+
+The following advisory is available for the OpenShift Compliance Operator 0.1.59:
+
+* link:https://access.redhat.com/errata/RHBA-2022:8538[RHBA-2022:8538 - OpenShift Compliance Operator bug fix update]
+
+[id="compliance-operator-0-1-59-new-features-and-enhancements"]
+=== New features and enhancements
+
+* The Compliance Operator now supports Payment Card Industry Data Security Standard (PCI-DSS) `ocp4-pci-dss` and `ocp4-pci-dss-node` profiles on the `ppc64le` architecture.
+
+[id="compliance-operator-0-1-59-bug-fixes"]
+=== Bug fixes
+
+* Previously, the Compliance Operator did not support the Payment Card Industry Data Security Standard (PCI DSS) `ocp4-pci-dss` and `ocp4-pci-dss-node` profiles on different architectures such as `ppc64le`. Now, the Compliance Operator supports `ocp4-pci-dss` and `ocp4-pci-dss-node` profiles on the `ppc64le` architecture. (link:https://issues.redhat.com/browse/OCPBUGS-3252[*OCPBUGS-3252*])
+
+* Previously, after the recent update to version 0.1.57, the `rerunner` service account (SA) was no longer owned by the cluster service version (CSV), which caused the SA to be removed during the Operator upgrade. Now, the CSV owns the `rerunner` SA in 0.1.59, and upgrades from any previous version will not result in a missing SA. (link:https://issues.redhat.com/browse/OCPBUGS-3452[*OCPBUGS-3452*])
+
+* In 0.1.57, the Operator started the controller metrics endpoint listening on port `8080`. This resulted in `TargetDown` alerts since cluster monitoring expected port is `8383`. With 0.1.59, the Operator starts the endpoint listening on port `8383` as expected. (link:https://issues.redhat.com/browse/OCPBUGS-3097[*OCPBUGS-3097*])
+
 [id="compliance-operator-release-notes-0-1-57"]
 == OpenShift Compliance Operator 0.1.57
 


### PR DESCRIPTION
[OSDOCS-4568](https://issues.redhat.com//browse/OSDOCS-4568)
This PR reverts the changes made in https://github.com/openshift/openshift-docs/pull/53681, and re-adds the changes from https://github.com/openshift/openshift-docs/pull/52987

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

**Version(s):**

- PR applies to 4.8+


**Issue:**
https://issues.redhat.com/browse/OSDOCS-4568

**Link to docs preview:**
https://53748--docspreview.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-release-notes.html#compliance-operator-release-notes-0-1-59

**Additional information:**
Release Notes for Compliance Operator 0.1.59 was merged into documentation without the advisory link being shipped live. This PR corrects this error and errata is `shipped live`

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
