### PR TITLE
OSASINFRA-3066: Added migration procedure for Kuryr SDN.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1239,6 +1239,8 @@ Topics:
     File: migrate-from-openshift-sdn
   - Name: Rolling back to the OpenShift SDN network plugin
     File: rollback-to-openshift-sdn
+  - Name: Migrate from the Kuryr network plug-in
+    File: migrate-from-kuryr-sdn
   - Name: Converting to IPv4/IPv6 dual stack networking
     File: converting-to-dual-stack
   - Name: Logging for egress firewall and network policy rules

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1267,6 +1267,8 @@ Topics:
     File: migrate-from-openshift-sdn
   - Name: Rolling back to the OpenShift SDN network plugin
     File: rollback-to-openshift-sdn
+  - Name: Migrating from Kuryr
+    File: migrate-from-kuryr-sdn
   - Name: Converting to IPv4/IPv6 dual stack networking
     File: converting-to-dual-stack
   - Name: Logging for egress firewall and network policy rules

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1239,7 +1239,7 @@ Topics:
     File: migrate-from-openshift-sdn
   - Name: Rolling back to the OpenShift SDN network plugin
     File: rollback-to-openshift-sdn
-  - Name: Migrate from the Kuryr network plug-in
+  - Name: Migrating from Kuryr
     File: migrate-from-kuryr-sdn
   - Name: Converting to IPv4/IPv6 dual stack networking
     File: converting-to-dual-stack

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -137,7 +137,7 @@ done
 (venv) $ oc delete namespace openshift-kuryr
 ----
 
-. To remove the Kuryr service subnet from router, enter the following command:
+. To remove the Kuryr service subnet from the router, enter the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -7,7 +7,7 @@
 = Cleaning up resources after migration
 
 After migration from the Kuryr network plugin to the OVN-Kubernetes network
-plugin, you must to clean up the resources that Kuryr created previously.
+plugin, you must clean up the resources that Kuryr created previously.
 
 [NOTE]
 ====
@@ -92,7 +92,7 @@ $ source /tmp/venv/bin/activate
 }
 ----
 +
-The function takes two parameters: first parameter is name of the resource, while second one is the finalizer to remove.
+The function takes two parameters: the first parameter is name of the resource, and the second parameter is the finalizer to remove.
 The named resource is removed from the cluster and its definition is replaced with copied data, excluding the specified finalizer.
 
 . Clean up Kuryr related resources.

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -247,7 +247,7 @@ done
 [source,terminal]
 ----
 (venv) $ networks=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.netId")
-for existingNet in $(openstack network list --tags $CLUSTERTAG -f value -c ID); do
+(venv) $ for existingNet in $(openstack network list --tags $CLUSTERTAG -f value -c ID); do
     if [[ $networks =~ $existingNet ]]; then
         echo "Network still exists: $existingNet"
     fi

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -23,27 +23,6 @@ version 0.54.0, `python-openstackclient` version 5.5.0 and
 * You have access to the underlying {rh-openstack} cloud.
 * You can access the cluster as a user with the `cluster-admin` role.
 
-[NOTE]
-====
-At the time of writing when Red Hat OpenStack 16.2 is used, it includes
-ancient version of `openstacksdk` package, that does not support tags for
-Octavia objects. It is recommended to use either workstation with modern
-operating system with newer version of `openstacksdk` package or `virtualenv`
-and install appropriate version from link:https://pypi.org[pypi].
-
-The minimal versions of the following OpenStack components need to be used to
-fulfill cleaning procedure:
-
-- openstacksdk 0.54.0
-- python-openstackclient 5.5.0
-- python-octaviaclient 2.3.0
-
-Newer versions should also work, although there is a tiny chance for
-incompatibilities. If you have issues, either downgrade to version mentioned
-above or consult individual component documentation and/or changelog for
-details.
-====
-
 .Procedure
 . Create a clean-up Python virtual environment:
 .. Create a temporary directory for your environment. For example, with `venv`:
@@ -116,6 +95,15 @@ $ source /tmp/venv/bin/activate
 The function takes two parameters: the first parameter is name of the resource, and the second parameter is the
 finalizer to remove. The named resource is removed from the cluster and its definition is replaced with copied data excluding the specified finalizer.
 
+. To remove Kuryr service `service-subnet-gateway-ip`, enter the following command:
++
+[source,terminal]
+----
+(venv) $ if $(oc get -n openshift-kuryr service service-subnet-gateway-ip 2>/dev/null >/dev/null); then
+    oc get -n openshift-kuryr delete service service-subnet-gateway-ip
+fi
+----
+
 . To remove Kuryr finalizers from services, enter the following command:
 +
 [source,terminal]
@@ -137,6 +125,13 @@ done
 [source,terminal]
 ----
 (venv) $ REMFIN kuryrloadbalancers.openstack.org kuryr.openstack.org/kuryrloadbalancer-finalizers
+----
+
+. To remove openshift-kuryr namespace, enter the following command:
++
+[source,terminal]
+----
+(venv) $ oc delete namespace openshift-kuryr
 ----
 
 . To remove the Kuryr service subnet from router, enter the following command:
@@ -182,7 +177,7 @@ This will trigger deleting of the KuryrPort Custom Resources.
 (venv) $ REMFIN kuryrnetworkpolicies.openstack.org kuryr.openstack.org/networkpolicy-finalizer
 ----
 
-. To remove subports that Kuryr created from trunks, enter the following command:
+. To remove subports that Kuryr created from trunks, enter the following commands:
 +
 [source,terminal]
 ----
@@ -205,7 +200,7 @@ This will trigger deleting of the KuryrPort Custom Resources.
 done
 ----
 
-. To retrieve all networks and subnets from `KuryrNetwork` CRs and remove ports, router interfaces and the network itself, enter the following command:
+. To retrieve all networks and subnets from `KuryrNetwork` CRs and remove ports, router interfaces and the network itself, enter the following commands:
 +
 [source,terminal]
 ----
@@ -251,7 +246,7 @@ done
 done
 ----
 
-. To check that all of the networks based on `KuryrNetwork` CRs were removed, enter the following command:
+. To check that all of the networks based on `KuryrNetwork` CRs were removed, enter the following commands:
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -237,7 +237,7 @@ done
 +
 [source,terminal]
 ----
-$ for subnetpool in $(openstack subnet pool list --tags $CLUSTERTAG -f value -c ID); do
+(venv) $ for subnetpool in $(openstack subnet pool list --tags $CLUSTERTAG -f value -c ID); do
     openstack subnet pool delete $subnetpool
 done
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -7,7 +7,7 @@
 = Cleaning up resources after migration
 
 After migration from the Kuryr network plugin to the OVN-Kubernetes network
-plugin, you need toneed to  clean up the resources that Kuryr created previously.
+plugin, you must to clean up the resources that Kuryr created previously.
 
 [NOTE]
 ====

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -95,15 +95,14 @@ $ source /tmp/venv/bin/activate
 The function takes two parameters: the first parameter is name of the resource, and the second parameter is the finalizer to remove.
 The named resource is removed from the cluster and its definition is replaced with copied data, excluding the specified finalizer.
 
-. Clean up Kuryr related resources.
-.. To remove Kuryr finalizers from services, enter the following command:
+. To remove Kuryr finalizers from services, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN services kuryr.openstack.org/service-finalizer
 ----
 
-.. To remove the Kuryr `service-subnet-gateway-ip` service, enter the following command:
+. To remove the Kuryr `service-subnet-gateway-ip` service, enter the following command:
 +
 [source,terminal]
 ----
@@ -112,7 +111,7 @@ The named resource is removed from the cluster and its definition is replaced wi
 fi
 ----
 
-.. To remove all tagged {rh-openstack} load balancers from Octavia, enter the following command:
+. To remove all tagged {rh-openstack} load balancers from Octavia, enter the following command:
 +
 [source,terminal]
 ----
@@ -121,42 +120,42 @@ fi
 done
 ----
 
-.. To remove Kuryr finalizers from all `KuryrLoadBalancer` CRs, enter the following command:
+. To remove Kuryr finalizers from all `KuryrLoadBalancer` CRs, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN kuryrloadbalancers.openstack.org kuryr.openstack.org/kuryrloadbalancer-finalizers
 ----
 
-.. To remove the `openshift-kuryr` namespace, enter the following command:
+. To remove the `openshift-kuryr` namespace, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ oc delete namespace openshift-kuryr
 ----
 
-.. To remove the Kuryr service subnet from the router, enter the following command:
+. To remove the Kuryr service subnet from the router, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ openstack router remove subnet $ROUTERID ${CLUSTERID}-kuryr-service-subnet
 ----
 
-.. To remove the Kuryr service network, enter the following command:
+. To remove the Kuryr service network, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ openstack network delete ${CLUSTERID}-kuryr-service-network
 ----
 
-.. To remove Kuryr finalizers from all pods, enter the following command:
+. To remove Kuryr finalizers from all pods, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN pods kuryr.openstack.org/pod-finalizer
 ----
 
-.. To remove Kuryr finalizers from all `KuryrPort` CRs, enter the following command:
+. To remove Kuryr finalizers from all `KuryrPort` CRs, enter the following command:
 +
 [source,terminal]
 ----
@@ -164,21 +163,21 @@ done
 ----
 This will delete the KuryrPort Custom Resources.
 
-.. To remove Kuryr finalizers from network policies, enter the following command:
+. To remove Kuryr finalizers from network policies, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN networkpolicy kuryr.openstack.org/networkpolicy-finalizer
 ----
 
-.. To remove Kuryr finalizers from remaining network policies, enter the following command:
+. To remove Kuryr finalizers from remaining network policies, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN kuryrnetworkpolicies.openstack.org kuryr.openstack.org/networkpolicy-finalizer
 ----
 
-.. To remove subports that Kuryr created from trunks, enter the following command:
+. To remove subports that Kuryr created from trunks, enter the following command:
 +
 [source,terminal]
 ----
@@ -201,7 +200,7 @@ for trunk in "${trunks[@]}"; do
 done
 ----
 
-.. To retrieve all networks and subnets from `KuryrNetwork` CRs and remove ports, router interfaces and the network itself, enter the following command:
+. To retrieve all networks and subnets from `KuryrNetwork` CRs and remove ports, router interfaces and the network itself, enter the following command:
 +
 [source,terminal]
 ----
@@ -231,14 +230,14 @@ for kn in "${kuryrnetworks[@]}"; do
 done
 ----
 
-.. To remove the Kuryr security group, enter the following command:
+. To remove the Kuryr security group, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ openstack security group delete ${CLUSTERID}-kuryr-pods-security-group
 ----
 
-.. To remove all tagged subnet pools, enter the following command:
+. To remove all tagged subnet pools, enter the following command:
 +
 [source,terminal]
 ----
@@ -247,7 +246,7 @@ done
 done
 ----
 
-.. To check that all of the networks based on `KuryrNetwork` CRs were removed, enter the following command:
+. To check that all of the networks based on `KuryrNetwork` CRs were removed, enter the following command:
 +
 [source,terminal]
 ----
@@ -261,7 +260,7 @@ done
 +
 If the command returns any existing networks, intestigate and remove them before you continue.
 
-.. To remove security groups that are related to network policy, enter the following command:
+. To remove security groups that are related to network policy, enter the following command:
 +
 [source,terminal]
 ----
@@ -270,14 +269,14 @@ If the command returns any existing networks, intestigate and remove them before
 done
 ----
 
-.. To remove finalizers from `KuryrNetwork` CRs, enter the following command:
+. To remove finalizers from `KuryrNetwork` CRs, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN kuryrnetworks.openstack.org kuryrnetwork.finalizers.kuryr.openstack.org
 ----
 
-.. To remove the Kuryr router, enter the following command:
+. To remove the Kuryr router, enter the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -170,7 +170,7 @@ This will trigger deleting of the KuryrPort Custom Resources.
 +
 [source,terminal]
 ----
-$ REMFIN kuryrnetworkpolicies.openstack.org kuryr.openstack.org/networkpolicy-finalizer
+(venv) $ REMFIN kuryrnetworkpolicies.openstack.org kuryr.openstack.org/networkpolicy-finalizer
 ----
 
 . To remove subports that Kuryr created from trunks, enter the following command:

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -19,18 +19,14 @@ After migration from the Kuryr network plugin to the OVN-Kubernetes network plug
 
 [NOTE]
 ====
-At the time of writing when Red Hat OpenStack 16.2 is used, it includes ancient version of
-`openstacksdk` package, that does not support tags for Octavia objects. It is
-recommended to use either workstation with modern operating system with newer
-version of `openstacksdk` package or `virtualenv` and install appropriate
-version from link:https://pypi.org[pypi].
-====
+At the time of writing when Red Hat OpenStack 16.2 is used, it includes 
+ancient version of `openstacksdk` package, that does not support tags for 
+Octavia objects. It is recommended to use either workstation with modern 
+operating system with newer version of `openstacksdk` package or `virtualenv` 
+and install appropriate version from link:https://pypi.org[pypi].
 
-.Setup virtualenv
-
-If you decide to use virtualenv, here is a quick guidance how to proceed.
-At the time of writing, minimal versions of the following OpenStack components
-has been used to fulfill cleaning procedure:
+The minimal versions of the following OpenStack components need to be used to 
+fulfill cleaning procedure:
 
 - openstacksdk 0.54.0
 - python-openstackclient 5.5.0
@@ -40,29 +36,36 @@ Newer versions should also work, although there is a tiny chance for
 incompatibilities. If you have issues, either downgrade to version mentioned
 above or consult individual component documentation and/or changelog for
 details.
+====
 
-To set up cleanup environment, create virtualenv, update pip and install needed
-components:
-
+.Procedure
+. Create a clean-up Python virtual environment:
+.. Create a temporary directory for your environment. For example, with `venv`:
++
 [source,terminal]
 ----
 $ python3 -m venv /tmp/venv
+----
++ 
+`venv` is used in all clean up examples.
+.. Enter the virtual environment. For example:
++
+[source,terminal]
+----
 $ source /tmp/venv/bin/activate
+----
+.. Upgrade `pip` in the virtual environment by running the following command:
++
+[source,terminal]
+----
 (venv) $ pip install pip --upgrade
+---- 
+.. Install the required Python packages by running the following command:
++
+[source,terminal]
+----
 (venv) $ pip install openstacksdk==0.54.0 python-openstackclient==5.5.0 python-octaviaclient==2.3.0
 ----
-
-[NOTE]
-====
-In the command prompt there will be visible indicator, that virtualenv is in
-use - here it will be additional `(venv)` string, as in the example above venv
-is a name of the directory and the virtual env at the same time.
-====
-
-Stay in the created environment during following procedure to be sure the
-right python components are used.
-
-.Procedure
 
 . On a command line, enter the following commands to set variables to cluster and Kuryr identifiers:
 
@@ -273,10 +276,9 @@ done
 ----
 
 . If the installer did not create your router, enter the following command to remove the router:
-+
-IMPORTANT: If the installer did create your router, do not remove the router.
-+
 [source,terminal]
 ----
-$ openstack router delete $ROUTERID
+(venv) $ if $(python3 -c "import sys; import openstack; n = openstack.connect().network; r = n.get_router('$ROUTERID'); sys.exit(0) if r.description != 'Created By OpenShift Installer' else sys.exit(1)"); then
+    openstack router delete $ROUTERID
+fi
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -102,7 +102,7 @@ finalizer to remove. The named resource is removed from the cluster and its defi
 +
 [source,terminal]
 ----
-(venv) $ if $(oc get -n openshift-kuryr service service-subnet-gateway-ip 2>/dev/null >/dev/null); then
+(venv) $ if $(oc get -n openshift-kuryr service service-subnet-gateway-ip &>/dev/null); then
     oc get -n openshift-kuryr delete service service-subnet-gateway-ip
 fi
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -123,7 +123,7 @@ fi
 done
 ----
 
-. To remove Kuryr finalizers from all KuryrLoadBalancer CRs, enter the following command:
+. To remove Kuryr finalizers from all `KuryrLoadBalancer` CRs, enter the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -246,7 +246,7 @@ done
 +
 [source,terminal]
 ----
-$ networks=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.netId")
+(venv) $ networks=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.netId")
 for existingNet in $(openstack network list --tags $CLUSTERTAG -f value -c ID); do
     if [[ $networks =~ $existingNet ]]; then
         echo "Network still exists: $existingNet"

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -11,7 +11,10 @@ plugin, you must clean up the resources that Kuryr created previously.
 
 [NOTE]
 ====
-The clean up process relies on a Python virtual environment. This ensure that the python packages version you use support tags for Octavia objects. If you are certain that your environment uses a minium `openstacksdk` version 0.54.0, `python-openstackclient` version 5.5.0 and `python-octaviaclient` version 2.3.0, you do not need the virtual environment.
+The clean up process relies on a Python virtual environment to ensure that the package versions that you use support tags for Octavia objects. You do not need a virtual environment if you are certain that your environment uses at minimum:
+* `openstacksdk` version 0.54.0
+* `python-openstackclient` version 5.5.0
+* `python-octaviaclient` version 2.3.0 
 ====
 
 .Prerequisites

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -200,7 +200,7 @@ done
 +
 [source,terminal]
 ----
