### PR TITLE
fixing build warnings for OCP 4.12

### DIFF
--- a/migration_toolkit_for_containers/installing-mtc-restricted.adoc
+++ b/migration_toolkit_for_containers/installing-mtc-restricted.adoc
@@ -49,7 +49,9 @@ OpenShift environments have the `PodSecurityAdmission` controller enabled by def
 
 To guarantee successful data transfer in all environments, {mtc-full} ({mtc-short}) 1.7.5 introduced changes in Rsync pods, including running Rsync pods as non-root user by default. This ensures that data transfer is possible even for workloads that do not necessarily require higher privileges. This change was made because it is best to run workloads with the lowest level of privileges possible.
 
-==== Manually overriding default non-root operation for data trannsfer
+[discrete]
+[id="migration-rsync-override-data-transfer_{context}"]
+=== Manually overriding default non-root operation for data transfer
 
 Although running Rsync pods as non-root user works in most cases, data transfer might fail when you run workloads as root user on the source side. {mtc-short} provides two ways to manually override default non-root operation for data transfer:
 

--- a/modules/installation-nutanix-config-yaml.adoc
+++ b/modules/installation-nutanix-config-yaml.adoc
@@ -94,8 +94,8 @@ endif::openshift-origin[]
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance.
 ====
 <4> Optional: Provide additional configuration for the machine pool parameters for the compute and control plane machines.
-ifndef::openshift-origin[]
 <5> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
+ifndef::openshift-origin[]
 <6> Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server and pointing the installation program to the image.
 <7> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +

--- a/modules/installing-ocp-agent.adoc
+++ b/modules/installing-ocp-agent.adoc
@@ -81,8 +81,8 @@ sshKey: |
 +
 <1> Required.
 <2> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
-<2> Enter your pull secret.
-<3> Enter your ssh public key.
+<3> Enter your pull secret.
+<4> Enter your ssh public key.
 
 +
 [NOTE]

--- a/modules/olm-overriding-operator-pod-affinity.adoc
+++ b/modules/olm-overriding-operator-pod-affinity.adoc
@@ -39,11 +39,11 @@ The following examples describe situations where you might want to schedule an O
 * If you want Operators dispersed throughout the infrastructure to avoid downtime due to network or hardware issues
 
 ifdef::olm[]
-You can control where an Operator pod is installed by adding node affinity, pod affinity, or pod anti-affinity constraints to the Operator's `Subscription` object. Node affinity is a set of rules used by the scheduler to determine where a pod can be placed. Pod affinity enables you to ensure that related pods are scheduled to the same node. Pod anti-affinity allows you to prevent a pod from being scheduled on a node. 
+You can control where an Operator pod is installed by adding node affinity, pod affinity, or pod anti-affinity constraints to the Operator's `Subscription` object. Node affinity is a set of rules used by the scheduler to determine where a pod can be placed. Pod affinity enables you to ensure that related pods are scheduled to the same node. Pod anti-affinity allows you to prevent a pod from being scheduled on a node.
 endif::olm[]
 
 ifdef::pod[]
-You can control where an Operator pod is installed by adding a pod affinity or anti-affinity to the Operator's `Subscription` object. 
+You can control where an Operator pod is installed by adding a pod affinity or anti-affinity to the Operator's `Subscription` object.
 endif::pod[]
 
 ifdef::node[]
@@ -133,7 +133,7 @@ spec:
   sourceNamespace: operator-registries
   config:
     affinity:
-      podAffinity:
+      podAffinity: <1>
         requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:

--- a/rest_api/objects/index.adoc
+++ b/rest_api/objects/index.adoc
@@ -702,7 +702,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -745,7 +745,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -788,7 +788,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -831,7 +831,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -874,7 +874,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -917,7 +917,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -960,7 +960,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -1003,7 +1003,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -1046,7 +1046,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -1089,7 +1089,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -1132,7 +1132,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -1175,7 +1175,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta[`ListMeta`]
-| 
+|
 
 |===
 
@@ -1218,7 +1218,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta[`ListMeta`]
-| 
+|
 
 |===
 
@@ -1261,7 +1261,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta[`ListMeta`]
-| 
+|
 
 |===
 
@@ -1304,7 +1304,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta[`ListMeta`]
-| 
+|
 
 |===
 
@@ -1339,7 +1339,7 @@ Required::
 
 | `items`
 | xref:../oauth_apis/useroauthaccesstoken-oauth-openshift-io-v1.adoc#useroauthaccesstoken-oauth-openshift-io-v1[`array (UserOAuthAccessToken)`]
-| 
+|
 
 | `kind`
 | `string`
@@ -1347,7 +1347,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta[`ListMeta`]
-| 
+|
 
 |===
 
@@ -1390,7 +1390,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -1433,7 +1433,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -1476,7 +1476,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -1519,7 +1519,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -1562,7 +1562,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -1605,7 +1605,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -1648,7 +1648,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta_v2[`ListMeta_v2`]
-| 
+|
 
 |===
 
@@ -1691,7 +1691,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta[`ListMeta`]
-| 
+|
 
 |===
 
@@ -1734,7 +1734,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta[`ListMeta`]
-| 
+|
 
 |===
 
@@ -1777,7 +1777,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta[`ListMeta`]
-| 
+|
 
 |===
 
@@ -1819,11 +1819,11 @@ Type::
 
 | `owned`
 | xref:../objects/index.adoc#com.github.operator-framework.api.pkg.operators.v1alpha1.APIServiceDescription[`array (APIServiceDescription)`]
-| 
+|
 
 | `required`
 | xref:../objects/index.adoc#com.github.operator-framework.api.pkg.operators.v1alpha1.APIServiceDescription[`array (APIServiceDescription)`]
-| 
+|
 
 |===
 
