### PR TITLE
[RHACS] Add patch release notes for older 3.72.2 version

### DIFF
--- a/release_notes/372-release-notes.adoc
+++ b/release_notes/372-release-notes.adoc
@@ -20,13 +20,6 @@ toc::[]
 
 |====
 
-[IMPORTANT]
-====
-Because of an unexpected schema change in an upstream vulnerability feed on 20 October 2022, Red Hat published a corrupted CVE data file to https://definitions.stackrox.io, and many Central instances downloaded the corrupted file. As a result, when Central processes the corrupted feed data, it fails and enters a `CrashLoopBackOff` state. Although Red Hat has already taken steps to fix the corrupted CVE data file, already affected Central instances do not automatically get out of the `CrashLoopBackOff` state.
-
-To get Central back to working condition, follow the instructions at  link:https://access.redhat.com/articles/6981104[Central in CrashLoopBackOff - 2022-10-20 Incident].
-====
-
 [id="about-this-release-372"]
 == About this release
 
@@ -295,6 +288,13 @@ The patch release 3.72.1 fixes this error and the reports show the correct CVEs.
 * In {product-title-short} 3.72.0, when you created a deployment bundle by using the `roxctl` CLI that explicitly disabled Pod Security Policies (PSP), the generated bundle still created manifests for the PSP.
 As a result, installing the deployment bundle failed when deploying on Kubernetes versions 1.25 or later.
 The patch release 3.72.1 correctly disables PSP when you specify `--enable-pod-security-policies=false` with the `roxctl` CLI.
+
+[id="resolved-in-version-3722"]
+=== Resolved in version 3.72.2
+
+Release date: 1 December 2022
+
+* Before this update, if Central downloaded a corrupted CVE data file, it failed and entered a `CrashLoopBackOff` state. The patch release 3.72.2 fixes this issue.
 
 [id="resolved-in-version-3723"]
 === Resolved in version 3.72.3


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-14360

Preview: https://openshift-docs-git-rhacs-docs-372-gnelson.vercel.app/openshift-acs/master/release_notes/372-release-notes.html#resolved-in-version-3722

Merge into `rhacs-docs-3.72`

No cherrypicks

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.


