### PR TITLE
ECOPROJECT-1127: NHC update channel is stable since 4.11

### DIFF
--- a/modules/eco-node-health-check-operator-installation-cli.adoc
+++ b/modules/eco-node-health-check-operator-installation-cli.adoc
@@ -7,7 +7,7 @@
 = Installing the Node Health Check Operator by using the CLI
 You can use the OpenShift CLI (`oc`) to install the Node Health Check Operator.
 
-To install the Operator in your own namespace, follow the steps in the procedure. 
+To install the Operator in your own namespace, follow the steps in the procedure.
 
 To install the Operator in the `openshift-operators` namespace, skip to step 3 of the procedure because the steps to create a new `Namespace` custom resource (CR) and an `OperatorGroup` CR are not required.
 
@@ -64,7 +64,7 @@ metadata:
     name: node-health-check-operator
     namespace: node-health-check <1>
 spec:
-    channel: candidate <2>
+    channel: stable <2>
     installPlanApproval: Manual <3>
     name: node-healthcheck-operator
     source: redhat-operators
@@ -72,7 +72,7 @@ spec:
     package: node-healthcheck-operator
 ----
 <1> Specify the `Namespace` where you want to install the Node Health Check Operator. To install the Node Health Check Operator in the `openshift-operators` namespace, specify `openshift-operators` in the `Subscription` CR.
-<2> Specify the channel name for your subscription. To upgrade to the latest version of the Node Health Check Operator, you must manually change the channel name for your subscription from `alpha` to `candidate`.
+<2> Specify the channel name for your subscription. To upgrade to the latest version of the Node Health Check Operator, you must manually change the channel name for your subscription from `candidate` to `stable`.
 <3> Set the approval strategy to Manual in case your specified version is superseded by a later version in the catalog. This plan prevents an automatic upgrade to a later version and requires manual approval before the starting CSV can complete the installation.
 
 .. To create the `Subscription` CR, run the following command:


### PR DESCRIPTION
https://issues.redhat.com/browse/ECOPROJECT-1127 Doc: NHC update channel is stable since 4.11

Applies to OpenShift version : 4.11 +

Preview: [Installing the Node Health Check Operator by using the CLI](http://file.emea.redhat.com/pogrady/ECOPROJECT-1127/nodes/nodes/eco-node-health-check-operator.html#installing-node-health-check-operator-using-cli_node-health-check-operator)

Dev review complete/approved by @slintes
QE review complete/approved by @anna-savina
Peer review complete/approved @tmalove

Thank you.