### PR TITLE
OSDOCS-4701: Adds notes for 4.8.55 release

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -3696,3 +3696,26 @@ $ oc adm release info 4.8.54 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-8-55"]
+=== RHBA-2022:8927 - {product-title} 4.8.55 bug fix update
+
+Issued: 2022-12-16
+
+{product-title} release 4.8.55 is now available. There is no s390x architecture for this release. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:8927[RHBA-2022:8927] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:8926[RHBA-2022:8926] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.8.55 --pullspecs
+----
+
+[id="ocp-kubernetes-1-21-14-updates"]
+==== Updates from Kubernetes 1.21.14
+
+This update contains changes from Kubernetes 1.21.12 up to 1.21.14. More information can be found in the following changelogs: link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#v12112[1.21.12], link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#v12113[1.21.13], and link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#v12114[1.21.14].
+
+==== Updating
+
+To update an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.8.55 release

Version(s):
4.8 only

Issue:
https://issues.redhat.com/browse/OSDOCS-4701

Link to docs preview:
http://file.rdu.redhat.com/opayne/RN-4.8.55/release_notes/ocp-4-8-release-notes.html#ocp-4-8-55

QE review:
- [ ] QE has approved this change.
QE not required for this change.

Additional information:
Links will not work yet (Kubernetes ones should though)


