### PR TITLE
Adds SRIOV family support to networking release note table

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -558,10 +558,22 @@ For more information, see xref:../networking/ingress-controller-dnsmgt.adoc#ingr
 {product-title} 4.12 adds support for the following SR-IOV devices:
 
 * MT2892 Family [ConnectX&#8209;6{nbsp}Dx]
+* MT2894 Family [ConnectX-6 Lx]
 * MT42822 BlueField&#8209;2 in ConnectX&#8209;6 NIC mode
 * Silicom STS Family
 
 For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
+
+[id="ocp-4-12-networking-supported-hardware-for-ovs"]
+==== Supported hardware for OvS (Open vSwitch) Hardware Offload 
+
+{product-title} 4.12 adds OvS Hardware Offload support for the following devices:
+
+* MT2894 Family [ConnectX-6 Lx]
+* MT42822 BlueField&#8209;2 in ConnectX&#8209;6 NIC mode
+
+For more information, see xref:../networking/hardware_networks/configuring-hardware-offloading.adoc#supported_devices_configuring-hardware-offloading[Supported devices].
+
 
 [id="ocp-4-12-multi-network-policy-supported-for-sr-iov"]
 ==== Multi-network-policy supported for SR-IOV (Technology Preview)


### PR DESCRIPTION
4.12 only. 

Preview: https://54381--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-technology-preview

Jira:
https://issues.redhat.com/browse/OSDOCS-4778


QE not needed. 