### PR TITLE
OCPBUGS#3628 Adding access.redhat.com to allowlist.

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -22,6 +22,10 @@ There are no special configuration considerations for services running on only c
 |443, 80
 |Provides core container images
 
+|`access.redhat.com`
+|443, 80
+|Provides core container images
+
 |`quay.io`
 |443, 80
 |Provides core container images


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/OCPBUGS-3628

Link to docs preview:
https://54877--docspreview.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html#configuring-firewall_configuring-firewall

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

