### PR TITLE
OSDOCS-4762: make subscription-manager command for oc evergreen

### DIFF
--- a/cli_reference/index.adoc
+++ b/cli_reference/index.adoc
@@ -2,6 +2,7 @@
 [id="cli-tools-overview"]
 = {product-title} CLI tools overview
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-microshift.adoc[]
 :context: cli-tools-overview
 
 toc::[]

--- a/modules/cli-installing-cli-rpm.adoc
+++ b/modules/cli-installing-cli-rpm.adoc
@@ -44,9 +44,9 @@ For {op-system-base-full}, you can install the OpenShift CLI (`oc`) as an RPM if
 
 . Enable the repositories required by {product-title} {product-version}.
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-# subscription-manager repos --enable="rhocp-4.11-for-rhel-8-x86_64-rpms"
+# subscription-manager repos --enable="rhocp-{ocp-version}-for-{rhel-major}-x86_64-rpms"
 ----
 +
 [NOTE]


### PR DESCRIPTION
Update the instructions for enabling the rhocp RPM repo to use attributes to substitute the version number for OCP and RHEL so they are accurate based on the build of the docs.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-4762

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A -- MicroShift is Developer Preview
SME approval is required (see above)


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
