### PR TITLE
OSDOCS-4524: last minute 4.12 RN clean up

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -14,7 +14,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 == About this release
 
 // TODO: Update with the relevant information closer to release.
-{product-title} (link:https://access.redhat.com/errata/RHSA-2022:TODO[RHSA-2022:TODO]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md[Kubernetes 1.25] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2022:7399[RHSA-2022:7399]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md[Kubernetes 1.25] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title}, you can deploy OpenShift clusters to either on-premises or cloud environments.
 
@@ -24,11 +24,14 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517
 
-//TODO: Add the line below for EUS releases.
-//{product-title} 4.6 is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
+//TODO: Remove this for 4.13
+Starting with {product-title} {product-version} an additional six months of Extended Update Support (EUS) phase on even numbered releases from 18 months to two years. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
-//TODO: The line below is not true for 4.9 but should be used when it is next appropriate. Revisit in October 2022 timeframe.
-//Version 4.6 going end of life in October 2022. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
+//TODO: Add the line below for EUS releases.
+{product-title} 4.8 is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
+
+//TODO: The line below should be used when it is next appropriate. Revisit in April 2023 timeframe.
+Maintenance support ends for version 4.8 in January 2023 and goes to extended life phase. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
 
 [id="ocp-4-12-add-on-support-status"]
@@ -569,7 +572,6 @@ A new import value, `importMode`, has been added to the `importPolicy` parameter
 
 * `PreserveOriginal`: When active, the original manifest is preserved. For manifest lists, the manifest list and all of its sub-manifests are imported.
 
-
 //[id="ocp-4-12-security"]
 //=== Security and compliance
 //
@@ -752,7 +754,6 @@ For more information, see xref:../networking/hardware_networks/about-sriov.adoc#
 * MT42822 BlueField&#8209;2 in ConnectX&#8209;6 NIC mode
 
 For more information, see xref:../networking/hardware_networks/configuring-hardware-offloading.adoc#supported_devices_configuring-hardware-offloading[Supported devices].
-
 
 [id="ocp-4-12-multi-network-policy-supported-for-sr-iov"]
 ==== Multi-network-policy supported for SR-IOV (Technology Preview)
@@ -943,9 +944,6 @@ If a third-party CSI driver is present in the cluster, {product-title} does not 
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-csi-driver-reqs_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator requirements].
 
-[id="ocp-4-12-registry"]
-=== Registry
-
 [id="ocp-4-12-olm"]
 === Operator lifecycle
 
@@ -956,7 +954,7 @@ Starting in {product-title} 4.12, Operator Lifecycle Manager (OLM) introduces th
 
 A platform Operator is an OLM-based Operator that can be installed during or after an {product-title} cluster's Day 0 operations and participates in the cluster's lifecycle. As a cluster administrator, you can use platform Operators to further customize your {product-title} installation to meet your requirements and use cases.
 
-For more information on platform Operators, see xref:../operators/admin/olm-managing-po.adoc#olm-managing-po[Managing platform Operators]. For more information on RukPak and its resources, see xref:../operators/understanding/olm-packaging-format.adoc#olm-rukpak-about_olm-packaging-format[Operator Framework packaging format].
+For more information about platform Operators, see xref:../operators/admin/olm-managing-po.adoc#olm-managing-po[Managing platform Operators]. For more information about RukPak and its resources, see xref:../operators/understanding/olm-packaging-format.adoc#olm-rukpak-about_olm-packaging-format[Operator Framework packaging format].
 
 [id="ocp-4-12-olm-operator-node-affinity"]
 ==== Controlling where an Operator is installed
@@ -1063,9 +1061,6 @@ The Node Health Check Operator now also includes a web console plug-in for manag
 
 For installing or updating to the latest version of the Node Health Check Operator, use the `stable` subscription channel. For more information, see xref:../nodes/nodes/ecosystems/eco-node-health-check-operator.adoc#installing-node-health-check-operator-using-cli_node-health-check-operator[Installing the Node Health Check Operator by using the CLI].
 
-[id="ocp-4-11-logging"]
-=== Logging
-
 [id="ocp-4-12-monitoring"]
 === Monitoring
 
@@ -1120,7 +1115,6 @@ If you are upgrading to {product-title} {product-version} and have specified rel
 Otherwise, alert receivers that use the files will fail to deliver notifications.
 ====
 
-
 [id="ocp-4-12-scalability-and-performance"]
 === Scalability and performance
 
@@ -1162,7 +1156,7 @@ For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-d
 [id="scalability-and-performance-factory-precaching-tool"]
 ==== {factory-prestaging-tool-caps} to reduce {product-title} and Operator deployment times (Technology Preview)
 