-$ mapfile -t kuryrnetworks < <(oc get kuryrnetwork -A --template='{{range $i,$p := .items}}{{ $p.status.netId }}|{{ $p.status.subnetId }}{{"\n"}}{{end}}')
+(venv) $ mapfile -t kuryrnetworks < <(oc get kuryrnetwork -A --template='{{range $i,$p := .items}}{{ $p.status.netId }}|{{ $p.status.subnetId }}{{"\n"}}{{end}}')
 $ i=0
 $ for kn in "${kuryrnetworks[@]}"; do
     i=$((i+1))

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -155,7 +155,7 @@ done
 +
 [source,terminal]
 ----
-$ REMFIN kuryrports.openstack.org kuryr.openstack.org/kuryrport-finalizer
+(venv) $ REMFIN kuryrports.openstack.org kuryr.openstack.org/kuryrport-finalizer
 ----
 This will trigger deleting of the KuryrPort Custom Resources.
 

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -177,7 +177,7 @@ This will trigger deleting of the KuryrPort Custom Resources.
 +
 [source,terminal]
 ----
-$ read -ra trunks <<< $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x.id for x in n.trunks(any_tags='$CLUSTERTAG')]))")
+(venv) $ read -ra trunks <<< $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x.id for x in n.trunks(any_tags='$CLUSTERTAG')]))")
 $ i=0
 $ for trunk in "${trunks[@]}"; do
     i=$((i+1))

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -134,7 +134,7 @@ done
 +
 [source,terminal]
 ----
-$ openstack router remove subnet $ROUTERID ${CLUSTERID}-kuryr-service-subnet
+(venv) $ openstack router remove subnet $ROUTERID ${CLUSTERID}-kuryr-service-subnet
 ----
 
 . To remove the Kuryr service network, enter the following command:

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -6,9 +6,13 @@
 [id="nw-kuryr-cleanup_{context}"]
 = Cleaning up resources after migration
 
-After migration from the Kuryr network plugin to the OVN-Kubernetes network plugin completes, clean up the resources that Kuryr created previously. 
+After migration from the Kuryr network plugin to the OVN-Kubernetes network plugin completes, clean up the resources that Kuryr created previously.
 
-NOTE: The clean up process relies on a Python virtual environment to ensure that the `openstacksdk` package version that you use supports tags for Octavia objects. If you are certain that your environment uses `openstacksdk` version 0.54.0 or higher, you can forego the virtual environment.
+NOTE: The clean up process relies on a Python virtual environment to ensure
+that the python packages version that you use supports tags for Octavia
+objects. If you are certain that your environment uses a minium `openstacksdk`
+version 0.54.0, `python-openstackclient` version 5.5.0 and
+`python-octaviaclient` version 2.3.0, you can forego the virtual environment.
 
 .Prerequisites
 
@@ -21,13 +25,13 @@ NOTE: The clean up process relies on a Python virtual environment to ensure that
 
 [NOTE]
 ====
-At the time of writing when Red Hat OpenStack 16.2 is used, it includes 
-ancient version of `openstacksdk` package, that does not support tags for 
-Octavia objects. It is recommended to use either workstation with modern 
-operating system with newer version of `openstacksdk` package or `virtualenv` 
+At the time of writing when Red Hat OpenStack 16.2 is used, it includes
+ancient version of `openstacksdk` package, that does not support tags for
+Octavia objects. It is recommended to use either workstation with modern
+operating system with newer version of `openstacksdk` package or `virtualenv`
 and install appropriate version from link:https://pypi.org[pypi].
 
-The minimal versions of the following OpenStack components need to be used to 
+The minimal versions of the following OpenStack components need to be used to
 fulfill cleaning procedure:
 
 - openstacksdk 0.54.0
@@ -48,7 +52,7 @@ details.
 ----
 $ python3 -m venv /tmp/venv
 ----
-+ 
++
 `venv` is used in all clean up examples.
 .. Enter the virtual environment. For example:
 +
@@ -61,7 +65,7 @@ $ source /tmp/venv/bin/activate
 [source,terminal]
 ----
 (venv) $ pip install pip --upgrade
----- 
+----
 .. Install the required Python packages by running the following command:
 +
 [source,terminal]

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -83,7 +83,7 @@ right python components are used.
 +
 [source,terminal]
 ----
-$ ROUTERID=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.routerId"|head -n 1)
+(venv) $ ROUTERID=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.routerId"|head -n 1)
 ----
 
 . To create a Bash function that removes finalizers from specified resources, enter the following command:

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -90,7 +90,7 @@ right python components are used.
 +
 [source,terminal]
 ----
-$ function REMFIN {
+(venv) $ function REMFIN {
     local resource=$1
     local finalizer=$2
     for res in $(oc get $resource -A --template='{{range $i,$p := .items}}{{ $p.metadata.name }}|{{ $p.metadata.namespace }}{{"\n"}}{{end}}'); do

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -164,7 +164,7 @@ done
 ----
 (venv) $ REMFIN kuryrports.openstack.org kuryr.openstack.org/kuryrport-finalizer
 ----
-This will delete the KuryrPort Custom Resources.
+This command deletes the `KuryrPort` CRs.
 
 . To remove Kuryr finalizers from network policies, enter the following command:
 +

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -148,7 +148,7 @@ done
 +
 [source,terminal]
 ----
-$ REMFIN pods kuryr.openstack.org/pod-finalizer
+(venv) $ REMFIN pods kuryr.openstack.org/pod-finalizer
 ----
 
 . To remove Kuryr finalizers from all `KuryrPort` CRs, enter the following command:

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -178,7 +178,7 @@ This will trigger deleting of the KuryrPort Custom Resources.
 [source,terminal]
 ----
 (venv) $ read -ra trunks <<< $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x.id for x in n.trunks(any_tags='$CLUSTERTAG')]))")
-$ i=0
+(venv) $ i=0
 $ for trunk in "${trunks[@]}"; do
     i=$((i+1))
     echo "Processing trunk $trunk, ${i}/${#trunks[@]}."

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -260,7 +260,7 @@ If the command returns any existing networks, intestigate and remove them before
 +
 [source,terminal]
 ----
-$ for sgid in $(openstack security group list -f value -c ID -c Description | grep 'Kuryr-Kubernetes Network Policy' | cut -f 1 -d ' '); do
+(venv) $ for sgid in $(openstack security group list -f value -c ID -c Description | grep 'Kuryr-Kubernetes Network Policy' | cut -f 1 -d ' '); do
     openstack security group delete $sgid
 done
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -8,11 +8,14 @@
 
 After migration from the Kuryr network plugin to the OVN-Kubernetes network plugin completes, clean up the resources that Kuryr created previously.
 
-NOTE: The clean up process relies on a Python virtual environment to ensure
+[NOTE]
+====
+The clean up process relies on a Python virtual environment to ensure
 that the python packages version that you use supports tags for Octavia
 objects. If you are certain that your environment uses a minium `openstacksdk`
 version 0.54.0, `python-openstackclient` version 5.5.0 and
 `python-octaviaclient` version 2.3.0, you can forego the virtual environment.
+====
 
 .Prerequisites
 

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -279,7 +279,7 @@ done
 (venv) $ REMFIN kuryrnetworks.openstack.org kuryrnetwork.finalizers.kuryr.openstack.org
 ----
 
-. If the installer did not create your router, enter the following command to remove the router:
+. To remove the Kuryr router, enter the following command:
 [source,terminal]
 ----
 (venv) $ if $(python3 -c "import sys; import openstack; n = openstack.connect().network; r = n.get_router('$ROUTERID'); sys.exit(0) if r.description != 'Created By OpenShift Installer' else sys.exit(1)"); then

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -77,7 +77,7 @@ right python components are used.
 +
 [source,terminal]
 ----
-$ CLUSTERTAG="openshiftClusterID=${CLUSTERID}"
+(venv) $ CLUSTERTAG="openshiftClusterID=${CLUSTERID}"
 ----
 .. Set the router ID:
 +

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -202,7 +202,7 @@ done
 ----
 (venv) $ mapfile -t kuryrnetworks < <(oc get kuryrnetwork -A --template='{{range $i,$p := .items}}{{ $p.status.netId }}|{{ $p.status.subnetId }}{{"\n"}}{{end}}')
 (venv) $ i=0
-$ for kn in "${kuryrnetworks[@]}"; do
+(venv) $ for kn in "${kuryrnetworks[@]}"; do
     i=$((i+1))
     netID=${kn%%|*}
     subnetID=${kn##*|}

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -130,7 +130,7 @@ done
 (venv) $ REMFIN kuryrloadbalancers.openstack.org kuryr.openstack.org/kuryrloadbalancer-finalizers
 ----
 
-. To remove openshift-kuryr namespace, enter the following command:
+. To remove the `openshift-kuryr` namespace, enter the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -269,7 +269,7 @@ done
 +
 [source,terminal]
 ----
-$ REMFIN kuryrnetworks.openstack.org kuryrnetwork.finalizers.kuryr.openstack.org
+(venv) $ REMFIN kuryrnetworks.openstack.org kuryrnetwork.finalizers.kuryr.openstack.org
 ----
 
 . If the installer did not create your router, enter the following command to remove the router:

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -103,7 +103,7 @@ finalizer to remove. The named resource is removed from the cluster and its defi
 [source,terminal]
 ----
 (venv) $ if $(oc get -n openshift-kuryr service service-subnet-gateway-ip &>/dev/null); then
-    oc get -n openshift-kuryr delete service service-subnet-gateway-ip
+    oc -n openshift-kuryr delete service service-subnet-gateway-ip
 fi
 ----
 

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -111,7 +111,7 @@ finalizer to remove. The named resource is removed from the cluster and its defi
 +
 [source,terminal]
 ----
-$ REMFIN services kuryr.openstack.org/service-finalizer
+(venv) $ REMFIN services kuryr.openstack.org/service-finalizer
 ----
 
 . To remove all tagged {rh-openstack} load balancers from Octavia, enter the following command:

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -163,7 +163,7 @@ This will trigger deleting of the KuryrPort Custom Resources.
 +
 [source,terminal]
 ----
-$ REMFIN networkpolicy kuryr.openstack.org/networkpolicy-finalizer
+(venv) $ REMFIN networkpolicy kuryr.openstack.org/networkpolicy-finalizer
 ----
 
 . To remove Kuryr finalizers from remaining network policies, enter the following command:

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -141,7 +141,7 @@ done
 +
 [source,terminal]
 ----
-$ openstack network delete ${CLUSTERID}-kuryr-service-network
+(venv) $ openstack network delete ${CLUSTERID}-kuryr-service-network
 ----
 
 . To remove Kuryr finalizers from all pods, enter the following command:

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -19,7 +19,7 @@ After migration from the Kuryr network plugin to the OVN-Kubernetes network plug
 
 [NOTE]
 ====
-At the time of writing when OCP16 is used, it includes ancient version of
+At the time of writing when Red Hat OpenStack 16.2 is used, it includes ancient version of
 `openstacksdk` package, that does not support tags for Octavia objects. It is
 recommended to use either workstation with modern operating system with newer
 version of `openstacksdk` package or `virtualenv` and install appropriate

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -201,7 +201,7 @@ done
 [source,terminal]
 ----
 (venv) $ mapfile -t kuryrnetworks < <(oc get kuryrnetwork -A --template='{{range $i,$p := .items}}{{ $p.status.netId }}|{{ $p.status.subnetId }}{{"\n"}}{{end}}')
-$ i=0
+(venv) $ i=0
 $ for kn in "${kuryrnetworks[@]}"; do
     i=$((i+1))
     netID=${kn%%|*}

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -180,13 +180,13 @@ This will trigger deleting of the KuryrPort Custom Resources.
 (venv) $ REMFIN kuryrnetworkpolicies.openstack.org kuryr.openstack.org/networkpolicy-finalizer
 ----
 
-. To remove subports that Kuryr created from trunks, enter the following commands:
+. To remove subports that Kuryr created from trunks, enter the following command:
 +
 [source,terminal]
 ----
-(venv) $ read -ra trunks <<< $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x.id for x in n.trunks(any_tags='$CLUSTERTAG')]))")
-(venv) $ i=0
-(venv) $ for trunk in "${trunks[@]}"; do
+(venv) $ read -ra trunks <<< $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x.id for x in n.trunks(any_tags='$CLUSTERTAG')]))") && \
+i=0 && \
+for trunk in "${trunks[@]}"; do
     i=$((i+1))
     echo "Processing trunk $trunk, ${i}/${#trunks[@]}."
     subports=()
@@ -203,13 +203,13 @@ This will trigger deleting of the KuryrPort Custom Resources.
 done
 ----
 
-. To retrieve all networks and subnets from `KuryrNetwork` CRs and remove ports, router interfaces and the network itself, enter the following commands:
+. To retrieve all networks and subnets from `KuryrNetwork` CRs and remove ports, router interfaces and the network itself, enter the following command:
 +
 [source,terminal]
 ----
-(venv) $ mapfile -t kuryrnetworks < <(oc get kuryrnetwork -A --template='{{range $i,$p := .items}}{{ $p.status.netId }}|{{ $p.status.subnetId }}{{"\n"}}{{end}}')
-(venv) $ i=0
-(venv) $ for kn in "${kuryrnetworks[@]}"; do
+(venv) $ mapfile -t kuryrnetworks < <(oc get kuryrnetwork -A --template='{{range $i,$p := .items}}{{ $p.status.netId }}|{{ $p.status.subnetId }}{{"\n"}}{{end}}') && \
+i=0 && \
+for kn in "${kuryrnetworks[@]}"; do
     i=$((i+1))
     netID=${kn%%|*}
     subnetID=${kn##*|}
@@ -249,12 +249,12 @@ done
 done
 ----
 
-. To check that all of the networks based on `KuryrNetwork` CRs were removed, enter the following commands:
+. To check that all of the networks based on `KuryrNetwork` CRs were removed, enter the following command:
 +
 [source,terminal]
 ----
-(venv) $ networks=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.netId")
-(venv) $ for existingNet in $(openstack network list --tags $CLUSTERTAG -f value -c ID); do
+(venv) $ networks=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.netId") && \
+for existingNet in $(openstack network list --tags $CLUSTERTAG -f value -c ID); do
     if [[ $networks =~ $existingNet ]]; then
         echo "Network still exists: $existingNet"
     fi

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -230,7 +230,7 @@ done
 +
 [source,terminal]
 ----
-$ openstack security group delete ${CLUSTERID}-kuryr-pods-security-group
+(venv) $ openstack security group delete ${CLUSTERID}-kuryr-pods-security-group
 ----
 
 . To remove all tagged subnet pools, enter the following command:

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -118,7 +118,7 @@ finalizer to remove. The named resource is removed from the cluster and its defi
 +
 [source,terminal]
 ----
-$ for lb in $(openstack loadbalancer list --tags $CLUSTERTAG -f value -c id); do
+(venv) $ for lb in $(openstack loadbalancer list --tags $CLUSTERTAG -f value -c id); do
     openstack loadbalancer delete --cascade $lb
 done
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -6,20 +6,17 @@
 [id="nw-kuryr-cleanup_{context}"]
 = Cleaning up resources after migration
 
-After migration from the Kuryr network plugin to the OVN-Kubernetes network plugin completes, clean up the resources that Kuryr created previously.
+After migration from the Kuryr network plugin to the OVN-Kubernetes network
+plugin, you need toneed to  clean up the resources that Kuryr created previously.
 
 [NOTE]
 ====
-The clean up process relies on a Python virtual environment to ensure
-that the python packages version that you use supports tags for Octavia
-objects. If you are certain that your environment uses a minium `openstacksdk`
-version 0.54.0, `python-openstackclient` version 5.5.0 and
-`python-octaviaclient` version 2.3.0, you can forego the virtual environment.
+The clean up process relies on a Python virtual environment. This ensure that the python packages version you use support tags for Octavia objects. If you are certain that your environment uses a minium `openstacksdk` version 0.54.0, `python-openstackclient` version 5.5.0 and `python-octaviaclient` version 2.3.0, you do not need the virtual environment.
 ====
 
 .Prerequisites
 
-* You installed the {product-title} CLI, `oc`.
+* You installed the {product-title} CLI (`oc`).
 * You installed a Python interpreter.
 * You installed the `openstacksdk` Python package.
 * You installed the `openstack` CLI.
@@ -28,21 +25,21 @@ version 0.54.0, `python-openstackclient` version 5.5.0 and
 
 .Procedure
 . Create a clean-up Python virtual environment:
-.. Create a temporary directory for your environment. For example, with `venv`:
+.. Create a temporary directory for your environment. For example, with the `/tmp/venv`:
 +
 [source,terminal]
 ----
 $ python3 -m venv /tmp/venv
 ----
 +
-`venv` is used in all clean up examples.
+The virtual environment located in `/tmp/venv` directory is used in all clean up examples.
 .. Enter the virtual environment. For example:
 +
 [source,terminal]
 ----
 $ source /tmp/venv/bin/activate
 ----
-.. Upgrade `pip` in the virtual environment by running the following command:
+.. Upgrade the `pip` command in the virtual environment by running the following command:
 +
 [source,terminal]
 ----
@@ -55,7 +52,7 @@ $ source /tmp/venv/bin/activate
 (venv) $ pip install openstacksdk==0.54.0 python-openstackclient==5.5.0 python-octaviaclient==2.3.0
 ----
 
-. On a command line, enter the following commands to set variables to cluster and Kuryr identifiers:
+. In your terminal, set variables to cluster and Kuryr identifiers by running the following commands:
 
 .. Set the cluster ID:
 +
@@ -77,7 +74,7 @@ $ source /tmp/venv/bin/activate
 (venv) $ ROUTERID=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.routerId"|head -n 1)
 ----
 
-. To create a Bash function that removes finalizers from specified resources, enter the following command:
+. Create a Bash function that removes finalizers from specified resources by running the following command:
 +
 [source,terminal]
 ----
@@ -95,17 +92,18 @@ $ source /tmp/venv/bin/activate
 }
 ----
 +
