### PR TITLE
OSDOCS-3160: Console optional capability

### DIFF
--- a/modules/console-operator.adoc
+++ b/modules/console-operator.adoc
@@ -2,15 +2,33 @@
 //
 // *  operators/operator-reference.adoc
 
+// operators/operator-reference.adoc
+ifeval::["{context}" == "cluster-operators-ref"]
+:operator-ref:
+endif::[]
+
 [id="console-operator_{context}"]
-= Console Operator
+ifdef::operator-ref[= Console Operator]
+
+ifdef::operator-ref[]
+
+[NOTE]
+====
+The Console Operator is an optional cluster capability that can be disabled by cluster administrators during installation. If you disable the Console Operator at installation, your cluster is still supported and upgradable. For more information about optional cluster capabilities, see "Cluster capabilities" in _Post-installation configuration_.
+====
+
+endif::operator-ref[]
 
 [discrete]
 == Purpose
 
-The Console Operator installs and maintains the {product-title} web console on a cluster.
+The Console Operator installs and maintains the {product-title} web console on a cluster. The Console Operator is installed by default and automatically maintains a console.
 
 [discrete]
 == Project
 
 link:https://github.com/openshift/console-operator[console-operator]
+
+ifeval::["{context}" == "cluster-operators-ref"]
+:!operator-ref:
+endif::[]

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -15,6 +15,8 @@ Cluster administrators can view cluster Operators in the {product-title} web con
 Cluster Operators are not managed by Operator Lifecycle Manager (OLM) and OperatorHub. OLM and OperatorHub are part of the link:https://operatorframework.io/[Operator Framework] used in {product-title} for installing and running optional xref:../architecture/control-plane.adoc#olm-operators_control-plane[add-on Operators].
 ====
 
+Some of the following operators can be disabled prior to installation. For more information see xref:../post_installation_configuration/cluster-capabilities.adoc#viewing_the_cluster_capabilities_cluster-capabilities[Viewing the cluster capabilities].
+
 include::modules/baremetal-event-relay.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
[OSDOCS-3160](https://issues.redhat.com//browse/OSDOCS-3160): Console optional capability

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-3922

Link to docs preview:
https://53899--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#console-operator_cluster-operators-ref

https://53899--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Note for merge reviewer: Just want to get a double check on the Optional Capability xref**
