### PR TITLE
OSDOCS-4706-v2 update Architecture section k8s APIs

### DIFF
--- a/modules/microshift-k8s-apis.adoc
+++ b/modules/microshift-k8s-apis.adoc
@@ -6,17 +6,4 @@
 [id="microshift-k8s-apis_{context}"]
 = {product-title} Kubernetes APIs
 
-{product-title} supports the following standard Kubernetes APIs:
-
-NOTE: TABLE IS FOR PLACEMENT ONLY (FPO)
-
-[cols="1,1",options="header"]
-|===
-^| API ^| API group
-| xref:../microshift_rest_api/network_apis/route-route-openshift-io-v1.adoc#route-route-openshift-io-v1[Route]
-| route.openshift.io/v1
-| xref:../microshift_rest_api/security_apis/securitycontextconstraints-security-openshift-io-v1.adoc#securitycontextconstraints-security-openshift-io-v1[SecurityContextConstraints]
-| security.openshift.io/v1
-|===
-
-//FIXME: Links are broken, table is incorrectly displaying
+The Kubernetes API is fully accessible within {product-title} and can be managed with the `kubectl` command-line tool or the {OCP} CLI tool (`oc`). The `oc` binary is compatible with `kubectl` and offers a set of features that can be used with {product-title}. Installing both tools to use with {product-title} can help you access all of the resources you need to work with your deployments.

--- a/modules/microshift-openshift-apis.adoc
+++ b/modules/microshift-openshift-apis.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: CONCEPT
 [id="microshift-openshift-apis_{context}"]
-= MicroShift OpenShift APIs
+= {product-title} OpenShift APIs
 
 In addition to the standard Kubernetes APIs, {product-title} includes a subset of the APIs supported by {OCP}.
 
@@ -16,3 +16,19 @@ In addition to the standard Kubernetes APIs, {product-title} includes a subset o
 | xref:../microshift_rest_api/security_apis/securitycontextconstraints-security-openshift-io-v1.adoc#securitycontextconstraints-security-openshift-io-v1[SecurityContextConstraints]
 | security.openshift.io/v1
 |===
+
+When you use the {OCP} CLI tool (`oc`) to make a request call against an unsupported API, the `oc` binary can generate an error message about a resource that cannot be found.
+
+.Example output
+
+[source, terminal]
+----
+$ oc new-project test
+Error from server (NotFound): the server could not find the requested resource (get projectrequests.project.openshift.io)
+----
+
+[source, terminal]
+----
+$ oc get projects
+error: the server doesn't have a resource type "projects"
+----


### PR DESCRIPTION
OSDOCS:4706-v2 update Architecture section with blurb for k8s APIs support

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-4706

Link to docs preview:
https://53957--docspreview.netlify.app/microshift/latest/microshift_getting_started/microshift-architecture.html#microshift-k8s-apis_microshift-architecture

QE review:
N/A -- MicroShift is Developer Preview
SME approval is required