### PR TITLE
OSDOCS-4056: Update registry documentation for MCO behavior

### DIFF
--- a/modules/images-configuration-file.adoc
+++ b/modules/images-configuration-file.adoc
@@ -7,7 +7,17 @@
 [id="images-configuration-file_{context}"]
 = Configuring image registry settings
 
-You can configure image registry settings by editing the `image.config.openshift.io/cluster` custom resource (CR). The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` CR for any changes to the registries and reboots the nodes when it detects changes.
+You can configure image registry settings by editing the `image.config.openshift.io/cluster` custom resource (CR).
+When changes to the registry are applied to the `image.config.openshift.io/cluster` CR, the Machine Config Operator (MCO) performs the following sequential actions:
+
+. Cordons the node
+. Applies changes by restarting CRI-O
+. Uncordons the node
++
+[NOTE]
+====
+The MCO does not restart nodes when it detects changes.
+====
 
 .Procedure
 
@@ -75,11 +85,11 @@ $ oc get nodes
 .Example output
 [source,terminal]
 ----
-NAME                                       STATUS                     ROLES    AGE   VERSION
-ci-ln-j5cd0qt-f76d1-vfj5x-master-0         Ready                         master   98m   v1.25.0
-ci-ln-j5cd0qt-f76d1-vfj5x-master-1         Ready,SchedulingDisabled      master   99m   v1.25.0
-ci-ln-j5cd0qt-f76d1-vfj5x-master-2         Ready                         master   98m   v1.25.0
-ci-ln-j5cd0qt-f76d1-vfj5x-worker-b-nsnd4   Ready                         worker   90m   v1.25.0
-ci-ln-j5cd0qt-f76d1-vfj5x-worker-c-5z2gz   NotReady,SchedulingDisabled   worker   90m   v1.25.0
-ci-ln-j5cd0qt-f76d1-vfj5x-worker-d-stsjv   Ready                         worker   90m   v1.25.0
+NAME                                         STATUS                     ROLES                  AGE   VERSION
+ip-10-0-137-182.us-east-2.compute.internal   Ready,SchedulingDisabled   worker                 65m   v1.25.4+77bec7a
+ip-10-0-139-120.us-east-2.compute.internal   Ready,SchedulingDisabled   control-plane          74m   v1.25.4+77bec7a
+ip-10-0-176-102.us-east-2.compute.internal   Ready                      control-plane          75m   v1.25.4+77bec7a
+ip-10-0-188-96.us-east-2.compute.internal    Ready                      worker                 65m   v1.25.4+77bec7a
+ip-10-0-200-59.us-east-2.compute.internal    Ready                      worker                 63m   v1.25.4+77bec7a
+ip-10-0-223-123.us-east-2.compute.internal   Ready                      control-plane          73m   v1.25.4+77bec7a
 ----


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-4056

Link to docs preview:
https://53915--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-file_image-configuration

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
