### PR TITLE
OSDOCS-4580: RN for installing a cluster on vSphere with Multiple Failure Domains

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -469,6 +469,13 @@ The following metric has been removed:
 
 * `ovnkube_master_skipped_nbctl_daemon_total`
 
+[id="ocp-4-12-multi-zone-ipi-vsphere-installation"]
+==== Multi-zone Installer Provisioned Infrastructure VMware vSphere installation (Technology Preview)
+Beginning with {product-title} {product-version}, 
+the ability to configure multiple vCenter datacenters and multiple vCenter clusters in a single vCenter installation using installer-provisioned infrastructure is now available as a Technology Preview feature. Using vCenter tags, you can use this feature to associate vCenter datacenters and compute clusters with openshift-regions and openshift-zones. These associations define failure domains to enable application workloads to be associated with specific locations and failure domains.
+
+// The link to content will be added post-GA
+
 [id="ocp-4-12-k8s-nmstate-support-for-vsphere"]
 ==== Kubernetes NMState in VMware vSphere now supported
 Beginning with {product-title} {product-version}, you can configure the networking settings such as DNS servers or search domains, VLANs, bridges, and interface bonding using the Kubernetes NMState Operator on your VMware vSphere instance.


### PR DESCRIPTION
This release note announces "Installing a cluster on vSphere with Multiple Failure Domains" as Tech Preview

Version(s):
Release note for 4.12 only. This PR was opened from enterprise-4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4580

Link to docs preview:
https://54611--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-multi-zone-ipi-vsphere-installation

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
SME: Richard Vanderpool, QE: Wei Duan, PM: Ju Lim

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
