### PR TITLE
SPLAT-709: tech preview zonal IPI installation on vSphere

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -441,7 +441,7 @@ Topics:
     File: installing-vsphere-installer-provisioned-customizations
   - Name: Installing a cluster on vSphere with network customizations
     File: installing-vsphere-installer-provisioned-network-customizations
-  - Name: Installing a cluster on vSphere with Mutliple Failure Domains
+  - Name: Installing a cluster on vSphere with multiple failure domains
     File: installing-vsphere-installer-provisioned-zones
   - Name: Installing a cluster on vSphere with user-provisioned infrastructure
     File: installing-vsphere

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -441,6 +441,8 @@ Topics:
     File: installing-vsphere-installer-provisioned-customizations
   - Name: Installing a cluster on vSphere with network customizations
     File: installing-vsphere-installer-provisioned-network-customizations
+  - Name: Installing a cluster on vSphere with Mutliple Failure Domains
+    File: installing-vsphere-installer-provisioned-zones
   - Name: Installing a cluster on vSphere with user-provisioned infrastructure
     File: installing-vsphere
   - Name: Installing a cluster on vSphere with user-provisioned infrastructure and network customizations

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-zones.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-zones.adoc
@@ -1,12 +1,12 @@
 :_content-type: ASSEMBLY
 [id="installing-vsphere-installer-provisioned-zones"]
-= Installing a cluster on vSphere with Mutliple Failure Domains
+= Installing a cluster on vSphere with multiple failure domains
 include::_attributes/common-attributes.adoc[]
 :context: installing-vsphere-installer-provisioned-zones
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster in to multiple failure domains on your VMware vSphere instance by using installer-provisioned infrastructure. A failure domain describes a unique topology which may consist of:
+In {product-title} version {product-version}, you can install a cluster into multiple failure domains on your VMware vSphere instance by using installer-provisioned infrastructure. A failure domain describes a unique topology which may consist of:
 
 * datacenter
 * compute cluster
@@ -61,8 +61,6 @@ include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
-
-include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-vsphere-zones-config-yaml.adoc[leveloffset=+2]
 

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-zones.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-zones.adoc
@@ -1,0 +1,108 @@
+:_content-type: ASSEMBLY
+[id="installing-vsphere-installer-provisioned-zones"]
+= Installing a cluster on vSphere with Mutliple Failure Domains
+include::_attributes/common-attributes.adoc[]
+:context: installing-vsphere-installer-provisioned-zones
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a cluster in to multiple failure domains on your VMware vSphere instance by using installer-provisioned infrastructure. A failure domain describes a unique topology which may consist of:
+
+* datacenter
+* compute cluster
+* datastore
+* portgroup
+* resource pool
+
+By defining multiple failure domains, administrators are able to distribute key control plane and workload elements among varied hardware resources in their datacenter. To customize the installation to install to multiple failure domains, you modify parameters in the `install-config.yaml` file before you install the cluster.
+
+:FeatureName: vSphere installations with multiple failure domains on {product-title}
+include::snippets/technology-preview.adoc[]
+
+== Prerequisites
+
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide `ReadWriteMany` access modes.
+* The {product-title} installer requires access to port 443 on the vCenter and ESXi hosts. You verified that port 443 is accessible.
+* If you use a firewall, you confirmed with the administrator that port 443 is accessible. Control plane nodes must be able to reach vCenter and ESXi hosts on port 443 for the installation to succeed.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+
++
+[NOTE]
+====
+Be sure to also review this site list if you are configuring a proxy.
+====
+
+include::modules/installation-vsphere-zones-prerequisites.adoc[]
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
+
+include::modules/installation-vsphere-installer-network-requirements.adoc[leveloffset=+1]
+
+include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* To remove a third-party CSI driver, see xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
+* To update the hardware version for your vSphere nodes, see xref:../../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
+
+include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]
+
+include::modules/installation-initializing.adoc[leveloffset=+1]
+
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
+include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
+
+include::modules/installation-vsphere-zones-config-yaml.adoc[leveloffset=+2]
+
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+[id="installing-vsphere-installer-provisioned-zones-registry"]
+== Creating registry storage
+After you install the cluster, you must create storage for the registry Operator.
+
+include::modules/registry-removed.adoc[leveloffset=+2]
+
+include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
+
+include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+3]
+
+include::modules/installation-registry-storage-block-recreate-rollout.adoc[leveloffset=+3]
+
+For instructions about configuring registry storage so that it references the correct PVC, see xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#registry-configuring-storage-vsphere_configuring-registry-storage-vsphere[Configuring the registry for vSphere].
+
+include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
+
+include::modules/cluster-telemetry.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
+
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
+== Next steps
+
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
+* If necessary, you can
+xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Set up your registry and configure registry storage].
+* Optional: xref:../../installing/installing_vsphere/using-vsphere-problem-detector-operator.adoc#vsphere-problem-detector-viewing-events_vsphere-problem-detector[View the events from the vSphere Problem Detector Operator] to determine if the cluster has permission or storage configuration issues.

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -188,6 +188,10 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]
 :vsphere:
 endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-zones"]
