### PR TITLE
BZ1832275:removes PersistentVolumeLabel

### DIFF
--- a/modules/admission-plug-ins-default.adoc
+++ b/modules/admission-plug-ins-default.adoc
@@ -64,7 +64,6 @@ Default validating and admission plug-ins are enabled in {product-title} {produc
 * `Priority`
 * `DefaultTolerationSeconds`
 * `PodTolerationRestriction`
-* `PersistentVolumeLabel`
 * `DefaultStorageClass`
 * `StorageObjectInUseProtection`
 * `RuntimeClass`


### PR DESCRIPTION
- applies to 4.8 and above versions 
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1832275)
- [Preview](https://54710--docspreview.netlify.app/openshift-enterprise/latest/architecture/admission-plug-ins.html)