### PR TITLE
Improvement in the documentation to maintain consistency in the ClusterLogging CR yamls

### DIFF
--- a/modules/cluster-logging-forwarding-lokistack.adoc
+++ b/modules/cluster-logging-forwarding-lokistack.adoc
@@ -26,7 +26,7 @@ spec:
   logStore:
     type: lokistack
     lokistack:
-      name: lokistack-dev
+      name: logging-loki
   collection:
     type: vector
 ----


### PR DESCRIPTION
This PR changes the **_spec.logStore.lokistack.name_**  from **_lokistack-dev_** to **logging-loki** to maintain consistency in the documentation. 

Resolves #53727