### PR TITLE
CNV-19622: Version bump for HCOVersion 4.11.2

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -104,7 +104,7 @@ endif::[]
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 4.11
 :KubeVirtVersion: v0.53.2
-:HCOVersion: 4.11.0
+:HCOVersion: 4.11.2
 :delete: image:delete.png[title="Delete"]
 ifdef::openshift-origin[]
 :VirtProductName: OKD Virtualization


### PR DESCRIPTION
Version(s):
v4.11 only (No CP)

Issue:
[CNV-19622](https://issues.redhat.com//browse/CNV-19622)

Link to docs preview:
N/A

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
