### PR TITLE
[OSDOCS-4721]: Add CPMS links to the machine mgmt intro page

### DIFF
--- a/machine_management/index.adoc
+++ b/machine_management/index.adoc
@@ -6,59 +6,89 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use machine management to flexibly work with underlying infrastructure like Amazon Web Services (AWS), Azure, Google Cloud Platform (GCP), OpenStack, Red Hat Virtualization (RHV), and vSphere to manage the {product-title} cluster.
+You can use machine management to flexibly work with underlying infrastructure such as Amazon Web Services (AWS), Microsoft Azure, Google Cloud Platform (GCP), {rh-openstack-first}, {rh-virtualization-first}, and VMware vSphere to manage the {product-title} cluster.
 You can control the cluster and perform auto-scaling, such as scaling up and down the cluster based on specific workload policies.
 
-The {product-title} cluster can horizontally scale up and down when the load increases or decreases.
-It is important to have a cluster that adapts to changing workloads.
+It is important to have a cluster that adapts to changing workloads. The {product-title} cluster can horizontally scale up and down when the load increases or decreases.
 
-Machine management is implemented as a xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-extending-api-with-crds[Custom Resource Definition](CRD).
+Machine management is implemented as a xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-extending-api-with-crds[custom resource definition] (CRD).
 A CRD object defines a new unique object `Kind` in the cluster and enables the Kubernetes API server to handle the object's entire lifecycle.
 
 The Machine API Operator provisions the following resources:
 
-* MachineSet
-* Machine
-* Cluster Autoscaler
-* Machine Autoscaler
-* Machine Health Checks
+* `MachineSet`
+* `Machine`
+* `ClusterAutoscaler`
+* `MachineAutoscaler`
+* `MachineHealthCheck`
 
 [discrete]
-== What you can do with compute machine sets
+[id="machine-mgmt-intro-managing-compute"]
+== Managing compute machines
 
-As a cluster administrator you can:
+As a cluster administrator, you can perform the following actions:
 
-* Create a compute machine set on:
+* Create a compute machine set for the following cloud providers:
+
 ** xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#creating-machineset-aws[AWS]
+
 ** xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#creating-machineset-azure[Azure]
+
 ** xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#creating-machineset-gcp[GCP]
-** xref:../machine_management/creating_machinesets/creating-machineset-osp.adoc#creating-machineset-osp[OpenStack]
-** xref:../machine_management/creating_machinesets/creating-machineset-rhv.adoc#creating-machineset-rhv[RHV]
+
+** xref:../machine_management/creating_machinesets/creating-machineset-osp.adoc#creating-machineset-osp[{rh-openstack}]
+
+** xref:../machine_management/creating_machinesets/creating-machineset-rhv.adoc#creating-machineset-rhv[{rh-virtualization}]
+
 ** xref:../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere[vSphere]
 
 * xref:../machine_management/manually-scaling-machineset.adoc#manually-scaling-machineset[Manually scale a compute machine set] by adding or removing a machine from the compute machine set.
-* xref:../machine_management/modifying-machineset.adoc#modifying-machineset[Modify a compute machine set] through the MachineSet YAML configuration file.
+
+* xref:../machine_management/modifying-machineset.adoc#modifying-machineset[Modify a compute machine set] through the `MachineSet` YAML configuration file.
+
 * xref:../machine_management/deleting-machine.adoc#deleting-machine[Delete] a machine.
+
 * xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Create infrastructure compute machine sets].
+
 * Configure and deploy a xref:../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[machine health check] to automatically fix damaged machines in a machine pool.
 
 [discrete]
-== Autoscaler
+[id="machine-mgmt-intro-managing-control-plane"]
+== Managing control plane machines
 
-Autoscale your cluster to ensure flexibility to changing workloads.
-To xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[autoscale] your {product-title} cluster, you must first deploy a cluster autoscaler, and then deploy a machine autoscaler for each compute machine set.
-The cluster autoscaler increases and decreases the size of the cluster based on deployment needs.
-The machine autoscaler adjusts the number of machines in the compute machine sets that you deploy in your {product-title} cluster.
+As a cluster administrator, you can perform the following actions:
+
+* xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-feat-config-update_cpmso-using[Update your control plane configuration] with a control plane machine set for the following cloud providers:
+
+** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-aws_cpmso-configuration[AWS]
+
+** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-azure_cpmso-configuration[Azure]
+
+** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-vsphere_cpmso-configuration[vSphere]
+
+* Configure and deploy a xref:../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[machine health check] to automatically recover unhealthy control plane machines.
 
 [discrete]
-== User-provisioned infrastructure
-User-provisioned infrastructure is an environment where you can deploy infrastructure such as compute, network, and storage resources that host the {product-title}.
-You can xref:../machine_management//user_infra/adding-compute-user-infra-general.adoc#adding-compute-user-infra-general[add compute machines] to a cluster on user-provisioned infrastructure either as part of or after the installation process.
+[id="machine-mgmt-intro-autoscaling"]
+== Applying autoscaling to an {product-title} cluster
+
+You can automatically scale your {product-title} cluster to ensure flexibility for changing workloads. To xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[autoscale] your cluster, you must first deploy a cluster autoscaler, and then deploy a machine autoscaler for each compute machine set.
+
+* The xref:../machine_management/applying-autoscaling.adoc#cluster-autoscaler-about_applying-autoscaling[_cluster autoscaler_] increases and decreases the size of the cluster based on deployment needs.
+
+* The xref:../machine_management/applying-autoscaling.adoc#machine-autoscaler-about_applying-autoscaling[_machine autoscaler_] adjusts the number of machines in the compute machine sets that you deploy in your {product-title} cluster.
 
 [discrete]
-== What you can do with RHEL compute machines
+[id="machine-mgmt-intro-add-for-upi"]
+== Adding compute machines on user-provisioned infrastructure
+User-provisioned infrastructure is an environment where you can deploy infrastructure such as compute, network, and storage resources that host the {product-title}. You can xref:../machine_management//user_infra/adding-compute-user-infra-general.adoc#adding-compute-user-infra-general[add compute machines] to a cluster on user-provisioned infrastructure during or after the installation process.
 
-As a cluster administrator, you can:
+[discrete]
+[id="machine-mgmt-intro-add-rhel"]
+== Adding RHEL compute machines to your cluster
+
+As a cluster administrator, you can perform the following actions:
 
 ** xref:../machine_management/adding-rhel-compute.adoc#adding-rhel-compute[Add Red Hat Enterprise Linux (RHEL) compute machines], also known as worker machines, to a user-provisioned infrastructure cluster or an installation-provisioned infrastructure cluster.
+
 ** xref:../machine_management/more-rhel-compute.adoc#more-rhel-compute[Add more Red Hat Enterprise Linux (RHEL) compute machines] to an existing cluster.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-4721](https://issues.redhat.com//browse/OSDOCS-4721)

Link to docs preview:
[Overview of machine management](https://54089--docspreview.netlify.app/openshift-enterprise/latest/machine_management/index.html)

QE review:
- [x] QE has approved this change.

Additional information:
This page still needs a rework, but adding CPMS content for now in the existing format. Also cleaned up some issues in the asciidoc.