### PR TITLE
Updating more instances of plug-in to plugin in older versions

### DIFF
--- a/cicd/jenkins/images-other-jenkins-agent.adoc
+++ b/cicd/jenkins/images-other-jenkins-agent.adoc
@@ -22,7 +22,7 @@ The Maven v3.5, Node.js v10, and Node.js v12 images extend the Base image. They 
 Use a version of the agent image that is appropriate for your {product-title} release version. Embedding an `oc` client version that is not compatible with the {product-title} version can cause unexpected behavior.
 ====
 
-The {product-title} Jenkins image also defines the following sample pod templates to illustrate how you can use these agent images with the Jenkins Kubernetes plug-in:
+The {product-title} Jenkins image also defines the following sample pod templates to illustrate how you can use these agent images with the Jenkins Kubernetes plugin:
 
 - The `maven` pod template, which uses a single container that uses the {product-title} Maven Jenkins agent image.
 - The `nodejs` pod template, which uses a single container that uses the {product-title} Node.js Jenkins agent image.

--- a/cicd/jenkins/images-other-jenkins.adoc
+++ b/cicd/jenkins/images-other-jenkins.adoc
@@ -30,7 +30,7 @@ But for convenience, {product-title} provides image streams in the `openshift` n
 
 You can manage Jenkins authentication in two ways:
 
-* {product-title} OAuth authentication provided by the {product-title} Login plug-in.
+* {product-title} OAuth authentication provided by the {product-title} Login plugin.
 * Standard authentication provided by Jenkins.
 
 include::modules/images-other-jenkins-oauth-auth.adoc[leveloffset=+2]

--- a/modules/adding-new-extension-dynamic-plug-in.adoc
+++ b/modules/adding-new-extension-dynamic-plug-in.adoc
@@ -4,8 +4,8 @@
 
 :_content-type: PROCEDURE
 [id="adding-new-extension-dynamic-plugin_{context}"]
-= Adding a new extension to your plug-in
-You can add extensions that allow you to customize your plug-in. Those extensions are then loaded to the console at run-time.
+= Adding a new extension to your plugin
+You can add extensions that allow you to customize your plugin. Those extensions are then loaded to the console at run-time.
 
 . Edit the `console-extensions.json` file:
 +
@@ -31,5 +31,5 @@ You can add extensions that allow you to customize your plug-in. Those extension
   }
 ]
 ----
-<1> Add the extension type(s) you want to include with this plug-in. You can include multiple extensions separated with a comma.
-<2> The `$codeRef` value should be formatted as either `moduleName.exportName` for a named export or `moduleName` for the default export. Only the plug-in’s exported modules can be used in code references.
+<1> Add the extension type(s) you want to include with this plugin. You can include multiple extensions separated with a comma.
+<2> The `$codeRef` value should be formatted as either `moduleName.exportName` for a named export or `moduleName` for the default export. Only the plugin’s exported modules can be used in code references.

--- a/modules/dynamic-plug-ins-get-started.adoc
+++ b/modules/dynamic-plug-ins-get-started.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="getting-started-with-dynamic-plugins_{context}"]
-= Getting started with dynamic plug-ins
+= Getting started with dynamic plugins
 
-To get started using the dynamic plug-in, you must set up your environment to write a new OpenShift Console dynamic plug-in. 
+To get started using the dynamic plugin, you must set up your environment to write a new OpenShift Console dynamic plugin.
 
 .Prerequisites
 * Ensure you have link:https://nodejs.org/en/[`Node.js`] installed.
@@ -14,7 +14,7 @@ To get started using the dynamic plug-in, you must set up your environment to wr
 
 .Procedure
 
-. Edit the plug-in metadata in the `consolePlugin` declaration of `package.json`.
+. Edit the plugin metadata in the `consolePlugin` declaration of `package.json`.
 +
 [source,json]
 
@@ -32,7 +32,7 @@ To get started using the dynamic plug-in, you must set up your environment to wr
   }
 }
 ----
-<1> Update the name of your plug-in.
+<1> Update the name of your plugin.
 <2> Update the version.
-<3> Update the display name for your plug-in.
-<4> Update the description with a synopsis about your plug-in.
+<3> Update the display name for your plugin.
+<4> Update the description with a synopsis about your plugin.

