### PR TITLE
[GH#53801]: Updating the openshift loki documentation to improve "Deploying the LokiStack" section. 

### DIFF
--- a/modules/cluster-logging-loki-deploy.adoc
+++ b/modules/cluster-logging-loki-deploy.adoc
@@ -91,7 +91,7 @@ stringData:
 oc apply -f logging-loki.yaml
 ----
 +
-. Create or edit a  Create or edit a `ClusterLogging` CR:
+. Create or edit a `ClusterLogging` CR:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
A section in the Deploying the LokiStack documentation needs improvement. An error in the point 4 of Deploying the LokiStack. 

Resolves #53801

Preview: https://54703--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-loki.html#logging-loki-deploy_cluster-logging-loki