### PR TITLE
OSDOCS-3920: Adds release note for supported cluster products

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -156,6 +156,7 @@ With this release, there are several updates to the *Administrator* perspective 
 
 * The {product-title} web console displays a `ConsoleNotification` if the cluster is upgrading. Once the upgrade is done, the notification is removed.
 * A *_restart rollout_* option for the `Deployment` resource and a *_retry rollouts_* option for the `DeploymentConfig` resource are available on the *Action* and *Kebab* menus.
+* You can view a list of supported clusters on the *All Clusters* dropdown list. The supported clusters include {product-title}, {product-title} Service on AWS (ROSA), Azure Red Hat OpenShift (ARO), ROKS, and {product-dedicated}. 
 
 [id="ocp-4-12-multi-arch-console"]
 ===== Multi-architecture compute machines on the {product-title} web console


### PR DESCRIPTION
[OSDOCS-3920](https://issues.redhat.com//browse/OSDOCS-3920): Adds release note for supported cluster products

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-3920

Link to docs preview:
3rd bullet https://54258--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-Administrator-perspective

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

