### PR TITLE
OCPBUGS-5536 Removing text "The only allowed values.."

### DIFF
--- a/modules/nw-sriov-dpdk-example-mellanox.adoc
+++ b/modules/nw-sriov-dpdk-example-mellanox.adoc
@@ -39,7 +39,7 @@ spec:
   deviceType: netdevice <2>
   isRdma: true <3>
 ----
-<1> Specify the device hex code of the SR-IOV network device. The only allowed values for Mellanox cards are `1015` and `1017`.
+<1> Specify the device hex code of the SR-IOV network device.
 <2> Specify the driver type for the virtual functions to `netdevice`. A Mellanox SR-IOV Virtual Function (VF) can work in DPDK mode without using the `vfio-pci` device type. The VF device appears as a kernel network interface inside a container.
 <3> Enable Remote Direct Memory Access (RDMA) mode. This is required for Mellanox cards to work in DPDK mode.
 +


### PR DESCRIPTION
[OCPBUGS-5536]: SRIOV documentation page shows contradictory information on supported Mellanox device IDs

Version(s):
4.11, 4.12 and main
Issue:
https://issues.redhat.com/browse/OCPBUGS-5536

Link to docs preview: https://54754--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/using-dpdk-and-rdma.html#example-vf-use-in-dpdk-mode-mellanox_using-dpdk-and-rdma


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
