### PR TITLE
OSDOCS-4669-RN:adds zstream update

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3053,3 +3053,32 @@ $ oc adm release info 4.11.18 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-20"]
+=== RHSA-2022:8893 - {product-title} 4.11.20 bug fix and security update
+
+Issued: 2022-12-15
+
+{product-title} release 4.11.20, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:8893[RHSA-2022:8893] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:8892[RHBA-2022:8892] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.20 --pullspecs
+----
+
+[id="ocp-4-11-20-bug-fixes"]
+==== Bug fixes
+
+* Previously, the {product-title} installation program presented the user with an incomplete list of regions when installing a cluster on Google Cloud Platform (GCP). With this update, the installation program includes all supported regions. (link:https://issues.redhat.com/browse/OCPBUGS-3023[*OCPBUGS-3023*])
+
+[id="ocp-4-11-20-known-issues"]
+==== Known issues
+
+* Switching the router scope of the default Ingress Controller by setting the `spec.endpointPublishingStrategy.loadBalancer.scope` field results in a degraded Ingress Operator. Consequently, routes that use that endpoint such as the web console URL become inaccessible. As a workaround, restarting one of the router pods brings back several instances under the `loadbalancer` back to the `inService` status.(link:https://issues.redhat.com/browse/OCPBUGS-2554[*OCPBUGS-2554*])
+
+[id="ocp-4-11-20-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4669](https://issues.redhat.com//browse/OSDOCS-4669): adds zstream update 
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-4669
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://53856--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-20
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
GH #53794 closed this PR because of weird cherry-bot behavior
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
