### PR TITLE
[OSDOCS-3375] added cluster history tab information to ROSA OCM page

### DIFF
--- a/modules/ocm-cluster-history.adoc
+++ b/modules/ocm-cluster-history.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// ocm/ocm-overview.adoc
+
+:_content-type: CONCEPT
+[id="ocm-cluster-history-tab_{context}"]
+= Cluster history tab
+
+The **Cluster history** tab shows all the history of the cluster including: changes made to the cluster, descriptions of changes, severity, dates, and who made the changes. You can also download the information using the **Download history** button.

--- a/ocm/ocm-overview.adoc
+++ b/ocm/ocm-overview.adoc
@@ -46,6 +46,7 @@ Selecting an active, installed cluster shows tabs associated with that cluster. 
 include::modules/ocm-overview-tab.adoc[leveloffset=+2]
 include::modules/ocm-accesscontrol-tab.adoc[leveloffset=+2]
 include::modules/ocm-addons-tab.adoc[leveloffset=+2]
+include::modules/ocm-cluster-history.adoc[leveloffset=+2]
 include::modules/ocm-networking-tab-concept.adoc[leveloffset=+2]
 ifndef::openshift-rosa[]
 include::modules/ocm-networking-tab-adding-ingress.adoc[leveloffset=+3]


### PR DESCRIPTION
[OSDOCS-3375] added cluster history tab information to ROSA OCM page

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-3375

Link to docs preview:
https://54602--docspreview.netlify.app/openshift-rosa/latest/ocm/ocm-overview.html#ocm-cluster-history-tab_ocm-overview

QE review:
- [x] QE review not needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
