### PR TITLE
OSDOCS-4724: Adds notes for 4.11.21 release

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3087,3 +3087,31 @@ $ oc adm release info 4.11.20 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-21"]
+=== RHSA-2022:9107 - {product-title} 4.11.21 bug fix and security update
+
+Issued: 2023-01-04
+
+{product-title} release 4.11.21, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:9107[RHSA-2022:9107] advisory. There are no RPM packages for this release.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.21 --pullspecs
+----
+
+[id="ocp-4-11-21-bug-fixes"]
+==== Bug fixes
+
+* Previously, after rotating {rh-openstack-first} credentials, the Cinder CSI driver continued to use old credentials until it was restarted out of band. If the old credentials were no longer valid, all volume operations failed. With this update, the Cinder CSI driver is updated automatically when the {rh-openstack} credentials are rotated. (link:https://issues.redhat.com/browse/OCPBUGS-4103[*OCPBUGS-4103*])
+
+* Previously, in CoreDNS v1.7.1, all upstream cache refreshes used DNSSEC. Bufsize was hardcoded to 2048 bytes for the upstream query, causing some DNS upstream queries to break when there were UDP Payload limits within the networking infrastructure. With this update, {product-title} always uses bufsize 512 for upstream cache requests as that is the bufsize specified in the Corefile. Customers might be impacted if they rely on the incorrect functionality of bufsize 2048 for upstream DNS requests. (link:https://issues.redhat.com/browse/OCPBUGS-2901[*OCPBUGS-2901*])
+
+* Previously, availability sets were created when `vmSize` was invalid in a region that has zones. However, availability sets should only be created in regions that do not have zones. With this update, the correct `vmSize` is provided and an availability set is no longer provided for a machine set.(link:https://issues.redhat.com/browse/OCPBUGS-2123[*OCPBUGS-2123*])
+
+[id="ocp-4-11-21-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4724](https://issues.redhat.com//browse/OSDOCS-4724): Adds notes for 4.11.21 release

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-4724

Link to docs preview:
https://54204--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-21

QE review:
- [ ] QE has approved this change.
*QE not required for this change
