### PR TITLE
[enterprise-4.12] Rebrand to Red Hat OpenShift Networking

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -156,3 +156,8 @@ endif::[]
 // Factory-precaching-cli tool
 :factory-prestaging-tool: factory-precaching-cli tool
 :factory-prestaging-tool-caps: Factory-precaching-cli tool
+:openshift-networking: Red Hat OpenShift Networking
+// TODO - this probably needs to be different for OKD
+//ifdef::openshift-origin[]
+//:openshift-networking: OKD Networking
+//endif::[]

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1016,6 +1016,8 @@ Name: Networking
 Dir: networking
 Distros: openshift-enterprise,openshift-origin
 Topics:
+- Name: About networking
+  File: about-networking
 - Name: Understanding networking
   File: understanding-networking
 - Name: Accessing hosts
@@ -1157,10 +1159,50 @@ Topics:
     File: configuring-hardware-offloading
   - Name: Uninstalling the SR-IOV Operator
     File: uninstalling-sriov-operator
-- Name: OpenShift SDN default CNI network provider
+- Name: OVN-Kubernetes network plug-in
+  Dir: ovn_kubernetes_network_provider
+  Distros: openshift-origin,openshift-enterprise
+  Topics:
+  - Name: About the OVN-Kubernetes network plug-in
+    File: about-ovn-kubernetes
+  - Name: Migrating from the OpenShift SDN network plug-in
+    File: migrate-from-openshift-sdn
+  - Name: Rolling back to the OpenShift SDN network plug-in
+    File: rollback-to-openshift-sdn
+  - Name: Converting to IPv4/IPv6 dual stack networking
+    File: converting-to-dual-stack
+  - Name: Logging for egress firewall and network policy rules
+    File: logging-network-policy
+  - Name: Configuring IPsec encryption
+    File: configuring-ipsec-ovn
+  - Name: Configuring an egress firewall for a project
+    File: configuring-egress-firewall-ovn
+  - Name: Viewing an egress firewall for a project
+    File: viewing-egress-firewall-ovn
+  - Name: Editing an egress firewall for a project
+    File: editing-egress-firewall-ovn
+  - Name: Removing an egress firewall from a project
+    File: removing-egress-firewall-ovn
+  - Name: Configuring an egress IP address
+    File: configuring-egress-ips-ovn
+  - Name: Assigning an egress IP address
+    File: assigning-egress-ips-ovn
+  - Name: Considerations for the use of an egress router pod
+    File: using-an-egress-router-ovn
+  - Name: Deploying an egress router pod in redirect mode
+    File: deploying-egress-router-ovn-redirection
+  - Name: Enabling multicast for a project
+    File: enabling-multicast
+  - Name: Disabling multicast for a project
+    File: disabling-multicast
+  - Name: Tracking network flows
+    File: tracking-network-flows
+  - Name: Configuring hybrid networking
+    File: configuring-hybrid-networking
+- Name: OpenShift SDN network plug-in
   Dir: openshift_sdn
   Topics:
-  - Name: About the OpenShift SDN default CNI network provider
+  - Name: About the OpenShift SDN network plug-in
     File: about-openshift-sdn
   - Name: Configuring egress IPs for a project
     File: assigning-egress-ips
@@ -1195,48 +1237,6 @@ Topics:
   - Name: Configuring kube-proxy
     File: configuring-kube-proxy
     Distros: openshift-enterprise,openshift-origin
-- Name: OVN-Kubernetes default CNI network provider
-  Dir: ovn_kubernetes_network_provider
-  Distros: openshift-origin,openshift-enterprise
-  Topics:
-  - Name: About the OVN-Kubernetes network provider
-    File: about-ovn-kubernetes
-  - Name: Migrating from the OpenShift SDN cluster network provider
-    File: migrate-from-openshift-sdn
-  - Name: Rolling back to the OpenShift SDN cluster network provider
-    File: rollback-to-openshift-sdn
-  - Name: Converting to IPv4/IPv6 dual stack networking
-    File: converting-to-dual-stack
-  - Name: Logging for egress firewall and network policy rules
-    File: logging-network-policy
-  - Name: Configuring IPsec encryption
-    File: configuring-ipsec-ovn
-  - Name: Configuring an egress firewall for a project
-    File: configuring-egress-firewall-ovn
-  - Name: Viewing an egress firewall for a project
-    File: viewing-egress-firewall-ovn
-  - Name: Editing an egress firewall for a project
-    File: editing-egress-firewall-ovn
-  - Name: Removing an egress firewall from a project
-    File: removing-egress-firewall-ovn
-  - Name: Configuring an egress IP address
-    File: configuring-egress-ips-ovn
-  - Name: Assigning an egress IP address
-    File: assigning-egress-ips-ovn
-  - Name: Considerations for the use of an egress router pod
-    File: using-an-egress-router-ovn
-  - Name: Deploying an egress router pod in redirect mode
-    File: deploying-egress-router-ovn-redirection
-  - Name: Enabling multicast for a project
-    File: enabling-multicast
-    Distros: openshift-origin,openshift-enterprise,openshift-webscale
-  - Name: Disabling multicast for a project
-    File: disabling-multicast
-    Distros: openshift-origin,openshift-enterprise,openshift-webscale
-  - Name: Tracking network flows
-    File: tracking-network-flows
-  - Name: Configuring hybrid networking
-    File: configuring-hybrid-networking
 - Name: Configuring Routes
   Dir: routes
   Topics:

--- a/logging/cluster-logging-deploying.adoc
+++ b/logging/cluster-logging-deploying.adoc
@@ -31,7 +31,7 @@ include::modules/cluster-logging-deploy-console.adoc[leveloffset=+1]
 
 If you plan to use Kibana, you must xref:#cluster-logging-visualizer-indices_cluster-logging-deploying[manually create your Kibana index patterns and visualizations] to explore and visualize data in Kibana.
 
-If your cluster network provider enforces network isolation, xref:#cluster-logging-deploy-multitenant_cluster-logging-deploying[allow network traffic between the projects that contain the {logging} Operators].
+If your network plug-in enforces network isolation, xref:#cluster-logging-deploy-multitenant_cluster-logging-deploying[allow network traffic between the projects that contain the {logging} Operators].
 
 
 include::modules/cluster-logging-deploy-cli.adoc[leveloffset=+1]
@@ -40,7 +40,7 @@ include::modules/cluster-logging-deploy-cli.adoc[leveloffset=+1]
 
 If you plan to use Kibana, you must xref:#cluster-logging-visualizer-indices_cluster-logging-deploying[manually create your Kibana index patterns and visualizations] to explore and visualize data in Kibana.
 
-If your cluster network provider enforces network isolation, xref:#cluster-logging-deploy-multitenant_cluster-logging-deploying[allow network traffic between the projects that contain the {logging} Operators].
+If your network plug-in enforces network isolation, xref:#cluster-logging-deploy-multitenant_cluster-logging-deploying[allow network traffic between the projects that contain the {logging} Operators].
 
 include::modules/cluster-logging-visualizer-indices.adoc[leveloffset=+2]
 
@@ -50,8 +50,8 @@ include::modules/cluster-logging-deploy-multitenant.adoc[leveloffset=+2]
 .Additional resources
 
 * xref:../networking/network_policy/about-network-policy.adoc[About network policy]
-* xref:../networking/openshift_sdn/about-openshift-sdn.adoc[About the OpenShift SDN default CNI network provider]
-* xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc[About the OVN-Kubernetes default Container Network Interface (CNI) network provider]
+* xref:../networking/openshift_sdn/about-openshift-sdn.adoc[About the OpenShift SDN network plug-in]
+* xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc[About the OVN-Kubernetes network plug-in]
 
 
 // include::modules/cluster-logging-deploy-memory.adoc[leveloffset=+1]

--- a/modules/cluster-logging-deploy-multitenant.adoc
+++ b/modules/cluster-logging-deploy-multitenant.adoc
@@ -6,11 +6,11 @@
 [id="cluster-logging-deploy-multitenant_{context}"]
 = Allowing traffic between projects when network isolation is enabled
 
-Your cluster network provider might enforce network isolation. If so, you must allow network traffic between the projects that contain the operators deployed by OpenShift Logging.
+Your cluster network plug-in might enforce network isolation. If so, you must allow network traffic between the projects that contain the operators deployed by OpenShift Logging.
 
 Network isolation blocks network traffic between pods or services that are in different projects. The {logging} installs the _OpenShift Elasticsearch Operator_ in the `openshift-operators-redhat` project and the _Red Hat OpenShift Logging Operator_ in the `openshift-logging` project. Therefore, you must allow traffic between these two projects.
 
-{product-title} offers two supported choices for the default Container Network Interface (CNI) network provider, OpenShift SDN and OVN-Kubernetes. These two providers implement various network isolation policies.
+{product-title} offers two supported choices for the network plug-in, OpenShift SDN and OVN-Kubernetes. These two providers implement various network isolation policies.
 
 OpenShift SDN has three modes:
 

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -292,7 +292,7 @@ If the status is `Pending`, or the output lists more than one running etcd pod, 
 +
 [NOTE]
 ====
