### PR TITLE
Order should go from 2892 to 2894 to match the chronology of the rest…

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -83,14 +83,14 @@
 |101b
 
 |Mellanox
-|MT2894 Family [ConnectX&#8209;6{nbsp}Lx]
-|15b3
-|101f
-
-|Mellanox
 |MT2892 Family [ConnectX&#8209;6{nbsp}Dx]
 |15b3
 |101d
+
+|Mellanox
+|MT2894 Family [ConnectX&#8209;6{nbsp}Lx]
+|15b3
+|101f
 
 |Mellanox
 |MT42822 BlueField&#8209;2 in ConnectX&#8209;6 NIC mode

--- a/modules/ref_hardware-compatibility-with-irq-affinity.adoc
+++ b/modules/ref_hardware-compatibility-with-irq-affinity.adoc
@@ -86,14 +86,14 @@ For core isolation, all server hardware components must support IRQ affinity. To
 |101b
 
 |Mellanox
-|MT2894 Family [ConnectX&#8209;6{nbsp}Lx]
-|15b3
-|101f
-
-|Mellanox
 |MT2892 Family [ConnectX&#8209;6{nbsp}Dx]
 |15b3
 |101d
+
+|Mellanox
+|MT2894 Family [ConnectX&#8209;6{nbsp}Lx]
+|15b3
+|101f
 
 |Mellanox
 |MT42822 BlueField&#8209;2 in ConnectX&#8209;6 NIC mode


### PR DESCRIPTION
A followup PR to https://github.com/openshift/openshift-docs/pull/54429. This swaps the family order so that they're chronologically correct. 

Preview: https://54476--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov

No issue.

QE not needed. 
