### PR TITLE
[OSDOCS-4833]: Document private S3 bucket for OIDC in AWS STS

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -111,7 +111,7 @@ ifdef::aws-sts[]
 0000_50_cluster-storage-operator_03_credentials_request_aws.yaml <6>
 ----
 +
-<1> The Machine API Operator CR is required. 
+<1> The Machine API Operator CR is required.
 <2> The Cloud Credential Operator CR is required.
 <3> The Image Registry Operator CR is required.
 <4> The Ingress Operator CR is required.
@@ -169,18 +169,17 @@ ifdef::aws-sts[]
 [source,terminal]
 ----
 $ ccoctl aws create-all \
---name=<name> \
---region=<aws_region> \
---credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
+  --name=<name> \// <1>
+  --region=<aws_region> \// <2>
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <3>
+  --output-dir=<path_to_ccoctl_output_dir> \// <4>
+  --create-private-s3-bucket <5>
 ----
-+
-where:
-+
---
-** `<name>` is the name used to tag any cloud resources that are created for tracking.
-** `<aws_region>` is the AWS region in which cloud resources will be created.
-** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files for the component `CredentialsRequest` objects.
---
+<1> Specify the name used to tag any cloud resources that are created for tracking.
+<2> Specify the AWS region in which cloud resources will be created.
+<3> Specify the directory containing the files for the component `CredentialsRequest` objects.
+<4> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+<5> Optional: By default, the `ccoctl` utility stores the OpenID Connect (OIDC) configuration files in a public S3 bucket and uses the S3 URL as the public OIDC endpoint. To store the OIDC configuration in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL instead, use the `--create-private-s3-bucket` parameter.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.10+

Issue:
[OSDOCS-4833](https://issues.redhat.com//browse/OSDOCS-4833)

Link to docs preview:
[Step 3, callout 5](https://54882--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-at-once_cco-mode-sts)

QE review:
- [x] QE has approved this change.

Additional information:
- Also reformatted a bit because there are so many parameters to explain now
- Need change management acks since this was done in 4.12 but also backported to 4.10-4.11

Change management acks:
 - [x] Andrew Butcher
 - [x] Ju Lim
 - [x] Eric Rich
 - [x] Xiaoli Tian
 - [x] Kathryn Alexander
 - [x] Stephanie Stout