### PR TITLE
adding BZ2120585 to 411

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2476,6 +2476,7 @@ openshift.io/scc: hostmount-anyuid
 
 * Due to the inclusion of old images in some image indexes, running `oc adm catalog mirror` and `oc image mirror` might result in the following error: `error: unable to retrieve source image`. As a temporary workaround, you can use the `--skip-missing` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed].
 
+* It is not possible to create a macvlan on the physical function (PF) when a virtual function (VF) already exists. This issue affects the Intel E810 NIC. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2120585[*BZ#2120585*])
 
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
[BZ#2120585]: Intel E810 card unable to create a MACVLAN on interface already configured as SRIOV

Version(s):

Issue:
https://bugzilla.redhat.com/show_bug.cgi?id=2120585
https://issues.redhat.com/browse/TELCODOCS-1115

Link to docs preview:https://54992--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-known-issues

QE review: Merged to 4.12 in https://github.com/openshift/openshift-docs/pull/54573 needs merged in RN for 4.11. 

QE has approved this change.
Additional information: