### PR TITLE
OSDOCS-4521: clean-up of #54113

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -573,13 +573,13 @@ This update provides additional deployment specifications for MetalLB. When you 
 For more information about deployment specifications for MetalLB, see xref:../networking/metallb/metallb-operator-install.adoc#nw-metallb-operator-deployment-specifications-for-metallb_metallb-operator-install[Deployment specifications for MetalLB].
 
 [id="overriding-default-node-ip-selection-logic"]
-==== Node IP selection improvements 
+==== Node IP selection improvements
 
-Previously, the `nodeip-configuration` service on a cluster host selected the IP address from the interface that the default route used. If multiple routes were present, the service would select the route with the lowest metric value. As a result, network traffic could be distributed from the incorrect interface. 
+Previously, the `nodeip-configuration` service on a cluster host selected the IP address from the interface that the default route used. If multiple routes were present, the service would select the route with the lowest metric value. As a result, network traffic could be distributed from the incorrect interface.
 
-With {product-title} 4.12, a new interface has been added to the `nodeip-configuration` service, which allows users to create a hint file. The hint file contains a variable, `NODEIP_HINT`, that overrides the default IP selection logic and selects a specific node IP address from the subnet `NODEIP_HINT` variable. Using the `NODEIP_HINT` variable allows users to specify which IP address is used, ensuring that network traffic is distributed from the correct interface. 
+With {product-title} 4.12, a new interface has been added to the `nodeip-configuration` service, which allows users to create a hint file. The hint file contains a variable, `NODEIP_HINT`, that overrides the default IP selection logic and selects a specific node IP address from the subnet `NODEIP_HINT` variable. Using the `NODEIP_HINT` variable allows users to specify which IP address is used, ensuring that network traffic is distributed from the correct interface.
 
-For more information, see xref:../support/troubleshooting/troubleshooting-network-issues.html#overriding-default-node-ip-selection-logic_troubleshooting-network-issues[Optional: Overriding the default node IP selection logic]. 
+For more information, see xref:../support/troubleshooting/troubleshooting-network-issues.adoc#overriding-default-node-ip-selection-logic_troubleshooting-network-issues[Optional: Overriding the default node IP selection logic].
 
 [id="ocp-4-12-storage"]
 === Storage
