### PR TITLE
TELCODOCS-643: Additional worker nodes TP note

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -847,7 +847,7 @@ The low latency tuning has been updated to use the latest kernel features and op
 In {product-title} {product-version}, by enabling C-states and OS-controlled P-states, you can use different power-saving configurations for critical and non-critical workloads. You can apply the configurations through the new `perPodPowerManagement` workload hint, and the `cpu-c-states.crio.io` and `cpu-freq-governor.crio.io` CRI-O annotations. For more information about the feature, see xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#node-tuning-operator-pod-power-saving-config_cnf-master[Power-saving configurations].
 
 [id="scalability-and-performance-sno-additional-worker-node"]
-==== {sno-caps} cluster expansion with worker nodes
+==== {sno-caps} cluster expansion with worker nodes (Technology Preview)
 
 In {product-title} {product-version}, you can expand your existing {sno} clusters with additional worker nodes to increase available resources. For more information about {sno} expansion, see xref:../scalability_and_performance/ztp_far_edge/ztp-sno-additional-worker-node.adoc#ztp-additional-worker-sno_sno-additional-worker[Single-node OpenShift cluster expansion with worker nodes].
 
@@ -2079,6 +2079,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |{factory-prestaging-tool}
+|Not Available
+|Not Available
+|Technology Preview
+
+|Single-node OpenShift cluster expansion with worker nodes
 |Not Available
 |Not Available
 |Technology Preview


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-643
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
* https://54490--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#scalability-and-performance-sno-additional-worker-node
* https://54490--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-technology-preview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: LGTMs in original PR https://github.com/openshift/openshift-docs/pull/52489. This is just updating the TP table and adding `Technology Preview` to the RN, which were both missed in the original RN PR. The main content was merged with TP note [here](https://github.com/openshift/openshift-docs/pull/50251/files#diff-b79ec85439005ff5150992966521ea42a92adb527504f2a7cc680c794af16a20R220)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
