### PR TITLE
OSDOCS-3263: Update Deleting ROSA STS cluster documentation to clarify when to delete roles

### DIFF
--- a/modules/rosa-deleting-cluster.adoc
+++ b/modules/rosa-deleting-cluster.adoc
@@ -125,8 +125,13 @@ $ rosa delete oidc-provider -c <cluster_id> --mode auto <1>
 ====
 You can use the `-y` option to automatically answer yes to the prompts.
 ====
-
-. Delete the cluster-specific Operator IAM roles:
++
+. Optional. Delete the cluster-specific Operator IAM roles:
++
+[IMPORTANT]
+====
+The account-wide IAM roles can be used by other ROSA clusters in the same AWS account. Only remove the roles if they are not required by other clusters.
+====
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.12+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-3263

Link to docs preview:
https://54543--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-deleting-cluster.html#rosa-deleting-cluster_rosa-sts-deleting-cluster

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
