### PR TITLE
[OSDOCS-3993]: Port registry book to OSD and ROSA

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -213,6 +213,19 @@ Topics:
 - Name: Dynamic provisioning
   File: dynamic-provisioning
 ---
+Name: Registry
+Dir: registry
+Distros: openshift-dedicated
+Topics:
+- Name: Registry overview
+  File: index
+- Name: Image Registry Operator in OpenShift Dedicated
+  File: configuring-registry-operator
+- Name: Accessing the registry
+  File: accessing-the-registry
+- Name: Exposing the registry
+  File: securing-exposing-registry
+---
 Name: Networking
 Dir: networking
 Distros: openshift-dedicated

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -302,6 +302,19 @@ Topics:
 - Name: Dynamic provisioning
   File: dynamic-provisioning
 ---
+Name: Registry
+Dir: registry
+Distros: openshift-rosa
+Topics:
+- Name: Registry overview
+  File: index
+- Name: Image Registry Operator in Red Hat OpenShift Service on AWS
+  File: configuring-registry-operator
+- Name: Accessing the registry
+  File: accessing-the-registry
+- Name: Exposing the registry
+  File: securing-exposing-registry
+---
 Name: Networking
 Dir: networking
 Distros: openshift-rosa

--- a/modules/registry-accessing-directly.adoc
+++ b/modules/registry-accessing-directly.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="registry-accessing-directly_{context}"]
-= Accessing registry directly from the cluster
+= Accessing the registry directly from the cluster
 
 You can access the registry from inside the cluster.
 
@@ -12,7 +12,6 @@ You can access the registry from inside the cluster.
 
 Access the registry from the cluster by using internal routes:
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 . Access the node by getting the node's name:
 +
 [source,terminal]
@@ -32,11 +31,8 @@ $ oc debug nodes/<node_name>
 sh-4.2# chroot /host
 ----
 +
-endif::[]
-
 . Log in to the container image registry by using your access token:
 +
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 [source,terminal]
 ----
 sh-4.2# oc login -u kubeadmin -p <password_from_install_log> https://api-int.<cluster_name>.<base_domain>:6443
@@ -46,8 +42,6 @@ sh-4.2# oc login -u kubeadmin -p <password_from_install_log> https://api-int.<cl
 ----
 sh-4.2# podman login -u kubeadmin -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000
 ----
-endif::[]
-
 +
 You should see a message confirming login, such as:
 +
@@ -79,13 +73,11 @@ In the following examples, use:
 |====
 |Component |Value
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 |*<registry_ip>*
 |`172.30.124.220`
 
 |*<port>*
 |`5000`
-endif::[]
 
 |*<project>*
 |`openshift`
@@ -104,7 +96,6 @@ endif::[]
 sh-4.2# podman pull <name.io>/<image>
 ----
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 .. Tag the new image with the form `<registry_ip>:<port>/<project>/<image>`.
 The project name must appear in this pull specification for {product-title} to
 correctly place and later access the image in the registry:
@@ -113,7 +104,6 @@ correctly place and later access the image in the registry:
 ----
 sh-4.2# podman tag <name.io>/<image> image-registry.openshift-image-registry.svc:5000/openshift/<image>
 ----
-endif::[]
 +
 [NOTE]
 ====
@@ -125,9 +115,7 @@ to push the image.
 
 .. Push the newly tagged image to your registry:
 +
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 [source,terminal]
 ----
 sh-4.2# podman push image-registry.openshift-image-registry.svc:5000/openshift/<image>
 ----
-endif::[]

--- a/modules/registry-common-terms.adoc
+++ b/modules/registry-common-terms.adoc
@@ -23,8 +23,10 @@ The mirror registry is a registry that holds the mirror of {product-title} image
 namespace::
 A namespace isolates groups of resources within a single cluster.
 
+ifndef::openshift-rosa[]
 {product-title} registry::
 {product-title} registry is the registry provided by {product-title} to manage images.
+endif::openshift-rosa[]
 
 pod::
 The pod is the smallest logical unit in Kubernetes. A pod is comprised of one or more containers to run in a worker node.
@@ -37,6 +39,11 @@ A registry is a server that implements the container image registry API. A publi
 
 Quay.io::
 A public Red Hat Quay Container Registry instance provided and maintained by Red Hat, that serves most of the container images and Operators to {product-title} clusters.
+
+ifdef::openshift-rosa[]
+{product-title} registry::
+{product-title} registry is the registry provided by {product-title} to manage images.
+endif::openshift-rosa[]
 
 registry authentication::
 To push and pull images to and from private image repositories, the registry needs to authenticate its users with credentials.

--- a/modules/registry-exposing-default-registry-manually.adoc
+++ b/modules/registry-exposing-default-registry-manually.adoc
@@ -9,6 +9,7 @@ Instead of logging in to the default {product-title} registry from within the cl
 * The following prerequisites are automatically performed:
 ** Deploy the Registry Operator.
 ** Deploy the Ingress Operator.
