### PR TITLE
[enterprise-4.8] openshift-logging: fix Loki HTTP listen port

### DIFF
--- a/modules/cluster-logging-collector-log-forward-loki.adoc
+++ b/modules/cluster-logging-collector-log-forward-loki.adoc
@@ -25,10 +25,10 @@ spec:
   outputs:
    - name: loki-insecure <3>
      type: "loki" <4>
-     url: http://loki.insecure.com:9200 <5>
+     url: http://loki.insecure.com:3100 <5>
    - name: loki-secure
      type: "loki"
-     url: https://loki.secure.com:9200 <6>
+     url: https://loki.secure.com:3100 <6>
      secret:
         name: loki-secret <7>
   pipelines:


### PR DESCRIPTION
Signed-off-by: Vladimir Belousov <vbelouso@redhat.com>

Version(s):
4.8, 4.9

Additional information:
Fixed Loki HTTP port (3100 instead of 9200)
