### PR TITLE
CNV-18203: reversing about-virt placeholder

### DIFF
--- a/virt/about-virt.adoc
+++ b/virt/about-virt.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
 Documentation for {VirtProductName} will be available for {product-title} {product-version} in the near future.
 
 ifdef::openshift-origin[]
@@ -15,8 +16,8 @@ endif::[]
 ifdef::openshift-enterprise[]
 In the meantime, the link:https://docs.openshift.com/container-platform/4.11/virt/about-virt.html[{VirtProductName} 4.11 documentation] is available as part of the {product-title} 4.11 documentation.
 endif::[]
-
 ////
+
 Learn about {VirtProductName}'s capabilities and support scope.
 
 include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
@@ -52,4 +53,3 @@ include::modules/virt-sno-differences.adoc[leveloffset=+1]
 * xref:../virt/live_migration/virt-live-migration.adoc#virt-live-migration[Live migration]
 
 * xref:../virt/live_migration/virt-configuring-vmi-eviction-strategy.adoc#virt-configuring-vmi-eviction-strategy[Eviction strategy]
-////


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-18203](https://issues.redhat.com//browse/CNV-18203)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

<!--- Link to docs preview: --->
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

<!--- QE review:
- [ ] QE has approved this change. --->
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Placeholder reversal PR https://github.com/openshift/openshift-docs/pull/54534 had to be reverted because CNV GA was delayed. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
