### PR TITLE
BZ1990481: Add commands for chaning cronjob CR of Compliance Operator

### DIFF
--- a/modules/compliance-anatomy.adoc
+++ b/modules/compliance-anatomy.adoc
@@ -109,6 +109,17 @@ NAME                                           SCHEDULE    SUSPEND   ACTIVE   LA
 
 For the most important issues, events are emitted. View them with `oc describe compliancesuites/<name>`. The `Suite` objects also have a `Status` subresource that is updated when any of `Scan` objects that belong to this suite update their `Status` subresource. After all expected scans are created, control is passed to the scan controller.
 
+Sometimes, the `ComplianceSuite` CR cannot create a scan if the scan exceeds the default memory limit of the Compliance Operator. Exceeding this limit can result in an Out of Memory (OOM) error message. You can resolve this issue by changing the configuration of the `CronJob` CR, so that you can increase the memory limit for the Compliance Operator. The following example demonstrates a sequence of commands that change the configuration of a `CronJob` CR for this purpose:
+
+[source,terminal]
+----
+$ oc get cronjob -n openshift-compliance
+
+$ oc edit <cron-cr-resource>
+
+$ Update limit/request memory/cpu
+----
+
 [id="compliance-scan-lifecycle-debugging_{context}"]
 == ComplianceScan custom resource lifecycle and debugging
 The `ComplianceScan` CRs are handled by the `scanctrl` controller. This is also where the actual scans happen and the scan results are created. Each scan goes through several phases:


### PR DESCRIPTION
BZ1990481:Add commands for chaning cronjob CR of Compliance Operator


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.8+

Issue:
[BZ1990481](https://bugzilla.redhat.com/show_bug.cgi?id=1990481)

Link to docs preview:
[(http://file.emea.redhat.com/dfitzmau/)](http://file.emea.redhat.com/dfitzmau/BZ1990481/security/compliance_operator/compliance-operator-troubleshooting.html#compliance-suite-lifecycle-debugging_compliance-troubleshooting)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
