### PR TITLE
OCPBUGS-5047-All: New environment variable FEATURES=performance main

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
+++ b/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
@@ -38,7 +38,7 @@ where:
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
--e DISCOVERY_MODE=true -e IMAGE_REGISTRY="<disconnected_registry>" \
+-e DISCOVERY_MODE=true -e FEATURES=performance -e IMAGE_REGISTRY="<disconnected_registry>" \
 -e CNF_TESTS_IMAGE="cnf-tests-rhel8:v{product-version}" \
 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\ Latency\ Test"
 ----
@@ -56,6 +56,7 @@ You can run the latency tests using a custom test image and image registry using
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e IMAGE_REGISTRY="<custom_image_registry>" \
 -e CNF_TESTS_IMAGE="<custom_cnf-tests_image>" \
+-e FEATURES=performance \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 ----
 +
@@ -141,7 +142,7 @@ registry.redhat.io/openshift4/cnf-tests-rhel8:{product-version} \
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
--e DISCOVERY_MODE=true -e IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/cnftests \
+-e DISCOVERY_MODE=true -e FEATURES=performance -e IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/cnftests \
 cnf-tests-local:latest /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\ Latency\ Test"
 ----
 

--- a/modules/cnf-performing-end-to-end-tests-junit-test-output.adoc
+++ b/modules/cnf-performing-end-to-end-tests-junit-test-output.adoc
@@ -21,7 +21,7 @@ Use the following procedures to generate a JUnit latency test output and test fa
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -v $(pwd)/junitdest:<junit_folder_path> \
--e KUBECONFIG=/kubeconfig/kubeconfig  -e DISCOVERY_MODE=true \
+-e KUBECONFIG=/kubeconfig/kubeconfig -e DISCOVERY_MODE=true -e FEATURES=performance \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
 /usr/bin/test-run.sh --junit <junit_folder_path> \
 -ginkgo.focus="\[performance\]\ Latency\ Test"

--- a/modules/cnf-performing-end-to-end-tests-running-cyclictest.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-cyclictest.adoc
@@ -33,7 +33,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
--e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=worker-cnf \
+-e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e FEATURES=performance -e ROLE_WORKER_CNF=worker-cnf \
 -e LATENCY_TEST_CPUS=10 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
 /usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="cyclictest"

--- a/modules/cnf-performing-end-to-end-tests-running-hwlatdetect.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-hwlatdetect.adoc
@@ -31,7 +31,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
--e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=worker-cnf \
+-e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e FEATURES=performance -e ROLE_WORKER_CNF=worker-cnf \
 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
 /usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="hwlatdetect"

--- a/modules/cnf-performing-end-to-end-tests-running-in-single-node-cluster.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-in-single-node-cluster.adoc
@@ -31,7 +31,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
--e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=master \
+-e DISCOVERY_MODE=true -e FEATURES=performance -e ROLE_WORKER_CNF=master \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\ Latency\ Test"
 ----

--- a/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
@@ -30,13 +30,13 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
--e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e ROLE_WORKER_CNF=worker-cnf \
+-e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e FEATURES=performance -e ROLE_WORKER_CNF=worker-cnf \
 -e LATENCY_TEST_CPUS=7 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
 /usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="oslat"
 ----
 +
-`LATENCY_TEST_CPUS` specifices the list of CPUs to test with the `oslat` command.
+`LATENCY_TEST_CPUS` specifies the list of CPUs to test with the `oslat` command.
 +
 The command runs the `oslat` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs).
 +

--- a/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
@@ -29,7 +29,7 @@ You provide the test image with a `kubeconfig` file in current directory and its
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
--e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
+-e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e FEATURES=performance registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\ Latency\ Test"
 ----
 
@@ -42,7 +42,7 @@ $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
--e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
+-e LATENCY_TEST_RUN=true -e FEATURES=performance -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
 -e PERF_TEST_PROFILE=<performance_profile> registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
 /usr/bin/test-run.sh -ginkgo.focus="[performance]\ Latency\ Test"
 ----
@@ -55,5 +55,5 @@ where:
 +
 [IMPORTANT]
 ====
-For valid latency tests results, run the tests for at least 12 hours.
+For valid latency test results, run the tests for at least 12 hours.
 ====

--- a/modules/cnf-performing-end-to-end-tests-test-failure-report.adoc
+++ b/modules/cnf-performing-end-to-end-tests-test-failure-report.adoc
@@ -21,7 +21,7 @@ Use the following procedures to generate a JUnit latency test output and test fa
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -v $(pwd)/reportdest:<report_folder_path> \
--e KUBECONFIG=/kubeconfig/kubeconfig  -e DISCOVERY_MODE=true \
+-e KUBECONFIG=/kubeconfig/kubeconfig  -e DISCOVERY_MODE=true -e FEATURES=performance \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
 /usr/bin/test-run.sh --report <report_folder_path> \
 -ginkgo.focus="\[performance\]\ Latency\ Test"


### PR DESCRIPTION
Version(s):
main, 4.13, 4.12, 4.11

Summary of changes:

Added '-e FEATURES=performance' to all podman commands containing '/usr/bin/test-run.sh' and 'registry.redhat.io/openshift4/cnf-tests-rhel8:v4._n_'.

Link to issue:
OCPBUGS-5047](https://issues.redhat.com/browse/OCPBUGS-5047?filter=-1

Link to docs preview:
https://54143--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performing-platform-verification-latency-tests.html

QE review:
- [x] QE has approved this change.