### PR TITLE
OSDOCS-4824: Update ROSA Quotas Table

### DIFF
--- a/modules/rosa-required-aws-service-quotas.adoc
+++ b/modules/rosa-required-aws-service-quotas.adoc
@@ -18,71 +18,88 @@ If you need to modify or increase a specific quota, see Amazon's documentation o
 
 [options="header"]
 |===
-|Quota name |Service code |Quota code| Minimum required value | Recommended value
+|Quota name |Service code |Quota code| Default | Recommended value | Description
 
-|Number of EIPs - VPC EIPs
+|EC2-VPC Elastic IPs
 |ec2
 |L-0263D0A3
 |5
 |5
+| The maximum number of Elastic IP addresses that you can allocate for EC2-VPC in this Region.
 
 |Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances
 |ec2
 |L-1216C47A
 |100
 |100
+| Maximum number of vCPUs assigned to the Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances.
+
+The default value of 5 vCPUs is not sufficient to create ROSA clusters. ROSA has a minimum requirement of 100 vCPUs for cluster creation.
 
 |VPCs per Region
 |vpc
 |L-F678F1CE
 |5
 |5
+| The maximum number of VPCs per Region. This quota is directly tied to the maximum number of internet gateways per Region.
 
 |Internet gateways per Region
 |vpc
 |L-A4707A72
 |5
 |5
+| The maximum number of internet gateways per Region. This quota is directly tied to the maximum number of VPCs per Region. To increase this quota, increase the number of VPCs per Region.
 
 |Network interfaces per Region
 |vpc
 |L-DF5E4CA3
 |5,000
 |5,000
+| The maximum number of network interfaces per Region.
 
-|General Purpose SSD (gp2) volume storage
+|Storage for General Purpose SSD (gp3) volume storage in TiB
 |ebs
-|L-D18FCD1D
+|L-7A658B76
 |50
 |300
+| The maximum aggregated amount of storage, in TiB, that can be provisioned across General Purpose SSD (gp2) volumes in this Region.
 
-|Number of EBS snapshots
+300 TiB of storage is the required minimum for optimal performance.
+
+|Snapshots per Region
 |ebs
 |L-309BACF6
-|300
-|300
+|10,000
+|10,000
+| The maximum number of snapshots per Region
 
-|Provisioned IOPS
+|IOPS for Provisioned IOPS SSD (Io1) volumes
 |ebs
 |L-B3A130E6
 |300,000
 |300,000
+| The maximum aggregated number of IOPS that can be provisioned across Provisioned IOPS SDD (io1) volumes in this Region.
 
-|Provisioned IOPS SSD (io1) volume storage
+|Storage for Provisioned IOPS SSD (io1) volumes in TiB
 |ebs
 |L-FD252861
 |50
 |300
+| The maximum aggregated amount of storage, in TiB, that can be provisioned across Provisioned IOPS SSD (io1) volumes in this Region.
+
+300 TiB of storage is the required minimum for optimal performance.
 
 |Application Load Balancers per Region
 |elasticloadbalancing
 |L-53DA6B97
 |50
 |50
+|
 
 |Classic Load Balancers per Region
 |elasticloadbalancing
 |L-E9E9831D
 |20
 |20
+|
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
`enterprise-4.12+`

Issue:
[OSDOCS-4824](https://issues.redhat.com/browse/OSDOCS-4824)

Link to docs preview:
[ROSA Quota](https://55120--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-required-aws-service-quotas.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Updated the ROSA Quotas table to match the AWS documentation