### PR TITLE
docs.openshift.com CSS improvements - move search to nav

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -53,21 +53,6 @@ div.gsc-option-menu-container>div.gsc-selected-option-container {
   margin: 0 10px;
 }
 
-/* target safari only hack: https://stackoverflow.com/a/25975282/6758654 */
-/* Addresses https://github.com/openshift/openshift-docs/issues/40909 */
-@media not all and (min-resolution:.001dpcm) { @supports (-webkit-appearance:none) and (stroke-color:transparent) {
-    #hc-search.wide {
-      z-index:  50;
-      margin-top:  28px;
-      margin-left:  -15px;
-    }
-
-    .sidebar.wide {
-      padding-top:  30px;
-    }
-}}
-/* end safari only */
-
 /* ------------------------------------------------------------
 Image: "Spin" https://www.flickr.com/photos/eflon/3655695161/
 Author: eflon https://www.flickr.com/photos/eflon/
@@ -453,7 +438,7 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
     margin-left: 5px;
     display: flex;
     flex-flow: column;
-    top: 190px;
+    top: 160px;
     bottom: 10px;
     display: block;
     -webkit-animation: fadein 0.35s ease-in; /* Safari, Chrome and Opera > 12.1 */
@@ -461,19 +446,6 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
         -ms-animation: fadein 0.35s ease-in; /* Internet Explorer */
          -o-animation: fadein 0.35s ease-in; /* Opera < 12.1 */
             animation: fadein 0.35s ease-in;
-  }
-
-  #hc-search {
-    position: fixed;
-    top: 160px;
-    width: 358px;
-  }
-
-  #hc-search-btn {
-      border: 1px solid lightgrey;
-      font-size: 12px;
-      height: 25px;
-      width: 31px;
   }
 
   .breadcrumb {
@@ -547,7 +519,6 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
   }
 
   #toc {
-    user-select: none;
     float: right;
     padding-top: 0.1em !important;
     font-size: 0.8em;
@@ -677,6 +648,38 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
   overflow-wrap: break-word;
 }
 
+#hc-search-btn {
+    font-family: 'Material Icons Outlined';
+    border: none;
+    font-weight: normal;
+    font-style: normal;
+    font-weight: normal;
+    font-size: 24px;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    height: unset;
+    width: 28px;
+    background-color: transparent;
+    -webkit-font-feature-settings: 'liga';
+    -webkit-font-smoothing: antialiased;
+}
+
+#hc-search-input {
+    border: 1px solid lightgrey;
+    font-size: 16px;
+    height: unset;
+    width: 50%;
+    position: relative;
+    margin-right: -5px;
+    top: -6px;
+}
+
+
 /*tablet browsers*/
 
 @media (max-width: 1424px) {
@@ -708,7 +711,7 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
     margin-left: 5px;
     display: flex;
     flex-flow: column;
-    top: 190px;
+    top: 160px;
     bottom: 10px;
     display: block;
     -webkit-animation: fadein 0.35s ease-in; /* Safari, Chrome and Opera > 12.1 */
@@ -716,26 +719,6 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
         -ms-animation: fadein 0.35s ease-in; /* Internet Explorer */
          -o-animation: fadein 0.35s ease-in; /* Opera < 12.1 */
             animation: fadein 0.35s ease-in;
-  }
-
-  #hc-search {
-    position: fixed;
-    top: 160px;
-    width: 305px;
-  }
-
-  #hc-search-btn {
-    border: 1px solid lightgrey;
-    font-size: 12px;
-    height: 25px;
-    width: 30px;
-    padding: 1px;
-  }
-
-  #hc-search-input {
-      border: 1px solid lightgrey;
-      font-size: 12px;
-      height: 25px;
   }
 
   .breadcrumb {
@@ -956,10 +939,6 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
       width: 100%;
   }
 
-  .nav {
-    padding-top: 15px;
-  }
-
   #toc:before {
     display: none;
   }
@@ -1052,17 +1031,8 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
     margin-bottom: 3px;
   }
 
-  .btn-close {
-    padding: 2px;
-  }
-
   .close-btn-sm {
     display: unset;
-  }
-
-  #hc-search {
-    top: 40px;
-    position: unset;
   }
 
 }


### PR DESCRIPTION
Updates: 
1. Moved search bar into the right-hand side of the breadcrumb nav bar.
2. Clicking on main area of page closes the TOC on smaller viewports

http://file.emea.redhat.com/aireilly/fix-search-css-safari/welcome/index.html

Merge to enterprise-4.1 only

Merge alongside https://github.com/openshift/openshift-docs/pull/52979