@@ -1018,7 +1018,7 @@ CoreDNS will stop supporting wildcard DNS queries for names under the `cluster.l
 [id="ocp-4-12-z13-power8-x86v1-deprecations"]
 ==== Specific hardware models on `ppc64le`, `s390x`, and `x86_64` v1 CPU architectures are deprecated
 
-In {product-title} 4.12, support for {op-system} functionality is deprecated for: 
+In {product-title} 4.12, support for {op-system} functionality is deprecated for:
 
 * IBM POWER8 all models (ppc64le)
 * IBM POWER9 AC922 (ppc64le)
@@ -1267,6 +1267,28 @@ sourceStrategy:
 [id="ocp-4-12-networking-bug-fixes"]
 ==== Networking
 
+* Previously, routers that were in the terminating state delayed the `oc cp` command which would delay the `oc adm must-gather` command until the pod was terminated. With this update, a timeout for each issued `oc cp` command is set to prevent delaying the `must-gather` command from running. As a result, terminating pods no longer delay `must-gather` commands. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2103283[*BZ#2103283*])
+
+* Previously, an Ingress Controller could not be configured with both the `Private` endpoint publishing strategy type and PROXY protocol. With this update, users can now configure an Ingress Controller with both the `Private` endpoint publishing strategy type and PROXY protocol. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2104481[*BZ#2104481*])
+
+* Previously, the `routeSelector` parameter cleared the route status of the Ingress Controller prior to the router deployment. Because of this, the route status repopulated incorrectly. To avoid using stale data, route status detection has been updated to no longer rely on the Kubernetes object cache. Additionally, this update includes a fix to check the generation ID on route deployment in order to determine the route status. As a result, the route status is consistently cleared with a `routeSelector` update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2101878[*BZ#2101878*])
+
+* Previously, a cluster that was upgraded from a version of {product-title} earlier than 4.8 could have orphaned `Route` objects. This was caused by earlier versions of {product-title} translating `Ingress` objects into `Route` objects irrespective of a given `Ingress` object's indicated `IngressClass`. With this update, an alert is sent to the cluster administrator about any orphaned Route objects still present in the cluster after Ingress-to-Route translation. This update also adds another alert that notifies the cluster administrator about any Ingress objects that do not specify an `IngressClass`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1962502[*BZ#1962502*])
+
+* Previously, if a `configmap` that the router deployment depends on is not created, then the router deployment does not progress. With this update, the cluster Operator reports `ingress progressing=true` if the default ingress controller deployment is progressing. This results in users debugging issues with the ingress controller by using the command `oc get co`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2066560[*BZ#2066560*])
+
+* With this update, CoreDNS has been updated to version 1.10.0, which is based on Kubernetes 1.25. This keeps both the CoreDNS version and {product-title} {product-version}, which is also based on Kubernetes 1.25, in alignment with one another. (link:https://issues.redhat.com/browse/OCPBUGS-1731[*OCPBUGS-1731*])
+
+* With this update, the {product-title} router now uses `k8s.io/client-go` version 1.25.2, which supports Kubernetes 1.25. This keeps both the `openshift-router` and {product-title} {product-version}, which is also based on Kubernetes 1.25, in alignment with one another. (link:https://issues.redhat.com/browse/OCPBUGS-1730[*OCPBUGS-1730*])
+
+* With this update, the Ingress Operator now uses `k8s.io/client-go` version 1.25.2, which supports Kubernetes 1.25. This keeps both the Ingress Operator and {product-title} {product-version}, which is also based on Kubernetes 1.25, in alignment with one another. (link:https://issues.redhat.com/browse/OCPBUGS-1554[*OCPBUGS-1554*])
+
+* Previously, the DNS Operator did not reconcile the `openshift-dns` namespace. Because {product-title} {product-version} requires the `openshift-dns` namespace to have pod-security labels, this caused the namespace to be missing those labels upon cluster update. Without the pod-security labels, the pods failed to start. With this update, the DNS Operator now reconciles the `openshift-dns` namespace, and the pod-security labels are now present. As a result, pods start up as expected. (link:https://issues.redhat.com/browse/OCPBUGS-1549[*OCPBUGS-1549*])
+
+* Previously, the `ingresscontroller.spec.tuniningOptions.reloadInterval` did not support decimal numerals as valid parameter values because the Ingress Operator internally converts the specified value into milliseconds, which was not a supported time unit. This prevented an Ingress Controller from being deleted. With this update, `ingresscontroller.spec.tuningOptions.reloadInterval` now supports decimal numerals and users can delete Ingress Controllers with `reloadInterval` parameter values which were previously unsupported. (link:https://issues.redhat.com/browse/OCPBUGS-236[*OCPBUGS-236*])
+
+* Previously, the `ingresscontroller.spec.tuniningOptions.reloadInterval` did not support decimal numerals as valid parameter values because the Ingress Operator internally converts the specified value into milliseconds, which was not a supported time unit. This prevented an Ingress Controller from being deleted. With this update, `ingresscontroller.spec.tuningOptions.reloadInterval` now supports decimal numerals and users can delete Ingress Controllers with `reloadInterval` parameter values which were previously unsupported. (link:https://issues.redhat.com/browse/OCPBUGS-236[*OCPBUGS-236*])
+
 [discrete]
 [id="ocp-4-12-ne-perf-improvements"]
 ==== Networking performance improvements
@@ -1374,6 +1396,11 @@ In the following tables, features are marked with the following statuses:
 |Cloud controller manager for VMware vSphere
 |Technology Preview
 |Technology Preview
+|Technology Preview
+
+|Ingress Node Firewall Operator
+|Not Available
+|Not Available
 |Technology Preview
 
 |====


### PR DESCRIPTION
Fixes a typo in #54113 

Version(s): 4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4521

Link to docs preview:
https://54154--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
