### PR TITLE
OSSMDOC-642 Removed sentence "Federation of meshes is not supported on Microsoft Azure Red Hat OpenShift (ARO)"

### DIFF
--- a/modules/ossm-federation-limitations.adoc
+++ b/modules/ossm-federation-limitations.adoc
@@ -9,4 +9,3 @@ This module included in the following assemblies:
 The {SMProductName} federated approach to joining meshes has the following limitations:
 
 * Federation of meshes is not supported on OpenShift Dedicated.
-* Federation of meshes is not supported on Microsoft Azure Red Hat OpenShift (ARO).


### PR DESCRIPTION
Per [OSSMDOC-642](https://issues.redhat.com//browse/OSSMDOC-642), the sentence: "Federation of meshes is not supported on Microsoft Azure Red Hat OpenShift (ARO)" has been removed.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.9x

Issue:
https://issues.redhat.com/browse/OSSMDOC-642

Link to docs preview:
https://54530--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-federation.html#ossm-federation-limitations_federation

QE review:
- QE is not required. 
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This change only removes the sentence as requested. Further review of docs related to federation are to be handled separately.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
