### PR TITLE
Adding BZ2120585

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2553,6 +2553,8 @@ configmap/gateway-mode-config created
 
 For additional guidance, see (link:https://access.redhat.com/solutions/6962127[*KCS*]) and (link:https://bugzilla.redhat.com/show_bug.cgi?id=2089389[*BZ#2089389*]). This setting will be addressed further in a future release.
 
+* It is not possible to create a macvlan on the physical function (PF) when a virtual function (VF) already exists. This issue affects the Intel E810 NIC. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2120585[*BZ#2120585*])
+
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
[BZ#2120585]: Intel E810 card unable to create a MACVLAN on interface already configured as SRIOV

Version(s):

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2120585
https://issues.redhat.com/browse/TELCODOCS-1115

Link to docs preview:


QE review: Merged to 4.12 in https://github.com/openshift/openshift-docs/pull/54573 needs merged in RN for 4.8. 

 QE has approved this change.
Additional information:
