### PR TITLE
FIO and CO removed from release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -405,8 +405,10 @@ A new import value, `importMode`, has been added to the `importPolicy` parameter
 * `PreserveOriginal`: When active, the original manifest is preserved. For manifest lists, the manifest list and all of its sub-manifests are imported.
 
 
-[id="ocp-4-12-security"]
-=== Security and compliance
+//[id="ocp-4-12-security"]
+//=== Security and compliance
+//
+// This content will be added post-GA, as it is asynchronous content.
 
 [id="ocp-4-12-networking"]
 === Networking
@@ -1390,20 +1392,6 @@ sourceStrategy:
 * Previously, the Machine Config Operator (MCO) `ControllerConfig` resource, which contains important certificates, was only synced if the Operator's daemon sync succeeded. By design, unready nodes during a daemon sync prevent that daemon sync from succeeding, so unready nodes were indirectly preventing the `ControllerConfig` resource, and therefore those certificates, from syncing. This resulted in eventual cluster degradation when there were unready nodes due to inability to rotate the certificates contained in the `ControllerConfig` resource. With this release, the sync of the `ControllerConfig` resource is no longer dependent on the daemon sync succeeding, so the `ControllerConfig` resource now continues to sync if the daemon sync fails. This means that unready nodes no longer prevent the `ControllerConfig` resource from syncing, so certificates continue to be updated even when there are unready nodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2034883[*BZ#2034883*])
 
 [discrete]
-[id="ocp-4-12-compliance-operator-bug-fixes"]
-==== Compliance Operator
-
-* Previously, the Compliance Operator used an old version of the Operator SDK, which is a dependency for building Operators. This caused alerts about deprecated Kubernetes functionality used by the Operator SDK. With this release, the Compliance Operator is upgraded to version 0.1.55, which includes an updated version of the Operator SDK. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2098581[*BZ#2098581*])
-
-* Previously, applying automatic remediation for the `rhcos4-high-master-sysctl-kernel-yama-ptrace-scope` and `rhcos4-sysctl-kernel-core-pattern` rules resulted in subsequent failures of those rules in scan results, even though they were remediated. The issue is fixed in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2094382[*BZ#2094382*])
-
-* Previously, the Compliance Operator hard-coded notifications to the default namespace. As a result, notifications from the Operator would not appear if the Operator was installed in a different namespace. This issue is fixed in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2060726[*BZ#2060726*])
-
-* Previously, the Compliance Operator failed to fetch API resources when parsing machine configurations without ignition specifications. This caused the `api-check-pods` check to crash loop. With this release, the Compliance Operator is updated to gracefully handle machine config pools without ignition specifications. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2117268[*BZ#2117268*])
-
-* Previously, the Compliance Operator held machine configurations in a stuck state because it could not determine the relationship between machine configurations and kubelet configurations due to incorrect assumptions about machine configuration names. With this release, the Compliance Operator is able to determine if a kubelet configuration is a subset of a machine configuration. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102511[*BZ#2102511*])
-
-[discrete]
 [id="ocp-4-12-management-console-bug-fixes"]
 ==== Management Console
 
@@ -1559,17 +1547,6 @@ sourceStrategy:
 
 * Before this update, users could not silence alerts in the *Developer* perspective in the {product-title} web console when a user-defined Alertmanager service was deployed because the web console would forward the request to the platform Alertmanager service in the `openshift-monitoring` namespace. With this update, when you view the *Developer* perspective in the web console and try to silence an alert, the request is forwarded to the corrrect Alertmanager service. (link:https://issues.redhat.com/browse/OCPBUGS-1789[*OCPBUGS-1789*])
 
-[discrete]
-[id="ocp-4-12-file-integrity-operator-bug-fixes"]
-==== File Integrity Operator
-
-* Previously, underlying dependencies of the File Integrity Operator changed how alerts and notifications were handled, and the Operator didn't send metrics as a result. With this release the Operator ensures that the metrics endpoint is correct and reachable on startup. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2115821[*BZ#2115821*])
-
-* Previously, alerts issued by the File Integrity Operator did not set a namespace. This made it difficult to understand where the alert was coming from, or what component was responsible for issuing it. With this release, the Operator includes the namespace it was installed into in the alert, making it easier to narrow down what component needs attention. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2101393[*BZ#2101393*])
-
-* Previously, the File Integrity Operator did not properly handle modifying alerts during an upgrade. As a result, alerts did not include the namespace in which the Operator was installed. With this release, the Operator includes the namespace it was installed into in the alert, making it easier to narrow down what component needs attention. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2112394[*BZ#2112394*])
-
-* Previously, the File Integrity Operator daemon used the `ClusterRoles` parameter instead of the `Roles` parameter for a recent permission change. As a result, OLM could not upgrade the Operator. With this release, the Operator daemon reverts to using the `Roles` parameter and upgrades from older versions to version 0.1.29 are successful. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2108475[*BZ#2108475*])
 
 [id="ocp-4-12-technology-preview"]
 == Technology Preview features


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4764
https://issues.redhat.com/browse/OSDOCS-4765

Link to docs preview:
[4.12 release notes](http://file.rdu.redhat.com/antaylor/OSDOCS-4764/release_notes/ocp-4-12-release-notes.html)

Additional information:
Removed Compliance Operator and File Integrity Operator bug fixes, as they are documented in the asynchronous release notes in the documentation for these Operators.