### PR TITLE
OSDOCS-4760: remove use of oc login for microshift

### DIFF
--- a/cli_reference/openshift_cli/getting-started-cli.adoc
+++ b/cli_reference/openshift_cli/getting-started-cli.adoc
@@ -39,8 +39,10 @@ endif::[]
 // Installing the CLI by using Homebrew
 include::modules/cli-installing-cli-brew.adoc[leveloffset=+2]
 
+ifndef::microshift[]
 // Logging in to the CLI
 include::modules/cli-logging-in.adoc[leveloffset=+1]
+endif::[]
 
 // Using the CLI
 include::modules/cli-using-cli.adoc[leveloffset=+1]
@@ -48,5 +50,7 @@ include::modules/cli-using-cli.adoc[leveloffset=+1]
 // Getting help
 include::modules/cli-getting-help.adoc[leveloffset=+1]
 
+ifndef::microshift[]
 // Logging out of the CLI
 include::modules/cli-logging-out.adoc[leveloffset=+1]
+endif::[]


### PR DESCRIPTION
Version(s): 4.12

Issue: [OSDOCS-4760](https://issues.redhat.com//browse/OSDOCS-4760)

Link to docs preview:
Removed for MicroShift: https://54332--docspreview.netlify.app/microshift/latest/cli_reference/openshift_cli/getting-started-cli.html
Retained for OpenShift: https://54332--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands


QE review:
N/A -- MicroShift is Developer Preview
SME approval is required, author is the SME approver

Additional information:

OCP has APIs called User and Project. We do not have those APIs in MicroShift. There is certificate-based authentication, using the kubeconfig file, but you can't use `oc login`.