### PR TITLE
RHDEVDOCS-4735-fix-broken-links-in-monitoring-config-map-ref

### DIFF
--- a/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -231,7 +231,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 [options="header"]
 |===
 | Property | Type | Description 
-|additionalAlertmanagerConfigs|[]link:additionalalertmanagerconfig[AdditionalAlertmanagerConfig]|Configures additional Alertmanager instances that receive alerts from the Prometheus component. By default, no additional Alertmanager instances are configured.
+|additionalAlertmanagerConfigs|[]link:#additionalalertmanagerconfig[AdditionalAlertmanagerConfig]|Configures additional Alertmanager instances that receive alerts from the Prometheus component. By default, no additional Alertmanager instances are configured.
 
 |enforcedBodySizeLimit|string|Enforces a body size limit for Prometheus scraped metrics. If a scraped target's body response is larger than the limit, the scrape will fail. The following values are valid: an empty value to specify no limit, a numeric value in Prometheus size format (such as `64MB`), or the string `automatic`, which indicates that the limit will be automatically calculated based on cluster capacity. The default value is empty, which indicates no limit.
 
@@ -379,7 +379,7 @@ The `TelemeterClientConfig` resource defines settings for the `telemeter-client`
 * `nodeSelector`
 * `tolerations`
 
-Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfiguration]
+Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===


### PR DESCRIPTION
Summary: Fixes two broken links in them config map reference for monitoring:
- link to the AdditionalAlertManagerConfig table located in the first row of the PrometheusK8sConfig table
- link to the ClusterMonitoringConfiguration table in Required in the TelemeterClientConfig table

No QE review necessary because no technical content is being changed.

- Aligned team: DevTools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4735
- Direct links to doc preview: 
- - https://53924--docspreview.netlify.app/openshift-enterprise/latest/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html#prometheusk8sconfig
- - https://53924--docspreview.netlify.app/openshift-enterprise/latest/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html#required-3
- SME review: @ n/a
- QE review: @ n/a
- Peer review: @rh-tokeefe 