### PR TITLE
TELCODOCS-781: ACM and MCE version flags decoupled

### DIFF
--- a/modules/ztp-precaching-downloading-artifacts.adoc
+++ b/modules/ztp-precaching-downloading-artifacts.adoc
@@ -258,7 +258,7 @@ You can customize the `ImageSetConfiguration` CR in the following ways:
 <3> Defines the {rh-rhacm} version.
 <4> Defines the MCE version.
 <5> Defines the folder where you want to download the images on the disk.
-<6> Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
+<6> Optional. Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
 <7> Specifies pre-caching the Operators included in the DU configuration.
 <8> The `--generate-imageset` argument generates the `ImageSetConfiguration` CR only, which allows you to customize the CR.
 

--- a/modules/ztp-precaching-downloading-artifacts.adoc
+++ b/modules/ztp-precaching-downloading-artifacts.adoc
@@ -20,8 +20,7 @@ The list of available Operator images can vary in different {product-title} rele
 [id="ztp-preparing-ocp-images_{context}"]
 == Preparing to download the {product-title} images
 
-To download the {product-title} container images, you need to know the {rh-rhacm-first} version running in the hub cluster that is going to provision the {sno}.
-The version of the hub cluster determines which multicluster engine (MCE) container images are used by the {sno} to provision and report the inventory and progress of the spoke cluster.
+To download {product-title} container images, you need to know the multicluster engine (MCE) version. When you use the `--du-profile` flag, you also need to specify the {rh-rhacm-first} version running in the hub cluster that is going to provision the {sno}.
 
 .Prerequisites
 
@@ -33,7 +32,7 @@ The version of the hub cluster determines which multicluster engine (MCE) contai
 
 .Procedure
 
-. Check the {rh-rhacm} and Multicluster engine (MCE) version by running the following commands in the hub cluster:
+. Check the {rh-rhacm} and MCE version by running the following commands in the hub cluster:
 +
 [source,terminal]
 ----
@@ -61,26 +60,6 @@ multicluster-engine                                cluster-group-upgrades-operat
 multicluster-engine                                multicluster-engine.v2.0.4                   multicluster engine for Kubernetes           2.0.4                 multicluster-engine.v2.0.3                        Succeeded
 multicluster-engine                                openshift-gitops-operator.v1.5.7             Red Hat OpenShift GitOps                     1.5.7                 openshift-gitops-operator.v1.5.6-0.1664915551.p   Succeeded
 multicluster-engine                                openshift-pipelines-operator-rh.v1.6.4       Red Hat OpenShift Pipelines                  1.6.4                 openshift-pipelines-operator-rh.v1.6.3            Succeeded
-----
-
-. Query the AI version on your hub cluster:
-+
-[source,terminal]
-----
-$ oc get cm assisted-service -n open-cluster-management -oyaml | \ <1>
-grep -E "AGENT_DOCKER_IMAGE|CONTROLLER_IMAGE|INSTALLER_IMAGE"
-----
-<1> The namespace can differ based on the installed {rh-rhacm} version.
-
-. Save the output, which is required for downloading the artifacts.
-
-+
-.Example output
-[source,terminal]
-----
-AGENT_DOCKER_IMAGE: registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:da1753f9fcb9e229d0a68de03fac90d15023e647a8db531ae489eb93845d5306
-CONTROLLER_IMAGE: registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@sha256:e8d6b78248352b1a8e05a22308185a468d4a139682d997a7f968b329abbc02cd
-INSTALLER_IMAGE: registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:33abd6e21cfdc36dd4337fa6f3c3442d33fc3f976471614dca5b8ef749e7a027
 ----
 
 . To access the container registry, copy a valid pull secret on the server to be installed:
@@ -120,17 +99,17 @@ The {factory-prestaging-tool} allows you to pre-cache all the container images r
 # podman run -v /mnt:/mnt -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools -- \
    factory-precaching-cli download \ <1>
    -r 4.11.5 \ <2>
