### PR TITLE
OSDOCS-4080: Updated AWS AMI image IDs

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -23,76 +23,76 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-0067394b051d857f9`
+|`ami-073850a7021953a5c`
 
 |`ap-east-1`
-|`ami-057f593cc29fd3e08`
+|`ami-0f8800a05c09be42d`
 
 |`ap-northeast-1`
-|`ami-0f5bfc3e39711a7d8`
+|`ami-0a226dbcc9a561c40`
 
 |`ap-northeast-2`
-|`ami-07b8f6b801b49a0b7`
+|`ami-041ae0537e2eddec1`
 
 |`ap-northeast-3`
-|`ami-0677b0ba9d47e5e3a`
+|`ami-0bb8d9b69dc5b7670`
 
 |`ap-south-1`
-|`ami-0755c7732de0421e7`
+|`ami-0e9c18058fc5f94fd`
 
 |`ap-southeast-1`
-|`ami-07b2f18a01b8ddce4`
+|`ami-03022d358ba2168be`
 
 |`ap-southeast-2`
-|`ami-075b1af2bc583944b`
+|`ami-09ffdc5be9b973be0`
 
 |`ap-southeast-3`
-|`ami-0b5a81f57762da2f4`
+|`ami-0facf1a0edeb20314`
 
 |`ca-central-1`
-|`ami-0fda98e014e64d6c4`
+|`ami-028cea206c2d03317`
 
 |`eu-central-1`
-|`ami-0ba6fa5b3d81c5d56`
+|`ami-002eb441f329ccb0f`
 
 |`eu-north-1`
-|`ami-08aed4be0d4d11b0c`
+|`ami-0b1a1fb68b3b9fee7`
 
 |`eu-south-1`
-|`ami-0349bc626dd021c7c`
+|`ami-0bd0fd41a1d3f799a`
 
 |`eu-west-1`
-|`ami-0706a49df2a8357b6`
+|`ami-04504e8799057980c`
 
 |`eu-west-2`
-|`ami-0681b7397b0ec9691`
+|`ami-0cc9297ddb3bce971`
 
 |`eu-west-3`
-|`ami-0919c4668782f35da`
+|`ami-06f98f607a50937c6`
 
 |`me-south-1`
-|`ami-07ef03ebf19799060`
+|`ami-0fe39da7871a5b2a5`
 
 |`sa-east-1`
-|`ami-046a4e6f57aea3234`
+|`ami-08265cc3226697767`
 
 |`us-east-1`
-|`ami-0722eb0819717090f`
+|`ami-0fe05b1aa8dacfa90`
 
 |`us-east-2`
-|`ami-026e5701f495c94a2`
+|`ami-0ff64f495c7e977cf`
 
 |`us-gov-east-1`
-|`ami-016dce87c45add851`
+|`ami-0c99658076c41872a`
 
 |`us-gov-west-1`
-|`ami-0c5bb1f0b393638a0`
+|`ami-0ca4acd5b8ba1cb1d`
 
 |`us-west-1`
-|`ami-021ef831672014a17`
+|`ami-01dc5d8e6bb6f23f4`
 
 |`us-west-2`
-|`ami-0bba4636ff1b1dc1c`
+|`ami-0404a109adfd00019`
 
 |===
 
@@ -104,62 +104,77 @@ ifndef::openshift-origin[]
 |AWS zone
 |AWS AMI
 
+|`af-south-1`
+|`ami-0574bcc5f80b0ad9a`
+
 |`ap-east-1`
-|`ami-083382a51b31f6bd1`
+|`ami-0a65e79822ae2d235`
 
 |`ap-northeast-1`
-|`ami-09b84fda1b7171183`
+|`ami-0f7ef19d48e22353b`
 
 |`ap-northeast-2`
-|`ami-06404fbe4209e9557`
+|`ami-051dc6de359975e3c`
+
+|`ap-northeast-3`
+|`ami-0fd0b4222595650ac`
 
 |`ap-south-1`
-|`ami-0b9655b3c7c3525ba`
+|`ami-05f9d14fe4a90ed6f`
 
 |`ap-southeast-1`
-|`ami-0a9b453d016e3dfde`
+|`ami-0afdb9133d22fba5f`
 
 |`ap-southeast-2`
-|`ami-0e7af060f6e927702`
+|`ami-0ef979abe82d07d44`
+
+|`ap-southeast-3`
+|`ami-025f9103ac4310e7f`
 
 |`ca-central-1`
-|`ami-0c8293928c44b6bbd`
+|`ami-0588cdf59e5c14847`
 
 |`eu-central-1`
-|`ami-08a950d054a165e21`
+|`ami-0ef24c0e18f93fa42`
 
 |`eu-north-1`
-|`ami-020dd619ad4f379dd`
+|`ami-0439e2a3bf315df1a`
 
 |`eu-south-1`
-|`ami-0b915ff416b9aad24`
+|`ami-0714e7c2e0106cdd3`
 
 |`eu-west-1`
-|`ami-034df7689a87ce826`
+|`ami-0b960e76764ccd0c3`
 
 |`eu-west-2`
-|`ami-02bf81e08b4b2f1ef`
+|`ami-02621f50de62b3b89`
 
 |`eu-west-3`
-|`ami-03878de77169a8599`
+|`ami-0933ce7f5e2bfb50e`
 
 |`me-south-1`
-|`ami-034b27bd530bac050`
+|`ami-074bde61a2ab740ee`
 
 |`sa-east-1`
-|`ami-06ab90bd7daf4dd8b`
+|`ami-03b4f97cfc8033ae0`
 
 |`us-east-1`
-|`ami-00d3196d06bc2a924`
+|`ami-02a574449d4f4d280`
 
 |`us-east-2`
-|`ami-028a3d23312630036`
+|`ami-020e5600ef28c60ae`
+
+|`us-gov-east-1`
+|`ami-069f60e1dcf766d24`
+
+|`us-gov-west-1`
+|`ami-0db3cda4dbaccda02`
 
 |`us-west-1`
-|`ami-05356b8fece665cf1`
+|`ami-0c90cabeb5dee3178`
 
 |`us-west-2`
-|`ami-0e6473997df31eb0f`
+|`ami-0f96437a23aeae53f`
 
 |===
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.12

Issue:
This PR addresses [osdocs-4080](https://issues.redhat.com/browse/OSDOCS-4080).

Link to docs preview:
[RHCOS AMIs for the AWS infrastructure](https://54164--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-aws-user-infra-rhcos-ami_installing-aws-user-infra)

QE review:
- [ ] QE has approved this change.