### PR TITLE
BZ1998936 - No doc to introduce swift storage for image registry (4.9)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1218,8 +1218,8 @@ Topics:
     File: configuring-registry-storage-aws-user-infrastructure
   - Name: Configuring the registry for GCP user-provisioned infrastructure
     File: configuring-registry-storage-gcp-user-infrastructure
-#  - Name: Configuring the registry for OpenStack user-provisioned infrastructure
-#    File: configuring-registry-storage-openstack-user-infrastructure
+  - Name: Configuring the registry for OpenStack user-provisioned infrastructure
+    File: configuring-registry-storage-openstack-user-infrastructure
   - Name: Configuring the registry for Azure user-provisioned infrastructure
     File: configuring-registry-storage-azure-user-infrastructure
   - Name: Configuring the registry for OpenStack

--- a/modules/registry-configuring-registry-storage-swift-trust.adoc
+++ b/modules/registry-configuring-registry-storage-swift-trust.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * registry/installing-openstack- .adoc
+// * registry/configuring-registry-operator.adoc
+// * registry/configuring-registry-storage-openstack-user-infrastructure.adoc
+:_content-type: PROCEDURE
+[id="registry-configuring-registry-storage-swift-trust_{context}"]
+= Configuring the Image Registry Operator to trust Swift storage
+
+You must configure the Image Registry Operator to trust {rh-openstack-first} Swift storage.
+
+// to allow the client to pull the image layers from the image registry rather than from links directly from Swift.
+
+.Procedure
+
+* From a command line, enter the following command to change the value of the `spec.disableRedirect` field in the `config.imageregistry` object to `true`:
++
+[source,terminal]
+----
+$ oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"disableRedirect":true}}'
+----

--- a/registry/configuring_registry_storage/configuring-registry-storage-openstack-user-infrastructure.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-openstack-user-infrastructure.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+You can configure the registry of a cluster that runs on your own {rh-openstack-first} infrastructure.
+
+include::modules/registry-configuring-registry-storage-swift-trust.adoc[leveloffset=+1]
 
 include::modules/registry-operator-config-resources-secret-openstack.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.9
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=1998936
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
http://file.pnq.redhat.com/agantony/BZ1998936-enterprise-4.9/registry/configuring_registry_storage/configuring-registry-storage-openstack-user-infrastructure.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
