### PR TITLE
OSDOCS-4918: Clarifies vSphere 8 is not supported

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -263,9 +263,9 @@ To install a CSI driver on a cluster running on vSphere, the following requireme
 
 * Virtual machines of hardware version 15 or later
 
-* VMware vSphere version 7.0.2 or later
+* VMware vSphere version 7.0.2 or later, up to but not including version 8. vSphere 8 is not supported.
 
-* vCenter 7.0.2 or later
+* vCenter 7.0.2 or later, up to but not including version 8. vCenter 8 is not supported.
 
 * No third-party CSI driver already installed in the cluster
 +
@@ -948,8 +948,8 @@ For more information, see xref:../storage/container_storage_interface/persistent
 ==== VMware vSphere CSI Driver Operator requirements
 For {product-title} 4.12, VMWare vSphere Container Storage Interface (CSI) Driver Operator requires the following minimum components installed:
 
-* VMware vSphere version 7.0.2 or later
-* vCenter 7.0.2 or later
+* VMware vSphere version 7.0.2 or later, up to but not including version 8. vSphere 8 is not supported.
+* vCenter 7.0.2 or later, up to but not including version 8. vCenter 8 is not supported.
 * Virtual machines of hardware version 15 or later
 * No third-party CSI driver already installed in the cluster
 


### PR DESCRIPTION
In the [OpenShift 4.12 release note,](https://docs.openshift.com/container-platform/4.12/release_notes/ocp-4-12-release-notes.html) it says that vSphere 7.0.2 or later is supported; however, we have not tested/validated OpenShift 4.12 with vSphere 8.0 yet, so vSphere 8.0 is not supported.

Version(s):
4.12 only

Issue:
https://issues.redhat.com/browse/OSDOCS-4918

Link to docs preview:
https://55166--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-csi-driver-install-vsphere

and

https://55166--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-vsphere-min-requirements

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR will require change management. Acks needed from: @kalexand-rh @mwerner2113 @sferich888 @xltian @jiajliu @julienlim