+:vsphere:
+:vsphere-zones:
+endif::[]
 ifeval::["{context}" == "installing-ibm-z"]
 :ibm-z:
 endif::[]
@@ -1586,6 +1590,48 @@ In {product-title} 4.12 and later, the `apiVIP` configuration setting is depreca
 In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a list format to enter a value in the `ingressVIPs` configuration setting.
 ====
 
+ifdef::vsphere-zones[] 
+|`platform.vsphere.failureDomains`
+|Optional. The list of failure domain definitions.
+|Array of `failureDomain` definitions.
+
+|`platform.vsphere.failureDomains.*.name`
+|Required. The name of the failure domain. This name will be referred to by the machine pools.
+|String
+
+|`platform.vsphere.failureDomains.*.region`
+|Required. The value of the openshift-region tag assigned to the topology for the failure failure domain.
+|String
+
+|`platform.vsphere.failureDomains.*.zone`
+|Required. The value of the openshift-zone tag assigned to the topology for the failure failure domain.
+|String
+
+|`platform.vsphere.failureDomains.*.topology.datacenter`
+|Required. The datacenter associated with the failure domain. If not defined, the datacenter defaults to `platform.vsphere.datacenter`.
+|String
+
+|`platform.vsphere.failureDomains.*.topology.computeCluster`
+|Required. The compute cluster associated with the failure domain. If not defined, the compute cluster is derived from `platform.vsphere.cluster` and `platform.vsphere.datacenter`.
+|String
+
+|`platform.vsphere.failureDomains.*.topology.datastore`
+|Required. The datastore associated with the failure domain. If not defined, the datastore is derived from `platform.vsphere.defaultDatastore`.
+|String
+
+|`platform.vsphere.failureDomains.*.topology.networks`
+|Required. The port groups associated with the failure domain. If not defined, the port group is derived from `platform.vsphere.network`.  Note: Only a single port group may be defined at this time.
+|String
+
+|`platform.vsphere.failureDomains.*.topology.resourcePool`
+|Required. The resource pool associated with the failure domain. If not defined, the resource pool is derived from `platform.vsphere.failureDomains.*.topology.computeCluster`.
+|String
+
+|`platform.vsphere.failureDomains.*.topology.folder`
+|Required. The VM folder associated with the failure domain where machines are to be deployed. If not defined, the folder is derived from `platform.vsphere.folder`.
+|String
+endif::vsphere-zones[] 
+
 |`platform.vsphere.diskType`
 |Optional. The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
 |Valid values are `thin`, `thick`, or `eagerZeroedThick`.
@@ -1612,6 +1658,12 @@ Optional VMware vSphere machine pool configuration parameters are described in t
 |`platform.vsphere.cpus`
 |The total number of virtual processor cores to assign a virtual machine.
 |Integer
+
+ifdef::vsphere-zones[] 
+|`platform.vsphere.zones`
+|Optional. Failure domains which are associated with machines in the machine pool.  If not defined, machines will be distributed among available failure domains.
+|String array of `platform.vsphere.failureDomains.*.name` names
+endif::vsphere-zones[]
 
 |`platform.vsphere.coresPerSocket`
 |The number of cores per socket in a virtual machine. The number of virtual sockets on the virtual machine is `platform.vsphere.cpus`/`platform.vsphere.coresPerSocket`. The default value is `1`

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1595,40 +1595,40 @@ ifdef::vsphere-zones[]
 |Optional. The list of failure domain definitions.
 |Array of `failureDomain` definitions.
 
