### PR TITLE
OCPBUGS#5440 Correcting oc create secret command

### DIFF
--- a/modules/registry-operator-config-resources-storage-credentials.adoc
+++ b/modules/registry-operator-config-resources-storage-credentials.adoc
@@ -21,7 +21,7 @@ credentials used by the Operator, if default credentials were found.
 +
 [source,terminal]
 ----
-$ oc create secret generic image-registry-private-configuration-user --from-file=KEY1=value1 --from-literal=KEY2=value2 --namespace openshift-image-registry
+$ oc create secret generic image-registry-private-configuration-user --from-literal=KEY1=value1 --from-literal=KEY2=value2 --namespace openshift-image-registry
 ----
 
 


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/OCPBUGS-5440

Link to docs preview:
https://54768--docspreview.netlify.app/openshift-enterprise/latest/registry/configuring-registry-operator.html#registry-operator-config-resources-storage-credentials_configuring-registry-operator

QE review:
- [X] QE has approved this change.

