### PR TITLE
CNV-18202: Updating repo names for 4.12

### DIFF
--- a/modules/virt-enabling-virt-repos.adoc
+++ b/modules/virt-enabling-virt-repos.adoc
@@ -20,12 +20,12 @@ Enable the {VirtProductName} repository for your version of {op-system-base-full
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable cnv-4.11-for-rhel-8-x86_64-rpms
+# subscription-manager repos --enable cnv-4.12-for-rhel-8-x86_64-rpms
 ----
 
 ** To enable the repository for {op-system-base} 7, run:
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable rhel-7-server-cnv-4.11-rpms
+# subscription-manager repos --enable rhel-7-server-cnv-4.12-rpms
 ----


### PR DESCRIPTION
Version(s):
CP to 4.12 only

Issue:
[CNV-18202](https://issues.redhat.com//browse/CNV-18202)

Link to docs preview:
[Enabling OpenShift Virtualization repositories](https://54421--docspreview.netlify.app/openshift-enterprise/latest/virt/install/virt-installing-virtctl.html#virt-enabling-virt-repos_virt-installing-virtctl)

QE review: @orenc1 

* [x]  QE has approved this change.

Additional information:
N/A
