### PR TITLE
TELCODOCS-432 - RN for iPXE network booting

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -784,6 +784,12 @@ In {product-title} {product-version}, by enabling C-states and OS-controlled P-s
 
 In {product-title} {product-version}, you can expand your existing {sno} clusters with additional worker nodes to increase available resources. For more information about {sno} expansion, see xref:../scalability_and_performance/ztp_far_edge/ztp-sno-additional-worker-node.adoc#ztp-additional-worker-sno_sno-additional-worker[Single-node OpenShift cluster expansion with worker nodes].
 
+[id="ocp-4-12-iPXE-ZTP"]
+==== Support for iPXE network booting with ZTP
+Zero touch provisioning (ZTP) uses the Metal3 service to boot RHCOS on the target host as part of the deployment of spoke clusters. With this update, ZTP leverages the capabilities of Metal3 by adding the option of Preboot Execution Environment (iPXE) network booting for these RHCOS installations.
+
+For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.adoc#about-ztp_ztp-deploying-far-edge-clusters-at-scale[Using ZTP to provision clusters at the network far edge].
+
 [id="ocp-4-12-insights-operator"]
 === Insights Operator
 


### PR DESCRIPTION
[TELCODOCS-432](https://issues.redhat.com//browse/TELCODOCS-432): You can use iPXE network booting to deploy OS on spoke clusters in ZTP.

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/TELCODOCS-432

Link to docs preview:
https://54196--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-iPXE-ZTP

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Got LGTM from SME and QE, noted here: https://docs.google.com/document/d/1JuYANg8iaSVwAhyV6cGBrtLNI3MS553wIpIFy_6sNbA/edit#


