### PR TITLE
[enterprise-4.12] OSDOCS-4708: add haproxy reload RN entry

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -622,6 +622,13 @@ In {product-title} {product-version}, CoreDNS uses version 1.10.0, which include
 * CoreDNS now always prefixes each log line in Kubernetes client logs with the associated log level.
 * CoreDNS now reloads more quickly at an approximate speed of 20ms.
 
+[id="ocp-4-12-ne-reload-interval"]
+==== Support for a configurable reload interval in HAProxy
+
+With this update, a cluster administrator can configure the reload interval to force HAProxy to reload its configuration less frequently in response to route and endpoint updates. The default minimum HAProxy reload interval is 5 seconds.
+
+For more information, see xref:../post_installation_configuration/network-configuration.adoc#configuring-haproxy-interval_post-install-network-configuration[Configuring HAProxy reload interval].
+
 [id="new-network-observability"]
 ==== New Network Observability Operator to observe network traffic flow
 As an administrator, you can now install the Network Observability Operator to observe the network traffic for {product-title} cluster in the console. You can view and monitor the network traffic data in different graphical representations. The Network Observability Operator uses eBPF technology to create the network flows. The network flows are enriched with {product-title} information, and stored in Loki. You can use the network traffic information for detailed troubleshooting and analysis.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-4708
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/jdohmann/OSDOCS-4708/release_notes/ocp-4-12-release-notes.html#ocp-4-12-ne-reload-interval
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: RN entry for #51892
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