--- a/modules/dynamic-provisioning-about.adoc
+++ b/modules/dynamic-provisioning-about.adoc
@@ -24,4 +24,4 @@ having any knowledge of the underlying infrastructure.
 Many storage types are available for use as persistent volumes in
 {product-title}. While all of them can be statically provisioned by an
 administrator, some types of storage are created dynamically using the
-built-in provider and plug-in APIs.
+built-in provider and plugin APIs.

--- a/modules/dynamic-provisioning-defining-storage-class.adoc
+++ b/modules/dynamic-provisioning-defining-storage-class.adoc
@@ -19,4 +19,4 @@ storage class.
 ====
 
 The following sections describe the basic definition for a
-`StorageClass` object and specific examples for each of the supported plug-in types.
+`StorageClass` object and specific examples for each of the supported plugin types.

--- a/modules/dynamic-provisioning-storage-class-definition.adoc
+++ b/modules/dynamic-provisioning-storage-class-definition.adoc
@@ -32,4 +32,4 @@ parameters: <6>
 <4> (optional) Annotations for the storage class.
 <5> (required) The type of provisioner associated with this storage class.
 <6> (optional) The parameters required for the specific provisioner, this
-will change from plug-in to plug-in.
+will change from plugin to plugin.

--- a/modules/images-other-jenkins-agent-pod-retention.adoc
+++ b/modules/images-other-jenkins-agent-pod-retention.adoc
@@ -6,10 +6,10 @@
 [id="images-other-jenkins-agent-pod-retention_{context}"]
 = Jenkins agent pod retention
 
-Jenkins agent pods, are deleted by default after the build completes or is stopped. This behavior can be changed by the Kubernetes plug-in pod retention setting. Pod retention can be set for all Jenkins builds, with overrides for each pod template. The following behaviors are supported:
+Jenkins agent pods, are deleted by default after the build completes or is stopped. This behavior can be changed by the Kubernetes plugin pod retention setting. Pod retention can be set for all Jenkins builds, with overrides for each pod template. The following behaviors are supported:
 
 * `Always` keeps the build pod regardless of build result.
-* `Default` uses the plug-in value, which is the pod template only.
+* `Default` uses the plugin value, which is the pod template only.
 * `Never` always deletes the pod.
 * `On Failure` keeps the pod if it fails during the build.
 

--- a/modules/images-other-jenkins-config-kubernetes.adoc
+++ b/modules/images-other-jenkins-config-kubernetes.adoc
@@ -4,11 +4,11 @@
 
 :_content-type: CONCEPT
 [id="images-other-jenkins-config-kubernetes_{context}"]
-= Configuring the Jenkins Kubernetes plug-in
+= Configuring the Jenkins Kubernetes plugin
 
-The OpenShift Jenkins image includes the pre-installed link:https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin[Kubernetes plug-in] so that Jenkins agents can be dynamically provisioned on multiple container hosts using Kubernetes and {product-title}.
+The OpenShift Jenkins image includes the pre-installed link:https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin[Kubernetes plugin] so that Jenkins agents can be dynamically provisioned on multiple container hosts using Kubernetes and {product-title}.
 
-To use the Kubernetes plug-in, {product-title} provides images that are suitable for use as Jenkins agents, including the Base, Maven, and Node.js images.
+To use the Kubernetes plugin, {product-title} provides images that are suitable for use as Jenkins agents, including the Base, Maven, and Node.js images.
 
 [IMPORTANT]
 ====
@@ -19,37 +19,37 @@ To use the Kubernetes plug-in, {product-title} provides images that are suitable
 For more information, see the "Important changes to OpenShift Jenkins images" link in the following "Additional resources" section.
 ====
 
-Both the Maven and Node.js agent images are automatically configured as Kubernetes pod template images within the {product-title} Jenkins image configuration for the Kubernetes plug-in. That configuration includes labels for each of the images that can be applied to any of your Jenkins jobs under their Restrict where this project can be run setting. If the label is applied, jobs run under an {product-title} pod running the respective agent image.
+Both the Maven and Node.js agent images are automatically configured as Kubernetes pod template images within the {product-title} Jenkins image configuration for the Kubernetes plugin. That configuration includes labels for each of the images that can be applied to any of your Jenkins jobs under their Restrict where this project can be run setting. If the label is applied, jobs run under an {product-title} pod running the respective agent image.
 
 [IMPORTANT]
 ====
