### PR TITLE
Fixed some callout errors in install yaml for baremetal

### DIFF
--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -64,7 +64,7 @@ endif::rhv[]
 
 You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 baseDomain: example.com <1>
@@ -287,14 +287,14 @@ endif::restricted[]
 ifndef::openshift-origin[]
 <14> The SSH public key for the `core` user in {op-system-first}.
 endif::openshift-origin[]
+ifdef::openshift-origin[]
+<13> The SSH public key for the `core` user in {op-system-first}.
+endif::openshift-origin[]
 +
 [NOTE]
 ====
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
-ifdef::openshift-origin[]
-<13> The SSH public key for the `core` user in {op-system-first}.
-endif::openshift-origin[]
 ifdef::restricted[]
 ifndef::ibm-z,ibm-z-kvm[]
 ifndef::openshift-origin[]


### PR DESCRIPTION
Some callout errors were introduced in 4.12, principally for OKD, possibly via https://github.com/openshift/openshift-docs/pull/52341. 

per @kalexand-rh 

```
asciidoctor: WARNING: modules/installation-bare-metal-config-yaml.adoc: line 310: callout list item index: expected 14, got 15
asciidoctor: WARNING: modules/installation-bare-metal-config-yaml.adoc: line 310: no callout found for <14>
asciidoctor: WARNING: modules/installation-bare-metal-config-yaml.adoc: line 311: callout list item index: expected 15, got 16
asciidoctor: WARNING: modules/installation-bare-metal-config-yaml.adoc: line 310: callout list item index: expected 14, got 15
asciidoctor: WARNING: modules/installation-bare-metal-config-yaml.adoc: line 310: no callout found for <14>
asciidoctor: WARNING: modules/installation-bare-metal-config-yaml.adoc: line 311: callout list item index: expected 15, got 16
asciidoctor: WARNING: modules/installation-bare-metal-config-yaml.adoc: line 325: no callout found for <14>
```

Previews: 
[bare metal sample yaml](https://54745--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-bare-metal-config-yaml_installing-bare-metal)
[bare metal network customiations sample yaml](https://54745--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-bare-metal-config-yaml_installing-bare-metal-network-customizations)
[bare metal restricted network sample yaml](https://54745--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html#installation-bare-metal-config-yaml_installing-restricted-networks-bare-metal)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
