### PR TITLE
Removes MCE from TP table bc it has been GA since 4.10

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -2629,11 +2629,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Multi-cluster Engine Operator
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
 |Node Observability Operator
 |Not Available
 |Not Available


### PR DESCRIPTION
Removes MCE from TP table bc it has been GA since 4.10

Version(s):
4.12

Issue:
No issue. Just change based on conversation in slack. FYI @lahinson 

Link to docs preview:
https://54887--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-technology-preview

QE review:
- [ ] QE has approved this change.
No QE needed

Additional information:
FYI @JoeAldinger 
