### PR TITLE
Revert "HOLD: Docs: Move MCD drain alert into the MCC, revisit error modes"

### DIFF
--- a/modules/machine-config-daemon-metrics.adoc
+++ b/modules/machine-config-daemon-metrics.adoc
@@ -5,9 +5,9 @@
 [id="machine-config-daemon-metrics_{context}"]
 = Machine Config Daemon metrics
 
-Beginning with {product-title} 4.3, the Machine Config Daemon, along with the Machine Config Controller (MCC), provides a set of metrics. These metrics can be accessed using the Prometheus Cluster Monitoring stack.
+Beginning with {product-title} 4.3, the Machine Config Daemon provides a set of metrics. These metrics can be accessed using the Prometheus Cluster Monitoring stack.
 
-The following table describes this set of metrics. Each of the metrics is provided by the MCD, except for the `mcc_drain_err*` error, which is provided by the MCC.
+The following table describes this set of metrics.
 
 [NOTE]
 ====
@@ -41,14 +41,14 @@ ifdef::openshift-origin[]
 |
 endif::openshift-origin[]
 
-|`mcc_drain_err*`
+|`mcd_drain_err*`
 |`{"drain_time", "err"}`
 |Logs errors received during failed drain. *
 |While drains might need multiple tries to succeed, terminal failed drains prevent updates from proceeding. The `drain_time` metric, which shows how much time the drain took, might help with troubleshooting.
 
 For further investigation, see the logs by running:
 
-`$ oc logs -f -n openshift-machine-config-operator machine-config-controller-<hash> -c machine-config-controller`
+`$ oc logs -f -n openshift-machine-config-operator machine-config-daemon-<hash> -c machine-config-daemon`
 
 |`mcd_pivot_err*`
 |`[]string{"err", "node", "pivot_target"}`


### PR DESCRIPTION
Reverts openshift/openshift-docs#53657 Change is in 4.13, not 4.12.