### PR TITLE
OSDOCS-4800: Fix xref typo in MicroShift installation guide

### DIFF
--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -53,7 +53,7 @@ include::modules/microshift-provisioning-ostree.adoc[leveloffset=+1]
 . https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/composing_installing_and_managing_rhel_for_edge_images/index[{op-system-ostree} documentation].
 . xref:../microshift_install/microshift-install-rpm.adoc#system-requirements-installing-microshift[System requirements for installing {product-title}].
 . Red Hat Hybrid Cloud Console link:https://console.redhat.com/openshift/install/pull-secret[pull secret].
-. xref:../microshift_networking/microshift_networking.doc#microshift-firewall-req-settings[Required firewall settings].
+. xref:../microshift_networking/microshift-networking.adoc#microshift-firewall-req-settings_microshift-networking[Required firewall settings].
 . link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/creating-kickstart-files_installing-rhel-as-an-experienced-user[Creating a kickstart file]
 . link:https://access.redhat.com/solutions/60959[How to embed a Kickstart file into an ISO image]
 

--- a/modules/microshift-firewall-req-settings.adoc
+++ b/modules/microshift-firewall-req-settings.adoc
@@ -3,7 +3,7 @@
 // * microshift_networking/microshift-networking.adoc
 
 :_content-type: CONCEPT
-[id="microshift-required-settings_{context}"]
+[id="microshift-firewall-req-settings_{context}"]
 = Required firewall settings
 
 An IP address range for the cluster network must be enabled during firewall configuration. You can use the default values or customize the IP address range. If you choose to customize the cluster network IP address range from the default `10.42.0.0/16` setting, you must also use the same custom range in the firewall configuration.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-4800

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- N/A, MicroShift is a developer preview

Additional information:
N/A