-In {product-title} 4.10 and later, the recommended pattern for running Jenkins agents using the Kubernetes plug-in is to use pod templates with both `jnlp` and `sidecar` containers. The `jnlp` container uses the {product-title} Jenkins Base agent image to facilitate launching a separate pod for your build. The `sidecar` container image has the tools needed to build in a particular language within the separate pod that was launched. Many container images from the Red Hat Container Catalog are referenced in the sample image streams present in the `openshift` namespace. The {product-title} Jenkins image has two pod templates named `java-build` and `nodejs-builder` with sidecar containers that demonstrate this approach. These two pod templates use the latest Java and NodeJS versions provided by the `java` and `nodejs` image streams in the `openshift` namespace.
+In {product-title} 4.10 and later, the recommended pattern for running Jenkins agents using the Kubernetes plugin is to use pod templates with both `jnlp` and `sidecar` containers. The `jnlp` container uses the {product-title} Jenkins Base agent image to facilitate launching a separate pod for your build. The `sidecar` container image has the tools needed to build in a particular language within the separate pod that was launched. Many container images from the Red Hat Container Catalog are referenced in the sample image streams present in the `openshift` namespace. The {product-title} Jenkins image has two pod templates named `java-build` and `nodejs-builder` with sidecar containers that demonstrate this approach. These two pod templates use the latest Java and NodeJS versions provided by the `java` and `nodejs` image streams in the `openshift` namespace.
 
 With this update, in {product-title} 4.10 and later, the non-sidecar `maven` and `nodejs` pod templates for Jenkins are deprecated. These pod templates are planned for removal in a future release. Bug fixes and support are provided through the end of that future life cycle, after which no new feature enhancements will be made.
 
 // Writer: This admonition is tied to the "Non-sidecar pod templates for Jenkins" deprecation item (JKNS-257) in the OpenShift 4.10 release notes. Update this admonition when this deprecation status eventually changes to "removed."
 ====
 
-The Jenkins image also provides auto-discovery and auto-configuration of additional agent images for the Kubernetes plug-in.
+The Jenkins image also provides auto-discovery and auto-configuration of additional agent images for the Kubernetes plugin.
 
-With the {product-title} sync plug-in, the Jenkins image on Jenkins startup searches for the following within the project that it is running or the projects specifically listed in the plug-in's configuration:
+With the {product-title} sync plugin, the Jenkins image on Jenkins startup searches for the following within the project that it is running or the projects specifically listed in the plugin's configuration:
 
 * Image streams that have the label `role` set to `jenkins-agent`.
 * Image stream tags that have the annotation `role` set to `jenkins-agent`.
 * Config maps that have the label `role` set to `jenkins-agent`.
 
-When it finds an image stream with the appropriate label, or image stream tag with the appropriate annotation, it generates the corresponding Kubernetes plug-in configuration so you can assign your Jenkins jobs to run in a pod that runs the container image that is provided by the image stream.
+When it finds an image stream with the appropriate label, or image stream tag with the appropriate annotation, it generates the corresponding Kubernetes plugin configuration so you can assign your Jenkins jobs to run in a pod that runs the container image that is provided by the image stream.
 
-The name and image references of the image stream or image stream tag are mapped to the name and image fields in the Kubernetes plug-in pod template. You can control the label field of the Kubernetes plug-in pod template by setting an annotation on the image stream or image stream tag object with the key `agent-label`. Otherwise, the name is used as the label.
+The name and image references of the image stream or image stream tag are mapped to the name and image fields in the Kubernetes plugin pod template. You can control the label field of the Kubernetes plugin pod template by setting an annotation on the image stream or image stream tag object with the key `agent-label`. Otherwise, the name is used as the label.
 
 [NOTE]
 ====
-Do not log in to the Jenkins console and change the pod template configuration. If you do so after the pod template is created, and the {product-title} Sync plug-in detects that the image associated with the image stream or image stream tag has changed, it replaces the pod template and overwrites those configuration changes. You cannot merge a new configuration with the existing configuration.
+Do not log in to the Jenkins console and change the pod template configuration. If you do so after the pod template is created, and the {product-title} Sync plugin detects that the image associated with the image stream or image stream tag has changed, it replaces the pod template and overwrites those configuration changes. You cannot merge a new configuration with the existing configuration.
 
 Consider the config map approach if you have more complex configuration needs.
 ====
 
