### PR TITLE
hides the second installation for MicroShift because there is no cont…

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -53,8 +53,8 @@ Distros: microshift
 Topics:
 - Name: Installing from RPM
   File: microshift-install-rpm
-- Name: Installing in a RHEL for Edge Image
-  File: microshift-install-rhel-for-edge
+#- Name: Installing in a RHEL for Edge Image
+#  File: microshift-install-rhel-for-edge
 ---
 Name: API reference
 Dir: microshift_rest_api

--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -5,19 +5,22 @@ include::_attributes/attributes-microshift.adoc[]
 :context: microshift-install-rpm
 toc::[]
 
-You can install MicroShift from an RPM package on a machine with {op-system-first} {op-system-version}. 
+You can install {product-title} from an RPM package on a machine with {op-system-first} {op-system-version}. 
 
-To embed MicroShift in a {op-system-ostree} image, see xref:../microshift_install/microshift-install-rhel-for-edge.adoc#microshift-install-rhel-for-edge[Embedding MicroShift into a {op-system-ostree-first} image].
+[IMPORTANT]
+====
+Red Hat will not provide or support an update or upgrade path from Developer Preview and Technology Preview versions to later versions of {product-title}. A new installation will be necessary.
+====
 
-include::modules/system-requirements-installing-microshift.adoc[leveloffset=+2]
+include::modules/system-requirements-installing-microshift.adoc[leveloffset=+1]
 
-include::modules/preparing-for-installing-microshift-rpm.adoc[leveloffset=+2]
+include::modules/preparing-for-installing-microshift-rpm.adoc[leveloffset=+1]
 
-include::modules/installing-microshift-rpm.adoc[leveloffset=+2]
+include::modules/installing-microshift-rpm.adoc[leveloffset=+1]
 
-include::modules/starting-microshift-service.adoc[leveloffset=+2]
+include::modules/starting-microshift-service.adoc[leveloffset=+1]
 
-include::modules/stopping-microshift-service.adoc[leveloffset=+2]
+include::modules/stopping-microshift-service.adoc[leveloffset=+1]
 
 include::modules/accessing-microshift.adoc[leveloffset=+1]
 

--- a/modules/preparing-for-installing-microshift-rpm.adoc
+++ b/modules/preparing-for-installing-microshift-rpm.adoc
@@ -3,11 +3,11 @@
 // microshift/microshift-install-rpm.adoc 
 
 [id="preparing-install-microshift-from-rpm-package_{context}"]
-= Preparing to install MicroShift from an RPM package
+= Preparing to install {product-title} from an RPM package
 
-Before installing MicroShift from an RPM package, you must configure your {op-system} machine to have a logical volume manager (LVM) volume group (VG) with sufficient capacity for the persistent volumes (PVs) of your workload.
+Before installing {product-title} from an RPM package, you must configure your {op-system} machine to have a logical volume manager (LVM) volume group (VG) with sufficient capacity for the persistent volumes (PVs) of your workload.
 
-MicroShift uses the logical volume manager storage (LVMS) Container Storage Interface (CSI) provider for storing PVs. LVMS relies on Linux's LVM to dynamically manage the backing storage for PVs. For this reason, your machine must have an LVM VG in which LVMS can create the LVM logical volumes (LVs) for your workload's PVs.  
+{product-title} uses the logical volume manager storage (LVMS) Container Storage Interface (CSI) provider for storing PVs. LVMS relies on Linux's LVM to dynamically manage the backing storage for PVs. For this reason, your machine must have an LVM VG in which LVMS can create the LVM logical volumes (LVs) for your workload's PVs.  
 
 To configure an LVM VG that allows LVMS to create the LVM LVs for your workload's PVs, adjust your root volume's size during the installation of {op-system}. Adjusting your root volume's size provides free space for additional LVs created by LVMS at runtime. 
 

--- a/modules/starting-microshift-service.adoc
+++ b/modules/starting-microshift-service.adoc
@@ -4,31 +4,31 @@
 
 :_content-type: PROCEDURE
 [id="starting-microshift_service_{context}"]
-= Starting the MicroShift service
+= Starting the {product-title} service
 
-Use the following procedure to start the MicroShift service. 
+Use the following procedure to start the {product-title} service. 
 
 .Prerequisites 
 
-* You have installed MicroShift from an RPM package. 
+* You have installed {product-title} from an RPM package. 
 
 .Procedure 
 
-. As a root user, start the MicroShift service by entering the following command: 
+. As a root user, start the {product-title} service by entering the following command: 
 +
 [source,terminal]
 ----
 $ sudo systemctl start microshift
 ----
 
