### PR TITLE
[OSDOCS-4273]: Adding release notes for etcd backup and DR in a hosted cluster

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -1072,6 +1072,16 @@ With each major, minor, or patch version release of {product-title}, the HyperSh
 
 The `HostedCluster` and `NodePool` API resources are available in the beta version of the API and follow a similar policy to xref:../rest_api/understanding-api-support-tiers.adoc[{product-title}] and link:https://kubernetes.io/docs/concepts/overview/kubernetes-api/[Kubernetes].
 
+[id="ocp-4-12-hcp-etcd-backup"]
+==== Backing up and restoring etcd on a hosted cluster
+
+If you use hosted control planes on {product-title}, you can back up and restore etcd by taking a snapshot of etcd and uploading it to a location where you can retrieve it later, such as an S3 bucket. Later, if needed, you can restore the snapshot. For more information, see xref:../backup_and_restore/control_plane_backup_and_restore/etcd-backup-restore-hosted-cluster.adoc[Backing up and restoring etcd on a hosted cluster].
+
+[id="ocp-4-12-hcp-dr-in-aws-region"]
+==== Disaster recovery for a hosted cluster within an AWS region
+
+In a situation where you need disaster recovery for a hosted cluster, you can recover the hosted cluster to the same region within AWS. For more information, see xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/dr-hosted-cluster-within-aws-region.adoc[Disaster recovery for a hosted cluster within an AWS region].
+
 [id="ocp-4-12-rhv"]
 === Red Hat Virtualization (RHV)
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-4273
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://54413--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-hcp-etcd-backup
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR adds two release note entries for 4.12 related to hosted control planes. One entry is about etcd backup in a hosted cluster, and the other is about disaster recovery for a hosted cluster within an AWS region.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
