### PR TITLE
[enterprise-4.10] Updates CX6 family name to correct ID

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -83,7 +83,7 @@
 |101b
 
 |Mellanox
-|MT28908 Family [ConnectX&#8209;6{nbsp}Lx]
+|MT2894 Family [ConnectX&#8209;6{nbsp}Lx]
 |15b3
 |101f
 


### PR DESCRIPTION
Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OSDOCS-4779

Link to docs preview:
(https://54429--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html)

QE review:
QE is not needed. This is an update to an incorrect family name ID.

ACKs received at https://github.com/openshift/openshift-docs/pull/54429

Preview: 

![image](https://user-images.githubusercontent.com/77019920/211670358-16605bdd-4582-4ce8-8717-b22e9bbb7c48.png)
