### PR TITLE
OSDOCS-4049: Updates to TP and dep/rem tables for 4.12

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -600,108 +600,219 @@ Some features available in previous releases have been deprecated or removed.
 
 Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. For the most recent list of major functionality deprecated and removed within {product-title} {product-version}, refer to the table below. Additional details for more functionality that has been deprecated and removed are listed after the table.
 
-In the table, features are marked with the following statuses:
+In the following tables, features are marked with the following statuses:
 
-* *GA*: _General Availability_
-* *DEP*: _Deprecated_
-* *REM*: _Removed_
+* _General Availability_
+* _Deprecated_
+* _Removed_
 
-//TODO: remove anything that has been REM since 4.9?
+[discrete]
+=== Operator deprecated and removed features
 
-.Deprecated and removed features tracker
-[cols="3,1,1,1",options="header"]
+.Operator deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
 |====
-|Feature |OCP 4.9 |OCP 4.10 | OCP 4.11
+|Feature |4.10 |4.11 | 4.12
 
 |SQLite database format for Operator catalogs
-|DEP
-|DEP
-|DEP
+|Deprecated
+|Deprecated
+|Deprecated
+
+|====
+
+[discrete]
+=== Images deprecated and removed features
+
+.Images deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
 
 |`ImageChangesInProgress` condition for Cluster Samples Operator
-|DEP
-|DEP
-|DEP
+|Deprecated
+|Deprecated
+|Deprecated
 
 |`MigrationInProgress` condition for Cluster Samples Operator
-|DEP
-|DEP
-|DEP
-
-|Cluster Loader
-|DEP
-|REM
-|REM
-
-|Bring your own {op-system-base} 7 compute machines
-|DEP
-|REM
-|REM
-
-|Jenkins Operator
-|DEP
-|REM
-|REM
-
-|Grafana component in monitoring stack
-|-
-|DEP
-|REM
-
-|Access to Prometheus and Grafana UIs in monitoring stack
-|
-|DEP
-|REM
-
-|vSphere 6.7 Update 2 or earlier
-|DEP
-|DEP
-|REM
-
-|vSphere 7.0 Update 1 or earlier
-|-
-|-
-|DEP
-
-|Virtual hardware version 13
-|DEP
-|DEP
-|REM
-
-|VMware ESXi 6.7 Update 2 or earlier
-|DEP
-|DEP
-|REM
-
-|VMware ESXi 7.0 Update 1 or earlier
-|-
-|-
-|DEP
-
-|Snapshot.storage.k8s.io/v1beta1 API endpoint
-|DEP
-|DEP
-|REM
-
-|Minting credentials for Microsoft Azure clusters
-|GA
-|REM
-|REM
-
-|Persistent storage using FlexVolume
-|-
-|DEP
-|DEP
-
-|Automatic generation of service account token secrets
-|GA
-|GA
-|REM
+|Deprecated
+|Deprecated
+|Deprecated
 
 |Removal of Jenkins images from install payload
-|GA
-|GA
-|REM
+|General Availability
+|Removed
+|Removed
+
+|====
+
+[discrete]
+=== Monitoring deprecated and removed features
+
+.Monitoring deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Grafana component in monitoring stack
+|Deprecated
+|Removed
+|Removed
+
+|Access to Prometheus and Grafana UIs in monitoring stack
+|Deprecated
+|Removed
+|Removed
+
+|====
+
+[discrete]
+=== Installation deprecated and removed features
+
+.Installation deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|vSphere 6.7 Update 2 or earlier
+|Deprecated
+|Removed
+|Removed
+
+|vSphere 7.0 Update 1 or earlier
+|General Availability
+|Deprecated
+|Deprecated
+
+|VMware ESXi 6.7 Update 2 or earlier
+|Deprecated
+|Removed
+|Removed
+
+|VMware ESXi 7.0 Update 1 or earlier
+|General Availability
+|Deprecated
+|Deprecated
+
+|CoreDNS wildcard queries for the `cluster.local` domain
+|General Availability
+|General Availability
+|Deprecated
+
+|====
+
+[discrete]
+=== Updating clusters deprecated and removed features
+
+.Updating clusters deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Virtual hardware version 13
+|Deprecated
+|Removed
+|Removed
+
+|====
+
+[discrete]
+=== Storage deprecated and removed features
+
+.Storage deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|`Snapshot.storage.k8s.io/v1beta1` API endpoint
+|Deprecated
+|Removed
+|Removed
+
+|Persistent storage using FlexVolume
+|Deprecated
+|Deprecated
+|Deprecated
+
+|====
+
+[discrete]
+=== Authentication and authorization deprecated and removed features
+
+.Authentication and authorization deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Automatic generation of service account token secrets
+|General Availability
+|Removed
+|Removed
+
+|====
+
+[discrete]
+=== Specialized hardware and driver enablement deprecated and removed features
+
+.Specialized hardware and driver enablement deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Special Resource Operator (SRO)
+|General Availability
+|General Availability
+|Deprecated
+
+|====
+
+[discrete]
+=== Multi-architecture deprecated and removed features
+
+.Multi-architecture deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|IBM POWER8 all models (`ppc64le`)
+|General Availability
+|General Availability
+|Deprecated
+
+|IBM IBM POWER9 AC922 (`ppc64le`)
+|General Availability
+|General Availability
+|Deprecated
+
+|IBM IBM POWER9 IC922 (`ppc64le`)
+|General Availability
+|General Availability
+|Deprecated
+
+|IBM IBM POWER9 LC922 (`ppc64le`)
+|General Availability
+|General Availability
+|Deprecated
+
+|IBM z13 all models (`s390x`)
+|General Availability
+|General Availability
+|Deprecated
+
+|IBM LinuxONE Emperor (`s390x`)
+|General Availability
+|General Availability
+|Deprecated
+
+|IBM LinuxONE Rockhopper (`s390x`)
+|General Availability
+|General Availability
+|Deprecated
+
+|AMD64 (x86_64) v1 CPU
+|General Availability
+|General Availability
+|Deprecated
 
 |====
 
