### PR TITLE
TechPreview feature set admonition update

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -12,6 +12,11 @@ You can activate the following feature set by using the `FeatureGate` CR:
 
 * `TechPreviewNoUpgrade`. This feature set is a subset of the current Technology Preview features. This feature set allows you to enable these tech preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents minor version updates. This feature set is not recommended on production clusters.
 +
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. Do not enable this feature set on production clusters.
+====
++
 The following Technology Preview features are enabled by this feature set:
 +
 *** Azure File (`CSIMigrationAzureFile`)

--- a/modules/nodes-cluster-enabling-features-cli.adoc
+++ b/modules/nodes-cluster-enabling-features-cli.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * nodes/cluster/nodes-cluster-enabling-features.adoc
+// * nodes/clusters/nodes-cluster-enabling-features.adoc
+// * post_installation_configuration/cluster-tasks.adoc
 
 :_content-type: PROCEDURE
 [id="nodes-cluster-enabling-features-cli_{context}"]
@@ -23,6 +24,12 @@ To enable feature sets:
 $ oc edit featuregate cluster
 ----
 +
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. Do not enable this feature set on production clusters.
+====
+
++
 .Sample FeatureGate custom resource
 [source,yaml]
 ----
@@ -41,11 +48,6 @@ spec:
 --
 +
 After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.
-+
-[NOTE]
-====
-Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
-====
 
 .Verification
 

--- a/modules/nodes-cluster-enabling-features-console.adoc
+++ b/modules/nodes-cluster-enabling-features-console.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * nodes/clusters/nodes-cluster-enabling-features.adoc
+// * post_installation_configuration/cluster-tasks.adoc
 
 :_content-type: PROCEDURE
 [id="nodes-cluster-enabling-features-console_{context}"]
@@ -22,6 +23,12 @@ To enable feature sets:
 
 . Edit the *cluster* instance to add specific feature sets:
 +
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. Do not enable this feature set on production clusters.
+====
+
++
 .Sample Feature Gate custom resource
 [source,yaml]
 ----
@@ -42,11 +49,7 @@ spec:
 --
 +
 After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.
-+
-[NOTE]
-====
-Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters. 
-====
+
 
 .Verification
 

--- a/modules/nodes-cluster-enabling-features-install.adoc
+++ b/modules/nodes-cluster-enabling-features-install.adoc
@@ -16,6 +16,12 @@ You can enable feature sets for all nodes in the cluster by editing the `install
 
 . Use the `featureSet` parameter to specify the name of the feature set you want to enable, such as `TechPreviewNoUpgrade`:
 +
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. Do not enable this feature set on production clusters.
+====
+
++
 .Sample `install-config.yaml` file with an enabled feature set
 
 [source,yaml]
@@ -39,11 +45,6 @@ featureSet: TechPreviewNoUpgrade
 ----
 
 . Save the file and reference it when using the installation program to deploy the cluster.
-
-[NOTE]
-====
-Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
-====
 
 .Verification
 


### PR DESCRIPTION
Versions: 4.8+

This PR improves the visibility of an important admonition about enabling the TechPreviewNoUpgrade feature set. The PR is made in response to a case where a customer enabled the feature set on their production cluster, and will either need to migrate their workloads onto a new cluster, or risk performing an unsupported action by doing a force update.

Two changes have been made to the admonition:
1. The admonition has been changed from a NOTE to a WARNING. When enabled on a production cluster, the potential consequences seem to satisfy the [Red Hat Supplementary Style Guide's description of Warnings](https://redhat-documentation.github.io/supplementary-style-guide/#admonitions). 
2. The admonition has been moved near the beginning of the step where users will actually enable the feature set and save their changes. Currently, this admonition is located near the end of the procedure. Users who perform procedures as they read them might not see this admonition until they have already saved their changes.

Preview:
https://55047--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-install_nodes-cluster-enabling
