### PR TITLE
TELCODOCS-1101: Update must-gather image versions

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -60,11 +60,11 @@ endif::openshift-dedicated[]
 |`registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:{sandboxed-containers-version}.0`
 |Data collection for {sandboxed-containers-first}.
 
-|`registry.redhat.io/workload-availability/self-node-remediation-must-gather-rhel8:v0.4.0`
-|Data collection for the Self Node Remediation Operator and the Node Health Check Operator.
+|`registry.redhat.io/workload-availability/self-node-remediation-must-gather-rhel8:v<installed-version-SNR>`
+|Data collection for the Self Node Remediation (SNR) Operator and the Node Health Check (NHC) Operator.
 
-|`registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v{product-version}.0`
-|Data collection for the Node Maintenance Operator.
+|`registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v<installed-version-NMO>`
+|Data collection for the Node Maintenance Operator (NMO).
 |===
 
 endif::openshift-origin[]


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-1101 Update must-gather image versions

Applies to OpenShift version : 4.12+

Preview: [Gathering data about specific features](https://54544--docspreview.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#gathering-data-specific-features_gathering-cluster-data)

Dev review complete/approved by @slintes 
QE review complete/approved by @anna-savina 
Peer review complete/approved @Amrita42 

Thank you.