### PR TITLE
OCPBUGS-4424: autoSizingReserved value is not honored in kubeletconfig

### DIFF
--- a/modules/nodes-nodes-resources-configuring-auto.adoc
+++ b/modules/nodes-nodes-resources-configuring-auto.adoc
@@ -66,8 +66,7 @@ kind: KubeletConfig
 metadata:
   name: dynamic-node <1>
 spec:
-  kubeletConfig:
-    autoSizingReserved: true <2>
+  autoSizingReserved: true <2>
   machineConfigPoolSelector:
     matchLabels:
       pools.operator.machineconfiguration.openshift.io/worker: "" <3>


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-4424

Preview: [Automatically allocating resources for nodes](https://53768--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-configuring.html#nodes-nodes-resources-configuring-auto_nodes-nodes-resources-configuring), Step 1

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

