### PR TITLE
BZ 1988292: Modified steps 3 & 4 related to machine config.

### DIFF
--- a/modules/rhcos-enabling-multipath-day-2.adoc
+++ b/modules/rhcos-enabling-multipath-day-2.adoc
@@ -64,7 +64,7 @@ spec:
 +
 [source,terminal]
 ----
-$ oc create -f ./99-master-kargs-mpath.yaml
+$ oc create -f ./99-worker-kargs-mpath.yaml
 ----
 
 . Check the machine configs to see that the new one was added:
@@ -84,10 +84,10 @@ NAME                                               GENERATEDBYCONTROLLER        
 01-master-kubelet                                  52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 01-worker-container-runtime                        52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 01-worker-kubelet                                  52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
-99-master-kargs-mpath                              52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             105s
 99-master-generated-registries                     52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 99-master-ssh                                                                                 3.2.0             40m
 99-worker-generated-registries                     52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
+99-worker-kargs-mpath                              52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             105s
 99-worker-ssh                                                                                 3.2.0             40m
 rendered-master-23e785de7587df95a4b517e0647e5ab7   52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 rendered-worker-5d596d9293ca3ea80c896a1191735bb1   52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m


### PR DESCRIPTION
BZ 1988292: Modified steps 3 & 4 related to Machine Config.

- Applies to 4.8 and above versions.
- [BZ 1988292](https://bugzilla.redhat.com/show_bug.cgi?id=1988292)
- [Docs Preview](https://54504--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#rhcos-enabling-multipath-day-2_post-install-machine-configuration-tasks)
- **Scope**- corrected the command in step 3 and accordingly modified the example output in step 4 in "Enabling multipathing with kernel arguments in RHCOS section. 

@jianli-wei ptal