-Perform the following step only if you are using `OVNKubernetes` Container Network Interface (CNI) plug-in.
+Perform the following step only if you are using `OVNKubernetes` network plug-in.
 ====
 +
 . Restart the Open Virtual Network (OVN) Kubernetes pods on all the hosts.

--- a/modules/install-sno-about-installing-on-a-single-node.adoc
+++ b/modules/install-sno-about-installing-on-a-single-node.adoc
@@ -10,5 +10,5 @@ You can create a single-node cluster with standard installation methods. {produc
 
 [IMPORTANT]
 ====
-The use of OpenShiftSDN with {sno} is not supported. OVN-Kubernetes is the default networking solution for {sno} deployments.
+The use of OpenShiftSDN with {sno} is not supported. OVN-Kubernetes is the default network plug-in for {sno} deployments.
 ====

--- a/modules/install-sno-generating-the-install-iso-manually.adoc
+++ b/modules/install-sno-generating-the-install-iso-manually.adoc
@@ -121,7 +121,7 @@ capabilities:
 <2> Set the `compute` replicas to `0`. This makes the control plane node schedulable.
 <3> Set the `controlPlane` replicas to `1`. In conjunction with the previous `compute` setting, this setting ensures the cluster runs on a single node.
 <4> Set the `metadata` name to the cluster name.
-<5> Set the `networking` details. OVN-Kubernetes is the only allowed networking type for single-node clusters.
+<5> Set the `networking` details. OVN-Kubernetes is the only allowed network plug-in type for single-node clusters.
 <6> Set the `cidr` value to match the subnet of the {sno} cluster.
 <7> Set the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
 <8> Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.

--- a/modules/installation-bare-metal-agent-installer-config-yaml.adoc
+++ b/modules/installation-bare-metal-agent-installer-config-yaml.adoc
@@ -69,7 +69,7 @@ Class E CIDR range is reserved for a future use. To use the Class E CIDR range, 
 ====
 +
 <8> The subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IP addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
-<9> The cluster network provider Container Network Interface (CNI) plug-in to install. The supported values are `OVNKubernetes` (default value) and `OpenShiftSDN` .
+<9> The cluster network plug-in to install. The supported values are `OVNKubernetes` (default value) and `OpenShiftSDN`.
 <10> The IP address pool to use for service IP addresses. You can enter only one IP address pool. This block must not overlap with existing physical networks. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 <11> You must set the platform to `none` for a single-node cluster. You can also set the platform to `vSphere` and `baremetal`.
 +

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -306,9 +306,9 @@ You can customize your installation configuration based on the requirements of y
 // https://bugzilla.redhat.com/show_bug.cgi?id=2020416
 // Once BM UPI supports dual-stack, uncomment all the following conditionals and blocks
 
-* If you use the OVN-Kubernetes cluster network provider, both IPv4 and IPv6 address families are supported.
+* If you use the {openshift-networking} OVN-Kubernetes network plug-in, both IPv4 and IPv6 address families are supported.
 
-* If you use the OpenShift SDN cluster network provider, only the IPv4 address family is supported.
+* If you use the {openshift-networking} OpenShift SDN network plug-in, only the IPv4 address family is supported.
 
 ifdef::ibm-cloud[]
 [NOTE]
@@ -358,7 +358,7 @@ You cannot modify parameters specified by the `networking` object after installa
 ====
 
 |`networking.networkType`
-|The cluster network provider Container Network Interface (CNI) plug-in to install.
+|The {openshift-networking} network plug-in to install.
 |
 ifdef::openshift-origin[]
 Either `OpenShiftSDN` or `OVNKubernetes`. The default value is `OVNKubernetes`.
@@ -390,7 +390,7 @@ networking:
 |
 Required if you use `networking.clusterNetwork`. An IP address block.
 
-If you use the OpenShift SDN network provider, specify an IPv4 network. If you use the OVN-Kubernetes network provider, you can specify IPv4 and IPv6 networks.
+If you use the OpenShift SDN network plug-in, specify an IPv4 network. If you use the OVN-Kubernetes network plug-in, you can specify IPv4 and IPv6 networks.
 |
 An IP address block in Classless Inter-Domain Routing (CIDR) notation.
 The prefix length for an IPv4 block is between `0` and `32`.
@@ -408,9 +408,9 @@ For an IPv6 network the default value is `64`. The default value is also the min
 |
 The IP address block for services. The default value is `172.30.0.0/16`.
 
-The OpenShift SDN and OVN-Kubernetes network providers support only a single IP address block for the service network.
+The OpenShift SDN and OVN-Kubernetes network plug-ins support only a single IP address block for the service network.
 
-If you use the OVN-Kubernetes network provider, you can specify an IP address block for both of the IPv4 and IPv6 address families.
+If you use the OVN-Kubernetes network plug-in, you can specify an IP address block for both of the IPv4 and IPv6 address families.
 
 |
 An array with an IP address block in CIDR format. For example:

--- a/modules/microshift-cni.adoc
+++ b/modules/microshift-cni.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: CONCEPT
 [id="microshift-cni_{context}"]
-= About the OVN-Kubernetes CNI network provider
+= About the OVN-Kubernetes network plugin
 
-OVN-Kubernetes is the default networking solution for {product-title} deployments. OVN-Kubernetes is a virtualized network for pods and services that is based on Open Virtual Network (OVN). The OVN-Kubernetes Container Network Interface (CNI) plug-in is the network provider for the cluster. A cluster that uses the OVN-Kubernetes network provider also runs Open vSwitch (OVS) on the node. OVN configures OVS on the node to implement the declared network configuration.
+OVN-Kubernetes is the default networking solution for {product-title} deployments. OVN-Kubernetes is a virtualized network for pods and services that is based on Open Virtual Network (OVN). The OVN-Kubernetes Container Network Interface (CNI) plugin is the network plugin for the cluster. A cluster that uses the OVN-Kubernetes network plugin also runs Open vSwitch (OVS) on the node. OVN configures OVS on the node to implement the declared network configuration.
 
 [id="microshift-network-topology_{context}"]
 == Network topology

--- a/modules/microshift-configuring-ovn.adoc
+++ b/modules/microshift-configuring-ovn.adoc
@@ -16,7 +16,7 @@ ovsInit:
   externalGatewayInterface: "" <2>
 mtu: 1400
 ----
-<1> Default value is an empty string, which means "not-specified." The CNI network provider auto-detects to interface with the default route.
+<1> Default value is an empty string, which means "not-specified." The CNI network plugin auto-detects to interface with the default route.
 <2> Default value is an empty string, which means disabled.
 
 To customize your configuration, use the following table to find valid values that you can use in your `ovn.yaml` config file.

--- a/modules/microshift-ki-cni-iptables-deleted.adoc
+++ b/modules/microshift-ki-cni-iptables-deleted.adoc
@@ -15,7 +15,7 @@ To troubleshoot this issue, delete the ovnkube-master pod to restart the ovnkube
 
 * The OpenShift CLI (`oc`) is installed.
 * Access to the cluster as a user with the `cluster-admin` role.
-* A cluster installed on infrastructure configured with the OVN-Kubernetes CNI cluster network provider.
+* A cluster installed on infrastructure configured with the OVN-Kubernetes network plug-in.
 * The KUBECONFIG environment variable is set.
 
 .Procedure

--- a/modules/nw-about-multicast.adoc
+++ b/modules/nw-about-multicast.adoc
@@ -24,7 +24,7 @@ At this time, multicast is best used for low-bandwidth coordination or service
 discovery and not a high-bandwidth solution.
 ====
 
-Multicast traffic between {product-title} pods is disabled by default. If you are using the {sdn} default Container Network Interface (CNI) network provider, you can enable multicast on a per-project basis.
+Multicast traffic between {product-title} pods is disabled by default. If you are using the {sdn} network plug-in, you can enable multicast on a per-project basis.
 
 ifdef::openshift-sdn[]
 When using the OpenShift SDN network plug-in in `networkpolicy` isolation mode:

--- a/modules/nw-cluster-mtu-change-about.adoc
+++ b/modules/nw-cluster-mtu-change-about.adoc
@@ -13,7 +13,7 @@ You might want to change the MTU of the cluster network for several reasons:
 * The MTU detected during cluster installation is not correct for your infrastructure
 * Your cluster infrastructure now requires a different MTU, such as from the addition of nodes that need a different MTU for optimal performance
 
-You can change the cluster MTU for only the OVN-Kubernetes and OpenShift SDN cluster network providers.
+You can change the cluster MTU for only the OVN-Kubernetes and OpenShift SDN cluster network plug-ins.
 
 // https://github.com/openshift/enhancements/blob/master/enhancements/network/allow-mtu-changes.md
 [id="service-interruption-considerations_{context}"]
@@ -31,11 +31,11 @@ When you initiate an MTU change on your cluster the following effects might impa
 When planning your MTU migration there are two related but distinct MTU values to consider.
 
 * *Hardware MTU*: This MTU value is set based on the specifics of your network infrastructure.
-* *Cluster network MTU*: This MTU value is always less than your hardware MTU to account for the cluster network overlay overhead. The specific overhead is determined by your cluster network provider:
+* *Cluster network MTU*: This MTU value is always less than your hardware MTU to account for the cluster network overlay overhead. The specific overhead is determined by your network plug-in:
 ** *OVN-Kubernetes*: `100` bytes
 ** *OpenShift SDN*: `50` bytes
 
-If your cluster requires different MTU values for different nodes, you must subtract the overhead value for your cluster network provider from the lowest MTU value that is used by any node in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1400`.
+If your cluster requires different MTU values for different nodes, you must subtract the overhead value for your network plug-in from the lowest MTU value that is used by any node in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1400`.
 
 [id="how-the-migration-process-works_{context}"]
 == How the migration process works
@@ -60,7 +60,7 @@ Set the following values in the Cluster Network Operator configuration:
 
 - The `mtu.machine.to` must be set to either the new hardware MTU or to the current hardware MTU if the MTU for the hardware is not changing. This value is transient and is used as part of the migration process. Separately, if you specify a hardware MTU that is different from your existing hardware MTU value, you must manually configure the MTU to persist by other means, such as with a machine config, DHCP setting, or a Linux kernel command line.
 - The `mtu.network.from` field must equal the `network.status.clusterNetworkMTU` field, which is the current MTU of the cluster network.
-- The `mtu.network.to` field must be set to the target cluster network MTU and must be lower than the hardware MTU to allow for the overlay overhead of the cluster network provider. For OVN-Kubernetes, the overhead is `100` bytes and for OpenShift SDN the overhead is `50` bytes.
+- The `mtu.network.to` field must be set to the target cluster network MTU and must be lower than the hardware MTU to allow for the overlay overhead of the network plug-in. For OVN-Kubernetes, the overhead is `100` bytes and for OpenShift SDN the overhead is `50` bytes.
 
 If the values provided are valid, the CNO writes out a new temporary configuration with the MTU for the cluster network set to the value of the `mtu.network.to` field.
 
@@ -73,7 +73,7 @@ If the values provided are valid, the CNO writes out a new temporary configurati
 - Changing the MTU through boot parameters
 |N/A
 
-|Set the `mtu` value in the CNO configuration for the cluster network provider and set `spec.migration` to `null`.
+|Set the `mtu` value in the CNO configuration for the network plug-in and set `spec.migration` to `null`.
 
 |
 *Machine Config Operator (MCO)*: Performs a rolling reboot of each node in the cluster with the new MTU configuration.

--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -14,7 +14,7 @@ The following procedure describes how to change the cluster MTU by using either 
 
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `cluster-admin` privileges.
-* You identified the target MTU for your cluster. The correct MTU varies depending on the cluster network provider that your cluster uses:
+* You identified the target MTU for your cluster. The correct MTU varies depending on the network plug-in that your cluster uses:
 ** *OVN-Kubernetes*: The cluster MTU must be set to `100` less than the lowest hardware MTU value in your cluster.
 ** *OpenShift SDN*: The cluster MTU must be set to `50` less than the lowest hardware MTU value in your cluster.
 
@@ -65,7 +65,7 @@ where:
 
 ... Find the primary network interface:
 
-**** If you are using the OpenShift SDN cluster network provider, enter the following command:
+**** If you are using the OpenShift SDN network plug-in, enter the following command:
 +
 [source,terminal]
 ----
@@ -78,7 +78,7 @@ where:
 `<node_name>`:: Specifies the name of a node in your cluster.
 --
 
-**** If you are using the OVN-Kubernetes cluster network provider, enter the following command:
+**** If you are using the OVN-Kubernetes network plug-in, enter the following command:
 +
 [source,terminal]
 ----
@@ -118,7 +118,7 @@ ovs-port-phys0      332ef950-b2e5-4991-a0dc-3158977c35ca  ovs-port       ens4
 ----
 +
 --
-For the OVN-Kubernetes cluster network provider, two or three connection manager profiles are returned.
+For the OVN-Kubernetes network plug-in, two or three connection manager profiles are returned.
 
 * If the previous command returns only two profiles, then you must use a default NetworkManager connection configuration as a template.
 * If the previous command returns three profiles, use the profile that is not named `ovs-if-phys0` or `ovs-port-phys0` as a template for the following modifications.
@@ -194,7 +194,7 @@ nm-generated=true
 **** Set the following values:
 ***** `802-3-ethernet.mtu`: Specify the MTU for the primary network interface of the system.
 ***** `connection.interface-name`: Optional: Specify the network interface name that this configuration applies to.
-***** `connection.autoconnect-priority`: Optional: Consider specifying an integer priority value above `0` to ensure this profile is used over other profiles for the same interface. If you are using the OVN-Kubernetes cluster network provider, this value must be less than `100`.
+***** `connection.autoconnect-priority`: Optional: Consider specifying an integer priority value above `0` to ensure this profile is used over other profiles for the same interface. If you are using the OVN-Kubernetes network plug-in, this value must be less than `100`.
 **** Remove the `connection.uuid` field.
 **** Change the following values:
 ***** `connection.id`: Optional: Specify a different NetworkManager connection profile name.
@@ -409,7 +409,7 @@ If the machine config is successfully deployed, the previous output contains the
 The machine config must not contain the `ExecStart=/usr/local/bin/mtu-migration.sh` line.
 
 . To finalize the MTU migration, enter one of the following commands:
-** If you are using the OVN-Kubernetes cluster network provider:
+** If you are using the OVN-Kubernetes network plug-in:
 +
 [source,terminal]
 +
@@ -424,7 +424,7 @@ where:
 `<mtu>`:: Specifies the new cluster network MTU that you specified with `<overlay_to>`.
 --
 
-** If you are using the OpenShift SDN cluster network provider:
+** If you are using the OpenShift SDN network plug-in:
 +
 [source,terminal]
 ----

--- a/modules/nw-cluster-network-operator.adoc
+++ b/modules/nw-cluster-network-operator.adoc
@@ -6,7 +6,7 @@
 = Cluster Network Operator
 
 The Cluster Network Operator implements the `network` API from the `operator.openshift.io` API group.
-The Operator deploys the OpenShift SDN default Container Network Interface (CNI) network provider plug-in, or the default network provider plug-in that you selected during cluster installation, by using a daemon set.
+The Operator deploys the OVN-Kubernetes network plug-in, or the network provider plug-in that you selected during cluster installation, by using a daemon set.
 
 .Procedure
 

--- a/modules/nw-dual-stack-convert-back-single-stack.adoc
+++ b/modules/nw-dual-stack-convert-back-single-stack.adoc
@@ -8,7 +8,7 @@ As a cluster administrator, you can convert your dual-stack cluster network to a
 
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `cluster-admin` privileges.
-* Your cluster uses the OVN-Kubernetes cluster network provider.
+* Your cluster uses the OVN-Kubernetes network plug-in.
 * The cluster nodes have IPv6 addresses.
 * You have enabled dual-stack networking.
 

--- a/modules/nw-dual-stack-convert.adoc
+++ b/modules/nw-dual-stack-convert.adoc
@@ -13,7 +13,7 @@ After converting to dual-stack networking only newly created pods are assigned I
 
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `cluster-admin` privileges.
-* Your cluster uses the OVN-Kubernetes cluster network provider.
+* Your cluster uses the OVN-Kubernetes network plug-in.
 * The cluster nodes have IPv6 addresses.
 * You have configured an IPv6-enabled router based on your infrastructure.
 

--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -139,13 +139,13 @@ ifdef::openshift-sdn[]
 [id="nw-egress-ips-limitations_{context}"]
 == Limitations
 
-The following limitations apply when using egress IP addresses with the OpenShift SDN cluster network provider:
+The following limitations apply when using egress IP addresses with the OpenShift SDN network plug-in:
 
 - You cannot use manually assigned and automatically assigned egress IP addresses on the same nodes.
 - If you manually assign egress IP addresses from an IP address range, you must not make that range available for automatic IP assignment.
 - You cannot share egress IP addresses across multiple namespaces using the OpenShift SDN egress IP address implementation.
 
-If you need to share IP addresses across namespaces, the OVN-Kubernetes cluster network provider egress IP address implementation allows you to span IP addresses across multiple namespaces.
+If you need to share IP addresses across namespaces, the OVN-Kubernetes network plug-in egress IP address implementation allows you to span IP addresses across multiple namespaces.
 
 [NOTE]
 ====

--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -109,7 +109,7 @@ ifdef::openshift-sdn[]
 
 * The `default` project cannot use an egress firewall.
 
-* When using the OpenShift SDN default Container Network Interface (CNI) network provider in multitenant mode, the following limitations apply:
+* When using the OpenShift SDN network plug-in in multitenant mode, the following limitations apply:
 
   - Global projects cannot use an egress firewall. You can make a project global by using the `oc adm pod-network make-projects-global` command.
 

--- a/modules/nw-egressnetworkpolicy-create.adoc
+++ b/modules/nw-egressnetworkpolicy-create.adoc
@@ -27,7 +27,7 @@ If the project already has an {kind} object defined, you must edit the existing 
 
 .Prerequisites
 
-* A cluster that uses the {cni} default Container Network Interface (CNI) network provider plug-in.
+* A cluster that uses the {cni} network plug-in.
 * Install the OpenShift CLI (`oc`).
 * You must log in to the cluster as a cluster administrator.
 

--- a/modules/nw-egressnetworkpolicy-delete.adoc
+++ b/modules/nw-egressnetworkpolicy-delete.adoc
@@ -22,7 +22,7 @@ As a cluster administrator, you can remove an egress firewall from a project.
 
 .Prerequisites
 
-* A cluster using the {cni} default Container Network Interface (CNI) network provider plug-in.
+* A cluster using the {cni} network plug-in.
 * Install the OpenShift CLI (`oc`).
 * You must log in to the cluster as a cluster administrator.
 

--- a/modules/nw-egressnetworkpolicy-edit.adoc
+++ b/modules/nw-egressnetworkpolicy-edit.adoc
@@ -22,7 +22,7 @@ As a cluster administrator, you can update the egress firewall for a project.
 
 .Prerequisites
 
-* A cluster using the {cni} default Container Network Interface (CNI) network provider plug-in.
+* A cluster using the {cni} network plug-in.
 * Install the OpenShift CLI (`oc`).
 * You must log in to the cluster as a cluster administrator.
 

--- a/modules/nw-egressnetworkpolicy-view.adoc
+++ b/modules/nw-egressnetworkpolicy-view.adoc
@@ -22,7 +22,7 @@ You can view an {kind} object in your cluster.
 
 .Prerequisites
 
-* A cluster using the {cni} default Container Network Interface (CNI) network provider plug-in.
+* A cluster using the {cni} network plug-in.
 * Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
 * You must log in to the cluster.
 

--- a/modules/nw-high-performance-multicast.adoc
+++ b/modules/nw-high-performance-multicast.adoc
@@ -5,7 +5,7 @@
 [id="nw-high-performance-multicast_{context}"]
 = High performance multicast
 
-The OpenShift SDN default Container Network Interface (CNI) network provider supports multicast between pods on the default network. This is best used for low-bandwidth coordination or service discovery, and not high-bandwidth applications.
+The OpenShift SDN network plug-in supports multicast between pods on the default network. This is best used for low-bandwidth coordination or service discovery, and not high-bandwidth applications.
 For applications such as streaming media, like Internet Protocol television (IPTV) and multipoint videoconferencing, you can utilize Single Root I/O Virtualization (SR-IOV) hardware to provide near-native performance.
 
 When using additional SR-IOV interfaces for multicast:

--- a/modules/nw-metallb-bgp.adoc
+++ b/modules/nw-metallb-bgp.adoc
@@ -10,7 +10,7 @@ In BGP mode, by default each `speaker` pod advertises the load balancer IP addre
 BGP peers are commonly network routers that are configured to use the BGP protocol.
 When a router receives traffic for the load balancer IP address, the router picks one of the nodes with a `speaker` pod that advertised the IP address.
 The router sends the traffic to that node.
-After traffic enters the node, the service proxy for the CNI network provider distributes the traffic to all the pods for the service.
+After traffic enters the node, the service proxy for the CNI network plugin distributes the traffic to all the pods for the service.
 
 The directly-connected router on the same layer 2 network segment as the cluster nodes can be configured as a BGP peer.
 If the directly-connected router is not configured as a BGP peer, you need to configure your network so that packets for load balancer IP addresses are routed between the BGP peers and the cluster nodes that run the `speaker` pods.

--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -30,7 +30,7 @@ endif::[]
 [id="modifying-nwoperator-config-startup_{context}"]
 = Specifying advanced network configuration
 
-You can use advanced network configuration for your cluster network provider to integrate your cluster into your existing network environment.
+You can use advanced network configuration for your network plug-in to integrate your cluster into your existing network environment.
 You can specify advanced network configuration only before you install the cluster.
 
 [IMPORTANT]

--- a/modules/nw-network-config.adoc
+++ b/modules/nw-network-config.adoc
@@ -39,4 +39,4 @@ The CIDR range `172.17.0.0/16` is reserved by libVirt. You cannot use this range
 
 Phase 2:: After creating the manifest files by running `openshift-install create manifests`, you can define a customized Cluster Network Operator manifest with only the fields you want to modify. You can use the manifest to specify advanced network configuration.
 
-You cannot override the values specified in phase 1 in the `install-config.yaml` file during phase 2. However, you can further customize the cluster network provider during phase 2.
+You cannot override the values specified in phase 1 in the `install-config.yaml` file during phase 2. However, you can further customize the network plug-in during phase 2.

--- a/modules/nw-networking-glossary-terms.adoc
+++ b/modules/nw-networking-glossary-terms.adoc
@@ -15,7 +15,7 @@ AWS Load Balancer Operator::
 The AWS Load Balancer (ALB) Operator deploys and manages an instance of the `aws-load-balancer-controller`.
 
 Cluster Network Operator::
-The Cluster Network Operator (CNO) deploys and manages the cluster network components in an {product-title} cluster. This includes deployment of the Container Network Interface (CNI) default network provider plug-in selected for the cluster during installation.
+The Cluster Network Operator (CNO) deploys and manages the cluster network components in an {product-title} cluster. This includes deployment of the Container Network Interface (CNI) network plugin selected for the cluster during installation.
 
 config map::
 A config map provides a way to inject configuration data into pods. You can reference the data stored in a config map in a volume of type `ConfigMap`. Applications running in a pod can use this data.

--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -7,7 +7,7 @@
 [id="nw-networkpolicy-about_{context}"]
 = About network policy
 
-In a cluster using a Kubernetes Container Network Interface (CNI) plug-in that supports Kubernetes network policy, network isolation is controlled entirely by `NetworkPolicy` objects.
+In a cluster using a network plug-in that supports Kubernetes network policy, network isolation is controlled entirely by `NetworkPolicy` objects.
 In {product-title} {product-version}, OpenShift SDN supports using network policy in its default network isolation mode.
 
 [WARNING]

--- a/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
+++ b/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
@@ -26,7 +26,7 @@ Follow this procedure to configure a policy that allows traffic from all pods in
 
 .Prerequisites
 
-* Your cluster uses a cluster network provider that supports `NetworkPolicy` objects, such as
+* Your cluster uses a network plug-in that supports `NetworkPolicy` objects, such as
 ifndef::ovn[]
 the OpenShift SDN network provider with `mode: NetworkPolicy` set.
 endif::ovn[]

--- a/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
+++ b/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
@@ -28,7 +28,7 @@ Follow this procedure to configure a policy that allows traffic to a pod with th
 
 .Prerequisites
 
-* Your cluster uses a cluster network provider that supports `NetworkPolicy` objects, such as
+* Your cluster uses a network plug-in that supports `NetworkPolicy` objects, such as
 ifndef::ovn[]
 the OpenShift SDN network provider with `mode: NetworkPolicy` set.
 endif::ovn[]

--- a/modules/nw-networkpolicy-allow-external-clients.adoc
+++ b/modules/nw-networkpolicy-allow-external-clients.adoc
@@ -27,7 +27,7 @@ Follow this procedure to configure a policy that allows external service from th
 
 .Prerequisites
 
-* Your cluster uses a cluster network provider that supports `NetworkPolicy` objects, such as
+* Your cluster uses a network plug-in that supports `NetworkPolicy` objects, such as
 ifndef::ovn[]
 the OpenShift SDN network provider with `mode: NetworkPolicy` set.
 endif::ovn[]

--- a/modules/nw-networkpolicy-audit-concept.adoc
+++ b/modules/nw-networkpolicy-audit-concept.adoc
@@ -1,7 +1,7 @@
 [id="nw-networkpolicy-audit-concept_{context}"]
 = Audit logging
 
-The OVN-Kubernetes cluster network provider uses Open Virtual Network (OVN) ACLs to manage egress firewalls and network policies. Audit logging exposes allow and deny ACL events.
+The OVN-Kubernetes network plug-in uses Open Virtual Network (OVN) ACLs to manage egress firewalls and network policies. Audit logging exposes allow and deny ACL events.
 
 You can configure the destination for audit logs, such as a syslog server or a UNIX domain socket.
 Regardless of any additional configuration, an audit log is always saved to `/var/log/ovn/acl-audit-log.log` on each OVN-Kubernetes pod in the cluster.

--- a/modules/nw-networkpolicy-create-cli.adoc
+++ b/modules/nw-networkpolicy-create-cli.adoc
@@ -30,7 +30,7 @@ endif::multi[]
 
 .Prerequisites
 
-* Your cluster uses a cluster network provider that supports `NetworkPolicy` objects, such as
+* Your cluster uses a network plug-in that supports `NetworkPolicy` objects, such as
 ifndef::ovn[]
 the OpenShift SDN network provider with `mode: NetworkPolicy` set.
 endif::ovn[]

--- a/modules/nw-networkpolicy-delete-cli.adoc
+++ b/modules/nw-networkpolicy-delete-cli.adoc
@@ -29,7 +29,7 @@ endif::multi[]
 
 .Prerequisites
 
-* Your cluster uses a cluster network provider that supports `NetworkPolicy` objects, such as
+* Your cluster uses a network plug-in that supports `NetworkPolicy` objects, such as
 ifndef::ovn[]
 the OpenShift SDN network provider with `mode: NetworkPolicy` set.
 endif::ovn[]

--- a/modules/nw-networkpolicy-deny-all-allowed.adoc
+++ b/modules/nw-networkpolicy-deny-all-allowed.adoc
@@ -25,7 +25,7 @@ If you log in with a user with the `cluster-admin` role, then you can create a n
 
 .Prerequisites
 
-* Your cluster uses a cluster network provider that supports `NetworkPolicy` objects, such as
+* Your cluster uses a network plug-in that supports `NetworkPolicy` objects, such as
 ifndef::ovn[]
 the OpenShift SDN network provider with `mode: NetworkPolicy` set.
 endif::ovn[]

--- a/modules/nw-networkpolicy-edit.adoc
+++ b/modules/nw-networkpolicy-edit.adoc
@@ -28,7 +28,7 @@ endif::multi[]
 
 .Prerequisites
 
-* Your cluster uses a cluster network provider that supports `NetworkPolicy` objects, such as
+* Your cluster uses a network plug-in that supports `NetworkPolicy` objects, such as
 ifndef::ovn[]
 the OpenShift SDN network provider with `mode: NetworkPolicy` set.
 endif::ovn[]

--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -16,7 +16,7 @@ project namespaces.
 
 .Prerequisites
 
-* Your cluster uses a cluster network provider that supports `NetworkPolicy` objects, such as
+* Your cluster uses a network plug-in that supports `NetworkPolicy` objects, such as
 ifndef::ovn[]
 the OpenShift SDN network provider with `mode: NetworkPolicy` set.
 endif::ovn[]

--- a/modules/nw-networkpolicy-optimize.adoc
+++ b/modules/nw-networkpolicy-optimize.adoc
@@ -9,7 +9,7 @@ Use a network policy to isolate pods that are differentiated from one another by
 
 [NOTE]
 ====
-The guidelines for efficient use of network policy rules applies to only the OpenShift SDN cluster network provider.
+The guidelines for efficient use of network policy rules applies to only the OpenShift SDN network plug-in.
 ====
 
 It is inefficient to apply `NetworkPolicy` objects to large numbers of individual pods in a single namespace. Pod labels do not exist at the IP address level, so a network policy generates a separate Open vSwitch (OVS) flow rule for every possible link between every pod selected with a `podSelector`.

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -48,7 +48,7 @@ The CNO configuration inherits the following fields during cluster installation 
 
 `clusterNetwork`:: IP address pools from which pod IP addresses are allocated.
 `serviceNetwork`:: IP address pool for services.
-`defaultNetwork.type`:: Cluster network provider, such as OpenShift SDN or OVN-Kubernetes.
+`defaultNetwork.type`:: Cluster network plug-in, such as OpenShift SDN or OVN-Kubernetes.
 
 // For the post installation assembly, no further content is provided.
 ifdef::post-install-network-configuration,operator[]
@@ -58,7 +58,7 @@ After cluster installation, you cannot modify the fields listed in the previous 
 ====
 endif::[]
 ifndef::post-install-network-configuration[]
-You can specify the cluster network provider configuration for your cluster by setting the fields for the `defaultNetwork` object in the CNO object named `cluster`.
+You can specify the cluster network plug-in configuration for your cluster by setting the fields for the `defaultNetwork` object in the CNO object named `cluster`.
 
 [id="nw-operator-cr-cno-object_{context}"]
 == Cluster Network Operator configuration object
@@ -98,7 +98,7 @@ endif::operator[]
 
 |`spec.serviceNetwork`
 |`array`
-|A block of IP addresses for services. The OpenShift SDN and OVN-Kubernetes Container Network Interface (CNI) network providers support only a single IP address block for the service network. For example:
+|A block of IP addresses for services. The OpenShift SDN and OVN-Kubernetes network plug-ins support only a single IP address block for the service network. For example:
 
 [source,yaml]
 ----
@@ -116,13 +116,13 @@ endif::operator[]
 
 |`spec.defaultNetwork`
 |`object`
-|Configures the Container Network Interface (CNI) cluster network provider for the cluster network.
+|Configures the network plug-in for the cluster network.
 
 |`spec.kubeProxyConfig`
 |`object`
 |
 The fields for this object specify the kube-proxy configuration.
-If you are using the OVN-Kubernetes cluster network provider, the kube-proxy configuration has no effect.
+If you are using the OVN-Kubernetes cluster network plug-in, the kube-proxy configuration has no effect.
 
 |====
 
@@ -139,32 +139,27 @@ The values for the `defaultNetwork` object are defined in the following table:
 
 |`type`
 |`string`
-|Either `OpenShiftSDN` or `OVNKubernetes`. The cluster network provider is selected during installation. This value cannot be changed after cluster installation.
+|Either `OpenShiftSDN` or `OVNKubernetes`. The {openshift-networking} network plug-in is selected during installation. This value cannot be changed after cluster installation.
 [NOTE]
 ====
-ifdef::openshift-origin[]
-{product-title} uses the OVN-Kubernetes Container Network Interface (CNI) cluster network provider by default.
-endif::openshift-origin[]
-ifndef::openshift-origin[]
-{product-title} uses the OpenShift SDN Container Network Interface (CNI) cluster network provider by default.
-endif::openshift-origin[]
+{product-title} uses the OVN-Kubernetes network plug-in by default.
 ====
 
 |`openshiftSDNConfig`
 |`object`
-|This object is only valid for the OpenShift SDN cluster network provider.
+|This object is only valid for the OpenShift SDN network plug-in.
 
 |`ovnKubernetesConfig`
 |`object`
-|This object is only valid for the OVN-Kubernetes cluster network provider.
+|This object is only valid for the OVN-Kubernetes network plug-in.
 
 |====
 
 [discrete]
 [id="nw-operator-configuration-parameters-for-openshift-sdn_{context}"]
-==== Configuration for the OpenShift SDN CNI cluster network provider
+==== Configuration for the OpenShift SDN network plug-in
 
-The following table describes the configuration fields for the OpenShift SDN Container Network Interface (CNI) cluster network provider.
+The following table describes the configuration fields for the OpenShift SDN network plug-in:
 
 .`openshiftSDNConfig` object
 [cols=".^2,.^2,.^6a",options="header"]
@@ -218,7 +213,7 @@ endif::operator[]
 ifdef::operator[]
 [NOTE]
 ====
-You can only change the configuration for your cluster network provider during cluster installation.
+You can only change the configuration for your cluster network plug-in during cluster installation.
 ====
 endif::operator[]
 
@@ -235,9 +230,9 @@ defaultNetwork:
 
 [discrete]
 [id="nw-operator-configuration-parameters-for-ovn-sdn_{context}"]
-==== Configuration for the OVN-Kubernetes CNI cluster network provider
+==== Configuration for the OVN-Kubernetes network plug-in
 
-The following table describes the configuration fields for the OVN-Kubernetes CNI cluster network provider.
+The following table describes the configuration fields for the OVN-Kubernetes network plug-in:
 
 .`ovnKubernetesConfig` object
 [cols=".^2,.^2,.^6a",options="header"]
@@ -313,7 +308,7 @@ This field cannot be changed after installation.
 ifdef::ibm-cloud[]
 [NOTE]
 ====
-IPsec for the OVN-Kubernetes network provider is not supported when installing a cluster on IBM Cloud.
+IPsec for the OVN-Kubernetes network plug-in is not supported when installing a cluster on IBM Cloud.
 ====
 endif::ibm-cloud[]
 
@@ -369,7 +364,7 @@ If you set this field to `true`, you do not receive the performance benefits of 
 ifdef::operator[]
 [NOTE]
 ====
-You can only change the configuration for your cluster network provider during cluster installation, except for the `gatewayConfig` field that can be changed at runtime as a post-installation activity.
+You can only change the configuration for your cluster network plug-in during cluster installation, except for the `gatewayConfig` field that can be changed at runtime as a post-installation activity.
 ====
 endif::operator[]
 

--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -5,7 +5,7 @@
 [id="nw-ovn-kubernetes-limitations_{context}"]
 = OVN-Kubernetes limitations
 
-The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has the following limitation:
+The OVN-Kubernetes network plug-in has the following limitations:
 
 * The `sessionAffinityConfig.clientIP.timeoutSeconds` service has no effect in an OpenShift OVN environment, but does in an OpenShift SDN environment. This incompatibility can make it difficult for users to migrate from OpenShift SDN to OVN.
 

--- a/modules/nw-ovn-kubernetes-features.adoc
+++ b/modules/nw-ovn-kubernetes-features.adoc
@@ -5,7 +5,7 @@
 [id="nw-ovn-kubernetes-features_{context}"]
 = OVN-Kubernetes features
 
-The OVN-Kubernetes Container Network Interface (CNI) cluster network provider implements the following features:
+The OVN-Kubernetes network plug-in implements the following features:
 
 // OVN (Open Virtual Network) is consistent with upstream usage.
 

--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -4,11 +4,11 @@
 
 :_content-type: REFERENCE
 [id="nw-ovn-kubernetes-matrix_{context}"]
-= Supported default CNI network provider feature matrix
+= Supported network plug-in feature matrix
 
-{product-title} offers two supported choices, OpenShift SDN and OVN-Kubernetes, for the default Container Network Interface (CNI) network provider. The following table summarizes the current feature support for both network providers:
+{openshift-networking} offers two options for the network plug-in, OpenShift SDN and OVN-Kubernetes, for the network plug-in. The following table summarizes the current feature support for both network plug-ins:
 
-.Default CNI network provider feature comparison
+.Default CNI network plugin feature comparison
 [cols="50%,25%,25%",options="header"]
 |===
 ifeval::["{context}" == "about-ovn-kubernetes"]

--- a/modules/nw-ovn-kubernetes-metrics.adoc
+++ b/modules/nw-ovn-kubernetes-metrics.adoc
@@ -5,7 +5,7 @@
 [id="nw-ovn-kubernetes-metrics_{context}"]
 = Exposed metrics for OVN-Kubernetes
 
-The OVN-Kubernetes default Container Network Interface (CNI) network provider exposes certain metrics for use by the Prometheus-based {product-title} cluster monitoring stack.
+The OVN-Kubernetes network plug-in exposes certain metrics for use by the Prometheus-based {product-title} cluster monitoring stack.
 
 // openshift/ovn-kubernetes => go-controller/pkg/metrics/master.go
 

--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -5,10 +5,10 @@
 [id="nw-ovn-kubernetes-migration-about_{context}"]
 = Migration to the OVN-Kubernetes network provider
 
-Migrating to the OVN-Kubernetes Container Network Interface (CNI) cluster network provider is a manual process that includes some downtime during which your cluster is unreachable. Although a rollback procedure is provided, the migration is intended to be a one-way process.
+Migrating to the OVN-Kubernetes network plug-in is a manual process that includes some downtime during which your cluster is unreachable. Although a rollback procedure is provided, the migration is intended to be a one-way process.
 
 
-A migration to the OVN-Kubernetes cluster network provider is supported on the following platforms:
+A migration to the OVN-Kubernetes network plug-in is supported on the following platforms:
 
 * Bare metal hardware
 * Amazon Web Services (AWS)
@@ -170,7 +170,7 @@ CNO:: Performs the following actions:
 --
 * Destroys the OpenShift SDN control plane pods.
 * Deploys the OVN-Kubernetes control plane pods.
-* Updates the Multus objects to reflect the new cluster network provider.
+* Updates the Multus objects to reflect the new network plug-in.
 --
 
 |
@@ -203,7 +203,7 @@ CNO:: Performs the following actions:
 --
 * Destroys the OVN-Kubernetes control plane pods.
 * Deploys the OpenShift SDN control plane pods.
-* Updates the Multus objects to reflect the new cluster network provider.
+* Updates the Multus objects to reflect the new network plug-in.
 --
 
 |

--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="nw-ovn-kubernetes-migration_{context}"]
-= Migrating to the OVN-Kubernetes default CNI network provider
+= Migrating to the OVN-Kubernetes network plugin
 
