### PR TITLE
OSDOCS-4727: Noting an OVN-K limitation

### DIFF
--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -103,6 +103,8 @@ An egress firewall has the following limitations:
 
 ifdef::ovn[]
 * A maximum of one {kind} object with a maximum of 8,000 rules can be defined per project.
+
+* If you are using the OVN-Kubernetes network plug-in with shared gateway mode in Red Hat OpenShift Networking, return ingress replies are affected by egress firewall rules. If the egress firewall rules drop the ingress reply destination IP, the traffic is dropped.
 endif::ovn[]
 ifdef::openshift-sdn[]
 * A maximum of one {kind} object with a maximum of 1,000 rules can be defined per project.


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/OSDOCS-4727

Link to docs preview:
https://54094--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.html#limitations-of-an-egress-firewall_configuring-egress-firewall-ovn