-When it finds a config map with the appropriate label, it assumes that any values in the key-value data payload of the config map contain Extensible Markup Language (XML) that is consistent with the configuration format for Jenkins and the Kubernetes plug-in pod templates. One key benefit of using config maps, rather than image streams or image stream tags, is that you can control all the parameters of the Kubernetes plug-in pod template.
+When it finds a config map with the appropriate label, it assumes that any values in the key-value data payload of the config map contain Extensible Markup Language (XML) that is consistent with the configuration format for Jenkins and the Kubernetes plugin pod templates. One key benefit of using config maps, rather than image streams or image stream tags, is that you can control all the parameters of the Kubernetes plugin pod template.
 
 .Sample config map for `jenkins-agent`
 [source,yaml]
@@ -159,20 +159,20 @@ data:
 
 [NOTE]
 ====
-If you log in to the Jenkins console and make further changes to the pod template configuration after the pod template is created, and the {product-title} Sync plug-in detects that the config map has changed, it will replace the pod template and overwrite those configuration changes. You cannot merge a new configuration with the existing configuration.
+If you log in to the Jenkins console and make further changes to the pod template configuration after the pod template is created, and the {product-title} Sync plugin detects that the config map has changed, it will replace the pod template and overwrite those configuration changes. You cannot merge a new configuration with the existing configuration.
 
-Do not log in to the Jenkins console and change the pod template configuration. If you do so after the pod template is created, and the {product-title} Sync plug-in detects that the image associated with the image stream or image stream tag has changed, it replaces the pod template and overwrites those configuration changes. You cannot merge a new configuration with the existing configuration.
+Do not log in to the Jenkins console and change the pod template configuration. If you do so after the pod template is created, and the {product-title} Sync plugin detects that the image associated with the image stream or image stream tag has changed, it replaces the pod template and overwrites those configuration changes. You cannot merge a new configuration with the existing configuration.
 
 Consider the config map approach if you have more complex configuration needs.
 ====
 
-After it is installed, the {product-title} Sync plug-in monitors the API server of {product-title} for updates to image streams, image stream tags, and config maps and adjusts the configuration of the Kubernetes plug-in.
+After it is installed, the {product-title} Sync plugin monitors the API server of {product-title} for updates to image streams, image stream tags, and config maps and adjusts the configuration of the Kubernetes plugin.
 
 The following rules apply:
 
-* Removing the label or annotation from the config map, image stream, or image stream tag results in the deletion of any existing `PodTemplate` from the configuration of the Kubernetes plug-in.
-* If those objects are removed, the corresponding configuration is removed from the Kubernetes plug-in.
+* Removing the label or annotation from the config map, image stream, or image stream tag results in the deletion of any existing `PodTemplate` from the configuration of the Kubernetes plugin.
+* If those objects are removed, the corresponding configuration is removed from the Kubernetes plugin.
 * Either creating appropriately labeled or annotated `ConfigMap`, `ImageStream`, or `ImageStreamTag` objects, or the adding of labels after their initial creation, leads to creating of a `PodTemplate` in the Kubernetes-plugin configuration.
-* In the case of the `PodTemplate` by config map form, changes to the config map data for the `PodTemplate` are applied to the `PodTemplate` settings in the Kubernetes plug-in configuration and overrides any changes that were made to the `PodTemplate` through the Jenkins UI between changes to the config map.
+* In the case of the `PodTemplate` by config map form, changes to the config map data for the `PodTemplate` are applied to the `PodTemplate` settings in the Kubernetes plugin configuration and overrides any changes that were made to the `PodTemplate` through the Jenkins UI between changes to the config map.
 
 To use a container image as a Jenkins agent, the image must run the agent as an entry point. For more details, see the official https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds#Distributedbuilds-Launchslaveagentheadlessly[Jenkins documentation].

--- a/modules/images-other-jenkins-env-var.adoc
+++ b/modules/images-other-jenkins-env-var.adoc
@@ -93,7 +93,7 @@ By default, the JVM sets the initial heap size.
 `image-registry.openshift-image-registry.svc:5000/openshift/java:latest`
 
 |`NODEJS_BUILDER_IMAGE`
