### PR TITLE
[OSDOCS-4787]: known issue replacing control plane machines on OVN-k8s clusters

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3056,6 +3056,10 @@ $ oc delete pods --all -n openshift-cloud-controller-manager
 
 * When an OVN cluster installed on IBM Public Cloud has more than 60 worker nodes, simultaneously creating 2000 or more services and route objects can cause pods created at the same time to remain in the `ContainerCreating` status. If this problem occurs, entering the `oc describe pod <podname>` command shows events with the following warning: `FailedCreatePodSandBox...failed to configure pod interface: timed out waiting for OVS port binding (ovn-installed)`. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-3470[*OCPBUGS-3470*])
 
+* When a control plane machine is replaced on a cluster that uses the OVN-Kubernetes network provider, the pods related to OVN-Kubernetes might not start on the replacement machine. When this occurs, the lack of networking on the new machine prevents etcd from allowing it to replace the old machine. As a result, the cluster is stuck in this state and might become degraded. This behavior can occur when the control plane is replaced manually or by the control plane machine set.
++
+There is currently no workaround to resolve this issue if encountered. To avoid this issue, xref:../machine_management/control_plane_machine_management/cpmso-disabling.adoc[disable the control plane machine set] and do not replace control plane machines manually if your cluster uses the OVN-Kubernetes network provider. (link:https://issues.redhat.com/browse/OCPBUGS-5306[*OCPBUGS-5306*])
+
 [id="ocp-4-12-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-4787](https://issues.redhat.com/browse/OSDOCS-4787)

Link to docs preview:
Added as last known issue, scroll up from [Asynchronous errata updates](https://54728--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-asynchronous-errata-updates)

QE review:
- [ ] QE has approved this change.

Additional information:
- Merge freeze [exception](https://docs.google.com/spreadsheets/d/1_boDK0-kq4NRoVip8nGhZjq1EQ0XoHAfzuAP6RvQxiA/) for 4.12 RNs
- Acks via Slack from DPM, Cloud dev lead, and Cloud PM. Main discussion [here](https://redhat-internal.slack.com/archives/C04DLQNN7B9/p1673622100512089).