### PR TITLE
Add missing letter p to word page

### DIFF
--- a/modules/nodes-cluster-resource-override-deploy-console.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-console.adoc
@@ -67,7 +67,7 @@ spec:
 
 .. On the *ClusterResourceOverride Operator* page, click *cluster*.
 
-.. On the *ClusterResourceOverride Details* age, click *YAML*. The `mutatingWebhookConfigurationRef` section appears when the webhook is called.
+.. On the *ClusterResourceOverride Details* page, click *YAML*. The `mutatingWebhookConfigurationRef` section appears when the webhook is called.
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Fixes #55036
Replaces: #55037

Version(s):
4.8+

Preview: [Installing the Cluster Resource Override Operator using the web console -> Step 4b](https://55044--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-resource-override-deploy-console_nodes-cluster-overcommit)

No QE review needed, typo