### PR TITLE
OSDOCS-4521: Adds batch of RN bug doc text

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -802,6 +802,10 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-4-12-bare-metal-hardware-bug-fixes"]
 ==== Bare Metal Hardware Provisioning
 
+* In recent versions of server firmware the time between server operations has increased. This causes timeouts during installer-provisioned infrastructure (IPI) installations when the {product-title} installation program waits for a response from the Baseboard Management Controller (BMC). The new `python3-sushy` release increases the number of server side attempts to contact the BMC. This update accounts for the extended waiting time and avoids timeouts during installation. (link:https://issues.redhat.com/browse/OCPBUGS-4097[*OCPBUGS-4097*])
+
+* Before this update, the Ironic provisioning service did not support Baseboard Management Controllers (BMC) that use weak eTags combined with strict eTag validation. By design, if the BMC provides a weak eTag, Ironic returns two eTags: the original eTag and the original eTag converted to the strong format for compatibility with BMC that do not support weak eTags. Although Ironic can send two eTags, BMC using strict eTag validation reject such requests due to the presence of the second eTag. As a result, on some older server hardware, bare-metal provisioning failed with the following error: `HTTP 412 Precondition Failed`. In {product-title} 4.12 and later, this behavior changes and Ironic no longer attempts to send two eTags in cases where a weak eTag is provided. Instead, if a Redfish request dependent on an eTag fails with an eTag validation error, Ironic retries the request with known workarounds. This minimizes the risk of bare-metal provisioning failures on machines with strict eTag validation. (link:https://issues.redhat.com/browse/OCPBUGS-3479[*OCPBUGS#3479*])
+
 [discrete]
 [id="ocp-4-12-builds-bug-fixes"]
 ==== Builds
@@ -809,6 +813,19 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [discrete]
 [id="ocp-4-12-cloud-compute-bug-fixes"]
 ==== Cloud Compute
+
+* Previously, instances were not set to respect the GCP infrastructure default option for automated restarts. As a result, instances could be created without using the infrastructure default for automatic restarts. This sometimes meant that instances were terminated in GCP but their associated machines were still listed in the `Running` state because they did not automatically restart. With this release, the code for passing the automatic restart option has been improved to better detect and pass on the default option selection from users. Instances now use the infrastructure default properly and are automatically restarted when the user requests the default functionality. (link:https://issues.redhat.com/browse/OCPBUGS-4504[*OCPBUGS-4504*])
+
+* Previously, the GCP machine controller reconciled the state of machines every 10 hours. Other providers set this value to 10 minutes so that changes that happen outside of the Machine API system are detected within a short period. The longer reconciliation period for GCP could cause unexpected issues such as missing certificate signing requests (CSR) approvals due to an external IP address being added but not detected for an extended period. With this release, the GCP machine controller is updated to reconcile every 10 minutes to be consistent with other platforms and so that external changes are picked up sooner. (link:https://issues.redhat.com/browse/OCPBUGS-4499[*OCPBUGS-4499*])
+
+* Previously, due to a deployment misconfiguration for the Cluster Machine Approver Operator, enabling the `TechPreviewNoUpgrade` feature set caused errors and sporadic Operator degradation. Because clusters with the `TechPreviewNoUpgrade` feature set enabled use two instances of the Cluster Machine Approver Operator and both deployments used the same set of ports, there was a conflict that lead to errors for single-node topology. With this release, the Cluster Machine Approver Operator deployment is updated to use a different set of ports for different deployments. (link:https://issues.redhat.com/browse/OCPBUGS-2621[*OCPBUGS-2621*])
+
+* Previously, the scale from zero functionality in Azure relied on a statically compiled list of instance types mapping the name of the instance type to the number of CPUs and the amount of memory allocated to the instance type. This list grew stale over time. With this release, information about instance type sizes is dynamically gathered from the Azure API directly to prevent the list from becoming stale. (link:https://issues.redhat.com/browse/OCPBUGS-2558[*OCPBUGS-2558*])
+
+* Previously, Machine API termination handler pods did not start on spot instances. As a result, pods that were running on tainted spot instances did not receive a termination signal if the instance was terminated. This could result in loss of data in workload applications. With this release, the Machine API termination handler deployment is modified to tolerate the taints and pods running on spot instances with taints now receive termination signals.
+(link:https://issues.redhat.com/browse/OCPBUGS-1274[*OCPBUGS-1274*])
+
+* Previously, error messages for Azure clusters did not explain that it is not possible to create new machines with public IP addresses for a disconnected install that uses only the internal publish strategy. With this release, the error message is updated for improved clarity. (link:https://issues.redhat.com/browse/OCPBUGS-519[*OCPBUGS-519*])
 
 [discrete]
 [id="ocp-4-12-cluster-version-operator-bug-fixes"]
@@ -851,6 +868,16 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [discrete]
 [id="ocp-4-12-management-console-bug-fixes"]
 ==== Management Console
+
+* Previously, the *Operator details* page attempted to display multiple error messages, but the error message component can only display a single error message at a time. As a result, relevant error messages were not displayed. With this update, the *Operator details* page displays only the first error message so the user sees a relevant error. (link: https://issues.redhat.com/browse/OCPBUGS-3927[*OCPBUGS-3927*])
+
+* Previously, the product name for Azure Red Hat OpenShift was incorrect in Customer Case Management (CCM). As a result, the console had to use the same incorrect product name to correctly populate the fields in CCM. Once the product name in CCM was updated, the console needed to be updated as well. With this update, the same, correct product name as CCM is correctly populated with the correct Azure product name when following the link from the console. (link: https://issues.redhat.com/browse/OCPBUGS-869[*OCPBUGS-869*])
+
+* Previously, when a plug-in page resulted in an error, the error did not reset when navigating away from the error page, and the error persisted after navigating to a page that was not the cause of the error. With this update, the error state is reset to its default when a user navigates to a new page, and the error no longer persists after navigating to a new page. (link: https://issues.redhat.com/browse/OCPBUGS-523[*OCPBUGS-523*])
+
+* Previously, the *_View it here_* link in the *Operator details* pane for installed Operators was incorrectly built when *_All Namespaces_* was selected. As a result, the link attempted to navigate to the *Operator details* page for a cluster service version (CSV) in *All Projects*, which is an invalid route. With this update, the *_View it here_* link to use the namespace where the CSV is installed now builds correctly and the link works as expected. (link:https://issues.redhat.com/browse/OCPBUGS-184[*OCPBUGS-184*])
+
+* Previously, line numbers with more than five digits resulted in a cosmetic issue where the line number overlays the vertical divider between the line number and the line contents making it harder to read. With this update, the amount of space available for line numbers was increased to account for longer line numbers, and the line number no longer overlays the vertical divider. (link: https://issues.redhat.com/browse/OCPBUGS-183[*OCPBUGS-183*])
 
 [discrete]
 [id="ocp-4-12-monitoring-bug-fixes"]


### PR DESCRIPTION
[OSDOCS-4521](https://issues.redhat.com//browse/OSDOCS-4521): Adds batch of RN bug doc text

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4521

Link to docs preview:
https://54042--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes

QE review:
- [ ] QE has approved this change.
* QE not needed for this change


