### PR TITLE
[enterprise-4.8] Add IBM Z to common attributes in 4.8

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -106,6 +106,8 @@ endif::[]
 :SMProductVersion1x: 1.1.18.2
 //Windows containers
 :productwinc: Red Hat OpenShift support for Windows Containers
+// IBM zSystems
+:ibmzProductName: IBM Z
 // Red Hat Quay Container Security Operator
 :rhq-cso: Red Hat Quay Container Security Operator
 :sno: single-node OpenShift


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.8
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: Preview build not working on enterprise-4.8 branch but looks good locally the IBM Z attribute resolves.
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change in this PR fdb3eafce93973ecab51ad5debc5b861b6cf4ae9.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- PR #53403, which contains the IBM Z attribute has been backported and attribute is missing in 4.8
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
