### PR TITLE
Removing IBM Power/Z support from release notes 4.6-49

### DIFF
--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -171,15 +171,6 @@ The following advisory is available for the OpenShift Compliance Operator 0.1.49
 
 * link:https://access.redhat.com/errata/RHBA-2022:1148[RHBA-2022:1148 - OpenShift Compliance Operator bug fix and enhancement update]
 
-[id="compliance-operator-0-1-49-new-features-and-enhancements"]
-=== New features and enhancements
-
-* The Compliance Operator is now supported on the following architectures:
-+
-** IBM Power
-** IBM Z
-** IBM LinuxONE
-
 [id="compliance-operator-0-1-49-bug-fixes"]
 === Bug fixes
 

--- a/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
@@ -34,14 +34,6 @@ The following advisory is available for the OpenShift File Integrity Operator 0.
 
 * link:https://access.redhat.com/errata/RHBA-2022:5538[RHBA-2022:5538 OpenShift File Integrity Operator Bug Fix and Enhancement Update]
 
-[id="file-integrity-operator-0-1-30-new-features-and-enhancements"]
-=== New features and enhancements
-
-* The File Integrity Operator is now supported on the following architectures:
-+
-** IBM Power
-** IBM Z and LinuxONE
-
 [id="file-integrity-operator-0-1-30-bug-fixes"]
 === Bug fixes
 


### PR DESCRIPTION
Version(s):
4.6 -4.9

Issue:
[OSDOCS-4801](https://issues.redhat.com/browse/OSDOCS-4801)

Link to docs preview:
[Compliance Operator release notes](http://file.rdu.redhat.com/antaylor/ibmpz/security/compliance_operator/compliance-operator-release-notes.html#compliance-operator-release-notes-0-1-49)
[File Integrity Operator release notes](http://file.rdu.redhat.com/antaylor/ibmpz/security/file_integrity_operator/file-integrity-operator-release-notes.html#file-integrity-operator-release-notes-0-1-30)

Additional information:
This PR removes text from release notes and will be required for inactive branches 4.6 and 4.7 as well.
