### PR TITLE
[OSDOCS-4103] Remove outdated limitations re: Kuryr, RHOSP 13, UDP/TCP, and load balancing

### DIFF
--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -38,12 +38,6 @@ use the Amphora driver. They are subject to the same resource concerns as earlie
 * Kuryr SDN does not support automatic unidling by a service.
 
 [discrete]
-[id="openstack-go-limitations_{context}"]
-== {rh-openstack} environment limitations
-
-* musl-based containers, including Alpine-based containers, do not support the `use-vc` option.
-
-[discrete]
 [id="openstack-upgrade-limitations_{context}"]
 == {rh-openstack} upgrade limitations
 

--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -41,20 +41,7 @@ use the Amphora driver. They are subject to the same resource concerns as earlie
 [id="openstack-go-limitations_{context}"]
 == {rh-openstack} environment limitations
 
-There are limitations when using Kuryr SDN that depend on your deployment environment.
-
-In Go versions 1.12 and earlier, applications that are compiled with CGO support disabled use UDP only. In this case,
-the native Go resolver does not recognize the `use-vc` option in `resolv.conf`, which controls whether TCP is forced for DNS resolution.
-As a result, UDP is still used for DNS resolution, which fails.
-
-To ensure that TCP forcing is allowed, compile applications either with the environment variable `CGO_ENABLED` set to `1`, i.e. `CGO_ENABLED=1`, or ensure that the variable is absent.
-
-In Go versions 1.13 and later, TCP is used automatically if DNS resolution using UDP fails.
-
-[NOTE]
-====
-musl-based containers, including Alpine-based containers, do not support the `use-vc` option.
-====
+* musl-based containers, including Alpine-based containers, do not support the `use-vc` option.
 
 [discrete]
 [id="openstack-upgrade-limitations_{context}"]
@@ -74,10 +61,3 @@ If the operator takes the first option, there might be short downtimes during fa
 
 If the operator takes the second option, the existing load balancers will not support upgraded Octavia
 API features, like UDP listeners. In this case, users must recreate their Services to use these features.
-
-[IMPORTANT]
-====
-If {product-title} detects a new Octavia version that supports UDP load balancing, it recreates the DNS service automatically. The service recreation ensures that the service default supports UDP load balancing.
-
-The recreation causes the DNS service approximately one minute of downtime.
-====

--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -35,13 +35,6 @@ services can cause you to run out of resources.
 Deployments of later versions of {rh-openstack} that have the OVN Octavia driver disabled also
 use the Amphora driver. They are subject to the same resource concerns as earlier versions of {rh-openstack}.
 
-* Octavia {rh-openstack} versions before 13.0.13 do not support UDP listeners. Therefore,
-{product-title} UDP services are not supported.
-
-* Octavia {rh-openstack} versions before 13.0.13 cannot listen to multiple protocols on the
-same port. Services that expose the same port to different protocols, like TCP
-and UDP, are not supported.
-
 * Kuryr SDN does not support automatic unidling by a service.
 
 [discrete]
@@ -49,8 +42,6 @@ and UDP, are not supported.
 == {rh-openstack} environment limitations
 
 There are limitations when using Kuryr SDN that depend on your deployment environment.
-
-Because of Octavia's lack of support for the UDP protocol and multiple listeners, if the {rh-openstack} version is earlier than 13.0.13, Kuryr forces pods to use TCP for DNS resolution.
 
 In Go versions 1.12 and earlier, applications that are compiled with CGO support disabled use UDP only. In this case,
 the native Go resolver does not recognize the `use-vc` option in `resolv.conf`, which controls whether TCP is forced for DNS resolution.

--- a/modules/installation-osp-kuryr-octavia-configuration.adoc
+++ b/modules/installation-osp-kuryr-octavia-configuration.adoc
@@ -77,24 +77,6 @@ The Octavia container versions vary depending upon the specific
 This may take some time depending on the speed of your network and Undercloud
 disk.
 
