### PR TITLE
OSDOCS-4587: Apply Quick filters to network traffic data

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1308,6 +1308,8 @@ Topics:
   Topics:
   - Name: Installing Network Observability operators
     File: installing-operators
+  - Name: Observing the network traffic
+    File: observing-network-traffic
 ---
 Name: Storage
 Dir: storage

--- a/modules/network-observability-quickfilter.adoc
+++ b/modules/network-observability-quickfilter.adoc
@@ -1,24 +1,23 @@
 = Filtering network traffic
 By default, the Network Traffic page displays the traffic flow data in the cluster based on the default filters configured in the FlowCollector instance. You can use the filter options to observe the required data by changing the preset filter. Following are the available filter options:
 
-.Query Options
-Following are the available options:
-
-** *Reporter Node*: Every flow can be reported from both source and destination nodes. For cluster ingress, the flow is reported from the destination node and for cluster egress, the flow is reported from the source node.You can select either *Source* or *Destination*. The option *Both* is disabled for Topology view. The default selected value is *Destination*.
-** *Match filters*: To determine whether the result has to match all the filters or any of them. The available options are *Match all* and *Match any*. The default value is *Match all*.
-** *Limit*: The limit for internal backend queries. Depending upon the matching and filter settings, several queries can be performed under the cover, each with this limit set, resulting in more results after aggregation.
 
 .Quick filters
-You can filter the traffic based on the categories that are defined in the `FlowCollector` config. 
-// to check with SME what are the default quick filters available in flowcollector
+The default values in *Quick filters* drop-down are defined in the `FlowCollector` config. You can select or select the options from console. 
 
-//what name to give this filter
-.Key-value filters
-You can filter the traffic by selecting the parameters, and entering the corresponding text values. To filter the exact matching data, enter the values in double-quotes. The default value is *Common Namespaces*.
+.Advanced filters
+To set advanced filters:
 
-Note: "Common" means filters for any of source or destination. For example, filtering name: 'my-pod' means all traffic from my-pod + all traffic to my-pod, regardless of the matching type used (all of / any of).
-//Do we have Common in flowcollector config too?
-//Check with SME what is values being themselves a list, as a comma-separated string
-* Click the search icon.
+* Select the parameters. The default selected parameter is *Common Namespaces*.
+* Enter the value. To filter the data that matches the text value exactly, enter the value in double quotation marks. 
 
-The traffic flow for specific workloads can also be viewed by navigating to the Network Traffic tab of workloads.
+The section *Common* in the parameter drop-down applies filter to both source and destination. To enable or disable the applied filter, you can click on the applied filter listed below the filter options.
+
+.Query Options
+You can use *Query Options* to optimize the search results, as listed below:
+
+** *Reporter Node*: Every flow can be reported from both source and destination nodes. For cluster ingress, the flow is reported from the destination node and for cluster egress, the flow is reported from the source node.You can select either *Source* or *Destination*. The option *Both* is disabled for topology view. The default selected value is *Destination*.
+** *Match filters*: You can determine the relation between different filter parameters selected in advanced filter. The available options are *Match all* and *Match any*. *Match all*  provides results that match all the values, and *Match any* provides results that match any of the values entered.The default value is *Match all*.
+** *Limit*: The limit for internal backend queries. Depending upon the matching and filter settings, several queries can be performed under the cover, each with this limit set, resulting in more results after aggregation.
+
+You can click *Reset default filter* to remove the existing filters, and apply the filter defined in `FlowCollector` config.

--- a/modules/network-observability-quickfilter.adoc
+++ b/modules/network-observability-quickfilter.adoc
@@ -3,7 +3,7 @@ By default, the Network Traffic page displays the traffic flow data in the clust
 
 
 .Quick filters
-The default values in *Quick filters* drop-down are defined in the `FlowCollector` config. You can select or select the options from console. 
+The default values in *Quick filters* drop-down are defined in the `FlowCollector` config. You can modify the options from console. 
 
 .Advanced filters
 To set advanced filters:
@@ -11,12 +11,12 @@ To set advanced filters:
 * Select the parameters. The default selected parameter is *Common Namespaces*.
 * Enter the value. To filter the data that matches the text value exactly, enter the value in double quotation marks. 
 
-The section *Common* in the parameter drop-down applies filter to both source and destination. To enable or disable the applied filter, you can click on the applied filter listed below the filter options.
+The section *Common* in the parameter drop-down filters results that match either *Source* or *Destination*. To enable or disable the applied filter, you can click on the applied filter listed below the filter options.
 
 .Query Options
 You can use *Query Options* to optimize the search results, as listed below:
 
-** *Reporter Node*: Every flow can be reported from both source and destination nodes. For cluster ingress, the flow is reported from the destination node and for cluster egress, the flow is reported from the source node.You can select either *Source* or *Destination*. The option *Both* is disabled for topology view. The default selected value is *Destination*.
+** *Reporter Node*: Every flow can be reported from both source and destination nodes. For cluster ingress, the flow is reported from the destination node and for cluster egress, the flow is reported from the source node.You can select either *Source* or *Destination*. The option *Both* is disabled for overview and topology view. The default selected value is *Destination*.
 ** *Match filters*: You can determine the relation between different filter parameters selected in advanced filter. The available options are *Match all* and *Match any*. *Match all*  provides results that match all the values, and *Match any* provides results that match any of the values entered.The default value is *Match all*.
 ** *Limit*: The limit for internal backend queries. Depending upon the matching and filter settings, several queries can be performed under the cover, each with this limit set, resulting in more results after aggregation.
 

