### PR TITLE
OSDOCS-4816: Added certificate renewal instructions

### DIFF
--- a/applications/deployments/osd-config-custom-domains-applications.adoc
+++ b/applications/deployments/osd-config-custom-domains-applications.adoc
@@ -9,3 +9,4 @@ toc::[]
 You can configure a custom domain for your applications. Custom domains are specific wildcard domains that can be used with {product-title} applications. 
 
 include::modules/osd-applications-config-custom-domains.adoc[leveloffset=+1]
+include::modules/osd-applications-renew-custom-domains.adoc[leveloffset=+1]

--- a/modules/osd-applications-renew-custom-domains.adoc
+++ b/modules/osd-applications-renew-custom-domains.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies for OSD and ROSA:
+//
+// * applications/deployments/osd-config-custom-domains-applications.adoc
+
+:_content-type: PROCEDURE
+[id="osd-applications-renew-custom-domains_{context}"]
+= Renewing a certificate for custom domains
+
+You can renew certificates with the Custom Domains Operator (CDO) by using the `oc` CLI tool.
+
+//s a customer of OSD/ROSA, I would like instructions on how to renew certificates with Custom Domains Operator (CDO).
+.Prerequisites
+* You have the latest version `oc` CLI tool installed.
+
+.Procedure 
+. Create new secret
++
+[source,terminal]
+----
+$ oc create secret tls <secret-new> --cert=fullchain.pem --key=privkey.pem -n <my_project>
+----
+ 
+. Patch CustomDomain CR
++
+[source,terminal]
+----
+$ oc patch customdomain <company_name> --type='merge' -p '{"spec":{"certificate":{"name":"<secret-new>"}}}'
+----
+
+. Delete old secret
++
+[source,terminal]
+----
+$ oc delete secret <secret-old> -n <my_project>
+----


### PR DESCRIPTION
Version(s):
Enterprise-4.12+

Issue:
[OSDOCS-4816](https://issues.redhat.com/browse/OSDOCS-4816)

Link to docs preview:
* **[ROSA](https://54742--docspreview.netlify.app/openshift-rosa/latest/applications/deployments/osd-config-custom-domains-applications.html#osd-applications-renew-custom-domains_osd-config-custom-domains-applications)**
* **[OSD](https://54742--docspreview.netlify.app/openshift-dedicated/latest/applications/deployments/osd-config-custom-domains-applications.html#osd-applications-renew-custom-domains_osd-config-custom-domains-applications)**

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added instructions for renewing a certificate for custom domains and included the deletion steps as well.