### PR TITLE
BZ2093425 Added ODF in the backup and restore index

### DIFF
--- a/backup_and_restore/index.adoc
+++ b/backup_and_restore/index.adoc
@@ -44,11 +44,11 @@ OADP has the following requirements:
 * You must be logged in as a user with a `cluster-admin` role.
 * You must have object storage for storing backups, such as one of the following storage types:
 
+** OpenShift Data Foundation
 ** Amazon Web Services
 ** Microsoft Azure
 ** Google Cloud Platform
-** Multicloud Object Gateway
-** S3-compatible object storage, such as Noobaa or Minio
+** S3-compatible object storage
 
 :FeatureName: The `CloudStorage` API for S3 storage
 include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
BZ2093425: Added OpenShift Data Foundation and removed Multicloud Object Gateway, Nooba, and min.io in storage types for backup and restore book.

Version(s): enterprise 4.8+

Issue: [BZ-2093425](https://bugzilla.redhat.com/show_bug.cgi?id=2093425)

Link to [docs preview](https://53942--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/index.html#oadp-requirements)

@duanwei33 ptal

