### PR TITLE
CNV-24330: metrics change for 4.12.1

### DIFF
--- a/modules/virt-live-migration-metrics.adoc
+++ b/modules/virt-live-migration-metrics.adoc
@@ -21,7 +21,7 @@ The following metrics can be queried to show live migration status:
 
 `kubevirt_migrate_vmi_running_count`:: The number of running migrations. Type: Gauge.
 
-`kubevirt_migrate_vmi_succeeded_total`:: The number of successfully completed migrations. Type: Gauge.
+`kubevirt_migrate_vmi_succeeded`:: The number of successfully completed migrations. Type: Gauge.
 
-`kubevirt_migrate_vmi_failed_total`:: The number of failed migrations. Type: Gauge.
+`kubevirt_migrate_vmi_failed`:: The number of failed migrations. Type: Gauge.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): Hold until 4.12.1 releases. When merging, CP to 4.12+ 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-24330](https://issues.redhat.com//browse/CNV-24330)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://54734--docspreview.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-prometheus-queries.html#virt-live-migration-metrics_virt-prometheus-queries
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: @dshchedr please review when you can. Thanks!
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
