### PR TITLE
OSDOCS-4477:Agent features release note addition

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -143,12 +143,81 @@ In earlier versions of {product-title}, Ironic container images used {op-system-
 
 For more information about the Ironic provisioning service, see xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc[Deploying installer-provisioned clusters on bare metal].
 
-[id="ocp-4-12-openstack-external-cloud-control-upgrade"]
-=== Cloud provider configuration updates for clusters that run on {rh-openstack}
+[id="ocp-4-12-agent-based-install-asset-input"]
+==== Agent-based installation supports two input modes
+The Agent-based installation supports two input modes:
 
-In {product-title} 4.12, clusters that run on {rh-openstack-first} are switched from the legacy OpenStack cloud provider to the external Cloud Controller Manager (CCM). This change follows the move in Kubernetes from in-tree, legacy cloud providers to external cloud providers that are implemented by using the link:https://kubernetes.io/docs/concepts/architecture/cloud-controller/[Cloud Controller Manager].
+.Preferred
 
-// For more information, see [LINK TO DOC ONCE AVAILABLE]
+* `install-config.yaml` file
+* `agent-config.yaml` file
+
+.Optional
+
+* Zero Touch Provisioning (ZTP) manifests
+
+With the preferred mode, you can configure the `install-config.yaml` file and specify Agent-based specific settings in the `agent-config.yaml` file.
+For more information, see xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#about-the-agent-based-installer[About the Agent-based {product-title} Installer].
+
+[id="ocp-4-12-agent-based-install-fips"]
+==== Agent-based installation supports installing {product-title} cluster in FIPS compliant mode
+Agent-based {product-title} Installer supports {product-title} clusters in Federal Information Processing Standards (FIPS) compliant mode. You must set the value of the `fips` field to `True` in the `install-config.yaml` file.
+For more information, see xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#agent-installer-configuring-fips-compliance_preparing-to-install-with-agent-based-installer[About FIPS compliance].
+
+[id="ocp-4-12-agent-based-install-disconnected"]
+==== Deploy an Agent-based {product-title} cluster in a disconnected environment
+You can perform an Agent-based installation in a disconnected environment. To create an image that is used in a disconnected environment, the `imageContentSources` section in the ` install-config.yaml` must contain the mirror information or `registries.conf` file if you are using ZTP manifests. The actual configuration settings to use in these files are supplied by either the `oc adm release mirror` or `oc mirror` command.
+For more information, see xref:../installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.html[Understanding disconnected installation mirroring].
+
+[id="ocp-4-12-agent-based-install-dual-stack"]
+==== Agent-based installation supports single and dual stack networking
+You can create the agent ISO image with the following IP address configurations:
+
+* IPv4
+* IPv6
+* IPv4 and IPv6 in parallel (dual-stack)
+
+For more information, see xref:../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent_installing-with-agent-based-installer[Dual and single IP stack clusters].
+
+[id="ocp-4-12-agent-based-install-mce"]
+==== Agent deployed {product-title} cluster can be used as a hub cluster
+
+You can install the multicluster engine for Kubernetes (MCE) Operator and deploy a hub cluster with the Agent-based {product-title} Installer.
+
+// TODO doc PR not merged see xref:..
+
+[id="ocp-4-12-agent-based-install-validations"]
+==== Agent-based installation performs installation validations
+
+The Agent-based {product-title} Installer performs validations on:
+
+* Installation image generation: The user-provided manifests are checked for validity and compatibility.
+* Installation: The installation service checks the hardware available for installation and emits validation events that can be retrieved with the `openshift-install agent wait-for` subcommands.
+
+For more information, see xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#validations-before-agent-iso-creation_preparing-to-install-with-agent-based-installer[Installation validations].
+
+[id="ocp-4-12-agent-based-install-static-networking"]
+==== Configure static networking in a Agent-based installation
+With the Agent-based {product-title} Installer, you can configure static IP addresses for IPv4, IPv6, or dual-stack (both IPv4 and IPv6) for all the hosts prior to creating the agent ISO image. You can add the static addresses to the `hosts` section of the `agent-config.yaml` file or in the `NMStateConfig.yaml` file if you are using the ZTP manifests.
+Note that the configuration of the addresses must follow the syntax rules for nmstate as described in link:https://nmstate.io/examples.html[NMState state examples].
+
+For more information, see xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#agent-install-networking_preparing-to-install-with-agent-based-installer[About networking].
+
+[id="ocp-4-12-agent-based-install-automated-deployment"]
+==== CLI based automated deployment in an Agent-based installation
+With the Agent-based {product-title} Installer, you can define your installation configurations, generate an ISO for all the nodes, and then have an unattended installation by booting the target systems with the generated ISO.
+For more information, see xref:../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-with-agent-based-installer[Installing a {product-title} cluster with the Agent-based {product-title} Installer].
+
+[id="ocp-4-12-agent-based-install-host-specific"]
+==== Agent-based installation supports host specific configuration at the instalation time
+You can configure the hostname, network configuration in NMState format, root device hints, and role in an Agent-based installation.
+
+For more information, see xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints].
+
+[id="ocp-4-12-agent-based-install-dhcp"]
+==== Agent-based installation supports DHCP
+With the Agent-based {product-title} Installer, you can deploy to environments where you rely on DHCP to configure networking for all the nodes, as long as you know the IP that at least one of the systems will receive. This IP is required so that all nodes use it as a meeting point.
+For more information, see xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#dhcp[DHCP].
 
 [id="ocp-4-12-post-installation"]
 === Post-installation configuration
@@ -895,7 +964,7 @@ You can now configure OS-level tuning for nodes in a hosted cluster by using the
 === Insights Operator
 
 [id="ocp-4-12-insights-alerts"]
-==== Insights alerts 
+==== Insights alerts
 In {product-title} {product-version}, active Insights recommendations are now presented to the user as alerts. You can view and configure these alerts with Alertmanager.
 
 [id="ocp-4-12-insights-data-collection"]
@@ -1969,7 +2038,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Agent-based Installer
+|Agent-based {product-title} Installer
 |Not Available
 |Not Available
 |General Availability
@@ -2412,7 +2481,7 @@ $ ./openshift-install wait-for install-complete
 
 * Due to an unresolved metadata API issue, you cannot install clusters that use bare-metal workers on {rh-openstack} 16.1. Clusters on {rh-openstack} 16.2 are not impacted by this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033953[*BZ#2033953*])
 
-* The `loadBalancerSourceRanges` attribute is not supported, and is thus ignored, in load-balancer type services in clusters that run on {rh-openstack} and use the OVN Octavia provider. There is no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-2789[*OCPBUGS-2789*]) 
+* The `loadBalancerSourceRanges` attribute is not supported, and is thus ignored, in load-balancer type services in clusters that run on {rh-openstack} and use the OVN Octavia provider. There is no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-2789[*OCPBUGS-2789*])
 
 * Platform Operator and RukPak known issues:
 


### PR DESCRIPTION
- Applies to 4.12 only
- [Jira](https://issues.redhat.com/browse/OSDOCS-4477)
- [Preview](https://54487--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-installation-and-upgrade)
- @celebdor ptal. The scope of this PR is for Agent-based Installer features. Known issues are taken care of by the doc release note team

NOTE: Only MCE does not have a cross ref as the PR is not yet merged. [TODO]