### PR TITLE
Update ocp-4-11-release-notes.adoc

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3130,7 +3130,7 @@ To update an existing {product-title} 4.11 cluster to this latest release, see x
 
 Issued: 2023-01-09
 
-{product-title} release 4.11.22 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:9107[RHBA-2023:0027] advisory. There are no RPM packages for this release.
+{product-title} release 4.11.22 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0027[RHBA-2023:0027] advisory. There are no RPM packages for this release.
 
 You can view the container images in this release by running the following command:
 


### PR DESCRIPTION
The hyperlink for RHBA-2023:0027 in the section "RHBA-2023:0027 - OpenShift Container Platform 4.11.22 bug fix update" in the [documentation](https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-22) points to [RHSA-2022:9107](https://access.redhat.com/errata/RHSA-2022:9107) instead of [RHBA-2023:0027](https://access.redhat.com/errata/RHBA-2023:0027). 

This PR resolves #54720