-   -f /mnt \ <3>
-   --ai-img registry.redhat.io/multicluster-engine/ assisted-installer-agent-rhel8@sha256:da1753f9fcb9e229d0a68de03fac90d15023e647a8db531ae489eb93845d5306 \ <4>
-   --ai-img registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@sha256:e8d6b78248352b1a8e05a22308185a468d4a139682d997a7f968b329abbc02cd \ <4>
-   --ai-img registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:33abd6e21cfdc36dd4337fa6f3c3442d33fc3f976471614dca5b8ef749e7a027 \ <4>
-   --img quay.io/custom/repository <5>
+   --acm-version 2.5.4 \ <3>
+   --mce-version 2.0.4 \ <4>
+   -f /mnt \ <5>
+   --img quay.io/custom/repository <6>
 ----
 <1> Specifies the downloading function of the {factory-prestaging-tool}.
 <2> Defines the {product-title} release version.
-<3> Defines the folder where you want to download the images on the disk.
-<4> Defines the MCE and AI artifacts required for provisioning.
-<5> Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
+<3> Defines the {rh-rhacm} version.
+<4> Defines the MCE version.
+<5> Defines the folder where you want to download the images on the disk.
+<6> Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
 
 +
 .Example output
@@ -147,6 +126,15 @@ Processing artifact [6/176]: ocp-v4.0-art-dev@sha256_e142bf5020f5ca0d1bdda0026bf
 ...
 Processing artifact [175/176]: ocp-v4.0-art-dev@sha256_16cd7eda26f0fb0fc965a589e1e96ff8577e560fcd14f06b5fda1643036ed6c8
 Processing artifact [176/176]: ocp-v4.0-art-dev@sha256_cf4d862b4a4170d4f611b39d06c31c97658e309724f9788e155999ae51e7188f
+...
+Summary:
+
+Release:                            4.11.5
+Hub Version:                        2.5.4
+ACM Version:                        2.5.4
+MCE Version:                        2.0.4
+Include DU Profile:                 No
+Workers:                            83
 ----
 
 .Verification
@@ -189,7 +177,7 @@ You can also pre-cache Day-2 Operators used in the 5G Radio Access Network (RAN)
 
 [IMPORTANT]
 ====
-You need to include the {rh-rhacm} hub version, so that the {factory-prestaging-tool} can pre-stage the appropriate containers images for the {rh-rhacm} and MCE Operators.
+You need to include the {rh-rhacm} hub and MCE Operator versions by using the `--acm-version` and `--mce-version` flags so the {factory-prestaging-tool} can pre-cache the appropriate containers images for the {rh-rhacm} and MCE Operators.
 ====
 
 .Procedure
