### PR TITLE
TELCODOCS-961 release note: Configuring PGT CRs with compliance duration settings

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1124,6 +1124,15 @@ For this release, namespaces that are prefixed with `openshift-` do not have res
 
 For more information, see xref:../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission].
 
+[id="ocp-4-11-scalability-performance"]
+=== Scalability and performance
+
+[id="ocp-4-11-pgt-compliance-duration-settings"]
+==== Configuring PolicyGenTemplate CRs with compliance duration settings in GitOps ZTP
+
+In GitOps ZTP, you can now configure the evaluation interval for all policies in `PolicyGenTemplate` CRs.
+For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc#ztp-configuring-pgt-compliance-eval-timeouts_ztp-advanced-policy-config[Configuring policy compliance evaluation timeouts for PolicyGenTemplate CRs].
+
 [id="ocp-4-11-notable-technical-changes"]
 == Notable technical changes
 


### PR DESCRIPTION
[TELCODOCS-961](https://issues.redhat.com//browse/TELCODOCS-961) release note for configuring PGT CRs with compliance duration settings feature.

Version(s):
enterprise-4.11

Issue:
https://issues.redhat.com/browse/TELCODOCS-961

Link to docs preview:
https://54147--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-pgt-compliance-duration-settings

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
