### PR TITLE
OSDOCS-4927: Release note for node port issue

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -17,7 +17,7 @@ toc::[]
 
 [IMPORTANT]
 ====
-Red Hat will not provide or support an update or upgrade path from Developer Preview and Technology Preview versions to later versions of {product-title}. A new installation will be necessary.
+Red Hat does not provide or support an update or upgrade path from Developer Preview and Technology Preview versions to later versions of {product-title}. A new installation is necessary.
 ====
 
 [id="microshift-known-issues"]
@@ -56,6 +56,8 @@ You can suppress all `runc` mount logs through `systemd`. Create the file `/etc/
 And reload the daemon.
 
 * There is an issue with the way {product-title}'s CNI driver manages the firewall rules. If the firewall settings are modified after {product-title} is started then {product-title} must be restarted. The recommended workaround is to configure firewall rules before starting {product-title}.
+
+* After a new installation of {product-title}, the `NodePort` service traffic might be stopped. To work around this issue, manually restart the `ovnkube-master` pod in the `openshift-ovn-kubernetes` namespace.
 
 [id="microshift-4-12-asynchronous-errata-updates"]
 == Asynchronous errata updates

--- a/modules/microshift-about.adoc
+++ b/modules/microshift-about.adoc
@@ -7,7 +7,7 @@
 
 Working with resource-constrained field environments and hardware presents many challenges not experienced with cloud computing. {product-title} enables you to solve problems for edge devices by:
 
-* Overcoming the operational challenge of minimal system resources, for example, a {op-system-chip}.
+* Overcoming the operational challenge of minimal system resources, for example, a dual-core processor.
 * Addressing the environmental challenges of severe networking constraints such as low or no connectivity.
 * Meeting the physical constraint of hard-to-access locations by installing your system images directly on edge devices.
 * Building on and integrating with edge-optimized operating systems such as {op-system-first}.


### PR DESCRIPTION
Version(s):
4.12 (publishing with z-stream, 4.12.1)

Issue:
https://issues.redhat.com/browse/OSDOCS-4926

Link to docs preview:
https://55214--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html#microshift-known-issues
(It is the last bullet in this section)

QE review:
Developer Preview software; SME ack required
No QE required

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
