### PR TITLE
OSDOCS-4347 RN: Uncommenting the Correct Link for AWS Local Zones Content

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -85,8 +85,7 @@ For more information, see xref:../installing/installing_aws/installing-aws-netwo
 
 With this update you can install {product-title} to an existing VPC with installer-provisioned infrastructure, extending the worker nodes to Local Zones subnets. The installation program will provision worker nodes on the edge of the AWS network that are specifically designated for user applications by using NoSchedule taints. Applications deployed on the Local Zones locations deliver low latency for end users. 
 
-// Link commented out pending release of details on AWS Local Zone. All approvals received.
-// For more information, see .../installing/installing_aws/installing-aws-localzone.adoc[Local Zone customizations for installation on AWS VPC subnets].
+For more information, see xref:../installing/installing_aws/installing-aws-localzone.adoc[Installing a cluster using AWS Local Zones].
 
 
 [id="ocp-4-12-installation-and-upgrade-gcp-marketplace"]


### PR DESCRIPTION
This release note announces "Installing cluster worker nodes on AWS Local Zones"
This PR is simply to uncomment the correct link to the new material.

Version(s):
enterprise-4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4753

Link to docs preview:


SME, QE and PM approval has been given.

Additional information:
SME: Marco Braga, QE: Yunfei Jiang, PM: Ju Lim