### PR TITLE
[enterprise-4.12] CCXDEV-9565 Insights Operator 4.12 RN

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -875,6 +875,17 @@ You can now configure OS-level tuning for nodes in a hosted cluster by using the
 [id="ocp-4-12-insights-operator"]
 === Insights Operator
 
+[id="ocp-4-12-insights-alerts"]
+==== Insights alerts 
+In {product-title} {product-version}, active Insights recommendations are now presented to the user as alerts. You can view and configure these alerts with Alertmanager.
+
+[id="ocp-4-12-insights-data-collection"]
+==== Insights Operator data collection enhancements
+In {product-title} {product-version}, the Insights Operator now collects the following metrics:
+
+* `console_helm_uninstalls_total`
+* `console_helm_upgrades_total`
+
 [id="ocp-4-12-auth"]
 === Authentication and authorization
 


### PR DESCRIPTION
Updates to 4.12 RN for Insights Operator

Version(s):
This applies to `enterprise-4.12`


Issue:
https://issues.redhat.com/browse/CCXDEV-9565?filter=-1

Link to docs preview:
https://54501--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-insights-operator

QE review:
- [x] QE has approved this change.




<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
