### PR TITLE
removing OCPBUGS-5423 added in error by CORN process

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -895,7 +895,7 @@ You can now configure OS-level tuning for nodes in a hosted cluster by using the
 === Insights Operator
 
 [id="ocp-4-12-insights-alerts"]
-==== Insights alerts 
+==== Insights alerts
 In {product-title} {product-version}, active Insights recommendations are now presented to the user as alerts. You can view and configure these alerts with Alertmanager.
 
 [id="ocp-4-12-insights-data-collection"]
@@ -2412,7 +2412,7 @@ $ ./openshift-install wait-for install-complete
 
 * Due to an unresolved metadata API issue, you cannot install clusters that use bare-metal workers on {rh-openstack} 16.1. Clusters on {rh-openstack} 16.2 are not impacted by this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033953[*BZ#2033953*])
 
-* The `loadBalancerSourceRanges` attribute is not supported, and is thus ignored, in load-balancer type services in clusters that run on {rh-openstack} and use the OVN Octavia provider. There is no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-2789[*OCPBUGS-2789*]) 
+* The `loadBalancerSourceRanges` attribute is not supported, and is thus ignored, in load-balancer type services in clusters that run on {rh-openstack} and use the OVN Octavia provider. There is no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-2789[*OCPBUGS-2789*])
 
 * Platform Operator and RukPak known issues:
 
@@ -2431,22 +2431,6 @@ $ ./openshift-install wait-for install-complete
 * There is currently a known issue when you run the Agent-based {product-title} Installer to generate an ISO image from a directory where the previous release was used for ISO image generation. An error message is displayed with the release version not matching. As a workaround, create and use a new directory. (link:https://issues.redhat.com/browse/OCPBUGS-5159[*OCPBUGS#5159*])
 
 * The defined capabilities in the `install-config.yaml` file are not applied in the Agent-based {product-title} installation. Currently, there is no workaround. (link:https://issues.redhat.com/browse/OCPBUGS-5129[*OCPBUGS#5129*])
-
-* Pods in the `openshift-marketplace` namespace cause `PodSecurityViolation` alerts in a default {product-title} cluster. This is because the newly created project's `pod-security.kubernetes.io/warn` annotation and audit are restricted, and the CatalogSource's `spec.grpcPodConfig.securityContextConfig` field is not restricted by default, so you will get the related pod security admission (PSA) warnings, like below:
-+
-[source,terminal]
-----
-W0105 03:04:13.729506 1 warnings.go:70 would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "registry-server" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "registry-server" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "registry-server" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "registry-server" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
-----
-+
-The following `PodSecurityViolation` alert is also displayed in the `Status` window of the web console:
-+
-[source,terminal]
-----
-A workload (pod,deployment,daemonsset,...) was created in the cluster but it did not match the PodSecurity `restricted` profile defined by its namespace either via the cluster-wide configuration (which triggers on a `restricted` profile violations) or by the namespace local Pod Security labels. Refer to Kubernetes documentation on Pod Security Admission to learn more about these viloations.
-----
-+
-As a workaround, remove those warnings by changing the project's `pod-security.kubernetes.io/warn` label and audit to `baseline` or change the CatalogSource's `spec.grpcPodConfig.securityContextConfig` field to `restricted`. (link:https://issues.redhat.com/browse/OCPBUGS-5423[*OCPBUGS-5423])
 
 [id="ocp-4-12-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
[OCPBUGS-5423]: openshift-marketplace pods cause PodSecurityViolation alert to fire
Description added by mistake by CORN Process so removing as not a known issue

Version(s):
4.12 RN
Issue:
https://issues.redhat.com/browse/OCPBUGS-5423

preview: https://54572--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-known-issues

Additional information:
This PR removes the issue OCPBUGS-5423 added in error by CORN process. Issue identified as addressed by as evidenced by comments in https://issues.redhat.com/browse/OCPBUGS-5423