-In {product-title} {product-version}, you can use the {factory-prestaging-tool} to pre-cache {product-title} and Operator images on a server at the factory, and then you can ship the pre-cached server to the site for deployment. For more information about the {factory-prestaging-tool}, see xref:../scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc[Pre-caching images for single-node OpenShift deployments].
+In {product-title} {product-version}, you can use the {factory-prestaging-tool} to pre-cache {product-title} and Operator images on a server at the factory, and then you can include the pre-cached server to the site for deployment. For more information about the {factory-prestaging-tool}, see xref:../scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc[Pre-caching images for single-node OpenShift deployments].
 
 [id="scalability-and-performance-factory-precaching-tool-in-ztp"]
 ==== Zero touch provisioning (ZTP) integration of the {factory-prestaging-tool} (Technology Preview)
@@ -1320,8 +1314,10 @@ In a situation where you need disaster recovery for a hosted cluster, you can re
 [id="ocp-4-12-rhv"]
 === Red Hat Virtualization (RHV)
 
-* With this update, the oVirt CSI driver logging was revised with new error messages to improve the clarity and readability of the logs.
-* Previously, you had to restart the cluster API provider when the credentials changed. With this release, the cluster API provider automatically updates oVirt and Red Hat Virtualization (RHV) credentials when they are changed in {product-title}.
+This release provides several updates to Red Hat Virtualization (RHV). With this release:
+
+* The oVirt CSI driver logging was revised with new error messages to improve the clarity and readability of the logs.
+* The cluster API provider automatically updates oVirt and Red Hat Virtualization (RHV) credentials when they are changed in {product-title}.
 
 [id="ocp-4-12-notable-technical-changes"]
 == Notable technical changes
@@ -1744,6 +1740,10 @@ Kubernetes 1.25 removed the following deprecated APIs, so you must migrate manif
 [.small]
 1. For more information about pod security admission in {product-title}, see xref:../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission].
 
+[id="ocp-4-12-empty-file-support-removed"]
+==== oc registry command for empty file support
+The `--registry-config` and `--to option` options in the `oc registry login` command will stop accepting empty files. These options will continue to work with files that do not exist. The ability to write output to `-`(stdout) is also removed.
+
 [id="ocp-4-12-oc-rhel-7"]
 ==== {op-system-base} 7 support for the OpenShift CLI (oc) has been removed
 
@@ -1813,7 +1813,7 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-4-12-api-auth-bug-fixes"]
 ==== API Server and Authentication
 
