### PR TITLE
OSDOCS-4719: Drop OSDK version to 1.25.0

### DIFF
--- a/modules/osdk-installing-cli-linux-macos.adoc
+++ b/modules/osdk-installing-cli-linux-macos.adoc
@@ -3,7 +3,7 @@
 // * cli_reference/osdk/cli-osdk-install.adoc
 // * operators/operator_sdk/osdk-installing-cli.adoc
 
-:osdk_ver: v1.25.1
+:osdk_ver: v1.25.0
 
 :_content-type: PROCEDURE
 [id="osdk-installing-cli-linux-macos_{context}"]

--- a/modules/osdk-scorecard-config.adoc
+++ b/modules/osdk-scorecard-config.adoc
@@ -2,7 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
-:osdk_ver: v1.25.1
+:osdk_ver: v1.25.0
 
 [id="osdk-scorecard-config_{context}"]
 = Scorecard configuration

--- a/modules/osdk-scorecard-output.adoc
+++ b/modules/osdk-scorecard-output.adoc
@@ -2,7 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
-:osdk_ver: v1.25.1
+:osdk_ver: v1.25.0
 
 [id="osdk-scorecard-output_{context}"]
 = Scorecard output

--- a/modules/osdk-scorecard-parallel.adoc
+++ b/modules/osdk-scorecard-parallel.adoc
@@ -2,7 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
-:osdk_ver: v1.25.1
+:osdk_ver: v1.25.0
 
 :_content-type: PROCEDURE
 [id="osdk-scorecard-parallel_{context}"]

--- a/modules/osdk-updating-projects.adoc
+++ b/modules/osdk-updating-projects.adoc
@@ -22,7 +22,7 @@ ifeval::["{context}" == "osdk-hybrid-helm-updating-projects"]
 :type: Hybrid Helm
 endif::[]
 
-:osdk_ver: v1.25.1
+:osdk_ver: v1.25.0
 :osdk_ver_n1: v1.22.0
 
 :_content-type: PROCEDURE

--- a/modules/osdk-updating-v1220-to-v1250.adoc
+++ b/modules/osdk-updating-v1220-to-v1250.adoc
@@ -27,7 +27,7 @@ ifeval::["{context}" == "osdk-java-updating-projects"]
 :type: Java
 endif::[]
 
-:osdk_ver: v1.25.1
+:osdk_ver: v1.25.0
 :osdk_ver_n1: v1.22.0
 
 :_content-type: PROCEDURE

--- a/operators/operator_sdk/ansible/osdk-ansible-updating-projects.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-updating-projects.adoc
@@ -4,7 +4,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: osdk-ansible-updating-projects
 
-:osdk_ver: v1.25.1
+:osdk_ver: v1.25.0
 :osdk_ver_n1: v1.22.0
 
 toc::[]
@@ -13,7 +13,7 @@ toc::[]
 
 However, to ensure your existing Operator projects maintain compatibility with Operator SDK {osdk_ver}, update steps are required for the associated breaking changes introduced since {osdk_ver_n1}. You must perform the update steps manually in any of your Operator projects that were previously created or maintained with {osdk_ver_n1}.
 
-include::modules/osdk-updating-v1220-to-v1251.adoc[leveloffset=+1]
+include::modules/osdk-updating-v1220-to-v1250.adoc[leveloffset=+1]
 
 [id="additional-resources_osdk-ansible-upgrading-projects"]
 [role="_additional-resources"]

--- a/operators/operator_sdk/golang/osdk-golang-updating-projects.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-updating-projects.adoc
@@ -4,7 +4,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: osdk-golang-updating-projects
 
-:osdk_ver: v1.25.1
+:osdk_ver: v1.25.0
 :osdk_ver_n1: v1.22.0
 
 toc::[]
@@ -13,7 +13,7 @@ toc::[]
 
 However, to ensure your existing Operator projects maintain compatibility with Operator SDK {osdk_ver}, update steps are required for the associated breaking changes introduced since {osdk_ver_n1}. You must perform the update steps manually in any of your Operator projects that were previously created or maintained with {osdk_ver_n1}.
 
-include::modules/osdk-updating-v1220-to-v1251.adoc[leveloffset=+1]
+include::modules/osdk-updating-v1220-to-v1250.adoc[leveloffset=+1]
 
 [id="additional-resources_osdk-upgrading-projects-golang"]
 [role="_additional-resources"]

--- a/operators/operator_sdk/helm/osdk-helm-updating-projects.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-updating-projects.adoc
@@ -4,7 +4,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: osdk-helm-updating-projects
 
