### PR TITLE
RHDEVDOCS-4351-update-description-of-CMO-in-overview

### DIFF
--- a/modules/monitoring-default-monitoring-components.adoc
+++ b/modules/monitoring-default-monitoring-components.adoc
@@ -15,7 +15,7 @@ By default, the {product-title} {product-version} monitoring stack includes thes
 |Component|Description
 
 |Cluster Monitoring Operator
-|The Cluster Monitoring Operator (CMO) is a central component of the monitoring stack. It deploys and manages Prometheus instances, the Thanos Querier, the Telemeter Client, and metrics targets and ensures that they are up to date. The CMO is deployed by the Cluster Version Operator (CVO).
+|The Cluster Monitoring Operator (CMO) is a central component of the monitoring stack. It deploys, manages, and automatically updates Prometheus and Alertmanager instances, Thanos Querier, Telemeter Client, and metrics targets. The CMO is deployed by the Cluster Version Operator (CVO).
 
 |Prometheus Operator
 |The Prometheus Operator (PO) in the `openshift-monitoring` project creates, configures, and manages platform Prometheus instances and Alertmanager instances. It also automatically generates monitoring target configurations based on Kubernetes label queries.
@@ -39,10 +39,10 @@ By default, the {product-title} {product-version} monitoring stack includes thes
 |The `node-exporter` agent (NE in the preceding diagram) collects metrics about every node in a cluster. The `node-exporter` agent is deployed on every node.
 
 |Thanos Querier
-|The Thanos Querier aggregates and optionally deduplicates core {product-title} metrics and metrics for user-defined projects under a single, multi-tenant interface.
+|Thanos Querier aggregates and optionally deduplicates core {product-title} metrics and metrics for user-defined projects under a single, multi-tenant interface.
 
 |Telemeter Client
-|The Telemeter Client sends a subsection of the data from platform Prometheus instances to Red Hat to facilitate Remote Health Monitoring for clusters.
+|Telemeter Client sends a subsection of the data from platform Prometheus instances to Red Hat to facilitate Remote Health Monitoring for clusters.
 
 |===
 


### PR DESCRIPTION
Summary: This PR adds Alertmanager into the CMO description and makes some minor edits to the wording.

- Aligned team: DevTools
- For branches: 4.8+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4351
- Direct link to doc preview: https://55016--docspreview.netlify.app/openshift-enterprise/latest/monitoring/monitoring-overview.html#default-monitoring-components_monitoring-overview
- SME review: n/a
- QE review: @juzhao 
- Peer review: @rolfedh 