### PR TITLE
[enterprise-4.12] GH53536: [OKD] Documentation is unclear about status of cgroups v2

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -489,7 +489,6 @@ Topics:
     File: configuring-firewall
   - Name: Enabling Linux control group version 2 (cgroup v2)
     File: enabling-cgroup-v2
-    Distros: openshift-enterprise
 - Name: Validating an installation
   File: validating-an-installation
   Distros: openshift-origin,openshift-enterprise

--- a/installing/install_config/enabling-cgroup-v2.adoc
+++ b/installing/install_config/enabling-cgroup-v2.adoc
@@ -6,20 +6,34 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+
+ifndef::openshift-origin[]
 You can enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2) in your cluster by editing the `node.config` object. Enabling cgroup v2 in {product-title} disables all cgroups version 1 controllers and hierarchies in your cluster. cgroup v1 is enabled by default.
 
 cgroup v2 is the next version of the Linux cgroup API. cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation. 
 
 :FeatureName: {product-title} cgroups version 2 support
 include::snippets/technology-preview.adoc[leveloffset=+0]
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+By default, {product-title} uses link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2) in your cluster. You can switch to link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1.html[Linux control group version 1] (cgroup v1), if needed.
+
+cgroup v2 is the next version of the kernel link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/resource_management_guide/ch01[control group] and offers multiple improvements. However, it can have some unwanted effects on your nodes.
+endif::openshift-origin[]
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-
+ifndef::openshift-origin[]
 include::modules/nodes-clusters-cgroups-2-install.adoc[leveloffset=+1]
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+include::modules/nodes-clusters-cgroups-okd-configure.adoc[leveloffset=+1]
+endif::openshift-origin[]
 
 .Additional resources
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/53696
