### PR TITLE
OSDOCS-4759: Adds notes for 4.8.56 release

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -3758,3 +3758,22 @@ This update contains changes from Kubernetes 1.21.12 up to 1.21.14. More informa
 ==== Updating
 
 To update an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-8-56"]
+=== RHBA-2023:0018 - {product-title} 4.8.56 bug fix and security update
+
+Issued: 2023-01-12
+
+{product-title} release 4.8.56, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:0018[RHBA-2023:0018] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0017[RHSA-2023:0017] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.8.56 --pullspecs
+----
+
+[id="ocp-4-8-56-updating"]
+==== Updating
+
+To update an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4759](https://issues.redhat.com//browse/OSDOCS-4759): Adds notes for 4.8.56 release

Version(s):
4.8 only

Issue:
https://issues.redhat.com/browse/OSDOCS-4759

Link to docs preview:
http://file.rdu.redhat.com/opayne/RN-4.8.56/release_notes/ocp-4-8-release-notes.html#ocp-4-8-56

QE review:
- [ ] QE has approved this change.
QE not required for this change

Additional information:
Links will not work yet.
