### PR TITLE
Adding glossary term for Assisted Installer

### DIFF
--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -91,6 +91,15 @@ You can host a WordPress application on OpenShift.
 ====
 
 ''''
+=== Assisted Installer
+
+Usage: Assisted Installer
+
+In Red Hat OpenShift, the Assisted Installer is an installation solution that is offered on the Red Hat Hybrid Cloud Console to provide Software-as-a-Service functionality for cluster installations.  
+
+Do not use: AI, assisted installer
+
+''''
 === authorization
 
 Usage: authorization


### PR DESCRIPTION
Addresses #54370 

Version(s):
Unsure how glossary entries are maintained? Assisted Installer appears in the docs from 4.10

Issue:
https://github.com/openshift/openshift-docs/issues/54370