-* Previously, the Cluster Authentication Operator state was set to `progressing = false` after receiving a `workloadIsBeingUpdatedTooLong` error. At the same time, `degraded = false` was kept for the time of the `inertia` defined. Consequently, the shortened amount of progressing and increased time of degradedation would create a situation where `progressing = false` and `degraded = false` were set prematurely. This caused inconsistent OpenShift CI tests because a healthy state was assumed, which was incorrect. This issue has been fixed by removing the `progressing = false` setting after the `workloadIsBeingUpdatedTooLong` error is returned. Now, because there is no `progressing = false` state, OpenShift CI tests are more consistent. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2111842[*BZ2111842*])
+* Previously, the Cluster Authentication Operator state was set to `progressing = false` after receiving a `workloadIsBeingUpdatedTooLong` error. At the same time, `degraded = false` was kept for the time of the `inertia` defined. Consequently, the shortened amount of progressing and increased time of degradedation would create a situation where `progressing = false` and `degraded = false` were set prematurely. This caused inconsistent OpenShift CI tests because a healthy state was assumed, which was incorrect. This issue has been fixed by removing the `progressing = false` setting after the `workloadIsBeingUpdatedTooLong` error is returned. Now, because there is no `progressing = false` state, OpenShift CI tests are more consistent. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2111842[*BZ#2111842*])
 
 //Bug fix work for TELCODOCS-750
 [discrete]
@@ -1893,26 +1893,18 @@ sourceStrategy:
 * Previously, a bug in the {rh-openstack} legacy cloud provider resulted in a crash if certain {rh-openstack} operations were attempted after authentication had failed. For example, shutting down a server causes the Kubernetes controller manager to fetch server information from {rh-openstack}, which triggered this bug. As a result, if initial cloud authentication failed or was configured incorrectly, shutting down a server caused the Kubernetes controller manager to crash. With this release, the {rh-openstack} legacy cloud provider is updated to not attempt any {rh-openstack} API calls if it has not previously authenticated successfully. Now, shutting down a server with invalid cloud credentials no longer causes Kubernetes controller manager to crash. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102383[*BZ#2102383*])
 
 [discrete]
-[id="ocp-4-12-cluster-version-operator-bug-fixes"]
-==== Cluster Version Operator
-
-[discrete]
-[id="ocp-4-12-console-Metal3-bug-fixes"]
-==== Console Metal3 Plug-in
-
-[discrete]
-[id="ocp-4-12-dns-bug-fixes"]
-==== Domain Name System (DNS)
-
-[discrete]
 [id="ocp-4-12-dev-console-bug-fixes"]
 ==== Developer Console
 
-* Previously, the `openshift-config` namespace was hardcoded for the `HelmChartRepository` custom resource, which was the same namespace for the `ProjectHelmChartRepository` custom resource. This prevented users from adding private `ProjectHelmChartRepository` custom resources in their desired namespace. Consquently, users were unable to access secrets and configmaps in the `openshift-config` namespace. This update fixes the `ProjectHelmChartRepository` custom resource definition with a `namespace` field that can read the secret and configmaps from a namespace of choice by a user with the correct permissions. Additionally, the user can add secrets and configmaps to the accessible namespace, and they can add private Helm chart repositories in the namespace used the creation resources. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2071792[*BZ#2071792*])
+* Previously, the `openshift-config` namespace was hard coded for the `HelmChartRepository` custom resource, which was the same namespace for the `ProjectHelmChartRepository` custom resource. This prevented users from adding private `ProjectHelmChartRepository` custom resources in their desired namespace. Consequently, users were unable to access secrets and configmaps in the `openshift-config` namespace. This update fixes the `ProjectHelmChartRepository` custom resource definition with a `namespace` field that can read the secret and configmaps from a namespace of choice by a user with the correct permissions. Additionally, the user can add secrets and configmaps to the accessible namespace, and they can add private Helm chart repositories in the namespace used the creation resources. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2071792[*BZ#2071792*])
 
 [discrete]
 [id="ocp-4-12-image-registry-bug-fixes"]
 ==== Image Registry
+
+* Previously, the image trigger controller did not have permissions to change objects. Consequently, image trigger annotations did not work on some resources. This update creates a cluster role binding that provides the controller the required permissions to update objects according to annotations. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2055620[*BZ#2055620*])
+
+* Previously, the Image Registry Operator did not have a `progressing` condition for the `node-ca` daemon set and used `generation` from an incorrect object. Consequently, the `node-ca` daemon set could be marked as `degraded` while the Operator was still running. This update adds the `progressing` condition, which indicates that the installation is not complete. As a result, the Image Registry Operator successfully installs the `node-ca` daemon set, and the installer waits until it is fully deployed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2093440[[*BZ#2093440*])
 
 [discrete]
 [id="ocp-4-12-installer-bug-fixes"]
@@ -1930,7 +1922,7 @@ sourceStrategy:
 
 * Previously, when an installation on Google Cloud provider (GCP) failed because an invalid GCP region was specified, the resulting error message did not mention this as the cause of the failure. This update improves the error message, which now states the region is not valid. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102324[*BZ#2102324*])
 
-* Previously, cluster installations using Hive could fail if Hive used an older version of the install-config.yaml file. This update allows the installer to accept older versions of the `install-config.yaml` file provided by Hive. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2098299[*BZ#2098299*])
+* Previously, cluster installations using Hive could fail if Hive used an older version of the install-config.yaml file. This update allows the installation program to accept older versions of the `install-config.yaml` file provided by Hive. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2098299[*BZ#2098299*])
 
 * Previously, the installation program would incorrectly allow the `apiVIP` and `ingressVIP` parameters to use the same IPv6 address if they represented the address differently, such as listing the address in an abbreviated format. In this update, the installer correctly validates these two parameters regardless of their formatting, requiring separate IP addresses for each parameter. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2103144[*BZ#2103144*])
 
@@ -1938,11 +1930,11 @@ sourceStrategy:
 
 * Previously, when installing a cluster on {rh-openstack-first} with multiple networks defined in the `machineNetwork` parameter, the installation program only created security group rules for the first network. With this update, the installation program creates security group rules for all networks defined in the `machineNetwork` so that users no longer need to manually edit security group rules after installation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2095323[*BZ#2095323*])
 
-* Previously, users could manually set the API and Ingress virtual IP addresses to values that conflicted with the allocation pool of the DHCP server when installing a cluster on OpenStack. This could cause the DHCP server to assign one of the VIP addresses to a new machine, which would fail to start. In this update, the installation program validates the user-provided VIP addresses to ensure that they do not conflict with any DHCP pools. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1944365[*BZ1944365*])
+* Previously, users could manually set the API and Ingress virtual IP addresses to values that conflicted with the allocation pool of the DHCP server when installing a cluster on OpenStack. This could cause the DHCP server to assign one of the VIP addresses to a new machine, which would fail to start. In this update, the installation program validates the user-provided VIP addresses to ensure that they do not conflict with any DHCP pools. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1944365[*BZ#1944365*])
 
-* Previously, when installing a cluster on vSphere using a datacenter that is embedded inside a folder, the installation program could not locate the datacenter object, causing the installation to fail. In this update, the installation program can traverse the directory that contains the datacenter object, allowing the installation to succeed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097691[*BZ2097691*])
+* Previously, when installing a cluster on vSphere using a datacenter that is embedded inside a folder, the installation program could not locate the datacenter object, causing the installation to fail. In this update, the installation program can traverse the directory that contains the datacenter object, allowing the installation to succeed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097691[*BZ#2097691*])
 
-* Previously, when installing a cluster on Azure using arm64 architecture with installer-provisioned infrastructure, the image definition resource for hyperVGeneration V1 incorrectly had an architecture value of `x64`. With this update, the image definition resource for hyperVGeneration V1 has the correct architecture value of `Arm64`. (link:https://issues.redhat.com/browse/OCPBUGS-3639[*OCPBUGS-3639*])
+* Previously, when installing a cluster on Azure using arm64 architecture with installer-provisioned infrastructure, the image definition resource for `hyperVGeneration` V1 incorrectly had an architecture value of `x64`. With this update, the image definition resource for `hyperVGeneration` V1 has the correct architecture value of `Arm64`. (link:https://issues.redhat.com/browse/OCPBUGS-3639[*OCPBUGS-3639*])
 
 * Previously, when installing a cluster on VMware vSphere, the installation could fail if the user specified a user-defined folder in the `failureDomain` section of the `install-config.yaml` file. With this update, the installation program correctly validates user-defined folders in the `failureDomain` section of the `install-config.yaml` file. (link:https://issues.redhat.com/browse/OCPBUGS-3343[*OCPBUGS-3343*])
 
@@ -1951,10 +1943,6 @@ sourceStrategy:
 * Previously, when installing a cluster on VMware vSphere, the installation failed if the user specified the `platform.vsphere.vcenters` parameter but did not specify the `platform.vsphere.failureDomains.topology.networks` parameter in the `install-config.yaml` file. With this update, the installation program alerts the user that the `platform.vsphere.failureDomains.topology.networks` field is required when specifying `platform.vsphere.vcenters`. (link:https://issues.redhat.com/browse/OCPBUGS-1698[*OCPBUGS-1698*])
 
 * Previously, when installing a cluster on VMware vSphere, the installation failed if the user defined the `platform.vsphere.vcenters` and `platform.vsphere.failureDomains` parameters but did not define `platform.vsphere.defaultMachinePlatform.zones`, or `compute.platform.vsphere.zones` and `controlPlane.platform.vsphere.zones`. With this update, the installation program validates that the user has defined the `zones` parameter in multi-region or multi-zone deployments prior to installation. (link:https://issues.redhat.com/browse/OCPBUGS-1490[*OCPBUGS-1490*])
-
-[discrete]
-[id="ocp-4-12-kube-api-server-bug-fixes"]
-==== Kubernetes API server
 
 [discrete]
 [id="ocp-4-12-kube-controller-bug-fixes"]
@@ -1969,6 +1957,8 @@ sourceStrategy:
 ==== Kubernetes Scheduler
 
 * Previously, the secondary scheduler deployment was not deleted after a secondary scheduler custom resource was deleted. Consequently, the Secondary Schedule Operator and Operand were not fully uninstalled. With this update, the correct owner reference is set in the secondary scheduler custom resource so that it points to the secondary scheduler deployment. As a result, secondary scheduler deployments are deleted when the secondary scheduler custom resource is deleted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2100923[*BZ#2100923*])
+
+* For the {product-title} {product-version} release, the descheduler can now publish events to an API group because the release adds additional role-based access controls (RBAC) rules to the descheduler's profile.(link:https://issues.redhat.com/browse/OCPBUGS-2330[*OCPBUGS-2330*])
 
 [discrete]
 [id="ocp-4-12-machine-config-operator-bug-fixes"]
@@ -2008,6 +1998,10 @@ sourceStrategy:
 
 * Previously, incomplete YAML was not synced was occasionally displayed to users. With this update, synced YAML always displays. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2084453[*BZ#2084453*])
 
+* Previously, when installing an Operator that required a custom resource (CR) to be created for use, the *Create resource* button could fail to install the CR because it was pointing to the incorrect namespace. With this update, the *Create resource* button works as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2094502[*BZ#2094502*])
+
+* Previously, the *Cluster update* modal was not displaying errors properly. As a result, the *Cluster update* modal did not display or explain errors when they occurred. With this update, the *Cluster update* modal correctly display errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2096350[*BZ#2096350*])
+
 [discrete]
 [id="ocp-4-12-monitoring-bug-fixes"]
 ==== Monitoring
@@ -2038,7 +2032,7 @@ sourceStrategy:
 
 * Previously, an Ingress Controller could not be configured with both the `Private` endpoint publishing strategy type and PROXY protocol. With this update, users can now configure an Ingress Controller with both the `Private` endpoint publishing strategy type and PROXY protocol. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2104481[*BZ#2104481*])
 
-* Previously, the `routeSelector` parameter cleared the route status of the Ingress Controller prior to the router deployment. Because of this, the route status repopulated incorrectly. To avoid using stale data, route status detection has been updated to no longer rely on the Kubernetes object cache. Additionally, this update includes a fix to check the generation ID on route deployment in order to determine the route status. As a result, the route status is consistently cleared with a `routeSelector` update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2101878[*BZ#2101878*])
+* Previously, the `routeSelector` parameter cleared the route status of the Ingress Controller prior to the router deployment. Because of this, the route status repopulated incorrectly. To avoid using stale data, route status detection has been updated to no longer rely on the Kubernetes object cache. Additionally, this update includes a fix to check the generation ID on route deployment to determine the route status. As a result, the route status is consistently cleared with a `routeSelector` update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2101878[*BZ#2101878*])
 
 * Previously, a cluster that was upgraded from a version of {product-title} earlier than 4.8 could have orphaned `Route` objects. This was caused by earlier versions of {product-title} translating `Ingress` objects into `Route` objects irrespective of a given `Ingress` object's indicated `IngressClass`. With this update, an alert is sent to the cluster administrator about any orphaned Route objects still present in the cluster after Ingress-to-Route translation. This update also adds another alert that notifies the cluster administrator about any Ingress objects that do not specify an `IngressClass`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1962502[*BZ#1962502*])
 
@@ -2056,20 +2050,17 @@ sourceStrategy:
 
 * With this update, the Ingress Operator now uses `k8s.io/client-go` version 1.25.2, which supports Kubernetes 1.25. This keeps both the Ingress Operator and {product-title} {product-version}, which is also based on Kubernetes 1.25, in alignment with one another. (link:https://issues.redhat.com/browse/OCPBUGS-1554[*OCPBUGS-1554*])
 
-* Previously, the DNS Operator did not reconcile the `openshift-dns` namespace. Because {product-title} {product-version} requires the `openshift-dns` namespace to have pod-security labels, this caused the namespace to be missing those labels upon cluster update. Without the pod-security labels, the pods failed to start. With this update, the DNS Operator now reconciles the `openshift-dns` namespace, and the pod-security labels are now present. As a result, pods start up as expected. (link:https://issues.redhat.com/browse/OCPBUGS-1549[*OCPBUGS-1549*])
+* Previously, the DNS Operator did not reconcile the `openshift-dns` namespace. Because {product-title} {product-version} requires the `openshift-dns` namespace to have pod-security labels, this caused the namespace to be missing those labels upon cluster update. Without the pod-security labels, the pods failed to start. With this update, the DNS Operator now reconciles the `openshift-dns` namespace, and the pod-security labels are now present. As a result, pods start as expected. (link:https://issues.redhat.com/browse/OCPBUGS-1549[*OCPBUGS-1549*])
 
 * Previously, the `ingresscontroller.spec.tuniningOptions.reloadInterval` did not support decimal numerals as valid parameter values because the Ingress Operator internally converts the specified value into milliseconds, which was not a supported time unit. This prevented an Ingress Controller from being deleted. With this update, `ingresscontroller.spec.tuningOptions.reloadInterval` now supports decimal numerals and users can delete Ingress Controllers with `reloadInterval` parameter values which were previously unsupported. (link:https://issues.redhat.com/browse/OCPBUGS-236[*OCPBUGS-236*])
 
-* Previously, the Cluster DNS Operator used GO kubernetes libraries that were based on Kubernetes 1.24 while {product-title} 4.12 is based on Kubernetes 1.25. With this update, GO Kubernetes API is v1.25.2, which aligns the Cluster DNS Operator with {product-title} 4.12 that uses Kubernetes 1.25 APIs. (link: https://issues.redhat.com/browse/OCPBUGS-1558[*OCPBUGS-1558*])
+* Previously, the Cluster DNS Operator used GO Kubernetes libraries that were based on Kubernetes 1.24 while {product-title} 4.12 is based on Kubernetes 1.25. With this update, GO Kubernetes API is v1.25.2, which aligns the Cluster DNS Operator with {product-title} 4.12 that uses Kubernetes 1.25 APIs. (link: https://issues.redhat.com/browse/OCPBUGS-1558[*OCPBUGS-1558*])
 
 * Previously, setting the `disableNetworkDiagnostics` configuration to `true` did not persist when the `network-operator` pod was re-created. With this update, the `disableNetworkDiagnostics` configuration property of network`operator.openshift.io/cluster` no longer resets to its default value after network operator restart. (link:https://issues.redhat.com/browse/OCPBUGS-392[*OCPBUGS-392*])
+
 * Previously, `ovn-kubernetes` did not configure the correct MAC address of bonded interfaces in `br-ex` bridge. As a result, a node that uses bonding for the primary Kubernetes interface fails to join the cluster. With this update, `ovn-kubernetes` configures the correct MAC address of bonded interfaces in `br-ex` bridge, and nodes that use bonding for the primary Kubernetes interface successfully join the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2096413[*BZ2096413*])
 
 * Previously, when the Ingress Operator was configured to enable the use of mTLS, the Operator would not check if CRLs needed updating until some other event caused it to reconcile. As a result, CRLs used for mTLS could become out of date. With this update, the Ingress Operator now automatically reconciles when any CRL expires, and CRLs will be updated at the time specified by their `nextUpdate` field. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2117524[*BZ#2117524*])
-
-[discrete]
-[id="ocp-4-12-ne-perf-improvements"]
-==== Networking performance improvements
 
 [discrete]
 [id="ocp-4-12-node-bug-fixes"]
@@ -2105,6 +2096,8 @@ sourceStrategy:
 
 * The `package-server-manifest` (PSM) is a controller that ensures that the correct `package-server` Cluster Service Version (CSV) is installed on a cluster. Previously, changes to the `package-server` CSV were not being reverted because of a logical error in the reconcile function in which an on-cluster object could influence the expected object. Users could modify the `package-server` CSV and the changes would not be reverted. Additionally, cluster upgrades would not update the YAML for the `package-server` CSV. With this update, the expected version of the CSV is now always built from scratch, which removes the ability for an on-cluster object to influence the expected values. As a result, the PSM now reverts any attempts to modify the `package-server` CSV, and cluster upgrades now deploy the expected `package-server` CSV. (link:https://issues.redhat.com/browse/OCPBUGS-858[*OCPBUGS-858*])
 
+* Previously, OLM would upgrade an Operator according to the Operator's CRD status. A CRD lists component references in an order defined by the group/version/kind (GVK) identifier. Operators that share the same components might cause the GVK to change the component listings for an Operator, and this can cause the OLM to require more system resources to continuously update the status of a CRD. With this update, the Operator Lifecycle Manager (OLM) now upgrades an Operator according to the Operator's component references. A change to the custom resource definition (CRD) status of an Operator does not impact the OLM Operator upgrade process.(link:https://issues.redhat.com/browse/OCPBUGS-3795[*OCPBUGS-3795*])
+
 [discrete]
 [id="ocp-4-12-openshift-operator-sdk-bug-fixes"]
 ==== Operator SDK
@@ -2123,7 +2116,7 @@ sourceStrategy:
 
 * Previously, the File Integrity Operator did not properly handle modifying alerts during an upgrade. As a result, alerts did not include the namespace in which the Operator was installed. With this release, the Operator includes the namespace it was installed into in the alert, making it easier to narrow down what component needs attention. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2112394[*BZ#2112394*])
 
-* Previously, service account ownership for the File Integrity Operator regressed due to underlying OLM updates, and updates from 0.1.24 to 0.1.29 were broken. With this update, the Operator should default to upgrading to 0.1.30. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2109153[*BZ#2109153*]
+* Previously, service account ownership for the File Integrity Operator regressed due to underlying OLM updates, and updates from 0.1.24 to 0.1.29 were broken. With this update, the Operator defaults to upgrading to 0.1.30. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2109153[*BZ#2109153*])
 
 * Previously, the File Integrity Operator daemon used the `ClusterRoles` parameter instead of the `Roles` parameter for a recent permission change. As a result, OLM could not update the Operator. With this release, the Operator daemon reverts to using the `Roles` parameter and updates from older versions to version 0.1.29 are successful. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2108475[*BZ#2108475*])
 
@@ -2135,7 +2128,7 @@ sourceStrategy:
 
 * Previously, applying automatic remediation for the `rhcos4-high-master-sysctl-kernel-yama-ptrace-scope` and `rhcos4-sysctl-kernel-core-pattern` rules resulted in subsequent failures of those rules in scan results, even though they were remediated. The issue is fixed in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2094382[*BZ#2094382*])
 
-* Previously, the Compliance Operator hardcoded notifications to the default namespace. As a result, notifications from the Operator would not appear if the Operator was installed in a different namespace. This issue is fixed in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2060726[*BZ#2060726*])
+* Previously, the Compliance Operator hard coded notifications to the default namespace. As a result, notifications from the Operator would not appear if the Operator was installed in a different namespace. This issue is fixed in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2060726[*BZ#2060726*])
 
 * Previously, the Compliance Operator failed to fetch API resources when parsing machine configurations without Ignition specifications. This caused the `api-check-pods` check to crash loop. With this release, the Compliance Operator is updated to gracefully handle machine configuration pools without Ignition specifications. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2117268[*BZ#2117268*])
 
@@ -2162,24 +2155,20 @@ sourceStrategy:
 * Previously, custom SELinux policy modules were not properly supported by `rpm-ostree`, so they were not updated along with the rest of the system upon update. This would surface as failures in unrelated components. Pending SELinux userspace improvements landing in a future {product-title} release, this update provides a workaround to {op-system} that will rebuild and reload the SELinux policy during boot as needed. (link:https://issues.redhat.com/browse/OCPBUGS-595[*OCPBUGS-595*])
 
 [discrete]
-[id="ocp-4-12-routing-bug-fixes"]
-==== Routing
-
-[discrete]
 [id="ocp-4-12-scalability-and-performance-bug-fixes"]
 ==== Scalability and performance
 
 * The tuned profile has been modified to assign the same priority as `ksoftirqd` and `rcuc` to the newly introduced per-CPU kthreads (`ktimers`) added in a recent Red Hat Enterprise Linux (RHEL) kernel patch. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-3475[*OCPBUGS-3475*], link:https://bugzilla.redhat.com/show_bug.cgi?id=2117780[*BZ#2117780*] and link:https://bugzilla.redhat.com/show_bug.cgi?id=2122220[*BZ#2122220*].
 
-* Previously, restarts of the `tuned` service caused improper reset of the `irqbalance` configuration, leading to IRQ operation being served again on the isolated CPUs, therefore violating the isolation guarantees. With this fix, the `irqbalance` service configuration is properly preserved across `tuned` service restarts (explicit or caused by bugs), therefore preserving the CPU isolation guarantees with respect to IRQ serving. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-585[*OCPBUGS-585*].
+* Previously, restarts of the `tuned` service caused improper reset of the `irqbalance` configuration, leading to IRQ operation being served again on the isolated CPUs, therefore violating the isolation guarantees. With this fix, the `irqbalance` service configuration is properly preserved across `tuned` service restarts (explicit or caused by bugs), therefore preserving the CPU isolation guarantees with respect to IRQ serving. (link:https://issues.redhat.com/browse/OCPBUGS-585[*OCPBUGS-585*])
 
-* Previously, when the tuned daemon was restarted out of order as part of the cluster Node Tuning Operator, the CPU affinity of interrupt handlers was reset and the tuning was compromised. With this fix, the `irqbalance` plug-in in tuned is disabled, and {product-title} now relies on the logic and interaction between `CRI-O` and `irqbalance`. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2105123[*BZ#2105123*].
+* Previously, when the tuned daemon was restarted out of order as part of the cluster Node Tuning Operator, the CPU affinity of interrupt handlers was reset and the tuning was compromised. With this fix, the `irqbalance` plug-in in tuned is disabled, and {product-title} now relies on the logic and interaction between `CRI-O` and `irqbalance`.(link:https://bugzilla.redhat.com/show_bug.cgi?id=2105123[*BZ#2105123*])
 
-* Previously, a low latency hook script executing for every new `veth` device took too long when the node was under load. The resultant accumulated delays during pod start events caused the rollout time for `kube-apiserver` to be slow and sometimes exceed the 5-minute rollout timeout. With this fix, the container start time should be shorter and within the 5-minute threshold. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2109965[*BZ#2109965*].
+* Previously, a low latency hook script executing for every new `veth` device took too long when the node was under load. The resultant accumulated delays during pod start events caused the rollout time for `kube-apiserver` to be slow and sometimes exceed the 5-minute rollout timeout. With this fix, the container start time should be shorter and within the 5-minute threshold. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2109965[*BZ#2109965*]).
 
-* Previously, the `oslat` control thread was collocated with one of the test threads, which caused latency spikes in the measurements. With this fix, the `oslat` runner now reserves one CPU for the control thread, meaning the test uses one less CPU for running the busy threads. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2051443[*BZ#2051443*].
+* Previously, the `oslat` control thread was collocated with one of the test threads, which caused latency spikes in the measurements. With this fix, the `oslat` runner now reserves one CPU for the control thread, meaning the test uses one less CPU for running the busy threads. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2051443[*BZ#2051443*])
 
-* Latency measurement tools, also known as `oslat`, `cyclictest`, and `hwlatdetect`, now run on completely isolated CPUs without the helper process running in the background that might cause latency spikes, thus providing more accurate latency measurements. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-2618[*OCPBUGS-2618*].
+* Latency measurement tools, also known as `oslat`, `cyclictest`, and `hwlatdetect`, now run on completely isolated CPUs without the helper process running in the background that might cause latency spikes, therefore providing more accurate latency measurements. (link:https://issues.redhat.com/browse/OCPBUGS-2618[*OCPBUGS-2618*])
 
 * Previously, although the reference `PolicyGenTemplate` for `group-du-sno-ranGen.yaml` includes two `StorageClass`  entries, the generated policy included only one. With this update, the generated policy now includes both policies. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049306[*BZ#2049306*]).
 
@@ -2187,7 +2176,7 @@ sourceStrategy:
 [id="ocp-4-12-storage-bug-fixes"]
 ==== Storage
 
-* Previously, checks for generic ephemeral volumes failed. With this update, checks for expandable volumes now include generic ephemeral volumes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2082773[*BZ#2082773*]
+* Previously, checks for generic ephemeral volumes failed. With this update, checks for expandable volumes now include generic ephemeral volumes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2082773[*BZ#2082773*])
 
 * Previously, if more than one secret was present for vSphere, the vSphere CSI Operator randomly picked a secret and sometimes caused the Operator to restart. With this update, a warning appears when there is more than one secret on the vCenter CSI Operator. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2108473[*BZ#2108473*])
 
@@ -2199,15 +2188,7 @@ sourceStrategy:
 +
 To opt out of using the VHD feature, remove the `fstype` parameter from your storage class. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2080449[*BZ#2080449*])
 
-* Previously, checks for generic ephemeral volumes failed. With this update, checks for expandable volumes now include generic ephemeral volumes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2082773[*BZ#2082773*])
-
 * Previously, if more than one secret was present for vSphere, the vSphere CSI Operator randomly picked a secret and sometimes caused the Operator to restart. With this update, a warning appears when there is more than one secret on the vCenter CSI Operator. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2108473[*BZ#2108473*])
-
-[discrete]
-[id="ocp-4-12-windows-containers-bug-fixes"]
-==== Windows containers
-
-* Previously, restarting the Windows Machine Config Operator (WMCO) in a cluster with running Windows nodes caused the Windows exporter endpoint to be removed. Because of this, each Windows node could not report any metrics data. With this update, the endpoint is retained when the WMCO is started. As a result, metrics data is reported properly after restarting WMCO. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2107261[*BZ#2107261*])
 
 [discrete]
 [id="ocp-4-12-web-console-developer-perspective-bug-fixes"]
@@ -2218,6 +2199,8 @@ To opt out of using the VHD feature, remove the `fstype` parameter from your sto
 * In {product-title} 4.9, when it is minimal or no data in the *Developer Perspective*, most of the monitoring charts or graphs (CPU consumption, memory usage, and bandwidth) show a range of -1 to 1. However, none of these values can ever go below zero. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904106[*BZ#1904106*])
 
 * Before this update, users could not silence alerts in the *Developer* perspective in the {product-title} web console when a user-defined Alertmanager service was deployed because the web console would forward the request to the platform Alertmanager service in the `openshift-monitoring` namespace. With this update, when you view the *Developer* perspective in the web console and try to silence an alert, the request is forwarded to the correct Alertmanager service. (link:https://issues.redhat.com/browse/OCPBUGS-1789[*OCPBUGS-1789*])
+
+* Previously, there was a known issue in the *Add Helm Chart Repositories* form to extend the Developer Catalog of a project. The *Quick Start* guides shows that you can add the `ProjectHelmChartRepository` CR in the required namespace whereas it does not mention that to perform this you need permission from the kubeadmin. This issue was resolved with *Quickstart* mentioning the correct steps to create `ProjectHelmChartRepository` CR. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2057306[*BZ#2057306*])
 
 [id="ocp-4-12-technology-preview"]
 == Technology Preview features
@@ -2909,7 +2892,7 @@ $ ./openshift-install wait-for install-complete
 
 * Due to an unresolved metadata API issue, you cannot install clusters that use bare-metal workers on {rh-openstack} 16.1. Clusters on {rh-openstack} 16.2 are not impacted by this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033953[*BZ#2033953*])
 
-* The `loadBalancerSourceRanges` attribute is not supported, and is ignored, in load-balancer type services in clusters that run on {rh-openstack} and use the OVN Octavia provider. There is no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-2789[*OCPBUGS-2789*])
+* The `loadBalancerSourceRanges` attribute is not supported, and is therefore ignored, in load-balancer type services in clusters that run on {rh-openstack} and use the OVN Octavia provider. There is no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-2789[*OCPBUGS-2789*])
 
 * After a catalog source update, it takes time for OLM to update the subscription status. 
 This can mean that the status of the subscription policy may continue to show as compliant when {cgu-operator-first} decides whether remediation is needed. 
@@ -3094,11 +3077,11 @@ For any {product-title} release, always review the instructions on xref:../updat
 
 //Update with relevant advisory information
 [id="ocp-4-12-0-ga"]
-=== RHSA-2022:xxx - {product-title} 4.12.0 image release, bug fix, and security update advisory
+=== RHSA-2022:7399 - {product-title} 4.12.0 image release, bug fix, and security update advisory
 
-Issued: TBD
+Issued: 2023-01-17
 
-{product-title} release 4.12.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:xxxx[RHSA-2022:xxxx] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:xxxx[RHSA-2022:xxxx] advisory.
+{product-title} release 4.12.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:7399[RHSA-2022:7399] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:7398[RHSA-2022:7398] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 


### PR DESCRIPTION
[OSDOCS-4524](https://issues.redhat.com//browse/OSDOCS-4524): last minute 4.12 RN clean up

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4524

Link to docs preview:
https://54694--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html

QE review:
- [ ] QE has approved this change.
* not needed
