### PR TITLE
fix typo in RHACS docs

### DIFF
--- a/modules/disable-language-specific-vulnerability-scanning.adoc
+++ b/modules/disable-language-specific-vulnerability-scanning.adoc
@@ -5,7 +5,7 @@
 [id="disable-language-specific-vulnerability-scanning_{context}"]
 = Disabling language-specific vulnerability scanning
 
-Scanner identifies the vulnerabilities in the programming language-specific dependencies by defalut. You can disable the language-specific dependency scanning.
+Scanner identifies the vulnerabilities in the programming language-specific dependencies by default. You can disable the language-specific dependency scanning.
 
 .Procedure
 * To disable language-specific vulnerability scanning, run the following command:


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.73`
- Cherry pick to `rhacs-docs-3.72`
- Cherry pick to `rhacs-docs-3.71`

Issue:
none (reported via GChat)

[Link to docs preview](https://openshift-docs-h1yb6zbw6-kcarmichael08.vercel.app/openshift-acs/master/operating/examine-images-for-vulnerabilities.html#disable-language-specific-vulnerability-scanning_examine-images-for-vulnerabilities)

QE review:
- [ ] QE has approved this change. (**N/A**)
