### PR TITLE
OCPBUGS-4196 - 4.9 vDU PerformanceProfile example is not synced with ZTP vDU profile

### DIFF
--- a/modules/sno-du-configuring-performance-addons.adoc
+++ b/modules/sno-du-configuring-performance-addons.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/sno-du-deploying-clusters-on-single-nodes.adoc
+// * scalability_and_performance/ztp-configuring-single-node-cluster-deployment-during-installation.adoc
 
 :_content-type: PROCEDURE
 [id="sno-du-configuring-performance-addons_{context}"]
@@ -12,39 +12,4 @@ This is a key configuration for the single node distributed unit (DU). Many of t
 
 * Configure the performance addons using the following example:
 +
-[source,yaml]
-----
-apiVersion: performance.openshift.io/v2
-kind: PerformanceProfile
-metadata:
-  name: perfprofile-policy
-spec:
-  additionalKernelArgs:
-    - idle=poll
-    - rcupdate.rcu_normal_after_boot=0
-  cpu:
-    isolated: 2-19,22-39 <1>
-    reserved: 0-1,20-21 <2>
-  hugepages:
-    defaultHugepagesSize: 1G
-    pages:
-      - count: 32 <3>
-        size: 1G <4>
-  machineConfigPoolSelector:
-    pools.operator.machineconfiguration.openshift.io/master: ""
-  net:
-    userLevelNetworking: true <5>
-  nodeSelector:
-    node-role.kubernetes.io/master: ""
-  numa:
-    topologyPolicy: restricted
-  realTimeKernel:
-    enabled: true    <6>
-----
-
-<1> Set the isolated CPUs. Ensure all of the HT pairs match.
-<2> Set the reserved CPUs.  In this case, a hyperthreaded pair is allocated on NUMA 0 and a pair on NUMA 1.
-<3> Set the huge page size.
-<4> Set the huge page number.
-<5> Set to `true` to isolate the CPUs from networking interrupts.
-<6> Set to `true` to install the real-time Linux kernel.
+include::snippets/ztp-performance-profile.adoc[]

--- a/snippets/ztp-performance-profile.adoc
+++ b/snippets/ztp-performance-profile.adoc
@@ -1,0 +1,40 @@
+:_content-type: SNIPPET
+.Recommended performance profile configuration
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: openshift-node-performance-profile <1>
+spec:
+  additionalKernelArgs:
+    - "idle=poll"
+    - "rcupdate.rcu_normal_after_boot=0"
+  cpu:
+    isolated: 2-51,54-103 <2>
+    reserved: 0-1,52-53   <3>
+  hugepages:
+    defaultHugepagesSize: 1G
+    pages:
+      - count: 32 <4>
+        size: 1G  <5>
+        node: 0 <6>
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/master: ""
+  net:
+    userLevelNetworking: true <7>
+  nodeSelector:
+    node-role.kubernetes.io/master: ''
+  numa:
+    topologyPolicy: "restricted"
+  realTimeKernel:
+    enabled: true    <8>
+----
+<1> Ensure that the value for `name` matches that specified in the `spec.profile.data` field of `TunedPerformancePatch.yaml` and the `status.configuration.source.name` field of `validatorCRs/informDuValidator.yaml`.
+<2> Set the isolated CPUs. Ensure all of the Hyper-Threading pairs match.
+<3> Set the reserved CPUs. When workload partitioning is enabled, system processes, kernel threads, and system container threads are restricted to these CPUs. All CPUs that are not isolated should be reserved.
+<4> Set the number of huge pages.
+<5> Set the huge page size.
+<6> Set `node` to the NUMA node where the `hugepages` are allocated.
+<7> Set `userLevelNetworking` to `true` to isolate the CPUs from networking interrupts.
+<8> Set `enabled` to `true` to install the real-time Linux kernel.


### PR DESCRIPTION
Version(s): 4.9 only

Issue:
https://issues.redhat.com/browse/OCPBUGS-4196

Link to docs preview: http://file.emea.redhat.com/aireilly/OCPBUGS-4196-49/scalability_and_performance/ztp-configuring-single-node-cluster-deployment-during-installation.html#sno-du-configuring-performance-addons_sno-du-deploying-distributed-units-manually-on-single-node-openshift


QE review:
- [ ] QE has approved this change.
