### PR TITLE
OSDOCS-4660: Add no-update warning to About page

### DIFF
--- a/modules/microshift-configuring-ovn.adoc
+++ b/modules/microshift-configuring-ovn.adoc
@@ -35,7 +35,7 @@ To customize your configuration, use the following table to find valid values th
 |bool
 |false
 |Skip configuring OVS bridge `br-ex` in `microshift-ovs-init.service`
-|true <1>
+|true ^[1]^
 
 |`ovsInit.gatewayInterface`
 |Alpha
@@ -56,7 +56,10 @@ To customize your configuration, use the following table to find valid values th
 |1300
 |===
 
-<1> The OVS bridge is required. When `disableOVSInit` is true, OVS bridge `br-ex` must be configured manually.
+[.small]
+--
+1. The OVS bridge is required. When `disableOVSInit` is true, OVS bridge `br-ex` must be configured manually.
+--
 
 .Example `ovn.yaml` config file:
 [source, yaml]

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -55,6 +55,16 @@ ifdef::openshift-online,openshift-aro[]
 Start with **xref:../architecture/architecture.adoc#architecture-overview-architecture[Architecture]**.
 endif::[]
 
+ifdef::microshift[]
+Start with xref:../microshift_getting_started/microshift-understanding.adoc#microshift-understanding[Understanding {product-title}] and xref:../microshift_install/microshift-install-rhel-for-edge.adoc#microshift-install-rhel-for-edge[Installing].
+Then, see the xref:../microshift_release_notes/microshift-4-12-release-notes.adoc#microshift-4-12-release-notes[release notes].
+
+[IMPORTANT]
+====
+Red Hat will not provide or support an update or upgrade path from Developer Preview and Technology Preview versions to later versions of {product-title}. A new installation will be necessary.
+====
+endif::[]
+
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 == Cluster installer activities
 Explore these {product-title} installation tasks.


### PR DESCRIPTION
[OSDOCS-4660](https://issues.redhat.com//browse/OSDOCS-4660): Add no-update warning to MicroShift About page

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4660

Link to docs preview:
https://53837--docspreview.netlify.app/microshift/latest/welcome/index.html
MicroShift build

http://file.rdu.redhat.com/shdiaz/OSDOCS-4660/welcome/
Included to be sure nothing was added or removed by accident.

QE review:
N/A -- MicroShift is Developer Preview
Only SME approval needed

Additional information:
We are warning early adopters that this version of MicroShift does not have the ability to be upgraded. Instead, a new install is be required when a new version is released.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
