### PR TITLE
OCPBUGS#4826: Azure disk set bug added to 4.11.16

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2994,6 +2994,10 @@ $ oc adm release info 4.11.16 --pullspecs
 
 * With this release, when you xref:../installing/installing_gcp/uninstalling-cluster-gcp.adoc#cco-ccoctl-deleting-sts-resources_uninstalling-cluster-gcp[delete GCP resources with the Cloud Credential Operator utility], you must specify the directory containing the files for the component `CredentialsRequest` objects.
 
+[id="ocp-4-11-16-bug-fixes"]
+==== Bug fixes
+* Previously, if you used upper-case letters when specifying an Azure Disk Encryption Set (DES) or Resource Group (RG) name, the validation would fail. With this release, you can now use upper and lower case letters in DES and RG names. (link:https://issues.redhat.com//browse/OCPBUGS-4826[*OCPBUGS#4826*])
+
 [id="ocp-4-11-16-updating"]
 ==== Updating
 


### PR DESCRIPTION
For version 4.11
[OCPBUGS-4826](https://issues.redhat.com//browse/OCPBUGS-4826)

Preview:
[Release notes ->  RHSA-2022:8535 - OpenShift Container Platform 4.11.16 bug fix and security update](https://53827--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-16)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->