### PR TITLE
[enterprise-4.11] Simple table reorgn for SDN docs

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -83,14 +83,14 @@
 |101b
 
 |Mellanox
-|MT2894 Family [ConnectX&#8209;6{nbsp}Lx]
-|15b3
-|101f
-
-|Mellanox
 |MT2892 Family [ConnectX&#8209;6{nbsp}Dx]
 |15b3
 |101d
+
+|Mellanox
+|MT2894 Family [ConnectX&#8209;6{nbsp}Lx]
+|15b3
+|101f
 
 |Pensando ^[1]^
 |DSC-25 dual-port 25G distributed services card for ionic driver


### PR DESCRIPTION
A followup PR to https://github.com/openshift/openshift-docs/pull/54429. This swaps the family order so that they're chronologically correct. 

Preview: https://54595--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov

No issue.

Peer review acks received at https://github.com/openshift/openshift-docs/pull/54476. 

No QE needed. 