### PR TITLE
RHDEVDOCS-4825-add-monitoring-tech-preview-feature-to-list

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -34,6 +34,7 @@ The following Technology Preview features are enabled by this feature set:
 ** Cluster API. Enables the integrated upstream Cluster API in {product-title} with the `ClusterAPIEnabled` feature gate. Available as a Technology Preview for:
 *** Amazon Web Services (AWS)
 *** Google Cloud Platform (GCP)
+** Managing alerting rules for core platform monitoring
 
 ////
 Do not document per Derek Carr: https://github.com/openshift/api/pull/370#issuecomment-510632939

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -17,6 +17,7 @@ include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+1]
 ** xref:../../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_cluster-operators-ref[Cluster Cloud Controller Manager Operator]
 ** xref:../../cicd/builds/build-strategies.adoc#builds-using-build-volumes_build-strategies-s2i[Source-to-image (S2I) build volumes] and xref:../../cicd/builds/build-strategies.adoc#builds-using-build-volumes_build-strategies-docker[Docker build volumes]
 ** xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-swap-memory_nodes-nodes-jobs[Swap memory on nodes]
+** xref:../../monitoring/managing-alerts.adoc#managing-core-platform-alerting-rules_managing-alerts[Managing alerting rules for core platform monitoring]
 
 include::modules/nodes-cluster-enabling-features-install.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Summary: This PR adds "Managing alerting rules for core platform monitoring" to the list of Tech Preview features that are available after tech previews are enabled.

- Aligned team: DevTools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4825
- Direct link to doc preview: https://54598--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling
- SME review: n/a
- QE review: @juzhao 
- Peer review: @jc-berger 