-|Setting this value overrides the image used for the `nodejs-builder` container in the `nodejs-builder` sample Kubernetes plug-in pod templates provided with this image. Otherwise, the image from the `nodejs:latest` image stream tag in the `openshift` namespace is used.
+|Setting this value overrides the image used for the `nodejs-builder` container in the `nodejs-builder` sample Kubernetes plugin pod templates provided with this image. Otherwise, the image from the `nodejs:latest` image stream tag in the `openshift` namespace is used.
 |Default:
 `image-registry.openshift-image-registry.svc:5000/openshift/nodejs:latest`
 

--- a/modules/images-other-jenkins-kubernetes-plugin.adoc
+++ b/modules/images-other-jenkins-kubernetes-plugin.adoc
@@ -4,11 +4,11 @@
 
 :_content-type: CONCEPT
 [id="images-other-jenkins-kubernetes-plugin_{context}"]
-= Using the Jenkins Kubernetes plug-in
+= Using the Jenkins Kubernetes plugin
 
 In the following example, the `openshift-jee-sample` `BuildConfig` object causes a Jenkins Maven agent pod to be dynamically provisioned. The pod clones some Java source code, builds a WAR file, and causes a second `BuildConfig`, `openshift-jee-sample-docker` to run. The second `BuildConfig` layers the new WAR file into a container image.
 
-.Sample `BuildConfig` that uses the Jenkins Kubernetes plug-in
+.Sample `BuildConfig` that uses the Jenkins Kubernetes plugin
 [source,yaml]
 ----
 kind: List
@@ -57,7 +57,7 @@ items:
 
 It is also possible to override the specification of the dynamically created Jenkins agent pod. The following is a modification to the preceding example, which overrides the container memory and specifies an environment variable.
 
-.Sample `BuildConfig` that uses the Jenkins Kubernetes Plug-in, specifying memory limit and environment variable
+.Sample `BuildConfig` that uses the Jenkins Kubernetes Plugin, specifying memory limit and environment variable
 [source,yaml]
 ----
 kind: BuildConfig
@@ -102,7 +102,7 @@ spec:
 
 // Writer, remove or update jenkins-agent-maven reference in 4.12
 
-By default, the pod is deleted when the build completes. This behavior can be modified with the plug-in or within a pipeline Jenkinsfile.
+By default, the pod is deleted when the build completes. This behavior can be modified with the plugin or within a pipeline Jenkinsfile.
 
 Upstream Jenkins has more recently introduced a YAML declarative format for defining a `podTemplate` pipeline DSL in-line with your pipelines. An example of this format, using the sample `java-builder` pod template that is defined in the {product-title} Jenkins image:
 

--- a/modules/nodes-cluster-disabling-features-list.adoc
+++ b/modules/nodes-cluster-disabling-features-list.adoc
@@ -79,7 +79,7 @@ see the link:https://github.com/kubernetes/community/blob/master/contributors/de
 | False
 
 | *DevicePlugins*
-| Enables device plug-in-based resource provisioning on nodes.
+| Enables device plugin-based resource provisioning on nodes.
 | True
 
 | *DryRun*

--- a/modules/persistent-storage-csi-driver-daemonset.adoc
+++ b/modules/persistent-storage-csi-driver-daemonset.adoc
@@ -17,6 +17,6 @@ UNIX Domain Socket available on the node.
 * A CSI driver.
 
 The CSI driver deployed on the node should have as few credentials to the
-storage back end as possible. {product-title} will only use the node plug-in
+storage back end as possible. {product-title} will only use the node plugin
 set of CSI calls such as `NodePublish`/`NodeUnpublish` and
 `NodeStage`/`NodeUnstage`, if these calls are implemented.

--- a/modules/running-your-dynamic-plug-in.adoc
+++ b/modules/running-your-dynamic-plug-in.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="running-your-dynamic-plugin_{context}"]
-= Running your dynamic plug-in
+= Running your dynamic plugin
 
-You can run the plug-in using a local development environment. The {product-title} web console runs in a container connected to the cluster you have logged into.
+You can run the plugin using a local development environment. The {product-title} web console runs in a container connected to the cluster you have logged into.
 
 .Prerequisites
 * You must have the OpenShift CLI (`oc`) installed.
