### PR TITLE
BZ#2094228 Adding to procedure - overiding default file system overhead

### DIFF
--- a/modules/virt-overriding-default-fs-overhead-value.adoc
+++ b/modules/virt-overriding-default-fs-overhead-value.adoc
@@ -37,6 +37,12 @@ spec:
 <2> The file system overhead percentage for the specified storage class. For example, `mystorageclass: "0.04"` changes the default overhead value for PVCs in the `mystorageclass` storage class to 4%.
 
 . Save and exit the editor to update the `CDI` object.
+. Patch the default file system overhead with the following JsonPatch:
++
+[source,terminal]
+----
+$ oc annotate --overwrite -n openshift-cnv hco kubevirt-hyperconverged 'containerizeddataimporter.kubevirt.io/jsonpatch=[{"op": "add", "path": "/spec/config/filesystemOverhead", "value": {}}, {"op": "add", "path": "/spec/config/filesystemOverhead/global", "value": "0.10"}]'
+----
 
 .Verification
 


### PR DESCRIPTION
Signed-off-by: emarcusRH <emarcus@redhat.com>

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
**CNV** 
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
enterprise-4.10
enterprise-4.11
enterprise-4.12
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/CNV-18943
https://bugzilla.redhat.com/show_bug.cgi?id=2094228

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