-The function takes two parameters: the first parameter is name of the resource, and the second parameter is the
-finalizer to remove. The named resource is removed from the cluster and its definition is replaced with copied data excluding the specified finalizer.
+The function takes two parameters: first parameter is name of the resource, while second one is the finalizer to remove.
+The named resource is removed from the cluster and its definition is replaced with copied data, excluding the specified finalizer.
 
-. To remove Kuryr finalizers from services, enter the following command:
+. Clean up Kuryr related resources.
+.. To remove Kuryr finalizers from services, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN services kuryr.openstack.org/service-finalizer
 ----
 
-. To remove Kuryr service `service-subnet-gateway-ip`, enter the following command:
+.. To remove the Kuryr `service-subnet-gateway-ip` service, enter the following command:
 +
 [source,terminal]
 ----
@@ -114,7 +112,7 @@ finalizer to remove. The named resource is removed from the cluster and its defi
 fi
 ----
 
-. To remove all tagged {rh-openstack} load balancers from Octavia, enter the following command:
+.. To remove all tagged {rh-openstack} load balancers from Octavia, enter the following command:
 +
 [source,terminal]
 ----
@@ -123,64 +121,64 @@ fi
 done
 ----
 
-. To remove Kuryr finalizers from all `KuryrLoadBalancer` CRs, enter the following command:
+.. To remove Kuryr finalizers from all `KuryrLoadBalancer` CRs, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN kuryrloadbalancers.openstack.org kuryr.openstack.org/kuryrloadbalancer-finalizers
 ----
 
-. To remove the `openshift-kuryr` namespace, enter the following command:
+.. To remove the `openshift-kuryr` namespace, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ oc delete namespace openshift-kuryr
 ----
 
-. To remove the Kuryr service subnet from the router, enter the following command:
+.. To remove the Kuryr service subnet from the router, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ openstack router remove subnet $ROUTERID ${CLUSTERID}-kuryr-service-subnet
 ----
 
-. To remove the Kuryr service network, enter the following command:
+.. To remove the Kuryr service network, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ openstack network delete ${CLUSTERID}-kuryr-service-network
 ----
 
-. To remove Kuryr finalizers from all pods, enter the following command:
+.. To remove Kuryr finalizers from all pods, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN pods kuryr.openstack.org/pod-finalizer
 ----
 
-. To remove Kuryr finalizers from all `KuryrPort` CRs, enter the following command:
+.. To remove Kuryr finalizers from all `KuryrPort` CRs, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN kuryrports.openstack.org kuryr.openstack.org/kuryrport-finalizer
 ----
-This will trigger deleting of the KuryrPort Custom Resources.
+This will delete the KuryrPort Custom Resources.
 
-. To remove Kuryr finalizers from network policies, enter the following command:
+.. To remove Kuryr finalizers from network policies, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN networkpolicy kuryr.openstack.org/networkpolicy-finalizer
 ----
 
-. To remove Kuryr finalizers from remaining network policies, enter the following command:
+.. To remove Kuryr finalizers from remaining network policies, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN kuryrnetworkpolicies.openstack.org kuryr.openstack.org/networkpolicy-finalizer
 ----
 
-. To remove subports that Kuryr created from trunks, enter the following command:
+.. To remove subports that Kuryr created from trunks, enter the following command:
 +
 [source,terminal]
 ----
@@ -203,7 +201,7 @@ for trunk in "${trunks[@]}"; do
 done
 ----
 
-. To retrieve all networks and subnets from `KuryrNetwork` CRs and remove ports, router interfaces and the network itself, enter the following command:
+.. To retrieve all networks and subnets from `KuryrNetwork` CRs and remove ports, router interfaces and the network itself, enter the following command:
 +
 [source,terminal]
 ----
@@ -233,14 +231,14 @@ for kn in "${kuryrnetworks[@]}"; do
 done
 ----
 
-. To remove the Kuryr security group, enter the following command:
+.. To remove the Kuryr security group, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ openstack security group delete ${CLUSTERID}-kuryr-pods-security-group
 ----
 
-. To remove all tagged subnet pools, enter the following command:
+.. To remove all tagged subnet pools, enter the following command:
 +
 [source,terminal]
 ----
@@ -249,7 +247,7 @@ done
 done
 ----
 
-. To check that all of the networks based on `KuryrNetwork` CRs were removed, enter the following command:
+.. To check that all of the networks based on `KuryrNetwork` CRs were removed, enter the following command:
 +
 [source,terminal]
 ----
@@ -263,7 +261,7 @@ done
 +
 If the command returns any existing networks, intestigate and remove them before you continue.
 
-. To remove security groups that are related to network policy, enter the following command:
+.. To remove security groups that are related to network policy, enter the following command:
 +
 [source,terminal]
 ----
@@ -272,14 +270,15 @@ If the command returns any existing networks, intestigate and remove them before
 done
 ----
 
-. To remove finalizers from `KuryrNetwork` CRs, enter the following command:
+.. To remove finalizers from `KuryrNetwork` CRs, enter the following command:
 +
 [source,terminal]
 ----
 (venv) $ REMFIN kuryrnetworks.openstack.org kuryrnetwork.finalizers.kuryr.openstack.org
 ----
 
-. To remove the Kuryr router, enter the following command:
+.. To remove the Kuryr router, enter the following command:
++
 [source,terminal]
 ----
 (venv) $ if $(python3 -c "import sys; import openstack; n = openstack.connect().network; r = n.get_router('$ROUTERID'); sys.exit(0) if r.description != 'Created By OpenShift Installer' else sys.exit(1)"); then

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -70,7 +70,7 @@ right python components are used.
 +
 [source,terminal]
 ----
-$ CLUSTERID=$(oc get infrastructure.config.openshift.io cluster -o=jsonpath='{.status.infrastructureName}')
+(venv) $ CLUSTERID=$(oc get infrastructure.config.openshift.io cluster -o=jsonpath='{.status.infrastructureName}')
 ----
 
 .. Set the cluster tag:

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -98,6 +98,13 @@ $ source /tmp/venv/bin/activate
 The function takes two parameters: the first parameter is name of the resource, and the second parameter is the
 finalizer to remove. The named resource is removed from the cluster and its definition is replaced with copied data excluding the specified finalizer.
 
+. To remove Kuryr finalizers from services, enter the following command:
++
+[source,terminal]
+----
+(venv) $ REMFIN services kuryr.openstack.org/service-finalizer
+----
+
 . To remove Kuryr service `service-subnet-gateway-ip`, enter the following command:
 +
 [source,terminal]
@@ -105,13 +112,6 @@ finalizer to remove. The named resource is removed from the cluster and its defi
 (venv) $ if $(oc get -n openshift-kuryr service service-subnet-gateway-ip &>/dev/null); then
     oc -n openshift-kuryr delete service service-subnet-gateway-ip
 fi
-----
-
-. To remove Kuryr finalizers from services, enter the following command:
-+
-[source,terminal]
-----
-(venv) $ REMFIN services kuryr.openstack.org/service-finalizer
 ----
 
 . To remove all tagged {rh-openstack} load balancers from Octavia, enter the following command:

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -8,6 +8,8 @@
 
 After migration from the Kuryr network plugin to the OVN-Kubernetes network plugin completes, clean up the resources that Kuryr created previously. 
 
+NOTE: The clean up process relies on a Python virtual environment to ensure that the `openstacksdk` package version that you use supports tags for Octavia objects. If you are certain that your environment uses `openstacksdk` version 0.54.0 or higher, you can forego the virtual environment.
+
 .Prerequisites
 
 * You installed the {product-title} CLI, `oc`.

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -272,7 +272,9 @@ done
 $ REMFIN kuryrnetworks.openstack.org kuryrnetwork.finalizers.kuryr.openstack.org
 ----
 
-. If the your router *was not* created by the installer, enter the following command to remove the router:
+. If the installer did not create your router, enter the following command to remove the router:
++
+IMPORTANT: If the installer did create your router, do not remove the router.
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -28,7 +28,7 @@ The clean up process relies on a Python virtual environment to ensure that the p
 
 .Procedure
 . Create a clean-up Python virtual environment:
-.. Create a temporary directory for your environment. For example, with the `/tmp/venv`:
+.. Create a temporary directory for your environment. For example:
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -179,7 +179,7 @@ This will trigger deleting of the KuryrPort Custom Resources.
 ----
 (venv) $ read -ra trunks <<< $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x.id for x in n.trunks(any_tags='$CLUSTERTAG')]))")
 (venv) $ i=0
-$ for trunk in "${trunks[@]}"; do
+(venv) $ for trunk in "${trunks[@]}"; do
     i=$((i+1))
     echo "Processing trunk $trunk, ${i}/${#trunks[@]}."
     subports=()

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -127,7 +127,7 @@ done
 +
 [source,terminal]
 ----
-$ REMFIN kuryrloadbalancers.openstack.org kuryr.openstack.org/kuryrloadbalancer-finalizers
+(venv) $ REMFIN kuryrloadbalancers.openstack.org kuryr.openstack.org/kuryrloadbalancer-finalizers
 ----
 
 . To remove the Kuryr service subnet from router, enter the following command:

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -1,0 +1,217 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
+
+:_content-type: PROCEDURE
+[id="nw-kuryr-cleanup_{context}"]
+= Cleaning up resources after migration
+
+After migration is done, there are necessary steps to clean up resources created by Kuryr. From high level perspective it will include:
+
+* Removing Kuryr finalizers from resources
+* Removing Kuryr CRDs
+* Removing {rh-openstack-first} resources
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Install `jq` tool
+* Install Python interpreter
+* Install `openstacksdk` python package
+* Install `openstack` cli tool
+* Access to the underlying {rh-openstack}
+* Access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Find out cluster and Kuryr related identifiers, which will be used later:
++
+[source,terminal]
+----
+$ CLUSTERID=$(oc get infrastructure.config.openshift.io cluster -o=jsonpath='{.status.infrastructureName}')
+$ CLUSTERTAG="openshiftClusterID=${CLUSTERID}"
+$ ROUTERID=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.routerId"|head -n 1)
+----
+
+. Create helper bash function, which will help out with removing finalizers
+from specified resources. It might look complicated, but it simply gets two
+parameters - first one is name of the resource, and the second is the
+finalizer to be removed. Than it will get all the desired resource from the
+cluster and replace it's definition with the same data excluding specified
+finalizer. Note, that executing this function for certain resources may
+require to execute it again with the same parameters in case of conflict
+errors.
++
+[source,terminal]
+----
+$ function REMFIN {
+    local resource=$1
+    local finalizer=$2
+    for res in $(oc get $resource -A --template='{{range $i,$p := .items}}{{ $p.metadata.name }}|{{ $p.metadata.namespace }}{{"\n"}}{{end}}'); do
+        name=${res%%|*}
+        ns=${res##*|}
+        oc get -n $ns $resource $name -o json |
+            jq -Mcr "if .metadata.finalizers != null then del(.metadata.finalizers[] | select(. == \"${finalizer}\")) else . end" |
+            oc replace -n $ns $resource $name -f -
+    done
+}
+----
+
+. Remove Kuryr finalizers from services:
++
+[source,terminal]
+----
+$ REMFIN services kuryr.openstack.org/service-finalizer
+----
+
+. Remove all tagged {rh-openstack} Load Balancers from Octavia:
++
+[source,terminal]
+----
+$ for lb in $(openstack loadbalancer list --tags $CLUSTERTAG -f value -c id); do
+    openstack loadbalancer delete --cascade $lb
+done
+----
+
+. Remove Kuryr finalizers from all KuryrLoadBalancer CRs. This will trigger their deletion:
++
+[source,terminal]
+----
+$ REMFIN kuryrloadbalancers.openstack.org kuryr.openstack.org/kuryrloadbalancer-finalizers
+----
+
+. Remove Kuryr service network:
++
+[source,terminal]
+----
+$ openstack router remove subnet $ROUTERID ${CLUSTERID}-kuryr-service-subnet
+$ openstack network delete ${CLUSTERID}-kuryr-service-network
+----
+
+. Remove Kuryr finalizers from all pods:
++
+[source,terminal]
+----
+$ REMFIN pods kuryr.openstack.org/pod-finalizer
+----
+
+. Remove Kuryr finalizers from all KuryrPort CRs, as a consequence, KuryrPort CRs will be deleted:
++
+[source,terminal]
+----
+$ REMFIN kuryrports.openstack.org kuryr.openstack.org/kuryrport-finalizer
+----
+
+. Remove Kuryr finalizers from all Network Policies:
++
+[source,terminal]
+----
+$ REMFIN networkpolicy kuryr.openstack.org/networkpolicy-finalizer
+$ REMFIN kuryrnetworkpolicies.openstack.org kuryr.openstack.org/networkpolicy-finalizer
+----
+
+. Remove subports created by Kuryr from trunks. Note, it will take a time, since for every subport there is a check if such port is tagged with `$CLUSTERTAG`:
++
+[source,terminal]
+----
+$ read -ra trunks <<< $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x.id for x in n.trunks(any_tags='$CLUSTERTAG')]))")
+$ i=0
+$ for trunk in "${trunks[@]}"; do
+    i=$((i+1))
+    echo "Processing trunk $trunk, ${i}/${#trunks[@]}."
+    subports=()
+    for subport in $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x['port_id'] for x in n.get_trunk('$trunk').sub_ports if '$CLUSTERTAG' in n.get_port(x['port_id']).tags]))"); do 
+        subports+=("$subport");
+    done
+    args=()
+    for sub in "${subports[@]}" ; do
+        args+=("--subport $sub")
+    done
+    if [ ${#args[@]} -gt 0 ]; then
+        openstack network trunk unset ${args[*]} $trunk
+    fi
+done
+----
+
+. Get all networks and subnets from KuryrNetwork CRs and remove ports, router interfaces and network itself:
++
+[source,terminal]
+----
+$ mapfile -t kuryrnetworks < <(oc get kuryrnetwork -A --template='{{range $i,$p := .items}}{{ $p.status.netId }}|{{ $p.status.subnetId }}{{"\n"}}{{end}}')
+$ i=0
+$ for kn in "${kuryrnetworks[@]}"; do
+    i=$((i+1))
+    netID=${kn%%|*}
+    subnetID=${kn##*|}
+    echo "Processing network $netID, ${i}/${#kuryrnetworks[@]}"
+    # Remove all ports from the network.
+    for port in $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x.id for x in n.ports(network_id='$netID') if x.device_owner != 'network:router_interface']))"); do
+        ( openstack port delete $port ) &
+
+        # Only allow 20 jobs in parallel.
+        if [[ $(jobs -r -p | wc -l) -ge 20 ]]; then
+            wait -n
+        fi
+    done
+    wait
+
+    # Remove the subnet from the router.
+    openstack router remove subnet $ROUTERID $subnetID
+
+    # Remove the network.
+    openstack network delete $netID
+done
+----
+
+. Remove Kuryr security group
++
+[source,terminal]
+----
+openstack security group delete ${CLUSTERID}-kuryr-pods-security-group
+----
+
+. Remove all tagged subnetpools and remove them:
++
+[source,terminal]
+----
+$ for subnetpool in $(openstack subnet pool list --tags $CLUSTERTAG -f value -c ID); do
+    openstack subnet pool delete $subnetpool
+done
+----
+
+. Check for all the networks based on KuryrNetwork CRs are removed. This command will give you list of still existing networks, otherwise it should return no output.
++
+[source,terminal]
+----
+networks=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.netId")
+for existingNet in $(openstack network list --tags $CLUSTERTAG -f value -c ID); do
+    if [[ $networks =~ $existingNet ]]; then
+        echo "Network still exists: $existingNet"
+    fi
+done
+----
++
+If there are any existing networks listed, they should be investigated and removed one by one before continuing.
+
+. Removing network policy related security groups:
++
+[source,terminal]
+----
+$ for sgid in $(openstack security group list -f value -c ID -c Description | grep 'Kuryr-Kubernetes Network Policy' | cut -f 1 -d ' '); do
+    openstack security group delete $sgid
+done
+----
+
+. Remove finalizers from KuryrNetwork CRs:
++
+[source,terminal]
+----
+$ REMFIN kuryrnetworks.openstack.org kuryrnetwork.finalizers.kuryr.openstack.org
+----
+
+. Finally, if router was created by Cluster Network Operator, router might be removed:
++
+[source,terminal]
+----
+$ openstack router delete $ROUTERID
+----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -6,41 +6,45 @@
 [id="nw-kuryr-cleanup_{context}"]
 = Cleaning up resources after migration
 
-After migration is done, there are necessary steps to clean up resources created by Kuryr. From high level perspective it will include:
-
-* Removing Kuryr finalizers from resources
-* Removing Kuryr CRDs
-* Removing {rh-openstack-first} resources
+After migration from the Kuryr network plugin to the OVN-Kubernetes network plugin completes, clean up the resources that Kuryr created previously. 
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
+* You installed the {product-title} CLI, `oc`.
+// TODO: replace jq
 * Install `jq` tool
