### PR TITLE
OSDOCS-4884: Add notes for the 4.8.57 release

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -3779,3 +3779,22 @@ $ oc adm release info 4.8.56 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-8-57"]
+=== RHSA-2023:0237 - {product-title} 4.8.57 bug fix and security update
+
+Issued: 2023-01-25
+
+{product-title} release 4.8.57, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2023:0237[RHSA-2023:0237] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0236[RHBA-2023:0236] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.8.57 --pullspecs
+----
+
+[id="ocp-4-8-57-updating"]
+==== Updating
+
+To update an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4884](https://issues.redhat.com//browse/OSDOCS-4884) : Add notes for 4.8.57 release

Version(s):
4.8

Issue:
Jira [OSDOCS-4884](https://issues.redhat.com//browse/OSDOCS-4884)](https://issues.redhat.com/browse/OSDOCS-4884)

Links to docs preview: [Share drive](http://file.emea.redhat.com/dfitzmau/OSDOCS-4884/release_notes/)



QE review:
- [ ] QE has approved this change.

* QE not required for this change