-|`platform.vsphere.failureDomains.*.name`
-|Required. The name of the failure domain. This name will be referred to by the machine pools.
+|`platform.vsphere.failureDomains.name`
+|Required. The name of the failure domain. The machine pools will use this name to reference the failure domain.
 |String
 
-|`platform.vsphere.failureDomains.*.region`
-|Required. The value of the openshift-region tag assigned to the topology for the failure failure domain.
+|`platform.vsphere.failureDomains.region`
+|Required. The value of the openshift-region tag assigned to the topology for the failure domain.
 |String
 
-|`platform.vsphere.failureDomains.*.zone`
-|Required. The value of the openshift-zone tag assigned to the topology for the failure failure domain.
+|`platform.vsphere.failureDomains.zone`
+|Required. The value of the openshift-zone tag assigned to the topology for the failure domain.
 |String
 
-|`platform.vsphere.failureDomains.*.topology.datacenter`
+|`platform.vsphere.failureDomains.topology.datacenter`
 |Required. The datacenter associated with the failure domain. If not defined, the datacenter defaults to `platform.vsphere.datacenter`.
 |String
 
-|`platform.vsphere.failureDomains.*.topology.computeCluster`
-|Required. The compute cluster associated with the failure domain. If not defined, the compute cluster is derived from `platform.vsphere.cluster` and `platform.vsphere.datacenter`.
+|`platform.vsphere.failureDomains.topology.computeCluster`
+|Required. The compute cluster associated with the failure domain. If not defined, the compute cluster takes the value of `platform.vsphere.cluster` and `platform.vsphere.datacenter`.
 |String
 
-|`platform.vsphere.failureDomains.*.topology.datastore`
-|Required. The datastore associated with the failure domain. If not defined, the datastore is derived from `platform.vsphere.defaultDatastore`.
+|`platform.vsphere.failureDomains.topology.datastore`
+|Required. The datastore associated with the failure domain. If not defined, the datastore takes the value of `platform.vsphere.defaultDatastore`.
 |String
 
-|`platform.vsphere.failureDomains.*.topology.networks`
-|Required. The port groups associated with the failure domain. If not defined, the port group is derived from `platform.vsphere.network`.  Note: Only a single port group may be defined at this time.
+|`platform.vsphere.failureDomains.topology.networks`
+|Required. The port groups associated with the failure domain. If not defined, the port group takes the value of `platform.vsphere.network`.  Note: Only a single port group may be defined at this time.
 |String
 
-|`platform.vsphere.failureDomains.*.topology.resourcePool`
-|Required. The resource pool associated with the failure domain. If not defined, the resource pool is derived from `platform.vsphere.failureDomains.*.topology.computeCluster`.
+|`platform.vsphere.failureDomains.topology.resourcePool`
+|Required. The resource pool associated with the failure domain. If not defined, the resource pool takes the value of `platform.vsphere.failureDomains.topology.computeCluster`.
 |String
 
-|`platform.vsphere.failureDomains.*.topology.folder`
-|Required. The VM folder associated with the failure domain where machines are to be deployed. If not defined, the folder is derived from `platform.vsphere.folder`.
+|`platform.vsphere.failureDomains.topology.folder`
+|Required. The VM folder associated with the failure domain where machines are to be deployed. If not defined, the folder takes the value of `platform.vsphere.folder`.
 |String
 endif::vsphere-zones[] 
 
@@ -1970,6 +1970,10 @@ ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations
 endif::[]
 ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
 :!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-zones"]
+:!vsphere:
+:!vsphere-zones:
 endif::[]
 ifeval::["{context}" == "installing-vmc-customizations"]
 :!vmc:

