### PR TITLE
CNV-20962: SCC updates for 4.11+

### DIFF
--- a/modules/virt-additional-scc-for-kubevirt-controller.adoc
+++ b/modules/virt-additional-scc-for-kubevirt-controller.adoc
@@ -8,11 +8,9 @@
 
 Security context constraints (SCCs) control permissions for pods. These permissions include actions that a pod, a collection of containers, can perform and what resources it can access. You can use SCCs to define a set of conditions that a pod must run with to be accepted into the system.
 
-The `kubevirt-controller` is a cluster controller that creates the virt-launcher pods for virtual machines in the cluster. These virt-launcher pods are granted permissions by the `kubevirt-controller` service account.
+The `virt-controller` is a cluster controller that creates the `virt-launcher` pods for virtual machines in the cluster. These pods are granted permissions by the `kubevirt-controller` service account.
 
-== Additional SCCs granted to the kubevirt-controller service account
-
-The `kubevirt-controller` service account is granted additional SCCs and Linux capabilities so that it can create virt-launcher pods with the appropriate permissions. These extended permissions allow virtual machines to take advantage of {VirtProductName} features that are beyond the scope of typical pods.
+The `kubevirt-controller` service account is granted additional SCCs and Linux capabilities so that it can create `virt-launcher` pods with the appropriate permissions. These extended permissions allow virtual machines to use {VirtProductName} features that are beyond the scope of typical pods.
 
 The `kubevirt-controller` service account is granted the following SCCs:
 
@@ -22,11 +20,11 @@ This allows virtual machines to use the hostpath volume plug-in.
 * `scc.AllowPrivilegedContainer = false` +
 This ensures the virt-launcher pod is not run as a privileged container.
 
-* `scc.AllowedCapabilities = []corev1.Capability{"NET_ADMIN", "NET_RAW", "SYS_NICE"}` +
-This provides the following additional Linux capabilities
-`NET_ADMIN`,
-`NET_RAW`, and
-`SYS_NICE`.
+* `scc.AllowedCapabilities = []corev1.Capability{"SYS_NICE", "NET_BIND_SERVICE", "SYS_PTRACE"}` +
+
+** `SYS_NICE` allows setting the CPU affinity.
+** `NET_BIND_SERVICE` allows DHCP and Slirp operations.
+** `SYS_PTRACE` enables certain versions of `libvirt` to find the process ID (PID) of `swtpm`, a software Trusted Platform Module (TPM) emulator.
 
 == Viewing the SCC and RBAC definitions for the kubevirt-controller
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-20962](https://issues.redhat.com//browse/CNV-20962)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://54600--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-additional-security-privileges-controller-and-launcher.html#additional-sccs-granted-to-the-kubevirt-controller-service-account
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: I plan to open a separate PR for 4.10 that includes these changes but omits SYS_PTRACE. If time allows, I will look into earlier versions as well.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
