### PR TITLE
OSDOCS-4653-v2: MicroShift release notes

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -6,15 +6,67 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-// Update All for MicroShift; text is FPO (for placement only)
-Red Hat {product-title} provides developers and IT organizations with small form factor and edge computing, delivered as an application that customers can deploy on top of their managed {op-system-first} devices at the edge. Built on {op-system-first} and Kubernetes, {product-title} provides an efficient way to operate single-node clusters in low-resource edge environments.
+{product-title} provides developers and IT organizations with small-form-factor and edge computing, delivered as an application that customers can deploy on top of their managed {op-system-first} devices at the edge. Built on {op-system-first} and Kubernetes, {product-title} provides an efficient way to operate single-node clusters in low-resource edge environments.
 
 {product-title} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
 
-//[id="microshift-4-12-about-this-release"]
+[id="microshift-4-12-about-this-release"]
 == About this release
 
-// TODO: Update with the relevant information/ links.
-{product-title} is now available as a Developer Preview. Features and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} is now available as a Developer Preview software. Features and known issues that pertain to {product-title} {product-version} are included in this topic. For more information about the support scope of Red Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
 
-{product-title} {product-version} is supported on {op-system-first} 4.12 and {op-system-base-full} 8.4 and 8.5.
+[IMPORTANT]
+====
+Red Hat will not provide or support an update or upgrade path from Developer Preview and Technology Preview versions to later versions of {product-title}. A new installation will be necessary.
+====
+
+[id="microshift-known-issues"]
+== Known issues
+* There is an issue exporting services via the Route API when the host and routerCanonicalHostname do not include the sub domain name. To work around this problem, use the subdomain setting when creating a Route.
++
+.Example
+[source, terminal]
+----
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: route-1
+spec:
+  subdomain: svc-subdomain  ⇐ specify the subdomain
+  port:
+    targetPort: 8080
+  to:
+    kind: Service
+    name: svc-1
+----
+
+* There is an issue resuming pods when a service is idled. The {product-title} software does not support automatically reactivating services, and manual re-scaling the replicas is required.
+
+* It is possible to over-provision the storage system by creating persistent volumes (PVs) that do not actually fit on the disk when using the `spare-gb` configuration value in `lvmd.conf`. To protect capacity from being used by the `topoLVM` driver, use a new separate volume group (VG) that is not exposed to `topoLVM`.
+
+* There is a known issue involving the `runc` CLI tool and `systemd`. `runc` is overly verbose about `mount ops`. These messages are innocuous and do not indicate a problem with the system's operation. This bug affects any Linux platform running a container runtime built on `runc`.
++
+You can suppress all `runc` mount logs through `systemd`. Create the file `/etc/systemd/system/run-containerd-.mount.d/10-silence.conf`, or whatever prefix you need to silence, with:
++
+[source, terminal]
+----
+[Mount] LogLevelMax=notice
+----
++
+And reload the daemon.
+
+* There is an issue with the way {product-title}'s CNI driver manages the firewall rules. If the firewall settings are modified after {product-title} is started then {product-title} must be restarted. The recommended workaround is to configure firewall rules before starting {product-title}.
+
+[id="microshift-4-12-asynchronous-errata-updates"]
+== Asynchronous errata updates
+
+Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red Hat Network. All {product-title} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
+
+Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified through email whenever new errata relevant to their registered systems are released.
+
+[NOTE]
+====
+Red Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
+====
+
+This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {product-version}. Versioned asynchronous releases, for example with the form {product-title} {product-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.


### PR DESCRIPTION
Replaces [OSDOCS-4653](https://issues.redhat.com//browse/OSDOCS-4653), a PR that broke upon attempted updates. This is the first set of Release Notes for MicroShift and contains a handful of Known Issues only. All of the peer-review changes are captured here.

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4653

Link to docs preview:
https://54556--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html

QE review:
N/A -- MicroShift is Developer Preview
SME approval is required (given, see https://github.com/openshift/openshift-docs/pull/54515)

Peer review:
Also done (see https://github.com/openshift/openshift-docs/pull/54515)

Additional information:
The original PR was SME approved and peer-reviewed. Upon pushing final updates, I encountered myriad errors. Tried All the Things until Git gave up and merged it with no changes. Redoing here what was approved there.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
