### PR TITLE
OSDOCS-4868: Add step to remove manifests for control plane machine set

### DIFF
--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -166,14 +166,14 @@ $ rm -f <installation_directory>/openshift/99_openshift-cluster-api_master-machi
 By removing these files, you prevent the cluster from automatically generating control plane machines.
 endif::aws,azure,ash,gcp[]
 
-ifdef::aws[]
+ifdef::aws,gcp[]
 . Remove the Kubernetes manifest files that define the control plane machine set:
 +
 [source,terminal]
 ----
 $ rm -f <installation_directory>/openshift/99_openshift-machine-api_master-control-plane-machine-set.yaml
 ----
-endif::aws[]
+endif::aws,gcp[]
 
 ifdef::gcp[]
 ifndef::user-infra-vpc[]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
This PR addresses [osdocs-4868](https://issues.redhat.com//browse/osdocs-4868)

Link to docs preview:
[Creating the Kubernetes manifest and Ignition config files](https://55059--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-user-infra-generate-k8s-manifest-ignition_installing-gcp-user-infra) (step 3).

QE review:
- [x] QE has approved this change.
