### PR TITLE
Document limitation in [Spike] Secure MCS Endpoint MCO-59

### DIFF
--- a/modules/installation-about-custom-azure-vnet.adoc
+++ b/modules/installation-about-custom-azure-vnet.adoc
@@ -99,10 +99,14 @@ The network security group rules must be in place before you install the cluster
 |
 |===
 
-[NOTE]
-====
-Since cluster components do not modify the user-provided network security groups, which the Kubernetes controllers update, a pseudo-network security group is created for the Kubernetes controller to modify without impacting the rest of the environment.
-====
+include::snippets/mcs-endpoint-limitation.adoc[]
+
+Because cluster components do not modify the user-provided network security groups, which the Kubernetes controllers update, a pseudo-network security group is created for the Kubernetes controller to modify without impacting the rest of the environment.
+
+.Additional resources
+
+* xref:../../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[About the OpenShift SDN network plugin]
+
 
 [id="installation-about-custom-azure-permissions_{context}"]
 == Division of permissions

--- a/modules/machine-config-operator.adoc
+++ b/modules/machine-config-operator.adoc
@@ -18,6 +18,12 @@ There are four components:
 * `machine-config-daemon`: Applies new machine configuration during update. Validates and verifies the state of the machine to the requested machine configuration.
 * `machine-config`: Provides a complete source of machine configuration at installation, first start up, and updates for a machine.
 
+include::snippets/mcs-endpoint-limitation.adoc[]
+
+.Additional resources
+
+* xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[About the OpenShift SDN network plugin].
+
 [discrete]
 == Project
 

--- a/security/certificate_types_descriptions/machine-config-operator-certificates.adoc
+++ b/security/certificate_types_descriptions/machine-config-operator-certificates.adoc
@@ -10,6 +10,13 @@ toc::[]
 
 Machine Config Operator certificates are used to secure connections between the Red Hat Enterprise Linux CoreOS (RHCOS) nodes and the Machine Config Server.
 
+include::snippets/mcs-endpoint-limitation.adoc[]
+
+.Additional resources
+
+* xref:../../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[About the OpenShift SDN network plugin].
+
+
 == Management
 
 These certificates are managed by the system and not the user.

--- a/snippets/mcs-endpoint-limitation.adoc
+++ b/snippets/mcs-endpoint-limitation.adoc
@@ -1,0 +1,14 @@
+// Text snippet included in the following modules:
+//
+// * modules/installation-about-custom-azure-vnet.adoc
+// * modules/machine-config-operator.adoc
+// * security/certificate_types_descriptions/machine-config-operator-certificates.adoc
+
+:_content-type: SNIPPET
+
+[IMPORTANT]
+====
+Currently, there is no supported way to block or restrict the machine config server endpoint. The machine config server must be exposed to the network so that newly-provisioned machines, which have no existing configuration or state, are able to fetch their configuration. In this model, the root of trust is the certificate signing requests (CSR) endpoint, which is where the kubelet sends its certificate signing request for approval to join the cluster. Because of this, machine configs should not be used to distribute sensitive information, such as secrets and certificates.
+
+To ensure that the machine config server endpoints, ports 22623 and 22624, are secured in bare metal scenarios, customers must configure proper network policies.
+====


### PR DESCRIPTION
https://issues.redhat.com/browse/MCO-59

Documenting a recommendation to use SDN to secure the MCS endpoints (22623 and 22624) and to not add secrets to the ignition configuration.

Previews:

Installing a cluster on Azure into an existing VNet  -> [Network security group requirements](https://55182--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-vnet.html#installation-about-custom-azure-vnet-nsg-requirements_installing-azure-vnet)

Installing a private cluster -> [Network security group requirements](https://55182--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-vnet.html#installation-about-custom-azure-vnet-nsg-requirements_installing-azure-vnet)

Installing a cluster on Azure into a government region -> [Network security group requirements](https://55182--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-vnet.html#installation-about-custom-azure-vnet-nsg-requirements_installing-azure-vnet)

Post-installation machine configuration tasks -> [Understanding the Machine Config Operator](https://55182--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks#understanding-the-machine-config-operator)

Security -> Certificate types and descriptions -> [Machine Config Operator certificates](https://55182--docspreview.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/machine-config-operator-certificates.html) 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

