### PR TITLE
OSDOCS-3160: Release note for console optional capability

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -110,6 +110,13 @@ For more information, see xref:../installing/disconnected_install/installing-mir
 
 With this release, there are several updates to the *Administrator* perspective of the web console.
 
+[id="ocp-4-12-console-optional-capability"]
+===== Console Operator is an optional cluster capability
+
+Beginning with {product-title} {product-version}, The Console Operator is an optional cluster capability that can be disabled by cluster administrators during installation.
+
+For more information, see xref:../operators/operator-reference.adoc#console-operator_cluster-operators-ref[Console Operator reference].
+
 [id="ocp-4-12-developer-perspective"]
 ==== Developer Perspective
 


### PR DESCRIPTION
[OSDOCS-3160](https://issues.redhat.com//browse/OSDOCS-3160): Release note for console optional capability

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-3922

Link to docs preview:
https://53912--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-console-optional-capability

QE review:
- [ ] QE has approved this change.

