### PR TITLE
Revert "TechPreview feature set admonition update"

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -12,11 +12,6 @@ You can activate the following feature set by using the `FeatureGate` CR:
 
 * `TechPreviewNoUpgrade`. This feature set is a subset of the current Technology Preview features. This feature set allows you to enable these tech preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents minor version updates. This feature set is not recommended on production clusters.
 +
-[WARNING]
-====
-Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. Do not enable this feature set on production clusters.
-====
-+
 The following Technology Preview features are enabled by this feature set:
 +
 --

--- a/modules/nodes-cluster-enabling-features-cli.adoc
+++ b/modules/nodes-cluster-enabling-features-cli.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
-// * nodes/clusters/nodes-cluster-enabling-features.adoc
-// * post_installation_configuration/cluster-tasks.adoc
+// * nodes/cluster/nodes-cluster-enabling-features.adoc
 
 :_content-type: PROCEDURE
 [id="nodes-cluster-enabling-features-cli_{context}"]
@@ -24,12 +23,6 @@ To enable feature sets:
 $ oc edit featuregate cluster
 ----
 +
-[WARNING]
-====
-Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. Do not enable this feature set on production clusters.
-====
-
-+
 .Sample FeatureGate custom resource
 [source,yaml]
 ----
@@ -48,6 +41,11 @@ spec:
 --
 +
 After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.
++
+[NOTE]
+====
+Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
+====
 
 .Verification
 

--- a/modules/nodes-cluster-enabling-features-console.adoc
+++ b/modules/nodes-cluster-enabling-features-console.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * nodes/clusters/nodes-cluster-enabling-features.adoc
-// * post_installation_configuration/cluster-tasks.adoc
 
 :_content-type: PROCEDURE
 [id="nodes-cluster-enabling-features-console_{context}"]
@@ -23,12 +22,6 @@ To enable feature sets:
 
 . Edit the *cluster* instance to add specific feature sets:
 +
-[WARNING]
-====
-Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. Do not enable this feature set on production clusters.
-====
-
-+
 .Sample Feature Gate custom resource
 [source,yaml]
 ----
@@ -49,7 +42,11 @@ spec:
 --
 +
 After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.
-
++
+[NOTE]
+====
+Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters. 
+====
 
 .Verification
 

--- a/modules/nodes-cluster-enabling-features-install.adoc
+++ b/modules/nodes-cluster-enabling-features-install.adoc
@@ -16,12 +16,6 @@ You can enable feature sets for all nodes in the cluster by editing the `install
 
 . Use the `featureSet` parameter to specify the name of the feature set you want to enable, such as `TechPreviewNoUpgrade`:
 +
-[WARNING]
-====
-Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. Do not enable this feature set on production clusters.
-====
-
-+
 .Sample `install-config.yaml` file with an enabled feature set
 
 [source,yaml]
@@ -45,6 +39,11 @@ featureSet: TechPreviewNoUpgrade
 ----
 
 . Save the file and reference it when using the installation program to deploy the cluster.
+
+[NOTE]
+====
+Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
+====
 
 .Verification
 


### PR DESCRIPTION
Reverts openshift/openshift-docs#55047

Reverting because we changed a "not recommended to" to "do not" and that would have required change management to sign off on.