-* Install Python interpreter
-* Install `openstacksdk` python package
-* Install `openstack` cli tool
-* Access to the underlying {rh-openstack}
-* Access to the cluster as a user with the `cluster-admin` role.
+// TODO: Can we outsource some of the other prereqs to openstack CLI docs?
+* You installed a Python interpreter.
+* You installed the `openstacksdk` Python package.
+* You installed the `openstack` CLI.
+* You have access to the underlying {rh-openstack} cloud.
+* You can access the cluster as a user with the `cluster-admin` role.
 
 .Procedure
 
-. Find out cluster and Kuryr related identifiers, which will be used later:
+. On a command line, enter the following commands to set variables to cluster and Kuryr identifiers:
+
+.. Set the cluster ID:
 +
 [source,terminal]
 ----
 $ CLUSTERID=$(oc get infrastructure.config.openshift.io cluster -o=jsonpath='{.status.infrastructureName}')
+----
+
+.. Set the cluster tag:
++
+[source,terminal]
+----
 $ CLUSTERTAG="openshiftClusterID=${CLUSTERID}"
+----
+.. Set the router ID:
++
+[source,terminal]
+----
 $ ROUTERID=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.routerId"|head -n 1)
 ----
 
-. Create helper bash function, which will help out with removing finalizers
-from specified resources. It might look complicated, but it simply gets two
-parameters - first one is name of the resource, and the second is the
-finalizer to be removed. Than it will get all the desired resource from the
-cluster and replace it's definition with the same data excluding specified
-finalizer. Note, that executing this function for certain resources may
-require to execute it again with the same parameters in case of conflict
-errors.
+. To create a Bash function that removes finalizers from specified resources, enter the following command:
 +
 [source,terminal]
 ----
@@ -56,15 +60,18 @@ $ function REMFIN {
     done
 }
 ----
++
+The function takes two parameters: the first parameter is name of the resource, and the second parameter is the
+finalizer to remove. The named resource is removed from the cluster and its definition is replaced with copied data excluding the specified finalizer.
 
-. Remove Kuryr finalizers from services:
+. To remove Kuryr finalizers from services, enter the following command:
 +
 [source,terminal]
 ----
 $ REMFIN services kuryr.openstack.org/service-finalizer
 ----
 
-. Remove all tagged {rh-openstack} Load Balancers from Octavia:
+. To remove all tagged {rh-openstack} load balancers from Octavia, enter the following command:
 +
 [source,terminal]
 ----
@@ -73,44 +80,56 @@ $ for lb in $(openstack loadbalancer list --tags $CLUSTERTAG -f value -c id); do
 done
 ----
 
-. Remove Kuryr finalizers from all KuryrLoadBalancer CRs. This will trigger their deletion:
+. To remove Kuryr finalizers from all KuryrLoadBalancer CRs, enter the following command:
 +
 [source,terminal]
 ----
 $ REMFIN kuryrloadbalancers.openstack.org kuryr.openstack.org/kuryrloadbalancer-finalizers
 ----
 
-. Remove Kuryr service network:
+. To remove the Kuryr service subnet, enter the following command:
 +
 [source,terminal]
 ----
 $ openstack router remove subnet $ROUTERID ${CLUSTERID}-kuryr-service-subnet
+----
+
+. To remove the Kuryr service network, enter the following command:
++
+[source,terminal]
+----
 $ openstack network delete ${CLUSTERID}-kuryr-service-network
 ----
 
-. Remove Kuryr finalizers from all pods:
+. To remove Kuryr finalizers from all pods, enter the following command:
 +
 [source,terminal]
 ----
 $ REMFIN pods kuryr.openstack.org/pod-finalizer
 ----
 
-. Remove Kuryr finalizers from all KuryrPort CRs, as a consequence, KuryrPort CRs will be deleted:
+. To remove Kuryr finalizers from all `KuryrPort` CRs, enter the following command:
 +
 [source,terminal]
 ----
 $ REMFIN kuryrports.openstack.org kuryr.openstack.org/kuryrport-finalizer
 ----
 
-. Remove Kuryr finalizers from all Network Policies:
+. To remove Kuryr finalizers from network policies, enter the following command:
 +
 [source,terminal]
 ----
 $ REMFIN networkpolicy kuryr.openstack.org/networkpolicy-finalizer
+----
+
+. To remove Kuryr finalizers from remaining network policies, enter the following command:
++
+[source,terminal]
+----
 $ REMFIN kuryrnetworkpolicies.openstack.org kuryr.openstack.org/networkpolicy-finalizer
 ----
 
-. Remove subports created by Kuryr from trunks. Note, it will take a time, since for every subport there is a check if such port is tagged with `$CLUSTERTAG`:
+. To remove subports that Kuryr created from trunks, enter the following command:
 +
 [source,terminal]
 ----
@@ -133,7 +152,7 @@ $ for trunk in "${trunks[@]}"; do
 done
 ----
 
-. Get all networks and subnets from KuryrNetwork CRs and remove ports, router interfaces and network itself:
+. To retrieve all networks and subnets from `KuryrNetwork` CRs and remove ports, router interfaces and the network itself, enter the following command:
 +
 [source,terminal]
 ----
@@ -163,14 +182,14 @@ $ for kn in "${kuryrnetworks[@]}"; do
 done
 ----
 
-. Remove Kuryr security group
+. To remove the Kuryr security group, enter the following command:
 +
 [source,terminal]
 ----
-openstack security group delete ${CLUSTERID}-kuryr-pods-security-group
+$ openstack security group delete ${CLUSTERID}-kuryr-pods-security-group
 ----
 
-. Remove all tagged subnetpools and remove them:
+. To remove all tagged subnet pools, enter the following command:
 +
 [source,terminal]
 ----
@@ -179,11 +198,11 @@ $ for subnetpool in $(openstack subnet pool list --tags $CLUSTERTAG -f value -c 
 done
 ----
 
-. Check for all the networks based on KuryrNetwork CRs are removed. This command will give you list of still existing networks, otherwise it should return no output.
+. To check that all of the networks based on `KuryrNetwork` CRs were removed, enter the following command:
 +
 [source,terminal]
 ----
-networks=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.netId")
+$ networks=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.netId")
 for existingNet in $(openstack network list --tags $CLUSTERTAG -f value -c ID); do
     if [[ $networks =~ $existingNet ]]; then
         echo "Network still exists: $existingNet"
@@ -191,9 +210,9 @@ for existingNet in $(openstack network list --tags $CLUSTERTAG -f value -c ID); 
 done
 ----
 +
-If there are any existing networks listed, they should be investigated and removed one by one before continuing.
+If the command returns any existing networks, intestigate and remove them before you continue.
 
-. Removing network policy related security groups:
+. To remove security groups that are related to network policy, enter the following command:
 +
 [source,terminal]
 ----
@@ -202,14 +221,14 @@ $ for sgid in $(openstack security group list -f value -c ID -c Description | gr
 done
 ----
 
-. Remove finalizers from KuryrNetwork CRs:
+. To remove finalizers from `KuryrNetwork` CRs, enter the following command:
 +
 [source,terminal]
 ----
 $ REMFIN kuryrnetworks.openstack.org kuryrnetwork.finalizers.kuryr.openstack.org
 ----
 
-. Finally, if router was created by Cluster Network Operator, router might be removed:
+. If the Cluster Network Operator created your router, enter the following command to remove the router:
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -1,0 +1,280 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
+
+:_content-type: PROCEDURE
+[id="nw-kuryr-cleanup_{context}"]
+= Cleaning up resources after migration
+
+After migration from the Kuryr network plugin to the OVN-Kubernetes network plugin completes, clean up the resources that Kuryr created previously. 
+
+.Prerequisites
+
+* You installed the {product-title} CLI, `oc`.
+* You installed a Python interpreter.
+* You installed the `openstacksdk` Python package.
+* You installed the `openstack` CLI.
+* You have access to the underlying {rh-openstack} cloud.
+* You can access the cluster as a user with the `cluster-admin` role.
+
+[NOTE]
+====
+At the time of writing when OCP16 is used, it includes ancient version of
+`openstacksdk` package, that does not support tags for Octavia objects. It is
+recommended to use either workstation with modern operating system with newer
+version of `openstacksdk` package or `virtualenv` and install appropriate
+version from link:https://pypi.org[pypi].
+====
+
+.Setup virtualenv
+
+If you decide to use virtualenv, here is a quick guidance how to proceed.
+At the time of writing, minimal versions of the following OpenStack components
+has been used to fulfill cleaning procedure:
+
+- openstacksdk 0.54.0
+- python-openstackclient 5.5.0
+- python-octaviaclient 2.3.0
+
+Newer versions should also work, although there is a tiny chance for
+incompatibilities. If you have issues, either downgrade to version mentioned
+above or consult individual component documentation and/or changelog for
+details.
+
+To set up cleanup environment, create virtualenv, update pip and install needed
+components:
+
+[source,terminal]
+----
+$ python3 -m venv /tmp/venv
+$ source /tmp/venv/bin/activate
+(venv) $ pip install pip --upgrade
+(venv) $ pip install openstacksdk==0.54.0 python-openstackclient==5.5.0 python-octaviaclient==2.3.0
+----
+
+[NOTE]
+====
+In the command prompt there will be visible indicator, that virtualenv is in
+use - here it will be additional `(venv)` string, as in the example above venv
+is a name of the directory and the virtual env at the same time.
+====
+
+Stay in the created environment during following procedure to be sure the
+right python components are used.
+
+.Procedure
+
+. On a command line, enter the following commands to set variables to cluster and Kuryr identifiers:
+
+.. Set the cluster ID:
++
+[source,terminal]
+----
+$ CLUSTERID=$(oc get infrastructure.config.openshift.io cluster -o=jsonpath='{.status.infrastructureName}')
+----
+
+.. Set the cluster tag:
++
+[source,terminal]
+----
+$ CLUSTERTAG="openshiftClusterID=${CLUSTERID}"
+----
+.. Set the router ID:
++
+[source,terminal]
+----
+$ ROUTERID=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.routerId"|head -n 1)
+----
+
+. To create a Bash function that removes finalizers from specified resources, enter the following command:
++
+[source,terminal]
+----
+$ function REMFIN {
+    local resource=$1
+    local finalizer=$2
+    for res in $(oc get $resource -A --template='{{range $i,$p := .items}}{{ $p.metadata.name }}|{{ $p.metadata.namespace }}{{"\n"}}{{end}}'); do
+        name=${res%%|*}
+        ns=${res##*|}
+        yaml=$(oc get -n $ns $resource $name -o yaml)
+        if echo "${yaml}" | grep -q "${finalizer}"; then
+            echo "${yaml}" | grep -v  "${finalizer}" | oc replace -n $ns $resource $name -f -
+        fi
+    done
+}
+----
++
+The function takes two parameters: the first parameter is name of the resource, and the second parameter is the
+finalizer to remove. The named resource is removed from the cluster and its definition is replaced with copied data excluding the specified finalizer.
+
+. To remove Kuryr finalizers from services, enter the following command:
++
+[source,terminal]
+----
+$ REMFIN services kuryr.openstack.org/service-finalizer
+----
+
+. To remove all tagged {rh-openstack} load balancers from Octavia, enter the following command:
++
+[source,terminal]
+----
+$ for lb in $(openstack loadbalancer list --tags $CLUSTERTAG -f value -c id); do
+    openstack loadbalancer delete --cascade $lb
+done
+----
+
+. To remove Kuryr finalizers from all KuryrLoadBalancer CRs, enter the following command:
++
+[source,terminal]
+----
+$ REMFIN kuryrloadbalancers.openstack.org kuryr.openstack.org/kuryrloadbalancer-finalizers
+----
+
+. To remove the Kuryr service subnet from router, enter the following command:
++
+[source,terminal]
+----
+$ openstack router remove subnet $ROUTERID ${CLUSTERID}-kuryr-service-subnet
+----
+
+. To remove the Kuryr service network, enter the following command:
++
+[source,terminal]
+----
+$ openstack network delete ${CLUSTERID}-kuryr-service-network
+----
+
+. To remove Kuryr finalizers from all pods, enter the following command:
++
+[source,terminal]
+----
+$ REMFIN pods kuryr.openstack.org/pod-finalizer
+----
+
+. To remove Kuryr finalizers from all `KuryrPort` CRs, enter the following command:
++
+[source,terminal]
+----
+$ REMFIN kuryrports.openstack.org kuryr.openstack.org/kuryrport-finalizer
+----
+This will trigger deleting of the KuryrPort Custom Resources.
+
+. To remove Kuryr finalizers from network policies, enter the following command:
++
+[source,terminal]
+----
+$ REMFIN networkpolicy kuryr.openstack.org/networkpolicy-finalizer
+----
+
+. To remove Kuryr finalizers from remaining network policies, enter the following command:
++
+[source,terminal]
+----
+$ REMFIN kuryrnetworkpolicies.openstack.org kuryr.openstack.org/networkpolicy-finalizer
+----
+
+. To remove subports that Kuryr created from trunks, enter the following command:
++
+[source,terminal]
+----
+$ read -ra trunks <<< $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x.id for x in n.trunks(any_tags='$CLUSTERTAG')]))")
+$ i=0
+$ for trunk in "${trunks[@]}"; do
+    i=$((i+1))
+    echo "Processing trunk $trunk, ${i}/${#trunks[@]}."
+    subports=()
+    for subport in $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x['port_id'] for x in n.get_trunk('$trunk').sub_ports if '$CLUSTERTAG' in n.get_port(x['port_id']).tags]))"); do
+        subports+=("$subport");
+    done
+    args=()
+    for sub in "${subports[@]}" ; do
+        args+=("--subport $sub")
+    done
+    if [ ${#args[@]} -gt 0 ]; then
+        openstack network trunk unset ${args[*]} $trunk
+    fi
+done
+----
+
+. To retrieve all networks and subnets from `KuryrNetwork` CRs and remove ports, router interfaces and the network itself, enter the following command:
++
+[source,terminal]
+----
+$ mapfile -t kuryrnetworks < <(oc get kuryrnetwork -A --template='{{range $i,$p := .items}}{{ $p.status.netId }}|{{ $p.status.subnetId }}{{"\n"}}{{end}}')
+$ i=0
+$ for kn in "${kuryrnetworks[@]}"; do
+    i=$((i+1))
+    netID=${kn%%|*}
+    subnetID=${kn##*|}
+    echo "Processing network $netID, ${i}/${#kuryrnetworks[@]}"
+    # Remove all ports from the network.
+    for port in $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x.id for x in n.ports(network_id='$netID') if x.device_owner != 'network:router_interface']))"); do
+        ( openstack port delete $port ) &
+
+        # Only allow 20 jobs in parallel.
+        if [[ $(jobs -r -p | wc -l) -ge 20 ]]; then
+            wait -n
+        fi
+    done
+    wait
+
+    # Remove the subnet from the router.
+    openstack router remove subnet $ROUTERID $subnetID
+
+    # Remove the network.
+    openstack network delete $netID
+done
+----
+
+. To remove the Kuryr security group, enter the following command:
++
+[source,terminal]
+----
+$ openstack security group delete ${CLUSTERID}-kuryr-pods-security-group
+----
+
+. To remove all tagged subnet pools, enter the following command:
++
+[source,terminal]
+----
+$ for subnetpool in $(openstack subnet pool list --tags $CLUSTERTAG -f value -c ID); do
+    openstack subnet pool delete $subnetpool
+done
+----
+
+. To check that all of the networks based on `KuryrNetwork` CRs were removed, enter the following command:
++
+[source,terminal]
+----
+$ networks=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.netId")
+for existingNet in $(openstack network list --tags $CLUSTERTAG -f value -c ID); do
+    if [[ $networks =~ $existingNet ]]; then
+        echo "Network still exists: $existingNet"
+    fi
+done
+----
++
+If the command returns any existing networks, intestigate and remove them before you continue.
+
+. To remove security groups that are related to network policy, enter the following command:
++
+[source,terminal]
+----
+$ for sgid in $(openstack security group list -f value -c ID -c Description | grep 'Kuryr-Kubernetes Network Policy' | cut -f 1 -d ' '); do
+    openstack security group delete $sgid
+done
+----
+
+. To remove finalizers from `KuryrNetwork` CRs, enter the following command:
++
+[source,terminal]
+----
+$ REMFIN kuryrnetworks.openstack.org kuryrnetwork.finalizers.kuryr.openstack.org
+----
+
+. If the your router *was not* created by the installer, enter the following command to remove the router:
++
+[source,terminal]
+----
+$ openstack router delete $ROUTERID
+----

--- a/modules/nw-kuryr-migration-about.adoc
+++ b/modules/nw-kuryr-migration-about.adoc
@@ -42,7 +42,7 @@ Machine Config Operator (MCO):: Deploys an update to the systemd configuration t
 CNO:: Performs the following actions:
 +
 --
-* Destroys the Kuryr control plane pods, which means Kuryr CNIs and the Kuryr controller.
+* Destroys the Kuryr control plane pods: Kuryr CNIs and the Kuryr controller.
 * Deploys the OVN-Kubernetes control plane pods.
 * Updates the Multus objects to reflect the new network plug-in.
 --

