### PR TITLE
TELCODOCS-889 redoing PR-54102 in new clean PR

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -139,7 +139,7 @@ For more information, see xref:../installing/installing_aws/installing-aws-netwo
 
 [id="ocp-4-12-ironic-base-image-rhel-9"]
 ==== Ironic container images use RHEL 9 base image
-In earlier versions of {product-title}, Ironic container images used {op-system-base-full} 8 as the base image. From {product-title} {product-version}, Ironic container images use {op-system-base} 9 as the base image. The {op-system-base} 9 base image adds support for CentOS Stream 9, Python 3.8, and Python 3.9 in Ironic components. 
+In earlier versions of {product-title}, Ironic container images used {op-system-base-full} 8 as the base image. From {product-title} {product-version}, Ironic container images use {op-system-base} 9 as the base image. The {op-system-base} 9 base image adds support for CentOS Stream 9, Python 3.8, and Python 3.9 in Ironic components.
 
 For more information about the Ironic provisioning service, see xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc[Deploying installer-provisioned clusters on bare metal].
 
@@ -1622,7 +1622,7 @@ sourceStrategy:
 
 * Previously, there were missing annotations on the Manila CSI Driver Operator's VolumeSnapshotClass. Consequently, the Manila CSI snapshotter could not locate secrets, and could not create snapshots with the default VolumeSnapshotClass. This update fixes the issue so that secret names and namespaces are included in the default VolumeSnapshotClass. As a result, users can now create snapshots in the Manila CSI Driver Operator using the default VolumeSnapshotClass. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057637[*BZ#2057637*])
 
-* Users can now opt into using the experimental VHD feature on Azure File. To opt in, users must specify the `fstype` parameter in a storage class and enable it with `--enable-vhd=true`. If `fstype` is used and the feature is not set to `true`, the volumes will fail to provision. 
+* Users can now opt into using the experimental VHD feature on Azure File. To opt in, users must specify the `fstype` parameter in a storage class and enable it with `--enable-vhd=true`. If `fstype` is used and the feature is not set to `true`, the volumes will fail to provision.
 +
 To opt out of using the VHD feature, remove the `fstype` parameter from your storage class. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2080449[*BZ#2080449*])
 
@@ -1695,6 +1695,26 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Ingress Node Firewall Operator
+|Not Available
+|Not Available
+|Technology Preview
+
+|Advertise using BGP mode the MetalLB service from a subset of nodes, using a specific pool of IP addresses
+|Not Available
+|Technology Preview
+|General Availability
+
+|Advertise using L2 mode the MetalLB service from a subset of nodes, using a specific pool of IP addresses
+|Not Available
+|Technology Preview
+|Technology Preview
+
+|Multi-network policies for SR-IOV networks
+|Not Available
+|Not Available
+|Technology Preview
+
+|Updating the interface-specific safe sysctls list
 |Not Available
 |Not Available
 |Technology Preview


### PR DESCRIPTION
[TELCODOCS-889]: Document supportability and uncategorized RN items (TP table)

Version(s):
4.12 RN

Issue:
https://issues.redhat.com/browse/TELCODOCS-889

Already SME reviewed in https://github.com/openshift/openshift-docs/pull/54102 and peer review done. Redoing afresh in this PR as rebasing and resolving conflicts lead to some weird deletion of existing Ingress Node Firewall Operator entry. 

~~Link to docs preview:https://54102--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-technology-preview~~

Link to docs preview: https://54400--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-technology-preview


