### PR TITLE
Replace the enable feature gate at install module

### DIFF
--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -22,7 +22,11 @@ include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+1]
 ** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#using-insights-operator[Using Insights Operator]
 ** xref:../../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints[Controlling pod placement by using pod topology spread constraints]
 
+include::modules/nodes-cluster-enabling-features-install.adoc[leveloffset=+1]
+
 include::modules/nodes-cluster-enabling-features-console.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-enabling-features-cli.adoc[leveloffset=+1]
+
+
 


### PR DESCRIPTION
Accidentally removed the Enable feature sets module at installation when [updating the feature gates for 4.12](https://github.com/openshift/openshift-docs/commit/baeca6b1041284130cba92697480e9caaa6a15bd#diff-225c1345cde5a15f7b7bcdada2533b57a2df3dfed5a54f77f811438817e85300L22), due to a merge error. This PR replaces the module.  No changes to the text.

Preview: [Enabling feature sets at installation](https://54956--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-install_nodes-cluster-enabling)

No QE required