### PR TITLE
modules/understanding-upgrade-channels: Fix "Condtional" to "Conditional" typo

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -70,7 +70,7 @@ Do not rely on consecutive patch numbers. In this example, {product-version}.2 i
 ====
 
 [id="conditional-updates-overview_{context}"]
-== Update recommendation removals and Condtional Updates
+== Update recommendation removals and Conditional Updates
 Red Hat monitors newly released versions and update paths associated with those versions before and after they are added to supported channels. If a serious regression is identified, Red Hat may remove affected update recommendations. When Red Hat chooses to remove update recommendations, that action is taken in all relevant channels simultaneously. The removal of recommended updates may happen either before or after updates have been promoted to supported channels.
 
 If Red Hat removes update recommendations from any supported release, a superseding update recommendation will be provided to a future version that corrects the regression. There may however be a delay while the defect is corrected, tested, and promoted to your selected channel.


### PR DESCRIPTION
This snuck in with a8d3109ebee (Focus the description of the channels only on what goes into the channels, 2022-06-30, #47333), which was backported [through 4.10][1].

[1]: https://github.com/openshift/openshift-docs/pull/53497/files#diff-a730a4f4ac2c41dde208df2277ff16a4411c015a889dc4ba15323ed8805df5ceR75