### PR TITLE
TELCODOCS:768 - Added new erratum to RN for OSC release 1.3.2

### DIFF
--- a/sandboxed_containers/sandboxed-containers-1.3-release-notes.adoc
+++ b/sandboxed_containers/sandboxed-containers-1.3-release-notes.adoc
@@ -139,7 +139,7 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {sandboxed-containers-first} {sandboxed-containers-version}.
 
 [id="sandboxed-containers-1-3-0"]
-=== RHSA-2022:6072 - {sandboxed-containers-first} {sandboxed-containers-version}.0 image release, bug fix, and enhancement advisory.
+=== RHSA-2022:6072 - {sandboxed-containers-first} {sandboxed-containers-version}.0 image release, bug fix, and enhancement advisory
 
 Issued: 2022-08-17
 
@@ -148,10 +148,19 @@ Issued: 2022-08-17
 The list of bug fixes included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2022:6072[RHSA-2022:6072] advisory.
 
 [id="sandboxed-containers-1-3-1"]
-=== RHSA-2022:7058 - {sandboxed-containers-first} {sandboxed-containers-version}.1 security fix and bug fix advisory.
+=== RHSA-2022:7058 - {sandboxed-containers-first} {sandboxed-containers-version}.1 security fix and bug fix advisory
 
 Issued: 2022-10-19
 
 {sandboxed-containers-first} release {sandboxed-containers-version}.1 is now available. This advisory contains an update for {sandboxed-containers-first} with security fixes and a bug fix.
 
 The list of bug fixes included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:7058[RHSA-2022:7058] advisory.
+
+[id="sandboxed-containers-1-3-2"]
+=== RHBA-2023:0390 - {sandboxed-containers-first} {sandboxed-containers-version}.2 bug fix advisory
+
+Issued: 2023-01-24
+
+{sandboxed-containers-first} release {sandboxed-containers-version}.2 is now available. This advisory contains an update for {sandboxed-containers-first} with bug fixes.
+
+The list of bug fixes included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0390[RHBA-2023:0390] advisory.


### PR DESCRIPTION
Version(s): Only 4.12

Issue: [TELCODOCS-768](https://issues.redhat.com/browse/TELCODOCS-768)

[Link to docs preview](https://54817--docspreview.netlify.app/openshift-enterprise/latest/sandboxed_containers/sandboxed-containers-1.3-release-notes.html#sandboxed-containers-1-3-2)

QE review:
- [x] QE has approved this change.
