### PR TITLE
OCPBUGS-4097 - release note for bug fix

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -745,6 +745,8 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-4-12-bare-metal-hardware-bug-fixes"]
 ==== Bare Metal Hardware Provisioning
 
+* In recent versions of server firmware the time between server operations has increased. This causes timeouts during installer-provisioned infrastructure (IPI) installations when the {product-title} installation program waits for a response from the Baseboard Management Controller (BMC). The new `python3-sushy` release increases the number of server side attempts to contact the BMC. This update accounts for the extended waiting time and avoids timeouts during installation. (link:https://issues.redhat.com/browse/OCPBUGS-4097[*OCPBUGS-4097*])
+
 [discrete]
 [id="ocp-4-12-builds-bug-fixes"]
 ==== Builds


### PR DESCRIPTION
OCPBUGS#4097: Timeout on IPI installations due to recent versions of server firmware increasing time between operations.

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-4097

Link to docs preview:
http://file.emea.redhat.com/rohennes/OCPBUGS-4097-fixed-issue-release-note/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

