### PR TITLE
OSDOCS-4773: Removed dual-stack networking for OSD/ROSA

### DIFF
--- a/networking/routes/route-configuration.adoc
+++ b/networking/routes/route-configuration.adoc
@@ -65,7 +65,9 @@ include::modules/nw-ingress-edge-route-default-certificate.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-reencrypt-route-custom-cert.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/nw-router-configuring-dual-stack.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s):
Enterprise-4.11+

Issue:
[OSDOCS-4773](https://issues.redhat.com/browse/OSDOCS-4773)

Link to docs preview:
- **[OCP](https://54411--docspreview.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-router-configuring-dual-stack_route-configuration)** for comparison
- **[ROSA](https://54411--docspreview.netlify.app/openshift-rosa/latest/networking/routes/route-configuration.html#creating-re-encrypt-route-with-custom-certificate_route-configuration)**
- **[OSD](https://54411--docspreview.netlify.app/openshift-dedicated/latest/networking/routes/route-configuration.html#creating-re-encrypt-route-with-custom-certificate_route-configuration)**

Additional information:
This PR removes the dual-stack networking modules from ROSA and OSD since those distros do not support this feature.