### PR TITLE
TELCODOCS:1153b - Update variables for OSC release 1.3.3

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -50,8 +50,8 @@ endif::openshift-origin[]
 :sandboxed-containers-first: OpenShift sandboxed containers
 :sandboxed-containers-operator: OpenShift sandboxed containers Operator
 :sandboxed-containers-version: 1.3
-:sandboxed-containers-version-z: 1.3.0
-:sandboxed-containers-legacy-version: 1.2.2
+:sandboxed-containers-version-z: 1.3.3
+:sandboxed-containers-legacy-version: 1.3.2
 :cert-manager-operator: cert-manager Operator for Red Hat OpenShift
 :secondary-scheduler-operator-full: Secondary Scheduler Operator for Red Hat OpenShift
 :secondary-scheduler-operator: Secondary Scheduler Operator


### PR DESCRIPTION
Version(s): Main, 4.12

[Issue](https://issues.redhat.com/browse/TELCODOCS-1153)

Link to docs preview: This PR only includes an update to the common attributes file. No preview available.

QE review:
- [x] QE has approved this change.
