### PR TITLE
OCPBUGS-4561 update recommended host practices

### DIFF
--- a/modules/aws-console-changing-aws-instance-type.adoc
+++ b/modules/aws-console-changing-aws-instance-type.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/recommended-host-practices.adoc
+
+:_content-type: PROCEDURE
+[id="aws-console-changing-aws-instance-type_{context}"]
+= Changing the Amazon Web Services instance type by using the AWS console
+
+You can change the Amazon Web Services (AWS) instance type that your control plane machines use by updating the instance type in the AWS console.
+
+.Prerequisites
+
+* You have access to the AWS console with the permissions required to modify the EC2 Instance for your cluster.
+* You have access to the {product-title} cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Open the AWS console and fetch the instances for the control plane machines.
+
+. Choose one control plane machine instance.
+
+.. For the selected control plane machine, back up the etcd data by creating an etcd snapshot. For more information, see "Backing up etcd".
+
+.. In the AWS console, stop the control plane machine instance.
+
+.. Select the stopped instance, and click *Actions* -> *Instance Settings* -> *Change instance type*.
+
+.. Change the instance to a larger type, ensuring that the type is the same base as the previous selection, and apply changes. For example, you can change `m6i.xlarge` to `m6i.2xlarge` or `m6i.4xlarge`.
+
+.. Start the instance.
+
+.. If your {product-title} cluster has a corresponding `Machine` object for the instance, update the instance type of the object to match the instance type set in the AWS console.
+
+. Repeat this process for each control plane machine.

--- a/modules/master-node-sizing.adoc
+++ b/modules/master-node-sizing.adoc
@@ -109,7 +109,12 @@ Operator Lifecycle Manager (OLM ) runs on the control plane nodes and it's memor
 
 [IMPORTANT]
 ====
-If you used an installer-provisioned infrastructure installation method, you cannot modify the control plane node size in a running {product-title} {product-version} cluster. Instead, you must estimate your total node count and use the suggested control plane node size during installation.
+You can modify the control plane node size in a running {product-title} {product-version} cluster for the following configurations only:
+
+* Clusters installed with a user-provisioned installation method.
+* AWS clusters installed with an installer-provisioned infrastructure installation method.
+
+For all other configurations, you must estimate your total node count and use the suggested control plane node size during installation.
 ====
 
 [IMPORTANT]

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -21,7 +21,13 @@ include::modules/modify-unavailable-workers.adoc[leveloffset=+1]
 
 include::modules/master-node-sizing.adoc[leveloffset=+1]
 
-include::modules/increasing-aws-flavor-size.adoc[leveloffset=+2]
+[id="increasing-aws-flavor-size_{context}"]
+=== Selecting a larger Amazon Web Services instance type for control plane machines
+
+If the control plane machines in an Amazon Web Services (AWS) cluster require more resources, you can select a larger AWS instance type for the control plane machines to use.
+
+//Changing the Amazon Web Services instance type by using the AWS console
+include::modules/aws-console-changing-aws-instance-type.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s):
4.8-4.11

Issue:
https://issues.redhat.com/browse/OCPBUGS-4561

Link to docs preview (VPN required):
[Selecting a larger Amazon Web Services instance type for control plane machines](http://file.rdu.redhat.com/antaylor/OCPBUGS-4561/scalability_and_performance/recommended-host-practices.html#increasing-aws-flavor-size_recommended-host-practices)
[Control plane node sizing](http://file.rdu.redhat.com/antaylor/OCPBUGS-4561/scalability_and_performance/recommended-host-practices.html#master-node-sizing_recommended-host-practices)
 - See the `IMPORTANT` admonition at the bottom of this section.

QE review:
- [x] QE has approved this change.

Additional information:
This resolves IPI and "flavor" language and brings terminology up to date with AWS functions.
