### PR TITLE
[enterprise-4.12] add CoreDNS bump updates

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -581,6 +581,15 @@ With {product-title} 4.12, a new interface has been added to the `nodeip-configu
 
 For more information, see xref:../support/troubleshooting/troubleshooting-network-issues.adoc#overriding-default-node-ip-selection-logic_troubleshooting-network-issues[Optional: Overriding the default node IP selection logic].
 
+[id="ocp-4-12-ne-coredns-bump"]
+==== CoreDNS update to version 1.10.0
+
+In {product-title} {product-version}, CoreDNS uses version 1.10.0, which includes the following changes:
+
+* CoreDNS does not expand the query UDP buffer size if it was previously set to a smaller value.
+* CoreDNS now always prefixes each log line in Kubernetes client logs with the associated log level.
+* CoreDNS now reloads more quickly at an approximate speed of 20ms.
+
 [id="ocp-4-12-storage"]
 === Storage
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:

- https://issues.redhat.com/browse/OSDOCS-4269
- https://issues.redhat.com/browse/OSDOCS-4270
- https://issues.redhat.com/browse/OSDOCS-4342

<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/jdohmann/core-dns-RN-entries/release_notes/ocp-4-12-release-notes.html#ocp-4-12-ne-coredns-bump
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
