### PR TITLE
OSDCOS-4814: Final AWS Local Zone updates ahead of GA

### DIFF
--- a/installing/installing_aws/installing-aws-localzone.adoc
+++ b/installing/installing_aws/installing-aws-localzone.adoc
@@ -42,8 +42,6 @@ Be sure to also review this site list if you are configuring a proxy.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
-
 include::modules/installation-aws-add-local-zone-locations.adoc[leveloffset=+1]
 
 include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]
@@ -66,7 +64,8 @@ include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
-
+include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-generate-aws-user-infra-install-config.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/modules/installation-aws-tested-machine-types.adoc
+++ b/modules/installation-aws-tested-machine-types.adoc
@@ -41,7 +41,11 @@ ifdef::localzone[]
 .Machine types based on x86_64 architecture for AWS Local Zones
 [%collapsible]
 ====
+* `c5.2xlarge`
+* `c5d.2xlarge`
 * `m5.xlarge`
+* `m5.2xlarge`
+* `t3.xlarge`
 ====
 endif::localzone[]
 

--- a/modules/installation-creating-aws-subnet-localzone.adoc
+++ b/modules/installation-creating-aws-subnet-localzone.adoc
@@ -62,7 +62,7 @@ requires:
 ----
 <1> A short, representative cluster name to use for hostnames, etc.
 <2> Specify the cluster name that you used when you generated the `install-config.yaml` file for the cluster.
-<3> The VPC ID in which the cluster's subnet will be created.
+<3> The VPC ID in which the Local Zone's subnet will be created.
 <4> Specify the `VpcId` value from the output of the CloudFormation template
 for the VPC.
 <5> The Public Route Table ID for the VPC.
@@ -90,11 +90,11 @@ You must enter the command on a single line.
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <name> \ <1>
+$ aws cloudformation create-stack --stack-name <subnet_stack_name> \ <1>
      --template-body file://<template>.yaml \ <2>
      --parameters file://<parameters>.json <3>
 ----
-<1> `<name>` is the name for the CloudFormation stack, such as `cluster-lz-<local_zone_shortname>`.
+<1> `<subnet_stack_name>` is the name for the CloudFormation stack, such as `cluster-lz-<local_zone_shortname>`.
 You need the name of this stack if you remove the cluster.
 <2> `<template>` is the relative path to and name of the CloudFormation template
 YAML file that you saved.
@@ -111,7 +111,7 @@ arn:aws:cloudformation:us-east-1:123456789012:stack/cluster-lz-nyc1/dbedae40-2fd
 +
 [source,terminal]
 ----
-$ aws cloudformation describe-stacks --stack-name <name>
+$ aws cloudformation describe-stacks --stack-name <subnet_stack_name>
 ----
 +
 After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values


### PR DESCRIPTION
Version(s):
4.12+

Issue:
This issue addresses [osdocs-4814](https://issues.redhat.com/browse/OSDOCS-4814), which addresses the final comments from SME/QE ahead of 4.12 GA.

Link to docs preview:

- [Creating the installation files for AWS](https://54727--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-localzone.html#installation-user-infra-generate_installing-aws-localzone) (provided to view update to TOC structure)
- [Tested instance types for AWS](https://54727--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-localzone.html#installation-aws-tested-machine-types_installing-aws-localzone)
-  [Creating a subnet in AWS Local Zones](https://54727--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-localzone.html#installation-creating-aws-subnet-localzone_installing-aws-localzone) (update to third annotation)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->