### PR TITLE
OSDOCS-4758:adds RNs for 4.10 zstream

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3717,3 +3717,34 @@ $ oc adm release info 4.10.46 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-47"]
+=== RHSA-2023:0032 - {product-title} 4.10.47 bug fix and security update
+
+Issued: 2023-01-04
+
+{product-title} release 4.10.47, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2023:0032[RHSA-2023:0032] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0031[RHBA-2023:0031] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.47 --pullspecs
+----
+
+[id="ocp-4-10-47-enhancements"]
+==== Enhancements
+
+* IPv6 unsolicited neighbor advertisements and IPv4 gratuitous address resolution protocol now default on the SR-IOV CNI plug-in. Pods created with the Single Root I/O Virtualization (SR-IOV) CNI plug-in, where the IP address management CNI plug-in has assigned IPs, now send IPv6 unsolicited neighbor advertisements and/or IPv4 gratuitous address resolution protocol by default onto the network. This enhancement notifies hosts of the new pod's MAC address for a particular IP to refresh ARP/NDP caches with the correct information. For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
+
+[id="ocp-4-10-47-bug-fixes"]
+==== Bug fixes
+
+* Previously, in CoreDNS v1.7.1, all upstream cache refreshes used DNSSEC. Bufsize was hardcoded to 2048 bytes for the upstream query, causing some DNS upstream queries to break when there were UDP Payload limits within the networking infrastructure. With this update, {product-title} always uses bufsize 512 for upstream cache requests as that is the bufsize specified in the Corefile. Customers might be impacted if they rely on the incorrect functionality of bufsize 2048 for upstream DNS requests. (link:https://issues.redhat.com/browse/OCPBUGS-2902[*OCPBUGS-2902*])
+
+* Previously, {product-title} did not handle object storage instances that responded with `204 No Content`. This caused problems for the {rh-openstack-first} SDK. With this update, the installation program works around the issue when there are zero objects to list in a Swift container. (link:https://issues.redhat.com/browse/OCPBUGS-5112[*OCPBUGS-5112*])
+
+[id="ocp-4-10-47-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4758](https://issues.redhat.com//browse/OSDOCS-4758): adds zstream update and includes backport 
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
zstream [Jira](https://issues.redhat.com/browse/OSDOCS-4758) 
Backport [Jira](https://issues.redhat.com/browse/NHE-226) to enable IPv6
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Preview](https://joealdinger.github.io/openshift-docs/OSDOCS-4758/release_notes/ocp-4-10-release-notes.html#ocp-4-10-47)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
