### PR TITLE
[RHACS] Replaced BZ link with Jira

### DIFF
--- a/support/getting-support.adoc
+++ b/support/getting-support.adoc
@@ -14,10 +14,9 @@ If you experience difficulty with a procedure described in this documentation, o
 * Submit a support case to Red Hat Support.
 * Access other product documentation.
 
-If you have a suggestion for improving this documentation or have found an
-error, please submit a link:http://bugzilla.redhat.com[Bugzilla report] against the
-*{product-title}* product for the *Documentation* component. Please
-provide specific details, such as the section name and {product-title} version.
+If you have a suggestion for improving the documentation or have identified an error, create a link:https://red.ht/rhacsdocsissue[Jira issue] against the
+*{product-title}* product for the *Documentation* component.
+Ensure that you include specific details such as the section name and the version of {product-title} for us to manage your feedback effectively.
 
 include::modules/support-knowledgebase-about.adoc[leveloffset=+1]
 include::modules/support-knowledgebase-search.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixes part of https://issues.redhat.com/browse/ROX-11797

Cherrypick into:
- `rhacs-docs-3.71`
- `rhacs-docs-3.72`
- `rhacs-docs-3.73`
- `rhacs-docs-3.74`

