### PR TITLE
[OSDOCS-4538] Build script jail 'n' hierarchy fix

### DIFF
--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -1147,6 +1147,11 @@ def guarantee_symlinks_to_project_root(distro="openshift-enterprise"):
             if not os.path.isdir(target_includes_dir):
                 os.symlink(drupal_build_path_includes_dir, target_includes_dir)
 
+    includes_within_includes_path = os.path.join(os.path.abspath(os.curdir), "drupal-build", distro, "includes", "includes")
+    if os.path.exists(includes_within_includes_path):
+        os.unlink(includes_within_includes_path)
+
+
 
 def retrieve_all_drupal_build_adoc_files(distro="openshift-enterprise"):
     """Retrieve all AsciiDoc files from drupal-build directory."""

--- a/makeBuild.py
+++ b/makeBuild.py
@@ -102,6 +102,10 @@ for distro in os.listdir("drupal-build"):
         if book == "rest_api":
           continue
 
+        # includes dir in project root is not something to process
+        if book == "includes":
+            continue
+
         os.chdir("drupal-build/" + distro + "/" + book)
         #print(os.getcwd() + "\n")
 


### PR DESCRIPTION
Version(s):
n/a


Issue: [OSDOCS-4538](https://issues.redhat.com//browse/OSDOCS-4538)


Link to docs preview: n/a


QE review: n/a
- [x] ~QE has approved this change.~


Linting/formatting/etc.:
- [ ]  I ran the Black formatter before merging this.



Additional information: This is just a place for thinking right now. :) 

Current approach is to create symlinks in books to an omnibus project-root `includes` directory.

Redo of #52762 