-. Optional: To configure your {op-system} machine to start MicroShift when your machine starts, enter the following command:
+. Optional: To configure your {op-system} machine to start {product-title} when your machine starts, enter the following command:
 +
 [source,terminal]
 ----
 $ sudo systemctl enable microshift
 ----
 
-. Optional: To disable MicroShift from automatically starting when your machine starts, enter the following command:
+. Optional: To disable {product-title} from automatically starting when your machine starts, enter the following command:
 +
 [source,terminal]
 ----
@@ -37,6 +37,6 @@ $ sudo systemctl disable microshift
 +
 [NOTE]
 ====
-The first time that the MicroShift service starts, it downloads and initializes MicroShift's container images. As a result, it can take several minutes for {product-title} to start the first time that the service is deployed. 
-Boot time is reduced for subsequent starts of the MicroShift service. 
+The first time that the {product-title} service starts, it downloads and initializes {product-title}'s container images. As a result, it can take several minutes for {product-title} to start the first time that the service is deployed. 
+Boot time is reduced for subsequent starts of the {product-title} service. 
 ====

--- a/modules/stopping-microshift-service.adoc
+++ b/modules/stopping-microshift-service.adoc
@@ -4,24 +4,24 @@
 
 :_content-type: PROCEDURE
 [id="stopping-microshift-service_{context}"]
-= Stopping the MicroShift service
+= Stopping the {product-title} service
 
-Use the following procedure to stop the MicroShift service. 
+Use the following procedure to stop the {product-title} service. 
 
 .Prerequisites 
 
-* The MicroShift service is running. 
+* The {product-title} service is running. 
 
 .Procedure
 
-. Enter the following command to stop the MicroShift service: 
+. Enter the following command to stop the {product-title} service: 
 +
 [source,terminal]
 ----
 $ sudo systemctl stop microshift
 ----
 
-. Workloads deployed on MicroShift will continue running even after the MicroShift service has been stopped. Enter the following command to display running workloads: 
+. Workloads deployed on {product-title} will continue running even after the {product-title} service has been stopped. Enter the following command to display running workloads: 
 +
 [source,terminal]
 ----

--- a/modules/system-requirements-installing-microshift.adoc
+++ b/modules/system-requirements-installing-microshift.adoc
@@ -3,19 +3,19 @@
 // microshift/microshift-install-rpm.adoc 
 
 [id="system-requirements-installing-microshift"]
-== System requirements for installing MicroShift 
+== System requirements for installing {product-title} 
 
-The following conditions must be met prior to installing MicroShift: 
+The following conditions must be met prior to installing {product-title}: 
 
 * {op-system-first} {op-system-version}
 * 2 CPU cores 
 * 2 GB of RAM 
 * 10 GB of storage 
 * You have an active {product-title} subscription on your Red Hat account. If you do not have a subscription, contact your sales representative for more information.
-* You have a subscription that includes MicroShift RPMs. 
+* You have a subscription that includes {product-title} RPMs. 
 * You have a Logical Volume Manager (LVM) Volume Group (VG) with sufficient capacity for the Persistent Volumes (PVs) of your workload.
 
-.MicroShift supported architectures
+.{product-title} supported architectures
 [options="header"]
 |===
 |Architecture |String
@@ -31,7 +31,7 @@ The following conditions must be met prior to installing MicroShift:
 |===
 
 
-.MicroShift supported operating systems 
+.{product-title} supported operating systems 
 [options="header"]
 |===
 |Operating system |String

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -56,7 +56,7 @@ Start with **xref:../architecture/architecture.adoc#architecture-overview-archit
 endif::[]
 
 ifdef::microshift[]
-Start with xref:../microshift_getting_started/microshift-understanding.adoc#microshift-understanding[Understanding {product-title}] and xref:../microshift_install/microshift-install-rhel-for-edge.adoc#microshift-install-rhel-for-edge[Installing].
+Start with xref:../microshift_getting_started/microshift-understanding.adoc#microshift-understanding[Understanding {product-title}] and xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm[Installing].
 Then, see the xref:../microshift_release_notes/microshift-4-12-release-notes.adoc#microshift-4-12-release-notes[release notes].
 
 [IMPORTANT]


### PR DESCRIPTION
PR does the following: 

Adds the IMPORTANT admonition
Swaps MicroShift -> {product-title}
Hides the other install guide, since we have no content for it yet

4.12 only. 

Preview: https://53971--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html

Pending SME approval. 

Jira: https://issues.redhat.com//browse/OSDOCS-4711
