### PR TITLE
OSDOCS-4667: document known issue with spare-gb feature of LVMS in microshift

### DIFF
--- a/modules/microshift-lvms-configuring.adoc
+++ b/modules/microshift-lvms-configuring.adoc
@@ -36,11 +36,16 @@ device-classes: <2>
 <2> `map[string]DeviceClass`. The `device-class` settings. 
 <3> String. The name of the `device-class`.
 <4> String. The group where the `device-class` creates the logical volumes. 
-<5> unit64. Storage capacity in GiB to be spared. Defaults to `10`. 
+<5> unit64. Storage capacity in GiB to be left unallocated in the volume group. Defaults to `10`. 
 <6> Boolean. Indicates that the `device-class` is used by default. Defaults to `false`. 
 <7> unit. The number of stripes in the logical volume.
 <8> String. The amount of data that is written to one device before moving to the next device. 
 <9> String. Extra arguments to pas `lvcreate`, for example, `[--type=raid1"`]. 
++
+[WARNING]
+====
+There is a race condition that prevents LVMS from accurately tracking the allocated space and preserving the `spare-gb` for a device class when multiple PVCs are created simultaneously. Use separate volume groups and device classes to protect the storage of highly dynamic workloads from each other.
+====
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s): 4.12

Issue: [OSDOCS-4667](https://issues.redhat.com//browse/OSDOCS-4667)

Link to docs preview:
https://54316--docspreview.netlify.app/microshift/latest/microshift_storage/persistent_storage_microshift/microshift-storage-plugin-overview.html

QE review:
N/A -- MicroShift is Developer Preview
SME approval is required, author is the SME approver