### PR TITLE
OCPBUGS-3856: Manual CP Fix typo: <rout_name> → <route_name>

### DIFF
--- a/modules/nw-disabling-hsts.adoc
+++ b/modules/nw-disabling-hsts.adoc
@@ -18,7 +18,7 @@ To disable HTTP strict transport security (HSTS) per-route, you can set the `max
 +
 [source,terminal]
 ----
-$ oc annotate route <rout_name> -n <namespace> --overwrite=true "haproxy.router.openshift.io/hsts_header"="max-age=0"
+$ oc annotate route <route_name> -n <namespace> --overwrite=true "haproxy.router.openshift.io/hsts_header"="max-age=0"
 ----
 +
 [TIP]

--- a/modules/nw-enabling-hsts-per-route.adoc
+++ b/modules/nw-enabling-hsts-per-route.adoc
@@ -14,7 +14,19 @@ HTTP strict transport security (HSTS) is implemented in the HAProxy template and
 
 .Procedure
 
-* To enable HSTS on a route, add the `haproxy.router.openshift.io/hsts_header` value to the edge-terminated or re-encrypt route:
+* To enable HSTS on a route, add the `haproxy.router.openshift.io/hsts_header` value to the edge-terminated or re-encrypt route. You can use the `oc annotate` tool to do this by running the following command:
++
+[source,terminal]
+----
+$ oc annotate route <route_name> -n <namespace> --overwrite=true "haproxy.router.openshift.io/hsts_header"="max-age=31536000;\ <1> 
+includeSubDomains;preload"
+----
+<1> In this example, the maximum age is set to `31536000` ms, which is approximately eight and a half hours.
++
+[NOTE]
+====
+In this example, the equal sign (`=`) is in quotes. This is required to properly execute the annotate command. 
+====
 +
 .Example route configured with an annotation
 [source,yaml]


### PR DESCRIPTION
* modules/nw-disabling-hsts.adoc:
* modules/nw-enabling-hsts-per-route.adoc: Replace "<rout_name>" with "<route_name>".

Manual CP of #52971
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
