### PR TITLE
BZ2151324: Updated namespace requirement for live migration

### DIFF
--- a/modules/virt-configuring-secondary-network-vm-live-migration.adoc
+++ b/modules/virt-configuring-secondary-network-vm-live-migration.adoc
@@ -6,7 +6,7 @@
 [id="virt-configuring-secondary-network-vm-live-migration_{context}"]
 = Configuring a dedicated secondary network for virtual machine live migration
 
-To configure a dedicated secondary network for live migration, you must first create a bridge network attachment definition for a namespace by using the CLI. Then, add the name of the `NetworkAttachmentDefinition` object to the `HyperConverged` custom resource (CR).
+To configure a dedicated secondary network for live migration, you must first create a bridge network attachment definition for the `openshift-cnv` namespace by using the CLI. Then, add the name of the `NetworkAttachmentDefinition` object to the `HyperConverged` custom resource (CR).
 
 .Prerequisites
 
@@ -27,24 +27,25 @@ apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
   name: my-secondary-network <1>
-  namespace: openshift-cnv
+  namespace: openshift-cnv <2>
 spec:
   config: '{
     "cniVersion": "0.3.1",
     "name": "migration-bridge",
     "type": "macvlan",
-    "master": "eth1", <2>
+    "master": "eth1", <3>
     "mode": "bridge",
     "ipam": {
-      "type": "whereabouts", <3>
-      "range": "10.200.5.0/24" <4>
+      "type": "whereabouts", <4>
+      "range": "10.200.5.0/24" <5>
     }
   }'
 ----
 <1> The name of the `NetworkAttachmentDefinition` object.
-<2> The name of the NIC to be used for live migration.
-<3> The name of the CNI plugin that provides the network for this network attachment definition.
-<4> The IP address range for the secondary network. This range must not have any overlap with the IP addresses of the main network.
+<2> The namespace where the `NetworkAttachmentDefinition` object resides. This must be `openshift-cnv`.
+<3> The name of the NIC to be used for live migration.
+<4> The name of the CNI plugin that provides the network for this network attachment definition.
+<5> The IP address range for the secondary network. This range must not have any overlap with the IP addresses of the main network.
 
 . Open the `HyperConverged` CR in your default editor by running the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2151324
[CNV-23200](https://issues.redhat.com//browse/CNV-23200)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://55168--docspreview.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-migrating-vm-on-secondary-network.html#virt-configuring-secondary-network-vm-live-migration_virt-migrating-vm-on-secondary-network
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
