### PR TITLE
OSDOCS-4795: Adds notes for 4.11.24 release

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3154,9 +3154,9 @@ $ oc adm release info 4.11.22 --pullspecs
 * Any 4.11 and later  `arm64` cluster that has more than around 470 containers to a node, can cause additional pod creation to fail with the following error:
 +
 [source,terminal]
-====
+----
 runc create failed: unable to start container process: unable to init seccomp: error loading seccomp filter into kernel: error loading seccomp filter: errno 524"
-====
+----
 +
 This is due to a CoreOS limitation in the number of seccomp profiles that can be created on the worker node. This most likely occurs on clusters with multiple containers per pod during an upgrade, worker node failure, or pod scaleup. This will be fixed in a later version of {product-title}. (link:https://issues.redhat.com/browse/OCPBUGS-2637[*OCPBUGS-2637*])
 
@@ -3164,3 +3164,22 @@ This is due to a CoreOS limitation in the number of seccomp profiles that can be
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-24"]
+=== RHSA-2023:0069 - {product-title} 4.11.24 bug fix and security update
+
+Issued: 2023-01-19
+
+{product-title} release 4.11.24, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0069[RHSA-2023:0069] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0068[RHBA-2023:0068] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.24 --pullspecs
+----
+
+[id="ocp-4-11-24-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions. 


### PR DESCRIPTION
[OSDOCS-4795](https://issues.redhat.com//browse/OSDOCS-4795) : Add notes for 4.11.24 release

Version(s):
4.11

Issue: 
https://issues.redhat.com//browse/OSDOCS-4795

Links to docs preview: [RHBA-2023:0068 - OpenShift Container Platform 4.11.24 bug fix update](https://54646--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-24)

QE review:
- [ ] QE has approved this change.

* QE not required for this change
