### PR TITLE
OCPBUGS-4196 - 4.10 vDU PerformanceProfile example is not synced with ZTP vDU profile 

### DIFF
--- a/snippets/ztp-performance-profile.adoc
+++ b/snippets/ztp-performance-profile.adoc
@@ -8,17 +8,17 @@ metadata:
   name: openshift-node-performance-profile <1>
 spec:
   additionalKernelArgs:
-    - idle=poll
-    - rcupdate.rcu_normal_after_boot=0
-    - "efi=runtime" <2>
+    - "idle=poll"
+    - "rcupdate.rcu_normal_after_boot=0"
   cpu:
-    isolated: 2-51,54-103 <3>
-    reserved: 0-1,52-53   <4>
+    isolated: 2-51,54-103 <2>
+    reserved: 0-1,52-53   <3>
   hugepages:
     defaultHugepagesSize: 1G
     pages:
-      - count: 32 <5>
-        size: 1G  <6>
+      - count: 32 <4>
+        size: 1G  <5>
+        node: 1 <6>
   machineConfigPoolSelector:
     pools.operator.machineconfiguration.openshift.io/master: ""
   net:
@@ -26,15 +26,15 @@ spec:
   nodeSelector:
     node-role.kubernetes.io/master: ""
   numa:
-    topologyPolicy: restricted
+    topologyPolicy: "restricted"
   realTimeKernel:
     enabled: true    <8>
 ----
 <1> Ensure that the value for `name` matches that specified in the `spec.profile.data` field of `TunedPerformancePatch.yaml` and the `status.configuration.source.name` field of `validatorCRs/informDuValidator.yaml`.
-<2> Configures UEFI secure boot for the cluster host.
-<3> Set the isolated CPUs. Ensure all of the Hyper-Threading pairs match.
-<4> Set the reserved CPUs. When workload partitioning is enabled, system processes, kernel threads, and system container threads are restricted to these CPUs. All CPUs that are not isolated should be reserved.
-<5> Set the number of huge pages.
-<6> Set the huge page size.
+<2> Set the isolated CPUs. Ensure all of the Hyper-Threading pairs match.
+<3> Set the reserved CPUs. When workload partitioning is enabled, system processes, kernel threads, and system container threads are restricted to these CPUs. All CPUs that are not isolated should be reserved.
+<4> Set the number of huge pages.
+<5> Set the huge page size.
+<6> Set `node` to the NUMA node where the `hugepages` are allocated.
 <7> Set `userLevelNetworking` to `true` to isolate the CPUs from networking interrupts.
 <8> Set `enabled` to `true` to install the real-time Linux kernel.


### PR DESCRIPTION
Version(s): 4.10 only

Issue:
https://issues.redhat.com/browse/OCPBUGS-4196

Link to docs preview: http://file.emea.redhat.com/aireilly/OCPBUGS-4196-410/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.html#ztp-sno-du-configuring-performance-addons_sno-configure-for-vdu


QE review:
- [ ] QE has approved this change.

