### PR TITLE
OSDOCS-5119 Removing DNS zones and createfirewallrules from GCP XPN

### DIFF
--- a/installing/installing_gcp/installing-gcp-shared-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-shared-vpc.adoc
@@ -11,8 +11,6 @@ In {product-title} version {product-version}, you can install a cluster into a s
 
 The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 [id="installation-gcp-shared-vpc-prerequisites_{context}"]
 == Prerequisites
 
@@ -45,8 +43,6 @@ include::modules/installation-launching-installer.adoc[leveloffset=+1]
 include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
-
-include::modules/installation-gcp-shared-vpc-ingress.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1180,26 +1180,6 @@ Additional GCP configuration parameters are described in the following table:
 |The name of the existing subnet where you want to deploy your compute machines.
 |The subnet name.
 
-|`platform.gcp.createFirewallRules`
-|Optional. Set this value to `Disabled` if you want to create and manage your firewall rules using network tags. By default, the cluster will automatically create and manage the firewall rules that are required for cluster communication. Your service account must have `roles/compute.networkAdmin` and `roles/compute.securityAdmin` privileges in the host project to perform these tasks automatically. If your service account does not have the `roles/dns.admin` privilege in the host project, it must have the `dns.networks.bindPrivateDNSZone` permission.
-|`Enabled` or `Disabled`. The default value is `Enabled`.
-
-|`platform.gcp.publicDNSZone.project`
-|Optional. The name of the project that contains the public DNS zone. If you set this value, your service account must have the `roles/dns.admin` privilege in the specified project. If you do not set this value, it defaults to `gcp.projectId`.
-|The name of the project that contains the public DNS zone.
-
-|`platform.gcp.publicDNSZone.id`
-|Optional. The ID or name of an existing public DNS zone.  The public DNS zone domain must match the `baseDomain` parameter. If you do not set this value, the installation program will use a public DNS zone in the service project.
-|The public DNS zone name.
-
-|`platform.gcp.privateDNSZone.project`
-|Optional. The name of the project that contains the private DNS zone. If you set this value, your service account must have the `roles/dns.admin` privilege in the host project. If you do not set this value, it defaults to `gcp.projectId`.
-|The name of the project that contains the private DNS zone.
-
-|`platform.gcp.privateDNSZone.id`
-|Optional. The ID or name of an existing private DNS zone.  If you do not set this value, the installation program will create a private DNS zone in the service project.
-|The private DNS zone name.
-
 |`platform.gcp.licenses`
 |A list of license URLs that must be applied to the compute images.
 [IMPORTANT]

--- a/modules/installation-gcp-shared-vpc-config.adoc
+++ b/modules/installation-gcp-shared-vpc-config.adoc
@@ -22,22 +22,18 @@ platform:
   gcp:
     computeSubnet: shared-vpc-subnet-1 <2>
     controlPlaneSubnet: shared-vpc-subnet-2 <3>
-    createFirewallRules: Disabled <4>
-    network: shared-vpc <5>
-    networkProjectID: host-project-name <6>
-    publicDNSZone:
-      id: public-dns-zone <7>
-      project: host-project-name <8> 
-    projectID: service-project-name <9>
+    network: shared-vpc <4>
+    networkProjectID: host-project-name <5>
+    projectID: service-project-name <6>
     region: us-east1
     defaultMachinePlatform:
-      tags: <10>
+      tags: <7>
       - global-tag1
 controlPlane:
   name: master
   platform:
     gcp:
-      tags: <10>
+      tags: <7>
       - control-plane-tag1
       type: n2-standard-4
       zones:
@@ -48,7 +44,7 @@ compute:
 - name: worker
   platform:
     gcp:
-      tags: <10>
+      tags: <7>
       - compute-tag1 
       type: n2-standard-4
       zones:
@@ -62,16 +58,13 @@ networking:
   machineNetwork:
   - cidr: 10.0.0.0/16
 pullSecret: '{"auths": ...}'
-sshKey: ssh-ed25519 AAAA... <11>
+sshKey: ssh-ed25519 AAAA... <8>
 ----
 <1> `credentialsMode` must be set to `Passthrough` to allow the cluster to use the provided GCP service account after cluster creation. See the "Prerequisites" section for the required GCP permissions that your service account must have.
 <2> The name of the subnet in the shared VPC for compute machines to use.
 <3> The name of the subnet in the shared VPC for control plane machines to use.
-<4> Optional. If you set `createFirewallRules` to `Disabled`, you can create and manage firewall rules manually through the use of network tags. By default, the cluster will automatically create and manage the firewall rules that are required for cluster communication. Your service account must have `roles/compute.networkAdmin` and `roles/compute.securityAdmin` privileges in the host project to perform these tasks automatically. If your service account does not have the `roles/dns.admin` privilege in the host project, it must have the `dns.networks.bindPrivateDNSZone` permission.
-<5> The name of the shared VPC.
-<6> The name of the host project where the shared VPC exists.
-<7> Optional. The name of a public DNS zone in the host project. If you set this value, your service account must have the `roles/dns.admin` privilege in the host project. The public DNS zone domain must match the `baseDomain` parameter. If you do not set this value, the installation program will use the public DNS zone in the service project.
-<8> Optional. The name of the host project which contains the public DNS zone. This value is required if you specify a public DNS zone that exists in another project.
-<9> The name of the GCP project where you want to install the cluster.
-<10> Optional. If you want to manually create and manage your GCP firewall rules, you can set `platform.gcp.createFirewallRules` to `Disabled` and then specify one or more network tags. You can set tags on the compute machines, the control plane machines, or all machines.
-<11> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<4> The name of the shared VPC.
+<5> The name of the host project where the shared VPC exists.
+<6> The name of the GCP project where you want to install the cluster.
+<7> Optional. One or more network tags to apply to compute machines, control plane machines, or all machines.
+<8> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.


### PR DESCRIPTION
Version(s):
4.13

https://issues.redhat.com/browse/OSDOCS-5119

Link to docs preview:
https://54736--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-shared-vpc.html

QE review:
- [X] QE has approved this change.

Removing public/private DNS zone parameters and createfirewall rules parameters from GCP XPN per https://github.com/openshift/installer/pull/6771 and https://github.com/openshift/installer/pull/6679