### PR TITLE
OSDOCS-4521: Adds another batch of 4.12 bugs and removes some duplicates

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -1452,6 +1452,10 @@ sourceStrategy:
 
 * Previously, when destroying a partially deployed cluster after an installation failed on VMWare vSphere, some virtual machine folders were not destroyed. This error could occur in clusters configured with multiple vSphere datacenters or multiple vSphere clusters. With this update, all installer-provisioned infrastructure is correctly deleted when destroying a partially deployed cluster after an installation failure. (link:https://issues.redhat.com/browse/OCPBUGS-1489[*OCPBUGS-1489*])
 
+* Previously, when installing a cluster on VMWare vSphere, the installation failed if the user specified the `platform.vsphere.vcenters` parameter but did not specify the `platform.vsphere.failureDomains.topology.networks` parameter in the `install-config.yaml` file. With this update, the installation program alerts the user that the `platform.vsphere.failureDomains.topology.networks` field is required when specifying `platform.vsphere.vcenters`. (link:https://issues.redhat.com/browse/OCPBUGS-1698[*OCPBUGS-1698*])
+
+* Previously, when installing a cluster on VMWare vSphere, the installation failed if the user defined the `platform.vsphere.vcenters` and `platform.vsphere.failureDomains` parameters but did not define `platform.vsphere.defaultMachinePlatform.zones`, or `compute.platform.vsphere.zones` and `controlPlane.platform.vsphere.zones`. With this update, the installation program validates that the user has defined the `zones` parameter in multi-region or multi-zone deployments prior to installation. (link:https://issues.redhat.com/browse/OCPBUGS-1490[*OCPBUGS-1490*])
+
 [discrete]
 [id="ocp-4-12-kube-api-server-bug-fixes"]
 ==== Kubernetes API server
@@ -1544,8 +1548,6 @@ sourceStrategy:
 
 * With this update, CoreDNS has been updated to version 1.10.0, which is based on Kubernetes 1.25. This keeps both the CoreDNS version and {product-title} {product-version}, which is also based on Kubernetes 1.25, in alignment with one another. (link:https://issues.redhat.com/browse/OCPBUGS-1731[*OCPBUGS-1731*])
 
-* Previously, CoreDNS was based on Kubernetes 1.24 while {product-title} 4.12 is based on Kubernetes 1.25. With this update, CoreDNS is v1.10.0, new features have been added, and {product-title} 4.12 uses Kubernetes 1.25 APIs. (link: https://issues.redhat.com/browse/OCPBUGS-1731[*OCPBUGS-1731*])
-
 * With this update, the {product-title} router now uses `k8s.io/client-go` version 1.25.2, which supports Kubernetes 1.25. This keeps both the `openshift-router` and {product-title} {product-version}, which is also based on Kubernetes 1.25, in alignment with one another. (link:https://issues.redhat.com/browse/OCPBUGS-1730[*OCPBUGS-1730*])
 
 * With this update, the Ingress Operator now uses `k8s.io/client-go` version 1.25.2, which supports Kubernetes 1.25. This keeps both the Ingress Operator and {product-title} {product-version}, which is also based on Kubernetes 1.25, in alignment with one another. (link:https://issues.redhat.com/browse/OCPBUGS-1554[*OCPBUGS-1554*])
@@ -1554,9 +1556,9 @@ sourceStrategy:
 
 * Previously, the `ingresscontroller.spec.tuniningOptions.reloadInterval` did not support decimal numerals as valid parameter values because the Ingress Operator internally converts the specified value into milliseconds, which was not a supported time unit. This prevented an Ingress Controller from being deleted. With this update, `ingresscontroller.spec.tuningOptions.reloadInterval` now supports decimal numerals and users can delete Ingress Controllers with `reloadInterval` parameter values which were previously unsupported. (link:https://issues.redhat.com/browse/OCPBUGS-236[*OCPBUGS-236*])
 
-* Previously, the `ingresscontroller.spec.tuniningOptions.reloadInterval` did not support decimal numerals as valid parameter values because the Ingress Operator internally converts the specified value into milliseconds, which was not a supported time unit. This prevented an Ingress Controller from being deleted. With this update, `ingresscontroller.spec.tuningOptions.reloadInterval` now supports decimal numerals and users can delete Ingress Controllers with `reloadInterval` parameter values which were previously unsupported. (link:https://issues.redhat.com/browse/OCPBUGS-236[*OCPBUGS-236*])
-
 * Previously, the Cluster DNS Operator used GO kubernetes libraries that were based on Kubernetes 1.24 while {product-title} 4.12 is based on Kubernetes 1.25. With this update, GO Kubernetes API is v1.25.2, which aligns the Cluster DNS Operator with {product-title} 4.12 that uses Kubernetes 1.25 APIs. (link: https://issues.redhat.com/browse/OCPBUGS-1558[*OCPBUGS-1558*])
+
+* Previously, setting the `disableNetworkDiagnostics` configuration to `true` did not persist when the `network-operator` pod was re-created. With this update, the `disableNetworkDiagnostics` configuration property of network`operator.openshift.io/cluster` no longer resets to its default value after network operator restart. (link:https://issues.redhat.com/browse/OCPBUGS-392[*OCPBUGS-392*])
 
 [discrete]
 [id="ocp-4-12-ne-perf-improvements"]
@@ -1578,15 +1580,17 @@ sourceStrategy:
 
 * Previously, `must-gather` was trying to collect resources that were not present on the server. Consequently, `must-gather` would print error messages. Now, before collecting resources, `must-gather` checks whether the resource exists. As a result, `must-gather` no longer prints an error when it fails to collect non-existing resources on the server. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2095708[*BZ#2095708*])
 
+* The {product-title} {product-version} release updates the `oc-mirror` library, so that the library supports multi-arch platform images. This means that you can choose from a wider selection of architectures, such as `arm64`, when mirroring a platform release payload. (link:https://issues.redhat.com/browse/OCPBUGS-617[*OCPBUGS-617*])
+
 [discrete]
 [id="ocp-4-12-olm-bug-fixes"]
 ==== Operator Lifecycle Manager (OLM)
 
-* For {product-title} {product-version}, the Operator Lifecycle Manager (OLM) now upgrades an Operator according to the Operator's component references. A change to the custom resource definition (CRD) status of an Operator does not impact the OLM Operator upgrade process. Before the {product-title} {product-version} release, OLM would upgrade an Operator according to the Operator's CRD status. A CRD lists component references in an order defined by the group/version/kind (GVK) identifier. Operators that share the same components might cause the GVK to change the component listings for an Operator, and this can cause the OLM to require more system resources to continuously update the status of a CRD. (link:https://issues.redhat.com/browse/OCPBUGS-3795[*OCPBUGS-3795*])
-
 * Before the {product-title} {product-version} release, the `package-server-manager` controller would not revert any changes made to a `package-server` cluster service version (CSV), because of an issue with the `on-cluster` function. These persistent changes might impact how an Operator starts in a cluster. For {product-title} {product-version}, the `package-server-manager` controller always rebuilds a `package-server` CSV to its original state, so that no modifications to the CSV persist after a cluster upgrade operation. The `on-cluster` function no longer controls the state of a `package-server` CSV. (link:https://issues.redhat.com/browse/OCPBUGS-867[*OCPBUGS-867*])
 
 * Previously, Operator Lifecycle Manager (OLM) would attempt to update namespaces to apply a label, even if the label was present on the namespace. Consequently, the update requests increased the workload in API and etcd services. With this update, OLM compares existing labels against the expected labels on a namespace before issuing an update. As a result, OLM no longer attempts to make unnecessary update requests on namespaces. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2105045[*BZ#2105045*])
+
+* The `package-server-manifest` (PSM) is a controller that ensures that the correct `package-server` Cluster Service Version (CSV) is installed on a cluster. Previously, changes to the `package-server` CSV were not being reverted because of a logical error in the reconcile function in which an on-cluster object could influence the expected object. Users could modify the `package-server` CSV and the changes would not be reverted. Additionally, cluster upgrades would not update the YAML for the `package-server` CSV. With this update, the expected version of the CSV is now always built from scratch, which removes the ability for an on-cluster object to influence the expected values. As a result, the PSM now reverts any attempts to modify the `package-server` CSV, and cluster upgrades now deploy the expected `package-server` CSV. (link:https://issues.redhat.com/browse/OCPBUGS-858[*OCPBUGS-858*])
 
 [discrete]
 [id="ocp-4-12-openshift-operator-sdk-bug-fixes"]
@@ -1598,6 +1602,8 @@ sourceStrategy:
 [discrete]
 [id="ocp-4-12-openshift-api-server-bug-fixes"]
 ==== OpenShift API server
+
+* Previously, adding a member could remove previous members from a group. As a result, the user lost group privileges. With this release, the dependencies were bumped and users no longer lose group privledges. (link:https://issues.redhat.com/browse/OCPBUGS-533[*OCPBUGS-533*])
 
 [discrete]
 [id="ocp-4-12-rhcos-bug-fixes"]
@@ -1656,7 +1662,6 @@ To opt out of using the VHD feature, remove the `fstype` parameter from your sto
 * In {product-title} 4.9, when it is minimal or no data in the *Developer Perspective*, most of the monitoring charts or graphs (CPU consumption, memory usage, and bandwidth) show a range of -1 to 1. However, none of these values can ever go below zero. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904106[*BZ#1904106*])
 
 * Before this update, users could not silence alerts in the *Developer* perspective in the {product-title} web console when a user-defined Alertmanager service was deployed because the web console would forward the request to the platform Alertmanager service in the `openshift-monitoring` namespace. With this update, when you view the *Developer* perspective in the web console and try to silence an alert, the request is forwarded to the corrrect Alertmanager service. (link:https://issues.redhat.com/browse/OCPBUGS-1789[*OCPBUGS-1789*])
-
 
 [id="ocp-4-12-technology-preview"]
 == Technology Preview features


### PR DESCRIPTION
[OSDOCS-4521](https://issues.redhat.com//browse/OSDOCS-4521): Adds another batch of 4.12 bugs and removes some duplicates

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4521

Link to docs preview:
https://54415--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes

QE review:
- [ ] QE has approved this change.
*QE not needed for this change

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