-As a cluster administrator, you can change the default Container Network Interface (CNI) network provider for your cluster to OVN-Kubernetes.
+As a cluster administrator, you can change the network plug-in for your cluster to OVN-Kubernetes.
 During the migration, you must reboot every node in your cluster.
 
 [IMPORTANT]
@@ -17,7 +17,7 @@ Perform the migration only when an interruption in service is acceptable.
 
 .Prerequisites
 
-* A cluster configured with the OpenShift SDN CNI cluster network provider in the network policy isolation mode.
+* A cluster configured with the OpenShift SDN CNI network plug-in in the network policy isolation mode.
 * Install the OpenShift CLI (`oc`).
 * Access to the cluster as a user with the `cluster-admin` role.
 * A recent backup of the etcd database is available.
@@ -224,7 +224,7 @@ where `pod` is the name of a machine config daemon pod.
 
 ... Resolve any errors in the logs shown by the output from the previous command.
 
-. To start the migration, configure the OVN-Kubernetes cluster network provider by using one of the following commands:
+. To start the migration, configure the OVN-Kubernetes network plug-in by using one of the following commands:
 
 ** To specify the network provider without changing the cluster network IP address block, enter the following command:
 +
@@ -294,7 +294,7 @@ If ssh access is not available, you might be able to reboot each node through th
 
 . Confirm that the migration succeeded:
 
