### PR TITLE
BZ2101827: adds examples for RunAsUser

### DIFF
--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -216,13 +216,59 @@ You can drop all capabilites from containers by setting the `requiredDropCapabil
 
 * `MustRunAs` - Requires a `runAsUser` to be configured. Uses the configured
 `runAsUser` as the default. Validates against the configured `runAsUser`.
+
++
+.Example `MustRunAs` snippet
+[source,yaml]
+----
+...
+runAsUser:
+  type: MustRunAs
+  uid: <id>
+...
+----
+
 * `MustRunAsRange` - Requires minimum and maximum values to be defined if not
 using pre-allocated values. Uses the minimum as the default. Validates against
 the entire allowable range.
+
++
+.Example `MustRunAsRange` snippet
+[source,yaml]
+----
+...
+runAsUser:
+  type: MustRunAsRange
+  uidRangeMax: <maxvalue>
+  uidRangeMin: <minvalue>
+...
+----
+
 * `MustRunAsNonRoot` - Requires that the pod be submitted with a non-zero
 `runAsUser` or have the `USER` directive defined in the image. No default
 provided.
+
++
+.Example `MustRunAsNonRoot` snippet
+[source,yaml]
+----
+...
+runAsUser:
+  type: MustRunAsNonRoot
+...
+----
+
 * `RunAsAny` - No default provided. Allows any `runAsUser` to be specified.
+
++
+.Example `RunAsAny` snippet
+[source,yaml]
+----
+...
+runAsUser:
+  type: RunAsAny
+...
+----
 
 .SELinuxContext
 


### PR DESCRIPTION
- Applies to 4.8 and above versions
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2101827)
- [Preview](https://54097--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html#authorization-SCC-strategies_configuring-internal-oauth)