### PR TITLE
[OCPBUGS-5351]: adding quorum guard instructions to etcd docs

### DIFF
--- a/modules/restore-replace-crashlooping-etcd-member.adoc
+++ b/modules/restore-replace-crashlooping-etcd-member.adoc
@@ -144,6 +144,15 @@ sh-4.2# etcdctl member list -w table
 +
 You can now exit the node shell.
 
+. Turn off the quorum guard by entering the following command:
++
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}'
+----
++
+This command ensures that you can successfully re-create secrets and roll out the static pods.
+
 . Remove the old secrets for the unhealthy etcd member that was removed.
 
 .. List the secrets for the unhealthy etcd member that was removed.
@@ -198,6 +207,20 @@ $ oc patch etcd cluster -p='{"spec": {"forceRedeploymentReason": "single-master-
 <1> The `forceRedeploymentReason` value must be unique, which is why a timestamp is appended.
 +
 When the etcd cluster Operator performs a redeployment, it ensures that all control plane nodes have a functioning etcd pod.
+
+. Turn the quorum guard back on by entering the following command:
++
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '\{"spec": {"unsupportedConfigOverrides": null}}
+----
+
+. You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:
++
+[source,terminal]
+----
+$ oc get etcd/cluster -oyaml
+----
 
 .Verification
 

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -115,6 +115,15 @@ You can now exit the node shell.
 After you remove the member, the cluster might be unreachable for a short time while the remaining etcd instances reboot.
 ====
 
+. Turn off the quorum guard by entering the following command:
++
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}'
+----
++
+This command ensures that you can successfully re-create secrets and roll out the static pods.
+
 . Remove the old secrets for the unhealthy etcd member that was removed by running the following commands.
 
 .. List the secrets for the unhealthy etcd member that was removed.
@@ -529,6 +538,20 @@ openshift-control-plane-1 Ready master 4h26m v1.25.0
 openshift-control-plane-2 Ready master 12m   v1.25.0
 openshift-compute-0       Ready worker 3h58m v1.25.0
 openshift-compute-1       Ready worker 3h58m v1.25.0
+----
+
+. Turn the quorum guard back on by entering the following command:
++
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '\{"spec": {"unsupportedConfigOverrides": null}}
+----
+
+. You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:
++
+[source,terminal]
+----
+$ oc get etcd/cluster -oyaml
 ----
 
 .Verification

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -114,6 +114,15 @@ You can now exit the node shell.
 After you remove the member, the cluster might be unreachable for a short time while the remaining etcd instances reboot.
 ====
 
+. Turn off the quorum guard by entering the following command:
++
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}'
+----
++
+This command ensures that you can successfully re-create secrets and roll out the static pods.
+
 . Remove the old secrets for the unhealthy etcd member that was removed.
 
 .. List the secrets for the unhealthy etcd member that was removed.
@@ -306,6 +315,20 @@ clustername-8qw5l-worker-us-east-1c-pkg26   Running        m4.large    us-east-1
 <1> The new machine, `clustername-8qw5l-master-3` is being created and is ready once the phase changes from `Provisioning` to `Running`.
 +
 It might take a few minutes for the new machine to be created. The etcd cluster Operator will automatically sync when the machine or node returns to a healthy state.
+
+. Turn the quorum guard back on by entering the following command:
++
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '\{"spec": {"unsupportedConfigOverrides": null}}
+----
+
+. You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:
++
+[source,terminal]
+----
+$ oc get etcd/cluster -oyaml
+----
 
 .Verification
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.8+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-5351
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://docs.openshift.com/container-platform/4.11/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#replacing-the-unhealthy-etcd-member
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This update to the etcd docs affects version 4.8+ of the OCP docs.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
