### PR TITLE
Add release notes for SBO v1.3.3

### DIFF
--- a/applications/connecting_applications_to_services/sbo-release-notes.adoc
+++ b/applications/connecting_applications_to_services/sbo-release-notes.adoc
@@ -41,6 +41,7 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 |*{servicebinding-title}* 2+|*API Group and Support Status*|*OpenShift Versions*
 
 |*Version*|*`binding.operators.coreos.com`* |*`servicebinding.io`* |
+|1.3.3    |GA                               |GA                    |4.9-4.12
 |1.3.1    |GA                               |GA                    |4.9-4.11
 |1.3      |GA                               |GA                    |4.9-4.11
 |1.2      |GA                               |GA                    |4.7-4.11
@@ -57,6 +58,7 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
 
 // Modules included, most to least recent
+include::modules/sbo-release-notes-1-3-3.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-3-1.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-3.adoc[leveloffset=+1]
 include::modules/sbo-release-notes-1-2.adoc[leveloffset=+1]

--- a/modules/sbo-release-notes-1-3-3.adoc
+++ b/modules/sbo-release-notes-1-3-3.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assembly:
+//
+// * applications/connecting_applications_to_services/sbo-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="sbo-release-notes-1-3-3_{context}"]
+= Release notes for {servicebinding-title} 1.3.3
+
+{servicebinding-title} 1.3.3 is now available on {product-title} 4.9, 4.10, 4.11 and 4.12.
+
+[id="fixed-issues-1-3-3_{context}"]
+== Fixed issues
+* Before this update, a security vulnerability `CVE-2022-41717` was noted for {servicebinding-title}. This update fixes the `CVE-2022-41717` error and updates the `golang.org/x/net` package from v0.0.0-20220906165146-f3363e06e74c to v0.4.0. link:https://issues.redhat.com/browse/APPSVC-1256[APPSVC-1256]
+
+* Before this update, Provisioned Services were only detected if the respective resource had the "servicebinding.io/provisioned-service: true" annotation set while other Provisioned Services were missed. With this update, the detection mechanism identifies all Provisioned Services correctly based on the "status.binding.name" attribute. link:https://issues.redhat.com/browse/APPSVC-1204[APPSVC-1204]


### PR DESCRIPTION
Signed-off-by: Pavel Macík <pavel.macik@gmail.com>

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
* 4.11
* 4.12
* 4.13 (Added gabriel-rh) 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Release notes for Service Binding Operator 1.3.3](https://55095--docspreview.netlify.app/openshift-enterprise/latest/applications/connecting_applications_to_services/sbo-release-notes.html#sbo-release-notes-1-3-3_servicebinding-release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