-. Since an Octavia load balancer is used to access the {product-title} API, you must
-increase their listeners' default timeouts for the connections. The default
-timeout is 50 seconds. Increase the timeout to 20 minutes by passing the
-following file to the Overcloud deploy command:
-+
-[source,terminal]
-----
-(undercloud) $ cat octavia_timeouts.yaml
-parameter_defaults:
-  OctaviaTimeoutClientData: 1200000
-  OctaviaTimeoutMemberData: 1200000
-----
-+
-[NOTE]
-====
-This is not needed for {rh-openstack} 13.0.13+.
-====
-
 . Install or update your Overcloud environment with Octavia:
 +
 [source,terminal]
@@ -120,113 +102,6 @@ When leveraging Kuryr SDN, the Overcloud installation requires the Neutron `trun
 Use the `openvswitch` firewall instead of the default `ovs-hybrid` when the Neutron
 backend is ML2/OVS. There is no need for modifications if the backend is
 ML2/OVN.
-====
-
-. In {rh-openstack} versions earlier than 13.0.13, add the project ID
-to the `octavia.conf` configuration file after you create the project.
-* To enforce
-network policies across services, like when traffic goes through
-the Octavia load balancer, you must ensure Octavia creates the Amphora VM
-security groups on the user project.
-+
-This change ensures that required load balancer security groups belong to that project,
-and that they can be updated to enforce services isolation.
-+
-[NOTE]
-====
-This task is unnecessary in {rh-openstack} version 13.0.13 or later.
-
-Octavia implements a new ACL API that restricts access to the load
-balancers VIP.
-====
-
-.. Get the project ID
-+
-[source,terminal]
-----
-$ openstack project show <project>
-----
-+
-.Example output
-[source,terminal]
-----
-+-------------+----------------------------------+
-| Field       | Value                            |
-+-------------+----------------------------------+
-| description |                                  |
-| domain_id   | default                          |
-| enabled     | True                             |
-| id          | PROJECT_ID                       |
-| is_domain   | False                            |
-| name        | *<project>*                      |
-| parent_id   | default                          |
-| tags        | []                               |
-+-------------+----------------------------------+
-----
-
-.. Add the project ID to `octavia.conf` for the controllers.
-
-... Source the `stackrc` file:
-+
-[source,terminal]
-----
-$ source stackrc  # Undercloud credentials
-----
-
-... List the Overcloud controllers:
-+
-[source,terminal]
-----
-$ openstack server list
-----
-+
-.Example output
-[source,terminal]
-----
-+--------------------------------------+--------------+--------+-----------------------+----------------+------------+
-│
-| ID                                   | Name         | Status | Networks
-| Image          | Flavor     |
-│
-+--------------------------------------+--------------+--------+-----------------------+----------------+------------+
-│
-| 6bef8e73-2ba5-4860-a0b1-3937f8ca7e01 | controller-0 | ACTIVE |
-ctlplane=192.168.24.8 | overcloud-full | controller |
-│
-| dda3173a-ab26-47f8-a2dc-8473b4a67ab9 | compute-0    | ACTIVE |
-ctlplane=192.168.24.6 | overcloud-full | compute    |
-│
-+--------------------------------------+--------------+--------+-----------------------+----------------+------------+
-----
-
-... SSH into the controller(s).
-+
-[source,terminal]
-----
-$ ssh heat-admin@192.168.24.8
-----
-
-... Edit the `octavia.conf` file to add the project into the list of projects where
-Amphora security groups are on the user's account.
-+
-----
-# List of project IDs that are allowed to have Load balancer security groups
-# belonging to them.
-amp_secgroup_allowed_projects = PROJECT_ID
-----
-
-.. Restart the Octavia worker so the new configuration loads.
-+
-[source,terminal]
-----
-controller-0$ sudo docker restart octavia_worker
-----
-
-[NOTE]
-====
-Depending on your {rh-openstack} environment, Octavia might not support UDP
-listeners. If you use Kuryr SDN on {rh-openstack} version 13.0.13 or earlier, UDP services are not supported.
-{rh-openstack} version 16 or later support UDP.
 ====
 
 [id="installation-osp-kuryr-octavia-driver_{context}"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-4103
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://53911--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-kuryr.html#installation-osp-kuryr-known-limitations_installing-openstack-installer-kuryr
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