--- a/modules/nw-kuryr-migration-about.adoc
+++ b/modules/nw-kuryr-migration-about.adoc
@@ -43,7 +43,7 @@ CNO:: Performs the following actions:
 --
 * Destroys the Kuryr control plane pods: Kuryr CNIs and the Kuryr controller.
 * Deploys the OVN-Kubernetes control plane pods.
-* Updates the Multus objects to reflect the new network plug-in.
+* Updates the Multus objects to reflect the new network plugin.
 --
 
 |

--- a/modules/nw-kuryr-migration-about.adoc
+++ b/modules/nw-kuryr-migration-about.adoc
@@ -6,12 +6,11 @@
 [id="nw-kuryr-ovn-kubernetes-migration-about_{context}"]
 = Migration to the OVN-Kubernetes network provider
 
-You can manually migrate a cluster that runs on {rh-openstack-first} to the OVN-Kubernetes network provider. During the migration process, your cluster will be unreachable for a brief time. 
+You can manually migrate a cluster that runs on {rh-openstack-first} to the OVN-Kubernetes network provider. 
 
 [IMPORTANT]
 ====
 Migration to OVN-Kubernetes is a one-way process.
-
 During migration, your cluster will be unreachable for a brief time. 
 ====
 
@@ -23,7 +22,7 @@ Kubernetes namespaces are kept by Kuryr in separate {rh-openstack} networking se
 [id="how-the-kuryr-migration-process-works_{context}"]
 == How the migration process works
 
-The following table summarizes the migration process by relating the steps that you perform in the process with the actions that your cluster and Operators take.
+The following table summarizes the migration process by relating the steps that you perform with the actions that your cluster and Operators take.
 
 .The Kuryr to OVN-Kubernetes migration process
 [cols="1,1a",options="header"]
@@ -32,7 +31,7 @@ The following table summarizes the migration process by relating the steps that 
 |User-initiated steps|Migration activity
 
 |
-Set the `migration` field of the `Network.operator.openshift.io` custom resource (CR) named `cluster` to `OVNKubernetes`. Verify that the value of the `migration` field is `null` before setting it to another value.
+Set the `migration` field of the `Network.operator.openshift.io` custom resource (CR) named `cluster` to `OVNKubernetes`. Verify that the value of the `migration` field prints the `null` value before setting it to another value.
 |
 Cluster Network Operator (CNO):: Updates the status of the `Network.config.openshift.io` CR named `cluster` accordingly.
 Machine Config Operator (MCO):: Deploys an update to the systemd configuration that is required by OVN-Kubernetes. By default, the MCO updates a single machine per pool at a time. As a result, large clusters have longer migration times.

--- a/modules/nw-kuryr-migration-about.adoc
+++ b/modules/nw-kuryr-migration-about.adoc
@@ -6,12 +6,12 @@
 [id="nw-kuryr-ovn-kubernetes-migration-about_{context}"]
 = Migration to the OVN-Kubernetes network provider
 
-You can manually migrate a cluster that runs on {rh-openstack-first} to the OVN-Kubernetes network provider. 
+You can manually migrate a cluster that runs on {rh-openstack-first} to the OVN-Kubernetes network provider.
 
 [IMPORTANT]
 ====
 Migration to OVN-Kubernetes is a one-way process.
-During migration, your cluster will be unreachable for a brief time. 
+During migration, your cluster will be unreachable for a brief time.
 ====
 
 [id="considerations-kuryr-migrating-network-provider_{context}"]

--- a/modules/nw-kuryr-migration-about.adoc
+++ b/modules/nw-kuryr-migration-about.adoc
@@ -2,41 +2,47 @@
 //
 // * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
 
+:_content-type: CONCEPT
 [id="nw-kuryr-ovn-kubernetes-migration-about_{context}"]
 = Migration to the OVN-Kubernetes network provider
 
-Migrating to the OVN-Kubernetes network plug-in is a manual process that includes some downtime during which your cluster is unreachable. Note, the migration is a one-way process.
+You can manually migrate a cluster that runs on {rh-openstack-first} to the OVN-Kubernetes network provider. During the migration process, your cluster will be unreachable for a brief time. 
 
-A migration to the OVN-Kubernetes network plug-in is supported basically on {rh-openstack-first} based platform.
+[IMPORTANT]
+====
+Migration to OVN-Kubernetes is a one-way process.
+
+During migration, your cluster will be unreachable for a brief time. 
+====
 
 [id="considerations-kuryr-migrating-network-provider_{context}"]
-== Considerations for migrating to the OVN-Kubernetes network provider
+== Considerations when migrating to the OVN-Kubernetes network provider
 
-Kubernetes namespaces are kept by Kuryr in separate Neutron subnets. Those subnets and the IP addresses assigned to individual pods are not preserved during the migration.
+Kubernetes namespaces are kept by Kuryr in separate {rh-openstack} networking service (Neutron) subnets. Those subnets and the IP addresses that are assigned to individual pods are not preserved during the migration.
 
 [id="how-the-kuryr-migration-process-works_{context}"]
 == How the migration process works
 
-The following table summarizes the migration process by segmenting between the user-initiated steps in the process and the actions that the migration performs in response.
+The following table summarizes the migration process by relating the steps that you perform in the process with the actions that your cluster and Operators take.
 
-.Migrating to OVN-Kubernetes from Kuryr
+.The Kuryr to OVN-Kubernetes migration process
 [cols="1,1a",options="header"]
 |===
 
 |User-initiated steps|Migration activity
 
 |
-Set the `migration` field of the `Network.operator.openshift.io` custom resource (CR) named `cluster` to `OVNKubernetes`. Make sure the `migration` field is `null` before setting it to a value.
+Set the `migration` field of the `Network.operator.openshift.io` custom resource (CR) named `cluster` to `OVNKubernetes`. Verify that the value of the `migration` field is `null` before setting it to another value.
 |
 Cluster Network Operator (CNO):: Updates the status of the `Network.config.openshift.io` CR named `cluster` accordingly.
-Machine Config Operator (MCO):: Rolls out an update to the systemd configuration necessary for OVN-Kubernetes; The MCO updates a single machine per pool at a time by default, causing the total time the migration takes to increase with the size of the cluster.
+Machine Config Operator (MCO):: Deploys an update to the systemd configuration that is required by OVN-Kubernetes. By default, the MCO updates a single machine per pool at a time. As a result, large clusters have longer migration times.
 
 |Update the `networkType` field of the `Network.config.openshift.io` CR.
 |
 CNO:: Performs the following actions:
 +
 --
-* Destroys the Kuryr control plane pods (Kuryr CNIs and Kuryr controller).
+* Destroys the Kuryr control plane pods, including Kuryr CNIs and the Kuryr controller.
 * Deploys the OVN-Kubernetes control plane pods.
 * Updates the Multus objects to reflect the new network plug-in.
 --
@@ -49,5 +55,5 @@ Cluster:: As nodes reboot, the cluster assigns IP addresses to pods on the OVN-K
 |
 Clean up remaining resources Kuryr controlled.
 |
-Cluster:: There are {rh-openstack} resources which need to be freed, as well as the {product-title} resources to be sorted out.
+Cluster:: Holds {rh-openstack} resources that need to be freed, as well as {product-title} resources to configure.
 |===

--- a/modules/nw-kuryr-migration-about.adoc
+++ b/modules/nw-kuryr-migration-about.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+
+[id="nw-kuryr-ovn-kubernetes-migration-about_{context}"]
+= Migration to the OVN-Kubernetes network provider
+
+Migrating to the OVN-Kubernetes network plug-in is a manual process that includes some downtime during which your cluster is unreachable. Note, the migration is a one-way process.
+
+A migration to the OVN-Kubernetes network plug-in is supported basically on {rh-openstack-first} based platform.
+
+[id="considerations-kuryr-migrating-network-provider_{context}"]
+== Considerations for migrating to the OVN-Kubernetes network provider
+
+Kubernetes namespaces are kept by Kuryr in separate Neutron subnets. Those subnets and the IP addresses assigned to individual pods are not preserved during the migration.
+
+[id="how-the-kuryr-migration-process-works_{context}"]
+== How the migration process works
+
+The following table summarizes the migration process by segmenting between the user-initiated steps in the process and the actions that the migration performs in response.
+
+.Migrating to OVN-Kubernetes from Kuryr
+[cols="1,1a",options="header"]
+|===
+
+|User-initiated steps|Migration activity
+
+|
+Set the `migration` field of the `Network.operator.openshift.io` custom resource (CR) named `cluster` to `OVNKubernetes`. Make sure the `migration` field is `null` before setting it to a value.
+|
+Cluster Network Operator (CNO):: Updates the status of the `Network.config.openshift.io` CR named `cluster` accordingly.
+Machine Config Operator (MCO):: Rolls out an update to the systemd configuration necessary for OVN-Kubernetes; The MCO updates a single machine per pool at a time by default, causing the total time the migration takes to increase with the size of the cluster.
+
+|Update the `networkType` field of the `Network.config.openshift.io` CR.
+|
+CNO:: Performs the following actions:
++
+--
+* Destroys the Kuryr control plane pods (Kuryr CNIs and Kuryr controller).
+* Deploys the OVN-Kubernetes control plane pods.
+* Updates the Multus objects to reflect the new network plug-in.
+--
+
+|
+Reboot each node in the cluster.
+|
+Cluster:: As nodes reboot, the cluster assigns IP addresses to pods on the OVN-Kubernetes cluster network.
+
+|
+Clean up remaining resources Kuryr controlled.
+|
+Cluster:: There are {rh-openstack} resources which need to be freed, as well as the {product-title} resources to be sorted out.
+|===

--- a/modules/nw-kuryr-migration-about.adoc
+++ b/modules/nw-kuryr-migration-about.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+
+:_content-type: CONCEPT
+[id="nw-kuryr-ovn-kubernetes-migration-about_{context}"]
+= Migration to the OVN-Kubernetes network provider
+
+You can manually migrate a cluster that runs on {rh-openstack-first} to the OVN-Kubernetes network provider. During the migration process, your cluster will be unreachable for a brief time. 
+
+[IMPORTANT]
+====
+Migration to OVN-Kubernetes is a one-way process.
+
+During migration, your cluster will be unreachable for a brief time. 
+====
+
+[id="considerations-kuryr-migrating-network-provider_{context}"]
+== Considerations when migrating to the OVN-Kubernetes network provider
+
+Kubernetes namespaces are kept by Kuryr in separate {rh-openstack} networking service (Neutron) subnets. Those subnets and the IP addresses that are assigned to individual pods are not preserved during the migration.
+
+[id="how-the-kuryr-migration-process-works_{context}"]
+== How the migration process works
+
+The following table summarizes the migration process by relating the steps that you perform in the process with the actions that your cluster and Operators take.
+
+.The Kuryr to OVN-Kubernetes migration process
+[cols="1,1a",options="header"]
+|===
+
+|User-initiated steps|Migration activity
+
+|
+Set the `migration` field of the `Network.operator.openshift.io` custom resource (CR) named `cluster` to `OVNKubernetes`. Verify that the value of the `migration` field is `null` before setting it to another value.
+|
+Cluster Network Operator (CNO):: Updates the status of the `Network.config.openshift.io` CR named `cluster` accordingly.
+Machine Config Operator (MCO):: Deploys an update to the systemd configuration that is required by OVN-Kubernetes. By default, the MCO updates a single machine per pool at a time. As a result, large clusters have longer migration times.
+
+|Update the `networkType` field of the `Network.config.openshift.io` CR.
+|
+CNO:: Performs the following actions:
++
+--
+* Destroys the Kuryr control plane pods, which means Kuryr CNIs and the Kuryr controller.
+* Deploys the OVN-Kubernetes control plane pods.
+* Updates the Multus objects to reflect the new network plug-in.
+--
+
+|
+Reboot each node in the cluster.
+|
+Cluster:: As nodes reboot, the cluster assigns IP addresses to pods on the OVN-Kubernetes cluster network.
+
+|
+Clean up remaining resources Kuryr controlled.
+|
+Cluster:: Holds {rh-openstack} resources that need to be freed, as well as {product-title} resources to configure.
+|===

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -268,7 +268,7 @@ Waiting for daemon set "multus" rollout to finish: 5 of 6 updated pods are avail
 daemon set "multus" successfully rolled out
 ----
 
-. To complete the migration, reboot each node in your cluster. For example, you can use a bash script similar to the following example. The script assumes that you can connect to each host by using `ssh` and that you have configured `sudo` to not prompt for a password.
+. To complete the migration, reboot each node in your cluster. For example, you can use a bash script similar to the following example. The script assumes that you can connect to each host by using `ssh` and that you have configured `sudo` to not prompt for a password:
 +
 [source,bash]
 ----
@@ -283,21 +283,21 @@ done
 +
 [NOTE]
 ====
-If ssh access is not available, you could alternatively use `openstack` command:
+If SSH access is not available, you can alternatively use the `openstack` command:
 [source,terminal]
 ----
 $ for name in $(openstack server list --name ${CLUSTERID}\* -f value -c Name); do openstack server reboot $name; done
 ----
-It might also be able to reboot each node through the management portal for
-your infrastructure provider. Otherwise, contact appropriate authority for
-either gaining access to the virtual machines through `ssh` or the management
-portal/OpenStack client.
+Alternatively, you might be able to to reboot each node through the management portal for
+your infrastructure provider. Otherwise, contact the appropriate authority to
+either gain access to the virtual machines through SSH or the management
+portal and OpenStack client.
 ====
 
-. Verification
-.. Confirm that the migration succeeded, and then remove the migration resources:
+.Verification
+. Confirm that the migration succeeded, and then remove the migration resources:
 
-... To confirm that the network plugin is OVN-Kubernetes, enter the following command.
+.. To confirm that the network plugin is OVN-Kubernetes, enter the following command.
 +
 [source,terminal]
 ----
@@ -306,14 +306,14 @@ $ oc get network.config/cluster -o jsonpath='{.status.networkType}{"\n"}'
 +
 The value of `status.networkType` must be `OVNKubernetes`.
 
-... To confirm that the cluster nodes are in the `Ready` state, enter the following command:
+.. To confirm that the cluster nodes are in the `Ready` state, enter the following command:
 +
 [source,terminal]
 ----
 $ oc get nodes
 ----
 
-... To confirm that your pods are not in an error state, enter the following command:
+.. To confirm that your pods are not in an error state, enter the following command:
 +
 [source,terminal]
 ----
@@ -322,7 +322,7 @@ $ oc get pods --all-namespaces -o wide --sort-by='{.spec.nodeName}'
 +
 If pods on a node are in an error state, reboot that node.
 
-... To confirm that all of the cluster Operators are not in an abnormal state, enter the following command:
+.. To confirm that all of the cluster Operators are not in an abnormal state, enter the following command:
 +
 [source,terminal]
 ----
@@ -337,7 +337,7 @@ Do not proceed if any of the previous verification steps indicate errors.
 You might encounter pods that have a `Terminating` state due to finalizers that are removed during clean up. They are not an error indication.
 ====
 +
-.. If the migration completed and your cluster is in a good state, remove the migration configuration from the CNO configuration object by entering the following command:
+. If the migration completed and your cluster is in a good state, remove the migration configuration from the CNO configuration object by entering the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -6,7 +6,7 @@
 [id="nw-kuryr-migration_{context}"]
 = Migrating to the OVN-Kubernetes network plugin
 
-As a cluster administrator, you can change the network plug-in for your cluster to OVN-Kubernetes.
+As a cluster administrator, you can change the network plugin for your cluster to OVN-Kubernetes.
 
 [IMPORTANT]
 ====
@@ -210,7 +210,7 @@ where:
 
 ... Resolve any errors in the logs shown by the output from the previous command.
 
-. To start the migration, configure the OVN-Kubernetes network plug-in by using one of the following commands:
+. To start the migration, configure the OVN-Kubernetes network plugin by using one of the following commands:
 
 ** To specify the network provider without changing the cluster network IP address block, enter the following command:
 +
@@ -283,7 +283,7 @@ done
 +
 [NOTE]
 ====
-If SSH access is not available, you can alternatively use the `openstack` command:
+If SSH access is not available, you can use the `openstack` command:
 [source,terminal]
 ----
 $ for name in $(openstack server list --name ${CLUSTERID}\* -f value -c Name); do openstack server reboot $name; done

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -74,16 +74,25 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
     "spec":{
       "defaultNetwork":{
         "ovnKubernetesConfig":{
-          "mtu":<mtu>, <1>
-          "genevePort":<port>, <2>
-          "v4InternalSubnet":"<ipv4_subnet>", <3>
-          "v6InternalSubnet":"<ipv6_subnet>" <4>
+          "mtu":<mtu>,
+          "genevePort":<port>,
+          "v4InternalSubnet":"<ipv4_subnet>",
+          "v6InternalSubnet":"<ipv6_subnet>"
     }}}}'
 ----
-<1> The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
-<2> The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by Kuryr. The default value for the VXLAN port is `4789`.
-<3> An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
-<4> An IPv6 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `fd98::/48`.
++
+where:
++
+--
+`mtu`::
+The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
+`port`::
+The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by Kuryr. The default value for the VXLAN port is `4789`.
+`ipv4_subnet`::
+An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
+`ipv6_subnet`::
+An IPv6 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `fd98::/48`.
+--
 +
 If you do not need to change the default value, omit the key from the patch.
 +
