### PR TITLE
BZ2045952: Adds back in accidental removal of 4.9.13

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2534,6 +2534,29 @@ $ oc adm release info 4.9.12 --pullspecs
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
 
+[id="ocp-4-9-13"]
+=== RHBA-2022:0029 - {product-title} 4.9.13 bug fix update
+
+{product-title} release 4.9.13 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0029[RHBA-2022:0029] advisory. There are no RPM packages for this release.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.9.13 --pullspecs
+----
+
+[id="ocp-4-9-13-bug-fixes"]
+==== Bug fixes
+
+* Previously, Windows file paths did not accept the colon character, which blocked mirroring on Windows machines. With this update, the colon is replaced with a dash, which allows mirroring on Windows machines. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1903545[*BZ#1903545*])
+
+* Previously, certificates belonging to the _Custom API Name certificate_ for the cluster had inconsistent file permission of `0644`. With this update, permissions are consistently set to `0600`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1977730[*BZ#1977730*])
+
+[id="ocp-4-9-13-upgrading"]
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
 [id="ocp-4-9-15"]
 === RHBA-2022:0110 - {product-title} 4.9.15 bug fix update
 


### PR DESCRIPTION
BZ2045952: Adds back in accidental removal of 4.9.13

Context: somehow 4.9.13 was removed from the release notes a bit ago. It may have accidentally happed when notes were added for 4.9.15.  

Version(s):
4.9 only

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2045952 
https://issues.redhat.com/browse/OCPBUGS-9093

Link to docs preview:
http://file.rdu.redhat.com/opayne/BZ2045952/release_notes/ocp-4-9-release-notes.html#ocp-4-9-13

QE review:
- [ ] QE has approved this change.

Additional information:
This change will need QE and will require the acks of @kalexand-rh @mwerner2113 @sferich888 @xltian 
