### PR TITLE
[enterprise-4.8] OCP#5305 Removed duplicate update service overview module.

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -29,8 +29,6 @@ include::modules/arch-olm-operators.adoc[leveloffset=+2]
 * For more details on running add-on Operators in {product-title}, see the _Operators_ guide sections on xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager (OLM)] and xref:../operators/understanding/olm-understanding-operatorhub.adoc#olm-understanding-operatorhub[OperatorHub].
 * For more details on the Operator SDK, see xref:../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Operators].
 
-include::modules/update-service-overview.adoc[leveloffset=+1]
-
 include::modules/understanding-machine-config-operator.adoc[leveloffset=+1]
 
 .Additional information

--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * architecture/architecture-installation.adoc
-// * architecture/control-plane.adoc
 // * updating/updating-cluster-within-minor.adoc
 // * updating/updating-cluster-cli.adoc
 // * updating/updating-cluster-rhel-compute.adoc


### PR DESCRIPTION
Manual cp of https://github.com/openshift/openshift-docs/pull/54320

