### PR TITLE
OCPBUGS-5423 adding known issue OCPBUGS-5423

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -139,7 +139,7 @@ For more information, see xref:../installing/installing_aws/installing-aws-netwo
 
 [id="ocp-4-12-ironic-base-image-rhel-9"]
 ==== Ironic container images use RHEL 9 base image
-In earlier versions of {product-title}, Ironic container images used {op-system-base-full} 8 as the base image. From {product-title} {product-version}, Ironic container images use {op-system-base} 9 as the base image. The {op-system-base} 9 base image adds support for CentOS Stream 9, Python 3.8, and Python 3.9 in Ironic components. 
+In earlier versions of {product-title}, Ironic container images used {op-system-base-full} 8 as the base image. From {product-title} {product-version}, Ironic container images use {op-system-base} 9 as the base image. The {op-system-base} 9 base image adds support for CentOS Stream 9, Python 3.8, and Python 3.9 in Ironic components.
 
 For more information about the Ironic provisioning service, see xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc[Deploying installer-provisioned clusters on bare metal].
 
@@ -2179,6 +2179,22 @@ $ ./openshift-install wait-for install-complete
 ** The RukPak provisioner implementations do not have the ability to inspect the health or state of the resources that they are managing. This has implications for surfacing the generated `BundleDeployment` resource state to the `PlatformOperator` resource that owns it. If a `registry+v1` bundle contains manifests that can be successfully applied to the cluster, but will fail at runtime, such as a `Deployment` object referencing a non-existent image, the result is a successful status being reflected in individual `PlatformOperator` and `BundleDeployment` resources.
 
 ** Cluster administrators configuring `PlatformOperator` resources before cluster creation cannot easily determine the desired package name without leveraging an existing cluster or relying on documented examples. There is curently no validation logic that ensures an individually configured `PlatformOperator` resource will be able to successfully roll out to the cluster.
+
+* Pods in the `openshift-marketplace` cause PodSecurityViolation alerts in a vanilla {product-title} cluster. This is because the newly created project's `pod-security.kubernetes.io/warn` and audit are restricted, and the CatalogSource's `spec.grpcPodConfig.securityContextConfig` is not restricted by default, so you will get the related pod security admission (PSA) warnings, like below:
++
+[source,terminal]
+----
+W0105 03:04:13.729506 1 warnings.go:70] would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "registry-server" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "registry-server" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "registry-server" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "registry-server" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
+----
++
+The following `PodSecurityViolation` is also displayed in the `Status` window of the web console:
++
+[source,terminal]
+----
+A workload (pod,deployment,daemonsset,...) was created in the cluster but it did not match the PodSecurity "restricted" profile defined by its namespace either via the cluster-wide configuration (which triggers on a "restricted" profile violations) or by the namespace local Pod Security labels. Refer to Kubernetes documentation on Pod Security Admission to learn more about these viloations.
+----
++
+As a workaround, remove those warnings by changing the project's `pod-security.kubernetes.io/warn` and audit to `baseline` or change the CatalogSource's `spec.grpcPodConfig.securityContextConfig` to `restricted`.
 
 * When using the Technology Preview OCI feature with the oc-mirror CLI plug-in, the mirrored catalog embeds all of the Operator bundles, instead of filtering only on those specified in the image set configuration file. (link:https://issues.redhat.com/browse/OCPBUGS-5085[*OCPBUGS-5085*])
 


### PR DESCRIPTION
[OCPBUGS-5423]:openshift-marketplace pods cause PodSecurityViolation alert to fire

Version(s):
4.12 RN
Issue:
https://issues.redhat.com/browse/OCPBUGS-5423

Link to docs preview:
https://54342--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-known-issues

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
