### PR TITLE
RHDEVDOCS-3456-how-to-view-default-monitoring-metrics

### DIFF
--- a/modules/monitoring-viewing-a-list-of-available-metrics.adoc
+++ b/modules/monitoring-viewing-a-list-of-available-metrics.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * monitoring/managing-metrics.adoc
+
+:_content-type: PROCEDURE
+[id="viewing-a-list-of-available-metrics_{context}"]
+= Viewing a list of available metrics
+
+As a cluster administrator or as a user with view permissions for all projects, you can view a list of metrics available in a cluster and output the list in JSON format.
+
+.Prerequisites
+* You have installed the {product-title} CLI (`oc`).
+* You have obtained the {product-title} API route for Thanos Querier.
+* You are a cluster administrator, or you have access to the cluster as a user with the `cluster-monitoring-view` role.
++
+[NOTE]
+====
+You can only use bearer token authentication to access the Thanos Querier API route.
+====
+
+.Procedure
+
+. If you have not obtained the {product-title} API route for Thanos Querier, run the following command:
++
+[source,terminal]
+----
+$ oc get routes -n openshift-monitoring thanos-querier -o jsonpath='{.status.ingress[0].host}'
+----
+
+. Retrieve a list of metrics in JSON format from the Thanos Querier API route by running the following command. This command uses `oc` to authenticate with a bearer token.
++
+[source,terminal]
+----
+$ curl -k -H "Authorization: Bearer $(oc whoami -t)" https://<thanos_querier_route>/api/v1/metadata <1>
+----
+<1> Replace `<thanos_querier_route>` with the {product-title} API route for Thanos Querier.

--- a/monitoring/managing-metrics.adoc
+++ b/monitoring/managing-metrics.adoc
@@ -30,6 +30,9 @@ include::modules/monitoring-specifying-how-a-service-is-monitored.adoc[leveloffs
 * xref:../rest_api/monitoring_apis/podmonitor-monitoring-coreos-com-v1.adoc[PodMonitor API]
 * xref:../rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.adoc[ServiceMonitor API]
 
+// Viewing a list of available metrics for a cluster
+include::modules/monitoring-viewing-a-list-of-available-metrics.adoc[leveloffset=+1]
+
 [id="next-steps_querying-metrics"]
 == Next steps
 


### PR DESCRIPTION
Summary: This PR documents a `curl` command that returns a list of all metrics available for a cluster, including metadata, using the Thanos Querier API route.

- Aligned team: DevTools
- For branches: 4.12+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3456
- Direct link to doc preview: https://54596--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-metrics.html#viewing-a-list-of-available-metrics_managing-metrics
- SME review: @simonpasquier 
- QE review: @juzhao 
- Peer review: @rh-tokeefe 