### PR TITLE
GH#53054 modules/update-upgrading-cli: Use 'oc adm upgrade' for current status

### DIFF
--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -18,24 +18,10 @@ of the Customer Portal.
 
 * Install the OpenShift CLI (`oc`) that matches the version for your updated version.
 * Log in to the cluster as user with `cluster-admin` privileges.
-* Install the `jq` package.
+
 * Pause all `MachineHealthCheck` resources.
 
 .Procedure
-
-. Ensure that your cluster is available:
-+
-[source,terminal]
-----
-$ oc get clusterversion
-----
-+
-.Example output
-[source,terminal]
-----
-NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
-version   4.9.23     True        False         158m    Cluster version is 4.9.23
-----
 
 . View the available updates and note the version number of the update that
 you want to apply:
@@ -51,7 +37,7 @@ $ oc adm upgrade
 Cluster version is 4.9.23
 
 Upstream is unset, so the cluster will use an appropriate default.
-Channel: stable-4.10 (available channels: candidate-4.10, candidate-4.9, fast-4.10, fast-4.9, stable-4.10, stable-4.9)
+Channel: stable-4.9 (available channels: candidate-4.10, candidate-4.9, fast-4.10, fast-4.9, stable-4.10, stable-4.9, eus-4.10)
 
 Recommended updates:
 
@@ -64,30 +50,27 @@ VERSION IMAGE
 4.9.29  quay.io/openshift-release-dev/ocp-release@sha256:b04ca01d116f0134a102a57f86c67e5b1a3b5da1c4a580af91d521b8fa0aa6ec
 4.9.31  quay.io/openshift-release-dev/ocp-release@sha256:2a28b8ebb53d67dd80594421c39e36d9896b1e65cb54af81fbb86ea9ac3bf2d7
 4.9.32  quay.io/openshift-release-dev/ocp-release@sha256:ecdb6d0df547b857eaf0edb5574ddd64ca6d9aff1fa61fd1ac6fb641203bedfa
-4.10.3  quay.io/openshift-release-dev/ocp-release@sha256:7ffe4cd612be27e355a640e5eec5cd8f923c1400d969fd590f806cffdaabcc56
-4.10.4  quay.io/openshift-release-dev/ocp-release@sha256:9f9c3aaca64f62af992bae5de1e984571c8b812f598b74c84dc630b064389fb7
-4.10.5  quay.io/openshift-release-dev/ocp-release@sha256:ee6a9c7a11f883e90489229f6c6dc78b434af12f5646f4f9411d73a98969f02a
-4.10.6  quay.io/openshift-release-dev/ocp-release@sha256:88b394e633e09dc23aa1f1a61ededd8e52478edf34b51a7dbbb21d9abde2511a
-4.10.8  quay.io/openshift-release-dev/ocp-release@sha256:0696e249622b4d07d8f4501504b6c568ed6ba92416176a01a12b7f1882707117
-4.10.9  quay.io/openshift-release-dev/ocp-release@sha256:39f360002b9b5c730d1167879ad6437352d51e72acc9fe80add3ec2a0d20400d
-4.10.10 quay.io/openshift-release-dev/ocp-release@sha256:39efe13ef67cb4449f5e6cdd8a26c83c07c6a2ce5d235dfbc3ba58c64418fcf3
-4.10.11 quay.io/openshift-release-dev/ocp-release@sha256:0dc1a4b4d9ea7954987f63e506474a4f0dc55e5f1ea5c1f6f1179e2c09eaffda
-4.10.12 quay.io/openshift-release-dev/ocp-release@sha256:f77f4f75c1e1a4ddd0a0355f298a834db3473fd9ca473235013e9419d1df16db
-4.10.13 quay.io/openshift-release-dev/ocp-release@sha256:4f516616baed3cf84585e753359f7ef2153ae139c2e80e0191902fbd073c4143
-----
 
-. Based on your organization requirements, set the upgrade channel to `stable-{product-version}`, `fast-{product-version}`, or `eus-{product-version}`:
+----
++
+[NOTE]
+====
+For details and information on how to perform an `EUS-to-EUS` channel upgrade, please refer to the 
+_Preparing to perform an EUS-to-EUS upgrade_ page, listed in the Additional resources section.
+====
+
+. Based on your organization requirements, set the appropriate upgrade channel. For example, you can set your channel to `stable-4.10`, `fast-4.10`, or `eus-4.10`. For more information about channels, refer to _Understanding update channels and releases_ listed in the Additional resources section.
 +
 [source,terminal]
 ----
 $ oc adm upgrade channel <channel>
 ----
 +
-For example, to set the channel to `stable-{product-version}`:
+For example, to set the channel to `stable-4.10`:
 +
