### PR TITLE
Fixes a leveling issue for MicroShift installation

### DIFF
--- a/modules/system-requirements-installing-microshift.adoc
+++ b/modules/system-requirements-installing-microshift.adoc
@@ -3,7 +3,7 @@
 // microshift/microshift-install-rpm.adoc 
 
 [id="system-requirements-installing-microshift"]
-== System requirements for installing {product-title} 
+= System requirements for installing {product-title} 
 
 The following conditions must be met prior to installing {product-title}: 
 


### PR DESCRIPTION
When building enterprise-4.12 locally, the following error occurs: 

Building MicroShift for branch 'enterprise-4.12'
asciidoctor: WARNING: modules/system-requirements-installing-microshift.adoc: line 6: section title out of sequence: expected level 1, got level 2

This is because of a level 1 heading in the aforementioned module. 

This PR fixes the above issue. It needs merged only to 4.12. 

No Jira ticket. 

QE/SME not needed. 

Preview: 