### PR TITLE
CNV-18203: activating redirect rule to prevent CNV from releasing wit…

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -300,7 +300,7 @@ AddType text/vtt                            vtt
     # OpenShift Virtualization (CNV) catchall redirect; use when CNV releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `virt` directory traffic to the about-virt page.
     # To activate the redirects, uncomment the next line and update the version number to the pending release.
-    # RewriteRule container-platform/4\.11/virt/(?!about-virt\.html)(.+)$ /container-platform/4.11/virt/about-virt.html [NE,R=302]
+    RewriteRule container-platform/4\.12/virt/(?!about-virt\.html)(.+)$ /container-platform/4.12/virt/about-virt.html [NE,R=302]
 
     # Red Hat OpenShift support for Windows Containers (WMCO) catchall redirect; use when WMCO releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `windows_containers` directory traffic to the /windows_containers/index.html page.


### PR DESCRIPTION
…h OCP

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-18203](https://issues.redhat.com//browse/CNV-18203)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: N/A
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
<!--- [ ] QE has approved this change. --->
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

- Activated rule to redirect all /virt/* content to the about-virt.adoc assembly to support asynchronous release from OCP
- To be reversed when CNV 4.12 GAs (after merging placeholder reversal)
- No CP

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