-[source,terminal,subs="attributes+"]
+[source,terminal]
 ----
-$ oc adm upgrade channel stable-{product-version}
+$ oc adm upgrade channel stable-4.10
 ----
 +
 [IMPORTANT]
@@ -116,78 +99,30 @@ $ oc adm upgrade --to=<version> <1>
 +
 [source,terminal]
 ----
-$ oc get clusterversion -o json|jq ".items[0].spec"
+$ oc adm upgrade
 ----
-+
-.Example output
-[source,terminal,subs="attributes+"]
-----
-{
-  "channel": "stable-{product-version}",
-  "clusterID": "990f7ab8-109b-4c95-8480-2bd1deec55ff",
-  "desiredUpdate": {
-    "force": false,
-    "image": "quay.io/openshift-release-dev/ocp-release@sha256:9c5f0df8b192a0d7b46cd5f6a4da2289c155fd5302dec7954f8f06c878160b8b",
-    "version": "<version>" <1>
-  }
-}
-----
-<1> If the `version` number in the `desiredUpdate` stanza matches the value that
-you specified, the update is in progress.
-
-. Review the cluster version status history to monitor the status of the update.
-It might take some time for all the objects to finish updating.
-+
-[source,terminal]
-----
-$ oc get clusterversion -o json|jq ".items[0].status.history"
-----
-+
-.Example output
-[source,terminal]
-----
-[
-  {
-    "completionTime": null,
-    "image": "quay.io/openshift-release-dev/ocp-release@sha256:b8fa13e09d869089fc5957c32b02b7d3792a0b6f36693432acc0409615ab23b7",
-    "startedTime": "2021-01-28T20:30:50Z",
-    "state": "Partial",
-    "verified": true,
-    "version": "4.10.13"
-  },
-  {
-    "completionTime": "2021-01-28T20:30:50Z",
-    "image": "quay.io/openshift-release-dev/ocp-release@sha256:b8fa13e09d869089fc5957c32b02b7d3792a0b6f36693432acc0409615ab23b7",
-    "startedTime": "2021-01-28T17:38:10Z",
-    "state": "Completed",
-    "verified": false,
-    "version": "4.9.23"
-  }
-]
-----
-+
-The history contains a list of the most recent versions applied to the cluster.
-This value is updated when the CVO applies an update. The list is ordered by
-date, where the newest update is first in the list. Updates in the history have
-state `Completed` if the rollout completed and `Partial` if the update failed
-or did not complete.
 
 . After the update completes, you can confirm that the cluster version has
 updated to the new version:
 +
 [source,terminal]
 ----
-$ oc get clusterversion
+$ oc adm upgrade
 ----
 +
 .Example output
-[source,terminal,subs="attributes+"]
-----
-NAME      VERSION     AVAILABLE   PROGRESSING   SINCE     STATUS
-version   {product-version}      True        False         2m        Cluster version is {product-version}
+[source,terminal]
 ----
 
-. If you are upgrading your cluster to the next minor version, like version 4.y to 4.(y+1), it is recommended to confirm your nodes are upgraded before deploying workloads that rely on a new feature:
+Cluster version is <version> 
+
+Upstream is unset, so the cluster will use an appropriate default.
+Channel: stable-4.10 (available channels: candidate-4.10, candidate-4.11, eus-4.10, fast-4.10, fast-4.11, stable-4.10) 
+
+No updates available. You may force an upgrade to a specific release image, but doing so might not be supported and might result in downtime or data loss.
+----
++
+. If you are upgrading your cluster to the next minor version, such as version X.y to X.(y+1), it is recommended to confirm that your nodes are upgraded before deploying workloads that rely on a new feature:
 +
 [source,terminal]
 ----
@@ -198,10 +133,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.25.0
-ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.25.0
-ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.25.0
-ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.25.0
-ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.25.0
-ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.25.0
+ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.23.12+8a6bfe4
+ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.23.12+8a6bfe4
+ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.23.12+8a6bfe4
+ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.23.12+8a6bfe4
+ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.23.12+8a6bfe4
+ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.23.12+8a6bfe4
 ----

--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -60,6 +60,7 @@ include::modules/update-upgrading-cli.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../updating/preparing-eus-eus-upgrade.adoc#preparing-eus-eus-upgrade[Preparing to perform an EUS-to-EUS update]
 * xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding upgrade channels and releases]
 
 include::modules/update-conditional-updates.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.10+

Issue:
Resolving conflicts from https://github.com/openshift/openshift-docs/pull/53054

Link to docs preview:
https://55005--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-cluster-cli.html#update-upgrading-cli_updating-cluster-cli

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
