### PR TITLE
OSDOCS-4521: Adds another batch of release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -1247,6 +1247,8 @@ sourceStrategy:
 
 * Previously, instances were not set to respect the GCP infrastructure default option for automated restarts. As a result, instances could be created without using the infrastructure default for automatic restarts. This sometimes meant that instances were terminated in GCP but their associated machines were still listed in the `Running` state because they did not automatically restart. With this release, the code for passing the automatic restart option has been improved to better detect and pass on the default option selection from users. Instances now use the infrastructure default properly and are automatically restarted when the user requests the default functionality. (link:https://issues.redhat.com/browse/OCPBUGS-4504[*OCPBUGS-4504*])
 
+* The `v1beta1` version of the `PodDisruptionBudget` object is now deprecated in Kubernetes. With this release, internal references to `v1beta1` are replaced with `v1`. This change is internal to the cluster autoscaler and does not require user action beyond the advice in the link:https://access.redhat.com/articles/6955381[Preparing to upgrade to OpenShift Container Platform 4.12] Red Hat Knowledgebase Article. (link:https://issues.redhat.com/browse/OCPBUGS-1484[*OCPBUGS-1484*])
+
 * Previously, the GCP machine controller reconciled the state of machines every 10 hours. Other providers set this value to 10 minutes so that changes that happen outside of the Machine API system are detected within a short period. The longer reconciliation period for GCP could cause unexpected issues such as missing certificate signing requests (CSR) approvals due to an external IP address being added but not detected for an extended period. With this release, the GCP machine controller is updated to reconcile every 10 minutes to be consistent with other platforms and so that external changes are picked up sooner. (link:https://issues.redhat.com/browse/OCPBUGS-4499[*OCPBUGS-4499*])
 
 * Previously, due to a deployment misconfiguration for the Cluster Machine Approver Operator, enabling the `TechPreviewNoUpgrade` feature set caused errors and sporadic Operator degradation. Because clusters with the `TechPreviewNoUpgrade` feature set enabled use two instances of the Cluster Machine Approver Operator and both deployments used the same set of ports, there was a conflict that lead to errors for single-node topology. With this release, the Cluster Machine Approver Operator deployment is updated to use a different set of ports for different deployments. (link:https://issues.redhat.com/browse/OCPBUGS-2621[*OCPBUGS-2621*])
@@ -1286,6 +1288,8 @@ sourceStrategy:
 
 * With this release, AWS security groups are tagged immediately instead of after creation. This means that fewer requests are sent to AWS and the required user privileges are lowered. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2098054[*BZ#2098054*], link:https://issues.redhat.com/browse/OCPBUGS-3094[*OCPBUGS-3094*])
 
+* Previously, a bug in the {rh-openstack} legacy cloud provider resulted in a crash if certain {rh-openstack} operations were attempted after authentication had failed. For example, shutting down a server causes the Kubernetes controller manager to fetch server information from {rh-openstack}, which triggered this bug. As a result, if initial cloud authentication failed or was configured incorrectly, shutting down a server caused the Kubernetes controller manager to crash. With this release, the {rh-openstack} legacy cloud provider is updated to not attempt any {rh-openstack} API calls if it has not previously authenticated successfully. Now, shutting down a server with invalid cloud credentials no longer causes Kubernetes controller manager to crash. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102383[*BZ#2102383*])
+
 [discrete]
 [id="ocp-4-12-cluster-version-operator-bug-fixes"]
 ==== Cluster Version Operator
@@ -1308,6 +1312,8 @@ sourceStrategy:
 
 * Previously, the number of supported user-defined tags was 8, and reserved {product-title} tags were 2 for AWS resources. With this release, the number of supported user-defined tags is now 25 and reserved {product-title} tags are 25 for AWS resources. You can now add up to 25 user tags during installation. (link:https://issues.redhat.com/browse/CFE-592[*CFE#592*])
 
+* Previously, installing a cluster on Amazon Web Services started and then failed when the IAM administrative user was not assigned the `s3:GetBucketPolicy` permission. This update adds this policy to checklist that the installation program uses to ensure that all of the required permissions are assigned. As a result, the installation program now stops the installation with a warning that the IAM administrative user is missing the `s3:GetBucketPolicy` permission. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2109388[*BZ#2109388*])
+
 * Previously, installing a cluster on Microsoft Azure failed when the Azure DCasv5-series or DCadsv5-series of confidential VMs were specified as control plane nodes. With this update, the installation program now stops the installation with an error, which states that confidential VMs are not yet supported. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2055247[*BZ#2055247*])
 
 * Previously, gathering bootstrap logs was not possible until the control plane machines were running. With this update, gathering bootstrap logs now only requires that the bootstrap machine be available. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2105341[*BZ#2105341*])
@@ -1328,6 +1334,12 @@ sourceStrategy:
 
 * Previously, when installing a cluster on vSphere using a datacenter that is embedded inside a folder, the installation program could not locate the datacenter object, causing the installation to fail. In this update, the installation program can traverse the directory that contains the datacenter object, allowing the installation to succeed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097691[*BZ2097691*])
 
+* Previously, when installing a cluster on Azure using arm64 architecture with installer-provisioned infrastructure, the image definition resource for hyperVGeneration V1 incorrectly had an architecture value of `x64`. With this update, the image definition resource for hyperVGeneration V1 has the correct architecture value of `Arm64`. (link:https://issues.redhat.com/browse/OCPBUGS-3639[*OCPBUGS-3639*])
+
+* Previously, when installing a cluster on VMWare vSphere, the installation could fail if the user specified a user-defined folder in the `failureDomain` section of the `install-config.yaml` file. With this update, the installation program correctly validates user-defined folders in the `failureDomain` section of the `install-config.yaml` file. (link:https://issues.redhat.com/browse/OCPBUGS-3343[*OCPBUGS-3343*])
+
+* Previously, when destroying a partially deployed cluster after an installation failed on VMWare vSphere, some virtual machine folders were not destroyed. This error could occur in clusters configured with multiple vSphere datacenters or multiple vSphere clusters. With this update, all installer-provisioned infrastructure is correctly deleted when destroying a partially deployed cluster after an installation failure. (link:https://issues.redhat.com/browse/OCPBUGS-1489[*OCPBUGS-1489*])
+
 [discrete]
 [id="ocp-4-12-kube-api-server-bug-fixes"]
 ==== Kubernetes API server
@@ -1345,6 +1357,16 @@ sourceStrategy:
 [discrete]
 [id="ocp-4-12-compliance-operator-bug-fixes"]
 ==== Compliance Operator
+
+* Previously, the Compliance Operator used an old version of the Operator SDK, which is a dependency for building Operators. This caused alerts about deprecated Kubernetes functionality used by the Operator SDK. With this release, the Compliance Operator is upgraded to version 0.1.55, which includes an updated version of the Operator SDK. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2098581[*BZ#2098581*])
+
+* Previously, applying automatic remediation for the `rhcos4-high-master-sysctl-kernel-yama-ptrace-scope` and `rhcos4-sysctl-kernel-core-pattern` rules resulted in subsequent failures of those rules in scan results, even though they were remediated. The issue is fixed in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2094382[*BZ#2094382*])
+
+* Previously, the Compliance Operator hard-coded notifications to the default namespace. As a result, notifications from the Operator would not appear if the Operator was installed in a different namespace. This issue is fixed in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2060726[*BZ#2060726*])
+
+* Previously, the Compliance Operator failed to fetch API resources when parsing machine configurations without ignition specifications. This caused the `api-check-pods` check to crash loop. With this release, the Compliance Operator is updated to gracefully handle machine config pools without ignition specifications. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2117268[*BZ#2117268*])
+
+* Previously, the Compliance Operator held machine configurations in a stuck state because it could not determine the relationship between machine configurations and kubelet configurations due to incorrect assumptions about machine configuration names. With this release, the Compliance Operator is able to determine if a kubelet configuration is a subset of a machine configuration. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102511[*BZ#2102511*])
 
 [discrete]
 [id="ocp-4-12-management-console-bug-fixes"]
@@ -1369,6 +1391,10 @@ sourceStrategy:
 [discrete]
 [id="ocp-4-12-monitoring-bug-fixes"]
 ==== Monitoring
+
+* Before this update, cluster administrators could not distinguish between a pod being not ready because of a scheduling issue and a pod being not ready because it could not be started by the kubelet. In both cases, the `KubePodNotReady` alert would fire. With this update, the `KubePodNotScheduled` alert now fires when a pod is not ready because of a scheduling issue, and the `KubePodNotReady` alert fires when a pod is not ready because it could not be started by the kubelet. (link:https://issues.redhat.com/browse/OCPBUGS-4431[*OCPBUGS-4431*])
+
+* Before this update, `node_exporter` would report metrics about virtual network interfaces such as `tun` interfaces, `br` interfaces, and `ovn-k8s-mp` interfaces. With this update, metrics for these virtual interfaces are no longer collected, which decreases monitoring resource consumption. (link:https://issues.redhat.com/browse/OCPBUGS-1321[*OCPBUGS-1321*])
 
 * Before this update, Alertmanager pod startup might time out because of slow DNS resolution, and the Alertmanager pods would not start. With this release, the timeout value has been increased to seven minutes, which prevents pod startup from timing out. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2083226[*BZ#2083226*])
 
@@ -1400,6 +1426,8 @@ sourceStrategy:
 
 * With this update, CoreDNS has been updated to version 1.10.0, which is based on Kubernetes 1.25. This keeps both the CoreDNS version and {product-title} {product-version}, which is also based on Kubernetes 1.25, in alignment with one another. (link:https://issues.redhat.com/browse/OCPBUGS-1731[*OCPBUGS-1731*])
 
+* Previously, CoreDNS was based on Kubernetes 1.24 while {product-title} 4.12 is based on Kubernetes 1.25. With this update, CoreDNS is v1.10.0, new features have been added, and {product-title} 4.12 uses Kubernetes 1.25 APIs. (link: https://issues.redhat.com/browse/OCPBUGS-1731[*OCPBUGS-1731*])
+
 * With this update, the {product-title} router now uses `k8s.io/client-go` version 1.25.2, which supports Kubernetes 1.25. This keeps both the `openshift-router` and {product-title} {product-version}, which is also based on Kubernetes 1.25, in alignment with one another. (link:https://issues.redhat.com/browse/OCPBUGS-1730[*OCPBUGS-1730*])
 
 * With this update, the Ingress Operator now uses `k8s.io/client-go` version 1.25.2, which supports Kubernetes 1.25. This keeps both the Ingress Operator and {product-title} {product-version}, which is also based on Kubernetes 1.25, in alignment with one another. (link:https://issues.redhat.com/browse/OCPBUGS-1554[*OCPBUGS-1554*])
@@ -1409,6 +1437,8 @@ sourceStrategy:
 * Previously, the `ingresscontroller.spec.tuniningOptions.reloadInterval` did not support decimal numerals as valid parameter values because the Ingress Operator internally converts the specified value into milliseconds, which was not a supported time unit. This prevented an Ingress Controller from being deleted. With this update, `ingresscontroller.spec.tuningOptions.reloadInterval` now supports decimal numerals and users can delete Ingress Controllers with `reloadInterval` parameter values which were previously unsupported. (link:https://issues.redhat.com/browse/OCPBUGS-236[*OCPBUGS-236*])
 
 * Previously, the `ingresscontroller.spec.tuniningOptions.reloadInterval` did not support decimal numerals as valid parameter values because the Ingress Operator internally converts the specified value into milliseconds, which was not a supported time unit. This prevented an Ingress Controller from being deleted. With this update, `ingresscontroller.spec.tuningOptions.reloadInterval` now supports decimal numerals and users can delete Ingress Controllers with `reloadInterval` parameter values which were previously unsupported. (link:https://issues.redhat.com/browse/OCPBUGS-236[*OCPBUGS-236*])
+
+* Previously, the Cluster DNS Operator used GO kubernetes libraries that were based on Kubernetes 1.24 while {product-title} 4.12 is based on Kubernetes 1.25. With this update, GO Kubernetes API is v1.25.2, which aligns the Cluster DNS Operator with {product-title} 4.12 that uses Kubernetes 1.25 APIs. (link: https://issues.redhat.com/browse/OCPBUGS-1558[*OCPBUGS-1558*])
 
 [discrete]
 [id="ocp-4-12-ne-perf-improvements"]
@@ -1421,6 +1451,8 @@ sourceStrategy:
 [discrete]
 [id="ocp-4-12-openshift-cli-bug-fixes"]
 ==== OpenShift CLI (oc)
+
+* The {product-title} {product-version} release fixes an issue with entering a debug session on a target node when the target namespace lacks the appropriate security level. This caused the `oc` CLI to prompt you with a pod security error message. If the existing namespace does not contain the appropriate security levels, {product-title} now creates a temporary namespace when you enter `oc` debug mode on a target node. (link:https://issues.redhat.com/browse/OCPBUGS-852[OCPBUGS-852])
 
 [discrete]
 [id="ocp-4-12-Kubernetes-controller-manage-bug-fixes"]
@@ -1479,6 +1511,8 @@ sourceStrategy:
 * Previously, the users could not deselect a Git secret in add and edit forms. As a result, the resources had to be recreated. This fix resolves the issue by adding the option to choose `No Secret` in the select secret option list. As a result, the users can easily select, deselect, or detach any attached secrets. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2089221[*BZ#2089221*])
 
 * In {product-title} 4.9, when it is minimal or no data in the *Developer Perspective*, most of the monitoring charts or graphs (CPU consumption, memory usage, and bandwidth) show a range of -1 to 1. However, none of these values can ever go below zero. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904106[*BZ#1904106*])
+
+* Before this update, users could not silence alerts in the *Developer* perspective in the {product-title} web console when a user-defined Alertmanager service was deployed because the web console would forward the request to the platform Alertmanager service in the `openshift-monitoring` namespace. With this update, when you view the *Developer* perspective in the web console and try to silence an alert, the request is forwarded to the corrrect Alertmanager service. (link:https://issues.redhat.com/browse/OCPBUGS-1789[*OCPBUGS-1789*])
 
 [discrete]
 [id="ocp-4-12-file-integrity-operator-bug-fixes"]


### PR DESCRIPTION
[OSDOCS-4521](https://issues.redhat.com//browse/OSDOCS-4521): Adds another batch of release notes

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4521

Link to docs preview:
https://54264--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes

QE review:
- [ ] QE has approved this change.
* QE not required for this change
