### PR TITLE
OCPBUGS#5305 Changing community operators link.

### DIFF
--- a/modules/olm-operatorhub-overview.adoc
+++ b/modules/olm-operatorhub-overview.adoc
@@ -25,7 +25,7 @@ Cluster administrators can choose from catalogs grouped into the following categ
 |Certified software that can be purchased from link:https://marketplace.redhat.com/[Red Hat Marketplace].
 
 |Community Operators
-|Optionally-visible software maintained by relevant representatives in the link:https://github.com/operator-framework/community-operators[operator-framework/community-operators] GitHub repository. No official support.
+|Optionally-visible software maintained by relevant representatives in the link:https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators[redhat-openshift-ecosystem/community-operators-prod/operators] GitHub repository. No official support.
 
 |Custom Operators
 |Operators you add to the cluster yourself. If you have not added any custom Operators, the *Custom* category does not appear in the web console on your OperatorHub.

--- a/modules/olm-rh-catalogs.adoc
+++ b/modules/olm-rh-catalogs.adoc
@@ -38,7 +38,7 @@ The following Operator catalogs are distributed by Red Hat:
 
 |`community-operators`
 |`registry.redhat.io/redhat/community-operator-index:{tag}`
-|Software maintained by relevant representatives in the link:https://github.com/operator-framework/community-operators[operator-framework/community-operators] GitHub repository. No official support.
+|Software maintained by relevant representatives in the link:https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators[redhat-openshift-ecosystem/community-operators-prod/operators] GitHub repository. No official support.
 |===
 
 During a cluster upgrade, the index image tag for the default Red Hat-provided catalog sources are updated automatically by the Cluster Version Operator (CVO) so that Operator Lifecycle Manager (OLM) pulls the updated version of the catalog. For example during an upgrade from {product-title} 4.8 to 4.9, the `spec.image` field in the `CatalogSource` object for the `redhat-operators` catalog is updated from:


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/OCPBUGS-5305

Link to docs preview:
https://54527--docspreview.netlify.app/openshift-enterprise/latest/operators/understanding/olm-rh-catalogs.html#olm-rh-catalogs_olm-rh-catalogs
https://54527--docspreview.netlify.app/openshift-enterprise/latest/operators/understanding/olm-understanding-operatorhub.html

QE review:
- [X] QE has approved this change.

