### PR TITLE
TechPreviewNoUpdate admonition change

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -12,6 +12,11 @@ You can activate the following feature set by using the `FeatureGate` CR:
 
 * `TechPreviewNoUpgrade`. This feature set is a subset of the current Technology Preview features. This feature set allows you to enable these tech preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents minor version updates. This feature set is not recommended on production clusters.
 +
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. You should not enable this feature set on production clusters.
+====
++
 The following Technology Preview features are enabled by this feature set:
 +
 --

--- a/modules/nodes-cluster-enabling-features-cli.adoc
+++ b/modules/nodes-cluster-enabling-features-cli.adoc
@@ -23,6 +23,12 @@ To enable feature sets:
 $ oc edit featuregate cluster
 ----
 +
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. You should not enable this feature set on production clusters.
+====
+
++
 .Sample FeatureGate custom resource
 [source,yaml]
 ----
@@ -41,11 +47,6 @@ spec:
 --
 +
 After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.
-+
-[NOTE]
-====
-Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
-====
 
 .Verification
 

--- a/modules/nodes-cluster-enabling-features-console.adoc
+++ b/modules/nodes-cluster-enabling-features-console.adoc
@@ -22,6 +22,12 @@ To enable feature sets:
 
 . Edit the *cluster* instance to add specific feature sets:
 +
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. You should not enable this feature set on production clusters.
+====
+
++
 .Sample Feature Gate custom resource
 [source,yaml]
 ----
@@ -42,11 +48,6 @@ spec:
 --
 +
 After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.
-+
-[NOTE]
-====
-Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters. 
-====
 
 .Verification
 

--- a/modules/nodes-cluster-enabling-features-install.adoc
+++ b/modules/nodes-cluster-enabling-features-install.adoc
@@ -16,6 +16,11 @@ You can enable feature sets for all nodes in the cluster by editing the `install
 
 . Use the `featureSet` parameter to specify the name of the feature set you want to enable, such as `TechPreviewNoUpgrade`:
 +
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. You should not enable this feature set on production clusters.
+====
++
 .Sample `install-config.yaml` file with an enabled feature set
 
 [source,yaml]
@@ -39,11 +44,6 @@ featureSet: TechPreviewNoUpgrade
 ----
 
 . Save the file and reference it when using the installation program to deploy the cluster.
-
-[NOTE]
-====
-Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
-====
 
 .Verification
 

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -640,6 +640,7 @@ endif::openshift-origin[]
 You can turn on a subset of the current Technology Preview features on for all nodes in the cluster by editing the `FeatureGate` custom resource (CR).
 
 include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+2]
+include::modules/nodes-cluster-enabling-features-console.adoc[leveloffset=+2]
 include::modules/nodes-cluster-enabling-features-cli.adoc[leveloffset=+2]
 
 [id="post-install-etcd-tasks"]


### PR DESCRIPTION
Versions: 4.8+

A fix of #55047 where the wording of the admonition has been reverted in this PR to avoid a change management issue.

Previews

Nodes section: https://55122--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html

Post install config section: https://55122--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#post-install-tp-tasks
