### PR TITLE
OSDOCS-4792: Bump to Nutanix AOS version

### DIFF
--- a/modules/installation-nutanix-infrastructure.adoc
+++ b/modules/installation-nutanix-infrastructure.adoc
@@ -13,6 +13,6 @@ You must install the {product-title} cluster to a Nutanix environment that meets
 [cols=2, options="header"]
 |===
 |Component |Required version
-|Nutanix AOS | 5.20.4+ or 6.1.1+
+|Nutanix AOS | 5.20.4+ or 6.5.1+
 |Prism Central | 2022.4+
 |===


### PR DESCRIPTION
Version(s):
4.12+

Issue:
This PR addresses [osdocs-4792](https://issues.redhat.com/browse/OSDOCS-4792)

Link to docs preview:

[Preparing to install on Nutanix](https://54593--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/preparing-to-install-on-nutanix.html)

QE review:
- [x ] QE has approved this change.
