### PR TITLE
Fixed bullet levels in tech preview feature set list

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -14,6 +14,8 @@ You can activate the following feature set by using the `FeatureGate` CR:
 +
 The following Technology Preview features are enabled by this feature set:
 +
+--
+** CSI automatic migration. Enables automatic migration for supported in-tree volume plugins to their equivalent Container Storage Interface (CSI) drivers. Supported for:
 *** Azure File (`CSIMigrationAzureFile`)
 *** VMware vSphere (`CSIMigrationvSphere`)
 ** Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds. Enables the Container Storage Interface (CSI) (`CSIDriverSharedResource`).
@@ -22,8 +24,9 @@ The following Technology Preview features are enabled by this feature set:
 ** cgroups v2. Enables cgroup v2, the next version of the Linux cgroup API (`CGroupsV2`).
 ** crun. Enables the crun container runtime (`Crun`).
 ** Insights Operator. Enables the Insights Operator, which gathers {product-title} configuration data and sends it to Red Hat (`InsightsConfigAPI`).
-* External cloud providers. Enables support for external cloud providers for clusters on vSphere, AWS, Azure, and GCP. Support for OpenStack is GA. (`ExternalCloudProvider`)
-* Pod topology spread constraints. Enables the `matchLabelKeys` parameter for pod topology contraints. The parameter is list of pod label keys to select the pods over which spreading will be calculated (`MatchLabelKeysInPodTopologySpread`).
+** External cloud providers. Enables support for external cloud providers for clusters on vSphere, AWS, Azure, and GCP. Support for OpenStack is GA. (`ExternalCloudProvider`)
+** Pod topology spread constraints. Enables the `matchLabelKeys` parameter for pod topology contraints. The parameter is list of pod label keys to select the pods over which spreading will be calculated (`MatchLabelKeysInPodTopologySpread`).
+--
 
 ////
 Do not document per Derek Carr: https://github.com/openshift/api/pull/370#issuecomment-510632939

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -10,7 +10,8 @@ As an administrator, you can use feature gates to enable features that are not p
 
 include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+1]
 
-* For more information about the features activated by the `TechPreviewNoUpgrade` feature gate, see the following topics:
+For more information about the features activated by the `TechPreviewNoUpgrade` feature gate, see the following topics:
+
 ** xref:../../storage/container_storage_interface/ephemeral-storage-csi-inline.adoc#ephemeral-storage-csi-inline[CSI inline ephemeral volumes]
 ** xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration]
 ** xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Using Container Storage Interface (CSI)]


### PR DESCRIPTION
The features listed for the TechPreviewNoUpgrade feature set were formatted incorrectly in the list. 

Preview: [Understanding feature sets](https://55057--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)

[Link to live docs for comparison](https://docs.openshift.com/container-platform/4.12/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)

No QE review needed