@@ -131,20 +140,26 @@ kubernetes.io/hostname=master-0
 machineconfiguration.openshift.io/currentConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b <2>
 machineconfiguration.openshift.io/desiredConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b <3>
 machineconfiguration.openshift.io/reason:
-machineconfiguration.openshift.io/state: Done <1>
+machineconfiguration.openshift.io/state: Done
 ----
 
 .. Review the output from the previous step. The following statements must be true:
-*** The value of `machineconfiguration.openshift.io/state` field is `Done`.
-*** The value of the `machineconfiguration.openshift.io/currentConfig` field is equal to the value of the `machineconfiguration.openshift.io/desiredConfig` field.
++
+--
+ * The value of `machineconfiguration.openshift.io/state` field is `Done`.
+ * The value of the `machineconfiguration.openshift.io/currentConfig` field is equal to the value of the `machineconfiguration.openshift.io/desiredConfig` field.
+--
 
 .. To confirm that the machine config is correct, enter the following command:
 +
 [source,terminal]
 ----
-$ oc get machineconfig <machine_config_name> -o yaml | grep ExecStart <1>
+$ oc get machineconfig <config_name> -o yaml | grep ExecStart
 ----
-<1> Specifies the name of the machine config from the `machineconfiguration.openshift.io/currentConfig` field.
++
+where:
+
+<config_name>:: Specifies the name of the machine config from the `machineconfiguration.openshift.io/currentConfig` field.
 +
 The machine config must include the following update to the systemd configuration:
 +
@@ -186,12 +201,13 @@ The names for the config daemon pods are in the following format: `machine-confi
 +
 [source,terminal]
 ----
-$ oc logs <pod_name> -n openshift-machine-config-operator <1>
+$ oc logs <pod> -n openshift-machine-config-operator
 ----
 +
---
-<1> Specifies the name of a machine config daemon pod.
---
+where:
+
+<pod>:: Specifies the name of a machine config daemon pod.
+
 ... Resolve any errors in the logs shown by the output from the previous command.
 
 . To start the migration, configure the OVN-Kubernetes network plug-in by using one of the following commands:
@@ -213,8 +229,8 @@ $ oc patch Network.config.openshift.io cluster \
     "spec": {
       "clusterNetwork": [
         {
-          "cidr": "<cidr>", <1>
-          "hostPrefix": "<prefix>" <2>
+          "cidr": "<cidr>",
+          "hostPrefix": "<prefix>"
         }
       ]
       "networkType": "OVNKubernetes"
@@ -222,10 +238,10 @@ $ oc patch Network.config.openshift.io cluster \
   }'
 ----
 +
---
-<1> Specifies a CIDR block.
-<2> Specifies a slice of the CIDR block that is apportioned to each node in your cluster.
---
+where:
+
+<cidr>:: Specifies a CIDR block.
+<prefix>:: Specifies a slice of the CIDR block that is apportioned to each node in your cluster.
 +
 [IMPORTANT]
 ====
@@ -267,7 +283,7 @@ done
 +
 [NOTE]
 ====
-If ssh access is not available, you could alternatively use `openstack` command
+If ssh access is not available, you could alternatively use `openstack` command:
 [source,terminal]
 ----
 $ for name in $(openstack server list --name ${CLUSTERID}\* -f value -c Name); do openstack server reboot $name; done

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -56,7 +56,7 @@ $ oc patch Network.operator.openshift.io cluster --type='merge' \
 This step does not deploy OVN-Kubernetes immediately. Specifying the `migration` field triggers the Machine Config Operator (MCO) to apply new machine configs to all the nodes in the cluster. This prepares the cluster for the OVN-Kubernetes deployment.
 ====
 
-. Optional: You can customize the following settings for OVN-Kubernetes for your network infrastructure requirements:
+. Optional: Customize the following settings for OVN-Kubernetes for your network infrastructure requirements:
 +
 --
 * Maximum transmission unit (MTU)

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -327,7 +327,6 @@ The status of every cluster Operator must be the following: `AVAILABLE="True"`, 
 [IMPORTANT]
 ====
 Do not proceed if any of the previous verification steps indicate errors.
-
 You might encounter pods that have a `Terminating` state due to finalizers that are removed during clean up. They are not an error indication.
 ====
 +

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -36,7 +36,7 @@ Perform the migration only if an interruption in service is acceptable.
 $ oc get Network.config.openshift.io cluster -o yaml > cluster-kuryr.yaml
 ----
 
-. To set the `CLUSTERID` variable, run the following
+. To set the `CLUSTERID` variable, run the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -38,6 +38,13 @@ Perform the migration only if an interruption in service is acceptable.
 $ oc get Network.config.openshift.io cluster -o yaml > cluster-kuryr.yaml
 ----
 
+. On a command line, enter the following command to set CLUSTERID variable:
++
+[source,terminal]
+----
+$ CLUSTERID=$(oc get infrastructure.config.openshift.io cluster -o=jsonpath='{.status.infrastructureName}')
+----
+
 . To prepare all the nodes for the migration, set the `migration` field on the Cluster Network Operator configuration object by entering the following command:
 +
 [source,terminal]
@@ -282,7 +289,6 @@ If ssh access is not available, you could alternatively use `openstack` command
 to do so:
 [source,terminal]
 ----
-$ CLUSTERID=$(oc get infrastructure.config.openshift.io cluster -o=jsonpath='{.status.infrastructureName}')
 $ for name in $(openstack server list --name ${CLUSTERID}\* -f value -c Name); do openstack server reboot $name; done
 ----
 It might also be able to reboot each node through the management portal for
@@ -326,14 +332,14 @@ $ oc get co
 ----
 +
 The status of every cluster Operator must be the following: `AVAILABLE="True"`, `PROGRESSING="False"`, `DEGRADED="False"`. If a cluster Operator is not available or degraded, check the logs for the cluster Operator for more information.
-
++
 [IMPORTANT]
 ====
 Do not proceed if any of the previous verification steps indicate errors.
 
-You might encounter pods that have a  `Terminating` state due to finalizers that are removed during clean up. They are not an error indication.  
+You might encounter pods that have a `Terminating` state due to finalizers that are removed during clean up. They are not an error indication.  
 ====
-
++
 . If the migration completed and your cluster is in a good state, remove the migration configuration from the CNO configuration object by entering the following command:
 +
 [source,terminal]

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -327,7 +327,12 @@ $ oc get co
 +
 The status of every cluster Operator must be the following: `AVAILABLE="True"`, `PROGRESSING="False"`, `DEGRADED="False"`. If a cluster Operator is not available or degraded, check the logs for the cluster Operator for more information.
 
-IMPORTANT: Do not proceed if the any of the previous verification steps indicate errors, but note, that there can be pods with Terminating state due to the finalzers which will be removed during cleanup step.
+[IMPORTANT]
+====
+Do not proceed if the any of the previous verification steps indicate errors.
+
+You might encounter pods that have a  `Terminating` state due to finalizers that are removed during clean up. They are not an error indication.  
+====
 
 . If the migration completed and your cluster is in a good state, remove the migration configuration from the CNO configuration object by entering the following command:
 +

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -329,7 +329,7 @@ The status of every cluster Operator must be the following: `AVAILABLE="True"`, 
 
 [IMPORTANT]
 ====
-Do not proceed if the any of the previous verification steps indicate errors.
+Do not proceed if any of the previous verification steps indicate errors.
 
 You might encounter pods that have a  `Terminating` state due to finalizers that are removed during clean up. They are not an error indication.  
 ====

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -87,11 +87,11 @@ where:
 `mtu`::
 Specifies the MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
 `port`::
-The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by Kuryr. The default value for the VXLAN port is `4789`.
+Specifies the UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by Kuryr. The default value for the VXLAN port is `4789`.
 `ipv4_subnet`::
-An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
+Specifies an IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
 `ipv6_subnet`::
-An IPv6 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `fd98::/48`.
+Specifies an IPv6 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `fd98::/48`.
 --
 +
 If you do not need to change the default value, omit the key from the patch.

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -80,13 +80,10 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
           "v6InternalSubnet":"<ipv6_subnet>" <4>
     }}}}'
 ----
-+
---
 <1> The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
 <2> The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by Kuryr. The default value for the VXLAN port is `4789`.
 <3> An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
 <4> An IPv6 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `fd98::/48`.
---
 +
 If you do not need to change the default value, omit the key from the patch.
 +
@@ -109,7 +106,7 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
 $ oc get mcp
 ----
 +
-As the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated before continuing.
+While the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated before continuing.
 +
 A successfully updated node has the following status: `UPDATED=true`, `UPDATING=false`, `DEGRADED=false`.
 +
@@ -137,12 +134,9 @@ machineconfiguration.openshift.io/reason:
 machineconfiguration.openshift.io/state: Done <1>
 ----
 
-.. Referring to that output, verify that the following statements are true:
-+
---
-<1> The value of `machineconfiguration.openshift.io/state` field is `Done`.
-<2> The value of the `machineconfiguration.openshift.io/currentConfig` field is equal to the value of the `machineconfiguration.openshift.io/desiredConfig` <3> field.
---
+.. Review the output from the previous step. The following statements must be true:
+*** The value of `machineconfiguration.openshift.io/state` field is `Done`.
+*** The value of the `machineconfiguration.openshift.io/currentConfig` field is equal to the value of the `machineconfiguration.openshift.io/desiredConfig` field.
 
 .. To confirm that the machine config is correct, enter the following command:
 +
@@ -150,10 +144,7 @@ machineconfiguration.openshift.io/state: Done <1>
 ----
 $ oc get machineconfig <machine_config_name> -o yaml | grep ExecStart <1>
 ----
-+
---
 <1> Specifies the name of the machine config from the `machineconfiguration.openshift.io/currentConfig` field.
---
 +
 The machine config must include the following update to the systemd configuration:
 +

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -11,23 +11,21 @@ As a cluster administrator, you can change the network plug-in for your cluster 
 [IMPORTANT]
 ====
 During the migration, you must reboot every node in your cluster.
-
 Your cluster is unavailable and workloads might be interrupted.
-
 Perform the migration only if an interruption in service is acceptable.
 ====
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-* Access to the cluster as a user with the `cluster-admin` role.
-* A recent backup of the etcd database is available.
-* A reboot can be triggered manually for each node.
-* The cluster is in a known good state, without any errors.
-* Install Python interpreter
-* Install `openstacksdk` python package
-* Install `openstack` cli tool
-* Access to the underlying {rh-openstack}
+* You installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have a recent backup of the etcd database is available.
+* You can manually reboot each node.
+* The cluster you plan to migrate is in a known good state, without any errors.
+* You installed the Python interpreter.
+* You installed the `openstacksdk` python package.
+* You installed the `openstack` CLI tool.
+* You have access to the underlying {rh-openstack} cloud.
 
 .Procedure
 
@@ -38,7 +36,7 @@ Perform the migration only if an interruption in service is acceptable.
 $ oc get Network.config.openshift.io cluster -o yaml > cluster-kuryr.yaml
 ----
 
-. To set the `CLUSTERID` variable, run the following 
+. To set the `CLUSTERID` variable, run the following
 +
 [source,terminal]
 ----
@@ -78,20 +76,16 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
         "ovnKubernetesConfig":{
           "mtu":<mtu>, <1>
           "genevePort":<port>, <2>
-          "v4InternalSubnet":"<ipv4_subnet>",
-          "v6InternalSubnet":"<ipv6_subnet>"
+          "v4InternalSubnet":"<ipv4_subnet>", <3>
+          "v6InternalSubnet":"<ipv6_subnet>" <4>
     }}}}'
 ----
-+
-where:
 +
 --
 <1> The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
 <2> The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by Kuryr. The default value for the VXLAN port is `4789`.
-`ipv4_subnet`::
-An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
-`ipv6_subnet`::
-An IPv6 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `fd98::/48`.
+<3> An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
+<4> An IPv6 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `fd98::/48`.
 --
 +
 If you do not need to change the default value, omit the key from the patch.
@@ -115,7 +109,7 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
 $ oc get mcp
 ----
 +
-As the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated before continuing. 
+As the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated before continuing.
 +
 A successfully updated node has the following status: `UPDATED=true`, `UPDATING=false`, `DEGRADED=false`.
 +
@@ -137,29 +131,29 @@ $ oc describe node | egrep "hostname|machineconfig"
 [source,terminal]
 ----
 kubernetes.io/hostname=master-0
-machineconfiguration.openshift.io/currentConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b
-machineconfiguration.openshift.io/desiredConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b
+machineconfiguration.openshift.io/currentConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b <2>
+machineconfiguration.openshift.io/desiredConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b <3>
 machineconfiguration.openshift.io/reason:
-machineconfiguration.openshift.io/state: Done
+machineconfiguration.openshift.io/state: Done <1>
 ----
 
 .. Referring to that output, verify that the following statements are true:
 +
 --
- * The value of `machineconfiguration.openshift.io/state` field is `Done`.
- * The value of the `machineconfiguration.openshift.io/currentConfig` field is equal to the value of the `machineconfiguration.openshift.io/desiredConfig` field.
+<1> The value of `machineconfiguration.openshift.io/state` field is `Done`.
+<2> The value of the `machineconfiguration.openshift.io/currentConfig` field is equal to the value of the `machineconfiguration.openshift.io/desiredConfig` <3> field.
 --
 
 .. To confirm that the machine config is correct, enter the following command:
 +
 [source,terminal]
 ----
-$ oc get machineconfig <config_name> -o yaml | grep ExecStart
+$ oc get machineconfig <machine_config_name> -o yaml | grep ExecStart <1>
 ----
 +
-where:
-
-<config_name>:: Specifies the name of the machine config from the `machineconfiguration.openshift.io/currentConfig` field.
+--
+<1> Specifies the name of the machine config from the `machineconfiguration.openshift.io/currentConfig` field.
+--
 +
 The machine config must include the following update to the systemd configuration:
 +
@@ -201,13 +195,12 @@ The names for the config daemon pods are in the following format: `machine-confi
 +
 [source,terminal]
 ----
-$ oc logs <pod> -n openshift-machine-config-operator
+$ oc logs <pod_name> -n openshift-machine-config-operator <1>
 ----
 +
-where:
-
-<pod>:: Specifies the name of a machine config daemon pod.
-
+--
+<1> Specifies the name of a machine config daemon pod.
+--
 ... Resolve any errors in the logs shown by the output from the previous command.
 
 . To start the migration, configure the OVN-Kubernetes network plug-in by using one of the following commands:
@@ -229,8 +222,8 @@ $ oc patch Network.config.openshift.io cluster \
     "spec": {
       "clusterNetwork": [
         {
-          "cidr": "<cidr>",
-          "hostPrefix": "<prefix>"
+          "cidr": "<cidr>", <1>
+          "hostPrefix": "<prefix>" <2>
         }
       ]
       "networkType": "OVNKubernetes"
@@ -238,10 +231,10 @@ $ oc patch Network.config.openshift.io cluster \
   }'
 ----
 +
-where:
-
-<cidr>:: Specifies a CIDR block.
-<prefix>:: Specifies a slice of the CIDR block that is apportioned to each node in your cluster.
+--
+<1> Specifies a CIDR block.
+<2> Specifies a slice of the CIDR block that is apportioned to each node in your cluster.
+--
 +
 [IMPORTANT]
 ====
@@ -294,10 +287,10 @@ either gaining access to the virtual machines through `ssh` or the management
 portal/OpenStack client.
 ====
 
-.Verification
-. Confirm that the migration succeeded, and then remove the migration resources:
+. Verification
+.. Confirm that the migration succeeded, and then remove the migration resources:
 
-.. To confirm that the network plugin is OVN-Kubernetes, enter the following command.
+... To confirm that the network plugin is OVN-Kubernetes, enter the following command.
 +
 [source,terminal]
 ----
@@ -306,14 +299,14 @@ $ oc get network.config/cluster -o jsonpath='{.status.networkType}{"\n"}'
 +
 The value of `status.networkType` must be `OVNKubernetes`.
 
-.. To confirm that the cluster nodes are in the `Ready` state, enter the following command:
+... To confirm that the cluster nodes are in the `Ready` state, enter the following command:
 +
 [source,terminal]
 ----
 $ oc get nodes
 ----
 
-.. To confirm that your pods are not in an error state, enter the following command:
+... To confirm that your pods are not in an error state, enter the following command:
 +
 [source,terminal]
 ----
@@ -322,7 +315,7 @@ $ oc get pods --all-namespaces -o wide --sort-by='{.spec.nodeName}'
 +
 If pods on a node are in an error state, reboot that node.
 
-.. To confirm that all of the cluster Operators are not in an abnormal state, enter the following command:
+... To confirm that all of the cluster Operators are not in an abnormal state, enter the following command:
 +
 [source,terminal]
 ----
@@ -335,10 +328,10 @@ The status of every cluster Operator must be the following: `AVAILABLE="True"`, 
 ====
 Do not proceed if any of the previous verification steps indicate errors.
 
-You might encounter pods that have a `Terminating` state due to finalizers that are removed during clean up. They are not an error indication.  
+You might encounter pods that have a `Terminating` state due to finalizers that are removed during clean up. They are not an error indication.
 ====
 +
-. If the migration completed and your cluster is in a good state, remove the migration configuration from the CNO configuration object by entering the following command:
+.. If the migration completed and your cluster is in a good state, remove the migration configuration from the CNO configuration object by entering the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -306,7 +306,7 @@ portal/OpenStack client.
 $ oc get network.config/cluster -o jsonpath='{.status.networkType}{"\n"}'
 ----
 +
