### PR TITLE
OSDOCS-4297: Update release note about hosted control plane versioning

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -924,7 +924,7 @@ The default version for the `hypershift.openshift.io` API, which is the API for 
 [id="ocp-4-12-hcp-versioning"]
 ==== Versioning for hosted control planes
 
-With each major, minor, or patch version release of {product-title}, two components of hosted control planes are released: the HyperShift Operator and the command-line interface (CLI). Any HyperShift Operator that is released for a minor version of {product-title} must work with all versions of {product-title} where hosted control planes are available.
+With each major, minor, or patch version release of {product-title}, the HyperShift Operator is released. The HyperShift command-line interface (CLI) is released as part of each HyperShift Operator release.
 
 The `HostedCluster` and `NodePool` API resources are available in the beta version of the API and follow a similar policy to xref:../rest_api/understanding-api-support-tiers.adoc[{product-title}] and link:https://kubernetes.io/docs/concepts/overview/kubernetes-api/[Kubernetes].
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-4297
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://54435--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-hcp-versioning
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: A late-breaking update to the versioning docs for hosted control planes required an update to the related release note. The wording has been approved by QE and engineering outside of this PR, on Slack.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
