### PR TITLE
Add back in accidentally deleted RHACS info

### DIFF
--- a/installing/installing_ocp/install-central-ocp.adoc
+++ b/installing/installing_ocp/install-central-ocp.adoc
@@ -25,12 +25,13 @@ include::modules/install-acs-operator.adoc[leveloffset=+2]
 
 include::modules/install-central-operator.adoc[leveloffset=+2]
 
-include::modules/verify-central-install-operator.adoc[leveloffset=+2]
-
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../installing_ocp/install-central-config-options-ocp.adoc#install-central-config-options-ocp[Central configuration options]
+
+include::modules/verify-central-install-operator.adoc[leveloffset=+2]
+
 
 // Install using Helm
 

--- a/modules/central-configuration-options-operator.adoc
+++ b/modules/central-configuration-options-operator.adoc
@@ -133,10 +133,20 @@ If no PVC with the given name exists, it will be created. The default value is `
 
 | `tls.additionalCAs`
 | Additional Trusted CA certificates for the secured cluster to trust.
-This is typically used when integrating with services using a private certificate authority.
+These certificates are typically used when integrating with services using a private certificate authority.
 
 | `misc.createSCCs`
 | Specify `true` to create `SecurityContextConstraints` (SCCs) for Central.
-It might cause issues in some environments.
+Setting to `true` might cause issues in some environments.
+
+| `customize.annotations`
+| Allows specifying custom annotations for the Central deployment.
+
+| `customize.envVars`
+| Advanced settings to configure environment variables.
+
+| `egress.connectivityPolicy`
+
+| Configures whether {product-title-short} should run in online or offline mode. In offline mode, automatic updates of vulnerability definitions and kernel modules are disabled.
 
 |===


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.73`
- Cherry pick to `rhacs-docs-3.74`

Issue: none, reported missing parameter via gchat

[Link to docs preview](https://openshift-docs-j4kqxfgbm-kcarmichael08.vercel.app/openshift-acs/master/installing/installing_ocp/install-central-config-options-ocp.html#general-and-miscellaneous-settings_install-central-config-options-ocp)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change. (**N/A**)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Some parameters were mistakenly deleted during reorganization of installation content with 3.73 docs. Adding these back into the doc.

- [original info in 3.72 doc](https://docs.openshift.com/acs/3.72/installing/install-ocp-operator.html#general-and-miscellaneous-settings-secured-cluster_install-ocp-operator)
- [table in 3.73 in which parameters are gone](https://docs.openshift.com/acs/3.73/installing/installing_ocp/install-central-config-options-ocp.html#general-and-miscellaneous-settings_install-central-config-options-ocp)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
