### PR TITLE
OSD Broken Links: This PR fixes some links that broke for Customer Po…

### DIFF
--- a/osd_install_access_delete_cluster/osd-revoking-cluster-privileges.adoc
+++ b/osd_install_access_delete_cluster/osd-revoking-cluster-privileges.adoc
@@ -1,5 +1,5 @@
 :_content-type: ASSEMBLY
-[id=" osd-revoking-cluster-privileges"]
+[id="osd-revoking-cluster-privileges"]
 = Revoking privileges and access to an {product-title} cluster
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: osd-revoking-cluster-privileges


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Link to docs preview:
[OSD](https://53796--docspreview.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/osd-revoking-cluster-privileges.html)

Additional information:
Removed a leading space from an ID. This seems to cause issues for the Customer Portal.