### PR TITLE
[RHACS] Updated release notes for patch release 3.73.1

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -47,7 +47,7 @@ endif::[]
 :osp: Red Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 3.73.0
+:rhacs-version: 3.73.1
 :ocp-supported-version: 4.5
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 3.73

--- a/release_notes/373-release-notes.adoc
+++ b/release_notes/373-release-notes.adoc
@@ -13,13 +13,8 @@ toc::[]
 |====
 |{product-title-short} version |Released on
 |`3.73.0` |6 December 2022
+|`3.73.1` |19 December 2022
 |====
-
-[WARNING]
-====
-Due to a critical bug discovered in {product-title-short} version 3.73.0, _do not_ upgrade to this version. For more information, review the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/6990153[After upgrading the RHACS to version 3.73, the Central pod takes several hours to move into the READY state]. If you have upgraded to 3.73.0 and encounter the issue, contact Red Hat Support.
-====
-
 
 [id="about-this-release-373"]
 == About this release
@@ -31,7 +26,6 @@ Due to a critical bug discovered in {product-title-short} version 3.73.0, _do no
 * PostgreSQL database option (Technology Preview)
 * Build-time Kubernetes network policy generator (Technology Preview)
 * Feature enhancements and bug fixes
-
 
 [id="new-features-373"]
 == New features
@@ -320,9 +314,19 @@ If you are using the in-product docs, you can instead download the required docu
 [id="bug-fixes-373"]
 == Bug fixes
 
+[id="resolved-in-version-3730"]
+=== Resolved in version 3.73.0
+
 * Previously, if you were using StackRox Kubernetes Security Platform - Splunk Technology Add-on, results for the `ocp4-cis-node` compliance standard was missing from Splunk. The Splunk integration now includes the `ocp4-cis-node` compliance standard results. (link:https://issues.redhat.com/browse/ROX-11937[ROX-11937])
 * Previously, Central failed on the `v1 CronJob` deployment YAML check. This issue is fixed. (link:https://issues.redhat.com/browse/ROX-13500[ROX-13500])
 * Previously, when you rebooted the {ocp} cluster `scanner-db` pod would get stuck in the `init` state. This issue is fixed. (link:https://issues.redhat.com/browse/ROX-12556[ROX-12556])
+
+[id="resolved-in-version-3731"]
+=== Resolved in version 3.73.1
+
+* Previously, after upgrading to {product-title-short} 3.73.0, the Central pod entered a `CrashLoopBackOff` state because of a failing readiness probe.
+The patch release 3.73.1 fixes this issue.
+* The patch release 3.73.1 fixes an issue where the Compliance dashboard in the {product-title-short} portal failed to load compliance results.
 
 [id="image-versions-373"]
 == Image versions


### PR DESCRIPTION
Updates for patch release 3.73.1

- Merge in `rhacs-docs`
- Cherry-pick in `rhacs-docs-3.73`

Preview: https://openshift-docs-git-patchrel3731-gnelson.vercel.app/openshift-acs/master/release_notes/373-release-notes.html

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.