### PR TITLE
[SRVCOM-2166] Add Serverless 1.27.0 release notes

### DIFF
--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -13,19 +13,33 @@ For the most recent list of major functionality deprecated and removed within {S
 // OCP + OSD table
 ifdef::openshift-enterprise,openshift-dedicated[]
 .Deprecated and removed features tracker
-[cols="3,1,1,1",options="header"]
+[cols="3,1,1,1,1",options="header"]
 |====
-|Feature |1.20|1.21|1.22 to 1.26
+|Feature |1.20|1.21|1.22 to 1.26|1.27
 
 |`KafkaBinding` API
 |Deprecated
 |Deprecated
+|Removed
 |Removed
 
 |`kn func emit` (`kn func invoke` in 1.21+)
 |Deprecated
 |Removed
 |Removed
+|Removed
+
+|Serving and Eventing `v1alpha1` API
+|-
+|-
+|-
+|Deprecated
+
+// |`enable-secret-informer-filtering` annotation
+// |-
+// |-
+// |-
+// |Deprecated
 
 |====
 endif::[]
@@ -33,21 +47,21 @@ endif::[]
 // ROSA table
 ifdef::openshift-rosa[]
 .Deprecated and removed features tracker
-[cols="3,1,1,1",options="header"]
+[cols="3,1,1",options="header"]
 |====
-|Feature |1.23|1.24|1.25|1.26
+|Feature |1.23 to 1.26|1.27
 
 |`KafkaBinding` API
-|Removed
-|Removed
 |Removed
 |Removed
 
 |`kn func emit` (`kn func invoke` in 1.21+)
 |Removed
 |Removed
-|Removed
-|Removed
+
+|Serving and Eventing `v1alpha1` API
+|-
+|Deprecated
 
 |====
 endif::[]

--- a/modules/serverless-kafka-sink.adoc
+++ b/modules/serverless-kafka-sink.adoc
@@ -6,7 +6,7 @@
 [id="serverless-kafka-sink_{context}"]
 = Using a Kafka sink
 
-You can create an event sink called a Kafka sink that sends events to a Kafka topic. Creating Knative resources by using YAML files uses a declarative API, which enables you to describe applications declaratively and in a reproducible manner. To create a Kafka sink by using YAML, you must create a YAML file that defines a `KafkaSink` object, then apply it by using the `oc apply` command.
+You can create an event sink called a Kafka sink that sends events to a Kafka topic. Creating Knative resources by using YAML files uses a declarative API, which enables you to describe applications declaratively and in a reproducible manner. By default, a Kafka sink uses the binary content mode, which is more efficient than the structured mode. To create a Kafka sink by using YAML, you must create a YAML file that defines a `KafkaSink` object, then apply it by using the `oc apply` command.
 
 .Prerequisites
 

--- a/modules/serverless-rn-1-27-0.adoc
+++ b/modules/serverless-rn-1-27-0.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-27_{context}"]
+= Release notes for Red Hat {ServerlessProductName} 1.27
+
+{ServerlessProductName} 1.27 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+[IMPORTANT]
+====
+{ServerlessProductName} 1.26 is the earliest release that is fully supported on {product-title} 4.12. {ServerlessProductName} 1.25 and older does not deploy on {product-title} 4.12.
+
+For this reason, before upgrading {product-title} to version 4.12, first upgrade {ServerlessProductName} to version 1.26 or 1.27.
+====
+
+[id="new-features-1-27_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.6.
+* {ServerlessProductName} now uses Knative Eventing 1.6.
+* {ServerlessProductName} now uses Kourier 1.6.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.6.
+* {ServerlessProductName} now uses Knative Kafka 1.6.
+* The `kn func` CLI plug-in now uses `func` 1.8.1.
+
+* Namespace-scoped brokers are now available as a Technology Preview. Such brokers can be used, for instance, to implement role-based access control (RBAC) policies.
+
+* `KafkaSink` now uses the `CloudEvent` binary content mode by default. The binary content mode is more efficient than the structured mode because it uses headers in its body instead of a `CloudEvent`. For example, for the HTTP protocol, it uses HTTP headers.
+
+* You can now use the gRPC framework over the HTTP/2 protocol for external traffic using the OpenShift Route on {product-title} 4.10 and later. This improves efficiency and speed of the communications between the client and server.
+
+* API version `v1alpha1` of the Knative Operator Serving and Eventings CRDs is deprecated in 1.27. It will be removed in future versions. Red Hat strongly recommends to use the `v1beta1` version instead. This does not affect the existing installations, because CRDs are updated automatically when upgrading the Serverless Operator.
+
+* The delivery timeout feature is now enabled by default. It allows you to specify the timeout for each sent HTTP request. The feature remains a Technology Preview.
+
+[id="fixed-issues-1-27_{context}"]
+== Fixed issues
+
+* Previously, Knative services sometimes did not get into the `Ready` state, reporting waiting for the load balancer to be ready. This issue has been fixed.
+
+[id="known-issues-1-27_{context}"]
+== Known issues
+
+* Integrating {ServerlessProductName} with {SMProductName} causes the `net-kourier` pod to run out of memory on startup when too many secrets are present on the cluster.
+
+* Namespace-scoped brokers might leave `ClusterRoleBindings` in the user namespace even after deletion of namespace-scoped brokers.
++
+If this happens, delete the `ClusterRoleBinding` named `rbac-proxy-reviews-prom-rb-knative-kafka-broker-data-plane-{{.Namespace}}` in the user namespace.
+
+* If you use `net-istio` for Ingress and enable mTLS via SMCP using `security.dataPlane.mtls: true`, Service Mesh deploys `DestinationRules` for the `*.local` host, which does not allow `DomainMapping` for {ServerlessProductName}.
++
+To work around this issue, enable mTLS by deploying `PeerAuthentication` instead of using `security.dataPlane.mtls: true`.
+

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -13,17 +13,19 @@ The following table provides information about which {ServerlessProductName} fea
 // OCP + OSD table
 ifdef::openshift-enterprise,openshift-dedicated[]
 .Generally Available and Technology Preview features tracker
-[cols="3,1,1,1,1",options="header"]
+[cols="3,1,1,1,1,1",options="header"]
 |====
-|Feature |1.23|1.24|1.25|1.26
+|Feature |1.23|1.24|1.25|1.26|1.27
 
 |`kn func`
 |TP
 |TP
 |TP
 |GA
+|GA
 
 |Service Mesh mTLS
+|GA
 |GA
 |GA
 |GA
@@ -34,8 +36,10 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |GA
 |GA
 |GA
+|GA
 
 |HTTPS redirection
+|GA
 |GA
 |GA
 |GA
@@ -46,15 +50,18 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |TP
 |GA
 |GA
+|GA
 
 |Kafka sink
 |TP
 |TP
 |GA
 |GA
+|GA
 
 |Init containers support for Knative services
 |TP
+|GA
 |GA
 |GA
 |GA
@@ -64,12 +71,22 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |TP
 |TP
 |GA
+|GA
 
 |TLS for internal traffic
 |-
 |-
 |TP
 |TP
+|TP
+
+|Namespace-scoped brokers
+|-
+|-
+|-
+|-
+|TP
+
 
 |====
 endif::[]
@@ -77,17 +94,19 @@ endif::[]
 // ROSA table
 ifdef::openshift-rosa[]
 .Generally Available and Technology Preview features tracker
-[cols="3,1,1,1,1",options="header"]
+[cols="3,1,1,1,1,1",options="header"]
 |====
-|Feature |1.23|1.24|1.25|1.26
+|Feature |1.23|1.24|1.25|1.26|1.27
 
 |`kn func`
 |TP
 |TP
 |TP
 |GA
+|GA
 
 |Service Mesh mTLS
+|GA
 |GA
 |GA
 |GA
@@ -98,8 +117,10 @@ ifdef::openshift-rosa[]
 |GA
 |GA
 |GA
+|GA
 
 |HTTPS redirection
+|GA
 |GA
 |GA
 |GA
@@ -110,8 +131,10 @@ ifdef::openshift-rosa[]
 |TP
 |GA
 |GA
+|GA
 
 |Kafka sink
+|TP
 |TP
 |TP
 |TP
@@ -122,17 +145,27 @@ ifdef::openshift-rosa[]
 |GA
 |GA
 |GA
+|GA
 
 |PVC support for Knative services
 |TP
 |TP
 |TP
 |GA
+|GA
 
 |TLS for internal traffic
 |-
 |-
 |TP
+|TP
+|TP
+
+|Namespace-scoped brokers
+|-
+|-
+|-
+|-
 |TP
 
 |====

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -28,6 +28,9 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-27-0.adoc[leveloffset=+1]
+
+// OCP + OSD + ROSA
 include::modules/serverless-rn-1-26-0.adoc[leveloffset=+1]
 // 1.26.0 additional resources
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-2166

Link to docs preview:
  GA/TP table, Deprecated & removed table, and the release notes for the current release:
    https://54913--docspreview.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-tech-preview-features_serverless-release-notes
  Note in the intro that Kafka sink uses binary content mode by default:
    https://54913--docspreview.netlify.app/openshift-enterprise/latest/serverless/develop/serverless-kafka-developer.html#serverless-kafka-developer-sink

QE review:
- [ ] QE has approved this change.