### PR TITLE
OCPBUGS#5149: Adding missing CurrentState API route info

### DIFF
--- a/modules/cnf-fast-event-notifications-api-refererence.adoc
+++ b/modules/cnf-fast-event-notifications-api-refererence.adoc
@@ -29,6 +29,9 @@ Use the following API endpoints to subscribe the `cloud-event-consumer` DU appli
 * `api/cloudNotifications/v1/publishers`
 - `GET`: Returns an array of `os-clock-sync-state`, `ptp-clock-class-change`, and `lock-state` messages for the cluster node
 
+* `/api/cloudnotifications/v1/<resource_address>/CurrentState`
+-  `GET`: Returns the current state of one the following event types: `os-clock-sync-state`, `ptp-clock-class-change`, or `lock-state` events
+
 [NOTE]
 ====
 `9089` is the default port for the `cloud-event-consumer` container deployed in the application pod. You can configure a different port for your DU application as required.
@@ -287,5 +290,116 @@ $ oc logs -f linuxptp-daemon-cvgr6 -n openshift-ptp -c cloud-event-proxy
          }
       ]
    }
+}
+----
+
+== /api/cloudnotifications/v1/<resource_address>/CurrentState
+
+[discrete]
+=== HTTP method
+
+`GET api/cloudNotifications/v1/cluster/node/<node_name>/sync/ptp-status/lock-state/CurrentState`
+
+`GET api/cloudNotifications/v1/cluster/node/<node_name>/sync/sync-status/os-clock-sync-state/CurrentState`
+
+`GET api/cloudNotifications/v1/cluster/node/<node_name>/sync/ptp-status/ptp-clock-class-change/CurrentState`
+
+[discrete]
+==== Description
+
+Configure the `CurrentState` API endpoint to return the current state of the `os-clock-sync-state`, `ptp-clock-class-change`, or `lock-state` events for the cluster node.
+
+* `os-clock-sync-state` notifications describe the host operating system clock synchronization state. Can be in `LOCKED` or `FREERUN` state.
+* `ptp-clock-class-change` notifications describe the current state of the PTP clock class.
+* `lock-state` notifications describe the current status of the PTP equipment lock state. Can be in `LOCKED`, `HOLDOVER` or `FREERUN` state.
+
+.Query parameters
+|===
+| Parameter | Type
+
+| `<resource_address>`
+| string
+|===
+
+.Example lock-state API response
+[source,json]
+----
+{
+  "id": "c1ac3aa5-1195-4786-84f8-da0ea4462921",
+  "type": "event.sync.ptp-status.ptp-state-change",
+  "source": "/cluster/node/compute-1.example.com/sync/ptp-status/lock-state",
+  "dataContentType": "application/json",
+  "time": "2023-01-10T02:41:57.094981478Z",
+  "data": {
+    "version": "v1",
+    "values": [
+      {
+        "resource": "/cluster/node/compute-1.example.com/ens5fx/master",
+        "dataType": "notification",
+        "valueType": "enumeration",
+        "value": "LOCKED"
+      },
+      {
+        "resource": "/cluster/node/compute-1.example.com/ens5fx/master",
+        "dataType": "metric",
+        "valueType": "decimal64.3",
+        "value": "29"
+      }
+    ]
+  }
+}
+----
+
+.Example os-clock-sync-state API response
+[source,json]
+----
+{
+  "specversion": "0.3",
+  "id": "4f51fe99-feaa-4e66-9112-66c5c9b9afcb",
+  "source": "/cluster/node/compute-1.example.com/sync/sync-status/os-clock-sync-state",
+  "type": "event.sync.sync-status.os-clock-sync-state-change",
+  "subject": "/cluster/node/compute-1.example.com/sync/sync-status/os-clock-sync-state",
+  "datacontenttype": "application/json",
+  "time": "2022-11-29T17:44:22.202Z",
+  "data": {
+    "version": "v1",
+    "values": [
+      {
+        "resource": "/cluster/node/compute-1.example.com/CLOCK_REALTIME",
+        "dataType": "notification",
+        "valueType": "enumeration",
+        "value": "LOCKED"
+      },
+      {
+        "resource": "/cluster/node/compute-1.example.com/CLOCK_REALTIME",
+        "dataType": "metric",
+        "valueType": "decimal64.3",
+        "value": "27"
+      }
+    ]
+  }
+}
+----
+
+.Example ptp-clock-class-change API response
+[source,json]
+----
+{
+  "id": "064c9e67-5ad4-4afb-98ff-189c6aa9c205",
+  "type": "event.sync.ptp-status.ptp-clock-class-change",
+  "source": "/cluster/node/compute-1.example.com/sync/ptp-status/ptp-clock-class-change",
+  "dataContentType": "application/json",
+  "time": "2023-01-10T02:41:56.785673989Z",
+  "data": {
+    "version": "v1",
+    "values": [
+      {
+        "resource": "/cluster/node/compute-1.example.com/ens5fx/master",
+        "dataType": "metric",
+        "valueType": "decimal64.3",
+        "value": "165"
+      }
+    ]
+  }
 }
 ----


### PR DESCRIPTION
OCPBUGS-5149: Adding missing CurrentState API route for PTP API

Version(s):
4.11+ 

Issue:
https://issues.redhat.com/browse/OCPBUGS-5149

Link to docs preview:
- https://54355--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#cnf-fast-event-notifications-api-refererence_using-ptp
- https://54355--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#apicloudnotificationsv1resource_addresscurrentstate

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
