### PR TITLE
Patch release update for 3.72.3

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -44,7 +44,7 @@ endif::[]
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 3.72.1
+:rhacs-version: 3.72.3
 :ocp-supported-version: 4.5
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 3.72

--- a/release_notes/372-release-notes.adoc
+++ b/release_notes/372-release-notes.adoc
@@ -11,9 +11,13 @@ toc::[]
 .Release dates
 [options="header"]
 |====
+
 |{product-title-short} version |Released on
 |`3.72.0` |26 September 2022
 |`3.72.1` |20 October 2022
+|`3.72.2` |1 December 2022
+|`3.72.3` |12 January 2023
+
 |====
 
 [IMPORTANT]
@@ -291,6 +295,17 @@ The patch release 3.72.1 fixes this error and the reports show the correct CVEs.
 * In {product-title-short} 3.72.0, when you created a deployment bundle by using the `roxctl` CLI that explicitly disabled Pod Security Policies (PSP), the generated bundle still created manifests for the PSP.
 As a result, installing the deployment bundle failed when deploying on Kubernetes versions 1.25 or later.
 The patch release 3.72.1 correctly disables PSP when you specify `--enable-pod-security-policies=false` with the `roxctl` CLI.
+
+[id="resolved-in-version-3723"]
+=== Resolved in version 3.72.3
+
+Release date: 12 January 2023
+
+* The release of RHACS 3.72.3 addresses the following security
+vulnerabilities identified in the previous release:
+
+- link:https://access.redhat.com/errata/RHSA-2022:7089[RHSA-2022:7089]
+- link:https://access.redhat.com/security/cve/cve-2022-3515[CVE-2022-3515]
 
 [id="image-versions-372"]
 == Image versions


### PR DESCRIPTION
Patch release updates for 3.72.3

Preview: https://openshift-docs-git-3723-patch-release-gnelson.vercel.app/openshift-acs/master/release_notes/372-release-notes.html

Merge into `rhacs-docs-3.72`
- No cherrypicks

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
