### PR TITLE
OADP-443 broken breadcrumb

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -170,6 +170,7 @@
         <%= breadcrumb_group %>
       </li>
       <%= breadcrumb_subgroup_block %>
+      <%= breadcrumb_subsubgroup_block %>
       <li class="hidden-xs active">
         <%= breadcrumb_topic %>
       </li>

--- a/_templates/page.html.erb
+++ b/_templates/page.html.erb
@@ -8,7 +8,7 @@
     subgroup_id = topics[0] + "::" + topics[1]
     subsubgroup_id = topics[0] + "::" + topics[1] + "::" + topics[2]
     # TO DO if breadcrumbs become an issue
-    breadcrumb_subsubgroup_block = ""
+    #breadcrumb_subsubgroup_block = ""
     breadcrumb_topic = topic_title
   end
 %>
@@ -23,6 +23,7 @@
            :subgroup_id => subgroup_id,
            :subsubgroup_id => subsubgroup_id,
            :subgroup_title => subgroup_title,
+           :subsubgroup_title => subsubgroup_title,
            :topic_id => topic_id,
            :topic_title => topic_title,
            :article_title => article_title,

--- a/serverless/serverless-support.adoc
+++ b/serverless/serverless-support.adoc
@@ -27,3 +27,4 @@ When you open a support case, it is helpful to provide debugging information abo
 
 include::modules/about-must-gather.adoc[leveloffset=+2]
 include::modules/serverless-about-collecting-data.adoc[leveloffset=+2]
+


### PR DESCRIPTION
Version(s):
4.8+

Issue:
[OADP-443](https://issues.redhat.com//browse/OADP-443)

Link to docs preview:
https://55077--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html

