### PR TITLE
OCPBUGS-4771: Decapitalize the first letter of ContainerLogMaxSize

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1325,7 +1325,7 @@ In {product-title} 4.11, support for VMware ESXi 7.0 Update 1 or earlier is depr
 [id="ocp-4-11-deprecated-features-crio-parameters"]
 ==== Support for `pidsLimit` and `logSizeMax` CRI-O parameters will be deprecated
 
-In {product-title} 4.11, the `pidsLimit` and `logSizeMax` fields in the `ContainerRuntimeConfig` CR will be deprecated and removed in a future release. Use the `podPidsLimit` and `ContainerLogMaxSize` fields in the `KubeletConfig` CR instead. The default value of the `podPidsLimit` field is `4096`.
+In {product-title} 4.11, the `pidsLimit` and `logSizeMax` fields in the `ContainerRuntimeConfig` CR will be deprecated and removed in a future release. Use the `podPidsLimit` and `containerLogMaxSize` fields in the `KubeletConfig` CR instead. The default value of the `podPidsLimit` field is `4096`.
 
 [id="ocp-4-11-removed-features"]
 === Removed features


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-4771
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://54632--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-deprecated-features-crio-parameters
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Original PR https://github.com/openshift/openshift-docs/pull/53222 which went through change management and introduced the typo. And here's the PR https://github.com/openshift/openshift-docs/pull/53762 that fixed the typo in the main docs (approved).
<!--- After you open your PR, ask fo
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
