### PR TITLE
Telcodocs 887 reorganising latency and moving under scalability

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -565,7 +565,7 @@ For more information, see xref:../networking/ingress-controller-dnsmgt.adoc#ingr
 For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
 
 [id="ocp-4-12-networking-supported-hardware-for-ovs"]
-==== Supported hardware for OvS (Open vSwitch) Hardware Offload 
+==== Supported hardware for OvS (Open vSwitch) Hardware Offload
 
 {product-title} 4.12 adds OvS Hardware Offload support for the following devices:
 
@@ -1676,8 +1676,12 @@ sourceStrategy:
 * Previously, custom SELinux policy modules were not properly supported by `rpm-ostree`, so they were not updated along with the rest of the system upon update. This would surface as failures in unrelated components. Pending SELinux userspace improvements landing in a future {product-title} release, this update provides a workaround to {op-system} that will rebuild and reload the SELinux policy during boot as needed. (link:https://issues.redhat.com/browse/OCPBUGS-595[*OCPBUGS-595*])
 
 [discrete]
-[id="ocp-4-12-low-latency-tuning-bug-fixes"]
-==== Low latency tuning
+[id="ocp-4-12-routing-bug-fixes"]
+==== Routing
+
+[discrete]
+[id="ocp-4-12-scalability-and-performance-bug-fixes"]
+==== Scalability and performance
 
 * The tuned profile has been modified to assign the same priority as `ksoftirqd` and `rcuc` to the newly introduced per-CPU kthreads (`ktimers`) added in a recent Red Hat Enterprise Linux (RHEL) kernel patch. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-3475[*OCPBUGS-3475*], link:https://bugzilla.redhat.com/show_bug.cgi?id=2117780[*BZ#2117780*] and link:https://bugzilla.redhat.com/show_bug.cgi?id=2122220[*BZ#2122220*].
 
@@ -1689,16 +1693,7 @@ sourceStrategy:
 
 * Previously, the `oslat` control thread was collocated with one of the test threads, which caused latency spikes in the measurements. With this fix, the `oslat` runner now reserves one CPU for the control thread, meaning the test uses one less CPU for running the busy threads. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2051443[*BZ#2051443*].
 
-
 * Latency measurement tools, also known as `oslat`, `cyclictest`, and `hwlatdetect`, now run on completely isolated CPUs without the helper process running in the background that might cause latency spikes, thus providing more accurate latency measurements. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-2618[*OCPBUGS-2618*].
-
-[discrete]
-[id="ocp-4-12-routing-bug-fixes"]
-==== Routing
-
-[discrete]
-[id="ocp-4-12-scalability-and-performance-bug-fixes"]
-==== Scalability and performance
 
 [discrete]
 [id="ocp-4-12-storage-bug-fixes"]


### PR DESCRIPTION
[Telcodocs 887]: Moving Low latency tuning bug fixes under Scalability and performance

Version(s):
4.12 RN

Issue:
https://issues.redhat.com/browse/TELCODOCS-887

Link to docs preview:
https://54517--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes


Additional information:
All content is already reviewed and was merged in https://github.com/openshift/openshift-docs/pull/53941 this is a simple move of the content which was in **Low latency tuning** moved under **Scalability and performance** to be consistent with the main docs menu and the previous doc releases.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
