### PR TITLE
OSDOCS-4521: Adds another batch of 4.12 bugs to RNs

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -933,6 +933,19 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-4-12-builds-bug-fixes"]
 ==== Builds
 
+* By default, Buildah prints steps to the log file, including the contents of environment variables, which might include xref:../cicd/builds/creating-build-inputs.adoc#builds-input-secrets-configmaps_creating-build-inputs[build input secrets]. Although you can use the `--quiet` build argument to suppress printing of those environment variables, this argument isn't available if you use the source-to-image (S2I) build strategy. The current release fixes this issue. To suppress printing of environment variables, set the `BUILDAH_QUIET` environment variable in your build configuration:
++
+[source,yaml]
+----
+sourceStrategy:
+...
+  env:
+    - name: "BUILDAH_QUIET"
+      value: "true"
+----
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2099991[*BZ#2099991*])
+
 [discrete]
 [id="ocp-4-12-cloud-compute-bug-fixes"]
 ==== Cloud Compute
@@ -999,6 +1012,26 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 ==== Installer
 
 * Previously, the number of supported user-defined tags was 8, and reserved {product-title} tags were 2 for AWS resources. With this release, the number of supported user-defined tags is now 25 and reserved {product-title} tags are 25 for AWS resources. You can now add up to 25 user tags during installation. (link:https://issues.redhat.com/browse/CFE-592[*CFE#592*])
+
+* Previously, installing a cluster on Microsoft Azure failed when the Azure DCasv5-series or DCadsv5-series of confidential VMs were specified as control plane nodes. With this update, the installation program now stops the installation with an error, which states that confidential VMs are not yet supported. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2055247[*BZ#2055247*])
+
+* Previously, gathering bootstrap logs was not possible until the control plane machines were running. With this update, gathering bootstrap logs now only requires that the bootstrap machine be available. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2105341[*BZ#2105341*])
+
+* Previously, if a cluster failed to install on Google Cloud Platform because the service account had insufficient permissions, the resulting error message did not mention this as the cause of the failure. This update improves the error message, which now instructs users to check the permissions that are assigned to the service account. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2103236[*BZ#2103236*])
+
+* Previously, when an installation on Google Cloud provider (GCP) failed because an invalid GCP region was specified, the resulting error message did not mention this as the cause of the failure. This update improves the error message, which now states the region is not valid. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102324[*BZ#2102324*])
+
+* Previously, cluster installations using Hive could fail if Hive used an older version of the install-config.yaml file. This update allows the installer to accept older versions of the `install-config.yaml` file provided by Hive. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2098299[*BZ#2098299*])
+
+* Previously, the installation program would incorrectly allow the `apiVIP` and `ingressVIP` parameters to use the same IPv6 address if they represented the address differently, such as listing the address in an abbreviated format. In this update, the installer correctly validates these two parameters regardless of their formatting, requiring separate IP addresses for each parameter. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2103144[*BZ#2103144*])
+
+* Previously, uninstalling a cluster using the installation program failed to delete all resources in clusters installed on GCP if the cluster name was more than 22 characters long. In this update, uninstalling a cluster using the installation program correctly locates and deletes all GCP cluster resources in cases of long cluster names. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2076646[*BZ#2076646*])
+
+* Previously, when installing a cluster on {rh-openstack-first} with multiple networks defined in the `machineNetwork` parameter, the installation program only created security group rules for the first network. With this update, the installation program creates security group rules for all networks defined in the `machineNetwork` so that users no longer need to manually edit security group rules after installation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2095323[*BZ#2095323*])
+
+* Previously, users could manually set the API and Ingress virtual IP addresses to values that conflicted with the allocation pool of the DHCP server when installing a cluster on OpenStack. This could cause the DHCP server to assign one of the VIP addresses to a new machine, which would fail to start. In this update, the installation program validates the user-provided VIP addresses to ensure that they do not conflict with any DHCP pools. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1944365[*BZ1944365*])
+
+* Previously, when installing a cluster on vSphere using a datacenter that is embedded inside a folder, the installation program could not locate the datacenter object, causing the installation to fail. In this update, the installation program can traverse the directory that contains the datacenter object, allowing the installation to succeed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097691[*BZ2097691*])
 
 [discrete]
 [id="ocp-4-12-kube-api-server-bug-fixes"]


### PR DESCRIPTION
[OSDOCS-4521](https://issues.redhat.com//browse/OSDOCS-4521): Adds another batch of 4.12 bugs to RNs

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4521

Link to docs preview:
https://54076--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes

QE review:
- [ ] QE has approved this change.
* QE not required for this PR
