### PR TITLE
Add `oc` command instead of `kubectl`

### DIFF
--- a/modules/creating-instance-aws-load-balancer-controller.adoc
+++ b/modules/creating-instance-aws-load-balancer-controller.adoc
@@ -139,7 +139,7 @@ spec:
 +
 [source,terminal]
 ----
-$ HOST=$(kubectl get ingress -n echoserver echoserver -o json | jq -r '.status.loadBalancer.ingress[0].hostname')
+$ HOST=$(oc get ingress -n echoserver echoserver -o json | jq -r '.status.loadBalancer.ingress[0].hostname')
 ----
 
 * Verify the status of the provisioned AWS Load Balancer (ALB) host by running the following command:


### PR DESCRIPTION
The official doc has `kubectl` CLI but in our OCP doc it should be `oc` CLI 
~~~
$ HOST=$(kubectl get ingress -n echoserver echoserver -o json | jq -r '.status.loadBalancer.ingress[0].hostname') 
~~~