### PR TITLE
Skip Netlify and Vale checks for cherrypick bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
     - stage: check-with-vale
       env:
         - CAN_FAIL=true
-      if: type IN (pull_request)
+      if: type IN (pull_request) AND sender != "openshift-cherrypick-robot"
       name: "Run Vale against PR asciidoc files"
       language: minimal
       before_script:
@@ -75,7 +75,7 @@ jobs:
       env:
         - CAN_FAIL=true
       language: minimal
-      if: branch IN (main, enterprise-4.12, enterprise-4.13)
+      if: branch IN (main, enterprise-4.12, enterprise-4.13) AND sender != "openshift-cherrypick-robot"
       script:
         - chmod +x autopreview.sh && ./autopreview.sh
 


### PR DESCRIPTION
Allows us to skip the Vale and Netlify stages for PRs from `openshift-cherrypick-robot`.
Saves Travis CI resources and approximately 1 minute 20 seconds.

Reference: https://docs.travis-ci.com/user/conditions-v1

Cherry-pick into:
- `enterprise-4.12`
- `enterprise-4.13`
- `enterprise-4.11`

And other branches as needed.