### PR TITLE
[SRVCOM-2104] Add the info on installing kn cli older that latest

### DIFF
--- a/modules/serverless-installing-cli-linux.adoc
+++ b/modules/serverless-installing-cli-linux.adoc
@@ -25,13 +25,16 @@ $ kn: No such file or directory
 .Procedure
 
 . Download the relevant Knative (`kn`) CLI `tar.gz` archive:
-
++
+--
 * link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
 
 * link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-s390x.tar.gz[Linux on IBM Z and LinuxONE (s390x)]
 
 * link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-ppc64le.tar.gz[Linux on IBM Power (ppc64le)]
-
+--
++
+You can also download any version of `kn` by navigating to that version's corresponding directory in the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/[Serverless client download mirror].
 
 . Unpack the archive:
 +

--- a/modules/serverless-installing-cli-macos.adoc
+++ b/modules/serverless-installing-cli-macos.adoc
@@ -13,6 +13,8 @@ If you are using macOS, you can install the Knative (`kn`) CLI as a binary file.
 .Procedure
 
 . Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-macos-amd64.tar.gz[Knative (`kn`) CLI `tar.gz` archive].
++
+You can also download any version of `kn` by navigating to that version's corresponding directory in the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/[Serverless client download mirror].
 
 . Unpack and extract the archive.
 

--- a/modules/serverless-installing-cli-windows.adoc
+++ b/modules/serverless-installing-cli-windows.adoc
@@ -13,6 +13,8 @@ If you are using Windows, you can install the Knative (`kn`) CLI as a binary fil
 .Procedure
 
 . Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-windows-amd64.zip[Knative (`kn`) CLI ZIP archive].
++
+You can also download any version of `kn` by navigating to that version's corresponding directory in the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/[Serverless client download mirror].
 
 . Extract the archive with a ZIP program.
 


### PR DESCRIPTION
Version(s):
4.8+ (needs cherrypicking)

Issue:
https://issues.redhat.com/browse/SRVCOM-2104

Link to docs preview:
https://55192--docspreview.netlify.app/openshift-enterprise/latest/serverless/cli_tools/installing-kn.html#installing-cli-linux_installing-kn
(this and the two following sections)

QE review:
- [ ] QE has approved this change.