### PR TITLE
OSDOCS-4521: Adds another batch of 4.12 bugs to release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -1283,6 +1283,8 @@ sourceStrategy:
 [id="ocp-4-12-machine-config-operator-bug-fixes"]
 ==== Machine Config Operator
 
+* Previously, the Machine Config Operator (MCO) `ControllerConfig` resource, which contains important certificates, was only synced if the Operator's daemon sync succeeded. By design, unready nodes during a daemon sync prevent that daemon sync from succeeding, so unready nodes were indirectly preventing the `ControllerConfig` resource, and therefore those certificates, from syncing. This resulted in eventual cluster degradation when there were unready nodes due to inability to rotate the certificates contained in the `ControllerConfig` resource. With this release, the sync of the `ControllerConfig` resource is no longer dependent on the daemon sync succeeding, so the `ControllerConfig` resource now continues to sync if the daemon sync fails. This means that unready nodes no longer prevent the `ControllerConfig` resource from syncing, so certificates continue to be updated even when there are unready nodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2034883[*BZ#2034883*])
+
 [discrete]
 [id="ocp-4-12-compliance-operator-bug-fixes"]
 ==== Compliance Operator
@@ -1416,6 +1418,22 @@ sourceStrategy:
 [discrete]
 [id="ocp-4-12-web-console-developer-perspective-bug-fixes"]
 ==== Web console (Developer perspective)
+
+* Previously, the users could not deselect a Git secret in add and edit forms. As a result, the resources had to be recreated. This fix resolves the issue by adding the option to choose `No Secret` in the select secret option list. As a result, the users can easily select, deselect, or detach any attached secrets. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2089221[*BZ#2089221*])
+
+* In {product-title} 4.9, when it is minimal or no data in the *Developer Perspective*, most of the monitoring charts or graphs (CPU consumption, memory usage, and bandwidth) show a range of -1 to 1. However, none of these values can ever go below zero. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904106[*BZ#1904106*])
+
+[discrete]
+[id="ocp-4-12-file-integrity-operator-bug-fixes"]
+==== File Integrity Operator
+
+* Previously, underlying dependencies of the File Integrity Operator changed how alerts and notifications were handled, and the Operator didn't send metrics as a result. With this release the Operator ensures that the metrics endpoint is correct and reachable on startup. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2115821[*BZ#2115821*])
+
+* Previously, alerts issued by the File Integrity Operator did not set a namespace. This made it difficult to understand where the alert was coming from, or what component was responsible for issuing it. With this release, the Operator includes the namespace it was installed into in the alert, making it easier to narrow down what component needs attention. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2101393[*BZ#2101393*])
+
+* Previously, the File Integrity Operator did not properly handle modifying alerts during an upgrade. As a result, alerts did not include the namespace in which the Operator was installed. With this release, the Operator includes the namespace it was installed into in the alert, making it easier to narrow down what component needs attention. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2112394[*BZ#2112394*])
+
+* Previously, the File Integrity Operator daemon used the `ClusterRoles` parameter instead of the `Roles` parameter for a recent permission change. As a result, OLM could not upgrade the Operator. With this release, the Operator daemon reverts to using the `Roles` parameter and upgrades from older versions to version 0.1.29 are successful. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2108475[*BZ#2108475*])
 
 [id="ocp-4-12-technology-preview"]
 == Technology Preview features


### PR DESCRIPTION
[OSDOCS-4521](https://issues.redhat.com//browse/OSDOCS-4521): Adds another batch of 4.12 bugs to release notes

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4521

Link to docs preview:
https://54207--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes

QE review:
- [ ] QE has approved this change.
*Qe not req for this addition


