### PR TITLE
4.12 GA

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -154,7 +154,7 @@ AddType text/vtt                            vtt
 
     # Redirects for "latest" version
     RewriteRule ^(container-platform|enterprise)/?$ /container-platform/latest [R=301]
-    RewriteRule ^(container-platform|enterprise)/latest/?(.*)$ /container-platform/4\.11/$2 [NE,R=301]
+    RewriteRule ^(container-platform|enterprise)/latest/?(.*)$ /container-platform/4\.12/$2 [NE,R=301]
     RewriteRule ^(online)/(3\.0|3\.1|3\.2|3\.3|3\.4|3\.5|3\.6|3\.7|3\.9|3\.10|3\.11|latest)/?(.*)$ /$1/pro/$3 [NE,R=301]
 
     # Release notes redirects
@@ -448,7 +448,7 @@ AddType text/vtt                            vtt
     RewriteRule ^rosa/?$ /rosa/welcome/index.html [L,R=301]
     RewriteRule ^enterprise/(3\.0|3\.1|3\.2)/?$ /enterprise/$1/welcome/index.html [L,R=301]
     RewriteRule ^enterprise/3\.3/?$ /container-platform/3.3/welcome/index.html [L,R=301]
-    RewriteRule ^container-platform/(3\.3|3\.4|3\.5|3\.6|3\.7|3\.9|3\.10|3\.11|4\.1|4\.2|4\.3|4\.4|4\.5|4\.6|4\.7|4\.8|4\.9|4\.10|4\.11)/?$ /container-platform/$1/welcome/index.html [L,R=301]
+    RewriteRule ^container-platform/(3\.3|3\.4|3\.5|3\.6|3\.7|3\.9|3\.10|3\.11|4\.1|4\.2|4\.3|4\.4|4\.5|4\.6|4\.7|4\.8|4\.9|4\.10|4\.11|4\.12)/?$ /container-platform/$1/welcome/index.html [L,R=301]
     RewriteRule ^container-platform-ocp/(4\.3|4\.4|4\.8)/?$ /container-platform-ocp/$1/welcome/index.html [L,R=301]
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ jobs:
         - pip3 install pyyaml
         - pip3 install aura.tar.gz
       script:
-        - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.11 --no-upstream-fetch && python3 makeBuild.py
+        - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.12 --no-upstream-fetch && python3 makeBuild.py
     - # stage name not required, will continue to use `build`
-      if: branch IN (main, enterprise-4.11, enterprise-4.12)
+      if: branch IN (main, enterprise-4.12, enterprise-4.13)
       name: "Build openshift-dedicated distro"
       before_install:
         - gem install asciidoctor
@@ -31,7 +31,7 @@ jobs:
       script:
         - python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch && python3 makeBuild.py
     - # stage name not required, will continue to use `build`
-      if: branch IN (main, enterprise-4.11, enterprise-4.12)
+      if: branch IN (main, enterprise-4.12, enterprise-4.13)
       name: "Build openshift-rosa distro"
       before_install:
         - gem install asciidoctor
@@ -75,7 +75,7 @@ jobs:
       env:
         - CAN_FAIL=true
       language: minimal
-      if: branch IN (main, enterprise-4.11, enterprise-4.12)
+      if: branch IN (main, enterprise-4.12, enterprise-4.13)
       script:
         - chmod +x autopreview.sh && ./autopreview.sh
 

--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -27,6 +27,9 @@ openshift-origin:
     enterprise-4.11:
       name: '4.11'
       dir: '4.11'
+    enterprise-4.12:
+      name: '4.12'
+      dir: '4.12'
     enterprise-3.6:
       name: '3.6'
       dir: '3.6'
@@ -144,7 +147,7 @@ openshift-dedicated:
     enterprise-3.11:
       name: '3'
       dir: dedicated/3
-    enterprise-4.11:
+    enterprise-4.12:
       name: ''
       dir: dedicated/
 openshift-aro:
@@ -167,7 +170,7 @@ openshift-rosa:
   site_name: Documentation
   site_url: https://docs.openshift.com/
   branches:
