### PR TITLE
OCPBUGS4880 Changing 'data' to  'binaryData' avoid storing the logo in the wrong file

### DIFF
--- a/modules/adding-a-custom-logo.adoc
+++ b/modules/adding-a-custom-logo.adoc
@@ -33,7 +33,7 @@ kind: ConfigMap
 metadata:
   name: console-custom-logo
   namespace: openshift-config
-data:
+binaryData:
   console-custom-logo.png: <base64-encoded_logo> ... <1>
 ----
 <1> Provide a valid base64-encoded logo.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-4880

Link to docs preview:
https://54146--docspreview.netlify.app/openshift-enterprise/latest/web_console/customizing-the-web-console.html#adding-a-custom-logo_customizing-web-console

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