@@ -15,7 +15,7 @@ You can run the plug-in using a local development environment. The {product-titl
 
 .Procedure
 
-. Build a plug-in and generate the output to the `dist` directory by running
+. Build a plugin and generate the output to the `dist` directory by running
 +
 [source,terminal]
 ----
@@ -47,7 +47,7 @@ Hit CTRL-C to stop the server
 $ yarn http-server -a <server name>
 ----
 
-.  Direct `bridge` to proxy requests to your local plug-in asset server by running
+.  Direct `bridge` to proxy requests to your local plugin asset server by running
 +
 [source,terminal]
 ----
@@ -55,4 +55,4 @@ $ ./bin/bridge -plugins console-demo-plugin=http://localhost:9001/
 ----
 
 .Verification
-* Visit link:http://localhost:9000/example[local host] to view the running plug-in. Inspect the value of `window.SERVER_FLAGS.consolePlugins` to see the list of plug-ins which load at runtime.
+* Visit link:http://localhost:9000/example[local host] to view the running plugin. Inspect the value of `window.SERVER_FLAGS.consolePlugins` to see the list of plugins which load at runtime.

--- a/modules/storage-expanding-flexvolume.adoc
+++ b/modules/storage-expanding-flexvolume.adoc
@@ -21,7 +21,7 @@ Similar to other volume types, FlexVolume volumes can also be expanded when in u
 
 .Procedure
 
-* To use resizing in the FlexVolume plug-in, you must implement the `ExpandableVolumePlugin` interface using these methods:
+* To use resizing in the FlexVolume plugin, you must implement the `ExpandableVolumePlugin` interface using these methods:
 
 `RequiresFSResize`::
 If `true`, updates the capacity directly. If `false`, calls the `ExpandFS` method to finish the filesystem resize.
@@ -31,5 +31,5 @@ If `true`, calls `ExpandFS` to resize filesystem after physical volume expansion
 
 [IMPORTANT]
 ====
-Because {product-title} does not support installation of FlexVolume plug-ins on control plane nodes, it does not support control-plane expansion of FlexVolume.
+Because {product-title} does not support installation of FlexVolume plugins on control plane nodes, it does not support control-plane expansion of FlexVolume.
 ====

--- a/modules/storage-persistent-storage-lifecycle.adoc
+++ b/modules/storage-persistent-storage-lifecycle.adoc
@@ -58,7 +58,7 @@ PVs by including `persistentVolumeClaim` in the pod's volumes block.
 ====
 If you attach persistent volumes that have high file counts to pods, those pods can fail or can take a long time to start. For
 more information, see link:https://access.redhat.com/solutions/6221251[When using Persistent Volumes with high file counts in OpenShift, why do pods fail to start or take an excessive amount of time to achieve "Ready" state?].
-==== 
+====
 
 ifdef::openshift-origin,openshift-enterprise,openshift-webscale[]
 
@@ -94,7 +94,7 @@ The reclaim policy of a persistent volume tells the cluster what to do with the 
 `Retain`, `Recycle`, or `Delete`.
 
 * `Retain` reclaim policy allows manual reclamation of the resource for
-those volume plug-ins that support it.
+those volume plugins that support it.
 
 * `Recycle` reclaim policy recycles the volume back into the pool of
 unbound persistent volumes once it is released from its claim.

--- a/modules/storage-persistent-storage-overview.adoc
+++ b/modules/storage-persistent-storage-overview.adoc
@@ -24,7 +24,7 @@ piece of existing storage in the cluster that was either statically provisioned
 by the cluster administrator or dynamically provisioned using a `StorageClass` object. It is a resource in the cluster just like a
 node is a cluster resource.
 
-PVs are volume plug-ins like `Volumes` but
+PVs are volume plugins like `Volumes` but
 have a lifecycle that is independent of any individual pod that uses the
 PV. PV objects capture the details of the implementation of the storage,
 be that NFS, iSCSI, or a cloud-provider-specific storage system.

--- a/modules/windows-node-services.adoc
+++ b/modules/windows-node-services.adoc
@@ -20,10 +20,10 @@ The following Windows-specific services are installed on each Windows node:
 |Exposes link:https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#networking[networking] for Windows nodes.
 
 |Windows Machine Config Bootstrapper (WMCB)
-|Configures the kubelet and CNI plug-ins.
+|Configures the kubelet and CNI plugins.
 
 |link:https://github.com/openshift/prometheus-community-windows_exporter[Windows Exporter]
-|Exports Prometheus metrics from Windows nodes 
+|Exports Prometheus metrics from Windows nodes
 
 |link:https://kubernetes.io/docs/concepts/architecture/cloud-controller/[Kubernetes Cloud Controller Manager (CCM)]
 |Interacts with the underlying Azure cloud platform.

--- a/networking/cluster-network-operator.adoc
+++ b/networking/cluster-network-operator.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The Cluster Network Operator (CNO) deploys and manages the cluster network components on an {product-title} cluster, including the Container Network Interface (CNI) default network provider plug-in selected for the cluster during installation.
+The Cluster Network Operator (CNO) deploys and manages the cluster network components on an {product-title} cluster, including the Container Network Interface (CNI) default network provider plugin selected for the cluster during installation.
 
 include::modules/nw-cluster-network-operator.adoc[leveloffset=+1]
 

--- a/networking/networking-operators-overview.adoc
+++ b/networking/networking-operators-overview.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 [id="networking-operators-overview-cluster-network-operator"]
 == Cluster Network Operator
-The Cluster Network Operator (CNO) deploys and manages the cluster network components in an {product-title} cluster. This includes deployment of the Container Network Interface (CNI) default network provider plug-in selected for the cluster during installation. For more information, see xref:../networking/cluster-network-operator.adoc#cluster-network-operator[Cluster Network Operator in {product-title}].
+The Cluster Network Operator (CNO) deploys and manages the cluster network components in an {product-title} cluster. This includes deployment of the Container Network Interface (CNI) default network provider plugin selected for the cluster during installation. For more information, see xref:../networking/cluster-network-operator.adoc#cluster-network-operator[Cluster Network Operator in {product-title}].
 
 [id="networking-operators-overview-dns-operator"]
 == DNS Operator

--- a/networking/openshift_sdn/about-openshift-sdn.adoc
+++ b/networking/openshift_sdn/about-openshift-sdn.adoc
@@ -17,7 +17,7 @@ include::modules/nw-openshift-sdn-modes.adoc[leveloffset=+1]
 ifdef::openshift-origin[]
 [NOTE]
 ====
-{product-title} uses the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes Container Network Interface (CNI) plug-in] by default.
+{product-title} uses the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes Container Network Interface (CNI) plugin] by default.
 ====
 endif::openshift-origin[]
 endif::[]

