### PR TITLE
CNV-20256: VM memory dump

### DIFF
--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -2,11 +2,11 @@
 //
 // * virt/virt-using-the-cli-tools.adoc
 
+:_content-type: REFERENCE
 [id="virt-virtctl-commands_{context}"]
-= Virtctl client commands
+= Virtctl commands
 
-The `virtctl` client is a command-line utility for managing {VirtProductName}
-resources.
+The `virtctl` client is a command-line utility for managing {VirtProductName} resources.
 
 To view a list of `virtctl` commands, run the following command:
 
@@ -29,71 +29,203 @@ To view a list of global command options that you can use with any `virtctl` com
 $ virtctl options
 ----
 
-The following table contains the `virtctl` commands used throughout the {VirtProductName} documentation.
+// apinnick: I recommend not breaking these commands into separate modules because of maintenance issues.
+// These sections would never be used independently.
 
-.`virtctl` client commands
+[id='vm-management-commands_{context}']
+== Virtual machine management commands
 
-[width="100%",cols="42%,58%",options="header",]
+You can use `virtctl` to manage virtual machine (VM) or virtual machine instance (VMI) states and to migrate a VM.
+
+.VM management commands
+[width="100%",cols="1a,2a",options="header"]
 |===
 |Command |Description
 
 |`virtctl start <vm_name>`
-|Start a virtual machine.
+|Start a VM.
 
 |`virtctl start --paused <vm_name>`
-|Start a virtual machine in a paused state. This option enables you to interrupt the boot process from the VNC console.
+|Start a VM in a paused state. This option enables you to interrupt the boot process from the VNC console.
 
 |`virtctl stop <vm_name>`
-|Stop a virtual machine.
+|Stop a VM.
 
 |`virtctl stop <vm_name> --grace-period 0 --force`
-|Force stop a virtual machine. This option might cause data inconsistency or data loss.
+|Force stop a VM. This option might cause data inconsistency or data loss.
 
-|`virtctl pause vm\|vmi <object_name>`
-|Pause a virtual machine or virtual machine instance. The machine state is kept
+|`virtctl pause vm\|vmi <vm_name>`
+|Pause a VM or VMI. The machine state is kept
 in memory.
 
-|`virtctl unpause vm\|vmi <object_name>`
-|Unpause a virtual machine or virtual machine instance.
+|`virtctl unpause vm\|vmi <vm_name>`
+|Unpause a VM or VMI.
 
 |`virtctl migrate <vm_name>`
-|Migrate a virtual machine.
+|Migrate a VM.
 
 |`virtctl restart <vm_name>`
-|Restart a virtual machine.
+|Restart a VM.
+|===
 
-|`virtctl expose <vm_name>`
-|Create a service that forwards a designated port
-of a virtual machine or virtual machine instance and expose the service on
-the specified port of the node.
+[id='vm-and-vmi-connection-commands_{context}']
+== VM and VMI connection commands
+
+You can use `virtctl` to connect to the serial console, expose a port, set a proxy connection, specify a port, and open a VNC connection to a VM.
+
+.`virtctl console`, `expose`, and `vnc` commands
+[width="100%",cols="1a,2a",options="header"]
+|===
+|Command |Description
 
 |`virtctl console <vmi_name>`
-|Connect to a serial console of a virtual machine instance.
+|Connect to the serial console of a VMI.
+
+|`virtctl expose <vm_name>`
+|Create a service that forwards a designated port of a VM or VMI and expose the service on the specified port of the node.
 
 |`virtctl vnc --kubeconfig=$KUBECONFIG <vmi_name>`
-|Open a VNC (Virtual Network Client) connection to a virtual machine instance. Access the graphical console of a virtual machine instance through a VNC which requires a remote viewer on your local machine.
+|Open a Virtual Network Client (VNC) connection to a VMI.
 
