### PR TITLE
Adjusting topic map name

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1363,7 +1363,7 @@ Topics:
   Topics:
   - Name: Network Observability overview
     File: network-observability-overview
-  - Name: Installing Network Observability Operators
+  - Name: Installing the Network Observability Operator
     File: installing-operators
   - Name: Understanding Network Observability Operator
     File: understanding-network-observability-operator


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->
Field [feedback](https://redhat-internal.slack.com/archives/C02939DP5L5/p1674069176365669) on the Network Observability documentation requesting to update the title of the Installation assembly from _Installing Network Observability Operators_ to _Installing the Network Observablity Operator_.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12+

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://54891--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/installing-operators.html

QE review not required

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
There are multiple operator installations contained in this assembly, so "Operators" was plural for that reason; however, it also makes sense have it as not plural since the other operator installation details are prerequisites for ultimately installing the Network Observability Operator. 
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
