### PR TITLE
[enterprise-4.12] Add xrefs for platform Operators in 4.12 RN

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -638,7 +638,7 @@ Starting in {product-title} 4.12, Operator Lifecycle Manager (OLM) introduces th
 
 A platform Operator is an OLM-based Operator that can be installed during or after an {product-title} cluster's Day 0 operations and participates in the cluster's lifecycle. As a cluster administrator, you can use platform Operators to further customize your {product-title} installation to meet your requirements and use cases.
 
-For more information on platform Operators, see "Managing platform Operators". For more information on RukPak and its resources, see "Operator Framework packaging format".
+For more information on platform Operators, see xref:../operators/admin/olm-managing-po.adoc#olm-managing-po[Managing platform Operators]. For more information on RukPak and its resources, see xref:../operators/understanding/olm-packaging-format.adoc#olm-rukpak-about_olm-packaging-format[Operator Framework packaging format].
 
 [id="ocp-4-12-osdk"]
 === Operator development


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/53859, just adding the `xref`s now that the main content has merged.

Preview: https://54213--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-platform-operators