### PR TITLE
Add urgent warning to not upgrade to RHACS 3.73.0

### DIFF
--- a/release_notes/373-release-notes.adoc
+++ b/release_notes/373-release-notes.adoc
@@ -15,6 +15,12 @@ toc::[]
 |`3.73.0` |6 December 2022
 |====
 
+[WARNING]
+====
+Due to a critical bug discovered in {product-title-short} version 3.73.0, _do not_ upgrade to this version. For more information, review the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/6990153[After upgrading the RHACS to version 3.73, the Central pod takes several hours to move into the READY state]. If you have upgraded to 3.73.0 and encounter the issue, contact Red Hat Support.
+====
+
+
 [id="about-this-release-373"]
 == About this release
 


### PR DESCRIPTION
Version(s):

- merge to `rhacs-docs-3.73`
- cherry pick to `rhacs-docs-3.73.1`

[Issue](https://issues.redhat.com/browse/ROX-13954)

<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[Link to docs preview
](https://openshift-docs-3ab62dn7v-kcarmichael08.vercel.app/openshift-acs/master/release_notes/373-release-notes.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change. (**N/A**)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Reviewed & approved by:

- [x] Product Management
- [x] Engineering
- [x] Support

(ACS doesn't have a "change management" process)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
