### PR TITLE
Replace `kubectl` with `oc`

### DIFF
--- a/modules/creating-instance-aws-load-balancer-controller.adoc
+++ b/modules/creating-instance-aws-load-balancer-controller.adoc
@@ -71,6 +71,8 @@ spec:
     spec:
       containers:
         - image: openshift/origin-node
+          command:
+           - "/bin/socat"
           args:
             - TCP4-LISTEN:8080,reuseaddr,fork
             - EXEC:'/bin/bash -c \"printf \\\"HTTP/1.0 200 OK\r\n\r\n\\\"; sed -e \\\"/^\r/q\\\"\"'
@@ -139,7 +141,7 @@ spec:
 +
 [source,terminal]
 ----
-$ HOST=$(kubectl get ingress -n echoserver echoserver -o json | jq -r '.status.loadBalancer.ingress[0].hostname')
+$ HOST=$(oc get ingress -n echoserver echoserver --template='{{(index .status.loadBalancer.ingress 0).hostname}}')
 ----
 
 * Verify the status of the provisioned AWS Load Balancer (ALB) host by running the following command:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> ---> Tracking changes from this [PR](https://github.com/openshift/openshift-docs/pull/54122) 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: None
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://54637--docspreview.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/create-instance-aws-load-balancer-controller.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
