### PR TITLE
Change plugin to remove hyphen per Style Guide

### DIFF
--- a/modules/configure-acs-kube-security-platform.adoc
+++ b/modules/configure-acs-kube-security-platform.adoc
@@ -3,7 +3,7 @@
 // * integration/integrate-using-email.adoc
 :_module-type: PROCEDURE
 [id="configure-acs-kube-security-platform"]
-= Configuring the email plug-in 
+= Configuring the email plugin 
 
 The {product-title-short} notifier can send email to a recipient specified in the integration, or it can use annotations to determine the recipient. 
 

--- a/modules/rbac-resource-definitions.adoc
+++ b/modules/rbac-resource-definitions.adoc
@@ -24,7 +24,7 @@ The following table lists the resources and describes the actions that users can
 //TODO: Add link to policy violations
 
 | AuthPlugin
-| View existing Authentication plug-ins
+| View existing Authentication plugins
 | Modify these configurations.
 _(Local administrator only.)_
 

--- a/operating/use-admission-controller-enforcement.adoc
+++ b/operating/use-admission-controller-enforcement.adoc
@@ -6,14 +6,15 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{product-title} works with link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/[Kubernetes admission controllers] and link:https://docs.openshift.com/container-platform/4.11/architecture/admission-plug-ins.html[{ocp} admission plug-ins] to allow you to enforce security policies before Kubernetes or {ocp} creates workloads, for example, deployments, daemon sets or jobs.
+{product-title} works with link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/[Kubernetes admission controllers] and link:https://docs.openshift.com/container-platform/4.11/architecture/admission-plug-ins.html[{ocp} admission plugins] to allow you to enforce security policies before Kubernetes or {ocp} creates workloads, for example, deployments, daemon sets or jobs.
+
 The {product-title} admission controller prevents users from creating workloads that violate policies you configure in {product-title}.
 Beginning from the {product-title} version 3.0.41, you can also configure the admission controller to prevent updates to workloads that violate policies.
 
 {product-title} uses the `ValidatingAdmissionWebhook` controller to verify that the resource being provisioned complies with the specified security policies.
 To handle this, {product-title} creates a `ValidatingWebhookConfiguration` which contains multiple webhook rules.
-When the Kubernetes or {ocp} API server receives a request that matches one of the webhook rules, the API server sends an `AdmissionReview` request to {product-title}.
-{product-title} then accepts or rejects the request based on the configured security policies.
+
+When the Kubernetes or {ocp} API server receives a request that matches one of the webhook rules, the API server sends an `AdmissionReview` request to {product-title}. {product-title} then accepts or rejects the request based on the configured security policies.
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.74`
- Cherry pick to `rhacs-docs-3.73`
- Cherry pick to `rhacs-docs-3.72`
- Cherry pick to `rhacs-docs-3.71`

[Issue](https://issues.redhat.com/browse/OSDOCS-4815)

Links to docs preview:

- https://openshift-docs-ho03zm59m-kcarmichael08.vercel.app/openshift-acs/master/integration/integrate-with-email.html#configure-acs-kube-security-platform
- https://openshift-docs-ho03zm59m-kcarmichael08.vercel.app/openshift-acs/master/operating/manage-user-access/manage-role-based-access-control-3630.html#resource-definitions_manage-role-based-access-control
- https://openshift-docs-ho03zm59m-kcarmichael08.vercel.app/openshift-acs/master/operating/use-admission-controller-enforcement.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: (**N/A**)
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

