### PR TITLE
[enterprise-4.8] SRVKE-1323 Add the Eventing distributed tracing configuration

### DIFF
--- a/modules/serverless-jaeger-config.adoc
+++ b/modules/serverless-jaeger-config.adoc
@@ -11,7 +11,7 @@ If you do not want to install all of the components of {DTProductName}, you can 
 .Prerequisites
 
 * You have access to an {product-title} account with cluster administrator access.
-* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have installed the {ServerlessOperatorName}, Knative Serving, and Knative Eventing.
 * You have installed the {JaegerName} Operator.
 * You have installed the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
@@ -32,7 +32,7 @@ metadata:
 
 . Enable tracing for Knative Serving, by editing the `KnativeServing` CR and adding a YAML configuration for tracing:
 +
-.Tracing YAML example
+.Tracing YAML example for Serving
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1alpha1
@@ -52,6 +52,30 @@ spec:
 <1> The `sample-rate` defines sampling probability. Using `sample-rate: "0.1"` means that 1 in 10 traces are sampled.
 <2> `backend` must be set to `zipkin`.
 <3> The `zipkin-endpoint` must point to your `jaeger-collector` service endpoint. To get this endpoint, substitute the namespace where the Jaeger CR is applied.
+<4> Debugging should be set to `false`. Enabling debug mode by setting `debug: "true"` allows all spans to be sent to the server, bypassing sampling.
+
+. Enable tracing for Knative Eventing by editing the `KnativeEventing` CR:
++
+.Tracing YAML example for Eventing
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  config:
+    tracing:
+      sample-rate: "0.1" <1>
+      backend: zipkin <2>
+      zipkin-endpoint: "http://jaeger-collector.default.svc.cluster.local:9411/api/v2/spans" <3>
+      debug: "false" <4>
+----
++
+<1> The `sample-rate` defines sampling probability. Using `sample-rate: "0.1"` means that 1 in 10 traces are sampled.
+<2> Set `backend` to `zipkin`.
+<3> Point the `zipkin-endpoint` to your `jaeger-collector` service endpoint. To get this endpoint, substitute the namespace where the Jaeger CR is applied.
 <4> Debugging should be set to `false`. Enabling debug mode by setting `debug: "true"` allows all spans to be sent to the server, bypassing sampling.
 
 .Verification

--- a/modules/serverless-open-telemetry.adoc
+++ b/modules/serverless-open-telemetry.adoc
@@ -11,7 +11,7 @@
 .Prerequisites
 
 * You have access to an {product-title} account with cluster administrator access.
-* You have not yet installed the {ServerlessOperatorName} and Knative Serving. These must be installed after the {DTProductName} installation.
+* You have not yet installed the {ServerlessOperatorName}, Knative Serving, and Knative Eventing. These must be installed after the {DTProductName} installation.
 * You have installed {DTProductName} by following the {product-title} "Installing distributed tracing" documentation.
 * You have installed the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
@@ -77,7 +77,7 @@ cluster-collector-collector-headless            ClusterIP   None             <no
 jaeger-all-in-one-inmemory-collector-headless   ClusterIP   None             <none>        9411/TCP,14250/TCP,14267/TCP,14268/TCP   16m
 ----
 +
-These services are used to configure Jaeger and Knative Serving. The name of the Jaeger service may vary.
+These services are used to configure Jaeger, Knative Serving, and Knative Eventing. The name of the Jaeger service may vary.
 
 . Install the {ServerlessOperatorName} by following the "Installing the {ServerlessOperatorName}" documentation.
 
@@ -96,7 +96,27 @@ spec:
     tracing:
       backend: "zipkin"
       zipkin-endpoint: "http://cluster-collector-collector-headless.tracing-system.svc:9411/api/v2/spans"
-      debug: "true"
+      debug: "false"
+      sample-rate: "0.1" <1>
+----
+<1> The `sample-rate` defines sampling probability. Using `sample-rate: "0.1"` means that 1 in 10 traces are sampled.
+
+. Install Knative Eventing by creating the following `KnativeEventing` CR:
++
+.Example KnativeEventing CR
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+    name: knative-eventing
+    namespace: knative-eventing
+spec:
+  config:
+    tracing:
+      backend: "zipkin"
+      zipkin-endpoint: "http://cluster-collector-collector-headless.tracing-system.svc:9411/api/v2/spans"
+      debug: "false"
       sample-rate: "0.1" <1>
 ----
 <1> The `sample-rate` defines sampling probability. Using `sample-rate: "0.1"` means that 1 in 10 traces are sampled.


### PR DESCRIPTION


Version(s):
4.8

Issue:
https://issues.redhat.com/browse/SRVKE-1323

Additional information:
Cherry pick to 4.8 for https://github.com/openshift/openshift-docs/pull/53463