### PR TITLE
adding OCPBUGS-2618 and removing duplicate BZ-2051443

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -156,7 +156,7 @@ With this release, there are several updates to the *Administrator* perspective 
 
 * The {product-title} web console displays a `ConsoleNotification` if the cluster is upgrading. Once the upgrade is done, the notification is removed.
 * A *_restart rollout_* option for the `Deployment` resource and a *_retry rollouts_* option for the `DeploymentConfig` resource are available on the *Action* and *Kebab* menus.
-* You can view a list of supported clusters on the *All Clusters* dropdown list. The supported clusters include {product-title}, {product-title} Service on AWS (ROSA), Azure Red Hat OpenShift (ARO), ROKS, and {product-dedicated}. 
+* You can view a list of supported clusters on the *All Clusters* dropdown list. The supported clusters include {product-title}, {product-title} Service on AWS (ROSA), Azure Red Hat OpenShift (ARO), ROKS, and {product-dedicated}.
 
 [id="ocp-4-12-multi-arch-console"]
 ===== Multi-architecture compute machines on the {product-title} web console
@@ -661,9 +661,9 @@ For more information, see xref:../networking/network_observability/network-obser
 If you configured and deployed your hosting service cluster, you can now deploy the SR-IOV Operator for a hosted cluster. For more information, see xref:../networking/hardware_networks/configuring-sriov-operator.adoc#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for hosted control planes].
 
 [id="ocp-4-12-nw-api-ingress-ipv6-support"]
-==== Support for IPv6 virtual IP (VIP) addresses for the Ingress VIP and API VIP services 
+==== Support for IPv6 virtual IP (VIP) addresses for the Ingress VIP and API VIP services
 
-With this update, in installer-provisioned infrastructure clusters, the `ingressVIP` and `apiVIP` configuration settings in the `install-config.yaml` file are deprecated. Instead, use the `ingressVIPs` and `apiVIPs` configuration settings. These settings support dual-stack networking for applications that require IPv4 and IPv6 access to the cluster by using the Ingress VIP and API VIP services. The `ingressVIPs` and `apiVIPs` configuration settings use a list format to specify an IPv4 address, an IPv6 address, or both IP address formats. The order of the list indicates the primary and secondary VIP address for each service. The primary IP address must be from the IPv4 network when using dual stack networking. 
+With this update, in installer-provisioned infrastructure clusters, the `ingressVIP` and `apiVIP` configuration settings in the `install-config.yaml` file are deprecated. Instead, use the `ingressVIPs` and `apiVIPs` configuration settings. These settings support dual-stack networking for applications that require IPv4 and IPv6 access to the cluster by using the Ingress VIP and API VIP services. The `ingressVIPs` and `apiVIPs` configuration settings use a list format to specify an IPv4 address, an IPv6 address, or both IP address formats. The order of the list indicates the primary and secondary VIP address for each service. The primary IP address must be from the IPv4 network when using dual stack networking.
 
 [id="ocp-4-12-storage"]
 === Storage
@@ -1627,7 +1627,8 @@ sourceStrategy:
 
 * Previously, the `oslat` control thread was collocated with one of the test threads, which caused latency spikes in the measurements. With this fix, the `oslat` runner now reserves one CPU for the control thread, meaning the test uses one less CPU for running the busy threads. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2051443[*BZ#2051443*].
 
-* Previously, the `oslat` runner configured `oslat` to use all available CPUs, which caused false spikes. With this update, the `oslat` runner reserves one CPU for the control thread. As a result, false spikes no longer occur. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2051443[*BZ#2051443*])
+
+* Latency measurement tools, also known as `oslat`, `cyclictest`, and `hwlatdetect`, now run on completely isolated CPUs without the helper process running in the background that might cause latency spikes, thus providing more accurate latency measurements. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-2618[*OCPBUGS-2618*].
 
 [discrete]
 [id="ocp-4-12-routing-bug-fixes"]


### PR DESCRIPTION
[OCPBUGS-2618]: CNF-TEST: OSLAT cpus not properly isolated

Version(s):
4.12 RN

Issue:
https://issues.redhat.com/browse/OCPBUGS-2618

Link to docs preview: https://54439--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Adding OCPBUGS-2618 and removing duplicate description for BZ-2051443