- The value of `status.networkType` must be `OVNKubernetes`.
+The value of `status.networkType` must be `OVNKubernetes`.
 
 .. To confirm that the cluster nodes are in the `Ready` state, enter the following command:
 +

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -29,7 +29,7 @@ Perform the migration only if an interruption in service is acceptable.
 
 .Procedure
 
-. You can backup the configuration for the cluster network by running the following command
+. Back up the configuration for the cluster network by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -31,21 +31,21 @@ Perform the migration only if an interruption in service is acceptable.
 
 .Procedure
 
-. To backup the configuration for the cluster network, enter the following command:
+. You can backup the configuration for the cluster network by running the following command
 +
 [source,terminal]
 ----
 $ oc get Network.config.openshift.io cluster -o yaml > cluster-kuryr.yaml
 ----
 
-. On a command line, enter the following command to set CLUSTERID variable:
+. To set the `CLUSTERID` variable, run the following 
 +
 [source,terminal]
 ----
 $ CLUSTERID=$(oc get infrastructure.config.openshift.io cluster -o=jsonpath='{.status.infrastructureName}')
 ----
 
-. To prepare all the nodes for the migration, set the `migration` field on the Cluster Network Operator configuration object by entering the following command:
+. To prepare all the nodes for the migration, set the `migration` field on the Cluster Network Operator configuration object by running the following command:
 +
 [source,terminal]
 ----
@@ -55,10 +55,10 @@ $ oc patch Network.operator.openshift.io cluster --type='merge' \
 +
 [NOTE]
 ====
-This step does not deploy OVN-Kubernetes immediately. Instead, specifying the `migration` field triggers the Machine Config Operator (MCO) to apply new machine configs to all the nodes in the cluster in preparation for the OVN-Kubernetes deployment.
+This step does not deploy OVN-Kubernetes immediately. Specifying the `migration` field triggers the Machine Config Operator (MCO) to apply new machine configs to all the nodes in the cluster. This prepares the cluster for the OVN-Kubernetes deployment.
 ====
 
-. Optional: You can customize the following settings for OVN-Kubernetes to meet your network infrastructure requirements:
+. Optional: You can customize the following settings for OVN-Kubernetes for your network infrastructure requirements:
 +
 --
 * Maximum transmission unit (MTU)
@@ -76,8 +76,8 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
     "spec":{
       "defaultNetwork":{
         "ovnKubernetesConfig":{
-          "mtu":<mtu>,
-          "genevePort":<port>,
+          "mtu":<mtu>, <1>
+          "genevePort":<port>, <2>
           "v4InternalSubnet":"<ipv4_subnet>",
           "v6InternalSubnet":"<ipv6_subnet>"
     }}}}'
@@ -86,10 +86,8 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
 where:
 +
 --
-`mtu`::
-The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
-`port`::
-The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by Kuryr. The default value for the VXLAN port is `4789`.
+<1> The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
+<2> The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by Kuryr. The default value for the VXLAN port is `4789`.
 `ipv4_subnet`::
 An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
 `ipv6_subnet`::
@@ -117,7 +115,7 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
 $ oc get mcp
 ----
 +
-As the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated. 
+As the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated before continuing. 
 +
 A successfully updated node has the following status: `UPDATED=true`, `UPDATING=false`, `DEGRADED=false`.
 +
@@ -286,17 +284,17 @@ done
 [NOTE]
 ====
 If ssh access is not available, you could alternatively use `openstack` command
-to do so:
 [source,terminal]
 ----
 $ for name in $(openstack server list --name ${CLUSTERID}\* -f value -c Name); do openstack server reboot $name; done
 ----
 It might also be able to reboot each node through the management portal for
-your infrastructure provider. Otherwise contact appropriate authority for
-either gaining access to the virtual machines through ssh or management
+your infrastructure provider. Otherwise, contact appropriate authority for
+either gaining access to the virtual machines through `ssh` or the management
 portal/OpenStack client.
 ====
 
+.Verification
 . Confirm that the migration succeeded, and then remove the migration resources:
 
 .. To confirm that the network plugin is OVN-Kubernetes, enter the following command.

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -85,7 +85,7 @@ where:
 +
 --
 `mtu`::
-The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
+Specifies the MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
 `port`::
 The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by Kuryr. The default value for the VXLAN port is `4789`.
 `ipv4_subnet`::

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -7,12 +7,14 @@
 = Migrating to the OVN-Kubernetes network plugin
 
 As a cluster administrator, you can change the network plug-in for your cluster to OVN-Kubernetes.
-During the migration, you must reboot every node in your cluster.
 
 [IMPORTANT]
 ====
-While performing the migration, your cluster is unavailable and workloads might be interrupted.
-Perform the migration only when an interruption in service is acceptable.
+During the migration, you must reboot every node in your cluster.
+
+Your cluster is unavailable and workloads might be interrupted.
+
+Perform the migration only if an interruption in service is acceptable.
 ====
 
 .Prerequisites
@@ -59,7 +61,7 @@ This step does not deploy OVN-Kubernetes immediately. Instead, specifying the `m
 * OVN-Kubernetes IPv6 internal subnet
 --
 +
-To customize either of the previously noted settings, enter and customize the following command. If you do not need to change the default value, omit the key from the patch.
+To customize these settings, enter and customize the following command:
 +
 [source,terminal]
 ----
@@ -88,6 +90,8 @@ An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that t
 An IPv6 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `fd98::/48`.
 --
 +
+If you do not need to change the default value, omit the key from the patch.
++
 .Example patch command to update `mtu` field
 [source,terminal]
 ----
@@ -100,18 +104,20 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
     }}}}'
 ----
 
-. As the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated. Check the machine config pool status by entering the following command:
+. Check the machine config pool status by entering the following command:
 +
 [source,terminal]
 ----
 $ oc get mcp
 ----
 +
+As the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated. 
++
 A successfully updated node has the following status: `UPDATED=true`, `UPDATING=false`, `DEGRADED=false`.
 +
 [NOTE]
 ====
-By default, the MCO updates one machine per pool at a time, causing the total time the migration takes to increase with the size of the cluster.
+By default, the MCO updates one machine per pool at a time. Large clusters take more time to migrate than small clusters.
 ====
 
 . Confirm the status of the new machine configuration on the hosts:
@@ -132,8 +138,8 @@ machineconfiguration.openshift.io/desiredConfig: rendered-master-c53e221d9d24e1c
 machineconfiguration.openshift.io/reason:
 machineconfiguration.openshift.io/state: Done
 ----
-+
-Verify that the following statements are true:
+
+.. Referring to that output, verify that the following statements are true:
 +
 --
  * The value of `machineconfiguration.openshift.io/state` field is `Done`.
@@ -147,16 +153,19 @@ Verify that the following statements are true:
 $ oc get machineconfig <config_name> -o yaml | grep ExecStart
 ----
 +
-where `<config_name>` is the name of the machine config from the `machineconfiguration.openshift.io/currentConfig` field.
+where:
+
+<config_name>:: Specifies the name of the machine config from the `machineconfiguration.openshift.io/currentConfig` field.
 +
 The machine config must include the following update to the systemd configuration:
 +
+.Example output
 [source,plain]
 ----
 ExecStart=/usr/local/bin/configure-ovs.sh OVNKubernetes
 ----
 
-.. If a node is stuck in the `NotReady` state, investigate the machine config daemon pod logs and resolve any errors.
+.. If a node is stuck in the `NotReady` state, investigate the machine config daemon pod logs and resolve any errors:
 
 ... To list the pods, enter the following command:
 +
@@ -191,7 +200,9 @@ The names for the config daemon pods are in the following format: `machine-confi
 $ oc logs <pod> -n openshift-machine-config-operator
 ----
 +
-where `pod` is the name of a machine config daemon pod.
+where:
+
+<pod>:: Specifies the name of a machine config daemon pod.
 
 ... Resolve any errors in the logs shown by the output from the previous command.
 
@@ -223,21 +234,26 @@ $ oc patch Network.config.openshift.io cluster \
   }'
 ----
 +
-where `cidr` is a CIDR block and `prefix` is the slice of the CIDR block apportioned to each node in your cluster. You cannot use any CIDR block that overlaps with the `100.64.0.0/16` CIDR block because the OVN-Kubernetes network provider uses this block internally.
+where:
+
+<cidr>:: Specifies a CIDR block.
+<prefix>:: Specifies a slice of the CIDR block that is apportioned to each node in your cluster.
 +
 [IMPORTANT]
 ====
 You cannot change the service network address block during the migration.
+
+You cannot use any CIDR block that overlaps with the `100.64.0.0/16` CIDR block because the OVN-Kubernetes network provider uses this block internally.
 ====
 
-. Verify that the Multus daemon set rollout is complete before continuing with subsequent steps:
+. Verify that the Multus daemon set rollout is complete by entering the following command:
 +
 [source,terminal]
 ----
 $ oc -n openshift-multus rollout status daemonset/multus
 ----
 +
-The name of the Multus pods is in the form of `multus-<xxxxx>` where `<xxxxx>` is a random sequence of letters. It might take several moments for the pods to restart.
+The name of the Multus pods is in the form of `multus-<xxxxx>`, where `<xxxxx>` is a random sequence of letters. It might take several moments for the pods to restart.
 +
 .Example output
 [source,text]
@@ -263,14 +279,16 @@ done
 +
 If ssh access is not available, you might be able to reboot each node through the management portal for your infrastructure provider.
 
-. Confirm that the migration succeeded:
+. Confirm that the migration succeeded, and then remove the migration resources:
 
-.. To confirm that the network plugin is OVN-Kubernetes, enter the following command.  The value of `status.networkType` must be `OVNKubernetes`.
+.. To confirm that the network plugin is OVN-Kubernetes, enter the following command.
 +
 [source,terminal]
 ----
 $ oc get network.config/cluster -o jsonpath='{.status.networkType}{"\n"}'
 ----
++
+ The value of `status.networkType` must be `OVNKubernetes`.
 
 .. To confirm that the cluster nodes are in the `Ready` state, enter the following command:
 +
@@ -297,9 +315,9 @@ $ oc get co
 +
 The status of every cluster Operator must be the following: `AVAILABLE="True"`, `PROGRESSING="False"`, `DEGRADED="False"`. If a cluster Operator is not available or degraded, check the logs for the cluster Operator for more information.
 
-. Complete the following steps only if the migration succeeds and your cluster is in a good state:
+IMPORTANT: Do not proceed if the any of the previous verification steps indicate errors.
 
-.. To remove the migration configuration from the CNO configuration object, enter the following command:
+. If the migration completed and your cluster is in a good state, remove the migration configuration from the CNO configuration object by entering the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -1,0 +1,308 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
+
+:_content-type: PROCEDURE
+[id="nw-kuryr-migration_{context}"]
+= Migrating to the OVN-Kubernetes network plugin
+
+As a cluster administrator, you can change the network plug-in for your cluster to OVN-Kubernetes.
+During the migration, you must reboot every node in your cluster.
+
+[IMPORTANT]
+====
+While performing the migration, your cluster is unavailable and workloads might be interrupted.
+Perform the migration only when an interruption in service is acceptable.
+====
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Access to the cluster as a user with the `cluster-admin` role.
+* A recent backup of the etcd database is available.
+* A reboot can be triggered manually for each node.
+* The cluster is in a known good state, without any errors.
+* Install `jq` tool
+* Install Python interpreter
+* Install `openstacksdk` python package 
+* Install `openstack` cli tool
+* Access to the underlying {rh-openstack}
+
+.Procedure
+
+. To backup the configuration for the cluster network, enter the following command:
++
+[source,terminal]
+----
+$ oc get Network.config.openshift.io cluster -o yaml > cluster-kuryr.yaml
+----
+
+. To prepare all the nodes for the migration, set the `migration` field on the Cluster Network Operator configuration object by entering the following command:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "migration": { "networkType": "OVNKubernetes" } } }'
+----
++
+[NOTE]
+====
+This step does not deploy OVN-Kubernetes immediately. Instead, specifying the `migration` field triggers the Machine Config Operator (MCO) to apply new machine configs to all the nodes in the cluster in preparation for the OVN-Kubernetes deployment.
+====
+
+. Optional: You can customize the following settings for OVN-Kubernetes to meet your network infrastructure requirements:
++
+--
+* Maximum transmission unit (MTU)
+* Geneve (Generic Network Virtualization Encapsulation) overlay network port
+* OVN-Kubernetes IPv4 internal subnet
+* OVN-Kubernetes IPv6 internal subnet
+--
++
+To customize either of the previously noted settings, enter and customize the following command. If you do not need to change the default value, omit the key from the patch.
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type=merge \
+  --patch '{
+    "spec":{
+      "defaultNetwork":{
+        "ovnKubernetesConfig":{
+          "mtu":<mtu>,
+          "genevePort":<port>,
+          "v4InternalSubnet":"<ipv4_subnet>",
+          "v6InternalSubnet":"<ipv6_subnet>"
+    }}}}'
+----
++
+where:
++
+--
+`mtu`::
+The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
+`port`::
+The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by Kuryr. The default value for the VXLAN port is `4789`.
+`ipv4_subnet`::
+An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
+`ipv6_subnet`::
+An IPv6 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `fd98::/48`.
+--
++
+.Example patch command to update `mtu` field
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type=merge \
+  --patch '{
+    "spec":{
+      "defaultNetwork":{
+        "ovnKubernetesConfig":{
+          "mtu":1200
+    }}}}'
+----
+
+. As the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated. Check the machine config pool status by entering the following command:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+A successfully updated node has the following status: `UPDATED=true`, `UPDATING=false`, `DEGRADED=false`.
++
+[NOTE]
+====
+By default, the MCO updates one machine per pool at a time, causing the total time the migration takes to increase with the size of the cluster.
+====
+
+. Confirm the status of the new machine configuration on the hosts:
+
+.. To list the machine configuration state and the name of the applied machine configuration, enter the following command:
++
+[source,terminal]
+----
+$ oc describe node | egrep "hostname|machineconfig"
+----
++
+.Example output
+[source,terminal]
+----
+kubernetes.io/hostname=master-0
+machineconfiguration.openshift.io/currentConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b
+machineconfiguration.openshift.io/desiredConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b
+machineconfiguration.openshift.io/reason:
+machineconfiguration.openshift.io/state: Done
+----
++
+Verify that the following statements are true:
++
+--
+ * The value of `machineconfiguration.openshift.io/state` field is `Done`.
+ * The value of the `machineconfiguration.openshift.io/currentConfig` field is equal to the value of the `machineconfiguration.openshift.io/desiredConfig` field.
+--
+
+.. To confirm that the machine config is correct, enter the following command:
++
+[source,terminal]
+----
+$ oc get machineconfig <config_name> -o yaml | grep ExecStart
+----
++
+where `<config_name>` is the name of the machine config from the `machineconfiguration.openshift.io/currentConfig` field.
++
+The machine config must include the following update to the systemd configuration:
++
+[source,plain]
+----
+ExecStart=/usr/local/bin/configure-ovs.sh OVNKubernetes
+----
+
+.. If a node is stuck in the `NotReady` state, investigate the machine config daemon pod logs and resolve any errors.
+
+... To list the pods, enter the following command:
++
+[source,terminal]
+----
+$ oc get pod -n openshift-machine-config-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         READY   STATUS    RESTARTS   AGE
+machine-config-controller-75f756f89d-sjp8b   1/1     Running   0          37m
+machine-config-daemon-5cf4b                  2/2     Running   0          43h
+machine-config-daemon-7wzcd                  2/2     Running   0          43h
+machine-config-daemon-fc946                  2/2     Running   0          43h
+machine-config-daemon-g2v28                  2/2     Running   0          43h
+machine-config-daemon-gcl4f                  2/2     Running   0          43h
+machine-config-daemon-l5tnv                  2/2     Running   0          43h
+machine-config-operator-79d9c55d5-hth92      1/1     Running   0          37m
+machine-config-server-bsc8h                  1/1     Running   0          43h
+machine-config-server-hklrm                  1/1     Running   0          43h
+machine-config-server-k9rtx                  1/1     Running   0          43h
+----
++
+The names for the config daemon pods are in the following format: `machine-config-daemon-<seq>`. The `<seq>` value is a random five character alphanumeric sequence.
+
+... Display the pod log for the first machine config daemon pod shown in the previous output by enter the following command:
++
+[source,terminal]
+----
+$ oc logs <pod> -n openshift-machine-config-operator
+----
++
+where `pod` is the name of a machine config daemon pod.
+
+... Resolve any errors in the logs shown by the output from the previous command.
+
+. To start the migration, configure the OVN-Kubernetes network plug-in by using one of the following commands:
+
+** To specify the network provider without changing the cluster network IP address block, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.config.openshift.io cluster \
+  --type='merge' --patch '{ "spec": { "networkType": "OVNKubernetes" } }'
+----
+
+** To specify a different cluster network IP address block, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.config.openshift.io cluster \
+  --type='merge' --patch '{
+    "spec": {
+      "clusterNetwork": [
+        {
+          "cidr": "<cidr>",
+          "hostPrefix": "<prefix>"
+        }
+      ]
+      "networkType": "OVNKubernetes"
+    } 
+  }'
+----
++
+where `cidr` is a CIDR block and `prefix` is the slice of the CIDR block apportioned to each node in your cluster. You cannot use any CIDR block that overlaps with the `100.64.0.0/16` CIDR block because the OVN-Kubernetes network provider uses this block internally.
++
+[IMPORTANT]
+====
+You cannot change the service network address block during the migration.
+====
+
+. Verify that the Multus daemon set rollout is complete before continuing with subsequent steps:
++
+[source,terminal]
+----
+$ oc -n openshift-multus rollout status daemonset/multus
+----
++
+The name of the Multus pods is in the form of `multus-<xxxxx>` where `<xxxxx>` is a random sequence of letters. It might take several moments for the pods to restart.
++
+.Example output
+[source,text]
+----
+Waiting for daemon set "multus" rollout to finish: 1 out of 6 new pods have been updated...
+...
+Waiting for daemon set "multus" rollout to finish: 5 of 6 updated pods are available...
+daemon set "multus" successfully rolled out
+----
+
+. To complete the migration, reboot each node in your cluster. For example, you can use a bash script similar to the following example. The script assumes that you can connect to each host by using `ssh` and that you have configured `sudo` to not prompt for a password.
++
+[source,bash]
+----
+#!/bin/bash
+
+for ip in $(oc get nodes  -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+do
+   echo "reboot node $ip"
+   ssh -o StrictHostKeyChecking=no core@$ip sudo shutdown -r -t 3
+done
+----
++
+If ssh access is not available, you might be able to reboot each node through the management portal for your infrastructure provider.
+
+. Confirm that the migration succeeded:
+
+.. To confirm that the network plugin is OVN-Kubernetes, enter the following command.  The value of `status.networkType` must be `OVNKubernetes`.
++
+[source,terminal]
+----
+$ oc get network.config/cluster -o jsonpath='{.status.networkType}{"\n"}'
+----
+
+.. To confirm that the cluster nodes are in the `Ready` state, enter the following command:
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
+.. To confirm that your pods are not in an error state, enter the following command:
++
+[source,terminal]
+----
+$ oc get pods --all-namespaces -o wide --sort-by='{.spec.nodeName}'
+----
++
+If pods on a node are in an error state, reboot that node.
+
+.. To confirm that all of the cluster Operators are not in an abnormal state, enter the following command:
++
+[source,terminal]
+----
+$ oc get co
+----
++
+The status of every cluster Operator must be the following: `AVAILABLE="True"`, `PROGRESSING="False"`, `DEGRADED="False"`. If a cluster Operator is not available or degraded, check the logs for the cluster Operator for more information.
+
+. Complete the following steps only if the migration succeeds and your cluster is in a good state:
+
+.. To remove the migration configuration from the CNO configuration object, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "migration": null } }'
+----

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -1,0 +1,338 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
+
+:_content-type: PROCEDURE
+[id="nw-kuryr-migration_{context}"]
+= Migrating to the OVN-Kubernetes network plugin
+
+As a cluster administrator, you can change the network plug-in for your cluster to OVN-Kubernetes.
+
+[IMPORTANT]
+====
+During the migration, you must reboot every node in your cluster.
+
+Your cluster is unavailable and workloads might be interrupted.
+
+Perform the migration only if an interruption in service is acceptable.
+====
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Access to the cluster as a user with the `cluster-admin` role.
+* A recent backup of the etcd database is available.
+* A reboot can be triggered manually for each node.
+* The cluster is in a known good state, without any errors.
+* Install Python interpreter
+* Install `openstacksdk` python package
+* Install `openstack` cli tool
+* Access to the underlying {rh-openstack}
+
+.Procedure
+
+. To backup the configuration for the cluster network, enter the following command:
++
+[source,terminal]
+----
+$ oc get Network.config.openshift.io cluster -o yaml > cluster-kuryr.yaml
+----
+
+. To prepare all the nodes for the migration, set the `migration` field on the Cluster Network Operator configuration object by entering the following command:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "migration": { "networkType": "OVNKubernetes" } } }'
+----
++
+[NOTE]
+====
+This step does not deploy OVN-Kubernetes immediately. Instead, specifying the `migration` field triggers the Machine Config Operator (MCO) to apply new machine configs to all the nodes in the cluster in preparation for the OVN-Kubernetes deployment.
+====
+
+. Optional: You can customize the following settings for OVN-Kubernetes to meet your network infrastructure requirements:
++
+--
+* Maximum transmission unit (MTU)
+* Geneve (Generic Network Virtualization Encapsulation) overlay network port
+* OVN-Kubernetes IPv4 internal subnet
+* OVN-Kubernetes IPv6 internal subnet
+--
++
+To customize these settings, enter and customize the following command:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type=merge \
+  --patch '{
+    "spec":{
+      "defaultNetwork":{
+        "ovnKubernetesConfig":{
+          "mtu":<mtu>,
+          "genevePort":<port>,
+          "v4InternalSubnet":"<ipv4_subnet>",
+          "v6InternalSubnet":"<ipv6_subnet>"
+    }}}}'
+----
++
+where:
++
+--
+`mtu`::
+The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
+`port`::
+The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by Kuryr. The default value for the VXLAN port is `4789`.
+`ipv4_subnet`::
+An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
+`ipv6_subnet`::
+An IPv6 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `fd98::/48`.
+--
++
+If you do not need to change the default value, omit the key from the patch.
++
+.Example patch command to update `mtu` field
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type=merge \
+  --patch '{
+    "spec":{
+      "defaultNetwork":{
+        "ovnKubernetesConfig":{
+          "mtu":1200
+    }}}}'
+----
+
+. Check the machine config pool status by entering the following command:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+As the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated. 
++
+A successfully updated node has the following status: `UPDATED=true`, `UPDATING=false`, `DEGRADED=false`.
++
+[NOTE]
+====
+By default, the MCO updates one machine per pool at a time. Large clusters take more time to migrate than small clusters.
+====
+
+. Confirm the status of the new machine configuration on the hosts:
+
+.. To list the machine configuration state and the name of the applied machine configuration, enter the following command:
++
+[source,terminal]
+----
+$ oc describe node | egrep "hostname|machineconfig"
+----
++
+.Example output
+[source,terminal]
+----
+kubernetes.io/hostname=master-0
+machineconfiguration.openshift.io/currentConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b
+machineconfiguration.openshift.io/desiredConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b
+machineconfiguration.openshift.io/reason:
+machineconfiguration.openshift.io/state: Done
+----
+
+.. Referring to that output, verify that the following statements are true:
++
+--
+ * The value of `machineconfiguration.openshift.io/state` field is `Done`.
+ * The value of the `machineconfiguration.openshift.io/currentConfig` field is equal to the value of the `machineconfiguration.openshift.io/desiredConfig` field.
+--
+
+.. To confirm that the machine config is correct, enter the following command:
++
+[source,terminal]
+----
+$ oc get machineconfig <config_name> -o yaml | grep ExecStart
+----
++
+where:
+
+<config_name>:: Specifies the name of the machine config from the `machineconfiguration.openshift.io/currentConfig` field.
++
+The machine config must include the following update to the systemd configuration:
++
+.Example output
+[source,plain]
+----
+ExecStart=/usr/local/bin/configure-ovs.sh OVNKubernetes
+----
+
+.. If a node is stuck in the `NotReady` state, investigate the machine config daemon pod logs and resolve any errors:
+
+... To list the pods, enter the following command:
++
+[source,terminal]
+----
+$ oc get pod -n openshift-machine-config-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         READY   STATUS    RESTARTS   AGE
+machine-config-controller-75f756f89d-sjp8b   1/1     Running   0          37m
+machine-config-daemon-5cf4b                  2/2     Running   0          43h
+machine-config-daemon-7wzcd                  2/2     Running   0          43h
+machine-config-daemon-fc946                  2/2     Running   0          43h
+machine-config-daemon-g2v28                  2/2     Running   0          43h
+machine-config-daemon-gcl4f                  2/2     Running   0          43h
+machine-config-daemon-l5tnv                  2/2     Running   0          43h
+machine-config-operator-79d9c55d5-hth92      1/1     Running   0          37m
+machine-config-server-bsc8h                  1/1     Running   0          43h
+machine-config-server-hklrm                  1/1     Running   0          43h
+machine-config-server-k9rtx                  1/1     Running   0          43h
+----
++
+The names for the config daemon pods are in the following format: `machine-config-daemon-<seq>`. The `<seq>` value is a random five character alphanumeric sequence.
+
+... Display the pod log for the first machine config daemon pod shown in the previous output by enter the following command:
++
+[source,terminal]
+----
+$ oc logs <pod> -n openshift-machine-config-operator
+----
++
+where:
+
+<pod>:: Specifies the name of a machine config daemon pod.
+
+... Resolve any errors in the logs shown by the output from the previous command.
+
+. To start the migration, configure the OVN-Kubernetes network plug-in by using one of the following commands:
+
+** To specify the network provider without changing the cluster network IP address block, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.config.openshift.io cluster \
+  --type='merge' --patch '{ "spec": { "networkType": "OVNKubernetes" } }'
+----
+
+** To specify a different cluster network IP address block, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.config.openshift.io cluster \
+  --type='merge' --patch '{
+    "spec": {
+      "clusterNetwork": [
+        {
+          "cidr": "<cidr>",
+          "hostPrefix": "<prefix>"
+        }
+      ]
+      "networkType": "OVNKubernetes"
+    }
+  }'
+----
++
+where:
+
+<cidr>:: Specifies a CIDR block.
+<prefix>:: Specifies a slice of the CIDR block that is apportioned to each node in your cluster.
++
+[IMPORTANT]
+====
+You cannot change the service network address block during the migration.
+
+You cannot use any CIDR block that overlaps with the `100.64.0.0/16` CIDR block because the OVN-Kubernetes network provider uses this block internally.
+====
+
+. Verify that the Multus daemon set rollout is complete by entering the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-multus rollout status daemonset/multus
+----
++
+The name of the Multus pods is in the form of `multus-<xxxxx>`, where `<xxxxx>` is a random sequence of letters. It might take several moments for the pods to restart.
++
+.Example output
+[source,text]
+----
+Waiting for daemon set "multus" rollout to finish: 1 out of 6 new pods have been updated...
+...
+Waiting for daemon set "multus" rollout to finish: 5 of 6 updated pods are available...
+daemon set "multus" successfully rolled out
+----
+
+. To complete the migration, reboot each node in your cluster. For example, you can use a bash script similar to the following example. The script assumes that you can connect to each host by using `ssh` and that you have configured `sudo` to not prompt for a password.
++
+[source,bash]
+----
+#!/bin/bash
+
+for ip in $(oc get nodes  -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+do
+   echo "reboot node $ip"
+   ssh -o StrictHostKeyChecking=no core@$ip sudo shutdown -r -t 3
+done
+----
++
+[NOTE]
+====
+If ssh access is not available, you could alternatively use `openstack` command
+to do so:
+[source,terminal]
+----
+$ CLUSTERID=$(oc get infrastructure.config.openshift.io cluster -o=jsonpath='{.status.infrastructureName}')
+$ for name in $(openstack server list --name ${CLUSTERID}\* -f value -c Name); do openstack server reboot $name; done
+----
+It might also be able to reboot each node through the management portal for
+your infrastructure provider. Otherwise contact appropriate authority for
+either gaining access to the virtual machines through ssh or management
+portal/OpenStack client.
+====
+
+. Confirm that the migration succeeded, and then remove the migration resources:
+
+.. To confirm that the network plugin is OVN-Kubernetes, enter the following command.
++
+[source,terminal]
+----
+$ oc get network.config/cluster -o jsonpath='{.status.networkType}{"\n"}'
+----
++
+ The value of `status.networkType` must be `OVNKubernetes`.
+
+.. To confirm that the cluster nodes are in the `Ready` state, enter the following command:
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
+.. To confirm that your pods are not in an error state, enter the following command:
++
+[source,terminal]
+----
+$ oc get pods --all-namespaces -o wide --sort-by='{.spec.nodeName}'
+----
++
+If pods on a node are in an error state, reboot that node.
+
+.. To confirm that all of the cluster Operators are not in an abnormal state, enter the following command:
++
+[source,terminal]
+----
+$ oc get co
+----
++
+The status of every cluster Operator must be the following: `AVAILABLE="True"`, `PROGRESSING="False"`, `DEGRADED="False"`. If a cluster Operator is not available or degraded, check the logs for the cluster Operator for more information.
+
+IMPORTANT: Do not proceed if the any of the previous verification steps indicate errors, but note, that there can be pods with Terminating state due to the finalzers which will be removed during cleanup step.
+
+. If the migration completed and your cluster is in a good state, remove the migration configuration from the CNO configuration object by entering the following command:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "migration": null } }'
+----

--- a/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Migration from Kuryr to OVN-Kubernetes
 include::snippets/technology-preview.adoc[]
 
 As the administrator of a cluster that runs on {rh-openstack-first}, you can migrate to the OVN-Kubernetes network plugin from the Kuryr SDN network plugin.

--- a/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 include::snippets/technology-preview.adoc[]
 
-As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin from the Kuryr SDN network plugin.
+As the administrator of a cluster that runs on {rh-openstack-first}, you can migrate to the OVN-Kubernetes network plugin from the Kuryr SDN network plugin.
 
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plug-in].
 

--- a/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
@@ -11,7 +11,7 @@ include::snippets/technology-preview.adoc[]
 
 As the administrator of a cluster that runs on {rh-openstack-first}, you can migrate to the OVN-Kubernetes network plugin from the Kuryr SDN network plugin.
 
-To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plug-in].
+To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plugin].
 
 include::modules/nw-kuryr-migration-about.adoc[leveloffset=+1]
 

--- a/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
@@ -1,0 +1,31 @@
+:_content-type: ASSEMBLY
+[id="migrate-from-kuryr"]
+= Migrating from the Kuryr network plug-in
+include::_attributes/common-attributes.adoc[]
+:context: migrate-from-openshift-sdn
+
+toc::[]
+
+include::snippets/technology-preview.adoc[]
+
+As a cluster administrator, you can migrate to the OVN-Kubernetes network plug-in from the Kuryr SDN network plug-in.
+
+To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plug-in].
+
+include::modules/nw-kuryr-migration-about.adoc[leveloffset=+1]
+
+include::modules/nw-kuryr-migration.adoc[leveloffset=+1]
+
+include::modules/nw-kuryr-cleanup.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="migrate-from-kuryr-additional-resources"]
+== Additional resources
+
+* xref:../../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes network plugin]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd]
+* xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
+* OVN-Kubernetes capabilities
+- xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address]
+- xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]
+- xref:../../networking/ovn_kubernetes_network_provider/enabling-multicast.adoc#nw-ovn-kubernetes-enabling-multicast[Enabling multicast for a project]

--- a/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
@@ -1,0 +1,31 @@
+:_content-type: ASSEMBLY
+[id="migrate-from-kuryr-sdn"]
+= Migrating from the Kuryr network plugin to the OVN-Kubernetes network plugin
+include::_attributes/common-attributes.adoc[]
+:context: migrate-from-kuryr-sdn
+
+toc::[]
+
+include::snippets/technology-preview.adoc[]
+
+As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin from the Kuryr SDN network plugin.
+
+To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plug-in].
+
+include::modules/nw-kuryr-migration-about.adoc[leveloffset=+1]
+
+include::modules/nw-kuryr-migration.adoc[leveloffset=+1]
+
+include::modules/nw-kuryr-cleanup.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="migrate-from-kuryr-additional-resources"]
+== Additional resources
+
+* xref:../../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes network plugin]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd]
+* xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
+* To learn more about OVN-Kubernetes capabilities, see:
+** xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address]
+** xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]
+** xref:../../networking/ovn_kubernetes_network_provider/enabling-multicast.adoc#nw-ovn-kubernetes-enabling-multicast[Enabling multicast for a project]

--- a/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
@@ -1,14 +1,14 @@
 :_content-type: ASSEMBLY
-[id="migrate-from-kuryr"]
-= Migrating from the Kuryr network plug-in
+[id="migrate-from-kuryr-sdn"]
+= Migrating from the Kuryr network plugin to the OVN-Kubernetes network plugin
 include::_attributes/common-attributes.adoc[]
-:context: migrate-from-openshift-sdn
+:context: migrate-from-kuryr-sdn
 
 toc::[]
 
 include::snippets/technology-preview.adoc[]
 
-As a cluster administrator, you can migrate to the OVN-Kubernetes network plug-in from the Kuryr SDN network plug-in.
+As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin from the Kuryr SDN network plugin.
 
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plug-in].
 
@@ -25,7 +25,7 @@ include::modules/nw-kuryr-cleanup.adoc[leveloffset=+1]
 * xref:../../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes network plugin]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd]
 * xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
-* OVN-Kubernetes capabilities
-- xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address]
-- xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]
-- xref:../../networking/ovn_kubernetes_network_provider/enabling-multicast.adoc#nw-ovn-kubernetes-enabling-multicast[Enabling multicast for a project]
+* To learn more about OVN-Kubernetes capabilities, see:
+** xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address]
+** xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]
+** xref:../../networking/ovn_kubernetes_network_provider/enabling-multicast.adoc#nw-ovn-kubernetes-enabling-multicast[Enabling multicast for a project]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSASINFRA-3066](https://issues.redhat.com//browse/OSASINFRA-3066)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://54822--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
