### PR TITLE
SVRCOM-2208 restore TP for some runtimes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3721,12 +3721,12 @@ Topics:
     File: serverless-functions-getting-started
   - Name: On-cluster function building and deploying
     File: serverless-functions-on-cluster-builds
+  - Name: Developing Quarkus functions
+    File: serverless-developing-quarkus-functions
   - Name: Developing Node.js functions
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions
     File: serverless-developing-typescript-functions
-  - Name: Developing Quarkus functions
-    File: serverless-developing-quarkus-functions
   - Name: Using functions with Knative Eventing
     File: serverless-functions-eventing
   - Name: Function project configuration in func.yaml

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -370,12 +370,12 @@ Topics:
     File: serverless-functions-setup
   - Name: Getting started with functions
     File: serverless-functions-getting-started
+  - Name: Developing Quarkus functions
+    File: serverless-developing-quarkus-functions
   - Name: Developing Node.js functions
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions
     File: serverless-developing-typescript-functions
-  - Name: Developing Quarkus functions
-    File: serverless-developing-quarkus-functions
   - Name: Using functions with Knative Eventing
     File: serverless-functions-eventing
   - Name: Function project configuration in func.yaml

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -571,12 +571,12 @@ Topics:
     File: serverless-functions-setup
   - Name: Getting started with functions
     File: serverless-functions-getting-started
+  - Name: Developing Quarkus functions
+    File: serverless-developing-quarkus-functions
   - Name: Developing Node.js functions
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions
     File: serverless-developing-typescript-functions
-  - Name: Developing Quarkus functions
-    File: serverless-developing-quarkus-functions
   - Name: Using functions with Knative Eventing
     File: serverless-functions-eventing
   - Name: Function project configuration in func.yaml

--- a/modules/serverless-rn-1-26-0.adoc
+++ b/modules/serverless-rn-1-26-0.adoc
@@ -11,7 +11,7 @@
 [id="new-features-1.26_{context}"]
 == New features
 
-* {FunctionsProductName} is now GA.
+* {FunctionsProductName} with Quarkus is now GA.
 * {ServerlessProductName} now uses Knative Serving 1.5.
 * {ServerlessProductName} now uses Knative Eventing 1.5.
 * {ServerlessProductName} now uses Kourier 1.5.

--- a/serverless/functions/serverless-developing-go-functions.adoc
+++ b/serverless/functions/serverless-developing-go-functions.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: {FunctionsProductName} with Go
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
 After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a Go function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 [id="prerequisites_serverless-developing-go-functions"]

--- a/serverless/functions/serverless-developing-nodejs-functions.adoc
+++ b/serverless/functions/serverless-developing-nodejs-functions.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: {FunctionsProductName} with NodeJS
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
 After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a Node.js function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 [id="prerequisites_serverless-developing-nodejs-functions"]

--- a/serverless/functions/serverless-developing-python-functions.adoc
+++ b/serverless/functions/serverless-developing-python-functions.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: {FunctionsProductName} with Python
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
 After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a Python function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 [id="prerequisites_serverless-developing-python-functions"]

--- a/serverless/functions/serverless-developing-typescript-functions.adoc
+++ b/serverless/functions/serverless-developing-typescript-functions.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: {FunctionsProductName} with TypeScript
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
 After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a TypeScript function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 [id="prerequisites_serverless-developing-typescript-functions"]


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-2208

Link to docs preview:
https://53913--docspreview.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#new-features-1.26_serverless-release-notes
"New features
OpenShift Serverless Functions with Quarkus is now GA."


https://53913--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-developing-quarkus-functions.html
(moved up in sidebar nav)

https://53913--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-developing-nodejs-functions.html
"OpenShift Serverless Functions with NodeJS is a Technology Preview feature only..."


https://53913--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-developing-typescript-functions.html
"OpenShift Serverless Functions with TypeScript is a Technology Preview feature only..."

QE review:
- [ ] QE has approved this change.
