### PR TITLE
OSDOCS-4736: Changed the language for Encrypted-at-rest

### DIFF
--- a/modules/rosa-policy-security-regulation-compliance.adoc
+++ b/modules/rosa-policy-security-regulation-compliance.adoc
@@ -15,7 +15,7 @@ Red Hat defines and follows a data classification standard to determine the sens
 
 [id="rosa-policy-data-management_{context}"]
 == Data management
-{product-title} (ROSA) uses AWS Key Management Service (KMS) to help securely manage keys for encrypted data. These keys are used for control plane data volumes that are encrypted by default. Persistent volumes (PVs) for customer applications also use AWS KMS for key management.
+{product-title} (ROSA) uses AWS Key Management Service (KMS) to help securely manage keys for encrypted data. These keys are used for control plane, infrastructure, and worker data volumes that are encrypted by default. Persistent volumes (PVs) for customer applications also use AWS KMS for key management.
 
 When a customer deletes their ROSA cluster, all cluster data is permanently deleted, including control plane data volumes and customer application data volumes, such as persistent volumes (PV).
 

--- a/modules/rosa-sdpolicy-storage.adoc
+++ b/modules/rosa-sdpolicy-storage.adoc
@@ -11,7 +11,7 @@ This section provides information about the service definition for {product-titl
 
 [id="rosa-sdpolicy-encrytpted-at-rest-storage_{context}"]
 == Encrypted-at-rest OS and node storage
-Control plane nodes use encrypted-at-rest AWS Elastic Block Store (EBS) storage.
+Control plane, infrastructure, and worker nodes use encrypted-at-rest AWS Elastic Block Store (EBS) storage.
 
 [id="rosa-sdpolicy-encrytpted-at-rest-pv_{context}"]
 == Encrypted-at-rest PV


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-4736](https://issues.redhat.com/browse/OSDOCS-4736)

Link to docs preview:
- [ROSA service definition change](https://54274--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-encrytpted-at-rest-storage_rosa-service-definition)
- [Data management change](https://54274--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.html#rosa-policy-data-management_rosa-policy-process-security) 

QE review:
- [ ] QE has approved this change.

Additional information:
Changed the language around encrypted-at-rest OS storage