-.. To confirm that the CNI cluster network provider is OVN-Kubernetes, enter the following command.  The value of `status.networkType` must be `OVNKubernetes`.
+.. To confirm that the network plugin is OVN-Kubernetes, enter the following command.  The value of `status.networkType` must be `OVNKubernetes`.
 +
 [source,terminal]
 ----

--- a/modules/nw-ovn-kubernetes-rollback.adoc
+++ b/modules/nw-ovn-kubernetes-rollback.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="nw-ovn-kubernetes-rollback_{context}"]
-= Rolling back the default CNI network provider to OpenShift SDN
+= Rolling back the network plugin to OpenShift SDN
 
-As a cluster administrator, you can rollback your cluster to the OpenShift SDN Container Network Interface (CNI) cluster network provider.
+As a cluster administrator, you can rollback your cluster to the OpenShift SDN Container Network Interface (CNI) network plug-in.
 During the rollback, you must reboot every node in your cluster.
 
 [IMPORTANT]
@@ -18,7 +18,7 @@ Only rollback to OpenShift SDN if the migration to OVN-Kubernetes fails.
 
 * Install the OpenShift CLI (`oc`).
 * Access to the cluster as a user with the `cluster-admin` role.
-* A cluster installed on infrastructure configured with the OVN-Kubernetes CNI cluster network provider.
+* A cluster installed on infrastructure configured with the OVN-Kubernetes network plugin.
 
 .Procedure
 
