### PR TITLE
BZ#1998936 - No doc to introduce swift storage for image registry (4.9)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1218,8 +1218,8 @@ Topics:
     File: configuring-registry-storage-aws-user-infrastructure
   - Name: Configuring the registry for GCP user-provisioned infrastructure
     File: configuring-registry-storage-gcp-user-infrastructure
-#  - Name: Configuring the registry for OpenStack user-provisioned infrastructure
-#    File: configuring-registry-storage-openstack-user-infrastructure
+  - Name: Configuring the registry for OpenStack user-provisioned infrastructure
+    File: configuring-registry-storage-openstack-user-infrastructure
   - Name: Configuring the registry for Azure user-provisioned infrastructure
     File: configuring-registry-storage-azure-user-infrastructure
   - Name: Configuring the registry for OpenStack


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.9
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=1998936
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
http://file.pnq.redhat.com/agantony/BZ1998936-enterprise-4.9/registry/configuring_registry_storage/configuring-registry-storage-openstack-user-infrastructure.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
