### PR TITLE
RHDEVDOCS-4350-fix-for-monitoring-persistent-storage-requirements

### DIFF
--- a/modules/monitoring-configuring-persistent-storage.adoc
+++ b/modules/monitoring-configuring-persistent-storage.adoc
@@ -15,9 +15,9 @@ Running cluster monitoring with persistent storage means that your metrics are s
 
 * Verify that you have a persistent volume (PV) ready to be claimed by the persistent volume claim (PVC), one PV for each replica. Because Prometheus and Alertmanager both have two replicas, you need four PVs to support the entire monitoring stack. The PVs are available from the Local Storage Operator, but not if you have enabled dynamically provisioned storage.
 
-* Use the block type of storage.
-
+* Use `Filesystem` as the storage type value for the `volumeMode` parameter when you configure the persistent volume.
++
 [NOTE]
 ====
-If you use a local volume for persistent storage, do not use a raw block volume, which is described with `volumeMode: block` in the `LocalVolume` object. Prometheus cannot use raw block volumes.
+If you use a local volume for persistent storage, do not use a raw block volume, which is described with `volumeMode: Block` in the `LocalVolume` object. Prometheus cannot use raw block volumes.
 ====


### PR DESCRIPTION
Summary: This PR fixes an issue where the wrong storage type was listed for setting up persistent storage for the OCP monitoring stack.

- Aligned team: DevTools
- For branches: 4.8+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4350
- Direct link to doc preview: https://54677--docspreview.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#persistent-storage-prerequisites
- SME review: n/a
- QE review: @juzhao 
- Peer review: @rolfedh 