### PR TITLE
OCPBUGS#6060 Firewall documentation should mention load balancer config

### DIFF
--- a/installing/installing-troubleshooting.adoc
+++ b/installing/installing-troubleshooting.adoc
@@ -6,8 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-To assist in troubleshooting a failed {product-title} installation, you can
-gather logs from the bootstrap and control plane, or master, machines. You can also get debug information from the installation program.
+To assist in troubleshooting a failed {product-title} installation, you can gather logs from the bootstrap and control plane machines. You can also get debug information from the installation program. If you are unable to resolve the issue using the logs and debug information, see xref:../support/troubleshooting/troubleshooting-installations.adoc#determining-where-installation-issues-occur_troubleshooting-installations[Determining where installation issues occur] for component-specific troubleshooting.
+
+[NOTE]
+====
+If your {product-title} installation fails and the debug output or logs contain network timeouts or other connectivity errors, review the guidelines for xref:../installing/install_config/configuring-firewall.adoc#configuring-firewall[configuring your firewall]. Gathering logs from your firewall and load balancer can help you diagnose network-related errors.
+====
 
 == Prerequisites
 

--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -10,6 +10,11 @@ Before you install {product-title}, you must configure your firewall to grant ac
 
 There are no special configuration considerations for services running on only controller nodes versus worker nodes.
 
+[NOTE]
+====
+If your environment has a dedicated load balancer in front of your {product-title} cluster, review the allowlists between your firewall and load balancer to prevent unwanted network restrictions to your cluster. 
+====
+
 .Procedure
 
 . Allowlist the following registry URLs:


### PR DESCRIPTION
Adding notes to firewall and troubleshooting docs to assist installation and troubleshooting in load balanced environments

Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/OCPBUGS-6060

Link to docs preview:
[Configuring your firewall (added note)](https://54975--docspreview.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html#configuring-firewall_configuring-firewall)
[Troubleshooting installation (added note)](https://54975--docspreview.netlify.app/openshift-enterprise/latest/installing/installing-troubleshooting.html)

QE review:
- [X] QE has approved this change.

