### PR TITLE
[OSDOCS-4100] RHOSP - Support IPv6 in the secondary network interface

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -937,6 +937,8 @@ If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is
 
 |`controlPlane.platform.openstack.additionalNetworkIDs`
 |Additional networks that are associated with control plane machines. Allowed address pairs are not created for additional networks.
+
+Additional networks that are attached to a control plane machine are also attached to the bootstrap node.
 |A list of one or more UUIDs as strings. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
 
 |`controlPlane.platform.openstack.additionalSecurityGroupIDs`

--- a/modules/nw-osp-pod-adding-connections-ipv6.adoc
+++ b/modules/nw-osp-pod-adding-connections-ipv6.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/network-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="nw-osp-pod-adding-connections-ipv6_{context}"]
+= Adding IPv6 connectivity to pods on {rh-openstack}
+
+After you enable IPv6 connectivity in pods, add connectivity to them by using a Container Network Interface (CNI) configuration.
+
+.Procedure
+
+. To edit the Cluster Network Operator (CNO), enter the following command:
++
+[source,terminal]
+----
+$ oc edit networks.operator.openshift.io cluster
+----
+
+. Specify your CNI configuration under the `spec` field. For example, the following configuration uses a SLAAC address mode with MACVLAN:
++
+[source,yaml]
+----
+...
+spec:
+  additionalNetworks:
+  - name: ipv6
+    namespace: ipv6 <1>
+    rawCNIConfig: '{ "cniVersion": "0.3.1", "name": "ipv6", "type": "macvlan", "master": "ens4"}' <2>
+    type: Raw
+----
+<1> Be sure to create pods in the same namespace.
+<2> The interface in the network attachment `"master"` field can differ from `"ens4"` when more networks are configured or when a different kernel driver is used.
++
+[NOTE]
+====
+If you are using stateful address mode, include the IP Address Management (IPAM) in the CNI configuration.
+
+DHCPv6 is not supported by Multus.
+====
+
+. Save your changes and quit the text editor to commit your changes.
+
+.Verification 
+
+* On a command line, enter the following command:
++
+[source,terminal]
+----
+$ oc get network-attachment-definitions -A
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE       NAME            AGE
+ipv6            ipv6            21h
+----
+
+You can now create pods that have secondary IPv6 connections. 

--- a/modules/nw-osp-pod-connections-ipv6.adoc
+++ b/modules/nw-osp-pod-connections-ipv6.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/network-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="nw-osp-pod-connections-ipv6_{context}"]
+= Enabling IPv6 connectivity to pods on {rh-openstack}
+
+To enable IPv6 connectivity between pods that have additional networks that are on different nodes, disable port security for the IPv6 port of the server. Disabling port security obviates the need to create allowed address pairs for each IPv6 address that is assigned to pods and enables traffic on the security group.
+
+[IMPORTANT]
+====
+Only the following IPv6 additional network configurations are supported:
+
+* SLAAC and host-device
+* SLAAC and MACVLAN
+* DHCP stateless and host-device
+* DHCP stateless and MACVLAN
+====
+
+.Procedure
+
+* On a command line, enter the following command:
++
+[source,terminal]
+----
+$ openstack port set --no-security-group --disable-port-security <compute_ipv6_port>
+----
++
+IMPORTANT: This command removes security groups from the port and disables port security. Traffic restrictions are removed entirely from the port.  
+
+where:
+
+<compute_ipv6_port>:: Specifies the IPv6 port of the compute server.

--- a/modules/nw-osp-pod-creating-ipv6.adoc
+++ b/modules/nw-osp-pod-creating-ipv6.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/network-configuration.adoc
+
+:_content-type: PROCEDURE
+[id="nw-osp-pod-creating-ipv6_{context}"]
+= Create pods that have IPv6 connectivity on {rh-openstack}
+
+After you enable IPv6 connectivty for pods and add it to them, create pods that have secondary IPv6 connections. 
+
+.Procedure
+
+. Define pods that use your IPv6 namespace and the annotation `k8s.v1.cni.cncf.io/networks: <additional_network_name>`, where `<additional_network_name` is the name of the additional network. For example, as part of a `Deployment` object:
++
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-openshift
+  namespace: ipv6
+spec:
+  affinity:
+    podAntiAffinity: 
+      requiredDuringSchedulingIgnoredDuringExecution:
+         - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In 
+              values:
+              - hello-openshift
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-openshift
+  template:
+    metadata:
+      labels:
+        app: hello-openshift
+      annotations:
+        k8s.v1.cni.cncf.io/networks: ipv6
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: hello-openshift
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        image: quay.io/openshift/origin-hello-openshift
+        ports:
+        - containerPort: 8080
+----
+
+. Create the pod. For example, on a command line, enter the following command:
++
+[source,terminal]
+----
+$ oc create -f <ipv6_enabled_resource>
+----
+
+where:
+
+<ipv6_enabled_resource>:: Specifies the file that contains your resource definition.

--- a/post_installation_configuration/network-configuration.adoc
+++ b/post_installation_configuration/network-configuration.adoc
@@ -124,3 +124,12 @@ include::modules/installation-osp-kuryr-port-pools.adoc[leveloffset=+2]
 include::modules/installation-osp-kuryr-settings-active.adoc[leveloffset=+2]
 include::modules/nw-osp-enabling-ovs-offload.adoc[leveloffset=+2]
 include::modules/nw-osp-hardware-offload-attaching-network.adoc[leveloffset=+2]
+include::modules/nw-osp-pod-connections-ipv6.adoc[leveloffset=+2]
+include::modules/nw-osp-pod-adding-connections-ipv6.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../networking/multiple_networks/configuring-additional-network.adoc#configuring-additional-network_configuration-additional-network-attachment[Configuration for an additional network attachment]
+
+include::modules/nw-osp-pod-creating-ipv6.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-4100
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://53860--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/network-configuration.html#nw-osp-pod-connections-ipv6_post-install-network-configuration, then scroll down
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

> we are supporting only the Following scenarios:
>
> Slaac and host-device
> Slaac and Macvlan
> DHCP stateless and host-device
> DHCP stateless and Macvlan