### PR TITLE
[OSDOCS-4297]: adding release note for versioning support for hosted control planes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -887,6 +887,13 @@ To use application credentials with your cluster as a {rh-openstack} administrat
 
 The default version for the `hypershift.openshift.io` API, which is the API for hosted control planes on {product-title}, is now v1beta1. Currently, for an existing cluster, the move from alpha to beta is not supported.
 
+[id="ocp-4-12-hcp-versioning"]
+==== Versioning for hosted control planes
+
+With each major, minor, or patch version release of {product-title}, two components of hosted control planes are released: the HyperShift Operator and the command-line interface (CLI). Any HyperShift Operator that is released for a minor version of {product-title} must work with all versions of {product-title} where hosted control planes are available. However, because the hosted control planes feature was introduced as a Technology Preview in {product-title} version 4.11, it is available with versions only as far back as 4.11.
+
+The `HostedCluster` and `NodePool` API resources are available in the beta version of the API and follow a similar policy to xref:../rest_api/understanding-api-support-tiers.adoc[{product-title}] and link:https://kubernetes.io/docs/concepts/overview/kubernetes-api/[Kubernetes].
+
 [id="ocp-4-12-notable-technical-changes"]
 == Notable technical changes
 


### PR DESCRIPTION
[OSDOCS-4297]: Adding a release note about versioning support for hosted control planes

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-4297
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://54255--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-hcp-versioning
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
