### PR TITLE
OSDOCS-4726: Adds notes for 4.10.46 release

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3693,3 +3693,22 @@ $ oc adm release info 4.10.45 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-46"]
+=== RHBA-2022:9099 - {product-title} 4.10.46 bug fix and security update
+
+Issued: 2023-01-04
+
+{product-title} release 4.10.46, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:9099[RHBA-2022:9099] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:9098[RHSA-2022:9098] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.46 --pullspecs
+----
+
+[id="ocp-4-10-46-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4726](https://issues.redhat.com//browse/OSDOCS-4726): Adds notes for 4.10.46 release

Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OSDOCS-4726

Link to docs preview:
http://file.rdu.redhat.com/opayne/RN-4.10.46/release_notes/ocp-4-10-release-notes.html#ocp-4-10-46

QE review:
- [ ] QE has approved this change.
* Qe not needed for this release

🙀 Note for reviewer: standby for preview, asciibinder being slow but need this merged today.
