### PR TITLE
[RHACS] ROX13902 Update reference to correct OCP version docs

### DIFF
--- a/operating/use-admission-controller-enforcement.adoc
+++ b/operating/use-admission-controller-enforcement.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{product-title} works with https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/[Kubernetes admission controllers] and https://docs.openshift.com/container-platform/4.5/architecture/admission-plug-ins.html[{ocp} admission plug-ins] to allow you to enforce security policies before Kubernetes or {ocp} creates workloads, for example, deployments, daemon sets or jobs.
+{product-title} works with link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/[Kubernetes admission controllers] and link:https://docs.openshift.com/container-platform/4.11/architecture/admission-plug-ins.html[{ocp} admission plug-ins] to allow you to enforce security policies before Kubernetes or {ocp} creates workloads, for example, deployments, daemon sets or jobs.
 The {product-title} admission controller prevents users from creating workloads that violate policies you configure in {product-title}.
 Beginning from the {product-title} version 3.0.41, you can also configure the admission controller to prevent updates to workloads that violate policies.
 


### PR DESCRIPTION
…ent.adoc file

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
3.71+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/ROX-13902
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
http://file.pnq.redhat.com/agantony/ROX13902-rhacs-docs/operating/use-admission-controller-enforcement.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Merge into `rhacs-docs` and cherry-pick into:

- `rhacs-docs-3.71`
- `rhacs-docs-3.72`
- `rhacs-docs-3.73`
- `rhacs-docs-3.74`
