### PR TITLE
Use `4.13` for microshift and skip Netlify step for merge commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       script:
         - python3 build.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch && python3 makeBuild.py
     - # stage name not required, will continue to use `build`
-      if: branch IN (main, enterprise-4.12)
+      if: branch IN (main, enterprise-4.12, enterprise-4.13)
       name: "Build microshift distro"
       before_install:
         - gem install asciidoctor
@@ -75,7 +75,7 @@ jobs:
       env:
         - CAN_FAIL=true
       language: minimal
-      if: branch IN (main, enterprise-4.12, enterprise-4.13) AND sender != "openshift-cherrypick-robot"
+      if: type IN (pull_request) AND branch IN (main, enterprise-4.12, enterprise-4.13) AND sender != "openshift-cherrypick-robot"
       script:
         - chmod +x autopreview.sh && ./autopreview.sh
 

--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -262,3 +262,6 @@ microshift:
     enterprise-4.12:
       name: '4.12'
       dir: microshift/4.12
+    enterprise-4.13:
+      name: '4.13'
+      dir: microshift/4.13


### PR DESCRIPTION
Updates for :
- building microshift from `4.13`
- Skiping Netlify step for merge commits.