### PR TITLE
adding 4.13 to the distro map

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -134,6 +134,9 @@ openshift-enterprise:
     enterprise-4.12:
       name: '4.12'
       dir: container-platform/4.12
+    enterprise-4.13:
+      name: '4.13'
+      dir: container-platform/4.13
 openshift-dedicated:
   name: OpenShift Dedicated
   author: OpenShift Documentation Project <openshift-docs@redhat.com>


### PR DESCRIPTION
I'm setting up the WIP banner for 4.13 on https://github.com/openshift/openshift-docs/pull/54599/files, but I need to add it to the distro map.