### PR TITLE
OSDOCS-4592 - Create JIRA issues from docs.openshift pages 

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -175,11 +175,22 @@
       </li>
       <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro" && distro_key != "openshift-acs") %>
       <span text-align="right" style="float: right !important">
-        <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-enterprise") ? "enterprise-#{version}" : "dedicated-4" %>/<%= repo_path %>"><span class="material-icons-outlined" title="Page history">history</span></a>
+        <a href="https://github.com/openshift/openshift-docs/commits/<%=
+        ((distro_key == "openshift-enterprise") ? "enterprise-#{version}"
+          : (distro_key == "openshift-aro") ? "aro-work"
+          : (distro_key=="openshift-dedicated" ) ? "dedicated-4"
+          : "main" ) %>/<%= repo_path %>"><span class="material-icons-outlined" title="Page history">history</span></a>
         <%
           unless (unsupported_versions.include? version)
         %>
-        <a href="https://github.com/openshift/openshift-docs/issues/new?title=<%= (distro_key == "openshift-enterprise") ? "[enterprise-#{version}] Issue in file #{repo_path}" : ((distro_key=="openshift-dedicated" ) ? "[dedicated] Issue in file #{repo_path}" : "[online] Issue in file #{repo_path}" ) %>">
+        <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&issuetype=1&components=12367614&priority=4&summary=<%=
+        ((distro_key == "openshift-enterprise") ? "[enterprise-#{version}]+Issue+in+file+#{repo_path}"
+          : (distro_key=="openshift-dedicated" ) ? "[dedicated-4]+Issue+in+file+#{repo_path}"
+          : (distro_key=="microshift" ) ? "[microshift-#{version}]+Issue+in+file+#{repo_path}"
+          : (distro_key=="openshift-aro" ) ? "[aro-#{version}]+Issue+in+file+#{repo_path}"
+          : (distro_key=="openshift-online" ) ? "[online-#{version}]+Issue+in+file+#{repo_path}"
+          : (distro_key=="openshift-rosa" ) ? "[rosa-#{version}]+Issue+in+file+#{repo_path}"
+          : "Issue+in+file+#{repo_path}" ) %>">
           <span class="material-icons-outlined" title="Open an issue">bug_report</span>
         </a>
         <a href="javascript: void(0);" onclick="window.print()"><span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span></a>


### PR DESCRIPTION
Removes **create GitHub issue** link in favour of **Create OCPBUGS issue** link. Also adjusts the GitHub history links. 

https://issues.redhat.com/browse/OSDOCS-4592

* Preview enterprise-4.11 build: http://file.emea.redhat.com/aireilly/enterprise-4.11/post_installation_configuration/configuring-private-cluster.html#private-clusters-setting-api-private_configuring-private-cluster
* Preview microshift distro 4.13 build: http://file.emea.redhat.com/aireilly/enterprise-4.13/welcome/index.html

(click on any :bug: icon)