--- a/modules/network-observability-quickfilter.adoc
+++ b/modules/network-observability-quickfilter.adoc
@@ -1,0 +1,24 @@
+= Filtering network traffic
+By default, the Network Traffic page displays the traffic flow data in the cluster based on the default filters configured in the FlowCollector instance. You can use the filter options to observe the required data by changing the preset filter. Following are the available filter options:
+
+.Query Options
+Following are the available options:
+
+** *Reporter Node*: Every flow can be reported from both source and destination nodes. For cluster ingress, the flow is reported from the destination node and for cluster egress, the flow is reported from the source node.You can select either *Source* or *Destination*. The option *Both* is disabled for Topology view. The default selected value is *Destination*.
+** *Match filters*: To determine whether the result has to match all the filters or any of them. The available options are *Match all* and *Match any*. The default value is *Match all*.
+** *Limit*: The limit for internal backend queries. Depending upon the matching and filter settings, several queries can be performed under the cover, each with this limit set, resulting in more results after aggregation.
+
+.Quick filters
+You can filter the traffic based on the categories that are defined in the `FlowCollector` config. 
+// to check with SME what are the default quick filters available in flowcollector
+
+//what name to give this filter
+.Key-value filters
+You can filter the traffic by selecting the parameters, and entering the corresponding text values. To filter the exact matching data, enter the values in double-quotes. The default value is *Common Namespaces*.
+
+Note: "Common" means filters for any of source or destination. For example, filtering name: 'my-pod' means all traffic from my-pod + all traffic to my-pod, regardless of the matching type used (all of / any of).
+//Do we have Common in flowcollector config too?
+//Check with SME what is values being themselves a list, as a comma-separated string
+* Click the search icon.
+
+The traffic flow for specific workloads can also be viewed by navigating to the Network Traffic tab of workloads.

--- a/modules/network-observability-quickfilter.adoc
+++ b/modules/network-observability-quickfilter.adoc
@@ -8,16 +8,22 @@ The default values in *Quick filters* drop-down are defined in the `FlowCollecto
 .Advanced filters
 To set advanced filters:
 
-* Select the parameters. The default selected parameter is *Common Namespaces*.
-* Enter the value. To filter the data that matches the text value exactly, enter the value in double quotation marks. 
+* Select the parameter from one of the sections: *Common*, *Source* or *Destination*. The default selected parameter is *Common Namespaces*.
+* Enter the value in the text area.
++
+[NOTE]
+====
+To understand the rules of specifying the text value, click *Learn More*.
+====
 
 The section *Common* in the parameter drop-down filters results that match either *Source* or *Destination*. To enable or disable the applied filter, you can click on the applied filter listed below the filter options.
+
 
 .Query Options
 You can use *Query Options* to optimize the search results, as listed below:
 
-** *Reporter Node*: Every flow can be reported from both source and destination nodes. For cluster ingress, the flow is reported from the destination node and for cluster egress, the flow is reported from the source node.You can select either *Source* or *Destination*. The option *Both* is disabled for overview and topology view. The default selected value is *Destination*.
-** *Match filters*: You can determine the relation between different filter parameters selected in advanced filter. The available options are *Match all* and *Match any*. *Match all*  provides results that match all the values, and *Match any* provides results that match any of the values entered.The default value is *Match all*.
+** *Reporter Node*: Every flow can be reported from both source and destination nodes. For cluster ingress, the flow is reported from the destination node and for cluster egress, the flow is reported from the source node. You can select either *Source* or *Destination*. The option *Both* is disabled for overview and topology view. The default selected value is *Destination*.
+** *Match filters*: You can determine the relation between different filter parameters selected in advanced filter. The available options are *Match all* and *Match any*. *Match all*  provides results that match all the values, and *Match any* provides results that match any of the values entered. The default value is *Match all*.
 ** *Limit*: The limit for internal backend queries. Depending upon the matching and filter settings, several queries can be performed under the cover, each with this limit set, resulting in more results after aggregation.
 
 You can click *Reset default filter* to remove the existing filters, and apply the filter defined in `FlowCollector` config.

--- a/networking/network_observability/observing-network-traffic.adoc
+++ b/networking/network_observability/observing-network-traffic.adoc
@@ -4,4 +4,6 @@
 
 toc::[]
 
-include::modules/network-observability-overview.adoc[leveloffset=+1]
+include::modules/network-observability-quickfilter.adoc[leveloffset=+1]
+
+Alternatively, you can view the traffic flow data in *Namespaces*, *Services*, *Routes*, *Nodes*, and *Workloads* by using the left navigation pane.

--- a/networking/network_observability/observing-network-traffic.adoc
+++ b/networking/network_observability/observing-network-traffic.adoc
@@ -1,0 +1,7 @@
+[id="nw-observe-network-traffic"]
+= Observing the network traffic
+:context: nw-observe-network-traffic
+
+toc::[]
+
+include::modules/network-observability-overview.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.12+

Issue: https://issues.redhat.com/browse/OSDOCS-4587

Link to docs preview: https://53954--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/observing-network-traffic.html

QE review:
- [ ] QE has approved this change.