--- a/networking/openshift_sdn/multitenant-isolation.adoc
+++ b/networking/openshift_sdn/multitenant-isolation.adoc
@@ -24,7 +24,7 @@ other projects.
 == Prerequisites
 
 * You must have a cluster configured to use the OpenShift SDN Container Network
-Interface (CNI) plug-in in multitenant isolation mode.
+Interface (CNI) plugin in multitenant isolation mode.
 
 include::modules/nw-multitenant-joining.adoc[leveloffset=+1]
 include::modules/nw-multitenant-isolation.adoc[leveloffset=+1]

--- a/web_console/dynamic-plug-ins.adoc
+++ b/web_console/dynamic-plug-ins.adoc
@@ -1,14 +1,14 @@
 :_content-type: ASSEMBLY
 [id="adding-dynamic-plugin-to-console"]
-= Adding a dynamic plug-in to the {product-title} web console
+= Adding a dynamic plugin to the {product-title} web console
 include::_attributes/common-attributes.adoc[]
 :context: dynamic-plugins
 
 toc::[]
 
-You can create and deploy a dynamic plug-in on your cluster that is loaded at run-time.
+You can create and deploy a dynamic plugin on your cluster that is loaded at run-time.
 
-:FeatureName: Creating a dynamic plug-in
+:FeatureName: Creating a dynamic plugin
 include::snippets/technology-preview.adoc[leveloffset=+1]
 //
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.8-4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-4815

Link to docs preview:
Not providing links since there are 23 files and these are just single word replacements.

QE review:
- No QE required

Additional information:
This isn't going to main because I already got most everything in main and backward. Now catching some instances of "plug-in" that only exist in older versions.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
