### PR TITLE
OCPBUGS-3053 - add worker nodes with static IPs to SNO clusters 

### DIFF
--- a/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
+++ b/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
@@ -6,7 +6,7 @@
 [id="sno-adding-worker-nodes-to-single-node-clusters-manually_{context}"]
 = Adding worker nodes to {sno} clusters manually
 
-You can add a worker node to a {sno} cluster manually by booting the worker node from {op-system-first} ISO and using the cluster `worker.ign` file to join the new worker node to the cluster.
+You can add a worker node to a {sno} cluster manually by booting the worker node from {op-system-first} ISO and by using the cluster `worker.ign` file to join the new worker node to the cluster.
 
 .Prerequisites
 
@@ -79,21 +79,90 @@ $ curl -L $ISO_URL -o rhcos-live.iso
 
 . Use the {op-system} ISO and the hosted `worker.ign` file to install the worker node:
 
-.. Boot the target host using the {op-system} ISO and your preferred method of installation.
+.. Boot the target host with the {op-system} ISO and your preferred method of installation.
 
-.. When the target host has booted from the {op-system} ISO, open a console on the target host, and run the following `coreos-installer` command to install the system:
+.. When the target host has booted from the {op-system} ISO, open a console on the target host.
+
+.. If your local network does not have DHCP enabled, you need to create an ignition file with the new hostname and configure the worker node static IP address before running the {op-system} installation. Perform the following steps:
+
+... Configure the worker host network connection with a static IP. Run the following command on the target host console:
 +
 [source,terminal]
 ----
-$ coreos-installer install --ignition-url=<hosted_worker_ign_file> <hard_disk>
+$ nmcli con mod <network_interface> ipv4.method manual /
+ipv4.addresses <static_ip> ipv4.gateway <network_gateway> ipv4.dns <dns_server>
 ----
 +
 where:
 +
 --
-<hosted_worker_ign_file>:: is the locally accessible URL for the hosted `worker.ign` file, for example, `http://webserver.example.com/worker.ign`
-<hard_disk>:: is hard disk where you install {op-system}, for example, `/dev/sda`.
+<static_ip>:: Is the host static IP address and CIDR, for example, `10.1.101.50/24`
+<network_gateway>:: Is the network gateway, for example, `10.1.101.1`
 --
+
+... Activate the modified network interface:
++
+[source,terminal]
+----
+$ nmcli con up <network_interface>
+----
+
+... Create a new ignition file `new-worker.ign` that includes a reference to the original `worker.ign` and an additional instruction that the `coreos-installer` program uses to populate the `/etc/hostname` file on the new worker host. For example:
++
+[source,json]
+----
+{
+  "ignition":{
+    "version":"3.2.0",
+    "config":{
+      "merge":[
+        {
+          "source":"<hosted_worker_ign_file>" <1>
+        }
+      ]
+    }
+  },
+  "storage":{
+    "files":[
+      {
+        "path":"/etc/hostname",
+        "contents":{
+          "source":"data:,<new_fqdn>" <2>
+        },
+        "mode":420,
+        "overwrite":true,
+        "path":"/etc/hostname"
+      }
+    ]
+  }
+}
+----
+<1> `<hosted_worker_ign_file>` is the locally accessible URL for the original `worker.ign` file. For example, `http://webserver.example.com/worker.ign`
+<2> `<new_fqdn>` is the new FQDN that you set for the worker node. For example, `new-worker.example.com`.
+
+... Host the `new-worker.ign` file on a web server accessible from your network.
+
+... Run the following `coreos-installer` command, passing in the `ignition-url` and hard disk details:
++
+[source,terminal]
+----
+$ sudo coreos-installer install --copy-network /
+--ignition-url=<new_worker_ign_file> <hard_disk> --insecure-ignition
+----
++
+where:
++
+--
+<new_worker_ign_file>:: is the locally accessible URL for the hosted `new-worker.ign` file, for example, `http://webserver.example.com/new-worker.ign`
+<hard_disk>:: Is the hard disk where you install {op-system}, for example, `/dev/sda`
+--
+
+.. For networks that have DHCP enabled, you do not need to set a static IP. Run the following `coreos-installer` command from the target host console to install the system:
++
+[source,terminal]
+----
+$ coreos-installer install --ignition-url=<hosted_worker_ign_file> <hard_disk>
+----
 
 . As the installation proceeds, the installation generates pending certificate signing requests (CSRs) for the worker node. When prompted, approve the pending CSRs to complete the installation.
 


### PR DESCRIPTION
Adds details for how to add worker nodes to SNO clusters when DHCP is not available

Version(s):
4.11, 4.12, 4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-3053

Link to docs preview:
https://54296--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-sno-worker-nodes.html#sno-adding-worker-nodes-to-single-node-clusters-manually_add-workers

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->