### PR TITLE
OSDOCS4709: Release notes for Network Observability Operator

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -581,6 +581,12 @@ With {product-title} 4.12, a new interface has been added to the `nodeip-configu
 
 For more information, see xref:../support/troubleshooting/troubleshooting-network-issues.html#overriding-default-node-ip-selection-logic_troubleshooting-network-issues[Optional: Overriding the default node IP selection logic]. 
 
+[id="new-network-observability"]
+==== New Network Observability Operator to observe network traffic flow
+As an administrator, you can now install the Network Observability Operator to observe the network traffic for {product-title} cluster in the console. You can view and monitor the network traffic data in different graphical representations. The Network Observability Operator uses eBPF technology to create the network flows. The network flows are enriched with {product-title} information, and stored in Loki. You can use the network traffic information for detailed troubleshooting and analysis.
+
+For more information, see xref:../networking/network_observability/network-observability-overview.html#network-observability-overview[Network Observability].
+
 [id="ocp-4-12-storage"]
 === Storage
 


### PR DESCRIPTION
Version(s): 4.12

Issue: https://issues.redhat.com/browse/OSDOCS-4709

Link to docs preview: https://54099--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#new-network-observability

QE review:
- [x] QE has approved this change.
