### PR TITLE
TELCODOCS:1040 - remove kata monitor image

### DIFF
--- a/modules/sandboxed-containers-check-node-eligiblilty.adoc
+++ b/modules/sandboxed-containers-check-node-eligiblilty.adoc
@@ -6,7 +6,7 @@
 [id="sandboxed-containers-check-node-eligiblilty_{context}"]
 = Checking whether cluster nodes are eligible to run {sandboxed-containers-first}
 
-Before running {sandboxed-containers-first}, you can check whether the nodes in your cluster are eligible to run Kata containers. Some cluster nodes might not comply with sandboxed containers' minimum requirements. The most common reason for node ineligibility is the lack of virtualization support on the node. If you attempt to run sandboxed workloads on ineligible nodes, you will experience errors. You can use the Node Feature Discovery Operator (NFD) and a `NodeFeatureDiscovery` resource to automatically check node eligibility.
+Before running {sandboxed-containers-first}, you can check whether the nodes in your cluster are eligible to run Kata containers. Some cluster nodes might not comply with sandboxed containers' minimum requirements. The most common reason for node ineligibility is the lack of virtualization support on the node. If you attempt to run sandboxed workloads on ineligible nodes, you will experience errors. You can use the Node Feature Discovery (NFD) Operator and a `NodeFeatureDiscovery` resource to automatically check node eligibility.
 
 [NOTE]
 ====

--- a/modules/sandboxed-containers-create-kata-config-resource-cli.adoc
+++ b/modules/sandboxed-containers-create-kata-config-resource-cli.adoc
@@ -46,8 +46,10 @@ kind: KataConfig
 metadata:
   name: cluster-kataconfig
 spec:
-  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:{sandboxed-containers-version}.0
+  checkNodeEligibility: false <1>
+  logLevel: info
 ----
+<1> Set`checkNodeEligibility` to `true` to detect node eligibility to run `kata` as a `RuntimeClass`. For more information, see "Checking whether cluster nodes are eligible to run {sandboxed-containers-first}".
 
 . (Optional) If you want to install `kata` as a `RuntimeClass` only on selected nodes, create a YAML file that includes the label in the manifest:
 +
@@ -58,7 +60,8 @@ kind: KataConfig
 metadata:
   name: cluster-kataconfig
 spec:
-  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:{sandboxed-containers-version}.0
+  checkNodeEligibility: false
+  logLevel: info
   kataConfigPoolSelector:
     matchLabels:
       <label_key>: '<label_value>'

--- a/modules/sandboxed-containers-create-kataconfig-resource-web-console.adoc
+++ b/modules/sandboxed-containers-create-kataconfig-resource-web-console.adoc
@@ -38,36 +38,31 @@ Kata is installed on all worker nodes by default. If you want to install `kata` 
 
 . In the *KataConfig* tab, click *Create KataConfig*.
 
-. In the *Create KataConfig* page, select to configure the `KataConfig` CR via *YAML view*.
-
-. Copy and paste the following manifest into the *YAML view*:
-
+. In the *Create KataConfig* page, enter the following details:
 +
-[source,yaml,subs="attributes+"]
-----
-apiVersion: kataconfiguration.openshift.io/v1
-kind: KataConfig
-metadata:
-  name: cluster-kataconfig
-spec:
-  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:{sandboxed-containers-version}.0
-----
-+
-If you want to install `kata` as a `RuntimeClass` only on selected nodes, include the label in the manifest:
+* *Name*: Enter a name for the `KataConfig` resource. By default, the name is defined as `example-kataconfig`.
 
+* *Labels* (Optional): Enter any relevant, identifying attributes to the `KataConfig` resource. Each label represents a key-value pair.
+
+* *`checkNodeEligibility`* (Optional): Select this checkbox to use the Node Feature Discovery Operator (NFD) to detect node eligibility to run `kata` as a `RuntimeClass`. For more information, see "Checking whether cluster nodes are eligible to run {sandboxed-containers-first}".
+
+* *`kataConfigPoolSelector`*: By default, `kata` is installed as a `RuntimeClass` on all nodes. If you want to install `kata` as a `RuntimeClass` only on selected nodes, you must add a *matchExpression*:
 +
-[source,yaml,subs="attributes+"]
-----
-apiVersion: kataconfiguration.openshift.io/v1
-kind: KataConfig
-metadata:
-  name: cluster-kataconfig
-spec:
-  kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:{sandboxed-containers-version}.0
-  kataConfigPoolSelector:
-    matchLabels:
-      <label_key>: '<label_value>'
-----
+.. Expand the *`kataConfigPoolSelector`* area.
+
+.. In the *`kataConfigPoolSelector`*, expand *matchExpressions*. This is a list of label selector requirements.
+
+.. Click *Add matchExpressions*.
+
+.. In the *key* field, add the label key the selector applies to.
+
+.. In the *operator* field, add the key's relationship to the label values. Valid operators are `In`, `NotIn`, `Exists`, and `DoesNotExist`.
+
+.. Expand  the *values* area, and then click *Add value*.
+
+.. In the *Value* field, enter `true` or `false` for *key* label value.
+
+* *`logLevel`*: Define the level of log data retrieved for nodes running `kata` as a `RuntimeClass`. For more information, see "Collecting {sandboxed-containers-first} data".
 
 . Click *Create*.
 


### PR DESCRIPTION
Version(s):
Main, 4.12, 4.13

Issue:
[TELCODOCS-1040](https://issues.redhat.com/browse/TELCODOCS-1040)

[Link to docs preview 1](https://54140--docspreview.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html#sandboxed-containers-create-kataconfig-resource-web-console_deploying-sandboxed-containers)
[Link to docs preview 2](https://54140--docspreview.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html#sandboxed-containers-create-kataconfig-rsource-cli_deploying-sandboxed-containers)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

