### PR TITLE
Correctly adds resource requests/limits to Troubleshooting

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -26,6 +26,29 @@ include::modules/velero-obtaining-by-accessing-binary.adoc[leveloffset=+1]
 include::modules/oadp-debugging-oc-cli.adoc[leveloffset=+1]
 include::modules/migration-debugging-velero-resources.adoc[leveloffset=+1]
 
+
+
+[id="oadp-pod-crash-resource-request"]
+== Pods crash or restart due to lack of memory or CPU
+
+If a Velero or Restic pod crashes due to a lack of memory or CPU, you can set specific resource requests for either of those resources.
+
+include::modules/oadp-pod-crash-set-resource-request-velero.adoc[leveloffset=+2]
+include::modules/oadp-pod-crash-set-resource-request-restic.adoc[leveloffset=+2]
+
+[IMPORTANT]
+====
+The values for the resource request fields must follow the same format as Kubernetes resource requirements.
+Also, if you do not specify `configuration.velero.podConfig.resourceAllocations` or `configuration.restic.podConfig.resourceAllocations`, the default `resources` specification for a Velero pod or a Restic pod is as follows:
+
+[source,yaml]
+----
+requests:
+  cpu: 500m
+  memory: 128Mi
+----
+====
+
 [id="issues-with-velero-and-admission-workbooks"]
 == Issues with Velero and admission webhooks
 

--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -67,6 +67,18 @@ Live migration has the following requirements:
 * Sufficient RAM and network bandwidth.
 * If the virtual machine uses a host model CPU, the nodes must support the virtual machine's host model CPU.
 
+[NOTE]
+====
+You must ensure that there is enough memory request capacity in the cluster to support node drains that result in live migrations. You can determine the approximate required spare memory by using the following calculation:
+
+----
+Product of (Maximum number of nodes that can drain in parallel) and (Highest total VM memory request allocations across nodes)
+----
+
+The default xref:../../virt/live_migration/virt-live-migration-limits.adoc#virt-live-migration-limits[number of migrations that can run in parallel] in the cluster is 5.
+====
+
+
 // The HA section actually belongs to OpenShift, not Virt
 [id="cluster-high-availability-options_{context}"]
 == Cluster high-availability options


### PR DESCRIPTION
OADP 1.x; OCP 4.10+

QE passed.

PR https://github.com/openshift/openshift-docs/pull/48202 was supposed to add an item to the OADP "Troubleshooting" section called "Pods crash or restart due to lack of memory or CPU". However, that PR did not include the necessary "include" statements to ../../backup_and_restore/application_backup_and_restore/troubleshooting.adoc, so the approved modules were not actually published.

This PR resolves that problem, enabling the item to be published. 

This PR also fixes an unrelated typo: repeated note marker and misformmated text at end of https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/backup_and_restore/application-backup-and-restore#oadp-setting-resource-limits-and-requests_installing-oadp-aws.   

Previews: 
1. The new item in "Troubleshooting": https://54123--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#oadp-pod-crash-resource-request

2.  The fixed typo: See note 1 to "Setting Velero CPU and memory resource allocations". https://54123--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-setting-resource-limits-and-requests_installing-oadp-aws



