### PR TITLE
update refs in Telco related modules for 411 to 412 or product-version

### DIFF
--- a/modules/about-must-gather.adoc
+++ b/modules/about-must-gather.adoc
@@ -25,9 +25,9 @@ Alternatively, you can collect specific information by running the command with 
 +
 For example:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather  --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8:v4.11.0
+$ oc adm must-gather  --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8:v{product-version}.0
 ----
 
 * To collect the audit logs, use the `-- /usr/bin/gather_audit_logs` argument, as described in a following section.

--- a/modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc
+++ b/modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc
@@ -45,7 +45,7 @@ To collect debugging information with `must-gather`, you must specify the Perfor
 
 [NOTE]
 ====
-In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. However, you must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command.
+In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11 and later, this functionality is part of the Node Tuning Operator. However, you must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command.
 ====
 
 [id="cnf-about-gathering-data_{context}"]

--- a/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
+++ b/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
@@ -32,7 +32,7 @@ When you configure reserved and isolated CPUs, the infra containers in pods use 
 
 . Create the pod that uses exclusive CPUs, and set `irq-load-balancing.crio.io` and `cpu-quota.crio.io` annotations to `disable`. For example:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: Pod
@@ -44,7 +44,7 @@ metadata:
 spec:
   containers:
   - name: dynamic-irq-pod
-    image: "registry.redhat.io/openshift4/cnf-tests-rhel8:v4.11"
+    image: "registry.redhat.io/openshift4/cnf-tests-rhel8:v4.{product-version}"
     command: ["sleep", "10h"]
     resources:
       requests:

--- a/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
+++ b/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
@@ -10,7 +10,7 @@ The Performance Profile Creator (PPC) tool requires `must-gather` data. As a clu
 
 [NOTE]
 ====
-In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. However, you must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command.
+In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11 and later, this functionality is part of the Node Tuning Operator. However, you must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command.
 ====
 
 .Prerequisites

--- a/modules/cnf-reducing-netqueues-using-nto.adoc
+++ b/modules/cnf-reducing-netqueues-using-nto.adoc
@@ -15,5 +15,5 @@ Too many queues are created by default for each CPU and these do not fit into th
 
 [NOTE]
 ====
-In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. 
+In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11 and later, this functionality is part of the Node Tuning Operator.
 ====

--- a/modules/eco-node-maintenance-operator-installation-cli.adoc
+++ b/modules/eco-node-maintenance-operator-installation-cli.adoc
@@ -58,7 +58,7 @@ $ oc create -f node-maintenance-operator-group.yaml
 . Create a `Subscription` CR:
 .. Define the `Subscription` CR and save the YAML file, for example, `node-maintenance-subscription.yaml`:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -71,7 +71,7 @@ spec:
   name: node-maintenance-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  StartingCSV: node-maintenance-operator.v4.11.0
+  StartingCSV: node-maintenance-operator.v{product-version}.0
 ----
 +
 <1> Specify the `Namespace` where you want to install the Node Maintenance Operator.

--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -63,7 +63,7 @@ endif::openshift-dedicated[]
 |`registry.redhat.io/workload-availability/self-node-remediation-must-gather-rhel8:v0.4.0`
 |Data collection for the Self Node Remediation Operator and the Node Health Check Operator.
 
-|`registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v4.11.0`
+|`registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v{product-version}.0`
 |Data collection for the Node Maintenance Operator.
 |===
 

--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -29,7 +29,7 @@ The Operator manages the containerized TuneD daemon for {product-title} as a Kub
 
 Node-level settings applied by the containerized TuneD daemon are rolled back on an event that triggers a profile change or when the containerized TuneD daemon is terminated gracefully by receiving and handling a termination signal.
 
-The Node Tuning Operator uses the Performance Profile controller to implement automatic tuning to achieve low latency performance for {product-title} applications. The cluster administrator configures a performance profile to define node-level settings such as the following: 
+The Node Tuning Operator uses the Performance Profile controller to implement automatic tuning to achieve low latency performance for {product-title} applications. The cluster administrator configures a performance profile to define node-level settings such as the following:
 
 * Updating the kernel to kernel-rt.
 * Choosing CPUs for housekeeping.
@@ -39,7 +39,7 @@ The Node Tuning Operator is part of a standard {product-title} installation in v
 
 [NOTE]
 ====
