### PR TITLE
Updates CX6 family name to correct ID

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -83,7 +83,7 @@
 |101b
 
 |Mellanox
-|MT28908 Family [ConnectX&#8209;6{nbsp}Lx]
+|MT2894 Family [ConnectX&#8209;6{nbsp}Lx]
 |15b3
 |101f
 

--- a/modules/ref_hardware-compatibility-with-irq-affinity.adoc
+++ b/modules/ref_hardware-compatibility-with-irq-affinity.adoc
@@ -86,7 +86,7 @@ For core isolation, all server hardware components must support IRQ affinity. To
 |101b
 
 |Mellanox
-|MT28908 Family [ConnectX&#8209;6{nbsp}Lx]
+|MT2894 Family [ConnectX&#8209;6{nbsp}Lx]
 |15b3
 |101f
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/OSDOCS-4779

Link to docs preview:
(https://54429--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html)

QE review:
QE is not needed. This is an update to an incorrect family name ID. 