--- a/modules/installation-vsphere-zones-config-yaml.adoc
+++ b/modules/installation-vsphere-zones-config-yaml.adoc
@@ -1,0 +1,105 @@
+[id="installation-vsphere-zones-config-yaml_{context}"]
+= Sample install-config.yaml customizations for an installer-provisioned VMware vSphere cluster in multiple failure domains
+
+You can further customize the install-config.yaml file to specify more details about your {product-title} cluster's failure domain topology.
+
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com
+featureGate: TechPreviewNoUpgrade<13>
+compute: 
+- hyperthreading: Enabled 
+  name: worker
+  replicas: 3 
+  vsphere:
+    zones: <1>
+      - "failure-domain-1"
+      - "failure-domain-2"
+      - "failure-domain-3"
+controlPlane: 
+  hyperthreading: Enabled
+  name: master
+  replicas: 3 
+  vsphere:
+    zones: <1>
+      - "failure-domain-1"
+      - "failure-domain-2"
+      - "failure-domain-3"
+metadata:
+  name: cluster
+platform:
+  vsphere: 
+    vcenter: your.vcenter.server <2>
+    username: username <2>
+    password: password <2>
+    datacenter: datacenter <2> 
+    defaultDatastore: datastore <2>
+    folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>" <2>
+    cluster: cluster <2>
+    resourcePool: "/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>" <2>
+    diskType: thin 
+    failureDomains: <3>
+    - name: failure-domain-1 <4>
+      region: region-a <5>
+      zone: zone-a <6>
+      topology: <7>
+        datacenter: region-a-dc <8>
+        computeCluster: /region-a-dc/host/zone-a-cluster <9>
+        resourcePool: <10>
+        networks: <11>
+        - port-group
+        datastore: datastore-a <12>
+    - name: failure-domain-2
+      region: region-a
+      zone: zone-b
+      topology:
+        datacenter: region-a-dc
+        computeCluster: /region-a-dc/host/zone-b-cluster
+        networks:
+        - port-group
+        datastore: datastore-b
+    - name: failure-domain-3
+      region: region-b
+      zone: zone-a
+      topology:
+        datacenter: region-b-dc
+        computeCluster: /region-b-dc/host/zone-a-cluster
+        networks:
+        - port-group
+        datastore: datastore-c
+----
+
+<1> Optional: The list of failure domains among which the nodes in the machine pool will be distributed.
+If not defined, nodes will be distributed among all defined failure-domains.
+
+<2> The default vCenter topology. This is used to deploy the bootstrap node and defines the
+default datastore for vSphere persistent volumes.
+
+<3> Optional: The list of failure domains associated with the vCenter.  If not defined, the default
+vCenter topology defined in <2> will be used.
+
+<4> The name of the failure domain.  This name is used in <1> to scope a machine pool to the failure domain.
+
+<5> The value of the `openshift-region` tag assigned to the topology for the failure failure domain.
+
+<6> The value of the `openshift-zone` tag assigned to the topology for the failure failure domain.
+
+<7> The vCenter reources associated with the failure domain.
+
+<8> Optional: The datacenter associated with the failure domain. If not defined, the datacenter is derived from <2>.
+
+<9> Optional: The full path of the compute cluster associated with the failure domain. If not defined, the compute cluster is derived from <2>.
+
+<10> Optional: The full path of the resource pool associated with the failure domain. If not defined, the resource pool is derived from <2>.
+
+<11> Optional: The port group associated with the failure domain. If not defined, the port group is derived from <2>.
+
+<12> Optional: The datastore associated with the failure domain. If not defined, the datastore is derived from <2>.
+
+<13> This feature is a technology preview and as such requires the `TechPreviewNoUpgrade` feature gate be configured in the `install-config.yaml`.
++
+[IMPORTANT]
+====
+Failure domains are immutable and may not to be changed after installation.  Additional failure domains, however, may be created.
+====

--- a/modules/installation-vsphere-zones-config-yaml.adoc
+++ b/modules/installation-vsphere-zones-config-yaml.adoc
@@ -7,7 +7,7 @@ You can further customize the install-config.yaml file to specify more details a
 ----
 apiVersion: v1
 baseDomain: example.com
-featureGate: TechPreviewNoUpgrade<13>
+featureGate: TechPreviewNoUpgrade <13>
 compute: 
 - hyperthreading: Enabled 
   name: worker
@@ -46,7 +46,7 @@ platform:
       topology: <7>
         datacenter: region-a-dc <8>
         computeCluster: /region-a-dc/host/zone-a-cluster <9>
