### PR TITLE
Adds release note for OSDOCS4376

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -386,6 +386,15 @@ This update provides additional deployment specifications for MetalLB. When you 
 
 For more information about deployment specifications for MetalLB, see xref:../networking/metallb/metallb-operator-install.adoc#nw-metallb-operator-deployment-specifications-for-metallb_metallb-operator-install[Deployment specifications for MetalLB].
 
+[id="overriding-default-node-ip-selection-logic"]
+==== Node IP selection improvements 
+
+Previously, the `nodeip-configuration` service on a cluster host selected the IP address from the interface that the default route used. If multiple routes were present, the service would select the route with the lowest metric value. As a result, network traffic could be distributed from the incorrect interface. 
+
+With {product-title} 4.12, a new interface has been added to the `nodeip-configuration` service, which allows users to create a hint file. The hint file contains a variable, `NODEIP_HINT`, that overrides the default IP selection logic and selects a specific node IP address from the subnet `NODEIP_HINT` variable. Using the `NODEIP_HINT` variable allows users to specify which IP address is used, ensuring that network traffic is distributed from the correct interface. 
+
+For more information, see xref:../support/troubleshooting/troubleshooting-network-issues.html#overriding-default-node-ip-selection-logic_troubleshooting-network-issues[Optional: Overriding the default node IP selection logic]. 
+
 [id="ocp-4-12-storage"]
 === Storage
 


### PR DESCRIPTION
Adds release note  for adding a hint file to the node ip configuration. Original pull request is at https://github.com/openshift/openshift-docs/pull/52200. 

Version: 4.12 Only

Issue:
https://issues.redhat.com/browse/OPNET-150 / https://issues.redhat.com/browse/OSDOCS-4376

Link to docs preview: https://54024--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#overriding-default-node-ip-selection-logic


QE/SME review:
QE/SME acks received at https://github.com/openshift/openshift-docs/pull/52200. 