### PR TITLE
[OSDOCS-3974]: adding relnote about node tuning hosted cluster

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -838,6 +838,11 @@ In {product-title} {product-version}, you can use the {factory-prestaging-tool} 
 
 In {product-title} {product-version}, you can use the {factory-prestaging-tool} in the GitOps ZTP workflow. For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc[Pre-caching images for single-node OpenShift deployments].
 
+[id="ocp-4-12-hcp-node-tuning-operator"]
+==== Node tuning in a hosted cluster (Technology Preview)
+
+You can now configure OS-level tuning for nodes in a hosted cluster by using the Node Tuning Operator. To configure node tuning, you can create config maps in the management cluster that contain `Tuned` objects, and reference those config maps in your node pools. The tuning configuration that is definied in the `Tuned` objects is applied to the nodes in the node pool. For more information, see xref:../scalability_and_performance/using-node-tuning-operator.adoc#node-tuning-hosted-cluster_node-tuning-operator[Configuring node tuning in a hosted cluster].
+
 [id="ocp-4-12-insights-operator"]
 === Insights Operator
 


### PR DESCRIPTION
[OSDOCS-3974]: Adding release note about node tuning a hosted cluster

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-3974
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://54254--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-hcp-node-tuning-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