@@ -198,22 +186,21 @@ You need to include the {rh-rhacm} hub version, so that the {factory-prestaging-
 +
 [source,terminal]
 ----
-# podman run -v /mnt:/mnt -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- factory-precaching-cli download \
--r 4.11.5 \ <1>
---hub-version 2.5.4 \ <2>
--f /mnt \ <3>
---ai-img registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:da1753f9fcb9e229d0a68de03fac90d15023e647a8db531ae489eb93845d5306 \ <4>
---ai-img registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@sha256:e8d6b78248352b1a8e05a22308185a468d4a139682d997a7f968b329abbc02cd \ <4>
---ai-img registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:33abd6e21cfdc36dd4337fa6f3c3442d33fc3f976471614dca5b8ef749e7a027 \ <4>
---img quay.io/custom/repository \ <5>
---du-profile -s <6>
+# podman run -v /mnt:/mnt -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- factory-precaching-cli download \ <1>
+   -r 4.11.5 \ <2>
+   --acm-version 2.5.4 \ <3>
+   --mce-version 2.0.4 \ <4>
+   -f /mnt \ <5>
+   --img quay.io/custom/repository <6>
+   --du-profile -s <7>
 ----
-<1> Defines the {product-title} release version.
-<2> Defines the version of the hub cluster.
-<3> Defines the folder where you want to pre-cache the images on the disk.
-<4> Defines the MCE and AI artifacts required for provisioning.
-<5> Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
-<6> The `--du-profile` argument specifies pre-caching the Operators included in the DU configuration.
+<1> Specifies the downloading function of the {factory-prestaging-tool}.
+<2> Defines the {product-title} release version.
+<3> Defines the {rh-rhacm} version.
+<4> Defines the MCE version.
+<5> Defines the folder where you want to download the images on the disk.
+<6> Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
+<7> Specifies pre-caching the Operators included in the DU configuration.
 
 +
 .Example output
@@ -227,6 +214,15 @@ Processing artifact [3/379]: ocp-v4.0-art-dev@sha256_370e47a14c798ca3f8707a38b28
 ...
 Processing artifact [378/379]: ose-local-storage-operator@sha256_0c81c2b79f79307305e51ce9d3837657cf9ba5866194e464b4d1b299f85034d0
 Processing artifact [379/379]: multicluster-operators-channel-rhel8@sha256_c10f6bbb84fe36e05816e873a72188018856ad6aac6cc16271a1b3966f73ceb3
+...
+Summary:
+
+Release:                            4.11.5
+Hub Version:                        2.5.4
+ACM Version:                        2.5.4
+MCE Version:                        2.0.4
+Include DU Profile:                 Yes
+Workers:                            83
 ----
 
 [id="ztp-custom-pre-caching-in-disconnected-environment_{context}"]
@@ -248,23 +244,23 @@ You can customize the `ImageSetConfiguration` CR in the following ways:
 +
 [source,terminal]
 ----
-# podman run -v /mnt:/mnt -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- factory-precaching-cli download \
--r 4.11.5 \ <1>
---hub-version 2.5.4 \ <2>
--f /mnt \ <3>
---ai-img registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:da1753f9fcb9e229d0a68de03fac90d15023e647a8db531ae489eb93845d5306 \ <4>
---ai-img registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@sha256:e8d6b78248352b1a8e05a22308185a468d4a139682d997a7f968b329abbc02cd \ <4>
---ai-img registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:33abd6e21cfdc36dd4337fa6f3c3442d33fc3f976471614dca5b8ef749e7a027 \ <4>
---img quay.io/custom/repository \ <5>
---du-profile -s \
---generate-imageset <6>
+# podman run -v /mnt:/mnt -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- factory-precaching-cli download \ <1>
+   -r 4.11.5 \ <2>
+   --acm-version 2.5.4 \ <3>
+   --mce-version 2.0.4 \ <4>
+   -f /mnt \ <5>
+   --img quay.io/custom/repository <6>
+   --du-profile -s \ <7>
+   --generate-imageset <8>
 ----
-<1> Defines the {product-title} release version.
-<2> Defines the version of the hub cluster.
-<3> Defines the folder where you want to pre-cache the images on the disk.
-<4> Defines the MCE and AI artifacts required for provisioning.
-<5> Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
-<6> The `--generate-imageset` argument generates the `ImageSetConfiguration` CR only, which allows you to customize the CR.
+<1> Specifies the downloading function of the {factory-prestaging-tool}.
+<2> Defines the {product-title} release version.
+<3> Defines the {rh-rhacm} version.
+<4> Defines the MCE version.
+<5> Defines the folder where you want to download the images on the disk.
+<6> Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
+<7> Specifies pre-caching the Operators included in the DU configuration.
+<8> The `--generate-imageset` argument generates the `ImageSetConfiguration` CR only, which allows you to customize the CR.
 
 +
 .Example output
@@ -285,48 +281,44 @@ mirror:
     - name: stable-4.11
       minVersion: 4.11.5 <1>
       maxVersion: 4.11.5
-  additionalImages: <2>
-    - name: registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:da1753f9fcb9e229d0a68de03fac90d15023e647a8db531ae489eb93845d5306
-    - name: registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@sha256:e8d6b78248352b1a8e05a22308185a468d4a139682d997a7f968b329abbc02cd
-    - name: registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:33abd6e21cfdc36dd4337fa6f3c3442d33fc3f976471614dca5b8ef749e7a027
-    - name: quay.io/user/troubleshoot
+  additionalImages:
+    - name: quay.io/custom/repository
   operators:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.11
       packages:
-        - name: advanced-cluster-management <3>
+        - name: advanced-cluster-management <2>
           channels:
              - name: 'release-2.6'
              - name: 'release-2.5'
                minVersion: 2.5.4
                maxVersion: 2.5.4
-        - name: multicluster-engine <3>
+        - name: multicluster-engine <2>
           channels:
              - name: 'stable-2.1'
              - name: 'stable-2.0'
                minVersion: 2.0.4
                maxVersion: 2.0.4
-        - name: local-storage-operator <4>
+        - name: local-storage-operator <3>
           channels:
             - name: 'stable'
-        - name: ptp-operator <4>
+        - name: ptp-operator <3>
           channels:
             - name: 'stable'
-        - name: sriov-network-operator <4>
+        - name: sriov-network-operator <3>
           channels:
             - name: 'stable'
-        - name: cluster-logging <4>
+        - name: cluster-logging <3>
           channels:
             - name: 'stable'
     - catalog: registry.redhat.io/redhat/certified-operator-index:v4.11
       packages:
-        - name: sriov-fec <4>
+        - name: sriov-fec <3>
           channels:
             - name: 'stable'
 ----
 <1> The platform versions match the versions passed to the tool.
-<2> The CR contains the additional images.
-<3> The versions of {rh-rhacm} and MCE Operators match the versions passed to the tool.
-<4> The CR contains all the specified DU Operators.
+<2> The versions of {rh-rhacm} and MCE Operators match the versions passed to the tool.
+<3> The CR contains all the specified DU Operators.
 
 . Customize the catalog resource in the CR:
 +
@@ -366,34 +358,31 @@ When you download images by using a local or disconnected registry, you have to 
 [source,terminal]
 ----
 # podman run -v /mnt:/mnt -v /root/.docker:/root/.docker -v /etc/pki:/etc/pki --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- \
-factory-precaching-cli download \
--r 4.11.5 \ <1>
---hub-version 2.5.4 \ <2>
--f /mnt \ <3>
---ai-img registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:da1753f9fcb9e229d0a68de03fac90d15023e647a8db531ae489eb93845d5306 \ <4>
---ai-img registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@sha256:e8d6b78248352b1a8e05a22308185a468d4a139682d997a7f968b329abbc02cd \ <4>
---ai-img registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:33abd6e21cfdc36dd4337fa6f3c3442d33fc3f976471614dca5b8ef749e7a027 \ <4>
---img quay.io/custom/repository \ <5>
---du-profile -s \
---skip-imageset <6>
+factory-precaching-cli download \ <1>
+   -r 4.11.5 \ <2>
+   --acm-version 2.5.4 \ <3>
+   --mce-version 2.0.4 \ <4>
+   -f /mnt \ <5>
+   --img quay.io/custom/repository <6>
+   --du-profile -s \ <7>
+   --skip-imageset <8>
 ----
-<1> Defines the {product-title} release version.
-<2> Defines the version of the hub cluster.
-<3> Defines the folder where you want to pre-cache the images on the disk.
-<4> Defines the MCE and AI artifacts required for provisioning.
-<5> Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
-<6> The `--skip-imageset` argument allows you to download the images that you specified in your customized `ImageSetConfiguration` CR.
+<1> Specifies the downloading function of the {factory-prestaging-tool}.
+<2> Defines the {product-title} release version.
+<3> Defines the {rh-rhacm} version.
+<4> Defines the MCE version.
+<5> Defines the folder where you want to download the images on the disk.
+<6> Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
+<7> Specifies pre-caching the Operators included in the DU configuration.
+<8> The `--skip-imageset` argument allows you to download the images that you specified in your customized `ImageSetConfiguration` CR.
 
 . Download the images without generating a new `imageSetConfiguration` CR:
 +
 [source,terminal]
 ----
-# podman run -v /mnt:/mnt -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- factory-precaching-cli \
-    download -r 4.11.5 -f /mnt \
-    --ai-img registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8@sha256:da1753f9fcb9e229d0a68de03fac90d15023e647a8db531ae489eb93845d5306 \
-    --ai-img registry.redhat.io/multicluster-engine/assisted-installer-reporter-rhel8@sha256:e8d6b78248352b1a8e05a22308185a468d4a139682d997a7f968b329abbc02cd \
-    --ai-img registry.redhat.io/multicluster-engine/assisted-installer-rhel8@sha256:33abd6e21cfdc36dd4337fa6f3c3442d33fc3f976471614dca5b8ef749e7a027 \
-    --img quay.io/user/troubleshoot \
-    --du-profile -s \
-    --skip-imageset
+# podman run -v /mnt:/mnt -v /root/.docker:/root/.docker --privileged --rm quay.io/openshift-kni/telco-ran-tools:latest -- factory-precaching-cli download -r 4.11.5 \
+--acm-version 2.5.4 --mce-version 2.0.4 -f /mnt \
+--img quay.io/custom/repository \
+--du-profile -s \
+--skip-imageset
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-781
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://54486--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-precaching-tool.html#ztp-downloading-images_pre-caching
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Relevant bug: https://issues.redhat.com/browse/OCPBUGS-5162
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
