### PR TITLE
OSDOCS-4762: MicroShift: Fix OCP version reference in install command

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -4,7 +4,6 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
-:ocp-version: 4.12
 :rhel-major: rhel-8
 :op-system-first: Red Hat Enterprise Linux (RHEL)
 :op-system: RHEL

--- a/modules/microshift-installing-from-rpm.adoc
+++ b/modules/microshift-installing-from-rpm.adoc
@@ -20,7 +20,7 @@ Use the following procedure to install {product-title} from an RPM package.
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos \
-    --enable rhocp-{ocp-version}-for-rhel-8-$(uname -i)-rpms \
+    --enable rhocp-{product-version}-for-rhel-8-$(uname -i)-rpms \
     --enable fast-datapath-for-{rhel-major}-$(uname -i)-rpms
 ----
 


### PR DESCRIPTION
This commit also removes the previously-defined `{ocp-version}` attribute, as this was duplicated effort and represents an unnecessary maintenance cost.

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-4762

Link to docs preview:
https://54576--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html

QE review:
- N/A, MicroShift is a developer preview

Additional information:
N/A