+* You have access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
 

--- a/modules/registry-exposing-secure-registry-manually.adoc
+++ b/modules/registry-exposing-secure-registry-manually.adoc
@@ -16,6 +16,7 @@ to tag and push images to an existing project by using the route host.
 * The following prerequisites are automatically performed:
 ** Deploy the Registry Operator.
 ** Deploy the Ingress Operator.
+* You have access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
 

--- a/modules/registry-integrated-openshift-registry.adoc
+++ b/modules/registry-integrated-openshift-registry.adoc
@@ -5,7 +5,7 @@
 
 [id="registry-integrated-openshift-registry_{context}"]
 = Integrated {product-title} registry
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+
 {product-title} provides a built-in container image registry that runs as a
 standard workload on the cluster. The registry is configured and managed by an
 infrastructure Operator. It provides an out-of-the-box solution for users to
@@ -26,4 +26,3 @@ configurable storage location, such as cloud storage or a filesystem volume. The
 image metadata, which is exposed by the standard cluster APIs and is used to
 perform access control, is stored as standard API resources, specifically images
 and imagestreams.
-endif::[]

--- a/modules/registry-operator-configuration-resource-overview.adoc
+++ b/modules/registry-operator-configuration-resource-overview.adoc
@@ -69,12 +69,17 @@ for the route.
 
 |`spec.storage.managementState`
 
-|The Image Registry Operator sets the `spec.storage.managementState` parameter to `Managed` on new installations or upgrades of clusters using installer-provisioned infrastructure on AWS or Azure.
+a|
+ifndef::openshift-dedicated,openshift-rosa[]
+The Image Registry Operator sets the `spec.storage.managementState` parameter to `Managed` on new installations or upgrades of clusters using installer-provisioned infrastructure on AWS or Azure.
+endif::openshift-dedicated,openshift-rosa[]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+The Image Registry Operator sets the `spec.storage.managementState` parameter to `Managed` on new installations or upgrades of clusters on AWS.
+endif::openshift-dedicated,openshift-rosa[]
 
 * `Managed`: Determines that the Image Registry Operator manages underlying storage. If the Image Registry Operator's `managementState` is set to `Removed`, then the storage is deleted.
 ** If the `managementState` is set to `Managed`, the Image Registry Operator attempts to apply some default configuration on the underlying storage unit. For example, if set to `Managed`, the Operator tries to enable encryption on the S3 bucket before making it available to the registry. If you do not want the default settings to be applied on the storage you are providing, make sure the `managementState` is set to `Unmanaged`.
 * `Unmanaged`: Determines that the Image Registry Operator ignores the storage settings. If the Image Registry Operator's `managementState` is set to `Removed`, then the storage is not deleted. If you provided an underlying storage unit configuration, such as a bucket or container name, and the `spec.storage.managementState` is not yet set to any value, then the Image Registry Operator configures it to `Unmanaged`.
-
-
 
 |===

--- a/modules/registry-operator-distribution-across-availability-zones.adoc
+++ b/modules/registry-operator-distribution-across-availability-zones.adoc
@@ -34,6 +34,7 @@ The Image Registry Operator defaults to the following when deployed with a zone-
     whenUnsatisfiable: DoNotSchedule
 ----
 
+ifndef::openshift-dedicated,openshift-rosa[]
 The Image Registry Operator defaults to the following when deployed without a zone-related topology constraint, which applies to bare metal and vSphere instances:
 
 .Image Registry Operator deployed without a zone related topology constraint
@@ -53,5 +54,6 @@ The Image Registry Operator defaults to the following when deployed without a zo
     topologyKey: node-role.kubernetes.io/worker
     whenUnsatisfiable: DoNotSchedule
 ----
+endif::openshift-dedicated,openshift-rosa[]
 
 A cluster administrator can override the default `topologySpreadConstraints` by configuring the `configs.imageregistry.operator.openshift.io/cluster` spec file. In that case, only the constraints you provide apply.

--- a/modules/registry-third-party-registries.adoc
+++ b/modules/registry-third-party-registries.adoc
@@ -22,7 +22,7 @@ Some container image registries require access authorization. Podman is an open 
 
 . Click *Get this image* to find the command for your container image.
 
-. Login by running the following command and entering your username and password to authenticate:
+. Log in by running the following command and entering your username and password to authenticate:
 +
 [source,terminal]
 ----

--- a/registry/accessing-the-registry.adoc
+++ b/registry/accessing-the-registry.adoc
@@ -6,10 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 Use the following sections for instructions on accessing the registry, including
 viewing logs and metrics, as well as securing and exposing the registry.
-endif::[]
 
 You can access the registry directly to invoke `podman` commands. This allows
 you to push images to or pull them from the integrated registry directly using