@@ -1021,6 +1132,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
+|GCP Filestore
+|Not Available
+|Not Available
+|Technology Preview
+
 |Automatic device discovery and provisioning with Local Storage Operator
 |Technology Preview
 |Technology Preview
@@ -1037,11 +1153,6 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.10 |4.11 | 4.12
 
 |Adding kernel modules to nodes with kvc
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
-|Assisted Installer
 |Technology Preview
 |Technology Preview
 |Technology Preview
@@ -1070,6 +1181,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 |Technology Preview
+
+|Agent-based Installer
+|Not Available
+|Not Available
+|General Availability
 
 |====
 
@@ -1104,9 +1220,9 @@ In the following tables, features are marked with the following statuses:
 |====
 
 [discrete]
-=== Support Technology Preview features
+=== Multi-Architecture Technology Preview features
 
-.Support Technology Preview tracker
+.Multi-Architecture Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.10 |4.11 | 4.12
@@ -1129,6 +1245,11 @@ In the following tables, features are marked with the following statuses:
 |`kdump` on `ppc64le` architecture
 |Technology Preview
 |Technology Preview
+|Technology Preview
+
+|IBM Secure Execution on {ibmzProductName} and LinuxONE
+|Not Available
+|Not Available
 |Technology Preview
 
 |====
@@ -1159,12 +1280,12 @@ In the following tables, features are marked with the following statuses:
 |Driver Toolkit
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Special Resource Operator (SRO)
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|Not Available
 
 |====
 
@@ -1209,9 +1330,9 @@ In the following tables, features are marked with the following statuses:
 |====
 
 [discrete]
-=== Operators Technology Preview features
+=== Operator Technology Preview features
 
-.Operators Technology Preview tracker
+.Operator Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.10 |4.11 | 4.12
@@ -1225,6 +1346,26 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 |Technology Preview
+
+|Platform Operator
+|Not Available
+|Not Available
+|Technology Preview
+
+|Multi-cluster Engine Operator
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Node Observability Operator
+|Not Available
+|Not Available
+|Technology Preview
+
+|Network Observability Operator
+|Not Available
+|Not Available
+|General Availability
 
 |====
 
@@ -1264,7 +1405,7 @@ In the following tables, features are marked with the following statuses:
 |Support for external cloud providers for clusters on {rh-openstack}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |OVS hardware offloading for clusters on {rh-openstack}
 |Technology Preview
@@ -1283,6 +1424,11 @@ In the following tables, features are marked with the following statuses:
 
 |Hosted control planes for {product-title}
 |Not Available
+|Technology Preview
+|Technology Preview
+
+|Hosted control planes for Amazon Web Services (AWS)
+||Not Available
 |Technology Preview
 |Technology Preview
 
@@ -1329,7 +1475,7 @@ In the following tables, features are marked with the following statuses:
 |Cloud controller manager for {rh-openstack-first}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Custom Metrics Autoscaler Operator
 |Not Available


### PR DESCRIPTION
[OSDOCS-4049](https://issues.redhat.com//browse/OSDOCS-4049): Updates to TP and dep/rem tables for 4.12

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4049

Link to docs preview:
Dep/rem table: https://54028--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-deprecated-removed-features

TP table: https://54028--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-technology-preview

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
