### PR TITLE
OSDOCS-4808:Consistent wording for AWS

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -160,11 +160,11 @@ Alternatively, if you choose to not use a wildcard for Amazon Web Services (AWS)
 |443
 |Used to install and manage clusters in an AWS environment.
 
-|`servicequotas.<aws region>.amazonaws.com`
+|`servicequotas.<aws_region>.amazonaws.com`
 |443, 80
 |Required. Used to confirm quotas for deploying the service.
 
-|`tagging.<region>.amazonaws.com`
+|`tagging.<aws_region>.amazonaws.com`
 |443, 80
 |Allows the assignment of metadata about AWS resources in the form of tags.
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->
[OSDOCS-4808](https://issues.redhat.com//browse/OSDOCS-4808):Consistent wording for AWS
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-4808

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://54771--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
PTAL: @arendej 
