### PR TITLE
Adds a batch of release note doc text

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -1230,6 +1230,13 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 
 [id="ocp-4-12-bug-fixes"]
 == Bug fixes
+
+[discrete]
+[id="ocp-4-12-api-auth-bug-fixes"]
+==== API Server and Authentication
+
+* Previously, the Cluster Authentication Operator state was set to `progressing = false` after receiving a `workloadIsBeingUpdatedTooLong` error. At the same time, `degraded = false` was kept for the time of the `inertia` defined. Consequently, the shortened amount of progressing and increased time of degradedation would create a situation where `progressing = false` and `degraded = false` were set prematurely. This caused inconsistent OpenShift CI tests because a healthy state was assumed, which was incorrect. This issue has been fixed by removing the `progressing = false` setting after the `workloadIsBeingUpdatedTooLong` error is returned. Now, because there is no `progressing = false` state, OpenShift CI tests are more consistent. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2111842[*BZ2111842*])
+
 //Bug fix work for TELCODOCS-750
 [discrete]
 [id="ocp-4-12-bare-metal-hardware-bug-fixes"]
@@ -1320,6 +1327,12 @@ sourceStrategy:
 ==== Domain Name System (DNS)
 
 [discrete]
+[id="ocp-4-12-dev-console-bug-fixes"]
+==== Developer Console
+
+* Previously, the `openshift-config` namespace was hardcoded for the `HelmChartRepository` custom resource, which was the same namespace for the `ProjectHelmChartRepository` custom resource. This prevented users from adding private `ProjectHelmChartRepository` custom resources in their desired namespace. Consquently, users were unable to access secrets and configmaps in the `openshift-config` namespace. This update fixes the `ProjectHelmChartRepository` custom resource definition with a `namespace` field that can read the secret and configmaps from a namespace of choice by a user with the correct permissions. Additionally, the user can add secrets and configmaps to the accessible namespace, and they can add private Helm chart repositories in the namespace used the creation resources. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2071792[*BZ#2071792*])
+
+[discrete]
 [id="ocp-4-12-image-registry-bug-fixes"]
 ==== Image Registry
 
@@ -1362,8 +1375,18 @@ sourceStrategy:
 ==== Kubernetes API server
 
 [discrete]
+[id="ocp-4-12-kube-controller-bug-fixes"]
+==== Kubernetes Controller Manager
+
+* Previously, the Kubernetes Controller Manager Operator reported `degraded` on environments without a monitoring stack presence. With this update, the Kubernetes Controller Manager Operator skips checking the monitoring for cues about degradation when the monitoring stack is not present. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2118286[*BZ#2118286*])
+
+* With this update, Kubernetes Controller Manager alerts (`KubeControllerManagerDown`, `PodDisruptionBudgetAtLimit`, `PodDisruptionBudgetLimit`, and `GarbageCollectorSyncFailed`) have links to Github  runbooks. The runbooks help users to understand debug these alerts. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2001409[*BZ#2001409*])
+
+[discrete]
 [id="ocp-4-12-kube-scheduler-bug-fixes"]
 ==== Kubernetes Scheduler
+
+* Previously, the secondary scheduler deployment was not deleted after a secondary scheduler custom resource was deleted. Consequently, the Secondary Schedule Operator and Operand were not fully uninstalled. With this update, the correct owner reference is set in the secondary scheduler custom resource so that it points to the secondary scheduler deployment. As a result, secondary scheduler deployments are deleted when the secondary scheduler custom resource is deleted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2100923[*BZ#2100923*])
 
 [discrete]
 [id="ocp-4-12-machine-config-operator-bug-fixes"]
@@ -1404,6 +1427,16 @@ sourceStrategy:
 * Previously, the `MatchExpression` component did not account for array-type values. As a result,  only single values could be entered through forms using this component. With this update, the `MatchExpression` component accepts comma-separated values as an array. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2079690[*BZ#207690*])
 
 * Previously, there were redundant checks for the model resulting in tab reloading which occasionally resulted in a flickering of the tab contents where they rerendered. With this update, the redundant model check was removed, and the model is only checked once. As a result, the tab contents do not flicker and no longer rerender. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2037329[*BZ#2037329*])
+
+* Previously, when selecting the `edit` label from the action list on the OpenShift Dedicated node page, no response was elicited and a web hook error was returned. This issue has been fixed so that the error message is only returned when editing fails. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102098[*BZ#2102098*])
+
+* Previously, if issues were pending, clicking on the *Insights* link would crash the page. As a workaround, you can wait for the variable to become `initialized` before clicking the *Insights* link. As a result, the Insights page will open as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2052662[*BZ#2052662*])
+
+* Previously, when the `MachineConfigPool` resource was paused, the option to unpause said *Resume rollouts*. The wording has been updated so that it now says *Resume updates*. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2094240[*BZ#2094240*])
+
+* Previously, the wrong calculating method was used when counting master and worker nodes. With this update, the correct worker nodes are calculated when nodes have both the `master` and `worker` role. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1951901[*BZ#1951901*])
+
+* Previously, conflicting `react-router` routes for `ImageManifestVuln` resulted in attempts to render a details page for `ImageManifestVuln` with a `~new` name. Now, the container security plugin has been updated to remove conflicting routes and to ensure dynamic lists and details page extensions are used on the Operator details page. As a result, the console renders the correct create, list, and details pages for `ImageManifestVuln`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2080260[*BZ#2080260*])
 
 [discrete]
 [id="ocp-4-12-monitoring-bug-fixes"]
@@ -1465,15 +1498,17 @@ sourceStrategy:
 [id="ocp-4-12-node-bug-fixes"]
 ==== Node
 
+* Previously, a symlinks error message was printed out as raw data instead of formatted as an error, making it difficult to understand. This fix formats the error message properly, so that it is easily understood. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1977660[*BZ#1977660*])
+
 [discrete]
 [id="ocp-4-12-openshift-cli-bug-fixes"]
 ==== OpenShift CLI (oc)
 
 * The {product-title} {product-version} release fixes an issue with entering a debug session on a target node when the target namespace lacks the appropriate security level. This caused the `oc` CLI to prompt you with a pod security error message. If the existing namespace does not contain the appropriate security levels, {product-title} now creates a temporary namespace when you enter `oc` debug mode on a target node. (link:https://issues.redhat.com/browse/OCPBUGS-852[OCPBUGS-852])
 
-[discrete]
-[id="ocp-4-12-Kubernetes-controller-manage-bug-fixes"]
-==== Kubernetes Controller Manager
+* Previously, on macOS arm64 architecture, the `oc` binary needed to be signed manually. As a result, the `oc` binary did not work as expected. This update implements a self-signing binary for `oc` mimicking. As a result, the `oc` binary on macOS arm64 architectures works properly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2059125[*BZ#2059125*])
+
+* Previously, `must-gather` was trying to collect resources that were not present on the server. Consequently, `must-gather` would print error messages. Now, before collecting resources, `must-gather` checks whether the resource exists. As a result, `must-gather` no longer prints an error when it fails to collect non-existing resources on the server. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2095708[*BZ#2095708*])
 
 [discrete]
 [id="ocp-4-12-olm-bug-fixes"]
@@ -1483,9 +1518,14 @@ sourceStrategy:
 
 * Before the {product-title} {product-version} release, the `package-server-manager` controller would not revert any changes made to a `package-server` cluster service version (CSV), because of an issue with the `on-cluster` function. These persistent changes might impact how an Operator starts in a cluster. For {product-title} {product-version}, the `package-server-manager` controller always rebuilds a `package-server` CSV to its original state, so that no modifications to the CSV persist after a cluster upgrade operation. The `on-cluster` function no longer controls the state of a `package-server` CSV. (link:https://issues.redhat.com/browse/OCPBUGS-867[*OCPBUGS-867*])
 
+* Previously, Operator Lifecycle Manager (OLM) would attempt to update namespaces to apply a label, even if the label was present on the namespace. Consequently, the update requests increased the workload in API and etcd services. With this update, OLM compares existing labels against the expected labels on a namespace before issuing an update. As a result, OLM no longer attempts to make unnecessary update requests on namespaces. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2105045[*BZ#2105045*])
+
 [discrete]
 [id="ocp-4-12-openshift-operator-sdk-bug-fixes"]
 ==== Operator SDK
+
+* With this update, you can now set the security context for the registry pod by including the `securityContext` configuration field in the pod specification. This will apply the security context for all containers in the pod. The `securityContext` field also defines the pod's privileges. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2091864[*BZ#2091864*])
+
 
 [discrete]
 [id="ocp-4-12-openshift-api-server-bug-fixes"]
@@ -1509,6 +1549,8 @@ sourceStrategy:
 [id="ocp-4-12-performance-addon-operator-bug-fixes"]
 ==== Performance Addon Operator
 
+* Previously, the `oslat` runner configured `oslat` to use all available CPUs, which caused false spikes. With this update, the `oslat` runner reserves one CPU for the control thread. As a result, false spikes no longer occur. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2051443[*BZ#2051443*])
+
 [discrete]
 [id="ocp-4-12-routing-bug-fixes"]
 ==== Routing
@@ -1520,6 +1562,12 @@ sourceStrategy:
 [discrete]
 [id="ocp-4-12-storage-bug-fixes"]
 ==== Storage
+
+* Previously, there were missing annotations on the Manila CSI Driver Operator's VolumeSnapshotClass. Consequently, the Manila CSI snapshotter could not locate secrets, and could not create snapshots with the default VolumeSnapshotClass. This update fixes the issue so that secret names and namespaces are included in the default VolumeSnapshotClass. As a result, users can now create snapshots in the Manila CSI Driver Operator using the default VolumeSnapshotClass. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057637[*BZ#2057637*])
+
+* Users can now opt into using the experimental VHD feature on Azure File. To opt in, users must specify the `fstype` parameter in a storage class and enable it with `--enable-vhd=true`. If `fstype` is used and the feature is not set to `true`, the volumes will fail to provision. 
++
+To opt out of using the VHD feature, remove the `fstype` parameter from your storage class. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2080449[*BZ#2080449*])
 
 [discrete]
 [id="ocp-4-12-web-console-developer-perspective-bug-fixes"]


### PR DESCRIPTION
Adds first batch of release note doc text 

For 4.12 only. 

No QE necessary. 

Preview: https://54310--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes