### PR TITLE
OSDOCS-4521-batch2:adds the second batch of bugs

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -1237,7 +1237,7 @@ sourceStrategy:
 
 * Previously, the *_View it here_* link in the *Operator details* pane for installed Operators was incorrectly built when *_All Namespaces_* was selected. As a result, the link attempted to navigate to the *Operator details* page for a cluster service version (CSV) in *All Projects*, which is an invalid route. With this update, the *_View it here_* link to use the namespace where the CSV is installed now builds correctly and the link works as expected. (link:https://issues.redhat.com/browse/OCPBUGS-184[*OCPBUGS-184*])
 
-* Previously, line numbers with more than five digits resulted in a cosmetic issue where the line number overlays the vertical divider between the line number and the line contents making it harder to read. With this update, the amount of space available for line numbers was increased to account for longer line numbers, and the line number no longer overlays the vertical divider. (link: https://issues.redhat.com/browse/OCPBUGS-183[*OCPBUGS-183*])
+* Previously, line numbers with more than five digits resulted in a cosmetic issue where the line number overlaid the vertical divider between the line number and the line contents making it harder to read. With this update, the amount of space available for line numbers was increased to account for longer line numbers, and the line number no longer overlays the vertical divider. (link:https://issues.redhat.com/browse/OCPBUGS-183[*OCPBUGS-183*])
 
 * Previously, in the administrator perspective of the web console, the link to *_Learn more about the OpenShift local update services_* on the *Default update server* pop-up window in the *Cluster Settings* page produced a 404 error. With this update, the link works as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2098234[*BZ#2098234*])
 
@@ -1287,6 +1287,10 @@ sourceStrategy:
 [id="ocp-4-12-olm-bug-fixes"]
 ==== Operator Lifecycle Manager (OLM)
 
+* For {OCP} {ocp-version}, the Operator Lifecycle Manager (OLM) now upgrades an Operator according to the Operator's component references. A change to the custom resource definition (CRD) status of an Operator does not impact the OLM Operator upgrade process. Before the {OCP} {ocp-version} release, OLM would upgrade an Operator according to the Operator's CRD status. A CRD lists component references in an order defined by the group/version/kind (GVK) identifier. Operators that share the same components might cause the GVK to change the component listings for an Operator, and this can cause the OLM to require more system resources to continuously update the status of a CRD. (link:https://issues.redhat.com/browse/OCPBUGS-3795[*OCPBUGS-3795*])
+
+* Before the {OCP} {ocp-version} release, the `package-server-manager` controller would not revert any changes made to a `package-server` cluster service version (CSV), because of an issue with the `on-cluster` function. These persistent changes might impact how an Operator starts in a cluster. For {OCP} {ocp-version}, the `package-server-manager` controller always rebuilds a `package-server` CSV to its original state, so that no modifications to the CSV persist after a cluster upgrade operation. The `on-cluster` function no longer controls the state of a `package-server` CSV. (link:https://issues.redhat.com/browse/OCPBUGS-867[*OCPBUGS-867*])
+
 [discrete]
 [id="ocp-4-12-openshift-operator-sdk-bug-fixes"]
 ==== Operator SDK
@@ -1298,6 +1302,16 @@ sourceStrategy:
 [discrete]
 [id="ocp-4-12-rhcos-bug-fixes"]
 ==== {op-system-first}
+
+* Previously, updating to Podman 4.0 prevented users from using custom images with toolbox containers on {op-system}. This fix updates the toolbox library code to account for the new Podman behavior, so users can now use custom images with toolbox on {op-system} as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2048789[*BZ#2048789*])
+
+* Previously, the `podman exec` command did not work well with nested containers. Users encountered this issue when accessing a node using the `oc debug` command and then running a container with the `toolbox` command. Because of this, users were unable to reuse toolboxes on {op-system}. This fix updates the toolbox library code to account for this behavior, so users can now reuse toolboxes on {op-system}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1915537[*BZ#1915537*])
+
+* With this update, running the `toolbox` command now checks for updates to the default image before launching the container. This improves security and provides users with the latest bug fixes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049591[*BZ#2049591*])
+
+* Previously, updating to Podman 4.0 prevented users from running the `toolbox` command on {op-system}. This fix updates the toolbox library code to account for the new Podman behavior, so users can now run `toolbox` on {op-system} as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2093040[*BZ#2093040*])
+
+* Previously, custom SELinux policy modules were not properly supported by `rpm-ostree`, so they were not updated along with the rest of the system upon update. This would surface as failures in unrelated components. Pending SELinux userspace improvements landing in a future {product-title} release, this update provides a workaround to {op-system} that will rebuild and reload the SELinux policy during boot as needed. (link:https://issues.redhat.com/browse/OCPBUGS-595[*OCPBUGS-595*])
 
 [discrete]
 [id="ocp-4-12-performance-addon-operator-bug-fixes"]


### PR DESCRIPTION
[OSDOCS-4521](https://issues.redhat.com//browse/OSDOCS-4521)-b2: adds a second batch of bugs to the RN
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-4521
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://54117--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