-|`virtctl vnc --kubeconfig=$KUBECONFIG --proxy-only=true <vmi-name>`
-|Display the port number and connect manually to the virtual machine instance by using any viewer through the VNC connection.
+Accessing the graphical console of a VMI through VNC requires a remote viewer on your local machine.
 
-|`virtctl vnc --kubeconfig=$KUBECONFIG --port=<port-number> <vmi-name>`
-|Specify a port number to run the proxy on the specified port, if that port is available. If a port number is not specified, the proxy runs on a random port.
+|`virtctl vnc --kubeconfig=$KUBECONFIG --proxy-only=true <vmi_name>`
+|Display the port number and connect manually to a VMI by using any viewer through the VNC connection.
 
+|`virtctl vnc --kubeconfig=$KUBECONFIG --port=<port-number> <vmi_name>`
+|Specify a port number to run the proxy on the specified port, if that port is available.
+
+If a port number is not specified, the proxy runs on a random port.
+|===
+
+[id='vm-volume-export-commands_{context}']
+== VM volume export commands
+
+You can use `virtctl vmexport` commands to create, download, or delete a volume exported from a VM, VM snapshot, or persistent volume claim (PVC).
+
+.`virtctl vmexport` commands
+[width="100%",cols="1a,2a",options="header"]
+|===
+|Command |Description
+
+|`virtctl vmexport create <vmexport_name> --vm\|snapshot\|pvc=<object_name>`
+|Create a `VirtualMachineExport` custom resource (CR) to export a volume from a VM, VM snapshot, or PVC.
+
+* `--vm`: Exports the PVCs of a VM.
+* `--snapshot`: Exports the PVCs contained in a `VirtualMachineSnapshot` CR.
+* `--pvc`: Exports a PVC.
+* Optional: `--ttl=1h` specifies the time to live. The default duration is 2 hours.
+
+|`virtctl vmexport delete <vmexport_name>`
+|Delete a `VirtualMachineExport` CR manually.
+
+|`virtctl vmexport download <vmexport_name> --output=<output_file> --volume=<volume_name>`
+|Download the volume defined in a `VirtualMachineExport` CR.
+
+* `--output` specifies the file format. Example: `disk.img.gz`.
+* `--volume` specifies the volume to download. This flag is optional if only one volume is available.
+
+Optional:
+
+* `--keep-vme` retains the `VirtualMachineExport` CR after download. The default behavior is to delete the `VirtualMachineExport` CR after download.
+* `--insecure` enables an insecure HTTP connection.
+
+|`virtctl vmexport download <vmexport_name> --<vm\|snapshot\|pvc>=<object_name> --output=<output_file> --volume=<volume_name>`
+|Create a `VirtualMachineExport` CR and then download the volume defined in the CR.
+|===
+
+[id='vm-memory-dump-commands_{context}']
+== VM memory dump commands
+
+You can use the `virtctl memory-dump` command to output a virtual machine (VM) memory dump on a PVC. You can specify an existing PVC or use the `--create-claim` flag to create a new PVC.
+
+.Prerequisites
+
+* The PVC volume mode must be `FileSystem`.
+* The PVC must be large enough to contain the memory dump.
++
+The formula for calculating the PVC size is `(VMMemorySize + 100Mi) * FileSystemOverhead`, where `100Mi` is the memory dump overhead.
+
+* You must enable the hot plug feature gate in the `HyperConverged` custom resource by running the following command:
++
+[source,terminal]
+----
+$ oc patch hco kubevirt-hyperconverged -n openshift-cnv \
+  --type json -p '[{"op": "add", "path": "/spec/featureGates", \
+  "value": "HotplugVolumes"}]'
+----
+
+.Downloading the memory dump
+
+You must use the `virtctl vmexport download` command to download the memory dump:
+
+[source,terminal]
+----
+$ virtctl vmexport download <vmexport_name> --vm\|pvc=<object_name> \
+  --volume=<volume_name> --output=<output_file>
+----
+
+.`virtctl memory-dump` commands
+[width="100%",cols="1a,2a",options="header"]
+|===
+|Command |Description
+|`virtctl memory-dump get <vm_name> --claim-name=<pvc_name>`
+|Save the memory dump of a VM on a PVC. The memory dump status is displayed in the `status` section of the `VirtualMachine` resource.
+
+Optional:
+
+* `--create-claim` creates a new PVC with the appropriate size. This flag has the following options:
+
+** `--storage-class=<storage_class>`: Specify a storage class for the PVC.
+** `--access-mode=<access_mode>`: Specify `ReadWriteOnce` or `ReadWriteMany`.
+
+|`virtctl memory-dump get <vm_name>`
+|Rerun the `virtctl memory-dump` command with the same PVC.
+
+This command overwrites the previous memory dump.
+
+|`virtctl memory-dump remove <vm_name>`
+|Remove a memory dump.
+
+You must remove a memory dump manually if you want to change the target PVC.
+
+This command removes the association between the VM and the PVC, so that the memory dump is not displayed in the `status` section of the `VirtualMachine` resource. The PVC is not affected.
+|===
+
+[id='image-upload-commands_{context}']
+== Image upload commands
+
+You can use the `virtctl image-upload` commands to upload a VM image to a data volume.
+
+.`virtctl image-upload` commands
+[width="100%",cols="1a,2a",options="header"]
+|===
+|Command |Description
 |`virtctl image-upload dv <datavolume_name> --image-path=</path/to/image> --no-create`
