### PR TITLE
OCPBUGS6042: rectifies 3 and above to only 3 masters

### DIFF
--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -54,7 +54,7 @@ Recommended cluster resources for the following topologies:
 |Topology|Number of master nodes|Number of worker nodes|vCPU|Memory|Storage
 |Single-node cluster|1|0|8 vCPU cores|16GB of RAM| 120GB
 |Compact cluster|3|0 or 1|8 vCPU cores|16GB of RAM|120GB
-|HA cluster|3 and above|2 and above |8 vCPU cores|16GB of RAM|120GB
+|HA cluster|3|2 and above |8 vCPU cores|16GB of RAM|120GB
 |====
 
 


### PR DESCRIPTION
- Applies to main, 4.13, and 4.12
- [Jira](https://issues.redhat.com/browse/OCPBUGS-6042)
- [Preview](https://54907--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html)
- @celebdor please ack this change with lgtm