### PR TITLE
BZ2000290:  The PVC will be generated based on the default storage class. The default storage class may provide RWO volumes

### DIFF
--- a/modules/registry-configuring-storage-vsphere.adoc
+++ b/modules/registry-configuring-storage-vsphere.adoc
@@ -87,7 +87,7 @@ storage:
     claim: <1>
 ----
 +
-<1> Leave the `claim` field blank to allow the automatic creation of an `image-registry-storage` PVC.
+<1> Leave the `claim` field blank to allow the automatic creation of an `image-registry-storage` persistent volume claim (PVC). The PVC is generated based on the default storage class. However, be aware that the default storage class might provide ReadWriteOnce (RWO) volumes, such as a RADOS Block Device (RBD), which can cause issues when replicating to more than one replica.
 
 . Check the `clusteroperator` status:
 +


### PR DESCRIPTION
…ere.adoc

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.8+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2000290
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://54838--docspreview.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-vsphere.html#registry-configuring-storage-vsphere_configuring-registry-storage-vsphere
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Merge into `main` and cherry-pick into:
- `enterprise-4.13`
- `enterprise-4.12`
- `enterprise-4.11`
- `enterprise-4.10`
- `enterprise-4.9`
- `enterprise-4.8`
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
