### PR TITLE
OSDOCS-3940 Release Notes GCP VPC installation

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -121,6 +121,12 @@ Using the oc-mirror CLI plug-in to mirror file-based catalog Operator images in 
 
 For more information, see xref:../installing/disconnected_install/installing-mirroring-disconnected.adoc#oc-mirror-oci-format_installing-mirroring-disconnected[Mirroring file-based catalog Operator images in OCI format].
 
+[id="ocp-4-12-gcp-shared-vpc"]
+==== Installing an {product-title} cluster on GCP into a shared VPC (Technology Preview)
+In {product-title} {product-version}, you can install a cluster on GCP into a shared VPC as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]. In this installation method, the cluster is configured to use a VPC from a different GCP project. A shared VPC enables an organization to connect resources from multiple projects to a common VPC network. You can communicate within the organization securely and efficiently by using internal IP addresses from that network. 
+
+For more information, see xref:../installing/installing_gcp/installing-gcp-shared-vpc.adoc#installing-gcp-shared-vpc[Installing a cluster on GCP into a shared VPC].
+
 [id="ocp-4-12-consistent-address-for-ironicapi"]
 ==== Consistent IP address for Ironic API in bare-metal installations without a provisioning network
 With this update, in bare-metal installations without a provisioning network, the Ironic API service is accessible through a proxy server. This proxy server provides a consistent IP address for the Ironic API service. If the Metal3 pod that contains `metal3-ironic` relocates to another pod, the consistent proxy address ensures constant communication with the Ironic API service.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3940 Release Notes

Version(s):
4.12

Link to docs preview: https://54594--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-gcp-shared-vpc

QE review:
- [ ] QE has approved this change.

