### PR TITLE
TELCODOCS-905: expanding networkType explanation

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -359,7 +359,7 @@ ifdef::openshift-origin[]
 Either `OpenShiftSDN` or `OVNKubernetes`. The default value is `OVNKubernetes`.
 endif::openshift-origin[]
 ifndef::openshift-origin[]
-Either `OpenShiftSDN` or `OVNKubernetes`. The default value is `OpenShiftSDN`.
+Either `OpenShiftSDN` or `OVNKubernetes`. `OpenShiftSDN` is a CNI provider for all-Linux networks. `OVNKubernetes` is a CNI provider for Linux networks and hybrid networks that contain both Linux and Windows servers. The default value is `OpenShiftSDN`.
 endif::openshift-origin[]
 
 |`networking.clusterNetwork`
@@ -624,7 +624,7 @@ accounts for the dramatically decreased machine performance.
 |The only supported value is `3`, which is the default value.
 
 |`credentialsMode`
-|The Cloud Credential Operator (CCO) mode. If no mode is specified, the CCO dynamically tries to determine the capabilities of the provided credentials, with a preference for mint mode on the platforms where multiple modes are supported. 
+|The Cloud Credential Operator (CCO) mode. If no mode is specified, the CCO dynamically tries to determine the capabilities of the provided credentials, with a preference for mint mode on the platforms where multiple modes are supported.
 ifdef::gcp[If you are installing on GCP into a shared virtual private cloud (VPC), `credentialsMode` must be set to `Passthrough`.]
 [NOTE]
 ====


### PR DESCRIPTION
Version(s): 4.11, 4.10, 4.9.

Issue:  https://issues.redhat.com/browse/TELCODOCS-905

Link to docs preview: https://53956--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-configuration-parameters-network_installing-bare-metal-network-customizations

Search for "OVNKubernetes".

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
