### PR TITLE
TELCODOCS-429 removing TP from Pod-level bonding for secondary networks CNF-3877 (TELCODOCS-429)

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -543,15 +543,10 @@ A new `--node-selector` argument provides a way to identify which nodes you are 
 For more information, see xref:../support/gathering-cluster-data.adoc#support-network-trace-methods_gathering-cluster-data[Network trace methods] and xref:../support/gathering-cluster-data.adoc#support-collecting-host-network-trace_gathering-cluster-data[Collecting a host network trace].
 
 [id="ocp-4-10-pod-level-bonding"]
-==== Pod-level bonding for secondary networks (Technology Preview)
+==== Pod-level bonding for secondary networks
 Bonding at the pod level is vital to enable workloads inside pods that require high availability and more throughput. With pod-level bonding, you can create a bond interface from multiple single root I/O virtualization (SR-IOV) virtual function interfaces in kernel mode interface. The SR-IOV virtual functions are passed into the pod and attached to a kernel driver.
 
 Scenarios where pod-level bonding is required include creating a bond interface from multiple SR-IOV virtual functions on different physical functions. Creating a bond interface from two different physical functions on the host can be used to achieve high availability at pod level.
-
-[NOTE]
-====
-The current functionality of Bond CNI is available only in active-backup mode. For further details, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2037214[*BZ#2037214*].
-====
 
 [id="ocp-4-10-egress-ip-support-public-clouds"]
 ==== Egress IP address support for clusters installed on public clouds
@@ -2424,7 +2419,7 @@ In the table below, features are marked with the following statuses:
 |Pod-level bonding for secondary networks
 |-
 |-
-|TP
+|xref:../release_notes/ocp-4-10-release-notes.adoc#ocp-4-10-30-pod-level-bonding-ga[GA]
 
 |IPv6 dual stack
 |-
@@ -2499,7 +2494,7 @@ In the table below, features are marked with the following statuses:
 |Web Terminal Operator
 |TP
 |TP
-|GA ^[1]^
+|xref:../release_notes/ocp-4-10-release-notes.adoc#ocp-4-10-14-web-terminal-operator-ga[GA]
 
 |{cgu-operator-full}
 |-
@@ -2512,10 +2507,6 @@ In the table below, features are marked with the following statuses:
 |TP
 
 |====
-[.small]
---
-1. Starting in version xref:../release_notes/ocp-4-10-release-notes.adoc#ocp-4-10-14-web-terminal-operator-ga[4.10.14].
---
 
 [id="ocp-4-10-known-issues"]
 == Known issues
@@ -3368,6 +3359,14 @@ You can view the container images in this release by running the following comma
 ----
 $ oc adm release info 4.10.30 --pullspecs
 ----
+
+[id="ocp-4-10-30-features"]
+==== Features
+
+[id="ocp-4-10-30-pod-level-bonding-ga"]
+===== General availability of pod-level bonding for secondary networks
+
+With this update, xref:../networking/hardware_networks/using-pod-level-bonding.html[*Using pod-level bonding*] is now generally available.
 
 [id="ocp-4-10-30-bug-fixes"]
 ==== Bug fixes


### PR DESCRIPTION
[TELCODOCS-429]: [CNF-3877](https://issues.redhat.com//browse/CNF-3877) Promote bond CNI to GA

Version(s):
4.12 RN

Issue:
https://issues.redhat.com/browse/TELCODOCS-429

see also PR https://github.com/openshift/openshift-docs/pull/47172 for context
Link to docs preview: http://file.emea.redhat.com/kquinn/TELCODOCS-429-410/release_notes/ocp-4-10-release-notes.html#ocp-4-10-technology-preview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
