### PR TITLE
OSDOCS-4521:adds storage and OLM bug batch

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -1599,6 +1599,10 @@ sourceStrategy:
 
 * Previously, Operator Lifecycle Manager (OLM) would attempt to update namespaces to apply a label, even if the label was present on the namespace. Consequently, the update requests increased the workload in API and etcd services. With this update, OLM compares existing labels against the expected labels on a namespace before issuing an update. As a result, OLM no longer attempts to make unnecessary update requests on namespaces. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2105045[*BZ#2105045*])
 
+* Previously, Operator Lifecycle Manager (OLM) would prevent minor cluster upgrades that should not be blocked based on a miscalculation of the `ClusterVersion` custom resources's `spec.DesiredVersion` field. With this update, OLM no longer prevents cluster upgrades when the upgrade should be supported. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097557[*BZ#2097557*])
+
+* Previously, the reconciler would update a resource's annotation without making a copy of the resource. This caused an error that would terminate the reconciler process. With this update, the reconciler no longer stops due the error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2105045[*BZ#2105045*])
+
 * The `package-server-manifest` (PSM) is a controller that ensures that the correct `package-server` Cluster Service Version (CSV) is installed on a cluster. Previously, changes to the `package-server` CSV were not being reverted because of a logical error in the reconcile function in which an on-cluster object could influence the expected object. Users could modify the `package-server` CSV and the changes would not be reverted. Additionally, cluster upgrades would not update the YAML for the `package-server` CSV. With this update, the expected version of the CSV is now always built from scratch, which removes the ability for an on-cluster object to influence the expected values. As a result, the PSM now reverts any attempts to modify the `package-server` CSV, and cluster upgrades now deploy the expected `package-server` CSV. (link:https://issues.redhat.com/browse/OCPBUGS-858[*OCPBUGS-858*])
 
 [discrete]
@@ -1655,6 +1659,12 @@ sourceStrategy:
 [discrete]
 [id="ocp-4-12-storage-bug-fixes"]
 ==== Storage
+
+* Previously, checks for generic ephemeral volumes failed. With this update, checks for expandable volumes now include generic ephemeral volumes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2082773[*BZ#2082773*]
+
+* Previously, if more than one secret was present for vSphere, the vSphere CSI Operator randomly picked a secret and sometimes caused the Operator to restart. With this update, a warning appears when there is more than one secret on the vCenter CSI Operator. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2108473[*BZ#2108473*])
+
+* Previously, {product-title} detached a volume when a Container Storage Interface (CSI) driver was not able to unmount the volume from a node. Detaching a volume without unmount is not allowed by CSI specifications and drivers could enter an `undocumented` state. With this update, CSI drivers are detached before unmounting only on unhealthy nodes preventing the `undocumented` state. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049306[*BZ#2049306*])
 
 * Previously, there were missing annotations on the Manila CSI Driver Operator's VolumeSnapshotClass. Consequently, the Manila CSI snapshotter could not locate secrets, and could not create snapshots with the default VolumeSnapshotClass. This update fixes the issue so that secret names and namespaces are included in the default VolumeSnapshotClass. As a result, users can now create snapshots in the Manila CSI Driver Operator using the default VolumeSnapshotClass. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057637[*BZ#2057637*])
 


### PR DESCRIPTION
[OSDOCS-4521](https://issues.redhat.com//browse/OSDOCS-4521): adds a bug batch for Storage and OLM
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-4521
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://54450--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
