### PR TITLE
CMP-1662 FIO release notes 1.0.0

### DIFF
--- a/modules/file-integrity-operator-installing-cli.adoc
+++ b/modules/file-integrity-operator-installing-cli.adoc
@@ -68,7 +68,7 @@ metadata:
   name: file-integrity-operator
   namespace: openshift-file-integrity
 spec:
-  channel: "release-0.1"
+  channel: "v1"
   installPlanApproval: Automatic
   name: file-integrity-operator
   source: redhat-operators

--- a/modules/file-integrity-operator-release-channel.adoc
+++ b/modules/file-integrity-operator-release-channel.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-configuring.adoc
+
+:_content-type: PROCEDURE
+[id="file-integrity-operator-release-channel_{context}"]
+= Configuring the File Integrity Operator release channel
+
+If you are upgrading an existing installation of File Integrity Operator to 1.0.0 or later, users must change the release channel to access the latest content.
+
+.Prerequisites
+
+* You must have `admin` privileges.
+* You are subscribed to the `release-0.1` channel.
+
+.Procedure
+
+. Login to the {product-title} Web Console with `admin` credentials.
+
+. Navigate to the *Operators* -> *Installed Operators* -> *File Integrity Operator* page.
+
+. Click the *Subscription* tab.
+
+. Click on `edit` from *Subscription Details* -> *Channel*.
+
+. Select the `v1` bullet and click *Save*.

--- a/security/file_integrity_operator/file-integrity-operator-configuring.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-configuring.adoc
@@ -20,3 +20,5 @@ include::modules/file-integrity-supplying-custom-aide-config.adoc[leveloffset=+1
 include::modules/file-integrity-operator-defining-custom-config.adoc[leveloffset=+1]
 
 include::modules/file-integrity-operator-changing-custom-config.adoc[leveloffset=+1]
+
+include::modules/file-integrity-operator-release-channel.adoc[leveloffset=+1]

--- a/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
@@ -13,6 +13,15 @@ These release notes track the development of the File Integrity Operator in the 
 
 For an overview of the File Integrity Operator, see xref:../../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-operator[Understanding the File Integrity Operator].
 
+[id="file-integrity-operator-release-notes-1-0-0"]
+== OpenShift File Integrity Operator 1.0.0
+
+The following advisory is available for the OpenShift File Integrity Operator 1.0.0:
+
+* link:https://access.redhat.com/errata/RHBA-2023:0037[RHBA-2023:0037 OpenShift File Integrity Operator Bug Fix Update]
+
+The File Integrity Operator is now stable and the release channel is upgraded to `v1`. Future releases will follow link:https://semver.org/[Semantic Versioning]. To access the latest release, see xref:../../security/file_integrity_operator/file-integrity-operator-configuring.adoc#file-integrity-operator-release-channel_file-integrity-operator[Configuring the File Integrity Operator release channel].
+
 [id="file-integrity-operator-release-notes-0-1-32"]
 == OpenShift File Integrity Operator 0.1.32
 
@@ -76,7 +85,7 @@ The following advisory is available for the OpenShift File Integrity Operator 0.
 [id="openshift-file-integrity-operator-0-1-22-bug-fixes"]
 === Bug fixes
 
-* Previously, a system with a File Integrity Operator installed might interrupt the {product-title} update, due to the  `/etc/kubernetes/aide.reinit` file.  This occurred if the `/etc/kubernetes/aide.reinit` file was present, but later removed prior to the `ostree` validation. With this update, `/etc/kubernetes/aide.reinit` is moved to the `/run` directory so that it does not conflict with the {product-title} update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033311[*BZ#2033311*])
+* Previously, a system with a File Integrity Operator installed might interrupt the {product-title} update, due to the  `/etc/kubernetes/aide.reinit` file. This occurred if the `/etc/kubernetes/aide.reinit` file was present, but later removed prior to the `ostree` validation. With this update, `/etc/kubernetes/aide.reinit` is moved to the `/run` directory so that it does not conflict with the {product-title} update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033311[*BZ#2033311*])
 
 [id="file-integrity-operator-release-notes-0-1-21"]
 == OpenShift File Integrity Operator 0.1.21


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/CMP-1662
https://issues.redhat.com/browse/OSDOCS-4754

Link to docs preview:
[OpenShift File Integrity Operator 1.0.0](http://file.rdu.redhat.com/antaylor/CMP-1662/security/file_integrity_operator/file-integrity-operator-release-notes.html#file-integrity-operator-release-notes-1-0-0)
[Configuring the File Integrity Operator release channel](http://file.rdu.redhat.com/antaylor/CMP-1662/security/file_integrity_operator/file-integrity-operator-configuring.html#file-integrity-operator-release-channel_file-integrity-operator)

QE review:
- [x] QE has approved this change.

Additional information:
* Included a new procedure to change the subscription channel to `v1`. 
* Updated the CLI YAML to `channel: "v1"`.
* Release notes updated to include a link to the errata and xref to the release channel configuration procedure.