### PR TITLE
RHDEVDOCS-4741-Pipeline-1.9-RN: Bug Fixes, Known Issues, Deprecated C…

### DIFF
--- a/modules/op-release-notes-1-9.adoc
+++ b/modules/op-release-notes-1-9.adoc
@@ -236,3 +236,119 @@ If you do not add any configuration data, you can use the default data in the AP
 * With this update, the `PipelineRun` resource definition has the log URL included as an annotation. For example, the `tkn-pac describe` command shows the log link when describing a `PipelineRun`.
 
 * With this update, `tkn-pac` logs show repository name, instead of `PipelineRun` name.
+
+[id="breaking-changes-1-9_{context}"]	
+== Breaking changes	
+
+// .Pipelines	
+
+* With this update, the `Conditions` custom resource definition (CRD) type has been removed. As an alternative, use the `WhenExpressions` instead.	
+
+* With this update, support for `tekton.dev/v1alpha1` API pipeline resources, such as Pipeline, PipelineRun, Task, Clustertask, and TaskRun has been removed.	
+
+* With this update, the `tkn-pac setup` command has been removed. You can now re-use the functionality provided by the `tkn-pac setup` command by using the `tkn-pac webhook add` and `tkn-pac webhook update-token` commands. You can use the `tkn-pac webhook add` command to re-add a webhook to an existing Git repository. You can use the `tkn-pac webhook update-token` command to update the personal provider access token for an existing Secret object in the Git repository.	
+
+[id="deprecated-features-1-9_{context}"]	
+== Deprecated and removed features	
+
+* In the Red Hat OpenShift Pipelines 1.9.0 release, `ClusterTasks` are deprecated and planned to be removed in a future release. As an alternative, you can use `Cluster Resolver`.	
+
+* In the Red Hat OpenShift Pipelines 1.9.0 release, the use of the `triggers` and the `namespaceSelector` fields in a single `EventListener` specification is deprecated and planned to be removed in a future release. You can use these fields in different `EventListener` specifications successfully.	
+
+* In the Red Hat OpenShift Pipelines 1.9.0 release, the `tkn pipelinerun describe` command does not display timeouts for the `PipelineRun` resource.	
+
+* In the Red Hat OpenShift Pipelines 1.9.0 release, the PipelineResource` custom resource (CR) is deprecated. The `PipelineResource` CR was a Tech Preview feature and part of the `tekton.dev/v1alpha1` API.	
+
+* In the Red Hat OpenShift Pipelines 1.9.0 release, custom image parameters from cluster tasks are deprecated. As an alternative, you can copy a cluster task and use your custom image in it.	
+
+[id="known-issues-1-9_{context}"]	
+== Known issues	
+
+// .Operator	
+
+* The `chains-secret` and `chains-config` config maps are removed after you uninstall the Red Hat OpenShift Pipelines Operator. As they contain user data, they should be preserved and not deleted.	
+// https://issues.redhat.com/browse/SRVKP-2396	
+
+// .PAC	
+
+* When running the `tkn pac` set of commands on Windows, you may receive the following error message: `Command finished with error: not supported by Windows.`	
++	
+
+Workaround: Set the `NO_COLOR` environment variable to `true`.	
+// https://issues.redhat.com/browse/SRVKP-2197	
+
+* Running the `tkn pac resolve -f <filename> | oc create -f` command may not provide expected results, if the `tkn pac resolve` command uses a templated parameter value to function.	
++	
+Workaround: To mitigate this issue, save the output of `tkn pac resolve` in a temporary file by running the `tkn pac resolve -f <filename> -o tempfile.yaml` command and then run the `oc create -f tempfile.yaml` command. For example, `tkn pac resolve -f <filename> -o /tmp/pull-request-resolved.yaml && kubectl create -f /tmp/pull-request-resolved.yaml`.	
+
+[id="fixed-issues-1-9_{context}"]	
+== Fixed issues	
+
+// .Pipelines	
+
+* Before this update, after replacing an empty array, the original array returned an empty string rendering the paramaters inside it invalid. With this update, this issue is resolved and the original array returns as empty. 	
+// Vincent Demeester	
+
+* Before this update, if duplicate secrets were present in a service account for a pipelines run, it resulted in failure in task pod creation. With this update, this issue is resolved and the task pod is created successfully even if duplicate secrets are present in a service account.	
+// Vincent Demeester	
+
+* Before this update, by looking at the TaskRun's `spec.StatusMessage` field, users could not distinguish whether the `TaskRun` had been cancelled by the user or by a `PipelineRun` that was part of it. With this update, this issue is resolved and users can distinguish the status of the `TaskRun` by looking at the TaskRun's `spec.StatusMessage` field.	
+// Vincent Demeester	
+
+* Before this update, webhook validation was removed on deletion of old versions of invalid objects. With this update, this issue is resolved.	
+// Vincent Demeester @vdeemester	
+
+* Before this update, a race condition could occur if another tool updated labels or annotations on a PipelineRun or TaskRun. With this update, this issue is resolved and you can merge labels or annotations.	
+// Vincent Demeester @vdeemester	
+
+// .Triggers	
+
+* Before this update, log keys did not have the same keys as in pipelines controllers. With this update, this issue has been resolved and the log keys have been updated to match the log stream of pipeline controllers. The keys in logs have been changed from "ts" to "timestamp", from "level" to "severity", and from "message" to "msg".	
+// https://issues.redhat.com/browse/SRVKP-1959	
+// @KhurramBaig	
+
+// .CLI	
+
+* Before this update, if a PipelineRun was deleted with an unknown status, an error message was not generated. With this update, this issue is resolved and an error message is generated.	
+// https://github.com/tektoncd/cli/pull/1684	
+// Piyush Garg @piyush-garg	
+
+* Before this update, to access bundle commands like `list` and `push`, it was required to use the `kubeconfig` file . With this update, this issue has been resolved and the `kubeconfig` file is not required to access bundle commands.	
+// https://github.com/tektoncd/cli/pull/1557	
+// Piyush Garg @piyush-garg	
+
+* Before this update, if the parent pipelinerun was running while deleting TaskRuns, then TaskRuns would be deleted. With this update, this issue is resolved and TaskRuns are not getting deleted if the parent PipelineRun is running.	
+// https://github.com/tektoncd/cli/pull/1736	
+// Piyush Garg @piyush-garg	
+
+* Before this update, if the user attempted to build a bundle with more objects than the pipeline controller permitted, the Tekton CLI did not display an error message. With this update, this issue is resolved and the Tekton CLI displays an error message if the user attempts to build a bundle with more objects than the limit permitted in the pipeline controller.	
+// https://github.com/tektoncd/cli/pull/1572	
+// Piyush Garg @piyush-garg	
+
+// .Operator	
+
+* Before this update, if namespaces were removed from the cluster, then the operator did not remove namespaces from the `ClusterInterceptor ClusterRoleBinding` subjects. With this update, this issue has been resolved, and the operator removes the namespaces from the `ClusterInterceptor ClusterRoleBinding` subjects.	
+// Shubham Minglani	
+
+* Before this update, the default installation of the Red Hat OpenShift Pipelines Operator resulted in the `pipelines-scc-rolebinding security context constraint` (SCC) role binding resource remaining in the cluster. With this update, the default installation of the Red Hat OpenShift Pipelines Operator results in the `pipelines-scc-rolebinding security context constraint` (SCC) role binding resource resource being removed from the cluster.	
+// https://github.com/tektoncd/operator/pull/1156	
+// https://issues.redhat.com/browse/SRVKP-2520	
+// Shubham Minglani	
+
+// .PAC	
+
+* Before this update, {pac} did not get updated values from the {pac} ConfigMap object. With this update, this issue is fixed and {pac} ConfigMap object looks for any new changes.	
+// Savita Ashture	
+
+* Before this update, {pac} controller did not wait for the `tekton.dev/pipeline` label to be updated and added the `checkrun id` label, which would cause race conditions. With this update, the {pac} controller waits for the `tekton.dev/pipeline` label to be updated and then adds the `checkrun id` label, which helps to avoid race conditions.	
+// Savita Ashture	
+
+* Before this update, the `tkn-pac create repo` command did not override a `PipelineRun` if it already existed in the git repository. With this update, `tkn-pac create` command is fixed to override a `PipelineRun` if it exists in the git repository and this resolves the issue successfully.	
+// Savita Ashture	
+
+* Before this update, the `tkn pac describe` command did not display reasons for every message. With this update, this issue is fixed and the `tkn pac describe` command displays reasons for every message.	
+// Savita Ashture	
+
+* Before this update, a pull request failed if the user in the annotation provided values by using a regex form, for example, `refs/head/rel-*`. The pull request failed because it was missing `refs/heads` in its base branch. With this update, the prefix is added and checked that it matches. This resolves the issue and the pull request is successful.	
+// Savita Ashture
+


### PR DESCRIPTION
Purpose: To resolve the following issues:

https://issues.redhat.com/browse/RHDEVDOCS-4741
https://issues.redhat.com/browse/RHDEVDOCS-4743
https://issues.redhat.com/browse/RHDEVDOCS-4742
Aligned team: DevTools

OCP version this PR applies to (cherrypicking): enterprise 4.11 and later

Content for preview: https://54712--docspreview.netlify.app/openshift-enterprise/latest/welcome/index.html

SME review : @vdemeester @khrm @piyush-garg @sm43 @PuneetPunamiya @savitaashture @concaf

QE review: @ppitonak @VeereshAradhya 

Peer review: @gabriel-rh

SME and Peer review approval available in the old PR link as follows: https://github.com/openshift/openshift-docs/pull/54712