-:osdk_ver: v1.25.1
+:osdk_ver: v1.25.0
 :osdk_ver_n1: v1.22.0
 
 toc::[]
@@ -13,7 +13,7 @@ toc::[]
 
 However, to ensure your existing Operator projects maintain compatibility with Operator SDK {osdk_ver}, update steps are required for the associated breaking changes introduced since {osdk_ver_n1}. You must perform the update steps manually in any of your Operator projects that were previously created or maintained with {osdk_ver_n1}.
 
-include::modules/osdk-updating-v1220-to-v1251.adoc[leveloffset=+1]
+include::modules/osdk-updating-v1220-to-v1250.adoc[leveloffset=+1]
 
 [id="additional-resources_osdk-helm-upgrading-projects"]
 [role="_additional-resources"]

--- a/operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.adoc
+++ b/operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.adoc
@@ -4,7 +4,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: osdk-hybrid-helm-updating-projects
 
-:osdk_ver: v1.25.1
+:osdk_ver: v1.25.0
 :osdk_ver_n1: v1.22.0
 
 toc::[]
@@ -13,7 +13,7 @@ toc::[]
 
 However, to ensure your existing Operator projects maintain compatibility with Operator SDK {osdk_ver}, update steps are required for the associated breaking changes introduced since {osdk_ver_n1}. You must perform the update steps manually in any of your Operator projects that were previously created or maintained with {osdk_ver_n1}.
 
-include::modules/osdk-updating-v1220-to-v1251.adoc[leveloffset=+1]
+include::modules/osdk-updating-v1220-to-v1250.adoc[leveloffset=+1]
 
 [id="additional-resources_osdk-hybrid-helm-upgrading-projects"]
 [role="_additional-resources"]

--- a/operators/operator_sdk/java/osdk-java-updating-projects.adoc
+++ b/operators/operator_sdk/java/osdk-java-updating-projects.adoc
@@ -4,7 +4,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: osdk-java-updating-projects
 
-:osdk_ver: v1.25.1
+:osdk_ver: v1.25.0
 :osdk_ver_n1: v1.22.0
 
 toc::[]
@@ -13,7 +13,7 @@ toc::[]
 
 However, to ensure your existing Operator projects maintain compatibility with Operator SDK {osdk_ver}, update steps are required for the associated breaking changes introduced since {osdk_ver_n1}. You must perform the update steps manually in any of your Operator projects that were previously created or maintained with {osdk_ver_n1}.
 
-include::modules/osdk-updating-v1220-to-v1251.adoc[leveloffset=+1]
+include::modules/osdk-updating-v1220-to-v1250.adoc[leveloffset=+1]
 
 [id="additional-resources_osdk-java-upgrading-projects"]
 [role="_additional-resources"]

--- a/operators/operator_sdk/osdk-installing-cli.adoc
+++ b/operators/operator_sdk/osdk-installing-cli.adoc
@@ -4,7 +4,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: osdk-installing-cli
 
-:osdk_ver: v1.25.1
+:osdk_ver: v1.25.0
 
 toc::[]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->
The downstream sync of OSDK 1.25.1 never happened. This PR fixes the Operator SDK version to 1.25.0.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-4719](https://issues.redhat.com//browse/OSDOCS-4719)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

**OSDK installation docs**

- [Installing the OSDK CLI (Note admonition)](https://54064--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-installing-cli.htm)
- [Installing OSDK CLI on Linux and MacOS](https://54064--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-installing-cli.html#osdk-installing-cli-linux-macos_osdk-installing-cli)

**OSDK project migration docs**

- [Updating Go-based Operator projects](https://54064--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-updating-projects.html)
- [Updating Ansible-based Operator projects](https://54064--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-updating-projects.html)
- [Updating Helm-based Operator projects](https://54064--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-updating-projects.html)
- [Updating Hybrid Helm-based Operator projects](https://54064--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.html)
- [Updating Java-based Operator projects](https://54064--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/java/osdk-java-updating-projects.html)

**Scorecard docs**
This changes the tag on the quay hosted image to 1.25.0.

- [Scorecard config](https://54064--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-scorecard.html#osdk-scorecard-config_osdk-scorecard)
- [Scorecard output](https://54064--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-scorecard.html#osdk-scorecard-output_osdk-scorecard)
- [Scorecard parallel](https://54064--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-scorecard.html#osdk-scorecard-parallel_osdk-scorecard)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
