### PR TITLE
Automatically set footer year

### DIFF
--- a/_templates/_footer_other.html.erb
+++ b/_templates/_footer_other.html.erb
@@ -8,7 +8,7 @@
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2022 Red Hat, Inc.</p>
+              <p class="text-nowrap">Copyright © <%= Time.now.year %> Red Hat, Inc.</p>
             </div>
 
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->
Current year in the footer for the copyright is incorrect (2022). 

This PR sets the right year automatically so you don't have to manually change it every year. This needs to be merged to just the `main` branch. I have done a local build to verify. 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): N/A
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: N/A
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
No preview available as no asciidoc file changed.

QE review: N/A
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

@openshift/team-documentation and @kalexand-rh FYI