### PR TITLE
OSDOCS-4756: Adds notes for 4.11.22 release

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3124,3 +3124,43 @@ $ oc adm release info 4.11.21 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-22"]
+=== RHBA-2023:0027 - {product-title} 4.11.22 bug fix update
+
+Issued: 2023-01-09
+
+{product-title} release 4.11.22 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:9107[RHBA-2023:0027] advisory. There are no RPM packages for this release.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.22 --pullspecs
+----
+
+[id="ocp-4-11-22-bug-fixes"]
+==== Bug fixes
+
+* The {product-title} {product-version} release updates the `install-config.yaml` file to now list the `me-west1`, (Tel Aviv, Israel) region. After you install the {product-title} by running the `openshift-install` binary, you can select the `me-west1` region for your chosen cluster. (link:https://issues.redhat.com/browse/OCPBUGS-4720[*OCPBUGS-4720*])
+
+* Previously, some object storage instances responded with a `204 No Content` error message when content was supposed to display. The {rh-openstack-first} SDK used in {product-title} does not handle 204s correctly. With this update, the installation program works around the issue when there are zero objects to list in a Swift container. (link:https://issues.redhat.com/browse/OCPBUGS-5078[*OCPBUGS-5078*])
+
+* Previously, the deployment of {product-title} 4.11.ec4 build failed with the latest RHCOS image `412.86.202210072120-0` and `rhel-86` image. As a result, the {op-system-first} node is stuck at booting. With this update, the deployment completes successfully. (link:https://issues.redhat.com/browse/OCPBUGS-2321[*OCPBUGS-2321*])
+
+[id="ocp-4-11-22-known-issues"]
+==== Known issues
+
+* Any 4.11 and later  `arm64` cluster that has more than around 470 containers to a node, can cause additional pod creation to fail with the following error:
++
+[source,terminal]
+====
+runc create failed: unable to start container process: unable to init seccomp: error loading seccomp filter into kernel: error loading seccomp filter: errno 524"
+====
++
+This is due to a CoreOS limitation in the number of seccomp profiles that can be created on the worker node. This most likely occurs on clusters with multiple containers per pod during an upgrade, worker node failure, or pod scaleup. This will be fixed in a later version of {product-title}. (link:https://issues.redhat.com/browse/OCPBUGS-2637[*OCPBUGS-2637*])
+
+[id="ocp-4-11-22-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4756](https://issues.redhat.com//browse/OSDOCS-4756): Adds notes for 4.11.22 release

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-4756

Link to docs preview:
https://54331--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-22

QE review:
- [ ] QE has approved this change.
* Qe not needed for this change
