### PR TITLE
OSDOCS-4661:adds Agent-based Intaller to the Installing overview page

### DIFF
--- a/installing/index.adoc
+++ b/installing/index.adoc
@@ -8,6 +8,7 @@ toc::[]
 
 include::modules/installation-overview.adoc[leveloffset=+1]
 
+
 include::modules/install-openshift-common-terms.adoc[leveloffset=+2]
 
 include::modules/installation-process.adoc[leveloffset=+2]
@@ -23,6 +24,7 @@ include::modules/ipi-verifying-nodes-after-installation.adoc[leveloffset=+2]
 
 * xref:../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation]
 
+* xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Agent-based Installer]
 [discrete]
 === Installation scope
 

--- a/modules/installation-overview.adoc
+++ b/modules/installation-overview.adoc
@@ -22,6 +22,8 @@ Both cluster types have the following characteristics:
 * Highly available infrastructure with no single points of failure is available by default.
 * Administrators maintain control over what updates are applied and when.
 
+The Agent-based Installer is part of the {product-title} Installer. The installer provides you with the flexibility of user-provisioned infrastructure (UPI) installation and the ease of use of the Assisted Installer (AI).
+
 [id="about-the-installation-program"]
 == About the installation program
 


### PR DESCRIPTION
- Applies to main and 4.12
- [Jira](https://issues.redhat.com/browse/OSDOCS-4716)
- [Preview](https://54035--docspreview.netlify.app/openshift-enterprise/latest/installing/index.html)
- @celebdor  This PR adds the Agent-based Installer introduction in the Installation overview page. ptal and let me know if i need to add anything. Thanks