### PR TITLE
Adding BZ2120585 Telcodocs 1115 49 RN

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2267,6 +2267,8 @@ The `machine-config-daemon` applies the performance profile configuration to the
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2021151[*BZ#2021151*])
 
+* It is not possible to create a macvlan on the physical function (PF) when a virtual function (VF) already exists. This issue affects the Intel E810 NIC. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2120585[*BZ#2120585*])
+
 [id="ocp-4-9-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
[BZ#2120585]: Intel E810 card unable to create a MACVLAN on interface already configured as SRIOV

Version(s):

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2120585
https://issues.redhat.com/browse/TELCODOCS-1115

Link to docs preview: no preview generated

QE review:Merged to 4.12 in https://github.com/openshift/openshift-docs/pull/54573 needs merged in RN for 4.9.

QE has approved this change.
Additional information:
