### PR TITLE
[OSDOCS-2003]: AWS user-defined tags in machine sets

### DIFF
--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -54,8 +54,8 @@ ifndef::infra[]
         machine.openshift.io/cluster-api-machine-type: <role> <3>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <3>
-        machine.openshift.io/cluster-api-machine-type: <infra> <3>
+        machine.openshift.io/cluster-api-machine-role: infra <3>
+        machine.openshift.io/cluster-api-machine-type: infra <3>
 endif::infra[]
 ifndef::infra[]
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
@@ -71,19 +71,11 @@ ifndef::infra[]
 endif::infra[]
 ifdef::infra[]
           node-role.kubernetes.io/infra: "" <3>
-      taints: <4>
-        - key: node-role.kubernetes.io/infra
-          effect: NoSchedule
 endif::infra[]
       providerSpec:
         value:
           ami:
-ifndef::infra[]
             id: ami-046fe691f52a953f9 <4>
-endif::infra[]
-ifdef::infra[]
-            id: ami-046fe691f52a953f9 <5>
-endif::infra[]
           apiVersion: awsproviderconfig.openshift.io/v1beta1
           blockDevices:
             - ebs:
@@ -113,8 +105,15 @@ endif::infra[]
           tags:
             - name: kubernetes.io/cluster/<infrastructure_id> <1>
               value: owned
+            - name: <custom_tag_name> <5>
+              value: <custom_tag_value> <5>
           userDataSecret:
             name: worker-user-data
+ifdef::infra[]
+      taints: <6>
+        - key: node-role.kubernetes.io/infra
+          effect: NoSchedule
+endif::infra[]
 ----
 <1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 +
@@ -123,22 +122,30 @@ endif::infra[]
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
 ifndef::infra[]
-<2> Specify the infrastructure ID, node label, and zone.
-<3> Specify the node label to add.
-<4> Specify a valid {op-system-first} AMI for your AWS zone for your {product-title} nodes. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
+<2> Specify the infrastructure ID, role node label, and zone.
+<3> Specify the role node label to add.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the infrastructure ID, `<infra>` node label, and zone.
-<3> Specify the `<infra>` node label.
-<4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
-<5> Specify a valid {op-system-first} AMI for your AWS zone for your {product-title} nodes. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
+<2> Specify the infrastructure ID, `infra` role node label, and zone.
+<3> Specify the `infra` role node label.
+endif::infra[]
+<4> Specify a valid {op-system-first} Amazon
+Machine Image (AMI) for your AWS zone for your {product-title} nodes. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
 +
 [source,terminal]
 ----
 $ oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.ami.id}{"\n"}' \
-    get machineset/<infrastructure_id>-worker-<zone>
+    get machineset/<infrastructure_id>-<role>-<zone>
 ----
+<5> Optional: Specify custom tag data for your cluster. For example, you might add an admin contact email address by specifying a `name:value` pair of `Email:\admin-email@example.com`.
++
+[NOTE]
+====
+Custom tags can also be specified during installation in the `install-config.yml` file. If the `install-config.yml` file and the machine set include a tag with the same `name` data, the value for the tag from the machine set takes priority over the value for the tag in the `install-config.yml` file.
+====
+ifdef::infra[]
+<6> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-2003](https://issues.redhat.com//browse/OSDOCS-2003)

Link to docs preview:
- [Sample YAML for a compute machine set custom resource on AWS](https://53785--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machineset-yaml-aws_creating-machineset-aws) (regular compute machine)
- [Sample YAML for a compute machine set custom resource on AWS](https://53785--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-aws_creating-infrastructure-machinesets) (infrastructure machine)

(building...)

QE review:
- [ ] QE has approved this change.

Additional information:
- Cleans up AWS YAML sample condition use as well