### PR TITLE
OSDOCS-4747: adds user tag for aws resource Release Note entry

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -122,7 +122,7 @@ Using the oc-mirror CLI plug-in to mirror file-based catalog Operator images in 
 For more information, see xref:../installing/disconnected_install/installing-mirroring-disconnected.adoc#oc-mirror-oci-format_installing-mirroring-disconnected[Mirroring file-based catalog Operator images in OCI format].
 
 [id="ocp-4-12-consistent-address-for-ironicapi"]
-==== Consistent IP address for Ironic API in bare-metal installations without a provisioning network  
+==== Consistent IP address for Ironic API in bare-metal installations without a provisioning network
 With this update, in bare-metal installations without a provisioning network, the Ironic API service is accessible through a proxy server. This proxy server provides a consistent IP address for the Ironic API service. If the Metal3 pod that contains `metal3-ironic` relocates to another pod, the consistent proxy address ensures constant communication with the Ironic API service.
 
 [id="ocp-4-12-gcp-service-account-installation"]
@@ -131,7 +131,12 @@ In {product-title} {product-version}, you can install a cluster on GCP using a v
 
 For more information, see xref:../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-service-account_installing-gcp-account[Creating a GCP service account].
 
-[id="ocp-4-12-post-installation"]
+[id="ocp-4-12-aws-user-tag"]
+==== `propagateUserTags` parameter for AWS resources provisioned by the {product-title} cluster
+In {product-title} {product-version}, the `propagateUserTags` parameter is a flag that directs in-cluster Operators to include the specified user tags in the tags of the AWS resources that the Operators create.
+
+For more information, see xref:../installing/installing_aws/installing-aws-network-customizations.html#installation-configuration-parameters_installing-aws-network-customizations[Optional configuration parameters].
+
 === Post-installation configuration
 
 [id="ocp-4-12-web-console"]
@@ -680,7 +685,7 @@ For more information on platform Operators, see "Managing platform Operators". F
 
 Currently, {op-system} image layering allows you to work with Customer Experience and Engagement (CEE) to obtain and apply Hotfix packages on top of your {op-system} image, based on the link:https://access.redhat.com/solutions/2996001[Red Hat Hotfix policy]. It is planned for future releases that you can use {op-system} image layering to incorporate third-party software packages such as Libreswan or numactl.
 
-For more information, see xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering[{op-system} image layering]. 
+For more information, see xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering[{op-system} image layering].
 
 [id="ocp-4-12-nodes"]
 === Nodes


### PR DESCRIPTION
- Applies to 4.12 only 
- [Jira](https://issues.redhat.com/browse/OSDOCS-4747)
- [Preview](https://54228--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html)
@yunjiang29 ptal and provide an ack if all looks good