@@ -40,7 +40,7 @@ $ oc patch MachineConfigPool worker --type='merge' --patch \
   '{ "spec":{ "paused" :true } }'
 ----
 
-. To start the migration, set the cluster network provider back to OpenShift SDN by entering the following commands:
+. To start the migration, set the network plug-in back to OpenShift SDN by entering the following commands:
 +
 [source,terminal]
 ----
@@ -217,7 +217,7 @@ where `<config_name>` is the name of the machine config from the `machineconfigu
 
 . Confirm that the migration succeeded:
 
-.. To confirm that the default CNI network provider is OVN-Kubernetes, enter the following command.  The value of `status.networkType` must be `OpenShiftSDN`.
+.. To confirm that the network plugin is OpenShift SDN, enter the following command.  The value of `status.networkType` must be `OpenShiftSDN`.
 +
 [source,terminal]
 ----

--- a/modules/optimizing-mtu-networking.adoc
+++ b/modules/optimizing-mtu-networking.adoc
@@ -9,7 +9,7 @@ There are two important maximum transmission units (MTUs): the network interface
 
 The NIC MTU is only configured at the time of {product-title} installation. The MTU must be less than or equal to the maximum supported value of the NIC of your network. If you are optimizing for throughput, choose the largest possible value. If you are optimizing for lowest latency, choose a lower value.
 
-The SDN overlay's MTU must be less than the NIC MTU by 50 bytes at a minimum. This accounts for the SDN overlay header. So, on a normal ethernet network, set this to `1450`. On a jumbo frame ethernet network, set this to `8950`.
+The network plug-in overlay MTU must be less than the NIC MTU by 50 bytes at a minimum. This accounts for the SDN overlay header. So, on a normal ethernet network, set this to `1450`. On a jumbo frame ethernet network, set this to `8950`.
 
 For OVN and Geneve, the MTU must be less than the NIC MTU by 100 bytes at a minimum.
 

--- a/modules/virt-about-nmstate.adoc
+++ b/modules/virt-about-nmstate.adoc
@@ -29,5 +29,5 @@ Node networking is monitored and updated by the following objects:
 
 [NOTE]
 ====
-If your {product-title} cluster uses OVN-Kubernetes as the default Container Network Interface (CNI) provider, you cannot attach a Linux bridge or bonding to the default interface of a host because of a change in the host network topology of OVN-Kubernetes. As a workaround, you can use a secondary network interface connected to your host, or switch to the OpenShift SDN default CNI provider. 
+If your {product-title} cluster uses OVN-Kubernetes as the network plug-in, you cannot attach a Linux bridge or bonding to the default interface of a host because of a change in the host network topology of OVN-Kubernetes. As a workaround, you can use a secondary network interface connected to your host, or switch to the OpenShift SDN network plugin. 
 ====

--- a/modules/virt-configuring-masquerade-mode-dual-stack.adoc
+++ b/modules/virt-configuring-masquerade-mode-dual-stack.adoc
@@ -14,7 +14,7 @@ When the virtual machine is running, incoming and outgoing traffic for the virtu
 
 .Prerequisites
 
-* The {product-title} cluster must use the OVN-Kubernetes Container Network Interface (CNI) network provider configured for dual-stack.
+* The {product-title} cluster must use the OVN-Kubernetes Container Network Interface (CNI) network plugin configured for dual-stack.
 
 .Procedure
 

--- a/networking/about-networking.adoc
+++ b/networking/about-networking.adoc
@@ -1,0 +1,28 @@
+:_content-type: ASSEMBLY
+[id="about-networking"]
+= About networking
+include::_attributes/common-attributes.adoc[]
+:context: about-networking
+
+toc::[]
+
+{openshift-networking} is an ecosystem of features, plugins and advanced networking capabilities that extend Kubernetes networking with the advanced networking-related features that your cluster needs to manage its network traffic for one or multiple hybrid clusters. This ecosystem of networking capabilities integrates ingress, egress, load balancing, high-performance throughput, security, inter- and intra-cluster traffic management and provides role-based observability tooling to reduce its natural complexities.
+
+The following list highlights some of the most commonly used {openshift-networking} features available on your cluster:
+
+- Primary cluster network provided by either of the following Container Network Interface (CNI) plugins:
+  * OVN-Kubernetes network plugin, the default
+  * OpenShift SDN network plugin, an optional alternative
+- Certified 3rd-party alternative primary network plugins
+- Cluster Network Operator for network plugin management
+- Ingress Operator for TLS encrypted web traffic
+- DNS Operator for name assignment
+- MetalLB Operator for traffic load balancing on bare metal clusters
+- IP failover support for high-availability
+- Additional hardware network support through multiple CNI plugins, including for macvlan, ipvlan, and SR-IOV hardware networks
+- IPv4, IPv6, and dual stack addressing
+- Hybrid Linux-Windows host clusters for Windows-based workloads
+- {SMProductName} for discovery, load balancing, service-to-service authentication, failure recovery, metrics, and monitoring of services
+- {sno-caps}
+- Network Observability Operator for network debugging and insights
+- link:https://catalog.redhat.com/software/container-stacks/detail/5f0c67b7ce85fb9e399f3a12[Submariner] and link:https://access.redhat.com/documentation/en-us/red_hat_application_interconnect/1.0/html/introduction_to_application_interconnect/index[Red Hat Application Interconnect] technologies for inter-cluster networking

--- a/networking/changing-cluster-network-mtu.adoc
+++ b/networking/changing-cluster-network-mtu.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-As a cluster administrator, you can change the MTU for the cluster network after cluster installation. This change is disruptive as cluster nodes must be rebooted to finalize the MTU change. You can change the MTU only for clusters using the OVN-Kubernetes or OpenShift SDN cluster network providers.
+As a cluster administrator, you can change the MTU for the cluster network after cluster installation. This change is disruptive as cluster nodes must be rebooted to finalize the MTU change. You can change the MTU only for clusters using the OVN-Kubernetes or OpenShift SDN network plug-ins.
 
 include::modules/nw-cluster-mtu-change-about.adoc[leveloffset=+1]
 include::modules/nw-cluster-mtu-change.adoc[leveloffset=+1]

--- a/networking/cluster-network-operator.adoc
+++ b/networking/cluster-network-operator.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The Cluster Network Operator (CNO) deploys and manages the cluster network components on an {product-title} cluster, including the Container Network Interface (CNI) default network provider plug-in selected for the cluster during installation.
+The Cluster Network Operator (CNO) deploys and manages the cluster network components on an {product-title} cluster, including the Container Network Interface (CNI) network plugin selected for the cluster during installation.
 
 include::modules/nw-cluster-network-operator.adoc[leveloffset=+1]
 

--- a/networking/hardware_networks/configuring-hardware-offloading.adoc
+++ b/networking/hardware_networks/configuring-hardware-offloading.adoc
@@ -21,8 +21,8 @@ include::modules/nw-sriov-hwol-supported-devices.adoc[leveloffset=+1]
 
 * Your cluster has at least one bare metal machine with a network interface controller that is supported for hardware offloading.
 * You xref:../../networking/hardware_networks/installing-sriov-operator.adoc#installing-sr-iov-operator_installing-sriov-operator[installed the SR-IOV Network Operator].
-* Your cluster uses the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes CNI].
-* In your xref:../../networking/cluster-network-operator.adoc#gatewayConfig-object_cluster-network-operator[OVN-Kubernetes CNI configuration], the `gatewayConfig.routingViaHost` field is set to `false`.
+* Your cluster uses the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes network plugin].
+* In your xref:../../networking/cluster-network-operator.adoc#gatewayConfig-object_cluster-network-operator[OVN-Kubernetes network plugin configuration], the `gatewayConfig.routingViaHost` field is set to `false`.
 
 //Configure a machine config pool for hardware offloading
 include::modules/nw-sriov-hwol-configuring-machine-config-pool.adoc[leveloffset=+1]

--- a/networking/network_policy/multitenant-network-policy.adoc
+++ b/networking/network_policy/multitenant-network-policy.adoc
@@ -13,7 +13,7 @@ As a cluster administrator, you can configure your network policies to provide m
 
 [NOTE]
 ====
-If you are using the OpenShift SDN cluster network provider, configuring network policies as described in this section provides network isolation similar to multitenant mode but with network policy mode set.
+If you are using the OpenShift SDN network plug-in, configuring network policies as described in this section provides network isolation similar to multitenant mode but with network policy mode set.
 ====
 
 include::modules/nw-networkpolicy-multitenant-isolation.adoc[leveloffset=+1]

--- a/networking/networking-operators-overview.adoc
+++ b/networking/networking-operators-overview.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 [id="networking-operators-overview-cluster-network-operator"]
 == Cluster Network Operator
-The Cluster Network Operator (CNO) deploys and manages the cluster network components in an {product-title} cluster. This includes deployment of the Container Network Interface (CNI) default network provider plug-in selected for the cluster during installation. For more information, see xref:../networking/cluster-network-operator.adoc#cluster-network-operator[Cluster Network Operator in {product-title}].
+The Cluster Network Operator (CNO) deploys and manages the cluster network components in an {product-title} cluster. This includes deployment of the Container Network Interface (CNI) network plug-in selected for the cluster during installation. For more information, see xref:../networking/cluster-network-operator.adoc#cluster-network-operator[Cluster Network Operator in {product-title}].
 
 [id="networking-operators-overview-dns-operator"]
 == DNS Operator

--- a/networking/openshift_sdn/about-openshift-sdn.adoc
+++ b/networking/openshift_sdn/about-openshift-sdn.adoc
@@ -1,25 +1,19 @@
 :_content-type: ASSEMBLY
 [id="about-openshift-sdn"]
-= About the OpenShift SDN default CNI network provider
+= About the OpenShift SDN network plug-in
 include::_attributes/common-attributes.adoc[]
 :context: about-openshift-sdn
 
 toc::[]
 
-{product-title} uses a software-defined networking (SDN) approach to provide a
-unified cluster network that enables communication between pods across the
-{product-title} cluster. This pod network is established and maintained by the
-OpenShift SDN, which configures an overlay network using Open vSwitch (OVS).
+Part of {openshift-networking}, OpenShift SDN is a network plug-in that uses a
+software-defined networking (SDN) approach to provide a unified cluster network
+that enables communication between pods across the {product-title} cluster. This
+pod network is established and maintained by OpenShift SDN, which configures
+an overlay network using Open vSwitch (OVS).
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 include::modules/nw-openshift-sdn-modes.adoc[leveloffset=+1]
-
-ifdef::openshift-origin[]
-[NOTE]
-====
-{product-title} uses the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes Container Network Interface (CNI) plug-in] by default.
-====
-endif::openshift-origin[]
 endif::[]
 
 // flipped table for OpenShift SDN

--- a/networking/openshift_sdn/assigning-egress-ips.adoc
+++ b/networking/openshift_sdn/assigning-egress-ips.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-As a cluster administrator, you can configure the OpenShift SDN Container Network Interface (CNI) cluster network provider to assign one or more egress IP addresses to a project.
+As a cluster administrator, you can configure the OpenShift SDN Container Network Interface (CNI) network plug-in to assign one or more egress IP addresses to a project.
 
 include::modules/nw-egress-ips-about.adoc[leveloffset=+1]
 

--- a/networking/openshift_sdn/multitenant-isolation.adoc
+++ b/networking/openshift_sdn/multitenant-isolation.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 When your cluster is configured to use the multitenant isolation mode for the
-OpenShift SDN CNI plug-in, each project is isolated by default. Network traffic
+OpenShift SDN network plug-in, each project is isolated by default. Network traffic
 is not allowed between pods or services in different projects in multitenant
 isolation mode.
 
@@ -23,8 +23,7 @@ other projects.
 
 == Prerequisites
 
-* You must have a cluster configured to use the OpenShift SDN Container Network
-Interface (CNI) plug-in in multitenant isolation mode.
+* You must have a cluster configured to use the OpenShift SDN network plugin in multitenant isolation mode.
 
 include::modules/nw-multitenant-joining.adoc[leveloffset=+1]
 include::modules/nw-multitenant-isolation.adoc[leveloffset=+1]

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -1,18 +1,22 @@
 :_content-type: ASSEMBLY
 [id="about-ovn-kubernetes"]
-= About the OVN-Kubernetes default Container Network Interface (CNI) network provider
+= About the OVN-Kubernetes network plug-in
 include::_attributes/common-attributes.adoc[]
 :context: about-ovn-kubernetes
 
 toc::[]
 
 The {product-title} cluster uses a virtualized network for pod and service networks.
-The OVN-Kubernetes Container Network Interface (CNI) plug-in is a network provider for the default cluster network.
+
+Part of {openshift-networking}, the OVN-Kubernetes network plug-in is the default network provider for {product-title}.
 OVN-Kubernetes is based on Open Virtual Network (OVN) and provides an overlay-based networking implementation.
-A cluster that uses the OVN-Kubernetes network provider also runs Open vSwitch (OVS) on each node.
+A cluster that uses the OVN-Kubernetes plug-in also runs Open vSwitch (OVS) on each node.
 OVN configures OVS on each node to implement the declared network configuration.
 
-OVN-Kubernetes is the default networking plug-in in Red Hat OpenShift Networking. For all prior versions of {product-title}, OpenShift SDN was the default networking plug-in.
+[NOTE]
+====
+OVN-Kubernetes is the default networking solution for {product-title} and {sno} deployments.
+====
 
 include::modules/nw-ovn-kubernetes-features.adoc[leveloffset=+1]
 

--- a/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can configure the OVN-Kubernetes Container Network Interface (CNI) cluster network provider to assign one or more egress IP addresses to a namespace, or to specific pods in a namespace.
+As a cluster administrator, you can configure the OVN-Kubernetes Container Network Interface (CNI) network plug-in to assign one or more egress IP addresses to a namespace, or to specific pods in a namespace.
 
 include::modules/nw-egress-ips-about.adoc[leveloffset=+1]
 

--- a/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can configure the OVN-Kubernetes Container Network Interface (CNI) cluster network provider to allow Linux and Windows nodes to host Linux and Windows workloads, respectively.
+As a cluster administrator, you can configure the {openshift-networking} OVN-Kubernetes network plug-in to allow Linux and Windows nodes to host Linux and Windows workloads, respectively.
 
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 

--- a/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-With IPsec enabled, all network traffic between nodes on the OVN-Kubernetes Container Network Interface (CNI) cluster network travels through an encrypted tunnel.
+With IPsec enabled, all network traffic between nodes on the OVN-Kubernetes cluster network travels through an encrypted tunnel.
 
 IPsec is disabled by default. It can be enabled either during or after installing the cluster. For information about cluster installation, see xref:../../installing/index.adoc#ocp-installation-overview[{product-title} installation overview]. If you need to enable IPsec after cluster installation, you must first resize your cluster MTU to account for the overhead of the IPsec ESP IP header.
 
@@ -27,6 +27,6 @@ include::modules/nw-ovn-ipsec-disable.adoc[leveloffset=+1]
 [id="{context}_additional-resources"]
 == Additional resources
 
-* xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes Container Network Interface (CNI) network provider]
+* xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes Container Network Interface (CNI) network plugin]
 * xref:../../networking/changing-cluster-network-mtu.adoc#changing-cluster-network-mtu[Changing the MTU for the cluster network]
 * xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1]] API

--- a/networking/ovn_kubernetes_network_provider/logging-network-policy.adoc
+++ b/networking/ovn_kubernetes_network_provider/logging-network-policy.adoc
@@ -10,7 +10,7 @@ As a cluster administrator, you can configure audit logging for your cluster and
 
 [NOTE]
 ====
-Audit logging is available for only the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes cluster network provider].
+Audit logging is available for only the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes network plug-in].
 ====
 
 include::modules/nw-networkpolicy-audit-concept.adoc[leveloffset=+1]

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -1,14 +1,14 @@
 :_content-type: ASSEMBLY
 [id="migrate-from-openshift-sdn"]
-= Migrating from the OpenShift SDN cluster network provider
+= Migrating from the OpenShift SDN network plug-in
 include::_attributes/common-attributes.adoc[]
 :context: migrate-from-openshift-sdn
 
 toc::[]
 
-As a cluster administrator, you can migrate to the OVN-Kubernetes Container Network Interface (CNI) cluster network provider from the OpenShift SDN CNI cluster network provider.
+As a cluster administrator, you can migrate to the OVN-Kubernetes network plug-in from the OpenShift SDN network plug-in.
 
-To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network provider].
+To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plug-in].
 
 include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
 
@@ -18,7 +18,7 @@ include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]
 [id="migrate-from-openshift-sdn-additional-resources"]
 == Additional resources
 
-* xref:../../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes default CNI network provider]
+* xref:../../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes network plugin]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd]
 * xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
 * OVN-Kubernetes capabilities

--- a/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.adoc
@@ -6,6 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can rollback to the OpenShift SDN Container Network Interface (CNI) cluster network provider from the OVN-Kubernetes CNI cluster network provider if the migration to OVN-Kubernetes is unsuccessful.
+As a cluster administrator, you can rollback to the OpenShift SDN network plugin from the OVN-Kubernetes network plugin if the migration to OVN-Kubernetes is unsuccessful.
 
 include::modules/nw-ovn-kubernetes-rollback.adoc[leveloffset=+1]

--- a/post_installation_configuration/network-configuration.adoc
+++ b/post_installation_configuration/network-configuration.adoc
@@ -61,14 +61,14 @@ include::modules/nw-nodeport-service-range-edit.adoc[leveloffset=+3]
 [id="post-install-configuring-ipsec-ovn"]
 == Configuring IPsec encryption
 
-With IPsec enabled, all network traffic between nodes on the OVN-Kubernetes Container Network Interface (CNI) cluster network travels through an encrypted tunnel.
+With IPsec enabled, all network traffic between nodes on the OVN-Kubernetes network plug-in travels through an encrypted tunnel.
 
 IPsec is disabled by default.
 
 [id="post-install-configuring-ipsec-ovn-prerequisites"]
 === Prerequisites
 
-- Your cluster must use the OVN-Kubernetes cluster network provider.
+- Your cluster must use the OVN-Kubernetes network plug-in.
 
 include::modules/nw-ovn-ipsec-enable.adoc[leveloffset=+3]
 include::modules/nw-ovn-ipsec-verification.adoc[leveloffset=+3]

--- a/scalability_and_performance/optimizing-networking.adoc
+++ b/scalability_and_performance/optimizing-networking.adoc
@@ -36,6 +36,6 @@ include::modules/ipsec-impact-networking.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../installing/installing_aws/installing-aws-network-customizations.adoc#modifying-nwoperator-config-startup_installing-aws-network-customizations[Modifying advanced network configuration parameters]
-* xref:../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes default CNI network provider]
-* xref:../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-openshift-sdn_cluster-network-operator[Configuration parameters for the OpenShift SDN default CNI network provider]
+* xref:../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes network plugin]
+* xref:../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-openshift-sdn_cluster-network-operator[Configuration parameters for the OpenShift SDN network plugin]
 * xref:../scalability_and_performance/scaling-worker-latency-profiles.adoc#scaling-worker-latency-profiles[Improving cluster stability in high latency environments using worker latency profiles]

--- a/virt/about-virt.adoc
+++ b/virt/about-virt.adoc
@@ -13,7 +13,7 @@ include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
 // This line is attached to the above `virt-what-you-can-do-with-virt` module.
 // It is included here in the assembly because of the xref ban.
 
-You can use {VirtProductName} with the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes], xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShift SDN], or one of the other certified default Container Network Interface (CNI) network providers listed in link:https://access.redhat.com/articles/5436171[Certified OpenShift CNI Plug-ins].
+You can use {VirtProductName} with the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes], xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShift SDN], or one of the other certified network plug-ins listed in link:https://access.redhat.com/articles/5436171[Certified OpenShift CNI Plug-ins].
 
 You can check your {VirtProductName} cluster for compliance issues by installing the xref:../security/compliance_operator/compliance-operator-understanding.adoc#understanding-compliance[Compliance Operator] and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` xref:../security/compliance_operator/compliance-operator-supported-profiles.adoc#compliance-operator-supported-profiles[profiles]. The Compliance Operator uses OpenSCAP, a link:https://www.nist.gov/[NIST-certified tool], to scan and enforce security policies.
 


### PR DESCRIPTION
Previously, the networking components of OpenShift were standalone, but now the totality of provided networking capabilities fall under the Red Hat OpenShift Networking umbrella.

- https://issues.redhat.com/browse/SDN-3298

Refs https://github.com/openshift/openshift-docs/pull/51663.

Manual cherry-pick due to some odd merge conflicts, including:

- https://github.com/openshift/openshift-docs/pull/53956
- https://github.com/openshift/openshift-docs/pull/46470

Which might need separate resolutions.