### PR TITLE
OADP-1059: Remove featureFlags field from downstream documentation

### DIFF
--- a/modules/oadp-enabling-csi-dpa.adoc
+++ b/modules/oadp-enabling-csi-dpa.adoc
@@ -31,8 +31,5 @@ spec:
       defaultPlugins:
       - openshift
       - csi <1>
-    featureFlags:
-    - EnableCSI <2>
 ----
 <1> Add the `csi` default plugin.
-<2> Add the `EnableCSI` feature flag.


### PR DESCRIPTION
OADP 1.2; OCP 10.9+

Resolves  https://issues.redhat.com/browse/OADP-1059 by  removing the *featureFlags* field from downstream documentation.

Preview: https://54138--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-enabling-csi-dpa_installing-oadp-aws