### PR TITLE
OSDOCS-4711: fix headings in install guides

### DIFF
--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -5,9 +5,9 @@ include::_attributes/attributes-microshift.adoc[]
 :context: microshift-install-rpm
 toc::[]
 
-You can install MicroShift from an RPM package on a machine with {op-system-first} {op-system-version}. 
+You can install {product-title} from an RPM package on a machine with {op-system-first} {op-system-version}.
 
-To embed MicroShift in a {op-system-ostree} image, see xref:../microshift_install/microshift-install-rhel-for-edge.adoc#microshift-install-rhel-for-edge[Embedding MicroShift into a {op-system-ostree-first} image].
+To embed {product-title} in a {op-system-ostree} image, see xref:../microshift_install/microshift-install-rhel-for-edge.adoc#microshift-install-rhel-for-edge[Embedding MicroShift into a {op-system-ostree-first} image].
 
 include::modules/system-requirements-installing-microshift.adoc[leveloffset=+2]
 

--- a/modules/installing-microshift-rpm.adoc
+++ b/modules/installing-microshift-rpm.adoc
@@ -1,21 +1,21 @@
 // Module included in the following assemblies:
 //
-// microshift/microshift-install-rpm.adoc 
+// microshift/microshift-install-rpm.adoc
 
 :_content-type: PROCEDURE
 [id="installing-microshift-from-rpm-package_{context}"]
-= Installing MicroShift from an RPM package 
+= Installing {product-title} from an RPM package
 
-Use the following procedure to install MicroShift from an RPM package. 
+Use the following procedure to install {product-title} from an RPM package.
 
-.Prerequisites 
+.Prerequisites
 
-* The xref:../microshift_install/microshift-install-rpm.adoc#system-requirements-installing-microshift[system requirements for installing MicroShift] have been met. 
+* The xref:../microshift_install/microshift-install-rpm.adoc#system-requirements-installing-microshift[system requirements for installing MicroShift] have been met.
 * You have completed the steps at xref:../microshift_install/microshift-install-rpm.adoc#preparing-install-microshift-from-rpm-package_microshift-install-rpm[Preparing to install MicroShift from an RPM package].
 
 .Procedure
 
-. As a root user, enable the MicroShift repositories by entering the following command:
+. As a root user, enable the {product-title} repositories by entering the following command:
 +
 [source,terminal]
 ----
@@ -24,14 +24,14 @@ $ sudo subscription-manager repos \
     --enable fast-datapath-for-{rhel-major}-$(uname -i)-rpms
 ----
 
-. Install MicroShift by entering the following command:
+. Install {product-title} by entering the following command:
 +
 [source,terminal]
 ----
 $ sudo dnf install -y microshift
 ----
 
-. Download your installation link:https://console.redhat.com/openshift/install/pull-secret[pull secret] from the Red Hat Hybrid Cloud Console to a temporary folder, for example, `$HOME/openshift-pull-secret`. This pull secret allows you to authenticate with the container registries that serve the container images used by MicroShift.
+. Download your installation link:https://console.redhat.com/openshift/install/pull-secret[pull secret] from the Red Hat Hybrid Cloud Console to a temporary folder, for example, `$HOME/openshift-pull-secret`. This pull secret allows you to authenticate with the container registries that serve the container images used by {product-title}.
 
 . Enter the following command to copy the pull secret to the `/etc/crio` folder of your {op-system} machine: 
 +
@@ -40,7 +40,7 @@ $ sudo dnf install -y microshift
 $ sudo cp $HOME/openshift-pull-secret /etc/crio/openshift-pull-secret
 ----
 
-. Make the root user the owner of the `/etc/crio/openshift-pull-secret` file by entering the following command: 
+. Make the root user the owner of the `/etc/crio/openshift-pull-secret` file by entering the following command:
 +
 [source,terminal]
 ----
@@ -54,7 +54,7 @@ $ sudo chown root:root /etc/crio/openshift-pull-secret
 $ sudo chmod 600 /etc/crio/openshift-pull-secret
 ----
 
-. If your {op-system} machine has a firewall enabled, you must configure a few mandatory firewall rules. For `firewalld`, enter the following commands: 
+. If your {op-system} machine has a firewall enabled, you must configure a few mandatory firewall rules. For `firewalld`, enter the following commands:
 +
 [source,terminal]
 ----
@@ -71,4 +71,4 @@ $ sudo firewall-cmd --permanent --zone=trusted --add-source=169.254.169.1
 $ sudo firewall-cmd --reload
 ----
 
