### PR TITLE
Update OCP versions in links

### DIFF
--- a/modules/create-additional-routes-ocp-oauth.adoc
+++ b/modules/create-additional-routes-ocp-oauth.adoc
@@ -10,7 +10,7 @@ However, you can create additional routes by specifying them as annotations in t
 
 .Prerequisites
 
-* You must have configured link:https://docs.openshift.com/container-platform/4.11/authentication/using-service-accounts-as-oauth-client.html#service-accounts-as-oauth-clients_using-service-accounts-as-oauth-client[Service accounts as OAuth clients] for your {ocp} OAuth server.
+* You must have configured link:https://docs.openshift.com/container-platform/4.12/authentication/using-service-accounts-as-oauth-client.html#service-accounts-as-oauth-clients_using-service-accounts-as-oauth-client[Service accounts as OAuth clients] for your {ocp} OAuth server.
 
 .Procedure
 

--- a/operating/manage-user-access/configure-ocp-oauth.adoc
+++ b/operating/manage-user-access/configure-ocp-oauth.adoc
@@ -25,12 +25,12 @@ $ oc -n stackrox set env deploy/central ROX_ENABLE_OPENSHIFT_AUTH=true
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.openshift.com/container-platform/4.9/authentication/identity_providers/configuring-ldap-identity-provider.html[Configuring an LDAP identity provider]
+* link:https://docs.openshift.com/container-platform/4.12/authentication/identity_providers/configuring-ldap-identity-provider.html[Configuring an LDAP identity provider]
 * xref:../../configuration/add-trusted-ca.adoc#add-trusted-ca[Adding trusted certificate authorities]
 
 include::modules/create-additional-routes-ocp-oauth.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.openshift.com/container-platform/4.11/authentication/using-service-accounts-as-oauth-client.html#service-accounts-as-oauth-clients_using-service-accounts-as-oauth-client[Service accounts as OAuth clients]
-* link:https://docs.openshift.com/container-platform/4.11/authentication/using-service-accounts-as-oauth-client.html#redirect-uris-for-service-accounts_using-service-accounts-as-oauth-client[Redirect URIs for service accounts as OAuth clients]
+* link:https://docs.openshift.com/container-platform/4.12/authentication/using-service-accounts-as-oauth-client.html#service-accounts-as-oauth-clients_using-service-accounts-as-oauth-client[Service accounts as OAuth clients]
+* link:https://docs.openshift.com/container-platform/4.12/authentication/using-service-accounts-as-oauth-client.html#redirect-uris-for-service-accounts_using-service-accounts-as-oauth-client[Redirect URIs for service accounts as OAuth clients]

--- a/operating/use-admission-controller-enforcement.adoc
+++ b/operating/use-admission-controller-enforcement.adoc
@@ -6,7 +6,8 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{product-title} works with link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/[Kubernetes admission controllers] and link:https://docs.openshift.com/container-platform/4.11/architecture/admission-plug-ins.html[{ocp} admission plugins] to allow you to enforce security policies before Kubernetes or {ocp} creates workloads, for example, deployments, daemon sets or jobs.
+//note that link below to OCP docs has to be done this way because the branch is separate from the RHACS branch so an xref cannot be used.
+{product-title} works with link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/[Kubernetes admission controllers] and link:https://docs.openshift.com/container-platform/4.12/architecture/admission-plug-ins.html[{ocp} admission plugins] to allow you to enforce security policies before Kubernetes or {ocp} creates workloads, for example, deployments, daemon sets or jobs.
 
 The {product-title} admission controller prevents users from creating workloads that violate policies you configure in {product-title}.
 Beginning from the {product-title} version 3.0.41, you can also configure the admission controller to prevent updates to workloads that violate policies.


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.73`
- Cherry pick to `rhacs-docs-3.74`

Issue: None - see [related OCP PR](https://github.com/openshift/openshift-docs/pull/54968)

Link to docs preview:
- https://54979--docspreview.netlify.app/openshift-acs/latest/operating/manage-user-access/configure-ocp-oauth.html#create-additional-routes-ocp-oauth_configure-ocp-oauth
- https://54979--docspreview.netlify.app/openshift-acs/latest/operating/manage-user-access/configure-ocp-oauth.html#configure-ocp-oauth-identity-provider_configure-ocp-oauth
- https://54979--docspreview.netlify.app/openshift-acs/latest/operating/use-admission-controller-enforcement.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change. **(N/A)**

Additional info: `link` used instead of `xref` for OCP docs from RHACS docs because they are in separate branches, so `xref` doesn't work when linking to OCP docs.

