### PR TITLE
ROX-13700-central-endpoint-note

### DIFF
--- a/modules/run-roxctl-from-container.adoc
+++ b/modules/run-roxctl-from-container.adoc
@@ -30,6 +30,10 @@ $ docker run -e ROX_API_TOKEN=$ROX_API_TOKEN \
   -it registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8:{rhacs-version} \
   -e $ROX_CENTRAL_ADDRESS <command>
 ----
+[NOTE]
+====
+In {product-title-managed}, when using `roxctl` commands that require the Central address, use the *Central instance address* as displayed in the *Instance Details* section of the {cloud-console}. For example, use `acs-ABCD12345.acs.rhcloud.com` instead of `acs-data-ABCD12345.acs.rhcloud.com`.
+====
 
 .Verification
 

--- a/modules/using-cli.adoc
+++ b/modules/using-cli.adoc
@@ -23,6 +23,8 @@ $ export ROX_CENTRAL_ADDRESS=<address>:<port_number>
 ----
 
 * You can use the `--help` option to get more information about the commands.
+
+* In {product-title-managed}, when using `roxctl` commands that require the Central address, use the *Central instance address* as displayed in the *Instance Details* section of the {cloud-console}. For example, use `acs-ABCD12345.acs.rhcloud.com` instead of `acs-data-ABCD12345.acs.rhcloud.com`.
 ====
 
 [id="manage-central-db_{context}"]


### PR DESCRIPTION
Version(s):
- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.73`

[Issue](https://issues.redhat.com/browse/ROX-13700)

[Link to docs preview](https://openshift-docs-en5oswtc9-kcarmichael08.vercel.app/openshift-acs/master/cli/getting-started-cli.html#using-cli_cli-getting-started) (third bullet in note)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