-If the Volume Group (VG) that you have prepared for MicroShift used the default name `rhel`, no further configuration is necessary. If you have used a different name, or if you want to change more configuration settings, see xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-using-config-tools[Configuring MicroShift]. 
+If the Volume Group (VG) that you have prepared for MicroShift used the default name `rhel`, no further configuration is necessary. If you have used a different name, or if you want to change more configuration settings, see xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-using-config-tools[Configuring MicroShift].

--- a/modules/preparing-for-installing-microshift-rpm.adoc
+++ b/modules/preparing-for-installing-microshift-rpm.adoc
@@ -1,37 +1,37 @@
 // Module included in the following assemblies:
 //
-// microshift/microshift-install-rpm.adoc 
+// microshift/microshift-install-rpm.adoc
 
 [id="preparing-install-microshift-from-rpm-package_{context}"]
-= Preparing to install MicroShift from an RPM package
+= Preparing to install {product-title} from an RPM package
 
-Before installing MicroShift from an RPM package, you must configure your {op-system} machine to have a logical volume manager (LVM) volume group (VG) with sufficient capacity for the persistent volumes (PVs) of your workload.
+Before installing {product-title} from an RPM package, you must configure your {op-system} machine to have a logical volume manager (LVM) volume group (VG) with sufficient capacity for the persistent volumes (PVs) of your workload.
 
-MicroShift uses the logical volume manager storage (LVMS) Container Storage Interface (CSI) provider for storing PVs. LVMS relies on Linux's LVM to dynamically manage the backing storage for PVs. For this reason, your machine must have an LVM VG in which LVMS can create the LVM logical volumes (LVs) for your workload's PVs.  
+{product-title} uses the logical volume manager storage (LVMS) Container Storage Interface (CSI) provider for storing PVs. LVMS relies on Linux's LVM to dynamically manage the backing storage for PVs. For this reason, your machine must have an LVM VG in which LVMS can create the LVM logical volumes (LVs) for your workload's PVs.
 
-To configure an LVM VG that allows LVMS to create the LVM LVs for your workload's PVs, adjust your root volume's size during the installation of {op-system}. Adjusting your root volume's size provides free space for additional LVs created by LVMS at runtime. 
+To configure an LVM VG that allows LVMS to create the LVM LVs for your workload's PVs, adjust your root volume's size during the installation of {op-system}. Adjusting your root volume's size provides free space for additional LVs created by LVMS at runtime.
 
-.Prerequisites 
+.Prerequisites
 
-* The xref:../microshift_install/microshift-install-rpm.adoc#system-requirements-installing-microshift[system requirements for installing MicroShift] have been met. 
-* You have root user access to your machine. 
+* The xref:../microshift_install/microshift-install-rpm.adoc#system-requirements-installing-microshift[system requirements for installing MicroShift] have been met.
+* You have root user access to your machine.
 
-.Procedure 
+.Procedure
 
-. In the graphical installer under *Storage Configuration*, select *Custom* -> *Done* to open the dialog for configuring partitions and volumes. 
+. In the graphical installer under *Storage Configuration*, select *Custom* -> *Done* to open the dialog for configuring partitions and volumes.
 
-. Under *New Red Hat Enterprise Linux 8.x Installation*, select *Click here to create them automatically*. 
+. Under *New Red Hat Enterprise Linux 8.x Installation*, select *Click here to create them automatically*.
 
-. Select the root partition, */*, reduce *Desired Capacity* so that the VG has sufficient capacity for your PVs, and then click *Update Settings*. 
+. Select the root partition, */*, reduce *Desired Capacity* so that the VG has sufficient capacity for your PVs, and then click *Update Settings*.
 
-. Complete your installation. 
+. Complete your installation.
 +
 [NOTE]
 ====
-For more options on partition configuration, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_a_standard_rhel_8_installation/index#manual-partitioning_graphical-installation[Configuring Manual Partitioning]. 
+For more options on partition configuration, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_a_standard_rhel_8_installation/index#manual-partitioning_graphical-installation[Configuring Manual Partitioning].
 ====
 
-. As a root user, verify the VG capacity available on your system by entering the following command: 
+. As a root user, verify the VG capacity available on your system by entering the following command:
 +
 [source,terminal]
 ----

--- a/modules/starting-microshift-service.adoc
+++ b/modules/starting-microshift-service.adoc
@@ -1,34 +1,34 @@
 // Module included in the following assemblies:
 //
-// microshift/microshift-install-rpm.adoc 
+// microshift/microshift-install-rpm.adoc
 
 :_content-type: PROCEDURE
 [id="starting-microshift_service_{context}"]
-= Starting the MicroShift service
+= Starting the {product-title} service
 
-Use the following procedure to start the MicroShift service. 
+Use the following procedure to start the {product-title} service.
 
-.Prerequisites 
+.Prerequisites
 
