### PR TITLE
TELCODOCS: 945: Added comment on the CNI defaulting to OVN in 4.12. 

### DIFF
--- a/modules/assisted-installer-using-the-assisted-installer.adoc
+++ b/modules/assisted-installer-using-the-assisted-installer.adoc
@@ -21,7 +21,8 @@ The {ai-full} provides installation functionality as a service. This software-as
   - Eliminates the need to install and run the {product-title} installer locally.
   - Ensures the latest version of the installer up to the latest tested z-stream releases. Older versions remain available, if needed.
   - Enables building automation by using the API without the need to run the {product-title} installer locally.
-* *Advanced networking:* The {ai-full} supports IPv4/IPv6 dual stack networking, NMState-based static IP addressing, and an HTTP/S proxy.
+* *Advanced networking:* The {ai-full} supports IPv4 networking with SDN and OVN, IPv6 and dual stack networking with OVN only, NMState-based static IP addressing, and an HTTP/S proxy. OVN is the default Container Network Interface (CNI) for OpenShift Container Platform 4.12 and later releases, but you can use SDN.
+
 * *Pre-installation validation:* The {ai-full} validates the configuration before installation to ensure a high probability of success. Validation includes:
   - Ensuring network connectivity
   - Ensuring sufficient network bandwidth
@@ -39,4 +40,4 @@ The {ai-full} supports installing {product-title} on premises in a connected env
 
 The user interface provides an intuitive interactive workflow where automation does not exist or is not required. Users may also automate installations using the REST API.
 
-See link:https://console.redhat.com/openshift/assisted-installer/clusters/~new[Install OpenShift with the Assisted Installer] to create an {product-title} cluster with the {ai-full}.
+See link:https://console.redhat.com/openshift/assisted-installer/clusters/~new[Install OpenShift with the Assisted Installer] to create an {product-title} cluster with the {ai-full}. See the link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[Assisted Installer for OpenShift Container Platform] documentation for details on using the {ai-full}.


### PR DESCRIPTION
Added a note that OCP uses OVN in 4.12 and later by default. Also added a hyperlink to the new AI docs.

Fixes: [TELCODOCS-945](https://issues.redhat.com//browse/TELCODOCS-945)

Signed-off-by: John Wilkins <jowilkin@redhat.com>

Preview: https://54876--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_on_prem_assisted/installing-on-prem-assisted.html

Version(s): 4.13, 4.12
