### PR TITLE
OCPBUGS#5248 Removed duplicate update service overview module.

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -44,8 +44,6 @@ include::modules/arch-platform-operators.adoc[leveloffset=+2]
 * xref:../post_installation_configuration/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
 endif::[]
 
-include::modules/update-service-overview.adoc[leveloffset=+1]
-
 include::modules/understanding-machine-config-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * architecture/architecture-installation.adoc
-// * architecture/control-plane.adoc
 // * updating/updating-cluster-within-minor.adoc
 // * updating/updating-cluster-cli.adoc
 // * updating/updating-cluster-rhel-compute.adoc


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/OCPBUGS-5248

Link to docs preview:
https://54320--docspreview.netlify.app/openshift-enterprise/latest/architecture/control-plane.html

QE review:
QE not needed.


