### PR TITLE
OCPBUGS#5441: Adding procedure for filtering log messages

### DIFF
--- a/modules/cnf-configuring-log-filtering-for-linuxptp.adoc
+++ b/modules/cnf-configuring-log-filtering-for-linuxptp.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// * networking/using-ptp.adoc
+
+:_content-type: PROCEDURE
+[id="cnf-configuring-log-filtering-for-linuxptp_{context}"]
+= Configuring log filtering for linuxptp services
+
+The `linuxptp` daemon generates logs that you can use for debugging purposes. In telco or other deployment configurations that feature a limited storage capacity, these logs can add to the storage demand. 
+
+To reduce the number log messages, you can configure the `PtpConfig` custom resource (CR) to exclude log messages that report the `master offset` value. The `master offset` log message reports the difference between the current node's clock and the master clock in nanoseconds.  
+
+.Prerequisites
+* Install the OpenShift CLI (`oc`).
+
+* Log in as a user with `cluster-admin` privileges.
+
+* Install the PTP Operator.
+
+.Procedure
+
+. Edit the `PtpConfig` CR:
++
+[source,terminal]
+----
+$ oc edit PtpConfig -n openshift-ptp
+----
+
+. In `spec.profile`, add the `ptpSettings.logReduce` specification and set the value to `true`:
++
+[source,yaml]
+----
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: <ptp_config_name>
+  namespace: openshift-ptp
+...
+spec:
+  profile:
+  - name: "profile1"
+...
+    ptpSettings:
+      logReduce: "true"
+----
++
+[NOTE]
+====
+For debugging purposes, you can revert this specification to `False` to include the master offset messages.
+====
+
+. Save and exit to apply the changes to the `PtpConfig` CR.
+
+.Verification
+
+. Get the name of the `linuxptp-daemon` pod and corresponding node where the `PtpConfig` CR has been applied:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ptp -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                            READY   STATUS    RESTARTS   AGE     IP            NODE
+linuxptp-daemon-gmv2n           3/3     Running   0          1d17h   10.1.196.24   compute-0.example.com
+linuxptp-daemon-lgm55           3/3     Running   0          1d17h   10.1.196.25   compute-1.example.com
+ptp-operator-3r4dcvf7f4-zndk7   1/1     Running   0          1d7h    10.129.0.61   control-plane-1.example.com
+----
+
+. Verify that master offset messages are excluded from the logs by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ptp logs <linux_daemon_container> -c linuxptp-daemon-container | grep "master offset" <1>
+----
+<1> <linux_daemon_container> is the name of the `linuxptp-daemon` pod, for example `linuxptp-daemon-gmv2n`.
++
+When you configure the `logReduce` specification, this command does not report any instances of `master offset` in the logs of the `linuxptp` daemon.

--- a/networking/using-ptp.adoc
+++ b/networking/using-ptp.adoc
@@ -70,6 +70,8 @@ include::modules/nw-columbiaville-ptp-config-refererence.adoc[leveloffset=+2]
 
 include::modules/cnf-configuring-fifo-priority-scheduling-for-ptp.adoc[leveloffset=+2]
 
+include::modules/cnf-configuring-log-filtering-for-linuxptp.adoc[leveloffset=+2]
+
 include::modules/cnf-troubleshooting-common-ptp-operator-issues.adoc[leveloffset=+1]
 
 == PTP hardware fast event notifications framework


### PR DESCRIPTION
OCPBUGS#5441: Excessive logging of PTP statuses can cause issues on networks running latency-sensitive workloads, limited footprint. This spec in the PtpConfig resource filters out some of the logging noise to reduce the burden. 

Version(s):
4.12+ 

Issue:
https://issues.redhat.com/browse/OCPBUGS-5441

Link to docs preview:
https://54870--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#cnf-configuring-log-filtering-for-linuxptp_using-ptp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
