### PR TITLE
Fix broken links in Policies and service definition book

### DIFF
--- a/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
@@ -8,9 +8,10 @@ toc::[]
 
 include::modules/life-cycle-overview.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
 .Additional resources
 
-* xref:../rosa_policy_service_definition/rosa-service-definition.adoc#rosa-service-definition[{product-title} service definition]
+* xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-service-definition[{product-title} service definition]
 
 include::modules/life-cycle-definitions.adoc[leveloffset=+1]
 include::modules/life-cycle-major-versions.adoc[leveloffset=+1]
@@ -19,7 +20,7 @@ include::modules/life-cycle-minor-versions.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-limited-support_rosa-life-cycle[{product-title} limited support status]
+* xref:../../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-limited-support_rosa-life-cycle[{product-title} limited support status]
 
 include::modules/life-cycle-patch-versions.adoc[leveloffset=+1]
 include::modules/life-cycle-limited-support.adoc[leveloffset=+1]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc
@@ -25,9 +25,9 @@ include::modules/rosa-policy-identity-access-management.adoc[leveloffset=+1]
 include::modules/rosa-policy-security-regulation-compliance.adoc[leveloffset=+1]
 include::modules/rosa-policy-disaster-recovery.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
 
-== Additional resources
-
-* For more information about customer or shared responsibilities, see the xref:../rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc#rosa-policy-responsibilities_rosa-policy-responsibility-matrix[ROSA Responsibilities] document.
+* For more information about customer or shared responsibilities, see the xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc#rosa-policy-responsibilities_rosa-policy-responsibility-matrix[ROSA Responsibilities] document.
 
 * For more information about ROSA and its components, see the xref:../rosa_policy_service_definition/rosa-service-definition.adoc#rosa-service-definition[ROSA Service Definition].

--- a/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc
@@ -11,9 +11,9 @@ This documentation outlines Red Hat, cloud provider, and customer responsibiliti
 include::modules/rosa-policy-responsibilities.adoc[leveloffset=+1]
 include::modules/rosa-policy-shared-responsibility.adoc[leveloffset=+1]
 
-[id="additional-resources-rosa-policy-responsibility-matrix"]
 [role="_additional-resources"]
-=== Additional resources
+.Additional resources
+
 * xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc#rosa-nodes-machinepools-about[About machine pools]
 
 include::modules/rosa-policy-customer-responsibility.adoc[leveloffset=+1]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
@@ -17,11 +17,15 @@ include::modules/rosa-sdpolicy-am-billing.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-cluster-self-service.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-compute.adoc[leveloffset=+2]
 include::snippets/pid-limits.adoc[]
+
+[role="_additional-resources"]
 .Additional Resources
+
 * xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-red-hat-operator_rosa-service-definition[Red Hat Operator Support]
 
 include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+2]
-[role="_additional-resources-instance-types"]
+
+[role="_additional-resources"]
 .Additional Resources
 
 * link:https://aws.amazon.com/ec2/instance-types[AWS Instance Types]
@@ -37,8 +41,8 @@ include::modules/rosa-sdpolicy-storage.adoc[leveloffset=+1]
 include::modules/rosa-sdpolicy-platform.adoc[leveloffset=+1]
 include::modules/rosa-sdpolicy-security.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
 
-== Additional resources
-
-* See xref:../rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding process and security for ROSA] for the latest compliance information.
-* See xref:../rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[ROSA life cycle]
+* See xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding process and security for ROSA] for the latest compliance information.
+* See xref:../../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[ROSA life cycle]


### PR DESCRIPTION
This also addresses some formatting for additional resources. 

Version(s):
4.11+ 

Issue:
NA

Link to docs preview:
https://53786--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-understand-availability.html

QE review:
Not required. This PR is fixing broken links and formatting.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