-    enterprise-4.11:
+    enterprise-4.12:
       name: ''
       dir: rosa/
     rosa-preview:

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -46,7 +46,7 @@
   <div class="container">
     <button id="hc-open-btn" class="open-btn-sm" onclick="openNav()" aria-label="Open"><span class="fa fa-bars" /></button>
     <ol class="breadcrumb hide-for-print">
-      <% if (version == "4.12" || distro_key == "openshift-webscale" || distro_key == "openshift-dpu") %>
+      <% if (version == "4.13" || distro_key == "openshift-webscale" || distro_key == "openshift-dpu") %>
       <span>
         <div class="alert alert-danger" role="alert" id="support-alert">
           <strong>This documentation is work in progress and might not be complete or fully tested.</strong> The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html" class="link-primary" style="color: #545454 !important;">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.
@@ -100,6 +100,7 @@
             </a>
           <% end %>
           <select id="version-selector" onchange="versionSelector(this);">
+              <option value="4.12">4.12</option>
               <option value="4.11">4.11</option>
               <option value="4.10">4.10</option>
               <option value="4.9">4.9</option>
@@ -146,6 +147,7 @@
               </a>
               <select id="version-selector" onchange="versionSelector(this);">
                 <option value="latest">latest</option>
+                <option value="4.12">4.12</option>
                 <option value="4.11">4.11</option>
                 <option value="4.10">4.10</option>
                 <option value="4.9">4.9</option>

--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -475,22 +475,22 @@ possible values for `{product-title}` and `{product-version}`, depending on the 
 |`openshift-origin`
 |OKD
 a|* 3.6, 3.7, 3.9, 3.10, 3.11
-* 4.6, 4.7, 4.8, 4.9, 4.10, 4.11
+* 4.8, 4.9, 4.10, 4.11, 4.12
 * 4 for the `latest/` build from the `main` branch
 
 |`openshift-enterprise`
 |OpenShift Container Platform
 a|* 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.9, 3.10, 3.11
-* 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 4.10, 4.11, 4.12
+* 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 4.10, 4.11, 4.12, 4.13
 
 |`openshift-dedicated`
 |OpenShift Dedicated
-a|* No value set for the latest `dedicated/` build from the `enterprise-4.11` branch
+a|* No value set for the latest `dedicated/` build from the `enterprise-4.12` branch
 * 3 for the `dedicated/3` build from the `enterprise-3.11` branch
 
 |`openshift-rosa`
 |Red Hat OpenShift Service on AWS
-|No value set for the `rosa/` build from the `enterprise-4.11` branch
+|No value set for the `rosa/` build from the `enterprise-4.12` branch
 
 |`openshift-online`
 |OpenShift Online

--- a/index-commercial.html
+++ b/index-commercial.html
@@ -178,6 +178,7 @@
               <div class="btn-group">
                 <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">Select Version<span class="caret"></span></button>
                 <ul class="dropdown-menu" role="menu">
+                  <li><a href="container-platform/4.12/"><i class="fa fa-arrow-circle-o-right"></i> Container Platform 4.12</a></li>
                   <li><a href="container-platform/4.11/"><i class="fa fa-arrow-circle-o-right"></i> Container Platform 4.11</a></li>
                   <li><a href="container-platform/4.10/"><i class="fa fa-arrow-circle-o-right"></i> Container Platform 4.10</a></li>
                   <li><a href="container-platform/4.9/"><i class="fa fa-arrow-circle-o-right"></i> Container Platform 4.9</a></li>
@@ -292,7 +293,7 @@
           <h2>OpenShift Kubernetes Engine</h2>
           <div class="list-group">
             <p class="list-group-item-text">The OpenShift Kubernetes Engine is the core of the OpenShift Container Platform. Use OpenShift Container Platform docs links for OpenShift Kubernetes Engine documentation.</p>
-            Read more about <a href="/container-platform/4.11/welcome/oke_about.html">OKE</a>.
+            Read more about <a href="/container-platform/4.12/welcome/oke_about.html">OKE</a>.
           </div>
 
         </div>
