### PR TITLE
[RHACS] ROX-11797 Updated the issue link for ACS to point to Jira instead of GitHub

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -201,7 +201,7 @@
               </span>
             </a>
             <% unless (unsupported_versions.include? version) %>
-              <a href="https://github.com/openshift/openshift-docs/issues/new?title=<%= "[rhacs-docs-#{version}] Issue in file #{repo_path}" %>">
+              <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12331224&issuetype=1&components=12366876&priority=4&summary=<%= "[rhacs-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
                 <span class="material-icons-outlined" title="Open an issue">bug_report
                 </span>
               </a>


### PR DESCRIPTION
Fixes part of https://issues.redhat.com/browse/ROX-11797

Updates the bug link on docs.openshift to point to Jira issue instead of a GitHub issue.

To test:
1. Clone the `rhacs-docs` branch.
2. Update the `_templates/_page_openshift.html.erb` file with changes here.
3. Build using AsciiBinder.
4. Click the issue link to verify that it opens a Jira issue. PS: The issue title won't show any version number but it will work in production. You can also build with a version number by changing the distro YAML file.