-In earlier versions of {product-title}, the Performance Addon Operator was used to implement automatic tuning to achieve low latency performance for OpenShift applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. 
+In earlier versions of {product-title}, the Performance Addon Operator was used to implement automatic tuning to achieve low latency performance for OpenShift applications. In {product-title} 4.11 and later, this functionality is part of the Node Tuning Operator.
 ====
 
 ifdef::operators[]

--- a/modules/nw-metalLB-monitor-upgrading.adoc
+++ b/modules/nw-metalLB-monitor-upgrading.adoc
@@ -34,8 +34,8 @@ $ oc get csv
 [source,terminal]
 ----
 VERSION     REPLACES                                         PHASE
-4.11.0      metallb-operator.4.10-nnnnnnnnnnnn               Installing
-4.10.0                                                       Replacing
+4.12.0      metallb-operator.4.11-nnnnnnnnnnnn               Installing
+4.11.0                                                       Replacing
 ----
 
 . Run `get csv` again to verify the output:
@@ -49,5 +49,5 @@ $ oc get csv
 [source,terminal]
 ----
 NAME                                 DISPLAY                      VERSION   REPLACES                            PHASE
-metallb-operator.4.11-nnnnnnnnnnnn   MetalLB   4.11.0     metallb-operator.v4.10.0   Succeeded
+metallb-operator.4.12-nnnnnnnnnnnn   MetalLB   4.12.0     metallb-operator.v4.11.0   Succeeded
 ----

--- a/modules/nw-ptp-installing-operator-cli.adoc
+++ b/modules/nw-ptp-installing-operator-cli.adoc
@@ -99,5 +99,5 @@ $ oc get csv -n openshift-ptp -o custom-columns=Name:.metadata.name,Phase:.statu
 [source,terminal]
 ----
 Name                         Phase
-4.11.0-202201261535          Succeeded
+4.12.0-202301261535          Succeeded
 ----

--- a/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
+++ b/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
@@ -57,13 +57,13 @@ apiVersion: "k8s.cni.cncf.io/v1"
 ----
 <1> The type is `bond`.
 <2> The `ifname` attribute specifies the name of the bond interface.
-<3> The `mode` attribute specifies the bonding mode. 
+<3> The `mode` attribute specifies the bonding mode.
 +
 [NOTE]
 ====
 The bonding modes supported are:
 
-* `balance-rr` - 0 
+* `balance-rr` - 0
 * `active-backup` - 1
 * `balance-xor` - 2
 
@@ -78,7 +78,7 @@ For `balance-rr` or `balance-xor` modes, you must set the `trust` mode to `on` f
 
 You can now test the setup by creating a pod using a bond interface.
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
     kind: Pod
@@ -90,7 +90,7 @@ apiVersion: v1
     spec:
       containers:
       - name: podexample
-        image: quay.io/openshift/origin-network-interface-bond-cni:4.11.0
+        image: quay.io/openshift/origin-network-interface-bond-cni:{product-version}.0
         command: ["/bin/bash", "-c", "sleep INF"]
 ----
 <1> Note the network annotation: it contains two SR-IOV network attachments, and one bond network attachment. The bond attachment uses the two SR-IOV interfaces as bonded port interfaces.

--- a/modules/nw-sriov-installing-operator.adoc
+++ b/modules/nw-sriov-installing-operator.adoc
@@ -91,8 +91,8 @@ $ oc get csv -n openshift-sriov-network-operator \
 .Example output
 [source,terminal]
 ----
-Name                                        Phase
-sriov-network-operator.4.11.0-202110121402   Succeeded
+Name                                         Phase
+sriov-network-operator.4.12.0-202310121402   Succeeded
 ----
 
 [id="install-operator-web-console_{context}"]

--- a/modules/ztp-sno-du-configuring-performance-addons.adoc
+++ b/modules/ztp-sno-du-configuring-performance-addons.adoc
@@ -10,7 +10,7 @@
 
 [NOTE]
 ====
-In earlier versions of {product-title}, the Performance Addon Operator was used to implement automatic tuning to achieve low latency performance for OpenShift applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator.
+In earlier versions of {product-title}, the Performance Addon Operator was used to implement automatic tuning to achieve low latency performance for OpenShift applications. In {product-title} 4.11 and later, this functionality is part of the Node Tuning Operator.
 ====
 
 The following example `PerformanceProfile` CR illustrates the required cluster configuration.


### PR DESCRIPTION
[TELCODOCS-890]: Update variables version 4.11 to 4.12 or {product-version} where appropriate for Telco docs

Version(s):
4.12 and main
Issue:
https://issues.redhat.com/browse/TELCODOCS-890
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

An update of variable denoting versions relevant to Telco core docvs in OCP. 
