### PR TITLE
[OCPBUGS-3153]: Update ccoctl docs for optional components

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -96,6 +96,71 @@ endif::alibabacloud-default,alibabacloud-customizations[]
 This command can take a few moments to run.
 ====
 
+ifdef::aws-sts[]
+. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
++
+.Example `credrequests` directory contents for {product-title} 4.12 on AWS
++
+[source,terminal]
+----
+0000_30_machine-api-operator_00_credentials-request.yaml <1>
+0000_50_cloud-credential-operator_05-iam-ro-credentialsrequest.yaml <2>
+0000_50_cluster-image-registry-operator_01-registry-credentials-request.yaml <3>
+0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <4>
+0000_50_cluster-network-operator_02-cncc-credentials.yaml <5>
+0000_50_cluster-storage-operator_03_credentials_request_aws.yaml <6>
+----
++
+<1> The Machine API Operator CR is required. 
+<2> The Cloud Credential Operator CR is required.
+<3> The Image Registry Operator CR is required.
+<4> The Ingress Operator CR is required.
+<5> The Network Operator CR is required.
+<6> The Storage Operator CR is an optional component and might be disabled in your cluster.
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
++
+.Example `credrequests` directory contents for {product-title} 4.12 on GCP
++
+[source,terminal]
+----
+0000_26_cloud-controller-manager-operator_16_credentialsrequest-gcp.yaml <1>
+0000_30_machine-api-operator_00_credentials-request.yaml <2>
+0000_50_cloud-credential-operator_05-gcp-ro-credentialsrequest.yaml <3>
+0000_50_cluster-image-registry-operator_01-registry-credentials-request-gcs.yaml <4>
+0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <5>
+0000_50_cluster-network-operator_02-cncc-credentials.yaml <6>
+0000_50_cluster-storage-operator_03_credentials_request_gcp.yaml <7>
+----
++
+<1> The Cloud Controller Manager Operator CR is required.
+<2> The Machine API Operator CR is required.
+<3> The Cloud Credential Operator CR is required.
+<4> The Image Registry Operator CR is required.
+<5> The Ingress Operator CR is required.
+<6> The Network Operator CR is required.
+<7> The Storage Operator CR is an optional component and might be disabled in your cluster.
+endif::google-cloud-platform[]
+ifdef::alibabacloud-default,alibabacloud-customizations[]
+. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
++
+.Example `credrequests` directory contents for {product-title} 4.12 on Alibaba Cloud
++
+[source,terminal]
+----
+0000_30_machine-api-operator_00_credentials-request.yaml <1>
+0000_50_cluster-image-registry-operator_01-registry-credentials-request-alibaba.yaml <2>
+0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <3>
+0000_50_cluster-storage-operator_03_credentials_request_alibaba.yaml <4>
+----
++
+<1> The Machine API Operator CR is required.
+<2> The Image Registry Operator CR is required.
+<3> The Ingress Operator CR is required.
+<4> The Storage Operator CR is an optional component and might be disabled in your cluster.
+endif::alibabacloud-default,alibabacloud-customizations[]
+
 ifdef::aws-sts,google-cloud-platform[]
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 +

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -93,6 +93,27 @@ $ oc adm release extract --credentials-requests \
 +
 <1> `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
 
+.. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
++
+.Example `credrequests` directory contents for {product-title} 4.12 on AWS
++
+[source,terminal]
+----
+0000_30_machine-api-operator_00_credentials-request.yaml <1>
+0000_50_cloud-credential-operator_05-iam-ro-credentialsrequest.yaml <2>
+0000_50_cluster-image-registry-operator_01-registry-credentials-request.yaml <3>
+0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <4>
+0000_50_cluster-network-operator_02-cncc-credentials.yaml <5>
+0000_50_cluster-storage-operator_03_credentials_request_aws.yaml <6>
+----
++
+<1> The Machine API Operator CR is required. 
+<2> The Cloud Credential Operator CR is required.
+<3> The Image Registry Operator CR is required.
+<4> The Ingress Operator CR is required.
+<5> The Network Operator CR is required.
+<6> The Storage Operator CR is an optional component and might be disabled in your cluster.
+
 .. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 +
 [source,terminal]

--- a/modules/manually-configure-iam-nutanix.adoc
+++ b/modules/manually-configure-iam-nutanix.adoc
@@ -68,6 +68,17 @@ quay.io/<path_to>/ocp-release:<version>
       namespace: openshift-machine-api
 ----
 
+. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
++
+.Example `credrequests` directory contents for {product-title} 4.12 on Nutanix
++
+[source,terminal]
+----
+0000_30_machine-api-operator_00_credentials-request.yaml <1>
+----
++
+<1> The Machine API Operator CR is required.
+
 . Use the `ccoctl` tool to process all of the `CredentialsRequest` objects in the `credrequests` directory by running the following command:
 +
 [source,terminal]

--- a/modules/manually-create-iam-ibm-cloud.adoc
+++ b/modules/manually-create-iam-ibm-cloud.adoc
@@ -109,6 +109,24 @@ This command creates a YAML file for each `CredentialsRequest` object.
         - crn:v1:bluemix:public:iam::::role:Viewer
 ----
 
+. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
++
+.Example `credrequests` directory contents for {product-title} 4.12 on IBM Cloud VPC
++
+[source,terminal]
+----
+0000_26_cloud-controller-manager-operator_15_credentialsrequest-ibm.yaml <1>
+0000_30_machine-api-operator_00_credentials-request.yaml <2>
+0000_50_cluster-image-registry-operator_01-registry-credentials-request-ibmcos.yaml <3>
+0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <4>
+0000_50_cluster-storage-operator_03_credentials_request_ibm.yaml <5>
+----
+<1> The Cloud Controller Manager Operator CR is required.
+<2> The Machine API Operator CR is required.
+<3> The Image Registry Operator CR is required.
+<4> The Ingress Operator CR is required.
+<5> The Storage Operator CR is an optional component and might be disabled in your cluster.
+
 . Create the service ID for each credential request, assign the policies defined, create an API key in IBM Cloud VPC, and generate the secret:
 +
 [source,terminal]

--- a/modules/manually-maintained-credentials-upgrade.adoc
+++ b/modules/manually-maintained-credentials-upgrade.adoc
@@ -37,7 +37,8 @@ The "Manually creating IAM" section of the installation content for your cloud p
 
 
 . Update the manually maintained credentials on your cluster:
-
++
+--
 ** Create new secrets for any `CredentialsRequest` custom resources that are added by the new release image.
 ifndef::ibm-cloud[]
 ** If the `CredentialsRequest` custom resources for any existing credentials that are stored in secrets have changed their permissions requirements, update the permissions as required.
@@ -47,6 +48,12 @@ ifdef::ibm-cloud[]
 +
 The "Manually creating IAM for IBM Cloud" section of the installation content for IBM Cloud explains how to use the `ccoctl` utility to create new service IDs.
 endif::ibm-cloud[]
+--
++
+[NOTE]
+====
+If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
+====
 
 . When all of the secrets are correct for the new release, indicate that the cluster is ready to upgrade:
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-3153](https://issues.redhat.com/browse/OCPBUGS-3153)

Link to docs preview:
- [Creating AWS resources individually
](https://53809--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-individually_cco-mode-sts)
- [Creating AWS resources with a single command](https://53809--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-at-once_cco-mode-sts)
- [Creating GCP resources with the Cloud Credential Operator utility](https://53809--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.html#cco-ccoctl-creating-at-once_cco-mode-gcp-workload-identity)
- [Creating credentials for OpenShift Container Platform components with the ccoctl tool](https://53809--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-default.html#cco-ccoctl-creating-at-once_installing-alibaba-default) (Alibaba Cloud)
- [Manually creating IAM for IBM Cloud VPC](https://53809--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.html#manually-create-iam-ibm-cloud_installing-ibm-cloud-customizations)
- [Configuring IAM for Nutanix](https://53809--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#manually-create-iam-nutanix_installing-nutanix-installer-provisioned)
- [Upgrading clusters with manually maintained credentials](https://53809--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-cluster-within-minor.html#manually-maintained-credentials-upgrade_updating-cluster-within-minor)

QE review:
- [x] QE has approved this change.

Additional information: