### PR TITLE
Adds release note for bf2 dpu to nic tp

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -877,6 +877,13 @@ If you configured and deployed your hosting service cluster, you can now deploy 
 
 With this update, in installer-provisioned infrastructure clusters, the `ingressVIP` and `apiVIP` configuration settings in the `install-config.yaml` file are deprecated. Instead, use the `ingressVIPs` and `apiVIPs` configuration settings. These settings support dual-stack networking for applications that require IPv4 and IPv6 access to the cluster by using the Ingress VIP and API VIP services. The `ingressVIPs` and `apiVIPs` configuration settings use a list format to specify an IPv4 address, an IPv6 address, or both IP address formats. The order of the list indicates the primary and secondary VIP address for each service. The primary IP address must be from the IPv4 network when using dual stack networking.
 
+[id="ocp-4-12-bf2-switching-dpu-nic"]
+==== Support for switching the Bluefield-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode (Technology Preview)
+
+With this update, you can switch the Bluefield-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode. 
+
+For more information, see xref:../networking/hardware_networks/switching-bf2-nic-dpu.adoc#switching-bf2-nic-dpu[Switching Bluefield-2 from DPU to NIC].
+
 [id="ocp-4-12-storage"]
 === Storage
 
@@ -2317,6 +2324,11 @@ In the following tables, features are marked with the following statuses:
 |MT42822 BlueField-2 in ConnectX-6 NIC mode OvS Hardware Offload support
 |Not Available
 |Not Available
+|Technology Preview
+
+|Switching Bluefield-2 from DPU to NIC
+|Not available
+|Not available
 |Technology Preview
 
 |====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12 release notes only. 

Issue:
https://issues.redhat.com/browse/OSDOCS-4821

Link to docs preview:
https://54830--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bf2-switching-dpu-nic

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