@@ -17,9 +15,9 @@ operations like `podman push` or `podman pull`. To do so, you must be logged in
 to the registry using the `podman login` command. The operations you can perform
 depend on your user permissions, as described in the following sections.
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 == Prerequisites
 
+* You have access to the cluster as a user with the cluster-admin role.
 * You must have configured an identity provider (IDP).
 * For pulling images, for example when using the `podman pull` command,
 the user must have the `registry-viewer` role. To add this role, run the following command:
@@ -38,17 +36,17 @@ $ oc policy add-role-to-user registry-editor <user_name>
 ----
 +
 ** Your cluster must have an existing project where the images can be pushed to.
-endif::[]
 
 include::modules/registry-accessing-directly.adoc[leveloffset=+1]
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 include::modules/registry-checking-the-status-of-registry-pods.adoc[leveloffset=+1]
 
 include::modules/registry-viewing-logs.adoc[leveloffset=+1]
 
 include::modules/registry-accessing-metrics.adoc[leveloffset=+1]
 
+// These additional resources may be relevant to OSD/ROSA, but they xref topics that don't currently exist in the OSD/ROSA distros.
+ifndef::openshift-dedicated,openshift-rosa[]
 [id="accessing-the-registry-additional-resources"]
 [role="_additional-resources"]
 == Additional resources
@@ -59,4 +57,4 @@ xref:../authentication/remove-kubeadmin.adoc[Removing the kubeadmin user] for
 more information.
 * For more information on configuring an identity provider, see
 xref:../authentication/understanding-identity-provider.adoc[Understanding identity provider configuration].
-endif::[]
+endif::openshift-dedicated,openshift-rosa[]

--- a/registry/configuring-registry-operator.adoc
+++ b/registry/configuring-registry-operator.adoc
@@ -7,16 +7,23 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [id="image-registry-on-cloud"]
+ifndef::openshift-dedicated,openshift-rosa[]
 == Image Registry on cloud platforms and OpenStack
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+== Image Registry on {product-title}
+endif::openshift-dedicated,openshift-rosa[]
 
 The Image Registry Operator installs a single instance of the {product-title} registry, and manages all registry configuration, including setting up registry storage.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [NOTE]
 ====
 Storage is only automatically configured when you install an installer-provisioned infrastructure cluster on AWS, GCP, Azure, or OpenStack.
 
 When you install or upgrade an installer-provisioned infrastructure cluster on AWS or Azure, the Image Registry Operator sets the `spec.storage.managementState` parameter to `Managed`. If the `spec.storage.managementState` parameter is set to `Unmanaged`, the Image Registry Operator takes no action related to storage.
 ====
+endif::openshift-dedicated,openshift-rosa[]
 
 After the control plane deploys, the Operator creates a default `configs.imageregistry.operator.openshift.io` resource instance based on configuration detected in the cluster.
 
@@ -35,17 +42,21 @@ However, the `managementState` of the Image Registry Operator alters the behavio
 * `Unmanaged`: the `--prune-registry` flag for the image pruner is set to `false`.
 ====
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [id="image-registry-on-bare-metal-vsphere"]
 == Image Registry on bare metal and vSphere
 
 include::modules/registry-removed.adoc[leveloffset=+2]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/registry-operator-distribution-across-availability-zones.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints[Configuring pod topology spread constraints]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/registry-operator-configuration-resource-overview.adoc[leveloffset=+1]
 
@@ -55,6 +66,7 @@ include::modules/images-configuration-cas.adoc[leveloffset=+1]
 
 include::modules/registry-operator-config-resources-storage-credentials.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 == Additional resources
 
@@ -63,3 +75,4 @@ include::modules/registry-operator-config-resources-storage-credentials.adoc[lev
 * xref:../registry/configuring_registry_storage/configuring-registry-storage-azure-user-infrastructure.adoc#configuring-registry-storage-azure-user-infrastructure[Configuring the registry for Azure user-provisioned infrastructure]
 * xref:../registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc#configuring-registry-storage-baremetal[Configuring the registry for bare metal]
 * xref:../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Configuring the registry for vSphere]
+endif::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
This PR ports the Registry book from OCP to the OSD and ROSA books using single-sourcing. This PR should be merged after #53803.

Version(s):
This applies to:
- `main`
- `enterprise-4.12`
- `enterprise-4.13`

Issue:
https://issues.redhat.com/browse/OSDOCS-3993

Links to docs previews:
- OCP: http://file.rdu.redhat.com/bhardest/osdocs-3993/openshift-enterprise/registry/
- OSD: http://file.rdu.redhat.com/bhardest/osdocs-3993/openshift-dedicated/registry/
- ROSA: http://file.rdu.redhat.com/bhardest/osdocs-3993/openshift-rosa/registry/

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