-* You have installed MicroShift from an RPM package. 
+* You have installed {product-title} from an RPM package.
 
-.Procedure 
+.Procedure
 
-. As a root user, start the MicroShift service by entering the following command: 
+. As a root user, start the {product-title} service by entering the following command:
 +
 [source,terminal]
 ----
 $ sudo systemctl start microshift
 ----
 
-. Optional: To configure your {op-system} machine to start MicroShift when your machine starts, enter the following command:
+. Optional: To configure your {op-system} machine to start {product-title} when your machine starts, enter the following command:
 +
 [source,terminal]
 ----
 $ sudo systemctl enable microshift
 ----
 
-. Optional: To disable MicroShift from automatically starting when your machine starts, enter the following command:
+. Optional: To disable {product-title} from automatically starting when your machine starts, enter the following command:
 +
 [source,terminal]
 ----
@@ -37,6 +37,6 @@ $ sudo systemctl disable microshift
 +
 [NOTE]
 ====
-The first time that the MicroShift service starts, it downloads and initializes MicroShift's container images. As a result, it can take several minutes for {product-title} to start the first time that the service is deployed. 
-Boot time is reduced for subsequent starts of the MicroShift service. 
+The first time that the {product-title} service starts, it downloads and initializes {product-title}'s container images. As a result, it can take several minutes for {product-title} to start the first time that the service is deployed.
+Boot time is reduced for subsequent starts of the MicroShift service.
 ====

--- a/modules/stopping-microshift-service.adoc
+++ b/modules/stopping-microshift-service.adoc
@@ -1,34 +1,34 @@
 // Module included in the following assemblies:
 //
-// microshift/microshift-install-rpm.adoc 
+// microshift/microshift-install-rpm.adoc
 
 :_content-type: PROCEDURE
 [id="stopping-microshift-service_{context}"]
-= Stopping the MicroShift service
+= Stopping the {product-title} service
 
-Use the following procedure to stop the MicroShift service. 
+Use the following procedure to stop the {product-title} service.
 
-.Prerequisites 
+.Prerequisites
 
-* The MicroShift service is running. 
+* The {product-title} service is running.
 
 .Procedure
 
-. Enter the following command to stop the MicroShift service: 
+. Enter the following command to stop the {product-title} service:
 +
 [source,terminal]
 ----
 $ sudo systemctl stop microshift
 ----
 
-. Workloads deployed on MicroShift will continue running even after the MicroShift service has been stopped. Enter the following command to display running workloads: 
+. Workloads deployed on {product-title} will continue running even after the {product-title} service has been stopped. Enter the following command to display running workloads:
 +
 [source,terminal]
 ----
 $ sudo crictl ps -a
 ----
 
-. Enter the following commands to stop the deployed workloads: 
+. Enter the following commands to stop the deployed workloads:
 +
 [source,terminal]
 ----

--- a/modules/system-requirements-installing-microshift.adoc
+++ b/modules/system-requirements-installing-microshift.adoc
@@ -1,21 +1,21 @@
 // Module included in the following assemblies:
 //
-// microshift/microshift-install-rpm.adoc 
+// microshift/microshift-install-rpm.adoc
 
 [id="system-requirements-installing-microshift"]
-== System requirements for installing MicroShift 
+= System requirements for installing {product-title}
 
-The following conditions must be met prior to installing MicroShift: 
+The following conditions must be met prior to installing {product-title}:
 
 * {op-system-first} {op-system-version}
-* 2 CPU cores 
-* 2 GB of RAM 
-* 10 GB of storage 
+* 2 CPU cores
+* 2 GB of RAM
+* 10 GB of storage
 * You have an active {product-title} subscription on your Red Hat account. If you do not have a subscription, contact your sales representative for more information.
-* You have a subscription that includes MicroShift RPMs. 
+* You have a subscription that includes MicroShift RPMs.
 * You have a Logical Volume Manager (LVM) Volume Group (VG) with sufficient capacity for the Persistent Volumes (PVs) of your workload.
 
-.MicroShift supported architectures
+.{product-title} supported architectures
 [options="header"]
 |===
 |Architecture |String
@@ -31,7 +31,7 @@ The following conditions must be met prior to installing MicroShift:
 |===
 
 
-.MicroShift supported operating systems 
+.{product-title} supported operating systems
 [options="header"]
 |===
 |Operating system |String


### PR DESCRIPTION
[OSDOCS-4711](https://issues.redhat.com//browse/OSDOCS-4711): fix headings in install guides 


Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4711
See also https://github.com/openshift/openshift-docs/pull/53971

Link to docs preview:
N/A there is an asciibinder build warning; headings appear normal.

QE review:
N/A -- MicroShift is developer preview
Internal Docs correction/troubleshooting only
