### PR TITLE
[MULTIARCH-3176] Release Notes add deprecation for z13, power8, x86v1

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -704,6 +704,22 @@ Red Hat Virtualization (RHV) will be deprecated in an upcoming release of {produ
 
 CoreDNS will stop supporting wildcard DNS queries for names under the `cluster.local` domain. These queries will resolve in {product-title} {product-version} as they do in earlier versions, but support will be removed from a future {product-title} release.
 
+[id="ocp-4-12-z13-power8-x86v1-deprecations"]
+==== Specific hardware models on `ppc64le`, `s390x`, and `x86_64` v1 CPU architectures are deprecated
+
+In {product-title} 4.12, support for {op-system} functionality is deprecated for: 
+
+* IBM POWER8 all models (ppc64le)
+* IBM POWER9 AC922 (ppc64le)
+* IBM POWER9 IC922 (ppc64le)
+* IBM POWER9 LC922 (ppc64le)
+* IBM z13 all models (s390x)
+* LinuxONE Emperor (s390x)
+* LinuxONE Rockhopper (s390x)
+* AMD64 (x86_64) v1 CPU
+
+While these hardware models remain fully supported in {product-title} 4.12, Red Hat recommends that you use later hardware models.
+
 [id="ocp-4-12-removed-features"]
 === Removed features
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/MULTIARCH-3176
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://53838--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-z13-power8-x86v1-deprecations
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: 
- IBM Z: Holger Wolf
- IBM Power: Manoj Kumar
- x86: Mark Russell
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
fyi @opayne1 