### PR TITLE
OSDOCS-4853: Add step to remove manifests for control plane machine set

### DIFF
--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -166,14 +166,14 @@ $ rm -f <installation_directory>/openshift/99_openshift-cluster-api_master-machi
 By removing these files, you prevent the cluster from automatically generating control plane machines.
 endif::aws,azure,ash,gcp[]
 
-ifdef::aws,gcp[]
+ifdef::aws,ash,azure,gcp[]
 . Remove the Kubernetes manifest files that define the control plane machine set:
 +
 [source,terminal]
 ----
 $ rm -f <installation_directory>/openshift/99_openshift-machine-api_master-control-plane-machine-set.yaml
 ----
-endif::aws,gcp[]
+endif::aws,ash,azure,gcp[]
 
 ifdef::gcp[]
 ifndef::user-infra-vpc[]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
This issue addresses [osdocs-4853](https://issues.redhat.com/browse/OSDOCS-4853)

Link to docs preview:

- (Azure) [Creating the Kubernetes manifest and Ignition config files](https://55061--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#installation-user-infra-generate-k8s-manifest-ignition_installing-azure-user-infra) (step 3)
- (Azure Stack Hub) [Creating the Kubernetes manifest and Ignition config files](https://55061--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.html#installation-user-infra-generate-k8s-manifest-ignition_installing-azure-stack-hub-user-infra) (step 3)

QE review:
- [ ] QE has approved this change.