-        resourcePool: <10>
+        resourcePool: /region-a-dc/host/zone-a-cluster/Resources/resource-pool <10>
         networks: <11>
         - port-group
         datastore: datastore-a <12>
@@ -101,5 +101,5 @@ vCenter topology defined in <2> will be used.
 +
 [IMPORTANT]
 ====
-Failure domains are immutable and may not to be changed after installation.  Additional failure domains, however, may be created.
+Failure domains are immutable and may not be changed after installation.  Additional failure domains may be created after installation.
 ====

--- a/modules/installation-vsphere-zones-config-yaml.adoc
+++ b/modules/installation-vsphere-zones-config-yaml.adoc
@@ -7,7 +7,7 @@ You can further customize the install-config.yaml file to specify more details a
 ----
 apiVersion: v1
 baseDomain: example.com
-featureGate: TechPreviewNoUpgrade <13>
+featureSet: TechPreviewNoUpgrade <13>
 compute: 
 - hyperthreading: Enabled 
   name: worker

--- a/modules/installation-vsphere-zones-prerequisites.adoc
+++ b/modules/installation-vsphere-zones-prerequisites.adoc
@@ -1,0 +1,20 @@
+[id="installation-vsphere-zones-prerequisites_{context}"]
+== Prerequisites Specific to Multiple Failure Domains
+
+* All failure domains must share a common layer 3 network
+* Tag categories `openshift-region` and `openshift-zone` are created in vCenter.
+* Tags are applied to datacenters and compute clusters representing the name of their associated region and/or zone. 
+
+For example, if `datacenter-1` represents `region-a` and `compute-cluster-1` represents `zone-1` then a tag of category `openshift-region` with a value of `region-a` is applied to `datacenter-1`.  Addtionally, a tag of category `openshift-zone` with a value of `zone-1` is applied to `compute-cluster-1`.
+
++
+[IMPORTANT]
+====
+If tags are not applied prior to installation, nodes may not be labeled with the `topology.kubernetes.io/zone` and `topology.kubernetes.io/region` labels by the cloud provider.
+====
+
++
+[IMPORTANT]
+====
+The API and ingress VIPs require that failure domains share a common Layer 3 network. 
+====

--- a/modules/installation-vsphere-zones-prerequisites.adoc
+++ b/modules/installation-vsphere-zones-prerequisites.adoc
@@ -1,19 +1,17 @@
 [id="installation-vsphere-zones-prerequisites_{context}"]
-== Prerequisites Specific to Multiple Failure Domains
+== Prerequisites for multiple failure domains
 
-* All failure domains must share a common layer 3 network
-* Tag categories `openshift-region` and `openshift-zone` are created in vCenter.
-* Tags are applied to datacenters and compute clusters representing the name of their associated region and/or zone. 
+* All failure domains share a common layer 3 network
+* You created tag categories `openshift-region` and `openshift-zone` in vCenter.
+* Datacenters and compute clusters have tags representing the name of their associated region and/or zone. 
 
-For example, if `datacenter-1` represents `region-a` and `compute-cluster-1` represents `zone-1` then a tag of category `openshift-region` with a value of `region-a` is applied to `datacenter-1`.  Addtionally, a tag of category `openshift-zone` with a value of `zone-1` is applied to `compute-cluster-1`.
+For example, if `datacenter-1` represents `region-a` and `compute-cluster-1` represents `zone-1`, then a tag of category `openshift-region` with a value of `region-a` is applied to `datacenter-1`.  Addtionally, a tag of category `openshift-zone` with a value of `zone-1` is applied to `compute-cluster-1`.
 
-+
 [IMPORTANT]
 ====
 If tags are not applied prior to installation, nodes may not be labeled with the `topology.kubernetes.io/zone` and `topology.kubernetes.io/region` labels by the cloud provider.
 ====
 
-+
 [IMPORTANT]
 ====
 The API and ingress VIPs require that failure domains share a common Layer 3 network. 


### PR DESCRIPTION
Version(s):
4.12

Issue:
[SPLAT-863](https://issues.redhat.com/browse/SPLAT-863)

Link to docs preview:
https://54549--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-zones.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
In 4.12, IPI installs may be performed in to multiple failure domains.  This PR describes how to configure such an installation.