### PR TITLE
OCPDOCS-4341-RN Authenticating installer using VM service account

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -125,6 +125,12 @@ For more information, see xref:../installing/disconnected_install/installing-mir
 ==== Consistent IP address for Ironic API in bare-metal installations without a provisioning network  
 With this update, in bare-metal installations without a provisioning network, the Ironic API service is accessible through a proxy server. This proxy server provides a consistent IP address for the Ironic API service. If the Metal3 pod that contains `metal3-ironic` relocates to another pod, the consistent proxy address ensures constant communication with the Ironic API service.
 
+[id="ocp-4-12-gcp-service-account-installation"]
+==== Installing {product-title} on GCP using service account authentication
+In {product-title} {product-version}, you can install a cluster on GCP using a virtual machine with a service account attached to it. This allows you to perform an installation without needing to use a service account JSON file.
+
+For more information, see xref:../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-service-account_installing-gcp-account[Creating a GCP service account].
+
 [id="ocp-4-12-post-installation"]
 === Post-installation configuration
 


### PR DESCRIPTION
Release notes for https://issues.redhat.com/browse/OSDOCS-4341
4.12

Doc preview:
https://54184--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-gcp-service-account-installation

QE review:
- [ ] QE has approved this change.
