### PR TITLE
[OSDOCS-4769]: updated TP table for hosted control planes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -2051,12 +2051,12 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.10 |4.11 | 4.12
 
-|Hosted control planes for {product-title}
+|Hosted control planes for {product-title} on bare metal
 |Not Available
 |Technology Preview
 |Technology Preview
 
-|Hosted control planes for Amazon Web Services (AWS)
+|Hosted control planes for {product-title} on Amazon Web Services (AWS)
 ||Not Available
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
[OSDOCS-4769]: Update Technology Preview table to ensure the correct feature names for hosted control planes

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-4769
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
