### PR TITLE
Update/Add GCP shared VPC permission information to the docs.

### DIFF
--- a/installing/installing_gcp/installing-gcp-account.adoc
+++ b/installing/installing_gcp/installing-gcp-account.adoc
@@ -26,6 +26,8 @@ include::modules/installation-gcp-service-account.adoc[leveloffset=+1]
 
 include::modules/installation-gcp-permissions.adoc[leveloffset=+2]
 
+include::modules/installation-gcp-shared-vpc-permissions.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-regions.adoc[leveloffset=+1]
 
 == Next steps

--- a/installing/installing_gcp/installing-gcp-shared-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-shared-vpc.adoc
@@ -22,7 +22,8 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 * If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
 * You have a GCP host project which contains a shared VPC network.
 * You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a GCP project] to host the cluster. This project, known as the service project, must be attached to the host project. For more information, see link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#create-shared[Attaching service projects in the GCP documentation].
-* You have a GCP service account that has the xref:../../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-permissions_installing-gcp-account[required GCP permissions] in the host project.
+* You have a GCP service account that has the xref:../../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-permissions_installing-gcp-account[required GCP permissions] in the service project.
+* You have a GCP service account that has the xref:../../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-shared-vpc-permissions_installing-gcp-account[required GCP permissions] in the host project.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/modules/installation-gcp-permissions.adoc
+++ b/modules/installation-gcp-permissions.adoc
@@ -24,9 +24,7 @@ account requires the following permissions. If you deploy your cluster into an e
 
 .Required roles for the installation program
 * Compute Admin
-* IAM Security Admin
 * Service Account Admin
-* Service Account User
 * Storage Admin
 
 .Required roles for creating network resources during installation

--- a/modules/installation-gcp-shared-vpc-permissions.adoc
+++ b/modules/installation-gcp-shared-vpc-permissions.adoc
@@ -1,0 +1,21 @@
+// This file is referenced in the following assembly:
+// installing/installing_gcp/installing-gcp-shared-vpc.adoc
+
+:_content-type: PROCEDURE
+[id="installation-gcp-shared-vpc-permissions_{context}"]
+= Required GCP permissions for shared VPC installation
+
+When you attach the `Owner` role to the service account that you create, you
+grant that service account all permissions, including those that are required to
+install {product-title}. To deploy an {product-title} cluster into a shared VPC, the
+service account requires the following permissions in the host project.
+
+.Required roles for creating network resources during installation
+* Compute Network User
+* Compute Security Admin
++
+[NOTE]
+====
+If you do not want the installation program to automatically create firewall rules for your cluster, you do not need the Compute Security Admin permission.
+====
+


### PR DESCRIPTION
** New GCP module for permissions required for a service account in the Host Project 
** Added links to the GCP Account information for the above note. 
** Added Links to the shared vpc prerequisites to the permissions.

[CORS-2383](https://issues.redhat.com/browse/CORS-2383)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[Docs Preview](https://54885--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-shared-vpc-permissions_installing-gcp-account)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