@@ -1852,11 +1852,11 @@ Type::
 
 | `owned`
 | xref:../objects/index.adoc#com.github.operator-framework.api.pkg.operators.v1alpha1.CRDDescription[`array (CRDDescription)`]
-| 
+|
 
 | `required`
 | xref:../objects/index.adoc#com.github.operator-framework.api.pkg.operators.v1alpha1.CRDDescription[`array (CRDDescription)`]
-| 
+|
 
 |===
 
@@ -1886,11 +1886,11 @@ Required::
 
 | `supported`
 | `boolean`
-| 
+|
 
 | `type`
 | `string`
-| 
+|
 
 |===
 
@@ -1923,7 +1923,7 @@ Required::
 
 | `items`
 | xref:../operatorhub_apis/packagemanifest-packages-operators-coreos-com-v1.adoc#packagemanifest-packages-operators-coreos-com-v1[`array (PackageManifest)`]
-| 
+|
 
 | `kind`
 | `string`
@@ -1931,7 +1931,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta[`ListMeta`]
-| 
+|
 
 |===
 
@@ -2505,7 +2505,7 @@ Required::
 
 | `metadata`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta[`ListMeta`]
-| 
+|
 
 |===
 
@@ -2989,15 +2989,15 @@ Required::
 
 | `lastTransitionTime`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Time[`Time`]
-| 
+|
 
 | `message`
 | `string`
-| 
+|
 
 | `reason`
 | `string`
-| 
+|
 
 | `status`
 | `string`
@@ -3427,11 +3427,11 @@ Required::
 
 | `status`
 | `string`
-| 
+|
 
 | `type`
 | `string`
-| 
+|
 
 |===
 
@@ -5159,27 +5159,27 @@ Type::
 
 | `$ref`
 | `string`
-| 
+|
 
 | `$schema`
 | `string`
-| 
+|
 
 | `additionalItems`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool[``]
-| 
+|
 
 | `additionalProperties`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool[``]
-| 
+|
 
 | `allOf`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps[`array (undefined)`]
-| 
+|
 
 | `anyOf`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps[`array (undefined)`]
-| 
+|
 
 | `default`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON[`JSON`]
@@ -5187,35 +5187,35 @@ Type::
 
 | `definitions`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps[`object (undefined)`]
-| 
+|
 
 | `dependencies`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrStringArray[`object (undefined)`]
-| 
+|
 
 | `description`
 | `string`
-| 
+|
 
 | `enum`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON[`array (JSON)`]
-| 
+|
 
 | `example`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON[`JSON`]
-| 
+|
 
 | `exclusiveMaximum`
 | `boolean`
-| 
+|
 
 | `exclusiveMinimum`
 | `boolean`
-| 
+|
 
 | `externalDocs`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ExternalDocumentation[`ExternalDocumentation`]
-| 
+|
 
 | `format`
 | `string`
@@ -5225,87 +5225,87 @@ Type::
 
 | `id`
 | `string`
-| 
+|
 
 | `items`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrArray[``]
-| 
+|
 
 | `maxItems`
 | `integer`
-| 
+|
 
 | `maxLength`
 | `integer`
-| 
+|
 
 | `maxProperties`
 | `integer`
-| 
+|
 
 | `maximum`
 | `number`
-| 
+|
 
 | `minItems`
 | `integer`
-| 
+|
 
 | `minLength`
 | `integer`
-| 
+|
 
 | `minProperties`
 | `integer`
-| 
+|
 
 | `minimum`
 | `number`
-| 
+|
 
 | `multipleOf`
 | `number`
-| 
+|
 
 | `not`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps[``]
-| 
+|
 
 | `nullable`
 | `boolean`
-| 
+|
 
 | `oneOf`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps[`array (undefined)`]
-| 
+|
 
 | `pattern`
 | `string`
-| 
+|
 
 | `patternProperties`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps[`object (undefined)`]
-| 
+|
 
 | `properties`
 | xref:../objects/index.adoc#io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps[`object (undefined)`]
-| 
+|
 
 | `required`
 | `array (string)`
-| 
+|
 
 | `title`
 | `string`
-| 
+|
 
 | `type`
 | `string`
-| 
+|
 
 | `uniqueItems`
 | `boolean`
-| 
+|
 
 | `x-kubernetes-embedded-resource`
 | `boolean`
@@ -5381,19 +5381,14 @@ Quantity is a fixed-point representation of a number. It provides convenient mar
 
 The serialization format is:
 
-``` <quantity>        ::= <signedNumber><suffix>
-
-	(Note that <suffix> may be empty, from the "" case in <decimalSI>.)
-
+<quantity>        ::= <signedNumber><suffix>
+  (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
 <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
-
-	(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
-
+  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
 <decimalSI>       ::= m | "" | k | M | G | T | P | E
+  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+<decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
 
-	(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
-
-<decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber> ```
 
 No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
 
@@ -5552,15 +5547,15 @@ Required::
 
 | `group`
 | `string`
-| 
+|
 
 | `kind`
 | `string`
-| 
+|
 
 | `version`
 | `string`
-| 
+|
 
 |===
 
@@ -6073,7 +6068,7 @@ Required::
 
 | `type`
 | `string`
-| 
+|
 
 |===
 


### PR DESCRIPTION
Nutanix install: https://54738--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#installation-nutanix-config-yaml_installing-nutanix-installer-provisioned
Agent install: https://54738--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent_installing-with-agent-based-installer
Operator pod affinity: https://54738--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-adding-operators-to-cluster.html#olm-overriding-operator-pod-affinity_olm-adding-operators-to-a-cluster
API: https://54738--docspreview.netlify.app/openshift-enterprise/latest/rest_api/objects/index.html#io.k8s.apimachinery.pkg.api.resource.Quantity (This matches the live version)