### PR TITLE
OCPBUGS#3479 RN for bug fix - provisioning eTags

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -772,6 +772,8 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-4-12-bare-metal-hardware-bug-fixes"]
 ==== Bare Metal Hardware Provisioning
 
+* Before this update, the Ironic provisioning service did not support Baseboard Management Controllers (BMCs) that use weak eTags combined with strict eTag validation. By design, if the BMC provides a weak eTag, Ironic returns two eTags: the original eTag and the original eTag converted to the strong format for compatibility with BMCs that do not support weak eTags. Although Ironic can send two eTags, BMCs using strict eTag validation reject such requests due to the presence of the second eTag. As a result, on some older server hardware, bare-metal provisioning failed with the following error: `HTTP 412 Precondition Failed`. In {product-title} 4.12 and later, this behavior changes and Ironic no longer attempts to send two eTags in cases where a weak eTag is provided. Instead, if a Redfish request dependent on an eTag fails with an eTag validation error, Ironic retries the request with known workarounds. This minimizes the risk of bare-metal provisioning failures on machines with strict eTag validation. (link:https://issues.redhat.com/browse/OCPBUGS-3479[*OCPBUGS#3479*])
+
 [discrete]
 [id="ocp-4-12-builds-bug-fixes"]
 ==== Builds


### PR DESCRIPTION
OCPBUGS#3479: eTag management features broke bare-metal provisioning on certain older server hardware. This fix features a failback to eTag validation so provisioning can continue. 

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-3479

Link to docs preview:
https://53943--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
