### PR TITLE
[enterprise-4.10] OCPBUGS#4456: Correct nmstate data for bmh.yaml

### DIFF
--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -62,38 +62,25 @@ metadata:
  name: openshift-worker-<num>-network-config-secret <2>
 type: Opaque
 stringData:
- nmstate: |
-  hosts:
-  - name: openshift-master-0
-    role: master
-    bmc:
-      address: redfish+http://<out_of_band_ip>/redfish/v1/Systems/
-      username: <user>
-      password: <password>
-      disableCertificateVerification: null
-    bootMACAddress: <NIC1_mac_address>
-    bootMode: UEFI
-    rootDeviceHints:
-      deviceName: "/dev/sda"
-    networkConfig: <3>
-      interfaces:
-      - name: <nic1_name> <4>
-        type: ethernet
-        state: up
-        ipv4:
-          address:
-          - ip: <ip_address> <4>
-            prefix-length: 24
-          enabled: true
-      dns-resolver:
-        config:
-          server:
-          - <dns_ip_address> <4>
-      routes:
-        config:
-        - destination: 0.0.0.0/0
-          next-hop-address: <next_hop_ip_address> <4>
-          next-hop-interface: <next_hop_nic1_name> <4>
+ nmstate: | <3>
+  interfaces:
+  - name: <nic1_name> <4>
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: <ip_address> <4>
+        prefix-length: 24
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - <dns_ip_address> <4>
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: <next_hop_ip_address> <4>
+      next-hop-interface: <next_hop_nic1_name> <4>
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
This is a cherry-pick of [#53444](https://github.com/openshift/openshift-docs/pull/53444)

/assign bergerhoffer