-|Upload a virtual machine image to a data volume that already exists.
+|Upload a VM image to a data volume that already exists.
 
 |`virtctl image-upload dv <datavolume_name> --size=<datavolume_size> --image-path=</path/to/image>`
-|Upload a virtual machine image to a new data volume.
+|Upload a VM image to a new data volume of a specified requested size.
+|===
 
+[id='environment-information-commands_{context}']
+== Environment information commands
+
+You can use `virtctl` to view information about versions, file systems, guest operating systems, and logged-in users.
+
+.`virtctl` environment information commands
+[width="100%",cols="1a,2a",options="header"]
+|===
+|Command |Description
 |`virtctl version`
-|Display the client and server version information.
+|View the `virtctl` client and server versions.
 
 |`virtctl fslist <vmi_name>`
-|Return a full list of file systems available on the guest machine.
+|View the file systems available on a guest machine.
 
 |`virtctl guestosinfo <vmi_name>`
-|Return guest agent information about the operating system.
+|View information about the operating systems on a guest machine.
 
 |`virtctl userlist <vmi_name>`
-|Return a full list of logged-in users on the guest machine.
+|View the logged-in users on a guest machine.
 |===

--- a/virt/virt-using-the-cli-tools.adoc
+++ b/virt/virt-using-the-cli-tools.adoc
@@ -3,6 +3,7 @@
 = Using the CLI tools
 include::_attributes/common-attributes.adoc[]
 :context: virt-using-the-cli-tools
+:toclevels: 3
 
 toc::[]
 
@@ -21,7 +22,9 @@ For more comprehensive information on `oc` client commands, see the
 xref:../cli_reference/openshift_cli/developer-cli-commands.adoc#cli-developer-commands[{product-title} CLI tools] documentation.
 
 include::modules/virt-virtctl-commands.adoc[leveloffset=+1]
+
 include::modules/virt-creating-pvc-with-virtctl-guestfs.adoc[leveloffset=+1]
+
 include::modules/virt-about-libguestfs-tools-virtctl-guestfs.adoc[leveloffset=+1]
 
 [id="additional-resources_virt-using-the-cli-tools"]


### PR DESCRIPTION
Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-20256](https://issues.redhat.com//browse/CNV-20256)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Virtctl commands: Memory dump](https://54036--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-using-the-cli-tools.html#vm-memory-dump_virt-using-the-cli-tools)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
