### PR TITLE
[RHACS} Fixed installation docs for ROX-14047

### DIFF
--- a/installing/installing_ocp/install-central-ocp.adoc
+++ b/installing/installing_ocp/install-central-ocp.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 [role="_abstract"]
 
-Central is the resource that contains the {product-title-short} application management interface and services. It handles data persistence, API interactions, and {product-title-short} portal access. You can use the same Central instance to secure multiple {ocp} or Kubernetes clusters. 
+Central is the resource that contains the {product-title-short} application management interface and services. It handles data persistence, API interactions, and {product-title-short} portal access. You can use the same Central instance to secure multiple {ocp} or Kubernetes clusters.
 
 You can install Central on your {ocp} or Kubernetes cluster by using one of the following methods:
 
@@ -19,7 +19,7 @@ You can install Central on your {ocp} or Kubernetes cluster by using one of the 
 // Install using Operator
 
 [id="install-central-using-operator"]
-== Install Central using the Operator 
+== Install Central using the Operator
 
 include::modules/install-acs-operator.adoc[leveloffset=+2]
 
@@ -88,6 +88,6 @@ include::modules/install-roxctl-cli-linux.adoc[leveloffset=3]
 include::modules/install-roxctl-cli-macos.adoc[leveloffset=+3]
 include::modules/install-roxctl-cli-windows.adoc[leveloffset=+3]
 
-include::modules/using-the-interactive-installer.adoc[leveloffset=+3]
+include::modules/using-the-interactive-installer.adoc[leveloffset=+2]
 
 include::modules/install-central-roxctl.adoc[leveloffset=+2]

--- a/installing/installing_ocp/verify-installation-rhacs-ocp.adoc
+++ b/installing/installing_ocp/verify-installation-rhacs-ocp.adoc
@@ -9,4 +9,4 @@ toc::[]
 [role="_abstract"]
 Provides steps to verify that {product-title-short} is properly installed.
 
-include::modules/verify-acs-installation.adoc[leveloffset=+1]
+include::modules/verify-acs-installation-ocp.adoc[leveloffset=+1]

--- a/installing/installing_other/install-central-other.adoc
+++ b/installing/installing_other/install-central-other.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 [role="_abstract"]
 
-Central is the resource that contains the {product-title-short} application management interface and services. It handles data persistence, API interactions, and {product-title-short} portal access. You can use the same Central instance to secure multiple {ocp} or Kubernetes clusters. 
+Central is the resource that contains the {product-title-short} application management interface and services. It handles data persistence, API interactions, and {product-title-short} portal access. You can use the same Central instance to secure multiple {ocp} or Kubernetes clusters.
 
 You can install Central by using one of the following methods:
 
@@ -16,8 +16,6 @@ You can install Central by using one of the following methods:
 * Install using the `roxctl` CLI (do not use this method unless you have a specific installation need that requires using it)
 
 // Install using Helm
-
-[id="install-using-helm"]
 
 [id="install-using-helm-no-customizations-other"]
 == Install Central using Helm charts
@@ -70,6 +68,6 @@ include::modules/install-roxctl-cli-linux.adoc[leveloffset=3]
 include::modules/install-roxctl-cli-macos.adoc[leveloffset=+3]
 include::modules/install-roxctl-cli-windows.adoc[leveloffset=+3]
 
-include::modules/using-the-interactive-installer.adoc[leveloffset=+3]
+include::modules/using-the-interactive-installer.adoc[leveloffset=+2]
 
 include::modules/install-central-roxctl.adoc[leveloffset=+2]

--- a/installing/installing_other/verify-installation-rhacs-other.adoc
+++ b/installing/installing_other/verify-installation-rhacs-other.adoc
@@ -7,15 +7,6 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-After installing {product-title-managed-short}, you can perform some steps to verify that the installation was successful.
+Provides steps to verify that {product-title-short} is properly installed.
 
-:FeatureName: {product-title-managed-short}
-include::snippets/field-trial.adoc[leveloffset=+1]
-
-To verify installation, access your ACS Console from the {cloud-console}. The Dashboard will display the number of clusters that {product-title-managed-short} is monitoring, along with information about nodes, deployments, images, and violations.
-
-If there is no data in the ACS Console:
-
-* Ensure that at least one secured cluster is connected to your {product-title-managed-short} instance. For more information, see the "Installing secured cluster resources on each cluster" section.
-* Examine your Sensor pod logs to ensure that the connection to your {product-title-managed-short} instance is successful.
-* In the {ocp-short} cluster, navigate to *Platform Configuration* -> *Clusters* to verify that the components are healthy and view additional operational information.
+include::modules/verify-acs-installation-kube.adoc[leveloffset=+1]

--- a/modules/verify-acs-installation-kube.adoc
+++ b/modules/verify-acs-installation-kube.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * installing/verify-installation-rhacs-other.adoc
+:content-type: PROCEDURE
+[id="verify-acs-installation_{context}"]
+= Verifying installation
+
+After you complete the installation, run a few vulnerable applications and navigate to the {product-title-short} portal to evaluate the results of security assessments and policy violations.
+
+[NOTE]
+====
+The sample applications listed in the following section contain critical vulnerabilities and they are specifically designed to verify the build and deploy-time assessment features of {product-title}.
+====
+To verify installation:
+
+. Find the address of the {product-title-short} portal based on your exposure method:
+.. For a load balancer:
++
+[source,terminal]
+----
+$ kubectl get service central-loadbalancer -n stackrox
+----
+.. For port forward:
+... Run the following command:
++
+[source,terminal]
+----
+$ kubectl port-forward svc/central 18443:443 -n stackrox
+----
+... Navigate to `\https://localhost:18443/`.
+. Create a new namespace:
++
+[source,terminal]
+----
+$ kubectl create namespace test
+----
+. Start some applications with critical vulnerabilities:
++
+[source,terminal]
+----
+$ kubectl run shell --labels=app=shellshock,team=test-team \
+  --image=vulnerables/cve-2014-6271 -n test
+$ kubectl run samba --labels=app=rce \
+  --image=vulnerables/cve-2017-7494 -n test
+----
+
+{product-title} automatically scans these deployments for security risks and policy violations as soon as they are submitted to the cluster. Navigate to the {product-title-short} portal to view the violations. You can log in to the {product-title-short} portal by using the default username *admin* and the generated password.

--- a/modules/verify-acs-installation-ocp.adoc
+++ b/modules/verify-acs-installation-ocp.adoc
@@ -50,4 +50,4 @@ $ oc run samba --labels=app=rce \
   --image=vulnerables/cve-2017-7494 -n test
 ----
 
-{product-title} automatically scans these deployments for security risk and policy violations as soon as they are submitted to the cluster. Navigate to the {product-title-short} portal to view the violations. You can log in to the {product-title-short} portal by using the default username *admin* and the generated password.
+{product-title} automatically scans these deployments for security risks and policy violations as soon as they are submitted to the cluster. Navigate to the {product-title-short} portal to view the violations. You can log in to the {product-title-short} portal by using the default username *admin* and the generated password.


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-14047

Preview: 
- https://openshift-docs-git-install-warning-fix-gnelson.vercel.app/openshift-acs/master/installing/installing_other/install-central-other.html#install-using-roxctl-other
- https://openshift-docs-git-install-warning-fix-gnelson.vercel.app/openshift-acs/master/installing/installing_other/verify-installation-rhacs-other.html

Merge into `rhacs-docs`, cherry-pick into:
- `rhacs-docs-3.73`
---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.

