### PR TITLE
OSDOCS-4725: Adds notes for 4.9.54 release

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -3338,3 +3338,22 @@ $ oc adm release info 4.9.53 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-9-54"]
+=== RHSA-2022:9111 - {product-title} 4.9.54 bug fix and security update
+
+Issued: 2023-12-06
+
+{product-title} release 4.9.53, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2022:9111[RHSA-2022:9111] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:9110[RHSA-2022:9110] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.9.54 --pullspecs
+----
+
+[id="ocp-4-9-54-updating"]
+==== Updating
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4725](https://issues.redhat.com//browse/OSDOCS-4725): Adds notes for 4.9.54 release

Version(s):
4.9

Issue:
https://issues.redhat.com/browse/OSDOCS-4725

Link to docs preview:
http://file.rdu.redhat.com/opayne/RN-4.9.54/release_notes/ocp-4-9-release-notes.html#ocp-4-9-54

QE review:
- [ ] QE has approved this change.
*QE not needed for this change

