### PR TITLE
OCPBUGS#4634 Use config CR instead of operator CR

### DIFF
--- a/modules/nw-dual-stack-convert-back-single-stack.adoc
+++ b/modules/nw-dual-stack-convert-back-single-stack.adoc
@@ -14,12 +14,12 @@ As a cluster administrator, you can convert your dual-stack cluster network to a
 
 .Procedure
 
-. Edit the `Network.operator.openshift.io` custom resource (CR) by running the
+. Edit the `networks.config.openshift.io` custom resource (CR) by running the
 following command:
 +
 [source,terminal]
 ----
-$ oc edit networks.operator.openshift.io
+$ oc edit networks.config.openshift.io
 ----
 
 . Remove the IPv6 specific configuration that you have added to the `cidr` and `hostPrefix` fields in the previous procedure.


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-4634

Link to docs preview:
https://53828--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html#nw-dual-stack-convert-back-single-stack_converting-to-dual-stack

QE review:
- [X] QE has approved this change.

