### PR TITLE
TELCODOCS-905-fix: bug fix - OVNKube now the default from 4.12

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -369,7 +369,7 @@ ifdef::openshift-origin[]
 Either `OpenShiftSDN` or `OVNKubernetes`. The default value is `OVNKubernetes`.
 endif::openshift-origin[]
 ifndef::openshift-origin[]
-Either `OpenShiftSDN` or `OVNKubernetes`. `OpenShiftSDN` is a CNI plugin for all-Linux networks. `OVNKubernetes` is a CNI plugin for Linux networks and hybrid networks that contain both Linux and Windows servers. The default value is `OpenShiftSDN`.
+Either `OpenShiftSDN` or `OVNKubernetes`. `OpenShiftSDN` is a CNI plugin for all-Linux networks. `OVNKubernetes` is a CNI plugin for Linux networks and hybrid networks that contain both Linux and Windows servers. The default value is `OVNKubernetes`.
 endif::openshift-origin[]
 
 |`networking.clusterNetwork`
@@ -404,7 +404,7 @@ endif::bare[]
 Required if you use `networking.clusterNetwork`. An IP address block.
 
 ifndef::bare[]
-An IPv4 network. 
+An IPv4 network.
 endif::bare[]
 
 ifdef::bare[]


### PR DESCRIPTION
Version(s): 4.12 and later.

Issue: https://issues.redhat.com/browse/TELCODOCS-905

Link to docs preview: https://54718--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-configuration-parameters-network_installing-bare-metal-network-customizations

Search for OVN, second instance.

This fix is needed as an update to 4.11 and previous was accidentally merged to main. The default network type in 4.12 and onwards is OVNKubernetes.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
