### PR TITLE
OSDOCS-4326: Edits for Planning your environment according to object maximums

### DIFF
--- a/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
+++ b/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
@@ -168,10 +168,7 @@ labels:
   template: deployment-config-template
 ----
 
-The number of application pods that can run in a namespace is dependent on the number of services and the
-length of the service name when the environment variables are used for service discovery. `ARG_MAX` on the system 
-defines the maximum argument length for a new process and it is set to `2097152 KiB` by default. The Kubelet injects 
-environment variables in to each pod scheduled to run in the namespace including:
+The number of application pods that can run in a namespace is dependent on the number of services and the length of the service name when the environment variables are used for service discovery. `ARG_MAX` on the system defines the maximum argument length for a new process and it is set to 2097152 bytes (2 MiB) by default. The Kubelet injects environment variables in to each pod scheduled to run in the namespace including:
 
 * `<SERVICE_NAME>_SERVICE_HOST=<IP>`
 * `<SERVICE_NAME>_SERVICE_PORT=<PORT>`
@@ -181,6 +178,6 @@ environment variables in to each pod scheduled to run in the namespace including
 * `<SERVICE_NAME>_PORT_<PORT>_TCP_PORT=<PORT>`
 * `<SERVICE_NAME>_PORT_<PORT>_TCP_ADDR=<ADDR>`
 
-The pods in the namespace will start to fail if the argument length exceeds the allowed value and the number of 
-characters in a service name impacts it. For example, in a namespace with 5000 services, the limit on the service name 
+The pods in the namespace will start to fail if the argument length exceeds the allowed value and the number of
+characters in a service name impacts it. For example, in a namespace with 5000 services, the limit on the service name
 is 33 characters, which enables you to run 5000 pods in the namespace.

--- a/modules/how-to-plan-your-environment-according-to-cluster-maximums.adoc
+++ b/modules/how-to-plan-your-environment-according-to-cluster-maximums.adoc
@@ -20,7 +20,7 @@ While planning your environment, determine how many pods are expected to fit per
 required pods per cluster / pods per node = total number of nodes needed
 ----
 
-The current maximum number of pods per node is 250. However, the number of pods that fit on a node is dependent on the application itself. Consider the application's memory, CPU, and storage requirements, as described in _How to plan your environment according to application requirements_.
+The default maximum number of pods per node is 250. However, the number of pods that fit on a node is dependent on the application itself. Consider the application's memory, CPU, and storage requirements, as described in "How to plan your environment according to application requirements".
 
 .Example scenario
 
@@ -41,3 +41,5 @@ Where:
 ----
 required pods per cluster / total number of nodes = expected pods per node
 ----
+
+{product-title} comes with several system pods, such as SDN, DNS, Operators, and others, which run across every worker node by default. Therefore, the result of the above formula can vary.

--- a/modules/rosa-planning-environment-application-reqs.adoc
+++ b/modules/rosa-planning-environment-application-reqs.adoc
@@ -156,7 +156,7 @@ objects:
 template: deploymentConfigTemplate
 ----
 
-The number of application pods that can run in a namespace is dependent on the number of services and the length of the service name when the environment variables are used for service discovery. `ARG_MAX` on the system defines the maximum argument length for a new process and it is set to 2097152 KiB by default. The kubelet injects environment variables in to each pod scheduled to run in the namespace including:
+The number of application pods that can run in a namespace is dependent on the number of services and the length of the service name when the environment variables are used for service discovery. `ARG_MAX` on the system defines the maximum argument length for a new process and it is set to 2097152 bytes (2 MiB) by default. The kubelet injects environment variables in to each pod scheduled to run in the namespace including:
 
 * `<SERVICE_NAME>_SERVICE_HOST=<IP>`
 * `<SERVICE_NAME>_SERVICE_PORT=<PORT>`


### PR DESCRIPTION
Version(s):
4.11, 4.12, 4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-4326

Link to docs preview:
https://54383--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html