### PR TITLE
WMCO hiding docs from 4.12

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -656,8 +656,8 @@ Topics:
     File: troubleshooting-s2i
   - Name: Troubleshooting storage issues
     File: troubleshooting-storage-issues
-  - Name: Troubleshooting Windows container workload issues
-    File: troubleshooting-windows-container-workload-issues
+#  - Name: Troubleshooting Windows container workload issues
+#    File: troubleshooting-windows-container-workload-issues
   - Name: Investigating monitoring issues
     File: investigating-monitoring-issues
   - Name: Diagnosing OpenShift CLI (oc) issues
@@ -2266,38 +2266,38 @@ Topics:
   - Name: Adding worker nodes to single-node OpenShift clusters
     File: nodes-sno-worker-nodes
 ---
-Name: Windows Container Support for OpenShift
-Dir: windows_containers
-Distros: openshift-origin,openshift-enterprise
-Topics:
-- Name: Red Hat OpenShift support for Windows Containers overview
-  File: index
-- Name: Red Hat OpenShift support for Windows Containers release notes
-  File: windows-containers-release-notes-6-x
-- Name: Understanding Windows container workloads
-  File: understanding-windows-container-workloads
-- Name: Enabling Windows container workloads
-  File: enabling-windows-container-workloads
-- Name: Creating Windows MachineSet objects
-  Dir: creating_windows_machinesets
-  Topics:
-  - Name: Creating a Windows MachineSet object on AWS
-    File: creating-windows-machineset-aws
-  - Name: Creating a Windows MachineSet object on Azure
-    File: creating-windows-machineset-azure
-  - Name: Creating a Windows MachineSet object on vSphere
-    File: creating-windows-machineset-vsphere
-- Name: Scheduling Windows container workloads
-  File: scheduling-windows-workloads
-- Name: Windows node upgrades
-  File: windows-node-upgrades
-- Name: Using Bring-Your-Own-Host Windows instances as nodes
-  File: byoh-windows-instance
-- Name: Removing Windows nodes
-  File: removing-windows-nodes
-- Name: Disabling Windows container workloads
-  File: disabling-windows-container-workloads
----
+# Name: Windows Container Support for OpenShift
+# Dir: windows_containers
+# Distros: openshift-origin,openshift-enterprise
+# Topics:
+#- Name: Red Hat OpenShift support for Windows Containers overview
+#  File: index
+#- Name: Red Hat OpenShift support for Windows Containers release notes
+#  File: windows-containers-release-notes-6-x
+#- Name: Understanding Windows container workloads
+#  File: understanding-windows-container-workloads
+#- Name: Enabling Windows container workloads
+#  File: enabling-windows-container-workloads
+#- Name: Creating Windows MachineSet objects
+#  Dir: creating_windows_machinesets
+#  Topics:
+#  - Name: Creating a Windows MachineSet object on AWS
+#    File: creating-windows-machineset-aws
+#  - Name: Creating a Windows MachineSet object on Azure
+#    File: creating-windows-machineset-azure
+#  - Name: Creating a Windows MachineSet object on vSphere
+#    File: creating-windows-machineset-vsphere
+#- Name: Scheduling Windows container workloads
+#  File: scheduling-windows-workloads
+#- Name: Windows node upgrades
+#  File: windows-node-upgrades
+#- Name: Using Bring-Your-Own-Host Windows instances as nodes
+#  File: byoh-windows-instance
+#- Name: Removing Windows nodes
+#  File: removing-windows-nodes
+#- Name: Disabling Windows container workloads
+#  File: disabling-windows-container-workloads
+#---
 Name: Sandboxed Containers Support for OpenShift
 Dir: sandboxed_containers
 Distros: openshift-enterprise

--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -112,7 +112,7 @@ For a production cluster, you must configure the following integrations:
 == Preparing your cluster for workloads
 
 Depending on your workload needs, you might need to take extra steps before you begin deploying applications. For example, after you prepare infrastructure to support your application xref:../cicd/builds/build-strategies.adoc#build-strategies[build strategy], you might need to make provisions for xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#cnf-low-latency-tuning[low-latency] workloads or to xref:../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets[protect sensitive workloads]. You can also configure xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[monitoring] for application workloads.
-If you plan to run xref:../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Windows workloads], you must enable xref:../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-networking[hybrid networking with OVN-Kubernetes] during the installation process; hybrid networking cannot be enabled after your cluster is installed.
+//If you plan to run  ../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Windows workloads], you must enable xref:../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-networking[hybrid networking with OVN-Kubernetes] during the installation process; hybrid networking cannot be enabled after your cluster is installed.
 
 [id="supported-installation-methods-for-different-platforms"]
 == Supported installation methods for different platforms

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -66,12 +66,12 @@ include::modules/nw-aws-nlb-new-cluster.adoc[leveloffset=+1]
 
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-
+////
 [NOTE]
 ====