@@ -307,6 +308,7 @@
             <div class="btn-group">
               <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">バージョンを選択する<span class="caret"></span></button>
               <ul class="dropdown-menu" role="menu">
+                <li><a href="https://access.redhat.com/documentation/ja-jp/openshift_container_platform/4.12/"><i class="fa fa-arrow-circle-o-right"></i> 4.12</a></li>
                 <li><a href="https://access.redhat.com/documentation/ja-jp/openshift_container_platform/4.11/"><i class="fa fa-arrow-circle-o-right"></i> 4.11</a></li>
                 <li><a href="https://access.redhat.com/documentation/ja-jp/openshift_container_platform/4.10/"><i class="fa fa-arrow-circle-o-right"></i> 4.10</a></li>
                 <li><a href="https://access.redhat.com/documentation/ja-jp/openshift_container_platform/4.9/"><i class="fa fa-arrow-circle-o-right"></i> 4.9</a></li>
@@ -326,6 +328,7 @@
             <div class="btn-group">
               <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">选择版本<span class="caret"></span></button>
               <ul class="dropdown-menu" role="menu">
+                <li><a href="https://access.redhat.com/documentation/zh-cn/openshift_container_platform/4.12/"><i class="fa fa-arrow-circle-o-right"></i> 4.12</a></li>
                 <li><a href="https://access.redhat.com/documentation/zh-cn/openshift_container_platform/4.11/"><i class="fa fa-arrow-circle-o-right"></i> 4.11</a></li>
                 <li><a href="https://access.redhat.com/documentation/zh-cn/openshift_container_platform/4.10/"><i class="fa fa-arrow-circle-o-right"></i> 4.10</a></li>
                 <li><a href="https://access.redhat.com/documentation/zh-cn/openshift_container_platform/4.9/"><i class="fa fa-arrow-circle-o-right"></i> 4.9</a></li>
@@ -345,6 +348,7 @@
             <div class="btn-group">
               <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">버전 선택<span class="caret"></span></button>
               <ul class="dropdown-menu" role="menu">
+                <li><a href="https://access.redhat.com/documentation/ko-kr/openshift_container_platform/4.12/"><i class="fa fa-arrow-circle-o-right"></i> 4.12</a></li>
                 <li><a href="https://access.redhat.com/documentation/ko-kr/openshift_container_platform/4.11/"><i class="fa fa-arrow-circle-o-right"></i> 4.11</a></li>
                 <li><a href="https://access.redhat.com/documentation/ko-kr/openshift_container_platform/4.10/"><i class="fa fa-arrow-circle-o-right"></i> 4.10</a></li>
                 <li><a href="https://access.redhat.com/documentation/ko-kr/openshift_container_platform/4.9/"><i class="fa fa-arrow-circle-o-right"></i> 4.9</a></li>

--- a/index-community.html
+++ b/index-community.html
@@ -50,6 +50,7 @@
              <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">Select Version<span class="caret"></span></button>
              <ul class="dropdown-menu" role="menu">
                <li><a href="latest/"><i class="fa fa-arrow-circle-o-right"></i> OKD Latest</a></li>
+               <li><a href="4.12/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.12</a></li>
                <li><a href="4.11/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.11</a></li>
                <li><a href="4.10/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.10</a></li>
                <li><a href="4.9/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.9</a></li>


### PR DESCRIPTION
This PR completes multiple tasks required to support GA and is based on these PRs from the 4.11 GA.
* https://github.com/openshift/openshift-docs/pull/49637 - completes version bumps for Travis checks
* https://github.com/openshift/openshift-docs/pull/48243 - changes the branch that `latest` tracks for OKD and adds the new versions to the version selectors on the home page
* https://github.com/openshift/openshift-docs/pull/51374 - updates the distro versions in the contrib guide
* https://github.com/openshift/openshift-docs/pull/48932 - removes the WIP note from the 4.12 collection

@adellape, will you PTAL? 