### PR TITLE
TELCODOCS:766 - update variables for new OSC version

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -50,8 +50,8 @@ endif::openshift-origin[]
 :sandboxed-containers-first: OpenShift sandboxed containers
 :sandboxed-containers-operator: OpenShift sandboxed containers Operator
 :sandboxed-containers-version: 1.3
-:sandboxed-containers-version-z: 1.3.0
-:sandboxed-containers-legacy-version: 1.2.2
+:sandboxed-containers-version-z: 1.3.2
+:sandboxed-containers-legacy-version: 1.3.1
 :cert-manager-operator: cert-manager Operator for Red Hat OpenShift
 :secondary-scheduler-operator-full: Secondary Scheduler Operator for Red Hat OpenShift
 :secondary-scheduler-operator: Secondary Scheduler Operator


### PR DESCRIPTION
Version(s): Only 4.12

Issue:
[TELCODOCS-766](https://issues.redhat.com/browse/TELCODOCS-766)

Link to docs preview: N/A—this change was only to the attributes file.

QE review:
- [x] QE has approved this change.