-For more information on using Linux and Windows nodes in the same cluster, see xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information on using Linux and Windows nodes in the same cluster, see  ../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
-
+////
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/installing-azure-network-customizations.adoc
@@ -51,12 +51,12 @@ include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-
+////
 [NOTE]
 ====
-For more information on using Linux and Windows nodes in the same cluster, see xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information on using Linux and Windows nodes in the same cluster, see  ../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
-
+////
 
 // Enabling Accelerated Networking during install
 include::modules/machineset-azure-enabling-accelerated-networking-new-install.adoc[leveloffset=+1]

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
@@ -52,12 +52,12 @@ include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-
+////
 [NOTE]
 ====
-For more information on using Linux and Windows nodes in the same cluster, see xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information on using Linux and Windows nodes in the same cluster, see  ../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
-
+////
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
@@ -16,7 +16,7 @@ Complete any further installation configurations, and then create your cluster. 
 [id="configuring-hybrid-networking-additional-resources"]
 == Additional resources
 
-* xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads]
-* xref:../../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Enabling Windows container workloads]
+// ../../windows_containersunderstanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads]
+//* ../../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Enabling Windows container workloads]
 * xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[Installing a cluster on AWS with network customizations]
 * xref:../../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[Installing a cluster on Azure with network customizations]

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
@@ -27,7 +27,8 @@ include::modules/creating-the-vsphere-windows-vm-golden-image.adoc[leveloffset=+
 [role="_additional-resources"]
 ==== Additional resources
 
-* xref:../../windows_containers/enabling-windows-container-workloads.adoc#configuring-secret-for-wmco_enabling-windows-container-workloads[Configuring a secret for the Windows Machine Config Operator]
+//* ../../windows_containersenabling-windows-container-workloads.adoc#configuring-secret-for-wmco_enabling-windows-container-workloads[Configuring a secret for the Windows Machine Config Operator]
+
 * xref:../../installing/installing_vsphere/preparing-to-install-on-vsphere.adoc#installation-vsphere-infrastructure_preparing-to-install-on-vsphere[VMware vSphere infrastructure requirements]
 
 include::modules/enabling-internal-api-server-vsphere.adoc[leveloffset=+2]


### PR DESCRIPTION
Hiding the WinC topics from 4.12 awaiting WMCO 7.0.0. release. Redirects do not work in the portal

No QE review needed

Windows docs:
[Before with redirect in place](https://docs.openshift.com/container-platform/4.12/windows_containers/index.html)
[After](https://55210--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/index.html)

Installing a cluster on Azure with network customizations -> Configuring hybrid networking with OVN-Kubernetes -> Note at end hidden
[Before](https://docs.openshift.com/container-platform/4.12/installing/installing_azure/installing-azure-network-customizations.html#configuring-hybrid-ovnkubernetes_installing-azure-network-customizations)
[After](https://55210--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-network-customizations#configuring-hybrid-ovnkubernetes_installing-azure-network-customizations) 

Installing a cluster on Azure Stack Hub with network customizations -> Configuring hybrid networking with OVN-Kubernetes -> Note at end hidden
[Before](https://docs.openshift.com/container-platform/4.12/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.html#configuring-hybrid-ovnkubernetes_installing-azure-stack-hub-network-customizations)
[After](https://55210--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.html#configuring-hybrid-ovnkubernetes_installing-azure-stack-hub-network-customizations)

Installing a cluster on AWS with network customizations -> Configuring hybrid networking with OVN-Kubernetes -> Note at end hidden
[Before](https://docs.openshift.com/container-platform/4.12/installing/installing_aws/installing-aws-network-customizations.html#configuring-hybrid-ovnkubernetes_installing-aws-network-customizations)
[After](https://55210--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations#configuring-hybrid-ovnkubernetes_installing-aws-network-customizations)

Installing preparing -> Preparing your cluster for workloads -> _If you plan to run Windows workloads_ paragraph hidden
[Before](https://docs.openshift.com/container-platform/4.12/installing/installing-preparing.html#installing-preparing-cluster-for-workloads) 
[After](https://55210--docspreview.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#installing-preparing-cluster-for-workloads)

Networking -> OVN -> Configuring hybrid networking -> Additional resources -> Removed two bullets
[Before](https://docs.openshift.com/container-platform/4.12/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.html#configuring-hybrid-networking-additional-resources)
[After](https://55210--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.html#configuring-hybrid-networking-additional-resources)

Troubleshooting Windows container workload issues -- Assembly hidden[
Before](https://docs.openshift.com/container-platform/4.11/support/troubleshooting/troubleshooting-windows-container-workload-issues.html)
[After](https://55210--docspreview.netlify.app/openshift-enterprise/latest/supporttroubleshooting/troubleshooting-windows-container-workload-issues.html)