### PR TITLE
CNV-17808: set live migration network in UI

### DIFF
--- a/modules/virt-selecting-migration-network-ui.adoc
+++ b/modules/virt-selecting-migration-network-ui.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * virt/live_migration/virt-migrating-vm-on-secondary-network.adoc
+
+:_content-type: PROCEDURE
+[id="virt-selecting-migration-network-ui_{context}"]
+= Selecting a dedicated network by using the web console
+
+You can select a dedicated network for live migration by using the {product-title} web console.
+
+.Prerequisites
+
+* You configured a Multus network for live migration.
+
+.Procedure
+
+1. Navigate to *Virtualization > Overview* in the {product-title} web console.
+
+2. Click the *Settings* tab and then click *Live migration*.
+
+3. Select the network from the *Live migration network* list.

--- a/virt/live_migration/virt-migrating-vm-on-secondary-network.adoc
+++ b/virt/live_migration/virt-migrating-vm-on-secondary-network.adoc
@@ -8,8 +8,9 @@ toc::[]
 
 You can configure a dedicated xref:../../virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc#virt-attaching-vm-multiple-networks[Multus network] for live migration. A dedicated network minimizes the effects of network saturation on tenant workloads during live migration.
 
-
 include::modules/virt-configuring-secondary-network-vm-live-migration.adoc[leveloffset=+1]
+
+include::modules/virt-selecting-migration-network-ui.adoc[leveloffset=+1]
 
 [id="additional-resources_virt-migrating-vm-on-secondary-network"]
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-17808](https://issues.redhat.com//browse/CNV-17808)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Migrating over dedicated secondary network](https://54050--docspreview.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-migrating-vm-on-secondary-network.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @gouyang 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
