### PR TITLE
OSDOCS-4871: Create release notes stub for 4-13 in main

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -35,8 +35,8 @@ Name: Release notes
 Dir: microshift_release_notes
 Distros: microshift
 Topics:
-- Name: MicroShift 4.12 release notes
-  File: microshift-4-12-release-notes
+- Name: MicroShift 4.13 release notes
+  File: microshift-4-13-release-notes
 ---
 Name: Getting Started
 Dir: microshift_getting_started

--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -1,0 +1,11 @@
+[id="microshift-4-13-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/attributes-microshift.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+Release note changes should be added/edited in their own PR.
+
+This file is here to allow builds to work.

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -42,6 +42,12 @@ To navigate the {product-title} documentation, use the left navigation bar.
 For documentation that is not specific to {product-title}, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
 endif::[]
 
+ifdef::microshift[]
+To navigate the {product-title} documentation, use the left navigation bar.
+
+For documentation that is not specific to {product-title}, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
+endif::[]
+
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 Start with xref:../architecture/architecture.adoc#architecture-overview-architecture[Architecture] and
 xref:../security/container_security/security-understanding.adoc#understanding-security[Security and compliance].
@@ -57,11 +63,11 @@ endif::[]
 
 ifdef::microshift[]
 Start with xref:../microshift_getting_started/microshift-understanding.adoc#microshift-understanding[Understanding {product-title}] and xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm[Installing].
-Then, see the xref:../microshift_release_notes/microshift-4-12-release-notes.adoc#microshift-4-12-release-notes[release notes].
+Then, see the xref:../microshift_release_notes/microshift-4-13-release-notes.adoc#microshift-4-13-release-notes[release notes].
 
 [IMPORTANT]
 ====
-Red Hat will not provide or support an update or upgrade path from Developer Preview and Technology Preview versions to later versions of {product-title}. A new installation will be necessary.
+Red Hat does not provide or support an update or upgrade path from the Technology Preview version to later versions of {product-title}. A new installation is necessary.
 ====
 endif::[]
 


### PR DESCRIPTION
4.13-RNs: This PR places the stub in main for the MicroShift 4.13 release notes.

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-4871

Link to docs preview:

QE /SME review:
Not needed , internal docs repo structure.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
