### PR TITLE
SPLAT-767: permission validation now works for vsphere

### DIFF
--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -480,14 +480,12 @@ Use the `openshift-install` command from the bastion hosted in the VMC environme
 ====
 endif::vmc[]
 +
-ifndef::vsphere[]
 [NOTE]
 ====
 If the cloud provider account that you configured on your host does not have sufficient
 permissions to deploy the cluster, the installation process stops, and the
 missing permissions are displayed.
 ====
-endif::vsphere[]
 
 ifdef::aws[]
 . Optional: Remove or disable the `AdministratorAccess` policy from the IAM


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/SPLAT-767

Link to docs preview:
Because of the conditional statements, this change will appear in multiple vSphere topics, but [this one](https://54590--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-launching-installer_installing-vsphere-installer-provisioned-customizations) is representative.

QE review:
- [x] QE has approved this change.