### PR TITLE
[enterprise-4.11] Fixed a broken ID in LokiStack

### DIFF
--- a/modules/cluster-logging-feature-reference.adoc
+++ b/modules/cluster-logging-feature-reference.adoc
@@ -2,7 +2,6 @@
 //cluster-logging-loki.adoc
 :_content-type: REFERENCE
 [id="logging-feature-ref_{context}"]
-id="cluster-logging-about-vector"]
 = About Vector
 Vector is a log collector offered as an alternative to Fluentd for the {logging}.
 


### PR DESCRIPTION
This PR is a continuation of #53099 that fixes a broken ID present in the 4.10 and 4.11 versions of the documentation.

Preview:
* [Current](https://docs.openshift.com/container-platform/4.11/logging/cluster-logging-loki.html#cluster-logging-vector-enable_cluster-logging-loki)
![image](https://user-images.githubusercontent.com/16167833/214908595-716dddcd-845b-436b-b522-9082eab80645.png)
* [Fixed](https://55211--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-loki.html#logging-feature-ref_cluster-logging-loki)