### PR TITLE
OSDOCS#4918: Clarifies vSphere 8 is not supported in 4.11

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -202,10 +202,10 @@ For more information, see link:https://access.redhat.com/articles/6675791[Instal
 To install a CSI driver on a cluster running on vSphere, you must have the following components installed:
 
 * Virtual hardware version 15 or later
-* vSphere version 7.0 Update 2 or later
+* vSphere version 7.0 Update 2 or later, up to but not including version 8. vSphere 8 is not supported.
 * VMware ESXi version 7.0 Update 2 or later
 
-Components with versions earlier than those above are deprecated or removed. Deprecated versions are still fully supported, but Red Hat recommends that you use vSphere 7.0 Update 2 or later and ESXi 7.0 Update 2 or later.
+Components with versions earlier than those above are deprecated or removed. Deprecated versions are still fully supported, but Red Hat recommends that you use ESXi 7.0 Update 2 or later and vSphere 7.0 Update 2 up to but not including version 8. vSphere 8 is not supported.
 
 For more information, see xref:../release_notes/ocp-4-11-release-notes.adoc#ocp-4-11-deprecated-removed-features[Deprecated and removed features].
 
@@ -704,7 +704,7 @@ For more information, see xref:../storage/generic-ephemeral-vols.adoc[Generic ep
 
 * Snapshots:
 
-** Requires vSphere version 7.0 Update 3 or later for both vCenter Server and ESXi.
+** Requires vSphere version 7.0 Update 3 or later, up to but not including version 8. vSphere 8 is not supported for both vCenter Server and ESXi.
 
 ** Does not support fileshare volumes.
 
@@ -1316,7 +1316,7 @@ Red Hat Virtualization (RHV) will be deprecated in an upcoming release of {produ
 
 [id="ocp-4-11-deprecated-features-vsphere-7.0update1"]
 ==== Support for vSphere 7.0 Update 1 or earlier is deprecated
-In {product-title} 4.11, support for VMware vSphere 7.0 Update 1 or earlier is deprecated. While vSphere 7.0 Update 1 or earlier remains fully supported, Red Hat recommends that you use vSphere 7.0 Update 2 or later.
+In {product-title} 4.11, support for VMware vSphere 7.0 Update 1 or earlier is deprecated. While vSphere 7.0 Update 1 or earlier remains fully supported, Red Hat recommends that you use vSphere 7.0 Update 2 or later, up to but not including version 8. vSphere 8 is not supported.
 
 [id="ocp-4-11-deprecated-features-esxi7.0update1"]
 ==== Support for ESXi 7.0 Update 1 or earlier is deprecated
@@ -1361,7 +1361,7 @@ In {product-title} 4.11, support for virtual hardware version 13 is removed. Sup
 
 [id="ocp-4-11-removed-features-vsphere-6.7update2"]
 ==== Support for vSphere 6.7 Update 2 or earlier is removed
-In {product-title} 4.11, support for VMware vSphere 6.7 Update 2 or earlier is removed. Support for vSphere 6.7 Update 2 or earlier was deprecated in {product-title} 4.9. Red Hat recommends that you use vSphere 7.0 Update 2 or later.
+In {product-title} 4.11, support for VMware vSphere 6.7 Update 2 or earlier is removed. Support for vSphere 6.7 Update 2 or earlier was deprecated in {product-title} 4.9. Red Hat recommends that you use vSphere 7.0 Update 2 or later, up to but not including version 8. vSphere 8 is not supported.
 
 [id="ocp-4-11-removed-features-esxi6.7update2"]
 ==== Support for ESXi 6.7 Update 2 or earlier is removed


### PR DESCRIPTION
In the [OpenShift 4.11 release note,](https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html) it says that vSphere 7.0.2 or later is supported; however, we have not tested/validated OpenShift 4.12 with vSphere 8.0 yet, so vSphere 8.0 is not supported.

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-4918

Link to docs preview:
https://55170--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR will require change management. Acks needed from: @kalexand-rh @mwerner2113 @sferich888 @xltian @jiajliu @julienlim

changes to 4.12 is in #55166 
